### PR TITLE
Add ability to prefer particular versions in packages.

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -40,7 +40,6 @@ import spack.error
 from spack.version import *
 
 
-
 class DefaultConcretizer(object):
     """This class doesn't have any state, it just provides some methods for
        concretization.  You can subclass it to override just some of the
@@ -68,9 +67,17 @@ class DefaultConcretizer(object):
         # If there are known available versions, return the most recent
         # version that satisfies the spec
         pkg = spec.package
+
+        # Key function to sort versions first by whether they were
+        # marked `preferred=True`, then by most recent.
+        def preferred_key(v):
+            prefer = pkg.versions[v].get('preferred', False)
+            return (prefer, v)
+
         valid_versions = sorted(
             [v for v in pkg.versions
-             if any(v.satisfies(sv) for sv in spec.versions)])
+             if any(v.satisfies(sv) for sv in spec.versions)],
+            key=preferred_key)
 
         if valid_versions:
             spec.versions = ver([valid_versions[-1]])

--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -17,7 +17,7 @@ class Python(Package):
 
     version('2.7.8', 'd235bdfa75b8396942e360a70487ee00')
     version('2.7.10', 'c685ef0b8e9f27b5e3db5db12b268ac6')
-    version('2.7.11', '1dbcc848b4cd8399a8199d000f9f823c')
+    version('2.7.11', '1dbcc848b4cd8399a8199d000f9f823c', preferred=True)
     version('3.5.0', 'd149d2812f10cbe04c042232e7964171')
     version('3.5.1', 'e9ea6f2623fffcdd871b7b19113fde80')
 


### PR DESCRIPTION
This is a stopgap until I can merge PR #120, which includes more robust concretization preferences.  This allows any number of versions in a package to be marked `preferred=True`.  Packages are now sorted by preference, *then* most recent in concretization.  So you can mark directly in the package file what the preferred version is.

PR #120 provides the infrastructure we need to express these types of preferences per-platform, per-compiler, etc. but this is a first step.  This also allows Python 2.7.11 to remain the default while we get the Python stack working with 3.5.

@lee218llnl @alalazo @mplegendre: What do you think?

- Adding `preferred=True` to a version directive will change its sort
  order in concretization.

- This provides us a rudimentary ability to keep the Spack stack
  stable as new versions are added.

- Having multiple stacks will come next, but this at least allows us
  to specify default versions of things instead of always taking the
  newest.