### PR TITLE
Correct Python version constraint syntax

### DIFF
--- a/var/spack/packages/petsc/package.py
+++ b/var/spack/packages/petsc/package.py
@@ -12,7 +12,7 @@ class Petsc(Package):
     version('3.5.2', 'ad170802b3b058b5deb9cd1f968e7e13')
     version('3.5.1', 'a557e029711ebf425544e117ffa44d8f')
 
-    depends_on("python @2.6:@2.9")   # requires Python for building
+    depends_on("python @2.6:2.9")   # requires Python for building
 
     depends_on("boost")
     depends_on("blas")


### PR DESCRIPTION
See #321, #335.