### PR TITLE
Checksum fix for hwloc

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -17,8 +17,8 @@ class Hwloc(Package):
     list_url = "http://www.open-mpi.org/software/hwloc/"
     list_depth = 3
 
-    version('1.11.2', '486169cbe111cdea57be12638828ebbf')
-    version('1.11.1', '002742efd3a8431f98d6315365a2b543')
+    version('1.11.2', 'e4ca55c2a5c5656da4a4e37c8fc51b23')
+    version('1.11.1', 'feb4e416a1b25963ed565d8b42252fdc')
     version('1.9',    '1f9f9155682fe8946a97c08896109508')
 
     depends_on('libpciaccess')


### PR DESCRIPTION
I inadvertently introduced a bug in #342. Previously, some versions were explicitly told to download tar.gz and some tar.bz2. I wrote a url_for_version function to always download tar.gz but forgot to change the tar.bz2 checksums to tar.gz checksums.