### PR TITLE
python: make sure dependent modules are built

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -150,7 +150,7 @@ def main():
         sys.stderr.write('\n')
         tty.die("Keyboard interrupt.")
 
-    # Allow commands to return values if they want to exit with some ohter code.
+    # Allow commands to return values if they want to exit with some other code.
     if return_val is None:
         sys.exit(0)
     elif isinstance(return_val, int):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -145,7 +145,7 @@ def set_build_environment_variables(pkg):
     # Install root prefix
     os.environ[SPACK_INSTALL] = spack.install_path
 
-    # Remove these vars from the environment during build becaus they
+    # Remove these vars from the environment during build because they
     # can affect how some packages find libraries.  We want to make
     # sure that builds never pull in unintended external dependencies.
     pop_keys(os.environ, "LD_LIBRARY_PATH", "LD_RUN_PATH", "DYLD_LIBRARY_PATH")

--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -22,13 +22,19 @@ class Python(Package):
     depends_on("readline")
     depends_on("ncurses")
     depends_on("sqlite")
+    depends_on("zlib")
 
     def install(self, spec, prefix):
         # Need this to allow python build to find the Python installation.
         env['PYTHONHOME'] = prefix
         env['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
-        # Rest of install is pretty standard.
+        # Make sure the zlib, bz2, etc. modules get built; setup.py searches
+        # the include and library paths to decide which modules to build.
+        dep_prefixes = [dep.prefix for dep in spec.traverse(root=False)]
+        env['CPPFLAGS'] = ' '.join('-I' + p.include for p in dep_prefixes)
+        env['LDFLAGS'] = ' '.join('-L' + p.lib for p in dep_prefixes)
+
         configure("--prefix=%s" % prefix,
                   "--with-threads",
                   "--enable-shared")


### PR DESCRIPTION
In the `python` package, the `zlib`, `bz2`, `readline`, `_sqlite3`, etc. modules weren't being built because configure (specifically the `detect_modules()` routine in `setup.py`) decides which modules to build by searching the include and library paths. Since `depends_on()` "hides" these paths in the compiler wrappers, the modules were disabled.