### PR TITLE
another portability fix, this time for zsh/non-bash sh

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -58,7 +58,7 @@
 
 function spack {
     # save raw arguments into an array before butchering them
-    declare -a args=( "$@" )
+    args=( "$@" )
 
     # accumulate initial flags for main spack command
     _sp_flags=""


### PR DESCRIPTION
Yay for non-portable declaration syntax.  After the previous screwiness
I ran this through a number of shells, and found that this is the most
portable version I could seem to get.  Hopefully this will be the last of these.