### PR TITLE
Paraview fix

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -237,9 +237,9 @@ def set_module_variables_for_package(pkg, m):
 def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
     rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
-    rpaths.extend(d.prefix.lib for d in pkg.spec.traverse(root=False)
+    rpaths.extend(d.prefix.lib for d in pkg.spec.dependencies.values()
                   if os.path.isdir(d.prefix.lib))
-    rpaths.extend(d.prefix.lib64 for d in pkg.spec.traverse(root=False)
+    rpaths.extend(d.prefix.lib64 for d in pkg.spec.dependencies.values()
                   if os.path.isdir(d.prefix.lib64))
     return rpaths
 

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -9,7 +9,7 @@ class Netcdf(Package):
     homepage = "http://www.unidata.ucar.edu/software/netcdf/"
     url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.tar.gz"
 
-    version('4.4.0', 'f01cb26a0126dd9a6224e76472d25f6c')
+    version('4.4.0', 'cffda0cbd97fdb3a06e9274f7aef438e')
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 
     variant('mpi', default=True, description='Enables MPI parallelism')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -14,6 +14,7 @@ class Paraview(Package):
 
     variant('osmesa', default=False, description='Enable OSMesa support')
     variant('qt', default=False, description='Enable Qt support')
+    variant('opengl2', default=False, description='Enable OPengl2 backend')
 
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python')

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -20,6 +20,8 @@ class Qhull(Package):
 
     # https://github.com/qhull/qhull/pull/5
     patch('qhull-iterator.patch', when='@1.0')
+    
+    depends_on('cmake')
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -23,6 +23,7 @@ class Qt(Package):
     version('3.3.8b', '9f05b4125cfe477cc52c9742c3c09009',
             url="http://download.qt.io/archive/qt/3/qt-x11-free-3.3.8b.tar.gz")
 
+    variant('mesa', default=False, description='depend on mesa')
     # Add patch for compile issues with qt3 found with use in the OpenSpeedShop project
     variant('krellpatch', default=False, description="build with openspeedshop based patch.")
     patch('qt3krell.patch', when='@3.3.8b+krellpatch')
@@ -48,7 +49,7 @@ class Qt(Package):
     # depends_on("icu4c")
 
     # OpenGL hardware acceleration
-    depends_on("mesa", when='@4:')
+    depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb")
 
 


### PR DESCRIPTION
These are the fixes needed  in order to build paraview on my cluster, specifically I installed with
spack install paraview+qt+python+tcl+opengl2%gcc@4.8.2 ^netcdf -mpi

I added support for OpenGL2 backend and avoided to use mesa and mpi as this deployment is aimed at a node with graphics acceleration.
It seems that in order to let ParaView access numpy and matplotlib, these extensions have to be activated:
spack activate py-matplotlib
spack activate py-numpy