### PR TITLE
fix conflict with setuptools and cached pyc files

### DIFF
--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -117,7 +117,7 @@ class Python(Package):
 
         # Ignore pieces of setuptools installed by other packages.
         if ext_pkg.name != 'py-setuptools':
-            patterns.append(r'/site.*\.pyc?$')
+            patterns.append(r'/site[^/]*\.pyc?$')
             patterns.append(r'setuptools\.pth')
             patterns.append(r'bin/easy_install[^/]*$')
             patterns.append(r'setuptools.*egg$')

--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -117,11 +117,10 @@ class Python(Package):
 
         # Ignore pieces of setuptools installed by other packages.
         if ext_pkg.name != 'py-setuptools':
-            patterns.append(r'/site\.pyc?$')
+            patterns.append(r'/site.*\.pyc?$')
             patterns.append(r'setuptools\.pth')
             patterns.append(r'bin/easy_install[^/]*$')
             patterns.append(r'setuptools.*egg$')
-        patterns.append(r'__pycache__/.*.pyc$')
 
         return match_predicate(ignore_arg, patterns)
 

--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -35,7 +35,8 @@ class Python(Package):
 
         # Rest of install is pretty standard except setup.py needs to be able to read the CPPFLAGS
         # and LDFLAGS as it scans for the library and headers to build
-        configure("--prefix=%s" % prefix,
+        configure_args= [
+                  "--prefix=%s" % prefix,
                   "--with-threads",
                   "--enable-shared",
                   "CPPFLAGS=-I%s/include -I%s/include -I%s/include -I%s/include -I%s/include -I%s/include" % (
@@ -45,7 +46,11 @@ class Python(Package):
                   "LDFLAGS=-L%s/lib -L%s/lib -L%s/lib -L%s/lib -L%s/lib -L%s/lib" % (
                        spec['openssl'].prefix, spec['bzip2'].prefix,
                        spec['readline'].prefix, spec['ncurses'].prefix,
-                       spec['sqlite'].prefix, spec['zlib'].prefix))
+                       spec['sqlite'].prefix, spec['zlib'].prefix)
+                  ]
+        if spec.satisfies('@3:'):
+            configure_args.append('--without-ensurepip')
+        configure(*configure_args)
         make()
         make("install")
 
@@ -116,6 +121,7 @@ class Python(Package):
             patterns.append(r'setuptools\.pth')
             patterns.append(r'bin/easy_install[^/]*$')
             patterns.append(r'setuptools.*egg$')
+        patterns.append(r'__pycache__/.*.pyc$')
 
         return match_predicate(ignore_arg, patterns)
 


### PR DESCRIPTION
With Python 3, I noticed that when I activated py-nose that I was getting a conflict in setuptools and with cached .pyc files in the __cache__ directory. This had two sources, one was that Python 3 was automatically building setuptools. To resolve this, I added the --without-ensurepip configure arg for Python >3 and instead require users to explicitly build setuptools. The second issue is the cached .pyc files, so I just ignore any .pyc files in the __pycache__ directory upon activation. Let me know if this sounds reasonable and looks OK.