### PR TITLE
remove possible trailing slash in _sp_prefix or _sp_share_dir

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -175,6 +175,6 @@ _sp_share_dir=$(cd "$(dirname $_sp_source_file)" && pwd)
 _sp_prefix=$(cd "$(dirname $(dirname $_sp_share_dir))" && pwd)
 
 # TODO: fix SYS_TYPE to something non-LLNL-specific
-_spack_pathadd DK_NODE    "$_sp_share_dir/dotkit/$SYS_TYPE"
-_spack_pathadd MODULEPATH "$_sp_share_dir/modules/$SYS_TYPE"
-_spack_pathadd PATH       "$_sp_prefix/bin"
+_spack_pathadd DK_NODE    "${_sp_share_dir%/}/dotkit/$SYS_TYPE"
+_spack_pathadd MODULEPATH "${_sp_share_dir%/}/modules/$SYS_TYPE"
+_spack_pathadd PATH       "${_sp_prefix%/}/bin"


### PR DESCRIPTION
If the prefix for spack ends up being just `/` you end up with your path looking like:
```
//bin:*
```

This uses bash/zsh variable-isms to remove any trailing slashes.

My csh foo is weak, so I didn't attempt the fix there.