### PR TITLE
Require cmake @2.8: for metis

### DIFF
--- a/var/spack/packages/metis/package.py
+++ b/var/spack/packages/metis/package.py
@@ -12,6 +12,7 @@ class Metis(Package):
 
     version('5.1.0', '5465e67079419a69e0116de24fce58fe')
 
+    depends_on("cmake @2.8:")   # build-time dependency
     depends_on('mpi')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
metis requires cmake version 2.8+; make it a full requirement until Spack has build-time requirements.