### PR TITLE
Make Python build on Darwin

### DIFF
--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from contextlib import closing
 from llnl.util.lang import match_predicate
 from spack.util.environment import *
@@ -51,6 +52,8 @@ class Python(Package):
                   ]
         if spec.satisfies('@3:'):
             configure_args.append('--without-ensurepip')
+        if sys.platform == 'darwin':
+            configure_args.append("CC=/usr/bin/cc")
         configure(*configure_args)
         make()
         make("install")


### PR DESCRIPTION
On Darwin, Python wants to be built with the system compiler. Set CC explicitly to make this happen.

This is a simplified version of my previous patch, omitting code cleanups.