### PR TITLE
Add latest libgpg-error version

### DIFF
--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -9,6 +9,7 @@ class LibgpgError(Package):
     homepage = "https://www.gnupg.org/related_software/libgpg-error"
     url      = "ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.18.tar.bz2"
 
+    version('1.21', 'ab0b5aba6d0a185b41d07bda804fd8b2')
     version('1.18', '12312802d2065774b787cbfc22cc04e9')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
There is a known bug in libgpg-error that prevents some versions from being built with gcc 5:

https://dev.openwrt.org/ticket/20465

The repository that maintains libgpg-error has a patch available:

https://github.com/openwrt/packages/blob/master/libs/libgpg-error/patches/001-gcc5.patch

However I was unable to get it working with libgpg-error 1.18. This problem must be fixed in version 1.21 because I no longer have any problems compiling with gcc 5.