### PR TITLE
added zlib dependency to glib package specification

### DIFF
--- a/var/spack/packages/glib/package.py
+++ b/var/spack/packages/glib/package.py
@@ -11,6 +11,7 @@ class Glib(Package):
     version('2.42.1', '89c4119e50e767d3532158605ee9121a')
 
     depends_on("libffi")
+    depends_on("zlib")
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)


### PR DESCRIPTION
This adds `zlib` as an explicit dependency of `glib`. When trying to install `glib` on Ubuntu, we see the build fail due to missing `zlib` headers, for example:

    checking for python platform... linux2
    checking for python script directory... ${prefix}/lib/python2.7/site-packages
    checking for python extension module directory... ${exec_prefix}/lib/python2.7/site-packages
    checking for iconv_open... yes
    checking for ZLIB... no
    checking for inflate in -lz... no
    configure: error: *** Working zlib library and headers not found ***



