### PR TITLE
fix for array handling in ancient bash

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -55,13 +55,12 @@
 # avoids the need to come up with a user-friendly naming scheme for
 # spack dotfiles.
 ########################################################################
+arrtest[0]='test' || (echo 'Failure: arrays not supported in this version of bash.' && exit 2)
+
 function spack {
     # save raw arguments into an array before butchering them
-    args=()
-    for a in "$@"; do
-        # yup, this is awful, blame bash2 compat
-        args=("${args[@]}" "$a")
-    done
+    declare -a args=( "$@" )
+
     # accumulate initial flags for main spack command
     _sp_flags=""
     while [[ "$1" =~ ^- ]]; do


### PR DESCRIPTION
fixes #284 
Also adds a check for a version of bash that fails to support arrays.  Should only happen for versions older than 3.1-beta1.