### PR TITLE
Gperftools only work on Linux; make it a no-op on other architectures

### DIFF
--- a/var/spack/packages/gperftools/package.py
+++ b/var/spack/packages/gperftools/package.py
@@ -30,9 +30,16 @@ class Gperftools(Package):
     homepage = "https://code.google.com/p/gperftools"
     url      = "https://googledrive.com/host/0B6NtGsLhIcf7MWxMMF9JdTN3UVk/gperftools-2.3.tar.gz"
 
+    version('2.4', '2171cea3bbe053036fb5d5d25176a160', url="https://github.com/gperftools/gperftools/releases/download/gperftools-2.4/gperftools-2.4.tar.gz")
     version('2.3', 'f54dd119f0e46ac1f13264f8d97adf90', url="https://googledrive.com/host/0B6NtGsLhIcf7MWxMMF9JdTN3UVk/gperftools-2.3.tar.gz")
 
     def install(self, spec, prefix):
+        if not (spec.satisfies("=linux-x86_64") or
+                spec.satisfies("=linux-i686")):
+            # gperftools only work on Linux
+            mkdirp(prefix.lib)
+            return
+
         configure("--prefix=" + prefix)
         make()
         make("install")


### PR DESCRIPTION
Making it a no-op (instead of aborting the install) allows requiring gperftools unconditionally in other packages.

Also update to version 2.4.
