### PR TITLE
Bugfix/244 uninstall errors

### DIFF
--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -54,7 +54,9 @@ def extensions(parser, args):
     if not args.spec:
         tty.die("extensions requires a package spec.")
 
+    #
     # Checks
+    #
     spec = spack.cmd.parse_specs(args.spec)
     if len(spec) > 1:
         tty.die("Can only list extensions for one package.")
@@ -70,7 +72,9 @@ def extensions(parser, args):
     if not args.mode:
         args.mode = 'short'
 
+    #
     # List package names of extensions
+    #
     extensions = spack.db.extensions_for(spec)
     if not extensions:
         tty.msg("%s has no extensions." % spec.cshort_spec)
@@ -79,7 +83,9 @@ def extensions(parser, args):
     tty.msg("%d extensions:" % len(extensions))
     colify(ext.name for ext in extensions)
 
+    #
     # List specs of installed extensions.
+    #
     installed = [s.spec for s in spack.installed_db.installed_extensions_for(spec)]
     print
     if not installed:
@@ -88,7 +94,9 @@ def extensions(parser, args):
     tty.msg("%d installed:" % len(installed))
     spack.cmd.find.display_specs(installed, mode=args.mode)
 
+    #
     # List specs of activated extensions.
+    #
     activated = spack.install_layout.extension_map(spec)
     print
     if not activated:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -42,9 +42,9 @@ def setup_parser(subparser):
         help="Remove regardless of whether other packages depend on this one.")
     subparser.add_argument(
         '-a', '--all', action='store_true', dest='all',
-        help="USE CAREFULLY.  Remove ALL installed packages that match each supplied spec. " +
-        "i.e., if you say uninstall libelf, ALL versions of libelf are uninstalled. " +
-        "This is both useful and dangerous, like rm -r.")
+        help="USE CAREFULLY. Remove ALL installed packages that match each " +
+        "supplied spec. i.e., if you say uninstall libelf, ALL versions of " +
+        "libelf are uninstalled. This is both useful and dangerous, like rm -r.")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER, help="specs of packages to uninstall")
 
@@ -81,7 +81,8 @@ def uninstall(parser, args):
                     pkgs.append(s.package)
 
                 except spack.packages.UnknownPackageError, e:
-                    # The package.py file has gone away -- but still want to uninstall.
+                    # The package.py file has gone away -- but still want to
+                    # uninstall.
                     spack.Package(s).do_uninstall(force=True)
 
         # Sort packages to be uninstalled by the number of installed dependents

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -54,6 +54,7 @@ import spack.spec
 from spack.version import Version
 from spack.spec import Spec
 from spack.error import SpackError
+from spack.packages import UnknownPackageError
 
 # DB goes in this directory underneath the root
 _db_dirname = '.spack-db'

--- a/lib/spack/spack/hooks/extensions.py
+++ b/lib/spack/spack/hooks/extensions.py
@@ -27,9 +27,7 @@ import spack
 
 
 def pre_uninstall(pkg):
-    # Need to do this b/c uninstall does not automatically do it.
-    # TODO: store full graph info in stored .spec file.
-    pkg.spec.normalize()
+    assert(pkg.spec.concrete)
 
     if pkg.is_extension:
         if pkg.activated:


### PR DESCRIPTION
This fixes #244.  @lee218llnl: can you try it out?

Instead of adding conditional logic to the extended map right now, it was sufficient to modify the extension methods so that they check `spec.dependencies` to see whether the extendee is actually there.  I think this reduces the complexity of the implementation -- we just rely on all the logic that's already there to handle conditional dependencies rather than duplicating it.