### PR TITLE
Added package : SuiteSparse

### DIFF
--- a/var/spack/repos/builtin/packages/SuiteSparse/package.py
+++ b/var/spack/repos/builtin/packages/SuiteSparse/package.py
@@ -1,0 +1,27 @@
+from spack import *
+
+
+class Suitesparse(Package):
+    """
+    SuiteSparse is a suite of sparse matrix algorithms
+    """
+    homepage = 'http://faculty.cse.tamu.edu/davis/suitesparse.html'
+    url = 'http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.5.1.tar.gz'
+
+    version('4.5.1', 'f0ea9aad8d2d1ffec66a5b6bfeff5319')
+
+    depends_on('blas')
+    depends_on('lapack')
+
+    depends_on('metis@5.1.0', when='@4.5.1')
+
+    def install(self, spec, prefix):
+        # The build system of SuiteSparse is quite old-fashioned
+        # It's basically a plain Makefile which include an header (SuiteSparse_config/SuiteSparse_config.mk)
+        # with a lot of convoluted logic in it.
+        # Any kind of customization will need to go through filtering of that file
+
+        # FIXME : this actually uses the current workaround
+        # FIXME : (blas / lapack always provide libblas and liblapack as aliases)
+        make('install', 'INSTALL=%s' % prefix, 'BLAS=-lblas', 'LAPACK=-llapack')
+

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -41,13 +41,14 @@ class Eigen(Package):
     variant('metis', default=True, description='Enables metis backend')
     variant('scotch', default=True, description='Enables scotch backend')
     variant('fftw', default=True, description='Enables FFTW backend')
+    variant('suitesparse', default=True, description='Enables SuiteSparse support')
 
-    # TODO : dependency on SuiteSparse, googlehash, superlu, adolc missing
+    # TODO : dependency on googlehash, superlu, adolc missing
 
     depends_on('metis', when='+metis')
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
-
+    depends_on('SuiteSparse', when='+suitesparse')
     depends_on('mpfr@2.3.0:')  # Eigen 3.2.7 requires at least 2.3.0
     depends_on('gmp')
 


### PR DESCRIPTION
Modifications : 
- [x] basic installation of SuiteSparse
- [x] added SuiteSparse support to eigen

Notes:
A full spec must be given to appropriately set-up shared lapack and blas, i.e. : 
```
spack install  SuiteSparse ^ netlib-lapack+shared ^ netlib-blas+fpic
```
this relates to the discussion in #391 