### PR TITLE
cmake: enable ssl, for https downloads

### DIFF
--- a/var/spack/packages/cmake/package.py
+++ b/var/spack/packages/cmake/package.py
@@ -43,6 +43,7 @@ class Cmake(Package):
 
     def install(self, spec, prefix):
         configure('--prefix='   + prefix,
-                  '--parallel=' + str(make_jobs))
+                  '--parallel=' + str(make_jobs),
+                  '--', '-DCMAKE_USE_OPENSSL=ON')
         make()
         make('install')


### PR DESCRIPTION
By default cmake builds its own curl, without SSL support. This
patch enables SSL when building cmake, fixing the following error:

```
  error: downloading 'https://...' failed

    status_code: 1
    status_string: "Unsupported protocol"
    log: Protocol "https" not supported or disabled in libcurl
```

Refs:

https://cmake.org/pipermail/cmake/2010-December/041295.html
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=187374