### PR TITLE
enhancement proposal : variant forwarding

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -49,12 +49,12 @@ class DefaultConcretizer(object):
     def concretize_version(self, spec):
         """If the spec is already concrete, return.  Otherwise take
            the most recent available version, and default to the package's
-           version if there are no avaialble versions.
+           version if there are no available versions.
 
            TODO: In many cases we probably want to look for installed
                  versions of each package and use an installed version
                  if we can link to it.  The policy implemented here will
-                 tend to rebuild a lot of stuff becasue it will prefer
+                 tend to rebuild a lot of stuff because it will prefer
                  a compiler in the spec to any compiler already-
                  installed things were built with.  There is likely
                  some better policy that finds some middle ground

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -804,8 +804,6 @@ class Spec(object):
         for name, dependent in self.dependents.items():
             del dependent.dependencies[self.name]
             dependent._add_dependency(concrete)
-            # Associates the variants to be forwarded with the concrete spec
-            dependent.package.forwarded_variants[concrete.name] = dependent.package.forwarded_variants.pop(self.name)
 
     def _expand_virtual_packages(self):
         """Find virtual packages in this spec, replace them with providers,
@@ -1035,6 +1033,9 @@ class Spec(object):
             visited.add(dep.name)
             provider = self._find_provider(dep, provider_index)
             if provider:
+                if dep.name in self.package.forwarded_variants:
+                    # Associates the variants to be forwarded with the concrete spec
+                    self.package.forwarded_variants[provider.name] = self.package.forwarded_variants.pop(dep.name)
                 dep = provider
 
         else:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -234,6 +234,50 @@ class SpecSematicsTest(MockPackagesTest):
         self.assertFalse(Spec('netlib-lapack ^openblas').satisfies('netlib-lapack ^netlib-blas'))
         self.assertTrue(Spec('netlib-lapack ^netlib-blas').satisfies('netlib-lapack ^netlib-blas'))
 
+    def test_scalapack_variant_forwarding(self):
+        """
+        Ensure that the correct semantic for variant forwarding is maintained in presence of:
+        - virtual dependencies
+        - multiple forwarded variants
+        """
+        #
+        s = Spec('netlib-scalapack')
+        s.concretize()
+        self.assertTrue('~debug' in s)
+        self.assertTrue('~debug' in s['lapack']['blas'])
+        self.assertTrue('~debug' in s['lapack'])
+        self.assertTrue('~debug' in s['lapack']['blas'])
+        self.assertTrue('+shared' in s)
+        self.assertTrue('+shared' in s['lapack'])
+        self.assertTrue('+shared' in s['lapack']['blas'])
+        #
+        s = Spec('netlib-scalapack+debug')
+        s.concretize()
+        self.assertTrue('+debug' in s)
+        self.assertTrue('+debug' in s['lapack'])
+        self.assertTrue('+debug' in s['lapack']['blas'])
+        self.assertTrue('+shared' in s)
+        self.assertTrue('+shared' in s['lapack'])
+        self.assertTrue('+shared' in s['lapack']['blas'])
+        #
+        s = Spec('netlib-scalapack+debug ^ netlib-lapack~debug')
+        s.concretize()
+        self.assertTrue('+debug' in s)
+        self.assertTrue('~debug' in s['lapack'])
+        self.assertTrue('~debug' in s['lapack']['blas'])
+        self.assertTrue('+shared' in s)
+        self.assertTrue('+shared' in s['lapack'])
+        self.assertTrue('+shared' in s['lapack']['blas'])
+        #
+        s = Spec('netlib-scalapack+debug~shared ^ netlib-lapack+shared ^ openblas~debug+shared')
+        s.concretize()
+        self.assertTrue('+debug' in s)
+        self.assertTrue('+debug' in s['lapack'])
+        self.assertTrue('~debug' in s['lapack']['blas'])
+        self.assertTrue('~shared' in s)
+        self.assertTrue('+shared' in s['lapack'])
+        self.assertTrue('+shared' in s['lapack']['blas'])
+
 
     # ================================================================================
     # Indexing specs

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -24,7 +24,7 @@
 ##############################################################################
 """Variant is a class describing flags on builds, or "variants".
 
-Could be generalized later to describe aribitrary parameters, but
+Could be generalized later to describe arbiitrary parameters, but
 currently variants are just flags.
 
 """

