### PR TITLE
fix environment module path when $SYS_TYPE isn't defined

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -32,13 +32,16 @@ import spack
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-c', dest='python_command', help='Command to execute.')
+    subparser.add_argument(
         'python_args', nargs=argparse.REMAINDER, help="File to run plus arguments.")
 
 description = "Launch an interpreter as spack would launch a command"
 
 def python(parser, args):
     # Fake a main python shell by setting __name__ to __main__.
-    console = code.InteractiveConsole({'__name__' : '__main__'})
+    console = code.InteractiveConsole({'__name__' : '__main__',
+                                       'spack'    : spack})
 
     if "PYTHONSTARTUP" in os.environ:
         startup_file = os.environ["PYTHONSTARTUP"]
@@ -47,7 +50,10 @@ def python(parser, args):
                 console.runsource(startup.read(), startup_file, 'exec')
 
     python_args = args.python_args
-    if python_args:
+    python_command = args.python_command
+    if python_command:
+        console.runsource(python_command)
+    elif python_args:
         sys.argv = python_args
         with open(python_args[0]) as file:
             console.runsource(file.read(), python_args[0], 'exec')

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -173,8 +173,8 @@ fi
 #
 _sp_share_dir=$(cd "$(dirname $_sp_source_file)" && pwd)
 _sp_prefix=$(cd "$(dirname $(dirname $_sp_share_dir))" && pwd)
-
-# TODO: fix SYS_TYPE to something non-LLNL-specific
-_spack_pathadd DK_NODE    "${_sp_share_dir%/}/dotkit/$SYS_TYPE"
-_spack_pathadd MODULEPATH "${_sp_share_dir%/}/modules/$SYS_TYPE"
 _spack_pathadd PATH       "${_sp_prefix%/}/bin"
+
+_sp_sys_type=$(spack-python -c 'print(spack.architecture.sys_type())')
+_spack_pathadd DK_NODE    "${_sp_share_dir%/}/dotkit/$_sp_sys_type"
+_spack_pathadd MODULEPATH "${_sp_share_dir%/}/modules/$_sp_sys_type"


### PR DESCRIPTION
Use `spack.architecture.sys_type()` to set `MODULEPATH` and `DK_NODE`, instead of the `SYS_TYPE` environment variable.