### PR TITLE
Adding https support in git even if system lib are missing

### DIFF
--- a/var/spack/packages/curl/package.py
+++ b/var/spack/packages/curl/package.py
@@ -1,0 +1,25 @@
+from spack import *
+
+class Curl(Package):
+    """cURL is an open source command line tool and library for
+    transferring data with URL syntax"""
+
+    homepage = "http://curl.haxx.se"
+    url      = "http://curl.haxx.se/download/curl-7.46.0.tar.bz2"
+
+    version('7.46.0', '9979f989a2a9930d10f1b3deeabc2148')
+    version('7.45.0', '62c1a352b28558f25ba6209214beadc8')
+    version('7.44.0', '6b952ca00e5473b16a11f05f06aa8dae')
+    version('7.43.0', '11bddbb452a8b766b932f859aaeeed39')
+    version('7.42.1', '296945012ce647b94083ed427c1877a8')
+
+    depends_on("openssl")
+    depends_on("zlib")
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix,
+                  '--with-zlib=%s' % spec['zlib'].prefix,
+                  '--with-ssl=%s' % spec['openssl'].prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/expat/package.py
+++ b/var/spack/packages/expat/package.py
@@ -1,0 +1,17 @@
+from spack import *
+
+class Expat(Package):
+    """<eXpat/> is an XML parser library written in C"""
+    homepage = "http://expat.sourceforge.net/"
+    url      = "http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz"
+
+    version('2.1.0', 'dd7dab7a5fea97d2a6a43f511449b7cd')
+
+
+    def install(self, spec, prefix):
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *std_cmake_args)
+            make()
+            make('install')
+

--- a/var/spack/packages/git/package.py
+++ b/var/spack/packages/git/package.py
@@ -7,10 +7,25 @@ class Git(Package):
     homepage = "http://git-scm.com"
     url      = "https://www.kernel.org/pub/software/scm/git/git-2.2.1.tar.xz"
 
+    version('2.6.3', '5a6375349c3f13c8dbbabfc327bae429')
+    version('2.6.2', '32ae5ad29763fc927bfcaeab55385fd9')
+    version('2.6.1', 'dd4a3a7fe96598c553edd39d40c9c290')
+    version('2.6.0', '6b7d43d615fb3f0dfecf4d131e23f438')
+    version('2.5.4', 'ec118fcd1cf984edc17eb6588b78e81b')
     version('2.2.1', '43e01f9d96ba8c11611e0eef0d9f9f28')
 
-    # Use system openssl.
-    # depends_on("openssl")
+
+    # Git compiles with curl support by default on but if your system
+    # does not have it you will not be able to clone https repos
+    variant("curl", default=False, description="Add the internal support of curl for https clone")
+
+    # Git compiles with expat support by default on but if your system
+    # does not have it you will not be able to push https repos
+    variant("expat", default=False, description="Add the internal support of expat for https push")
+
+    depends_on("openssl")
+    depends_on("curl", when="+curl")
+    depends_on("expat", when="+expat")
 
     # Use system perl for now.
     # depends_on("perl")
@@ -19,9 +34,26 @@ class Git(Package):
     depends_on("zlib")
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix,
-                  "--without-pcre",
-                  "--without-python")
+        configure_args = [
+            "--prefix=%s" % prefix,
+            "--without-pcre",
+            "--with-openssl=%s" % spec['openssl'].prefix,
+            "--with-zlib=%s" % spec['zlib'].prefix
+            ]
 
+        if '+curl' in spec:
+            configure_args.append("--with-curl=%s" % spec['curl'].prefix)
+
+        if '+expat' in spec:
+            configure_args.append("--with-expat=%s" % spec['expat'].prefix)
+
+        configure(*configure_args)
         make()
         make("install")
+
+
+
+
+
+
+


### PR DESCRIPTION
The PR adds the dependency to curl and expat for https clone and pushes.
The variants just state that the version from spack should be used, if they are not used on and the system provides libcurl and libexpat the https support will still be activated.

I also made the dependency with zlib and openssl interne to spack.
For zlib the dependency was already there but if the system also provide zlib it was linking with the system one.

This PR is complementary to the changes of @justintoo in PR #105.

For the curl packages added as a dependency, it is curl and libcurl that are build. I don't know if it is preferable to only install the libcurl and not the curl executable, since the system should already have curl in order to use spack.