### PR TITLE
Features/unittest xml output

### DIFF
--- a/lib/spack/spack/cmd/test-install.py
+++ b/lib/spack/spack/cmd/test-install.py
@@ -23,7 +23,6 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from external import argparse
-import xml.etree.ElementTree as ET
 import itertools
 import re
 import os
@@ -35,6 +34,7 @@ from llnl.util.filesystem import *
 import spack
 from spack.build_environment import InstallError
 from spack.fetch_strategy import FetchError
+from spack.test.testutils import JunitResultFormat, TestResult, TestId
 import spack.cmd
 
 description = "Treat package installations as unit tests and output formatted test results"
@@ -55,37 +55,6 @@ def setup_parser(subparser):
         'package', nargs=argparse.REMAINDER, help="spec of package to install")
 
 
-class JunitResultFormat(object):
-    def __init__(self):
-        self.root = ET.Element('testsuite')
-        self.tests = []
-        
-    def add_test(self, buildId, testResult, buildInfo=None):
-        self.tests.append((buildId, testResult, buildInfo))
-    
-    def write_to(self, stream):
-        self.root.set('tests', '{0}'.format(len(self.tests)))
-        for buildId, testResult, buildInfo in self.tests:
-            testcase = ET.SubElement(self.root, 'testcase')
-            testcase.set('classname', buildId.name)
-            testcase.set('name', buildId.stringId())
-            if testResult == TestResult.FAILED:
-                failure = ET.SubElement(testcase, 'failure')
-                failure.set('type', "Build Error")
-                failure.text = buildInfo
-            elif testResult == TestResult.SKIPPED:
-                skipped = ET.SubElement(testcase, 'skipped')
-                skipped.set('type', "Skipped Build")
-                skipped.text = buildInfo
-        ET.ElementTree(self.root).write(stream)
-
-
-class TestResult(object):
-    PASSED = 0
-    FAILED = 1
-    SKIPPED = 2
-    
-
 class BuildId(object):
     def __init__(self, spec):
         self.name = spec.name
@@ -94,6 +63,9 @@ class BuildId(object):
     
     def stringId(self):
         return "-".join(str(x) for x in (self.name, self.version, self.hashId))
+
+    def testId(self):
+        return TestId(self.stringId(), self.name)
 
     def __hash__(self):
         return hash((self.name, self.version, self.hashId))
@@ -150,7 +122,7 @@ def create_test_output(topSpec, newInstalls, output, getLogFunc=fetch_log):
             errOutput = None
         
         bId = BuildId(spec)
-        output.add_test(bId, result, errOutput)
+        output.add_test(bId.testId(), result, errOutput)
 
 
 def test_install(parser, args):

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -40,6 +40,12 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-v', '--verbose', action='store_true', dest='verbose',
         help="verbose output")
+    subparser.add_argument(
+        '--junitXmlOutput', action='store_true', dest='junitXmlOutput',
+        help="Create JUnit XML output")
+    subparser.add_argument(
+        '--outputFile', dest='outputFile',
+        help="Write test output to a file other than the default")        
 
 
 def test(parser, args):

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -29,6 +29,7 @@ from llnl.util.lang import list_modules
 
 import spack
 import spack.test
+from spack.test.testutils import JunitResultFormat, test_output_path
 
 description ="Run unit tests"
 
@@ -44,7 +45,7 @@ def setup_parser(subparser):
         '--junitXmlOutput', action='store_true', dest='junitXmlOutput',
         help="Create JUnit XML output")
     subparser.add_argument(
-        '--outputFile', dest='outputFile',
+        '--outputPath', dest='outputPath',
         help="Write test output to a file other than the default")        
 
 
@@ -54,4 +55,14 @@ def test(parser, args):
         colify(spack.test.list_tests(), indent=2)
 
     else:
-        spack.test.run(args.names, args.verbose)
+        if args.junitXmlOutput:
+            output = JunitResultFormat()
+            # Note some unit tests change the CWD, so using test_output_path
+            # to create the directory after running spack.test.run can choose
+            # a path that is not relative the the CWD where "spack test" is run
+            outputFpath = args.outputPath or test_output_path('unit_tests.xml')
+            spack.test.run(args.names, args.verbose, output)
+            with open(outputFpath, 'wb') as F:
+                output.write_to(F)
+        else:
+            spack.test.run(args.names, args.verbose)

--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -67,7 +67,7 @@ def list_tests():
     return test_names
 
 
-def run(names, verbose=False):
+def run(names, verbose=False, output=None):
     """Run tests with the supplied names.  Names should be a list.  If
        it's empty, run ALL of Spack's tests."""
     verbosity = 1 if not verbose else 2
@@ -95,6 +95,8 @@ def run(names, verbose=False):
         testsRun += result.testsRun
         errors   += len(result.errors)
         failures += len(result.failures)
