### PR TITLE
add version-based url map for cmake, provide md5 for cmake 3.3.1

### DIFF
--- a/var/spack/packages/cmake/package.py
+++ b/var/spack/packages/cmake/package.py
@@ -23,20 +23,29 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import llnl.util.tty as tty
 
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
        tools designed to build, test and package software."""
     homepage  = 'https://www.cmake.org'
 
-    version('2.8.10.2', '097278785da7182ec0aea8769d06860c',
-            url = 'http://www.cmake.org/files/v2.8/cmake-2.8.10.2.tar.gz')
- 
-    version('3.0.2', 'db4c687a31444a929d2fdc36c4dfb95f',
-            url = 'http://www.cmake.org/files/v3.0/cmake-3.0.2.tar.gz')
-
+    version('2.8.10.2', '097278785da7182ec0aea8769d06860c')
+    version('3.0.2', 'db4c687a31444a929d2fdc36c4dfb95f')
+    version('3.3.1', '52638576f4e1e621fed6c3410d3a1b12')
+    
 #    version('3.0.1', 'e2e05d84cb44a42f1371d9995631dcf5')
 #    version('3.0.0', '21a1c85e1a3b803c4b48e7ff915a863e')
+
+    def url_for_version(self, version):
+        """Handle CMake's version-based custom URLs."""
+        parts = [str(p) for p in Version(version)]
+        if len(parts) < 3:
+            tty.error("Version '%s'does not match CMake's version naming scheme (z.y.x)." % version)
+        version_short = ".".join(parts[:2])
+        version_full  = ".".join(parts)
+        return "http://www.cmake.org/files/v%s/cmake-%s.tar.gz" % (version_short,version_full)
+
 
     def install(self, spec, prefix):
         configure('--prefix='   + prefix,


### PR DESCRIPTION
-added "url_for_verison" w/ version-based url map for cmake
-added a md5 for the cmake 3.3.1 source release tarball
