### PR TITLE
Improved build of tau and related dependencies

### DIFF
--- a/var/spack/packages/cube/package.py
+++ b/var/spack/packages/cube/package.py
@@ -12,6 +12,9 @@ class Cube(Package):
     homepage = "http://www.scalasca.org/software/cube-4.x/download.html"
     url      = "http://apps.fz-juelich.de/scalasca/releases/cube/4.2/dist/cube-4.2.3.tar.gz"
 
+    version('4.3.3', '07e109248ed8ffc7bdcce614264a2909',
+            url='http://apps.fz-juelich.de/scalasca/releases/cube/4.3/dist/cube-4.3.3.tar.gz')
+
     version('4.2.3', '8f95b9531f5a8f8134f279c2767c9b20')
 
     version('4.3TP1', 'a2090fbc7b2ba394bd5c09ba971e237f', 

--- a/var/spack/packages/opari2/package.py
+++ b/var/spack/packages/opari2/package.py
@@ -17,6 +17,8 @@ class Opari2(Package):
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "http://www.vi-hps.org/upload/packages/opari2/opari2-1.1.2.tar.gz"
 
+    version('1.1.4', '245d3d11147a06de77909b0805f530c0',
+            url='http://www.vi-hps.org/upload/packages/opari2/opari2-1.1.4.tar.gz')
     version('1.1.2', '9a262c7ca05ff0ab5f7775ae96f3539e')
 
     backend_user_provided = """\

--- a/var/spack/packages/otf2/package.py
+++ b/var/spack/packages/otf2/package.py
@@ -11,6 +11,10 @@ class Otf2(Package):
     homepage = "http://www.vi-hps.org/score-p"
     url      = "http://www.vi-hps.org/upload/packages/otf2/otf2-1.4.tar.gz"
 
+    version('2.0', '5b546188b25bc1c4e285e06dddf75dfc',
+            url="http://www.vi-hps.org/upload/packages/otf2/otf2-2.0.tar.gz")
+    version('1.5.1', '16a9df46e0da78e374f5d12c8cdc1109',
+            url='http://www.vi-hps.org/upload/packages/otf2/otf2-1.5.1.tar.gz')
     version('1.4',   'a23c42e936eb9209c4e08b61c3cf5092',
             url="http://www.vi-hps.org/upload/packages/otf2/otf2-1.4.tar.gz")
     version('1.3.1', 'd0ffc4e858455ace4f596f910e68c9f2',

--- a/var/spack/packages/pdt/package.py
+++ b/var/spack/packages/pdt/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Pdt(Package):
+    """
+    Program Database Toolkit (PDT) is a framework for analyzing source code written in several programming languages
+    and for making rich program knowledge accessible to developers of static and dynamic analysis tools. PDT implements
+    a standard program representation, the program database (PDB), that can be accessed in a uniform way through a
+    class library supporting common PDB operations.
+    """
+    homepage = "https://www.cs.uoregon.edu/research/pdt/home.php"
+    url      = "https://www.cs.uoregon.edu/research/tau/pdt_releases/pdt-3.21.tar.gz"
+
+    version('3.21', '8df94298b71703decf680709a4ddf68f')
+    version('3.19', 'ba5591994998771fdab216699e362228')
+
+    def install(self, spec, prefix):
+        configure('-prefix=%s' % prefix)
+        make()
+        make("install")

--- a/var/spack/packages/scorep/package.py
+++ b/var/spack/packages/scorep/package.py
@@ -1,74 +1,84 @@
-# FIXME: Add copyright statement
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 
 from spack import *
 
+
 class Scorep(Package):
-    """The Score-P measurement infrastructure is a highly scalable and
+    """
+    The Score-P measurement infrastructure is a highly scalable and
        easy-to-use tool suite for profiling, event tracing, and online
        analysis of HPC applications."""
 
-    # FIXME: add a proper url for your package's homepage here.
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "http://www.vi-hps.org/upload/packages/scorep/scorep-1.2.3.tar.gz"
 
-    version('1.3', '9db6f957b7f51fa01377a9537867a55c',
-            url = 'http://www.vi-hps.org/upload/packages/scorep/scorep-1.3.tar.gz')
+    version('1.4.2', '3b9a042b13bdd5836452354e6567f71e',
+            url='http://www.vi-hps.org/upload/packages/scorep/scorep-1.4.2.tar.gz')
+    #version('1.3', '9db6f957b7f51fa01377a9537867a55c',
+    #        url='http://www.vi-hps.org/upload/packages/scorep/scorep-1.3.tar.gz')
+    #version('1.2.3', '4978084e7cbd05b94517aa8beaea0817')
 
-    version('1.2.3', '4978084e7cbd05b94517aa8beaea0817')
+    ##########
+    # Dependencies for SCORE-P are quite tight. See the homepage for more information.
+    # SCOREP 1.4.2
+    depends_on('otf2@1.5:1.6', when='@1.4.2')
+    depends_on('opari2@1.1.4', when='@1.4.2')
+    depends_on('cube@4.3:4.4', when='@1.4.2')
+    # SCOREP 1.3
+
+    ##########
+
+    # FIXME : check version for 1.3
+    #depends_on("otf2")
+    #depends_on("opari2")
+    #depends_on("cube")
 
     depends_on("mpi")
     depends_on("papi")
-    # depends_on("otf2@1.2:1.2.1") # only Score-P 1.2.x
-    depends_on("otf2")
-    depends_on("opari2")
-    depends_on("cube@4.2:4.2.3")
 
-    backend_user_provided = """\
-CC=cc
-CXX=c++
-F77=f77
-FC=f90
-CFLAGS=-fPIC
-CXXFLAGS=-fPIC
-"""
-    frontend_user_provided = """\
-CC_FOR_BUILD=cc
-CXX_FOR_BUILD=c++
-F77_FOR_BUILD=f70
-FC_FOR_BUILD=f90
-CFLAGS_FOR_BUILD=-fPIC
-CXXFLAGS_FOR_BUILD=-fPIC
-"""
-    mpi_user_provided = """\
-MPICC=mpicc
-MPICXX=mpicxx
-MPIF77=mpif77
-MPIFC=mpif90
-MPI_CFLAGS=-fPIC
-MPI_CXXFLAGS=-fPIC
-"""
+    def get_compiler_config_line(self):
+        backend_user_provided = ['CC=%s' % self.compiler.cc_names[0],
+                                 'CXX=%s' % self.compiler.cxx_names[0],
+                                 'F77=%s' % self.compiler.f77_names[0] if len(self.compiler.f77_names) else "",
+                                 'FC=%s' % self.compiler.fc_names[0] if len(self.compiler.fc_names) else "",
+                                 'CFLAGS=-fPIC %s' % self.rpath_args,
+                                 'CXXFLAGS=-fPIC %s'% self.rpath_args]
+        return backend_user_provided
 
     def install(self, spec, prefix):
-        # Use a custom compiler configuration, otherwise the score-p
-        # build system messes with spack's compiler settings.
-        # Create these three files in the build directory
-        with open("platform-backend-user-provided", "w") as backend_file:
-            backend_file.write(self.backend_user_provided)
-        with open("platform-frontend-user-provided", "w") as frontend_file:
-            frontend_file.write(self.frontend_user_provided)
-        with open("platform-mpi-user-provided", "w") as mpi_file:
-            mpi_file.write(self.mpi_user_provided)
-
-        configure_args = ["--prefix=%s" % prefix,
-                          "--with-custom-compilers",
-                          "--with-otf2=%s" % spec['otf2'].prefix.bin,
-                          "--with-opari2=%s" % spec['opari2'].prefix.bin,
-                          "--with-cube=%s" % spec['cube'].prefix.bin,
-                          "--with-papi-header=%s" % spec['papi'].prefix.include,
-                          "--with-papi-lib=%s" % spec['papi'].prefix.lib,
-                          "--enable-shared"]
-
-        configure(*configure_args)
-
-        make()
-        make("install")
+        configure = Executable( join_path(self.stage.source_path, 'configure') )
+        with working_dir('spack-build', create=True):
+            configure_args = ["--prefix=%s" % prefix,
+                              "--with-otf2=%s" % spec['otf2'].prefix.bin,
+                              "--with-opari2=%s" % spec['opari2'].prefix.bin,
+                              "--with-cube=%s" % spec['cube'].prefix.bin,
+                              "--with-papi-header=%s" % spec['papi'].prefix.include,
+                              "--with-papi-lib=%s" % spec['papi'].prefix.lib,
+                              "--enable-shared"]
+            configure_args.extend(self.get_compiler_config_line())
+            configure(*configure_args)
+            make()
+            make("install")

--- a/var/spack/packages/scorep/package.py
+++ b/var/spack/packages/scorep/package.py
@@ -37,9 +37,8 @@ class Scorep(Package):
 
     version('1.4.2', '3b9a042b13bdd5836452354e6567f71e',
             url='http://www.vi-hps.org/upload/packages/scorep/scorep-1.4.2.tar.gz')
-    #version('1.3', '9db6f957b7f51fa01377a9537867a55c',
-    #        url='http://www.vi-hps.org/upload/packages/scorep/scorep-1.3.tar.gz')
-    #version('1.2.3', '4978084e7cbd05b94517aa8beaea0817')
+    version('1.3', '9db6f957b7f51fa01377a9537867a55c',
+            url='http://www.vi-hps.org/upload/packages/scorep/scorep-1.3.tar.gz')
 
     ##########
     # Dependencies for SCORE-P are quite tight. See the homepage for more information.
@@ -48,13 +47,10 @@ class Scorep(Package):
     depends_on('opari2@1.1.4', when='@1.4.2')
     depends_on('cube@4.3:4.4', when='@1.4.2')
     # SCOREP 1.3
-
+    depends_on("otf2@1.4", when='@1.3')
+    depends_on("opari2@1.1.4", when='@1.3')
+    depends_on("cube@4.2.3", when='@1.3')
     ##########
-
-    # FIXME : check version for 1.3
-    #depends_on("otf2")
-    #depends_on("opari2")
-    #depends_on("cube")
 
     depends_on("mpi")
     depends_on("papi")

--- a/var/spack/packages/tau/package.py
+++ b/var/spack/packages/tau/package.py
@@ -1,16 +1,94 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
 from spack import *
 
 import os
+import os.path
+
 from llnl.util.filesystem import join_path
 
 class Tau(Package):
-    """A portable profiling and tracing toolkit for performance
-       analysis of parallel programs written in Fortran, C, C++, UPC,
-       Java, Python."""
+    """
+    A portable profiling and tracing toolkit for performance
+    analysis of parallel programs written in Fortran, C, C++, UPC,
+    Java, Python.
+    """
     homepage = "http://www.cs.uoregon.edu/research/tau"
-    url      = "http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/tau-2.23.1.tar.gz"
+    url      = "https://www.cs.uoregon.edu/research/tau/tau_releases/tau-2.25.tar.gz"
 
+    version('2.25', '46cd48fa3f3c4ce0197017b3158a2b43')
+    version('2.24.1', '6635ece6d1f08215b02f5d0b3c1e971b')
+    version('2.24', '57ce33539c187f2e5ec68f0367c76db4')
     version('2.23.1', '6593b47ae1e7a838e632652f0426fe72')
+
+    # FIXME : shmem variant missing
+    variant('download', default=True, description='Downloads and builds various dependencies')
+    variant('openmp', default=True, description='Use OpenMP threads')
+    variant('mpi', default=True, description='Specify use of TAU MPI wrapper library')
+    variant('phase', default=True, description='Generate phase based profiles')
+    variant('comm', default=True, description=' Generate profiles with MPI communicator info')
+
+    depends_on('pdt')  # Required for TAU instrumentation
+    depends_on('scorep')
+    #depends_on('otf2', when='%gcc')  # FIXME : still missing logic for intel and other compilers
+    depends_on('binutils', when='~download')
+    depends_on('mpi', when='+mpi')
+
+    def set_compiler_options(self):
+
+        name = self.compiler.name  # Name of the current toolchain
+        useropt = ["-O2", self.rpath_args]
+
+        ##########
+        # Selecting a compiler with TAU configure is quite tricky:
+        # 1 - compilers are mapped to a given set of strings (and spack cc, cxx, etc. wrappers are not among them)
+        # 2 - absolute paths are not allowed
+        # 3 - the usual environment variables seems not to be checked ('CC', 'CXX' and 'FC')
+        # 4 - if no -cc=<compiler> -cxx=<compiler> is passed tau is built with system compiler silently
+        # (regardless of what %<compiler> is used in the spec)
+        #
+        # In the following we give TAU what he expects and put compilers into PATH
+        compiler_path = os.path.dirname(self.compiler.cc)
+        os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
+        compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],
+                            '-cc=%s' % self.compiler.cc_names[0]]
+        if self.compiler.fc:
+            compiler_options.append('-fortran=%s' % self.compiler.fc_names[0])
+        # It turns out that some parts of the OTF support library in TAU are non-conformant, so if we want
+        # to compile them we must suppress some warnings. With Clang it seems impossible to do so, so OTF
+        # support is not built
+        #if name == 'gcc':
+        #    useropt.append("-fpermissive")
+        ##########
+
+        # Construct the string of custom compiler flags and append it to compiler related options
+        useropt = ' '.join(useropt)
+        useropt = "-useropt=%s" % useropt
+        compiler_options.append(useropt)
+        return compiler_options
 
     def install(self, spec, prefix):
         # TAU isn't happy with directories that have '@' in the path.  Sigh.
