### PR TITLE
Revert "Require Python for PETSc"

### DIFF
--- a/var/spack/packages/petsc/package.py
+++ b/var/spack/packages/petsc/package.py
@@ -12,8 +12,6 @@ class Petsc(Package):
     version('3.5.2', 'ad170802b3b058b5deb9cd1f968e7e13')
     version('3.5.1', 'a557e029711ebf425544e117ffa44d8f')
 
-    depends_on("python @2.6:@2.9")   # requires Python for building
-
     depends_on("boost")
     depends_on("blas")
     depends_on("lapack")


### PR DESCRIPTION
Reverts LLNL/spack#321

@eschnett: I accidentally merged this one.  The version constraint is wrong -- I think it's actually a bug in the parser that it works.  It should be `@2.6:2.9`.  Can you resubmit?