### PR TITLE
Require Python for PETSc

### DIFF
--- a/var/spack/packages/petsc/package.py
+++ b/var/spack/packages/petsc/package.py
@@ -12,6 +12,8 @@ class Petsc(Package):
     version('3.5.2', 'ad170802b3b058b5deb9cd1f968e7e13')
     version('3.5.1', 'a557e029711ebf425544e117ffa44d8f')
 
+    depends_on("python @2.6:@2.9")   # requires Python for building
+
     depends_on("boost")
     depends_on("blas")
     depends_on("lapack")


### PR DESCRIPTION
PETSc requires Python for building.

I have a case where an HPC system has a very old default Python version, too old for Spack. So I load a module for Python, which makes Spack work. This module relies on LD_LIBRARY_PATH.

When building PETSc, Spack unsets LD_LIBRARY_PATH, breaking the Python that PETSc finds.

Explicitly requiring Python for PETSc makes building PETSc work.