@@ -18,14 +96,44 @@ class Tau(Package):
         change_sed_delimiter('@', ';', 'utils/FixMakefile')
         change_sed_delimiter('@', ';', 'utils/FixMakefile.sed.default')
 
-        # After that, it's relatively standard.
-        configure("-prefix=%s" % prefix)
+        # TAU configure, despite the name , seems to be a manually written script (nothing related to autotools).
+        # As such it has a few #peculiarities# that make this build quite hackish.
+        options = ["-prefix=%s" % prefix,
+                   "-iowrapper",
+                   "-pdt=%s" % spec['pdt'].prefix,
+                   "-scorep=%s" % spec['scorep'].prefix]
+        # FIXME : I give up trying to compile OTF support with clang, as it seems there is no easy way to ignore errors
+        #if 'otf2' in spec:
+        #    options.append("-otf=%s" % spec['otf2'].prefix)
+        # If download is active, download and build suggested dependencies
+        if '+download' in spec:
+            options.extend(['-bfd=download',
+                            '-unwind=download',
+                            '-asmdex=download'])
+        else:
+            options.extend(["-bfd=%s" % spec['binutils'].prefix])
+            # TODO : unwind and asmdex are still missing
+
+        if '+openmp' in spec:
+            options.append('-openmp')
+
+        if '+mpi' in spec:
+            options.append('-mpi')
+
+        if '+phase' in spec:
+            options.append('-PROFILEPHASE')
+
+        if '+comm' in spec:
+            options.append('-PROFILECOMMUNICATORS')
+
+        compiler_specific_options = self.set_compiler_options()
+        options.extend(compiler_specific_options)
+        configure(*options)
         make("install")
 
         # Link arch-specific directories into prefix since there is
         # only one arch per prefix the way spack installs.
         self.link_tau_arch_dirs()
