### PR TITLE
fix : trilinos and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -11,13 +11,15 @@ class Netcdf(Package):
     version('4.4.0', 'f01cb26a0126dd9a6224e76472d25f6c')
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 
+    variant('mpi', default=True, description='Enables MPI parallelism')
     variant('fortran', default=False, description="Download and install NetCDF-Fortran")
     variant('hdf4',    default=False, description="Enable HDF4 support")
 
     # Dependencies:
     depends_on("curl")  # required for DAP support
     depends_on("hdf", when='+hdf4')
-    depends_on("hdf5")  # required for NetCDF-4 support
+    depends_on("hdf5+mpi~cxx", when='+mpi')  # required for NetCDF-4 support
+    depends_on("hdf5~mpi", when='~mpi')  # required for NetCDF-4 support
     depends_on("zlib")  # required for NetCDF-4 support
 
     def install(self, spec, prefix):
@@ -40,6 +42,9 @@ class Netcdf(Package):
             # necessary for DAP support
             "--enable-dap"
         ]
+
+        if '+mpi' in spec:
+            config_args.append('--enable-parallel')
 
         CPPFLAGS.append("-I%s/include" % spec['hdf5'].prefix)
         LDFLAGS.append( "-L%s/lib"     % spec['hdf5'].prefix)

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -1,5 +1,6 @@
 from spack import *
 
