### PR TITLE
add a path argument to the stage command

### DIFF
--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -35,6 +35,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
         help="Do not check downloaded packages against checksum")
+    subparser.add_argument(
+        '-p', '--path', dest='path',
+        help="Path to stage package, does not add to spack tree")
 
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages to stage")
@@ -50,4 +53,7 @@ def stage(parser, args):
     specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
-        package.do_stage()
+        if args.path:
+            package.do_stage(path=args.path)
+        else:
+            package.do_stage()

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -54,6 +54,5 @@ def stage(parser, args):
     for spec in specs:
         package = spack.repo.get(spec)
         if args.path:
-            package.do_stage(path=args.path)
-        else:
-            package.do_stage()
+            package.path = args.path
+        package.do_stage()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -709,14 +709,18 @@ class Package(object):
         if spack.do_checksum and self.version in self.versions:
             self.stage.check()
 
-
-    def do_stage(self, mirror_only=False):
+    def do_stage(self, mirror_only=False, path=None):
         """Unpacks the fetched tarball, then changes into the expanded tarball
            directory."""
+
         if not self.spec.concrete:
             raise ValueError("Can only stage concrete packages.")
 
         self.do_fetch(mirror_only)
+
+        if path is not None:
+            self.stage.path = path
+
         self.stage.expand_archive()
         self.stage.chdir_to_source()
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -89,7 +89,7 @@ class Stage(object):
     """
 
     def __init__(self, url_or_fetch_strategy,
-                 name=None, mirror_path=None, keep=False):
+                 name=None, mirror_path=None, keep=False, path=None):
         """Create a stage object.
            Parameters:
              url_or_fetch_strategy
@@ -135,7 +135,10 @@ class Stage(object):
 
         # Try to construct here a temporary name for the stage directory
         # If this is a named stage, then construct a named path.
-        self.path = join_path(spack.stage_path, self.name)
+        if path is not None:
+            self.path = path
+        else:
+            self.path = join_path(spack.stage_path, self.name)
 
         # Flag to decide whether to delete the stage folder on exit or not
         self.keep = keep


### PR DESCRIPTION
Allow users to use spack to stage a, potentially complex, package into a
given path.  This is nice for packages with multiple resources that must
be placed, for example LLVM with all sub-projects.

This may not be the preferred way to do this, but seemed to be the least impact change.