-
 
     def link_tau_arch_dirs(self):
         for subdir in os.listdir(self.prefix):

--- a/var/spack/packages/tau/package.py
+++ b/var/spack/packages/tau/package.py
@@ -46,6 +46,7 @@ class Tau(Package):
 
     # TODO : shmem variant missing
     variant('download', default=False, description='Downloads and builds various dependencies')
+    variant('scorep', default=False, description='Activates SCOREP support')
     variant('openmp', default=True, description='Use OpenMP threads')
     variant('mpi', default=True, description='Specify use of TAU MPI wrapper library')
     variant('phase', default=True, description='Generate phase based profiles')
@@ -54,7 +55,7 @@ class Tau(Package):
     # TODO : Try to build direct OTF2 support? Some parts of the OTF support library in TAU are non-conformant,
     # TODO : and fail at compile-time. Further, SCOREP is compiled with OTF2 support.
     depends_on('pdt')  # Required for TAU instrumentation
-    depends_on('scorep')
+    depends_on('scorep', when='+scorep')
     depends_on('binutils', when='~download')
     depends_on('mpi', when='+mpi')
 
@@ -95,8 +96,7 @@ class Tau(Package):
         # As such it has a few #peculiarities# that make this build quite hackish.
         options = ["-prefix=%s" % prefix,
                    "-iowrapper",
-                   "-pdt=%s" % spec['pdt'].prefix,
-                   "-scorep=%s" % spec['scorep'].prefix]
+                   "-pdt=%s" % spec['pdt'].prefix]
         # If download is active, download and build suggested dependencies
         if '+download' in spec:
             options.extend(['-bfd=download',
@@ -105,6 +105,9 @@ class Tau(Package):
         else:
             options.extend(["-bfd=%s" % spec['binutils'].prefix])
             # TODO : unwind and asmdex are still missing
+
+        if '+scorep' in spec:
+            options.append("-scorep=%s" % spec['scorep'].prefix)
 
         if '+openmp' in spec:
             options.append('-openmp')

--- a/var/spack/packages/tau/package.py
+++ b/var/spack/packages/tau/package.py
@@ -44,22 +44,22 @@ class Tau(Package):
     version('2.24', '57ce33539c187f2e5ec68f0367c76db4')
     version('2.23.1', '6593b47ae1e7a838e632652f0426fe72')
 
-    # FIXME : shmem variant missing
-    variant('download', default=True, description='Downloads and builds various dependencies')
+    # TODO : shmem variant missing
+    variant('download', default=False, description='Downloads and builds various dependencies')
     variant('openmp', default=True, description='Use OpenMP threads')
     variant('mpi', default=True, description='Specify use of TAU MPI wrapper library')
     variant('phase', default=True, description='Generate phase based profiles')
     variant('comm', default=True, description=' Generate profiles with MPI communicator info')
 
+    # TODO : Try to build direct OTF2 support? Some parts of the OTF support library in TAU are non-conformant,
+    # TODO : and fail at compile-time. Further, SCOREP is compiled with OTF2 support.
     depends_on('pdt')  # Required for TAU instrumentation
     depends_on('scorep')
-    #depends_on('otf2', when='%gcc')  # FIXME : still missing logic for intel and other compilers
     depends_on('binutils', when='~download')
     depends_on('mpi', when='+mpi')
 
     def set_compiler_options(self):
 
-        name = self.compiler.name  # Name of the current toolchain
         useropt = ["-O2", self.rpath_args]
 
         ##########
@@ -77,11 +77,6 @@ class Tau(Package):
                             '-cc=%s' % self.compiler.cc_names[0]]
         if self.compiler.fc:
             compiler_options.append('-fortran=%s' % self.compiler.fc_names[0])
-        # It turns out that some parts of the OTF support library in TAU are non-conformant, so if we want
-        # to compile them we must suppress some warnings. With Clang it seems impossible to do so, so OTF
-        # support is not built
-        #if name == 'gcc':
-        #    useropt.append("-fpermissive")
         ##########
 
         # Construct the string of custom compiler flags and append it to compiler related options
@@ -102,9 +97,6 @@ class Tau(Package):
                    "-iowrapper",
                    "-pdt=%s" % spec['pdt'].prefix,
                    "-scorep=%s" % spec['scorep'].prefix]
-        # FIXME : I give up trying to compile OTF support with clang, as it seems there is no easy way to ignore errors
-        #if 'otf2' in spec:
-        #    options.append("-otf=%s" % spec['otf2'].prefix)
         # If download is active, download and build suggested dependencies
         if '+download' in spec:
             options.extend(['-bfd=download',


### PR DESCRIPTION
Modifications :
- [X] added support for external packages to tau build
- [X] updated scorep build (based on unwrapped compiler, rather than unsupported files)
- [X] added pdt
- [X] updated versions of opari2, otf2, cube

Manually tested:
- Ubuntu 14.04 and RHLE 6 with GCC and MPICH