### PR TITLE
fix non-mpi hdf5 package build

### DIFF
--- a/var/spack/packages/hdf5/package.py
+++ b/var/spack/packages/hdf5/package.py
@@ -26,16 +26,14 @@ class Hdf5(Package):
         if '+mpi' in spec:
             extra_args.extend([
                 "--enable-parallel",
-                "CC=%s" % spec['mpich'].prefix.bin + "/mpicc",
-                "CXX=%s" % spec['mpich'].prefix.bin + "/mpic++",
+                "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
+                "CXX=%s" % spec['mpi'].prefix.bin + "/mpic++",
             ])
 
         configure(
             "--prefix=%s" % prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
             "--enable-shared",
-            "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
-            "CXX=%s" % spec['mpi'].prefix.bin + "/mpic++",
             *extra_args)
 
         make()


### PR DESCRIPTION
Fixes a couple of issues in 7125749919a18224ffd3ed19a38e27d62bed353d.