### PR TITLE
Add latest qhull version

### DIFF
--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -8,20 +8,18 @@ class Qhull(Package):
        implements the Quickhull algorithm for computing the convex
        hull. It handles roundoff errors from floating point
        arithmetic. It computes volumes, surface areas, and
-       approximations to the convex hull.
-
-       Qhull does not support triangulation of non-convex surfaces,
-       mesh generation of non-convex objects, medium-sized inputs in
-       9-D and higher, alpha shapes, weighted Voronoi diagrams,
-       Voronoi volumes, or constrained Delaunay triangulations."""
+       approximations to the convex hull."""
 
     homepage = "http://www.qhull.org"
+
+    version('7.2.0', 'e6270733a826a6a7c32b796e005ec3dc',
+            url="http://www.qhull.org/download/qhull-2015-src-7.2.0.tgz")
 
     version('1.0', 'd0f978c0d8dfb2e919caefa56ea2953c',
             url="http://www.qhull.org/download/qhull-2012.1-src.tgz")
 
     # https://github.com/qhull/qhull/pull/5
-    patch('qhull-iterator.patch')
+    patch('qhull-iterator.patch', when='@1.0')
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):


### PR DESCRIPTION
The qhull patch wasn't working when I tried to install it. There is a newer version available anyway, which didn't need to be patched for me. While I was at it, I shortened the description since it was really long. Let me know if you want me to change it back.

I'm not sure why 2012.1 is listed as version 1.0. There is a qhull-1.0.tar.gz on the website, so maybe it should point to that? In the Changes.txt, 2012.1 is something like version 6.3.1.

Maybe whoever created the package or wrote the patch could comment on why it isn't working or why 2012.1 is listed as version 1.0.