### PR TITLE
Virtual packages class to have a placeholder

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -158,8 +158,8 @@ sys_type = None
 # TODO: it's not clear where all the stuff that needs to be included in packages
 #       should live.  This file is overloaded for spack core vs. for packages.
 #
-__all__ = ['Package', 'Version', 'when', 'ver']
-from spack.package import Package, ExtensionConflictError
+__all__ = ['Package', 'VirtualPackage', 'Version', 'when', 'ver']
+from spack.package import Package, VirtualPackage, ExtensionConflictError
 from spack.version import Version, ver
 from spack.multimethod import when
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -231,6 +231,14 @@ def provides(pkg, *specs, **kwargs):
         for provided_spec in spack.spec.parse(string):
             if pkg.name == provided_spec.name:
                 raise CircularReferenceError('depends_on', pkg.name)
+            if not spack.repo.exists(provided_spec.name):
+                raise DirectiveError('provided',
+                                     'Package {0} tries to provide {1} which do not exist as a virtual package'.format(
+                                         pkg.name, string))
+            if not provided_spec.virtual:
+                raise DirectiveError('provided',
+                                     'Package {0} tries to provide {1} which is not a virtual dependency'.format(
+                                         pkg.name, string))
             pkg.provided[provided_spec] = provider_spec
 
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -316,6 +316,8 @@ class Package(object):
     """Most packages are NOT extendable.  Set to True if you want extensions."""
     extendable = False
 
+    """By default package are not virtual, VirtualPackage override this"""
+    virtual = False
 
     def __init__(self, spec):
         # this determines how the package should be built.
@@ -1222,6 +1224,16 @@ class Package(object):
     def rpath_args(self):
         """Get the rpath args as a string, with -Wl,-rpath= for each element."""
         return " ".join("-Wl,-rpath=%s" % p for p in self.rpath)
+
+
+class VirtualPackage(Package):
+    """Subclass of package to define virtual packages"""
+
+    """override the virtual state"""
+    virtual = True
+
+    def install(self, spec, prefix):
+        raise InstallError("You are trying to install a virtual package, this is not implemented")
 
 
 def validate_package_url(url_string):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -528,8 +528,8 @@ class Repo(object):
 
     @_autospec
     def get(self, spec, new=False):
