### PR TITLE
Ensure that OpenBLAS provides a file liblapack.a

### DIFF
--- a/var/spack/packages/openblas/package.py
+++ b/var/spack/packages/openblas/package.py
@@ -19,3 +19,7 @@ class Openblas(Package):
         with working_dir(prefix.lib):
             symlink('libopenblas.a', 'blas.a')
             symlink('libopenblas.a', 'libblas.a')
+
+        # Lapack virtual package should provide liblapack.a
+        with working_dir(prefix.lib):
+            symlink('libopenblas.a', 'liblapack.a')


### PR DESCRIPTION
OpenBLAS implements the virtual package "lapack", and its consumers apparently expect a "liblapack.a".