### PR TITLE
Add PnetCDF and M4 packages

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class M4(Package):
+    """GNU M4 is an implementation of the traditional Unix macro processor."""
+    homepage = "https://www.gnu.org/software/m4/m4.html"
+    url      = "ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz"
+
+    version('1.4.17', 'a5e9954b1dae036762f7b13673a2cf76')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -1,0 +1,20 @@
+from spack import *
+
+class ParallelNetcdf(Package):
+    """Parallel netCDF (PnetCDF) is a library providing high-performance
+    parallel I/O while still maintaining file-format compatibility with
+    Unidata's NetCDF."""
+
+    homepage = "https://trac.mcs.anl.gov/projects/parallel-netcdf"
+    url      = "http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/parallel-netcdf-1.6.1.tar.gz"
+
+    version('1.6.1', '62a094eb952f9d1e15f07d56e535052604f1ac34')
+
+    depends_on("m4")
+    depends_on("mpi")
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix,
+                  "--with-mpi=%s" % spec['mpi'].prefix)
+        make()
+        make("install")


### PR DESCRIPTION
Wow, getting PnetCDF to install was way easier than NetCDF. I tested this package by installing PnetCDF with OpenMPI, MPICH, and MVAPICH2. Everything built just fine, although I've only tested it with gcc.