### PR TITLE
Use "-Wl,-rpath," instead of "-Wl,-rpath="

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1711,15 +1711,15 @@ Compile-time library search paths
   * ``-L$dep_prefix/lib``
   * ``-L$dep_prefix/lib64``
 Runtime library search paths (RPATHs)
-  * ``-Wl,-rpath=$dep_prefix/lib``
-  * ``-Wl,-rpath=$dep_prefix/lib64``
+  * ``-Wl,-rpath,$dep_prefix/lib``
+  * ``-Wl,-rpath,$dep_prefix/lib64``
 Include search paths
   * ``-I$dep_prefix/include``
 
 An example of this would be the ``libdwarf`` build, which has one
 dependency: ``libelf``.  Every call to ``cc`` in the ``libdwarf``
 build will have ``-I$LIBELF_PREFIX/include``,
-``-L$LIBELF_PREFIX/lib``, and ``-Wl,-rpath=$LIBELF_PREFIX/lib``
+``-L$LIBELF_PREFIX/lib``, and ``-Wl,-rpath,$LIBELF_PREFIX/lib``
 inserted on the command line.  This is done transparently to the
 project's build system, which will just think it's using a system
 where ``libelf`` is readily available.  Because of this, you **do

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -176,17 +176,17 @@ while [ -n "$1" ]; do
         -Wl,*)
             arg="${1#-Wl,}"
             # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
-            if [[ $arg == '-rpath='* ]]; then
+            if [[ $arg == -rpath=* ]]; then
                 arg="${arg#-rpath=}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg == '-rpath,'* ]]; then
+            elif [[ $arg == -rpath,* ]]; then
                 arg="${arg#-rpath,}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg == '-rpath' ]]; then
