### PR TITLE
Update hwloc; don't require libpciaccess on OS X

### DIFF
--- a/var/spack/packages/hwloc/package.py
+++ b/var/spack/packages/hwloc/package.py
@@ -21,8 +21,7 @@ class Hwloc(Package):
             url='http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.1.tar.bz2')
     version('1.9', '1f9f9155682fe8946a97c08896109508')
 
-    # libpciaccess is not supported on OS X
-    depends_on('libpciaccess', when='=linux')
+    depends_on('libpciaccess')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)

--- a/var/spack/packages/hwloc/package.py
+++ b/var/spack/packages/hwloc/package.py
@@ -15,15 +15,17 @@ class Hwloc(Package):
     homepage = "http://www.open-mpi.org/projects/hwloc/"
     url      = "http://www.open-mpi.org/software/hwloc/v1.9/downloads/hwloc-1.9.tar.gz"
 
+    version('1.11.2', '486169cbe111cdea57be12638828ebbf',
+            url='http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.2.tar.bz2')
     version('1.11.1', '002742efd3a8431f98d6315365a2b543',
             url='http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.1.tar.bz2')
     version('1.9', '1f9f9155682fe8946a97c08896109508')
 
-    depends_on('libpciaccess')
+    # libpciaccess is not supported on OS X
+    depends_on('libpciaccess', when='=linux')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
 
         make()
         make("install")
-

--- a/var/spack/packages/libpciaccess/package.py
+++ b/var/spack/packages/libpciaccess/package.py
@@ -1,4 +1,5 @@
 from spack import *
+import os.path
 
 class Libpciaccess(Package):
     """Generic PCI access library."""
@@ -13,6 +14,12 @@ class Libpciaccess(Package):
     depends_on('libtool')
 
     def install(self, spec, prefix):
+        # libpciaccess does not support OS X
+        if spec.satisfies('=darwin-x86_64'):
+            # create a dummy directory
+            mkdir(prefix.lib)
+            return
+
         from subprocess import call
         call(["./autogen.sh"])
         configure("--prefix=%s" % prefix)


### PR DESCRIPTION
- hwloc 1.11.2 is available.
- libpciaccess is not supported on OS X; don't require it there.