--- a/var/spack/repos/builtin.mock/packages/netlib-blas/package.py
+++ b/var/spack/repos/builtin.mock/packages/netlib-blas/package.py
@@ -24,11 +24,15 @@
 ##############################################################################
 from spack import *
 
+
 class NetlibBlas(Package):
     homepage = "http://www.netlib.org/lapack/"
     url      = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
 
     version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
+
+    variant('debug', default=False, description='Builds a debug version of the library')
+    variant('shared', default=True, description='Builds a shared version of the library')
 
     provides('blas')
 

--- a/var/spack/repos/builtin.mock/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin.mock/packages/netlib-lapack/package.py
@@ -24,14 +24,18 @@
 ##############################################################################
 from spack import *
 
+
 class NetlibLapack(Package):
     homepage = "http://www.netlib.org/lapack/"
     url      = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
 
     version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
 
+    variant('debug', default=False, description='Builds a debug version of the library')
+    variant('shared', default=True, description='Builds a shared version of the library')
+
     provides('lapack')
-    depends_on('blas')
+    depends_on('blas', forward=('shared', 'debug'))
 
     def install(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin.mock/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin.mock/packages/netlib-scalapack/package.py
@@ -24,17 +24,18 @@
 ##############################################################################
 from spack import *
 
-class Openblas(Package):
-    """OpenBLAS: An optimized BLAS library"""
-    homepage = "http://www.openblas.net"
-    url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
 
-    version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
+class NetlibScalapack(Package):
+    homepage = "http://www.netlib.org/lapack/"
+    url      = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
+
+    version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
 
     variant('debug', default=False, description='Builds a debug version of the library')
     variant('shared', default=True, description='Builds a shared version of the library')
 
-    provides('blas')
+    provides('scalapack')
+    depends_on('lapack', forward=('debug', 'shared'))
 
     def install(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin/packages/netlib-blas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-blas/package.py
@@ -9,7 +9,7 @@ class NetlibBlas(Package):
 
     version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
 
-    variant('fpic', default=False, description="Build with -fpic compiler option")
+    variant('shared', default=False, description="Build with -fpic compiler option")
 
     # virtual dependency
     provides('blas')
@@ -25,7 +25,7 @@ class NetlibBlas(Package):
         mf.filter('^LOADER.*',  'LOADER = f90')
         mf.filter('^CC =.*',  'CC = cc')
 
-        if '+fpic' in self.spec:
+        if '+shared' in self.spec:
             mf.filter('^OPTS.*=.*',  'OPTS = -O2 -frecursive -fpic')
             mf.filter('^CFLAGS =.*',  'CFLAGS = -O3 -fpic')
 

--- a/var/spack/repos/builtin/packages/netlib-blas/package.py
+++ b/var/spack/repos/builtin/packages/netlib-blas/package.py
@@ -1,15 +1,42 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
-import os
 
 
 class NetlibBlas(Package):
-    """Netlib reference BLAS"""
+    """
+    Netlib reference BLAS
+    """
     homepage = "http://www.netlib.org/lapack/"
-    url      = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
+    url = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
 
+    version('3.6.0', 'f2f6c67134e851fe189bb3ca1fbb5101')
     version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
 
-    variant('shared', default=False, description="Build with -fpic compiler option")
+    variant('debug', default=False, description='Builds the library in debug mode')
+    variant('shared', default=True, description='Builds the shared library version')
 
     # virtual dependency
     provides('blas')
@@ -17,30 +44,32 @@ class NetlibBlas(Package):
     # Doesn't always build correctly in parallel
     parallel = False
 
-    def patch(self):
-        os.symlink('make.inc.example', 'make.inc')
-
-        mf = FileFilter('make.inc')
-        mf.filter('^FORTRAN.*', 'FORTRAN = f90')
-        mf.filter('^LOADER.*',  'LOADER = f90')
-        mf.filter('^CC =.*',  'CC = cc')
-
-        if '+shared' in self.spec:
-            mf.filter('^OPTS.*=.*',  'OPTS = -O2 -frecursive -fpic')
-            mf.filter('^CFLAGS =.*',  'CFLAGS = -O3 -fpic')
-
-
     def install(self, spec, prefix):
-        make('blaslib')
 
-        # Tests that blas builds correctly
-        make('blas_testing')
+        options = []
+        options.extend(std_cmake_args)
+        options.append('-DUSE_OPTIMIZED_BLAS:BOOL=OFF')  # to force it to create the blas target
 
-        # No install provided
-        mkdirp(prefix.lib)
-        install('librefblas.a', prefix.lib)
+        if '+shared' in spec:
+            options.extend([
+                '-DBUILD_SHARED_LIBS:BOOL=ON',
+                '-DBUILD_STATIC_LIBS:BOOL=OFF'
+            ])
+        else:
+            options.extend([
+                '-DBUILD_SHARED_LIBS:BOOL=OFF',
+                '-DBUILD_STATIC_LIBS:BOOL=ON'
+            ])
 
-        # Blas virtual package should provide blas.a and libblas.a
-        with working_dir(prefix.lib):
-            symlink('librefblas.a', 'blas.a')
-            symlink('librefblas.a', 'libblas.a')
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *options)
+
+        with working_dir('spack-build/BLAS'):
+            make()
+            make('test')
+            make('install')

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -1,4 +1,29 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
+
 
 class NetlibLapack(Package):
     """
@@ -10,50 +35,54 @@ class NetlibLapack(Package):
     use in the scientific community.
     """
     homepage = "http://www.netlib.org/lapack/"
-    url      = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
+    url = "http://www.netlib.org/lapack/lapack-3.5.0.tgz"
 
+    version('3.6.0', 'f2f6c67134e851fe189bb3ca1fbb5101')
     version('3.5.0', 'b1d3e3e425b2e44a06760ff173104bdf')
     version('3.4.2', '61bf1a8a4469d4bdb7604f5897179478')
     version('3.4.1', '44c3869c38c8335c2b9c2a8bb276eb55')
     version('3.4.0', '02d5706ec03ba885fc246e5fa10d8c70')
     version('3.3.1', 'd0d533ec9a5b74933c2a1e84eedc58b4')
 
-    variant('shared', default=False, description="Build shared library version")
+    variant('debug', default=False, description='Builds the library in debug mode')
+    variant('shared', default=True, description='Builds the shared library version')
 
     # virtual dependency
     provides('lapack')
 
     # blas is a virtual dependency.
-    depends_on('blas', forward='shared')
+    depends_on('blas', forward=('debug', 'shared'))
 
     depends_on('cmake')
 
     # Doesn't always build correctly in parallel
     parallel = False
 
-    @when('^netlib-blas')
-    def get_blas_libs(self):
-        blas = self.spec['netlib-blas']
-        return [join_path(blas.prefix.lib, 'blas.a')]
-
-
-    @when('^atlas')
-    def get_blas_libs(self):
-        blas = self.spec['atlas']
-        return [join_path(blas.prefix.lib, l)
-                for l in ('libf77blas.a', 'libatlas.a')]
-
-
     def install(self, spec, prefix):
-        blas_libs = ";".join(self.get_blas_libs())
-        cmake_args = [".", '-DBLAS_LIBRARIES=' + blas_libs]
+        cmake_args = []
+        cmake_args.extend(std_cmake_args)  # Put them first, so that they can be overridden
 
+        cmake_args.append('-DUSE_OPTIMIZED_BLAS:BOOL=ON')
+        cmake_args.append('-DBLAS_LIBRARIES:PATH={blas_libraries}'.format(
+                blas_libraries=join_path(spec['blas'].prefix.lib, 'libblas.a'))
+        )
         if '+shared' in spec:
-            cmake_args.append('-DBUILD_SHARED_LIBS=ON')
+            cmake_args.extend([
+                '-DBUILD_SHARED_LIBS:BOOL=ON',
+                '-DBUILD_STATIC_LIBS:BOOL=OFF'
+            ])
+        else:
+            cmake_args.extend([
+                '-DBUILD_SHARED_LIBS:BOOL=OFF',
+                '-DBUILD_STATIC_LIBS:BOOL=ON'
+            ])
 
-        cmake_args += std_cmake_args
+        if '+debug' in spec:
+            cmake_args.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            cmake_args.append('-DCMAKE_BUILD_TYPE:STRING=Release')
 
-        cmake(*cmake_args)
-        make()
-        make("install")
-
+        with working_dir('spack-build', create=True):
+            cmake('..', *cmake_args)
+            make()
+            make("install")

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -24,7 +24,7 @@ class NetlibLapack(Package):
     provides('lapack')
 
     # blas is a virtual dependency.
-    depends_on('blas')
+    depends_on('blas', forward='shared')
 
     depends_on('cmake')
 

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -1,40 +1,74 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
+
 
 class NetlibScalapack(Package):
     """ScaLAPACK is a library of high-performance linear algebra routines for parallel distributed memory machines"""
-    
+
     homepage = "http://www.netlib.org/scalapack/"
-    url      = "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz"
+    url = "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz"
 
     version('2.0.2', '2f75e600a2ba155ed9ce974a1c4b536f')
     version('2.0.1', '17b8cde589ea0423afe1ec43e7499161')
     version('2.0.0', '9e76ae7b291be27faaad47cfc256cbfe')
     # versions before 2.0.0 are not using cmake and requires blacs as
     # a separated package
-    
+
+    variant('debug', default=False, description='Builds the library in debug mode')
     variant('shared', default=True, description='Build the shared library version')
+
     variant('fpic', default=False, description="Build with -fpic compiler option")
-    
+
     provides('scalapack')
-    
+
     depends_on('mpi')
-    depends_on('lapack', forward='shared')
-    
-    def install(self, spec, prefix):       
-        options = [
-            "-DBUILD_SHARED_LIBS:BOOL=%s" % 'ON' if '+shared' in spec else 'OFF',
-            "-DBUILD_STATIC_LIBS:BOOL=%s" % 'OFF' if '+shared' in spec else 'ON',
-            "-DUSE_OPTIMIZED_LAPACK_BLAS:BOOL=ON", # forces scalapack to use find_package(LAPACK)
-            ]
+    depends_on('lapack', forward=('shared', 'debug'))
+
+    def install(self, spec, prefix):
+
+        options = []
+        options.extend(std_cmake_args)
+
+        options.extend([
+            "-DBUILD_SHARED_LIBS:BOOL=%s" % ('ON' if '+shared' in spec else 'OFF'),
+            "-DBUILD_STATIC_LIBS:BOOL=%s" % ('OFF' if '+shared' in spec else 'ON')
+        ])
+        options.append('-DUSE_OPTIMIZED_LAPACK_BLAS:BOOL=ON')  # forces scalapack to use find_package(LAPACK)
+
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
 
         if '+fpic' in spec:
             options.extend([
                 "-DCMAKE_C_FLAGS=-fPIC",
                 "-DCMAKE_Fortran_FLAGS=-fPIC"
             ])
-           
-        options.extend(std_cmake_args)
-        
+
         with working_dir('spack-build', create=True):
             cmake('..', *options)
             make()

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -18,7 +18,7 @@ class NetlibScalapack(Package):
     provides('scalapack')
     
     depends_on('mpi')
-    depends_on('lapack')
+    depends_on('lapack', forward='shared')
     
     def install(self, spec, prefix):       
         options = [


### PR DESCRIPTION
##### Rationale
This PR adds a `forward` keyword to the `depends_on` and `extends` directives to enable the forwarding of a variant from a dependent to a direct dependency. Forwarding is taken into consideration only if nothing was explicitly specified about the forwarded variant in the dependency.

##### Modifications
- [x] added a `forward` keyword to `depends_on` and `extends`
- [x] added unit tests for the new feature
- [ ] added documentation for the new feature
- [x] modified the netlib stack to forward the variants `shared` and `debug`
- [x] fix the failing unit tests (Package vs. Spec creation order)

##### Examples
```
$ spack install netlib-lapack+shared
==> Forwarding variant "shared" from package netlib-lapack to package netlib-blas : +shared
==> Installing netlib-lapack
...
$ spack install netlib-scalapack
==> Forwarding variant "shared" from package netlib-scalapack to package netlib-lapack : +shared
==> Forwarding variant "shared" from package netlib-lapack to package netlib-blas : +shared
==> Installing netlib-scalapack
...
$ spack install netlib-scalapack+shared ^ netlib-lapack~shared
==> Forwarding variant "shared" from package netlib-lapack to package netlib-blas : ~shared

```

##### Implementation notes
I had originally some issues with regression tests, due to the fact that I was modifying directly a dictionary in `spec.package` that was shared among multiple specs. As I couldn't find a way of copying the dictionary during `__init__`, I made it a property to compute it lazily the first time it's needed. I am not sure this is the best approach in terms of clarity. Hints on alternative ways to accomplish the same thing are welcome.