### PR TITLE
Add url for cmake, simplify url_for_version

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -23,13 +23,14 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import llnl.util.tty as tty
 
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
        tools designed to build, test and package software."""
     homepage  = 'https://www.cmake.org'
+    url       = 'https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz'
 
+    version('3.4.3',    '4cb3ff35b2472aae70f542116d616e63')
     version('3.4.0',    'cd3034e0a44256a0917e254167217fc8')
     version('3.3.1',    '52638576f4e1e621fed6c3410d3a1b12')
     version('3.0.2',    'db4c687a31444a929d2fdc36c4dfb95f')
@@ -40,12 +41,7 @@ class Cmake(Package):
 
     def url_for_version(self, version):
         """Handle CMake's version-based custom URLs."""
-        parts = [str(p) for p in Version(version)]
-        if len(parts) < 3:
-            tty.error("Version '%s'does not match CMake's version naming scheme (z.y.x)." % version)
-        version_short = ".".join(parts[:2])
-        version_full  = ".".join(parts)
-        return "http://www.cmake.org/files/v%s/cmake-%s.tar.gz" % (version_short,version_full)
+        return 'https://cmake.org/files/v%s/cmake-%s.tar.gz' % (version.up_to(2), version)
 
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This pull request was originally intended as a way to simplify #99 

After testing, I noticed the following problem:
```
$ spack versions cmake
==> Error: Cannot fetch versions for package Cmake because it does not define any URLs to fetch.
```

By adding a url variable, this problem is now solved:
```
$ spack versions cmake
==> Safe versions (already checksummed):
  3.4.3  3.4.0  3.3.1  3.0.2  2.8.10.2
==> Remote versions (not yet checksummed):
  3.4.2  3.4.1
```
While I was at it, I added the latest available version.