### PR TITLE
Make Boost build with MPI on OS X

### DIFF
--- a/var/spack/packages/boost/package.py
+++ b/var/spack/packages/boost/package.py
@@ -1,5 +1,8 @@
 from spack import *
 
+import os
+import sys
+
 class Boost(Package):
     """Boost provides free peer-reviewed portable C++ source
        libraries, emphasizing libraries that work well with the C++
@@ -127,6 +130,16 @@ class Boost(Package):
             '--layout=tagged'])
 
     def install(self, spec, prefix):
+        # On Darwin, Boost expects the Darwin libtool. However, one of the
+        # dependencies may have pulled in Spack's GNU libtool, and these two are
+        # not compatible. We thus create a symlink to Darwin's libtool and add
+        # it at the beginning of PATH.
+        if sys.platform == 'darwin':
+            newdir = os.path.abspath('darwin-libtool')
+            mkdirp(newdir)
+            force_symlink('/usr/bin/libtool', join_path(newdir, 'libtool'))
+            env['PATH'] = newdir + ':' + env['PATH']
+
         # to make Boost find the user-config.jam
         env['BOOST_BUILD_PATH'] = './'
 


### PR DESCRIPTION
Boost does not build on OS X with either gold or binutils. The gold linker does not exist on Darwin, and binutils on Darwin provides an assembler that doesn't work for Boost.

- Introduce a variant that specifies whether to build with binutils, defaulting to true for backward compatibility
- Auto-detect whether we build on Darwin; in this case, set the gold and binutils variant defaults to false
- Clean up configure flags for as and ld