+        
+        if output: testutils.generate_output_format(suite, result, output)
 
     succeeded = not errors and not failures
     tty.msg("Tests Complete.",
@@ -106,4 +108,3 @@ def run(names, verbose=False):
         tty.info("OK", format='g')
     else:
         tty.info("FAIL", format='r')
-        sys.exit(1)

--- a/lib/spack/spack/test/testutils.py
+++ b/lib/spack/spack/test/testutils.py
@@ -1,0 +1,70 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://scalability-llnl.github.io/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import xml.etree.ElementTree as ET
+
+class JunitResultFormat(object):
+    def __init__(self):
+        self.root = ET.Element('testsuite')
+        self.tests = []
+        
+    def add_test(self, testId, testResult, testInfo=None):
+        self.tests.append((testId, testResult, testInfo))
+    
+    def write_to(self, stream):
+        self.root.set('tests', '{0}'.format(len(self.tests)))
+        for testId, testResult, testInfo in self.tests:
+            testcase = ET.SubElement(self.root, 'testcase')
+            testcase.set('classname', testId.groupId)
+            testcase.set('name', testId.name)
+            if testResult == TestResult.FAILED:
+                failure = ET.SubElement(testcase, 'failure')
+                failure.set('type', "Build Error")
+                failure.text = testInfo
+            elif testResult == TestResult.SKIPPED:
+                skipped = ET.SubElement(testcase, 'skipped')
+                skipped.set('type', "Skipped Build")
+                skipped.text = testInfo
+        ET.ElementTree(self.root).write(stream)
+
+
+class TestResult(object):
+    PASSED = 0
+    FAILED = 1
+    SKIPPED = 2
+    
+
+class TestId(object):
+    def __init__(self, name, groupId=None):
+        self.name = name
+        self.groupId = groupId if groupId else name
+    
+    def __hash__(self):
+        return hash((self.name, self.groupId))
+    
+    def __eq__(self, other):
+        if not isinstance(other, TestId):
+            return False
+            
+        return ((self.name, self.groupId) == (other.name, other.groupId))

--- a/lib/spack/spack/test/unit_install.py
+++ b/lib/spack/spack/test/unit_install.py
@@ -28,7 +28,7 @@ import itertools
 import spack
 test_install = __import__("spack.cmd.test-install", 
     fromlist=["BuildId", "create_test_output"])
-from spack.test.testutils import TestResult
+from spack.test.testutils import TestStatus
 
 class MockOutput(object):
     def __init__(self):
@@ -94,8 +94,8 @@ class UnitInstallTest(unittest.TestCase):
         test_install.create_test_output(specX, [specX, specY], mo, getLogFunc=test_fetch_log)
         
         self.assertEqual(mo.results, 
-            {bIdX.testId():TestResult.PASSED, 
-            bIdY.testId():TestResult.PASSED})
+            {bIdX.testId():TestStatus.PASSED, 
+            bIdY.testId():TestStatus.PASSED})
 
     def test_dependency_already_installed(self):
         mo = MockOutput()
@@ -104,7 +104,7 @@ class UnitInstallTest(unittest.TestCase):
         pkgY.installed = True
         test_install.create_test_output(specX, [specX], mo, getLogFunc=test_fetch_log)
         
-        self.assertEqual(mo.results, {bIdX.testId():TestResult.PASSED})
+        self.assertEqual(mo.results, {bIdX.testId():TestStatus.PASSED})
 
     #TODO: add test(s) where Y fails to install
 

--- a/lib/spack/spack/test/unit_install.py
+++ b/lib/spack/spack/test/unit_install.py
@@ -27,7 +27,8 @@ import itertools
 
 import spack
 test_install = __import__("spack.cmd.test-install", 
-    fromlist=["BuildId", "create_test_output", "TestResult"])
+    fromlist=["BuildId", "create_test_output"])
+from spack.test.testutils import TestResult
 
 class MockOutput(object):
     def __init__(self):
@@ -93,8 +94,8 @@ class UnitInstallTest(unittest.TestCase):
         test_install.create_test_output(specX, [specX, specY], mo, getLogFunc=test_fetch_log)
         
         self.assertEqual(mo.results, 
-            {bIdX:test_install.TestResult.PASSED, 
-            bIdY:test_install.TestResult.PASSED})
+            {bIdX.testId():TestResult.PASSED, 
+            bIdY.testId():TestResult.PASSED})
 
     def test_dependency_already_installed(self):
         mo = MockOutput()
@@ -103,7 +104,7 @@ class UnitInstallTest(unittest.TestCase):
         pkgY.installed = True
         test_install.create_test_output(specX, [specX], mo, getLogFunc=test_fetch_log)
         
-        self.assertEqual(mo.results, {bIdX:test_install.TestResult.PASSED})
+        self.assertEqual(mo.results, {bIdX.testId():TestResult.PASSED})
 
     #TODO: add test(s) where Y fails to install
 


### PR DESCRIPTION
Work in progress

Generates JUnit XML output from unit tests. Unless testutils.generate_output_format only creates XML output for failed/error tests (and excludes passed/skipped) then it will be difficult to make it compatible across 2.6 and 2.7

Using nose may be a better option (since it provides an XML output option and is cross-compatible) but would require some different edits.