### PR TITLE
Hdf5 fix mpi dependency

### DIFF
--- a/var/spack/packages/SAMRAI/package.py
+++ b/var/spack/packages/SAMRAI/package.py
@@ -25,7 +25,7 @@ class Samrai(Package):
 
     depends_on("mpi")
     depends_on("zlib")
-    depends_on("hdf5")
+    depends_on("hdf5+mpi")
     depends_on("boost")
 
     # don't build tools with gcc

--- a/var/spack/packages/cleverleaf/package.py
+++ b/var/spack/packages/cleverleaf/package.py
@@ -14,7 +14,7 @@ class Cleverleaf(Package):
     version('develop', git='https://github.com/UK-MAC/CleverLeaf_ref.git', branch='develop')
 
     depends_on("SAMRAI@3.8.0:")
-    depends_on("hdf5")
+    depends_on("hdf5+mpi")
     depends_on("boost")
 
     def install(self, spec, prefix):

--- a/var/spack/packages/hdf5/package.py
+++ b/var/spack/packages/hdf5/package.py
@@ -15,19 +15,28 @@ class Hdf5(Package):
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
     version('1.8.13', 'c03426e9e77d7766944654280b467289')
 
-    depends_on("mpi")
+    variant('mpi', default=False, description='Enable MPI support')
+
+    depends_on("mpi", when='+mpi')
     depends_on("zlib")
 
     # TODO: currently hard-coded to use OpenMPI
     def install(self, spec, prefix):
+        extra_args = []
+        if '+mpi' in spec:
+            extra_args.extend([
+                "--enable-parallel",
+                "CC=%s" % spec['mpich'].prefix.bin + "/mpicc",
+                "CXX=%s" % spec['mpich'].prefix.bin + "/mpic++",
+            ])
 
         configure(
             "--prefix=%s" % prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
-            "--enable-parallel",
             "--enable-shared",
             "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
-            "CXX=%s" % spec['mpi'].prefix.bin + "/mpic++")
+            "CXX=%s" % spec['mpi'].prefix.bin + "/mpic++",
+            *extra_args)
 
         make()
         make("install")

--- a/var/spack/packages/paraview/package.py
+++ b/var/spack/packages/paraview/package.py
@@ -25,6 +25,7 @@ class Paraview(Package):
     depends_on('bzip2')
     depends_on('freetype')
     depends_on('hdf5')
+    depends_on('hdf5+mpi', when='+mpi')
     depends_on('jpeg')
     depends_on('libpng')
     depends_on('libtiff')

--- a/var/spack/packages/paraview/package.py
+++ b/var/spack/packages/paraview/package.py
@@ -24,7 +24,7 @@ class Paraview(Package):
 
     depends_on('bzip2')
     depends_on('freetype')
-    depends_on('hdf5') # drags in mpi
+    depends_on('hdf5')
     depends_on('jpeg')
     depends_on('libpng')
     depends_on('libtiff')

--- a/var/spack/packages/petsc/package.py
+++ b/var/spack/packages/petsc/package.py
@@ -18,7 +18,7 @@ class Petsc(Package):
     depends_on("hypre")
     depends_on("parmetis")
     depends_on("metis")
-    depends_on("hdf5")
+    depends_on("hdf5+mpi")
     depends_on("mpi")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
---
So this is a little more shaky. The packages which use HDF5 will need a sweep to find out if they need a parallel-enabled HDF5 and add the `+mpi` flag appropriately.