### PR TITLE
Use .tar.gz instead of .tar.xz in several packages for backward compatibility

### DIFF
--- a/var/spack/packages/gdb/package.py
+++ b/var/spack/packages/gdb/package.py
@@ -32,13 +32,13 @@ class Gdb(Package):
     -- or what another program was doing at the moment it crashed.
     """
     homepage = "https://www.gnu.org/software/gdb"
-    url = "http://ftp.gnu.org/gnu/gdb/gdb-7.10.tar.xz"
+    url = "http://ftp.gnu.org/gnu/gdb/gdb-7.10.tar.gz"
 
-    version('7.10.1', '39e654460c9cdd80200a29ac020cfe11')
-    version('7.10', '2a35bac41fa8e10bf04f3a0dd7f7f363')
-    version('7.9.1', '35374c77a70884eb430c97061053a36e')
-    version('7.9', 'e6279f26559d839f0b4218a482bcb43e')
-    version('7.8.2', 'a80cf252ed2e775d4e4533341bbf2459')
+    version('7.10.1', 'b93a2721393e5fa226375b42d567d90b')
+    version('7.10', 'fa6827ad0fd2be1daa418abb11a54d86')
+    version('7.9.1', 'f3b97de919a9dba84490b2e076ec4cb0')
+    version('7.9', '8f8ced422fe462a00e0135a643544f17')
+    version('7.8.2', '8b0ea8b3559d3d90b3ff4952f0aeafbc')
 
     depends_on('texinfo')
 

--- a/var/spack/packages/git/package.py
+++ b/var/spack/packages/git/package.py
@@ -5,14 +5,14 @@ class Git(Package):
        system designed to handle everything from small to very large
        projects with speed and efficiency."""
     homepage = "http://git-scm.com"
-    url      = "https://www.kernel.org/pub/software/scm/git/git-2.2.1.tar.xz"
+    url      = "https://www.kernel.org/pub/software/scm/git/git-2.2.1.tar.gz"
 
-    version('2.6.3', '5a6375349c3f13c8dbbabfc327bae429')
-    version('2.6.2', '32ae5ad29763fc927bfcaeab55385fd9')
-    version('2.6.1', 'dd4a3a7fe96598c553edd39d40c9c290')
-    version('2.6.0', '6b7d43d615fb3f0dfecf4d131e23f438')
-    version('2.5.4', 'ec118fcd1cf984edc17eb6588b78e81b')
-    version('2.2.1', '43e01f9d96ba8c11611e0eef0d9f9f28')
+    version('2.6.3', 'b711be7628a4a2c25f38d859ee81b423')
+    version('2.6.2', 'da293290da69f45a86a311ad3cd43dc8')
+    version('2.6.1', '4c62ee9c5991fe93d99cf2a6b68397fd')
+    version('2.6.0', 'eb76a07148d94802a1745d759716a57e')
+    version('2.5.4', '3eca2390cf1fa698b48e2a233563a76b')
+    version('2.2.1', 'ff41fdb094eed1ec430aed8ee9b9849c')
 
 
     # Git compiles with curl support by default on but if your system

--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -11,15 +11,16 @@ import spack
 class Python(Package):
     """The Python programming language."""
     homepage = "http://www.python.org"
-    url      = "http://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz"
+    url      = "http://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz"
 
     extendable = True
 
-    version('2.7.8', 'd235bdfa75b8396942e360a70487ee00')
-    version('2.7.10', 'c685ef0b8e9f27b5e3db5db12b268ac6')
-    version('2.7.11', '1dbcc848b4cd8399a8199d000f9f823c', preferred=True)
-    version('3.5.0', 'd149d2812f10cbe04c042232e7964171')
-    version('3.5.1', 'e9ea6f2623fffcdd871b7b19113fde80')
+    version('3.5.1', 'be78e48cdfc1a7ad90efff146dce6cfe')
+    version('3.5.0', 'a56c0c0b45d75a0ec9c6dee933c41c36')
+    version('2.7.11', '6b6076ec9e93f05dd63e47eb9c15728b', preferred=True)
+    version('2.7.10', 'd7547558fd673bd9d38e2108c6b42521')
+    version('2.7.9', '5eebcaa0030dc4061156d3429657fb83')
+    version('2.7.8', 'd4bca0159acb0b44a781292b5231936f')
 
     depends_on("openssl")
     depends_on("bzip2")

--- a/var/spack/packages/texinfo/package.py
+++ b/var/spack/packages/texinfo/package.py
@@ -33,12 +33,12 @@ class Texinfo(Package):
     used by many non-GNU projects as well.FIXME: put a proper description of your package here.
     """
     homepage = "https://www.gnu.org/software/texinfo/"
-    url      = "http://ftp.gnu.org/gnu/texinfo/texinfo-6.0.tar.xz"
+    url      = "http://ftp.gnu.org/gnu/texinfo/texinfo-6.0.tar.gz"
 
-    version('6.0', '02818e62a5b8ae0213a7ff572991bb50')
-    version('5.2', 'cb489df8a7ee9d10a236197aefdb32c5')
-    version('5.1', '52ee905a3b705020d2a1b6ec36d53ca6')
-    version('5.0', 'ef2fad34c71ddc95b20c7d6a08c0d7a6')
+    version('6.0', 'e1a2ef5dce5018b53f0f6eed45b247a7')
+    version('5.2', '1b8f98b80a8e6c50422125e07522e8db')
+    version('5.1', '54e250014fe698fb4832016158747c03')
+    version('5.0', '918432285abe6fe96c98355594c5656a')
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/packages/wget/package.py
+++ b/var/spack/packages/wget/package.py
@@ -8,9 +8,10 @@ class Wget(Package):
        etc."""
 
     homepage = "http://www.gnu.org/software/wget/"
-    url      = "http://ftp.gnu.org/gnu/wget/wget-1.16.tar.xz"
+    url      = "http://ftp.gnu.org/gnu/wget/wget-1.16.tar.gz"
 
-    version('1.16', 'fe102975ab3a6c049777883f1bb9ad07')
+    version('1.17', 'c4c4727766f24ac716936275014a0536')
+    version('1.16', '293a37977c41b5522f781d3a3a078426')
 
     depends_on("openssl")
 


### PR DESCRIPTION
Closes #315.