### PR TITLE
mpich, mvapich2: changes the filter for the wrappers mpi{cc, cxx, f77, fc}

### DIFF
--- a/var/spack/packages/mpich/package.py
+++ b/var/spack/packages/mpich/package.py
@@ -85,8 +85,13 @@ class Mpich(Package):
         mpif77 = os.path.join(bin, 'mpif77')
         mpif90 = os.path.join(bin, 'mpif90')
 
+        spack_cc  = os.environ['CC']
+        spack_cxx = os.environ['CXX']
+        spack_f77 = os.environ['F77']
+        spack_fc  = os.environ['FC']
+
         kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : True }
-        filter_file('CC="cc"',   'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
-        filter_file('CXX="c++"', 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="f77"', 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="f90"',  'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)
+        filter_file('CC="%s"' % spack_cc , 'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
+        filter_file('CXX="%s"'% spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
+        filter_file('F77="%s"'% spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
+        filter_file('FC="%s"' % spack_fc , 'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)


### PR DESCRIPTION
In my case I still add `/home/richart/spack/lib/spack/env/cc` in `mpicc`
This PR changes the filter to use the same value as the one set as compiler with the environment variable `CC`

I copy pasted the code from mpich to mvapich2 which is a bit ugly. But I don't know if there is a way to make `Mvapich2` inherit from `Mpich`