### PR TITLE
Paraview python osx

### DIFF
--- a/var/spack/packages/py-matplotlib/package.py
+++ b/var/spack/packages/py-matplotlib/package.py
@@ -26,6 +26,7 @@ class PyMatplotlib(Package):
     depends_on('py-pbr')
     depends_on('py-funcsigs')
 
+    depends_on('freetype')
     depends_on('qt', when='+gui')
     depends_on('bzip2')
     depends_on('tcl', when='+gui')

--- a/var/spack/packages/py-numpy/package.py
+++ b/var/spack/packages/py-numpy/package.py
@@ -7,15 +7,18 @@ class PyNumpy(Package):
 
     version('1.9.1', '78842b73560ec378142665e712ae4ad9')
     version('1.9.2', 'a1ed53432dbcd256398898d35bc8e645')
-    
+
+    variant('blas', default=True)
+
     extends('python')
     depends_on('py-nose')
-    depends_on('netlib-blas+fpic')
-    depends_on('netlib-lapack+shared')
+    depends_on('netlib-blas+fpic', when='+blas')
+    depends_on('netlib-lapack+shared', when='+blas')
 
     def install(self, spec, prefix):
-        with open('site.cfg', 'w') as f:
-            f.write('[DEFAULT]\n')
-            f.write('libraries=lapack,blas\n')
-            f.write('library_dirs=%s/lib:%s/lib\n' % (spec['blas'].prefix, spec['lapack'].prefix))
+        if '+blas' in spec:
+            with open('site.cfg', 'w') as f:
+                f.write('[DEFAULT]\n')
+                f.write('libraries=lapack,blas\n')
+                f.write('library_dirs=%s/lib:%s/lib\n' % (spec['blas'].prefix, spec['lapack'].prefix))
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/packages/qhull/package.py
+++ b/var/spack/packages/qhull/package.py
@@ -20,6 +20,9 @@ class Qhull(Package):
     version('1.0', 'd0f978c0d8dfb2e919caefa56ea2953c',
             url="http://www.qhull.org/download/qhull-2012.1-src.tgz")
 
+    # https://github.com/qhull/qhull/pull/5
+    patch('qhull-iterator.patch')
+
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             cmake('..', *std_cmake_args)

--- a/var/spack/packages/qhull/qhull-iterator.patch
+++ b/var/spack/packages/qhull/qhull-iterator.patch
@@ -1,0 +1,45 @@
+From 93f4b306c54bb5be7724dcc19c6e747b62ac76dd Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <mathstuf@gmail.com>
+Date: Thu, 28 May 2015 11:12:25 -0400
+Subject: [PATCH] iterator: use the header
+
+Standard libraries are doing funky things with inline namespaces which
+make these declarations impossible to get right. Just include the
+header.
+---
+ src/libqhullcpp/QhullIterator.h   | 3 +--
+ src/libqhullcpp/QhullLinkedList.h | 5 +----
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/src/libqhullcpp/QhullIterator.h b/src/libqhullcpp/QhullIterator.h
+index 9dde894..49f3a3b 100644
+--- a/src/libqhullcpp/QhullIterator.h
++++ b/src/libqhullcpp/QhullIterator.h
+@@ -14,10 +14,9 @@ extern "C" {
+ }
+ 
+ #include <assert.h>
++#include <iterator>
+ #include <string>
+ #include <vector>
+-//! Avoid dependence on <iterator>
+-namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }
+ 
+ namespace orgQhull {
+ 
+diff --git a/src/libqhullcpp/QhullLinkedList.h b/src/libqhullcpp/QhullLinkedList.h
+index d828ac6..00b9008 100644
+--- a/src/libqhullcpp/QhullLinkedList.h
++++ b/src/libqhullcpp/QhullLinkedList.h
+@@ -9,10 +9,7 @@
+ #ifndef QHULLLINKEDLIST_H
+ #define QHULLLINKEDLIST_H
+ 
+-namespace std {
+-    struct bidirectional_iterator_tag;
+-    struct random_access_iterator_tag;
+-}//std
++#include <iterator>
+ 
+ #include "QhullError.h"
+ extern "C" {


### PR DESCRIPTION
---
It still requires a `spack install paraview+python ^numpy -blas` to work without a Fortran compiler, but ParaView doesn't care whether blas is available or not.