+            elif [[ $arg == -rpath ]]; then
                 shift; arg="$1"
                 if [[ $arg != '-Wl,'* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -174,19 +174,26 @@ while [ -n "$1" ]; do
             libs+=("$arg")
             ;;
         -Wl,*)
+            echo "FOUND arg=[$arg]" >&2
             arg="${1#-Wl,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
+            echo "SHIFTED, arg=[$arg]" >&2
             if [[ $arg = -rpath=* ]]; then
+                echo "CASE 1" >&2
                 arg="${arg#-rpath=}"
                 for rpath in ${arg//,/ }; do
+                    echo "    RPATH=[$rpath]" >&2
                     rpaths+=("$rpath")
                 done
             elif [[ $arg = -rpath,* ]]; then
+                echo "CASE 2" >&2
                 arg="${arg#-rpath,}"
                 for rpath in ${arg//,/ }; do
+                    echo "    RPATH=[$rpath]" >&2
                     rpaths+=("$rpath")
                 done
             elif [[ $arg = -rpath ]]; then
+                echo "CASE 3" >&2
                 shift; arg="$1"
                 if [[ $arg != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
@@ -194,9 +201,11 @@ while [ -n "$1" ]; do
                 # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
                 arg="${arg#-Wl,}"
                 for rpath in ${arg//,/ }; do
+                    echo "    RPATH=[$rpath]" >&2
                     rpaths+=("$rpath")
                 done
             else
+                echo "OTHER" >&2
                 other_args+=("-Wl,$arg")
             fi
             ;;

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -176,14 +176,21 @@ while [ -n "$1" ]; do
         -Wl,*)
             arg="${1#-Wl,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if [[ "$arg" = -rpath=* ]]; then
-                rpaths+=("${arg#-rpath=}")
-            elif [[ "$arg" = -rpath ]]; then
+            if [[ $arg = -rpath=* ]]; then
+                arg="${arg#-rpath=}"
+                for rpath in ${arg//,/ }; do
+                    rpaths+=("$rpath")
+                done
+            elif [[ $arg = -rpath ]]; then
                 shift; arg="$1"
-                if [[ "$arg" != -Wl,* ]]; then
+                if [[ $arg != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
-                rpaths+=("${arg#-Wl,}")
+                # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
+                arg="${arg#-Wl,}"
+                for rpath in ${arg//,/ }; do
+                    rpaths+=("$rpath")
+                done
             else
                 other_args+=("-Wl,$arg")
             fi
@@ -191,11 +198,11 @@ while [ -n "$1" ]; do
         -Xlinker,*)
             arg="${1#-Xlinker,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if [[ "$arg" = -rpath=* ]]; then
+            if [[ $arg = -rpath=* ]]; then
                 rpaths+=("${arg#-rpath=}")
-            elif [[ "$arg" = -rpath ]]; then
+            elif [[ $arg = -rpath ]]; then
                 shift; arg="$1"
-                if [[ "$arg" != -Xlinker,* ]]; then
+                if [[ $arg != -Xlinker,* ]]; then
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"
                 fi
                 rpaths+=("${arg#-Xlinker,}")

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -175,22 +175,22 @@ while [ -n "$1" ]; do
             ;;
         -Wl,*)
             arg="${1#-Wl,}"
-            if [[ $arg = "-rpath=*" ]]; then
+            # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
+            if [[ $arg == '-rpath='* ]]; then
                 arg="${arg#-rpath=}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg = "-rpath,*" ]]; then
+            elif [[ $arg == '-rpath,'* ]]; then
                 arg="${arg#-rpath,}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg = "-rpath" ]]; then
+            elif [[ $arg == '-rpath' ]]; then
                 shift; arg="$1"
                 if [[ $arg != "-Wl,*" ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
-                # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
                 arg="${arg#-Wl,}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -188,7 +188,7 @@ while [ -n "$1" ]; do
                 done
             elif [[ $arg == '-rpath' ]]; then
                 shift; arg="$1"
-                if [[ $arg != "-Wl,*" ]]; then
+                if [[ $arg != '-Wl,'* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
                 arg="${arg#-Wl,}"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -175,20 +175,19 @@ while [ -n "$1" ]; do
             ;;
         -Wl,*)
             arg="${1#-Wl,}"
-            if [ -z "$arg" ]; then shift; arg="$1"; fi
-            if [[ $arg =~ -rpath=.* ]]; then
+            if [[ $arg = "-rpath=*" ]]; then
                 arg="${arg#-rpath=}"
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg =~ -rpath,.* ]]; then
+            elif [[ $arg = "-rpath,*" ]]; then
                 arg="${arg#-rpath,}"
                 for rpath in ${arg//,/ }; do
-                                        rpaths+=("$rpath")
+                    rpaths+=("$rpath")
                 done
-            elif [[ $arg = -rpath ]]; then
+            elif [[ $arg = "-rpath" ]]; then
                 shift; arg="$1"
-                if [[ $arg != -Wl,* ]]; then
+                if [[ $arg != "-Wl,*" ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
                 fi
                 # TODO: Handle multiple -Wl, continuations of -Wl,-rpath

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -181,6 +181,11 @@ while [ -n "$1" ]; do
                 for rpath in ${arg//,/ }; do
                     rpaths+=("$rpath")
                 done
+            elif [[ $arg = -rpath,* ]]; then
+                arg="${arg#-rpath,}"
+                for rpath in ${arg//,/ }; do
+                    rpaths+=("$rpath")
+                done
             elif [[ $arg = -rpath ]]; then
                 shift; arg="$1"
                 if [[ $arg != -Wl,* ]]; then

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -174,26 +174,19 @@ while [ -n "$1" ]; do
             libs+=("$arg")
             ;;
         -Wl,*)
-            echo "FOUND arg=[$arg]" >&2
             arg="${1#-Wl,}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
-            echo "SHIFTED, arg=[$arg]" >&2
-            if [[ $arg = -rpath=* ]]; then
-                echo "CASE 1" >&2
+            if [[ $arg =~ -rpath=.* ]]; then
                 arg="${arg#-rpath=}"
                 for rpath in ${arg//,/ }; do
-                    echo "    RPATH=[$rpath]" >&2
                     rpaths+=("$rpath")
                 done
-            elif [[ $arg = -rpath,* ]]; then
-                echo "CASE 2" >&2
+            elif [[ $arg =~ -rpath,.* ]]; then
                 arg="${arg#-rpath,}"
                 for rpath in ${arg//,/ }; do
-                    echo "    RPATH=[$rpath]" >&2
-                    rpaths+=("$rpath")
+                                        rpaths+=("$rpath")
                 done
             elif [[ $arg = -rpath ]]; then
-                echo "CASE 3" >&2
                 shift; arg="$1"
                 if [[ $arg != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
@@ -201,11 +194,9 @@ while [ -n "$1" ]; do
                 # TODO: Handle multiple -Wl, continuations of -Wl,-rpath
                 arg="${arg#-Wl,}"
                 for rpath in ${arg//,/ }; do
-                    echo "    RPATH=[$rpath]" >&2
                     rpaths+=("$rpath")
                 done
             else
-                echo "OTHER" >&2
                 other_args+=("-Wl,$arg")
             fi
             ;;

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1220,8 +1220,8 @@ class Package(object):
 
     @property
     def rpath_args(self):
-        """Get the rpath args as a string, with -Wl,-rpath= for each element."""
-        return " ".join("-Wl,-rpath=%s" % p for p in self.rpath)
+        """Get the rpath args as a string, with -Wl,-rpath, for each element."""
+        return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
 
 
 def validate_package_url(url_string):

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -39,11 +39,11 @@ test_command = [
     'arg1',
     '-Wl,--start-group',
     'arg2',
-    '-Wl,-rpath=/first/rpath', 'arg3', '-Wl,-rpath', '-Wl,/second/rpath',
+    '-Wl,-rpath,/first/rpath', 'arg3', '-Wl,-rpath', '-Wl,/second/rpath',
     '-llib1', '-llib2',
     'arg4',
     '-Wl,--end-group',
-    '-Xlinker,-rpath', '-Xlinker,/third/rpath', '-Xlinker,-rpath=/fourth/rpath',
+    '-Xlinker,-rpath', '-Xlinker,/third/rpath', '-Xlinker,-rpath,/fourth/rpath',
     '-llib3', '-llib4',
     'arg5', 'arg6']
 
@@ -95,13 +95,13 @@ class CompilerTest(unittest.TestCase):
     def test_ccld_mode(self):
         self.check_cc('dump-mode', [], "ccld")
         self.check_cc('dump-mode', ['foo.c', '-o', 'foo'], "ccld")
-        self.check_cc('dump-mode', ['foo.c', '-o', 'foo', '-Wl,-rpath=foo'], "ccld")
-        self.check_cc('dump-mode', ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath=foo'], "ccld")
+        self.check_cc('dump-mode', ['foo.c', '-o', 'foo', '-Wl,-rpath,foo'], "ccld")
+        self.check_cc('dump-mode', ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'], "ccld")
 
 
     def test_ld_mode(self):
         self.check_ld('dump-mode', [], "ld")
-        self.check_ld('dump-mode', ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath=foo'], "ld")
+        self.check_ld('dump-mode', ['foo.o', 'bar.o', 'baz.o', '-o', 'foo', '-Wl,-rpath,foo'], "ld")
 
 
     def test_includes(self):

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -43,7 +43,7 @@ test_command = [
     '-llib1', '-llib2',
     'arg4',
     '-Wl,--end-group',
-    '-Xlinker,-rpath', '-Xlinker,/third/rpath', '-Xlinker,-rpath,/fourth/rpath',
+    '-Xlinker,-rpath', '-Xlinker,/third/rpath', '-Xlinker,-rpath', '-Xlinker,/fourth/rpath',
     '-llib3', '-llib4',
     'arg5', 'arg6']
 


### PR DESCRIPTION
The former translates to a linker argument "-rpath DIR", whereas the latter translates to "-rpath=DIR". The latter is not support on OS X.