### PR TITLE
Improved packages : metis and parmetis

### DIFF
--- a/var/spack/packages/metis/package.py
+++ b/var/spack/packages/metis/package.py
@@ -1,28 +1,83 @@
+##############################################################################
+# Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
 from spack import *
 
-class Metis(Package):
-    """METIS is a set of serial programs for partitioning graphs,
-       partitioning finite element meshes, and producing fill reducing
-       orderings for sparse matrices. The algorithms implemented in
-       METIS are based on the multilevel recursive-bisection,
-       multilevel k-way, and multi-constraint partitioning schemes."""
 
-    homepage = "http://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
-    url      = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz"
+class Metis(Package):
+    """
+    METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes, and producing fill
+    reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the multilevel
+    recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes.
+    """
+
+    homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz"
 
     version('5.1.0', '5465e67079419a69e0116de24fce58fe')
 
-    depends_on("cmake @2.8:")   # build-time dependency
-    depends_on('mpi')
+    variant('shared', default=True, description='Enables the build of shared libraries')
+    variant('debug', default=False, description='Builds the library in debug mode')
+    variant('gdb', default=False, description='Enables gdb support')
+
+    variant('idx64', default=False, description='Use int64_t as default index type')
+    variant('double', default=False, description='Use double precision floating point types')
+
+    depends_on('cmake @2.8:')  # build-time dependency
+
+    depends_on('gdb', when='+gdb')
 
     def install(self, spec, prefix):
-        cmake(".",
-              '-DGKLIB_PATH=%s/GKlib' % pwd(),
-              '-DSHARED=1',
-              '-DCMAKE_C_COMPILER=mpicc',
-              '-DCMAKE_CXX_COMPILER=mpicxx',
-              '-DSHARED=1',
-              *std_cmake_args)
 
-        make()
-        make("install")
+        options = []
+        options.extend(std_cmake_args)
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+
+        options.append('-DGKLIB_PATH:PATH={metis_source}/GKlib'.format(metis_source=source_directory))
+
+        if '+shared' in spec:
+            options.append('-DSHARED:BOOL=ON')
+
+        if '+debug' in spec:
+            options.extend(['-DDEBUG:BOOL=ON',
+                            '-DCMAKE_BUILD_TYPE:STRING=Debug'])
+
+        if '+gdb' in spec:
+            options.append('-DGDB:BOOL=ON')
+
+        metis_header = join_path(source_directory, 'include', 'metis.h')
+
+        if '+idx64' in spec:
+            filter_file('IDXTYPEWIDTH 32', 'IDXTYPEWIDTH 64', metis_header)
+
+        if '+double' in spec:
+            filter_file('REALTYPEWIDTH 32', 'REALTYPEWIDTH 64', metis_header)
+
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")

--- a/var/spack/packages/parmetis/package.py
+++ b/var/spack/packages/parmetis/package.py
@@ -1,27 +1,96 @@
+##############################################################################
+# Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
 from spack import *
+import shutil
+
+# FIXME : lot of code is duplicated from packages/metis/package.py . Inheriting from there may reduce
+# FIXME : the installation rules to just a few lines
+
 
 class Parmetis(Package):
-    """ParMETIS is an MPI-based parallel library that implements a
-       variety of algorithms for partitioning unstructured graphs,
-       meshes, and for computing fill-reducing orderings of sparse
-       matrices."""
-    homepage = "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
-    url      = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz"
+    """
+    ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured
+    graphs, meshes, and for computing fill-reducing orderings of sparse matrices.
+    """
+    homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+    url = 'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz'
 
     version('4.0.3', 'f69c479586bf6bb7aff6a9bc0c739628')
 
-    depends_on('cmake @2.8:')   # build dependency
+    variant('shared', default=True, description='Enables the build of shared libraries')
+    variant('debug', default=False, description='Builds the library in debug mode')
+    variant('gdb', default=False, description='Enables gdb support')
+
+    variant('idx64', default=False, description='Use int64_t as default index type')
+    variant('double', default=False, description='Use double precision floating point types')
+
+    depends_on('cmake @2.8:')  # build dependency
     depends_on('mpi')
 
-    def install(self, spec, prefix):
-        cmake(".",
-              '-DGKLIB_PATH=%s/metis/GKlib' % pwd(),
-              '-DMETIS_PATH=%s/metis' % pwd(),
-              '-DSHARED=1',
-              '-DCMAKE_C_COMPILER=mpicc',
-              '-DCMAKE_CXX_COMPILER=mpicxx',
-              '-DSHARED=1',
-              *std_cmake_args)
+    # FIXME : this should conflict with metis as it builds its own version internally
 
-        make()
-        make("install")
+    depends_on('gdb', when='+gdb')
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+        metis_source = join_path(source_directory, 'metis')
+
+        # FIXME : Once a contract is defined, MPI compilers should be retrieved indirectly via spec['mpi'] in case
+        # FIXME : they use a non-standard name
+        options.extend(['-DGKLIB_PATH:PATH={metis_source}/GKlib'.format(metis_source=metis_source),
+                        '-DMETIS_PATH:PATH={metis_source}'.format(metis_source=metis_source),
+                        '-DCMAKE_C_COMPILER:STRING=mpicc',
+                        '-DCMAKE_CXX_COMPILER:STRING=mpicxx'])
+
+        if '+shared' in spec:
+            options.append('-DSHARED:BOOL=ON')
+
+        if '+debug' in spec:
+            options.extend(['-DDEBUG:BOOL=ON',
+                            '-DCMAKE_BUILD_TYPE:STRING=Debug'])
+
+        if '+gdb' in spec:
+            options.append('-DGDB:BOOL=ON')
+
+        metis_header = join_path(metis_source, 'include', 'metis.h')
+
+        if '+idx64' in spec:
+            filter_file('IDXTYPEWIDTH 32', 'IDXTYPEWIDTH 64', metis_header)
+
+        if '+double' in spec:
+            filter_file('REALTYPEWIDTH 32', 'REALTYPEWIDTH 64', metis_header)
+
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")
+            # Parmetis build system doesn't allow for an external metis to be used, but doesn't copy the required
+            # metis header either
+            shutil.copy(metis_header, join_path(self.prefix, 'include'))

--- a/var/spack/packages/parmetis/package.py
+++ b/var/spack/packages/parmetis/package.py
@@ -93,4 +93,4 @@ class Parmetis(Package):
             make("install")
             # Parmetis build system doesn't allow for an external metis to be used, but doesn't copy the required
             # metis header either
-            shutil.copy(metis_header, join_path(self.prefix, 'include'))
+            install(metis_header, self.prefix.include)

--- a/var/spack/packages/parmetis/package.py
+++ b/var/spack/packages/parmetis/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 
 from spack import *
-import shutil
 
 # FIXME : lot of code is duplicated from packages/metis/package.py . Inheriting from there may reduce
 # FIXME : the installation rules to just a few lines


### PR DESCRIPTION
Modifications : 
- [x] added variant to `metis` and `parmetis` according to `BUILD.txt`
- [x] fixed a bug in `metis` (removed false dependency on MPI)
- [x] `parmetis` installs its `metis.h` header 

Notes:
Apparently there is no clean way to build `parmetis` on top of an existing `metis`. In fact, `parmetis` ships with `metis` sources at an unspecified version and `metis` symbols are included into the `parmetis` library. This may cause conflicts if both metis and parmetis are used as a dependency to another package.