### PR TITLE
Paraview osx

### DIFF
--- a/var/spack/packages/paraview/package.py
+++ b/var/spack/packages/paraview/package.py
@@ -60,6 +60,10 @@ class Paraview(Package):
 
             feature_args.extend(std_cmake_args)
 
+            if 'darwin' in self.spec.architecture:
+                feature_args.append('-DVTK_USE_X:BOOL=OFF')
+                feature_args.append('-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON')
+
             cmake('..',
                 '-DCMAKE_INSTALL_PREFIX:PATH=%s' % prefix,
                 '-DBUILD_TESTING:BOOL=OFF',


### PR DESCRIPTION
---
With this, paraview builds without Python or Qt support, which is a start.