### PR TITLE
HDF5 + OpenMPI : modified existing packages

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -1,4 +1,30 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
 from spack import *
+
 
 class Hdf5(Package):
     """HDF5 is a data model, library, and file format for storing and managing
@@ -7,7 +33,7 @@ class Hdf5(Package):
     """
 
     homepage = "http://www.hdfgroup.org/HDF5/"
-    url      = "http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.gz"
+    url = "http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.gz"
     list_url = "http://www.hdfgroup.org/ftp/HDF5/releases"
     list_depth = 3
 
@@ -15,26 +41,53 @@ class Hdf5(Package):
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
     version('1.8.13', 'c03426e9e77d7766944654280b467289')
 
+    variant('debug', default=False, description='Builds a debug version of the library')
+
     variant('cxx', default=True, description='Enable C++ support')
     variant('fortran', default=True, description='Enable Fortran support')
+    variant('unsupported', default=False, description='Enables unsupported configuration options')
+
     variant('mpi', default=False, description='Enable MPI support')
-    variant('threadsafe', default=False, description='Enable multithreading')
+    variant('threadsafe', default=False, description='Enable thread-safe capabilities')
 
     depends_on("mpi", when='+mpi')
     depends_on("zlib")
 
-    # TODO: currently hard-coded to use OpenMPI
+    def validate(self, spec):
+        """
+        Checks if incompatible variants have been activated at the same time
+
+        :param spec: spec of the package
+        :raises RuntimeError: in case of inconsistencies
+        """
+        if '+fortran' in spec and not self.compiler.fc:
+            msg = 'cannot build a fortran variant without a fortran compiler'
+            raise RuntimeError(msg)
+
+        if '+threadsafe' in spec and ('+cxx' in spec or '+fortran' in spec):
+                raise RuntimeError("cannot use variant +threadsafe with either +cxx or +fortran")
+
     def install(self, spec, prefix):
+        self.validate(spec)
+        # Handle compilation after spec validation
         extra_args = []
+        if '+debug' in spec:
+            extra_args.append('--enable-debug=all')
+        else:
+            extra_args.append('--enable-production')
+
+        if '+unsupported' in spec:
+            extra_args.append("--enable-unsupported")
+
         if '+cxx' in spec:
-            extra_args.extend([
-                '--enable-cxx'
-            ])
+            extra_args.append('--enable-cxx')
+
         if '+fortran' in spec:
             extra_args.extend([
                 '--enable-fortran',
                 '--enable-fortran2003'
             ])
+
         if '+mpi' in spec:
             # The HDF5 configure script warns if cxx and mpi are enabled
             # together. There doesn't seem to be a real reason for this, except
@@ -43,27 +96,26 @@ class Hdf5(Package):
             # this is not actually a problem.
             extra_args.extend([
                 "--enable-parallel",
-                "--enable-unsupported",
                 "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
-                "CXX=%s" % spec['mpi'].prefix.bin + "/mpic++",
-                "FC=%s" % spec['mpi'].prefix.bin + "/mpifort",
             ])
-        if '+threads' in spec:
-            if '+cxx' in spec or '+fortran' in spec:
-                die("Cannot use variant +threads with either +cxx or +fortran")
+
+            if '+cxx' in spec:
+                extra_args.append("CXX=%s" % spec['mpi'].prefix.bin + "/mpic++")
+
+            if '+fortran' in spec:
+                extra_args.append("FC=%s" % spec['mpi'].prefix.bin + "/mpifort")
+
+        if '+threadsafe' in spec:
             extra_args.extend([
                 '--enable-threadsafe',
                 '--disable-hl',
-                'CPPFLAGS=-DHDatexit=""',
-                'CFLAGS=-DHDatexit=""'
             ])
 
         configure(
             "--prefix=%s" % prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
-            "--enable-shared",
+            "--enable-shared",  # TODO : this should be enabled by default, remove it?
             *extra_args)
-
         make()
         make("install")
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -19,43 +19,44 @@ class Openmpi(Package):
 
     version('1.10.1', 'f0fcd77ed345b7eafb431968124ba16e')
     version('1.10.0', '280cf952de68369cebaca886c5ce0304')
-    version('1.8.8',  '0dab8e602372da1425e9242ae37faf8c')
-    version('1.6.5',  '03aed2a4aa4d0b27196962a2a65fc475')
+    version('1.8.8', '0dab8e602372da1425e9242ae37faf8c')
+    version('1.6.5', '03aed2a4aa4d0b27196962a2a65fc475')
 
     patch('ad_lustre_rwcontig_open_source.patch', when="@1.6.5")
     patch('llnl-platforms.patch', when="@1.6.5")
     patch('configure.patch', when="@1.10.0:")
 
-    variant('psm',   default=False, description='Build support for the PSM library.')
+    variant('psm', default=False, description='Build support for the PSM library.')
     variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
+
+    # TODO : variant support for other schedulers is missing
+    variant('tm', default=False, description='Build TM (Torque, PBSPro, and compatible) support')
 
     provides('mpi@:2.2', when='@1.6.5')
     provides('mpi@:3.0', when='@1.7.5:')
 
-
     depends_on('hwloc')
-
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
 
-
     def setup_dependent_environment(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
-        os.environ['OMPI_CC']  = 'cc'
+        os.environ['OMPI_CC'] = 'cc'
         os.environ['OMPI_CXX'] = 'c++'
         os.environ['OMPI_FC'] = 'f90'
         os.environ['OMPI_F77'] = 'f77'
 
-
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,
                        "--with-hwloc=%s" % spec['hwloc'].prefix,
-                       "--with-tm",  # necessary for Torque support
                        "--enable-shared",
                        "--enable-static"]
 
         # Variants
+        if '+tm' in spec:
+            config_args.append("--with-tm")  # necessary for Torque support
+
         if '+psm' in spec:
             config_args.append("--with-psm")
 
@@ -85,7 +86,6 @@ class Openmpi(Package):
 
         self.filter_compilers()
 
-
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.
@@ -94,7 +94,7 @@ class Openmpi(Package):
            to Spack's generic cc, c++ and f90.  We want them to
            be bound to whatever compiler they were built with.
         """
-        kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : False }
+        kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
         dir = os.path.join(self.prefix, 'share/openmpi/')
 
         cc_wrappers = ['mpicc-vt-wrapper-data.txt', 'mpicc-wrapper-data.txt',
@@ -132,5 +132,3 @@ class Openmpi(Package):
             if not os.path.islink(path):
                 filter_file('compiler=.*', 'compiler=%s' % self.compiler.fc,
                             path, **kwargs)
-
-


### PR DESCRIPTION
OpenMPI : 
- [x] turned Torque support in `openmpi` into a variant (default = `False`)

HDF5 : 
- [x] added `debug` variant
- [x] refactored validation logic into its own function
- [x] fixed check for non-existent variant `threads` 
- [x] removed macro definitions that override the logic in the `H5private.h` header (`-DHDatexit=""`)
- [x] turned the option `--enable-unsupported` into a variant and removed it from being the default