### PR TITLE
removing ill-fated array check for non-portability

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -55,7 +55,6 @@
 # avoids the need to come up with a user-friendly naming scheme for
 # spack dotfiles.
 ########################################################################
-arrtest[0]='test' || (echo 'Failure: arrays not supported in this version of bash.' && exit 2)
 
 function spack {
     # save raw arguments into an array before butchering them


### PR DESCRIPTION
The array syntax available check actually caused a syntax error under some circumstances in zsh, so it's being removed.