### PR TITLE
updated openssl version

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -12,6 +12,7 @@ class Openssl(Package):
     version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')
     version('1.0.2d', '38dd619b2e77cbac69b99f52a053d25a')
     version('1.0.2e', '5262bfa25b60ed9de9f28d5d52d77fc5')
+    version('1.0.2f', 'b3bf73f507172be9292ea2a8c28b659d')
 
     depends_on("zlib")
     parallel = False


### PR DESCRIPTION
openssl often updates their downloads for a particular version by incrementing a letter after the version number. When they do this, they remove the previous lettered version, requiring the package to be updated. This is a bit annoying. Any ideas on how to ameliorate this?