### PR TITLE
LLVM depends on cmake, and does not depend on isl

### DIFF
--- a/var/spack/packages/llvm/package.py
+++ b/var/spack/packages/llvm/package.py
@@ -48,6 +48,9 @@ class Llvm(Package):
     variant('gold', default=True, description="Add support for LTO with the gold linker plugin")
 
 
+    # Build dependency
+    depends_on('cmake @2.8.12.2:')
+
     # Universal dependency
     depends_on('python@2.7:')
 
@@ -60,8 +63,8 @@ class Llvm(Package):
     depends_on('binutils+gold', when='+gold')
 
     # polly plugin
-    depends_on('gmp', when='+polly')
-    depends_on('isl', when='+polly')
+    depends_on('gmp', when='@:3.6.999 +polly')
+    depends_on('isl', when='@:3.6.999 +polly')
 
     base_url =  'http://llvm.org/releases/%%(version)s/%(pkg)s-%%(version)s.src.tar.xz'
     llvm_url = base_url % { 'pkg' : 'llvm'}
@@ -172,7 +175,7 @@ class Llvm(Package):
         env['CXXFLAGS'] = self.compiler.cxx11_flag
         cmake_args = [ arg for arg in std_cmake_args if 'BUILD_TYPE' not in arg ]
 
-        build_type = 'RelWithDebInfo'  if '+debug' in spec else 'Release'
+        build_type = 'RelWithDebInfo' if '+debug' in spec else 'Release'
         cmake_args.extend([
                 '..',
                 '-DCMAKE_BUILD_TYPE=' + build_type,


### PR DESCRIPTION
Add cmake requirement.

Remove gmp and isl requirements. Using an external isl leads to a build failure for me on a fairly standard Fedora Linux workstation. The Spack package file says that isl is required for polly, however, the polly documentation states that as of LLVM 3.7, polly includes isl, and has no external dependencies any more.