### PR TITLE
Fix regex to find version on OS X

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -54,4 +54,4 @@ class Clang(Compiler):
                Thread model: posix
         """
         return get_compiler_version(
-            comp, '--version', r'(?:clang version|based on LLVM) ([^ )]+)')
+            comp, '--version', r'(?:clang version|based on LLVM|LLVM version) ([^ )]+)')


### PR DESCRIPTION
This is to address Issues #259 and #237