### PR TITLE
hdf5: always pass the unsupported flag

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -45,7 +45,7 @@ class Hdf5(Package):
 
     variant('cxx', default=True, description='Enable C++ support')
     variant('fortran', default=True, description='Enable Fortran support')
-    variant('unsupported', default=False, description='Enables unsupported configuration options')
+    variant('unsupported', default=True, description='Enables unsupported configuration options')
 
     variant('mpi', default=False, description='Enable MPI support')
     variant('szip', default=False, description='Enable szip support')


### PR DESCRIPTION
Some of the variants need this flag to be given (parallel + cxx will do
it), so rather than making some builds impossible, just always pass it.

---
Cc: @tgamblin @adamjstewart @alalazo 