### PR TITLE
Install ncurses properly

### DIFF
--- a/var/spack/packages/ncurses/package.py
+++ b/var/spack/packages/ncurses/package.py
@@ -17,19 +17,14 @@ class Ncurses(Package):
     patch('patch_gcc_5.txt', when='%gcc@5.0:')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix,
-                  "--with-shared",
-                  "--enable-widec",
-                  "--disable-pc-files",
-                  "--without-ada")
+        opts = [
+            "--prefix=%s" % prefix,
+            "--with-shared",
+            "--with-cxx-shared",
+            "--enable-widec",
+            "--enable-overwrite",
+            "--disable-lib-suffixes",
+            "--without-ada"]
+        configure(*opts)
         make()
         make("install")
-
-        configure("--prefix=%s" % prefix,
-                  "--with-shared",
-                  "--disable-widec",
-                  "--disable-pc-files",
-                  "--without-ada")
-        make()
-        make("install")
-


### PR DESCRIPTION
Currently, ncurses's include files are installed into two separate subdirectories, `install/ncurses` and `install/ncursesw`. The second level of subdirectories (`ncurses` and `ncursesw`) are non-standard. I checked several systems to confirm this, and ncurses examples on the web also simply contain `#include <ncurses.h>` instead of `#include <ncurses/ncurses.h>`, which would be necessary to use the currently installed ncurses packages. For example, this also breaks llvm, which uses ncurses, but does not expect the second level of subdirectories.

I am now using the option `--enable-overwrite`, which installs the header files directly in to `.../include`. I also enable `widec` support all the time. These options are e.g. similar to the ones used by MacPorts, and I confirm that they make the llvm package build (which didn't build before).