+
 class Netcdf(Package):
     """NetCDF is a set of software libraries and self-describing, machine-independent
     data formats that support the creation, access, and sharing of array-oriented
@@ -44,7 +45,7 @@ class Netcdf(Package):
         ]
 
         if '+mpi' in spec:
-            config_args.append('--enable-parallel')
+            config_args.append('--enable-parallel4')
 
         CPPFLAGS.append("-I%s/include" % spec['hdf5'].prefix)
         LDFLAGS.append( "-L%s/lib"     % spec['hdf5'].prefix)

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -9,9 +9,10 @@ class Openssl(Package):
     homepage = "http://www.openssl.org"
     url      = "http://www.openssl.org/source/openssl-1.0.1h.tar.gz"
 
-    version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')
-    version('1.0.2d', '38dd619b2e77cbac69b99f52a053d25a')
-    version('1.0.2e', '5262bfa25b60ed9de9f28d5d52d77fc5')
+    version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')  # Not available
+    version('1.0.2d', '38dd619b2e77cbac69b99f52a053d25a')  # Not available
+    version('1.0.2e', '5262bfa25b60ed9de9f28d5d52d77fc5')  # Not available
+    version('1.0.2f', 'b3bf73f507172be9292ea2a8c28b659d')
 
     depends_on("zlib")
     parallel = False

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -1,5 +1,3 @@
-import urllib
-
 from spack import *
 
 class Openssl(Package):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -42,22 +42,3 @@ class Openssl(Package):
 
         make()
         make("install")
-
-    def url_for_version(self, version):
-        # This URL is computed pinging the place where the latest version is stored. To avoid slowdown
-        # due to repeated pinging, we store the URL in a private attribute
-        openssl_url = getattr(self, '_openssl_url', None)
-
-        if openssl_url is None:
-            latest = 'http://www.openssl.org/source/openssl-{version}.tar.gz'
-            older = 'http://www.openssl.org/source/old/{version_number}/openssl-{version_full}.tar.gz'
-            # Try to use the url where the latest tarballs are stored. If the url does not exist (404), then
-            # return the url for older format
-            version_number = '.'.join([str(x) for x in version[:-1]])
-            older_url = older.format(version_number=version_number, version_full=version)
-            latest_url = latest.format(version=version)
-            response = urllib.urlopen(latest.format(version=version))
-            openssl_url = older_url if response.getcode() == 404 else latest_url
-            self._openssl_url = openssl_url
-
-        return openssl_url

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -17,7 +17,6 @@ class Trilinos(Package):
     version('11.14.2', 'a43590cf896c677890d75bfe75bc6254')
     version('11.14.1', '40febc57f76668be8b6a77b7607bb67f')
 
-    variant('mpi', default=True, description='Add a dependency on MPI and enables MPI dependent packages')
     variant('shared', default=True, description='Enables the build of shared libraries')
     variant('debug', default=False, description='Builds a debug version of the libraries')
 
@@ -30,9 +29,8 @@ class Trilinos(Package):
     depends_on('swig')
 
     # MPI related dependencies
-    depends_on('mpi', when='+mpi')
-    depends_on('netcdf+mpi', when='+mpi')
-    depends_on('netcdf~mpi', when='~mpi')
+    depends_on('mpi')
+    depends_on('netcdf+mpi')
 
     depends_on('python') #  Needs py-numpy activated
 
@@ -45,7 +43,7 @@ class Trilinos(Package):
                         '-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF',
                         '-DCMAKE_BUILD_TYPE:STRING=%s' % ('Debug' if '+debug' in spec else 'Release'),
                         '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if '+shared' in spec else 'OFF'),
-                        '-DTPL_ENABLE_MPI:BOOL=%s' % ('ON' if '+mpi' in spec else 'OFF'),
+                        '-DTPL_ENABLE_MPI:STRING=ON',
                         '-DBLAS_LIBRARY_DIRS:PATH=%s' % spec['blas'].prefix,
                         '-DLAPACK_LIBRARY_DIRS:PATH=%s' % spec['lapack'].prefix
                         ])

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -10,6 +10,7 @@ class Trilinos(Package):
     homepage = "https://trilinos.org/"
     url = "http://trilinos.csbsju.edu/download/files/trilinos-12.2.1-Source.tar.gz"
 
+    version('12.4.2', '7c830f7f0f68b8ad324690603baf404e')
     version('12.2.1', '6161926ea247863c690e927687f83be9')
     version('12.0.1', 'bd99741d047471e127b8296b2ec08017')
     version('11.14.3', '2f4f83f8333e4233c57d0f01c4b57426')
@@ -17,33 +18,38 @@ class Trilinos(Package):
     version('11.14.1', '40febc57f76668be8b6a77b7607bb67f')
 
     variant('mpi', default=True, description='Add a dependency on MPI and enables MPI dependent packages')
+    variant('shared', default=True, description='Enables the build of shared libraries')
+    variant('debug', default=False, description='Builds a debug version of the libraries')
 
     # Everything should be compiled with -fpic
     depends_on('blas')
     depends_on('lapack')
     depends_on('boost')
-    depends_on('netcdf')
     depends_on('matio')
     depends_on('glm')
     depends_on('swig')
+
+    # MPI related dependencies
     depends_on('mpi', when='+mpi')
+    depends_on('netcdf+mpi', when='+mpi')
+    depends_on('netcdf~mpi', when='~mpi')
+
+    depends_on('python') #  Needs py-numpy activated
 
     def install(self, spec, prefix):
-
-        options = [
-            '-DTrilinos_ENABLE_ALL_PACKAGES:BOOL=ON',
-            '-DTrilinos_ENABLE_TESTS:BOOL=OFF',
-            '-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF',
-            '-DBUILD_SHARED_LIBS:BOOL=ON',
-            '-DBLAS_LIBRARY_DIRS:PATH=%s' % spec['blas'].prefix,
-            '-DLAPACK_LIBRARY_DIRS:PATH=%s' % spec['lapack'].prefix
-        ]
-        if '+mpi' in spec:
-            mpi_options = ['-DTPL_ENABLE_MPI:BOOL=ON']
-            options.extend(mpi_options)
-
-        # -DCMAKE_INSTALL_PREFIX and all the likes...
+        options = []
         options.extend(std_cmake_args)
+
+        options.extend(['-DTrilinos_ENABLE_ALL_PACKAGES:BOOL=ON',
+                        '-DTrilinos_ENABLE_TESTS:BOOL=OFF',
+                        '-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF',
+                        '-DCMAKE_BUILD_TYPE:STRING=%s' % ('Debug' if '+debug' in spec else 'Release'),
+                        '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if '+shared' in spec else 'OFF'),
+                        '-DTPL_ENABLE_MPI:BOOL=%s' % ('ON' if '+mpi' in spec else 'OFF'),
+                        '-DBLAS_LIBRARY_DIRS:PATH=%s' % spec['blas'].prefix,
+                        '-DLAPACK_LIBRARY_DIRS:PATH=%s' % spec['lapack'].prefix
+                        ])
+
         with working_dir('spack-build', create=True):
             cmake('..', *options)
             make()


### PR DESCRIPTION
Modifications : 
- [x] updated trilinos to meet changes in dependencies
- [x] added `mpi` variant to netcdf (default=`True`, triggers `--enable-parallel`)
- [x] updated openssl version (older ones cannot be retrieved anymore from the url) see #416 
- [x] added smarter logic in the computation of openssl URL

Known issues :

 - trilinos requires `numpy`. Currently one needs to activate it before installing trilinos :
```
spack install py-numpy
spack activate numpy
spack install  trilinos ^ netlib-lapack+shared ^ netlib-blas+fpic
```
- build is not working for GCC >= 5.0 (C++11 incompatibilities in some packages)


Should be related to #385 

@adamjstewart : please tell me if the modifications in netcdf are fine with you