-        if spec.virtual:
-            raise UnknownPackageError(spec.name)
+#        if spec.virtual:
+#            raise UnknownPackageError(spec.name)
 
         if spec.namespace and spec.namespace != self.namespace:
             raise UnknownPackageError("Repository %s does not contain package %s."

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -512,7 +512,9 @@ class Spec(object):
     @staticmethod
     def is_virtual(name):
         """Test if a name is virtual without requiring a Spec."""
-        return not spack.repo.exists(name)
+        pkg = spack.repo.get(name)
+        return pkg.virtual
+        #return not spack.repo.exists(name)
 
 
     @property
@@ -808,6 +810,7 @@ class Spec(object):
               a problem.
         """
         changed = False
+        # This generate an infinite loop when self is virtual ex: spack install lapack
         while True:
             virtuals =[v for v in self.traverse() if v.virtual]
             if not virtuals:
@@ -837,6 +840,9 @@ class Spec(object):
            with requirements of its pacakges.  See flatten() and normalize() for
            more details on this.
         """
+        if self.virtual:
+            raise SpecError("Cannot concretize {0} because it is a virtual package".format(self.name))
+
         if self._concrete:
             return
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -194,5 +194,4 @@ class ConcretizeTest(MockPackagesTest):
         self.assertTrue(spec['libelf'].compiler.satisfies('clang'))
 
     def test_concretize_virtual(self):
-        with self.assertRaises(SpecError):
-            self.check_concretize('lapack')
+        self.assertRaises(SpecError, self.check_concretize, 'lapack')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -25,7 +25,7 @@
 import unittest
 
 import spack
-from spack.spec import Spec, CompilerSpec
+from spack.spec import Spec, CompilerSpec, SpecError
 from spack.test.mock_packages_test import *
 
 class ConcretizeTest(MockPackagesTest):
@@ -192,3 +192,7 @@ class ConcretizeTest(MockPackagesTest):
         # TODO: not exactly the syntax I would like.
         self.assertTrue(spec['libdwarf'].compiler.satisfies('clang'))
         self.assertTrue(spec['libelf'].compiler.satisfies('clang'))
+
+    def test_concretize_virtual(self):
+        with self.assertRaises(SpecError):
+            self.check_concretize('lapack')

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -174,6 +174,8 @@ class DirectoryLayoutTest(MockPackagesTest):
         # Create install prefixes for all packages in the list
         installed_specs = {}
         for pkg in packages:
+            if pkg.virtual:
+                continue
             spec = pkg.spec.concretized()
             installed_specs[spec.name] = spec
             self.layout.create_install_directory(spec)

--- a/var/spack/repos/builtin.mock/packages/bar/package.py
+++ b/var/spack/repos/builtin.mock/packages/bar/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Bar(VirtualPackage):
+    """This package is a placeholder for bar"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/blas/package.py
+++ b/var/spack/repos/builtin.mock/packages/blas/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Blas(VirtualPackage):
+    """This package is a placeholder for BLAS"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/d/package.py
+++ b/var/spack/repos/builtin.mock/packages/d/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class D(VirtualPackage):
+    """This package is a placeholder for d"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/f/package.py
+++ b/var/spack/repos/builtin.mock/packages/f/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class F(VirtualPackage):
+    """This package is a placeholder for f"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/foo/package.py
+++ b/var/spack/repos/builtin.mock/packages/foo/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Foo(VirtualPackage):
+    """This package is a placeholder for foo"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/foobar/package.py
+++ b/var/spack/repos/builtin.mock/packages/foobar/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Foobar(VirtualPackage):
+    """This package is a placeholder for foobar"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/g/package.py
+++ b/var/spack/repos/builtin.mock/packages/g/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class G(VirtualPackage):
+    """This package is a placeholder for g"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/lapack/package.py
+++ b/var/spack/repos/builtin.mock/packages/lapack/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Lapack(VirtualPackage):
+    """This package is a placeholder for LAPACK"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/libgoblin/package.py
+++ b/var/spack/repos/builtin.mock/packages/libgoblin/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Libgoblin(VirtualPackage):
+    """This package is a placeholder for libgoblin"""
+    pass

--- a/var/spack/repos/builtin.mock/packages/mpi/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpi/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Mpi(VirtualPackage):
+    """This package is a placeholder for MPI"""
+    pass

--- a/var/spack/repos/builtin/packages/blas/package.py
+++ b/var/spack/repos/builtin/packages/blas/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Blas(VirtualPackage):
+    """This package is a placeholder for BLAS"""
+    pass

--- a/var/spack/repos/builtin/packages/elf/package.py
+++ b/var/spack/repos/builtin/packages/elf/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Elf(VirtualPackage):
+    """This package is a placeholder for ELF"""
+    pass

--- a/var/spack/repos/builtin/packages/lapack/package.py
+++ b/var/spack/repos/builtin/packages/lapack/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Lapack(VirtualPackage):
+    """This package is a placeholder for LAPACK"""
+    pass

--- a/var/spack/repos/builtin/packages/mpe/package.py
+++ b/var/spack/repos/builtin/packages/mpe/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Mpe(VirtualPackage):
+    """This package is a placeholder for MPE"""
+    pass

--- a/var/spack/repos/builtin/packages/mpi/package.py
+++ b/var/spack/repos/builtin/packages/mpi/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Mpi(VirtualPackage):
+    """This package is a placeholder for MPI"""
+    pass

--- a/var/spack/repos/builtin/packages/scalapack/package.py
+++ b/var/spack/repos/builtin/packages/scalapack/package.py
@@ -1,0 +1,6 @@
+from spack import *
+
+
+class Scalapack(VirtualPackage):
+    """This package is a placeholder for ScaLAPACK"""
+    pass


### PR DESCRIPTION
This PR add a VirtualPackage class as suggested by @tgamblin in #234
This packages act only as placeholders. Virtual packages could be used in a second time to enforce some properties on the providers.

Virtual packages have to exists in order to by provided. Before a package not present was considered as virtual, with this PR a package not present is an error. 

I encountered a problem, it is not possible to install a virtual package `spack install lapack` was resulting in an infinite loop. I added an exception when spack tries to concretize a virtual package, but that is most probably not the best solution.