### PR TITLE
qt: comment out the gtk+ dependency

### DIFF
--- a/var/spack/packages/qt/package.py
+++ b/var/spack/packages/qt/package.py
@@ -22,7 +22,7 @@ class Qt(Package):
     #depends_on("openssl")
 
     depends_on("glib")
-    depends_on("gtkplus")
+    #depends_on("gtkplus")
     depends_on("libxml2")
     depends_on("zlib")
     depends_on("dbus")


### PR DESCRIPTION
GTK integration is nice, but probably not required on a supercomputer.