### PR TITLE
scotch: adding dependencies + variants for mpi, shared, compression and esmumps

### DIFF
--- a/var/spack/packages/scotch/package.py
+++ b/var/spack/packages/scotch/package.py
@@ -1,5 +1,4 @@
 from spack import *
-import glob
 import os
 
 class Scotch(Package):
@@ -11,28 +10,116 @@ class Scotch(Package):
 
     version('6.0.3', '10b0cc0f184de2de99859eafaca83cfc')
 
-    depends_on('mpi')
+    variant('mpi', default=False, description='Activate the compilation of PT-Scotch')
+    variant('compression', default=True, description='Activate the posibility to use compressed files')
+    variant('esmumps', default=False, description='Activate the compilation of the lib esmumps needed by mumps')
+    variant('shared', default=True, description='Build shared libraries')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('zlib', when='+compression')
+    depends_on('flex')
+    depends_on('bison')
+
+    def compiler_specifics(self, makefile_inc, defines):
+        if self.compiler.name == 'gcc':
+            defines.append('-Drestrict=__restrict')
+        elif self.compiler.name == 'intel':
+            defines.append('-restrict')
+
+        makefile_inc.append('CCS       = $(CC)')
+
+        if '+mpi' in self.spec:
+            makefile_inc.extend([
+                    'CCP       = %s' % os.path.join(self.spec['mpi'].prefix.bin, 'mpicc'),
+                    'CCD       = $(CCP)'
+                    ])
+        else:
+            makefile_inc.extend([
+                    'CCP       = mpicc', # It is set but not used
+                    'CCD       = $(CCS)'
+                    ])
 
 
-    def patch(self):
-        with working_dir('src/Make.inc'):
-            makefiles = glob.glob('Makefile.inc.x86-64_pc_linux2*')
-            filter_file(r'^CCS\s*=.*$', 'CCS = cc', *makefiles)
-            filter_file(r'^CCD\s*=.*$', 'CCD = cc', *makefiles)
 
+    def library_build_type(self, makefile_inc, defines):
+        makefile_inc.extend([
+            'LIB       = .a',
+            'CLIBFLAGS = ',
+            'RANLIB    = ranlib',
+            'AR	       = ar',
+            'ARFLAGS   = -ruv '
+            ])
+
+    @when('+shared')
+    def library_build_type(self, makefile_inc, defines):
+        makefile_inc.extend([
+            'LIB       = .so',
+            'CLIBFLAGS = -shared -fPIC',
+            'RANLIB    = echo',
+            'AR	       = $(CC)',
+            'ARFLAGS   = -shared $(LDFLAGS) -o'
+            ])
+
+    def extra_features(self, makefile_inc, defines):
+        ldflags = []
+        
+        if '+compression' in self.spec:
+            defines.append('-DCOMMON_FILE_COMPRESS_GZ')
+            ldflags.append('-L%s -lz' % (self.spec['zlib'].prefix.lib))
+
+        defines.append('-DCOMMON_PTHREAD')
+        ldflags.append('-lm -lrt -pthread')
+           
+        makefile_inc.append('LDFLAGS   = %s' % ' '.join(ldflags))
+
+            
+    def write_make_inc(self):
+        makefile_inc = []
+        defines = [ 
+            '-DCOMMON_RANDOM_FIXED_SEED',
+            '-DSCOTCH_DETERMINISTIC',
+            '-DSCOTCH_RENAME',
+            '-DIDXSIZE64' ]
+
+        self.library_build_type(makefile_inc, defines)
+        self.compiler_specifics(makefile_inc, defines)
+        self.extra_features(makefile_inc, defines)
+
+        makefile_inc.extend([
+            'EXE       =',
+            'OBJ       = .o',
+            'MAKE      = make',
+            'CAT       = cat',
+            'LN        = ln',
+            'MKDIR     = mkdir',
+            'MV        = mv',
+            'CP        = cp',
+            'CFLAGS    = -O3 %s' % (' '.join(defines)),
+            'LEX       = %s -Pscotchyy -olex.yy.c' % os.path.join(self.spec['flex'].prefix.bin , 'flex'),
+            'YACC      = %s -pscotchyy -y -b y' %    os.path.join(self.spec['bison'].prefix.bin, 'bison'),
+            'prefix    = %s' % self.prefix,
+            ''
+            ])
+
+        with open('Makefile.inc', 'w') as fh:
+            fh.write('\n'.join(makefile_inc))
 
     def install(self, spec, prefix):
-        # Currently support gcc and icc on x86_64 (maybe others with
-        # vanilla makefile)
-        makefile = 'Make.inc/Makefile.inc.x86-64_pc_linux2'
-        if spec.satisfies('%icc'):
-            makefile += '.icc'
+        targets = ['scotch']
+        if '+mpi' in self.spec:
+            targets.append('ptscotch')
+
+        if '+esmumps' in self.spec:
+            targets.append('esmumps')
+            if '+mpi' in self.spec:
+                targets.append('ptesmumps')
 
         with working_dir('src'):
-            force_symlink(makefile, 'Makefile.inc')
-            for app in ('scotch', 'ptscotch'):
-                make(app)
+            self.write_make_inc()
+            for app in targets:
+                make(app, parallel=(not app=='ptesmumps'))
 
+        
         install_tree('bin', prefix.bin)
         install_tree('lib', prefix.lib)
         install_tree('include', prefix.include)

--- a/var/spack/packages/scotch/package.py
+++ b/var/spack/packages/scotch/package.py
@@ -72,8 +72,7 @@ class Scotch(Package):
            
         makefile_inc.append('LDFLAGS   = %s' % ' '.join(ldflags))
 
-            
-    def write_make_inc(self):
+    def patch(self):
         makefile_inc = []
         defines = [ 
             '-DCOMMON_RANDOM_FIXED_SEED',
@@ -101,12 +100,9 @@ class Scotch(Package):
             ''
             ])
 
-        with open('Makefile.inc', 'w') as fh:
-            fh.write('\n'.join(makefile_inc))
-
-    def patch(self):
         with working_dir('src'):
-            self.write_make_inc()
+            with open('Makefile.inc', 'w') as fh:
+                fh.write('\n'.join(makefile_inc))
             
     def install(self, spec, prefix):
         targets = ['scotch']

--- a/var/spack/packages/scotch/package.py
+++ b/var/spack/packages/scotch/package.py
@@ -104,6 +104,10 @@ class Scotch(Package):
         with open('Makefile.inc', 'w') as fh:
             fh.write('\n'.join(makefile_inc))
 
+    def patch(self):
+        with working_dir('src'):
+            self.write_make_inc()
+            
     def install(self, spec, prefix):
         targets = ['scotch']
         if '+mpi' in self.spec:
@@ -115,7 +119,6 @@ class Scotch(Package):
                 targets.append('ptesmumps')
 
         with working_dir('src'):
-            self.write_make_inc()
             for app in targets:
                 make(app, parallel=(not app=='ptesmumps'))
 


### PR DESCRIPTION
This PR adds dependencies to `flex` and `bison` and compression from the package already on spack.
The flex and bison dependencies are only for compilation and the makefiles have a fallback to pre-generated files so these dependencies could perhaps been removed.
The `zlib` dependency is configurable with a variant `compression`

It also permits to build shared libraries
What should be the default static or shared ? For now I put the default as shared since it works better with the rpath strategy in spack.

The dependency to mpi add the library `pt-scotch` so I made it a variant. In addition to `esmumps` that was not there.

I did not change the install strategy used in the package. But it also installs also a metis.h file that goes with `libscotchmetis` and could interfere with the package metis, if both module are loaded at the same time.