### PR TITLE
Add SZip package

### DIFF
--- a/var/spack/packages/szip/package.py
+++ b/var/spack/packages/szip/package.py
@@ -1,0 +1,21 @@
+from spack import *
+
+class Szip(Package):
+    """Szip is an implementation of the extended-Rice lossless compression algorithm.
+    It provides lossless compression of scientific data, and is provided with HDF
+    software products."""
+
+    homepage = "https://www.hdfgroup.org/doc_resource/SZIP/"
+    url      = "http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz"
+
+    version('2.1', '902f831bcefb69c6b635374424acbead')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix,
+                  '--enable-production',
+                  '--enable-shared',
+                  '--enable-static',
+                  '--enable-encoding')
+
+        make()
+        make("install")


### PR DESCRIPTION
This is my first ever pull request, yay!

SZip is a library with which HDF can optionally be built. As far as I know, it doesn't have its own website aside from the HDF webpage. I was only able to find one version.