### PR TITLE
gnuplot : added package

### DIFF
--- a/var/spack/packages/fontconfig/package.py
+++ b/var/spack/packages/fontconfig/package.py
@@ -8,9 +8,10 @@ class Fontconfig(Package):
     version('2.11.1' , 'e75e303b4f7756c2b16203a57ac87eba')
 
     depends_on('freetype')
+    depends_on('libxml2')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure("--prefix=%s" % prefix, "--enable-libxml2")
 
         make()
         make("install")

--- a/var/spack/packages/gnuplot/package.py
+++ b/var/spack/packages/gnuplot/package.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+import os
+
+class Gnuplot(Package):
+    """
+    Gnuplot is a portable command-line driven graphing utility for Linux, OS/2, MS Windows, OSX, VMS, and many other
+    platforms. The source code is copyrighted but freely distributed (i.e., you don't have to pay for it). It was
+    originally created to allow scientists and students to visualize mathematical functions and data interactively,
+    but has grown to support many non-interactive uses such as web scripting. It is also used as a plotting engine by
+    third-party applications like Octave. Gnuplot has been supported and under active development since 1986
+    """
+    homepage = "http://www.gnuplot.info"
+    url      = "http://downloads.sourceforge.net/project/gnuplot/gnuplot/5.0.1/gnuplot-5.0.1.tar.gz"
+
+    version('5.0.1', '79b4f9e203728f76b60b28bcd402d3c7')
+
+    depends_on('readline')
+    depends_on('libcerf')
+    depends_on('libgd')
+    depends_on('cairo')
+    depends_on('pango')
+    depends_on('wx')
+
+    def install(self, spec, prefix):
+        # It seems there's an open bug for wxWidgets support
+        # See : http://sourceforge.net/p/gnuplot/bugs/1694/
+        os.environ['TERMLIBS'] = '-lX11'
+
+        options = ['--prefix=%s' % prefix]
+
+        configure(*options)
+        make()
+        make("install")

--- a/var/spack/packages/gnuplot/package.py
+++ b/var/spack/packages/gnuplot/package.py
@@ -45,7 +45,9 @@ class Gnuplot(Package):
     depends_on('libgd')
     depends_on('cairo')
     depends_on('pango')
-    depends_on('wx')
+    depends_on('wx', when='+wx')
+
+    variant('wx', default=False, description='Activates wxWidgets terminal')
 
     def install(self, spec, prefix):
         # It seems there's an open bug for wxWidgets support

--- a/var/spack/packages/libcerf/package.py
+++ b/var/spack/packages/libcerf/package.py
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Libcerf(Package):
+    """
+    A self-contained C library providing complex error functions, based on Faddeeva's plasma dispersion function
+    w(z). Also provides Dawson's integral and Voigt's convolution of a Gaussian and a Lorentzian
+    """
+    homepage = "http://sourceforge.net/projects/libcerf"
+    url      = "http://downloads.sourceforge.net/project/libcerf/libcerf-1.3.tgz"
+
+    version('1.3', 'b3504c467204df71e62aeccf73a25612')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+        make()
+        make("install")

--- a/var/spack/packages/libgd/package.py
+++ b/var/spack/packages/libgd/package.py
@@ -39,6 +39,8 @@ class Libgd(Package):
 
     version('2.1.1', 'e91a1a99903e460e7ba00a794e72cc1e')
 
+    depends_on('libpng')
+
     def install(self, spec, prefix):
 
         with working_dir('spack-build', create=True):

--- a/var/spack/packages/libgd/package.py
+++ b/var/spack/packages/libgd/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Libgd(Package):
+    """
+    GD is an open source code library for the dynamic creation of images by programmers. GD is written in C, and
+    "wrappers" are available for Perl, PHP and other languages. GD creates PNG, JPEG, GIF, WebP, XPM, BMP images,
+    among other formats. GD is commonly used to generate charts, graphics, thumbnails, and most anything else, on the
+    fly. While not restricted to use on the web, the most common applications of GD involve website development.
+    """
+
+    homepage = "https://github.com/libgd/libgd"
+    url      = "https://github.com/libgd/libgd/archive/gd-2.1.1.tar.gz"
+
+    version('2.1.1', 'e91a1a99903e460e7ba00a794e72cc1e')
+
+    def install(self, spec, prefix):
+
+        with working_dir('spack-build', create=True):
+            cmake('..',
+                  '-DENABLE_JPEG:BOOL=ON',
+                  '-DENABLE_PNG:BOOL=ON',
+                  '-DENABLE_TIFF:BOOL=ON',
+                  *std_cmake_args)
+            make()
+            make("install")

--- a/var/spack/packages/ncurses/package.py
+++ b/var/spack/packages/ncurses/package.py
@@ -14,6 +14,8 @@ class Ncurses(Package):
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1',
             url='http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz')
 
+    patch('patch_gcc_5.txt', when='%gcc@5.0:')
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix,
                   "--with-shared",

--- a/var/spack/packages/ncurses/patch_gcc_5.txt
+++ b/var/spack/packages/ncurses/patch_gcc_5.txt
@@ -1,0 +1,12 @@
+diff -Naur ncurses-6.0/ncurses/Makefile.in ncurses-6.0-patched/ncurses/Makefile.in
+--- ncurses-6.0/ncurses/Makefile.in	2015-08-06 01:15:41.000000000 +0200
++++ ncurses-6.0-patched/ncurses/Makefile.in	2015-12-15 14:58:52.710199407 +0100
+@@ -219,7 +219,7 @@
+ 	$(SHELL) -e $(tinfo)/MKfallback.sh $(TERMINFO) $(TERMINFO_SRC) $(TIC_PATH) $(FALLBACK_LIST) >$@
+ 
+ ./lib_gen.c : $(base)/MKlib_gen.sh ../include/curses.h
+-	$(SHELL) -e $(base)/MKlib_gen.sh "$(CPP) $(CPPFLAGS)" "$(AWK)" generated <../include/curses.h >$@
++	$(SHELL) -e $(base)/MKlib_gen.sh "$(CPP) $(CPPFLAGS) -P" "$(AWK)" generated <../include/curses.h >$@
+ 
+ init_keytry.h: make_keys$(BUILD_EXEEXT) keys.list
+ 	./make_keys$(BUILD_EXEEXT) keys.list > $@

--- a/var/spack/packages/wx/package.py
+++ b/var/spack/packages/wx/package.py
@@ -16,6 +16,8 @@ class Wx(Package):
     version('3.0.1', 'dad1f1cd9d4c370cbc22700dc492da31',
             url="https://sourceforge.net/projects/wxwindows/files/3.0.1/wxWidgets-3.0.1.tar.bz2")
 
+    depends_on('gtkplus')
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix, "--enable-unicode", "--disable-precomp-headers")
 


### PR DESCRIPTION
Added GNUPLOT package :

- [X] support for `readline`, `cairo`, `pango` and other optional libraries
- [X] variant to activate the wxWidgets terminal
- [X] patch to fix build of `ncurses` when compiling with `gcc@5.0:` (I think the issue is similar to #149, and that was not solved for me under Ubuntu)

Build tested manually (with and without `wx`):
- Ubuntu 14.04
- RHLE 6

Missing in this PR:
- variant to support `qt` terminal (it seems I have troubles wit `mesa`, and I guess it could take some time to fix those)