### PR TITLE
enhancement proposal : mixin interface for providers

### DIFF
--- a/lib/spack/spack/provider_contracts.py
+++ b/lib/spack/spack/provider_contracts.py
@@ -26,7 +26,7 @@
 Collects all the explicit contracts enforced on providers
 """
 import abc
-
+from llnl.util.filesystem import join_path
 
 class MpiProviderContract(object):
     """

--- a/lib/spack/spack/provider_contracts.py
+++ b/lib/spack/spack/provider_contracts.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""
+Collects all the explicit contracts enforced on providers
+"""
+import abc
+
+
+class MpiProvider(object):
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractproperty
+    def cc_compiler_wrapper(self):
+        pass
+
+    @abc.abstractproperty
+    def cxx_compiler_wrapper(self):
+        pass
+
+    @abc.abstractproperty
+    def f77_compiler_wrapper(self):
+        pass
+
+    @abc.abstractproperty
+    def fc_compiler_wrapper(self):
+        pass
+

--- a/lib/spack/spack/provider_contracts.py
+++ b/lib/spack/spack/provider_contracts.py
@@ -28,7 +28,10 @@ Collects all the explicit contracts enforced on providers
 import abc
 
 
-class MpiProvider(object):
+class MpiProviderContract(object):
+    """
+    ABC that defines a common interface for MPI providers
+    """
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
@@ -47,3 +50,23 @@ class MpiProvider(object):
     def fc_compiler_wrapper(self):
         pass
 
+
+class StandardMpiProvider(MpiProviderContract):
+    """
+    Standard values that fit the most common FOSS implementations
+    """
+    @property
+    def cc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicc')
+
+    @property
+    def cxx_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicxx')
+
+    @property
+    def f77_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpif77')
+
+    @property
+    def fc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpifort')

--- a/var/spack/repos/builtin/packages/SAMRAI/package.py
+++ b/var/spack/repos/builtin/packages/SAMRAI/package.py
@@ -33,10 +33,11 @@ class Samrai(Package):
 
     # TODO: currently hard-coded to use openmpi - be careful!
     def install(self, spec, prefix):
+        mpi_provider = spec['mpi'].package
         configure(
             "--prefix=%s" % prefix,
-            "--with-CXX=%s" % spec['mpi'].prefix.bin + "/mpic++",
-            "--with-CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
+            "--with-CXX=%s" % mpi_provider.cxx_compiler_wrapper,
+            "--with-CC=%s" % mpi_provider.cc_compiler_wrapper,
             "--with-hdf5=%s" % spec['hdf5'].prefix,
             "--with-boost=%s" % spec['boost'].prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -126,10 +126,9 @@ class Boost(Package):
             compiler_wrapper = join_path(spack.build_env_path, 'c++')
             f.write("using {0} : : {1} ;\n".format(boostToolsetId, 
                 compiler_wrapper))
-            
+            mpi_provider = spec['mpi'].package
             if '+mpi' in spec:
-                f.write('using mpi : %s ;\n' %
-                    join_path(spec['mpi'].prefix.bin, 'mpicxx'))
+                f.write('using mpi : %s ;\n' % mpi_provider.cxx_compiler_wrapper)
             if '+python' in spec:
                 f.write('using python : %s : %s ;\n' %
                     (spec['python'].version,

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -43,8 +43,9 @@ class Dakota(Package):
                         '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if '+shared' in spec else 'OFF')])
 
         if '+mpi' in spec:
+            mpi_provider = spec['mpi'].package
             options.extend(['-DDAKOTA_HAVE_MPI:BOOL=ON',
-                            '-DMPI_CXX_COMPILER:STRING=%s' % join_path(spec['mpi'].prefix.bin, 'mpicxx')])
+                            '-DMPI_CXX_COMPILER:STRING=%s' % mpi_provider.cxx_compiler_wrapper])
 
         build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -96,16 +96,17 @@ class Hdf5(Package):
             # that parts of the MPI interface are not accessible via the C++
             # interface. Since they are still accessible via the C interface,
             # this is not actually a problem.
+            mpi_provider = spec['mpi'].package
             extra_args.extend([
                 "--enable-parallel",
-                "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
+                "CC=%s" % mpi_provider.cc_compiler_wrapper,
             ])
 
             if '+cxx' in spec:
-                extra_args.append("CXX=%s" % spec['mpi'].prefix.bin + "/mpic++")
+                extra_args.append("CXX=%s" % mpi_provider.cxx_compiler_wrapper)
 
             if '+fortran' in spec:
-                extra_args.append("FC=%s" % spec['mpi'].prefix.bin + "/mpifort")
+                extra_args.append("FC=%s" % mpi_provider.fc_compiler_wrapper)
 
         if '+szip' in spec:
             extra_args.append("--with-szlib=%s" % spec['szip'].prefix)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -24,11 +24,11 @@
 ##############################################################################
 import os
 
-from spack.provider_contracts import MpiProvider
+from spack.provider_contracts import StandardMpiProvider
 from spack import *
 
 
-class Mpich(MpiProvider, Package):
+class Mpich(StandardMpiProvider, Package):
     """
     MPICH is a high performance and widely portable implementation of
     the Message Passing Interface (MPI) standard.
@@ -49,22 +49,6 @@ class Mpich(MpiProvider, Package):
     variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
 
     provides('mpi')
-
-    @property
-    def cc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicc')
-
-    @property
-    def cxx_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicxx')
-
-    @property
-    def f77_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpif77')
-
-    @property
-    def fc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpifort')
 
     def setup_dependent_environment(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -22,37 +22,56 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
 import os
 
-class Mpich(Package):
-    """MPICH is a high performance and widely portable implementation of
-       the Message Passing Interface (MPI) standard."""
+from spack.provider_contracts import MpiProvider
+from spack import *
+
+
+class Mpich(MpiProvider, Package):
+    """
+    MPICH is a high performance and widely portable implementation of
+    the Message Passing Interface (MPI) standard.
+    """
     homepage = "http://www.mpich.org"
-    url      = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
-    list_url   = "http://www.mpich.org/static/downloads/"
+    url = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
+    list_url = "http://www.mpich.org/static/downloads/"
     list_depth = 2
 
-    version('3.2',   'f414cfa77099cd1fa1a5ae4e22db508a')
+    version('3.2', 'f414cfa77099cd1fa1a5ae4e22db508a')
     version('3.1.4', '2ab544607986486562e076b83937bba2')
     version('3.1.3', '93cb17f91ac758cbf9174ecb03563778')
     version('3.1.2', '7fbf4b81dcb74b07ae85939d1ceee7f1')
     version('3.1.1', '40dc408b1e03cc36d80209baaa2d32b7')
-    version('3.1',   '5643dd176499bfb7d25079aaff25f2ec')
+    version('3.1', '5643dd176499bfb7d25079aaff25f2ec')
     version('3.0.4', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
 
     variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
 
-    provides('mpi@:3.0', when='@3:')
-    provides('mpi@:1.3', when='@1:')
+    provides('mpi')
+
+    @property
+    def cc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicc')
+
+    @property
+    def cxx_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicxx')
+
+    @property
+    def f77_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpif77')
+
+    @property
+    def fc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpifort')
 
     def setup_dependent_environment(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
-        os.environ['MPICH_CC']  = 'cc'
+        os.environ['MPICH_CC'] = 'cc'
         os.environ['MPICH_CXX'] = 'c++'
         os.environ['MPICH_F77'] = 'f77'
         os.environ['MPICH_F90'] = 'f90'
-
 
     def install(self, spec, prefix):
         config_args = ["--prefix=" + prefix,
@@ -79,7 +98,6 @@ class Mpich(Package):
 
         self.filter_compilers()
 
-
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.
@@ -89,18 +107,18 @@ class Mpich(Package):
            be bound to whatever compiler they were built with.
         """
         bin = self.prefix.bin
-        mpicc  = os.path.join(bin, 'mpicc')
+        mpicc = os.path.join(bin, 'mpicc')
         mpicxx = os.path.join(bin, 'mpicxx')
         mpif77 = os.path.join(bin, 'mpif77')
         mpif90 = os.path.join(bin, 'mpif90')
 
-        spack_cc  = os.environ['CC']
+        spack_cc = os.environ['CC']
         spack_cxx = os.environ['CXX']
         spack_f77 = os.environ['F77']
-        spack_fc  = os.environ['FC']
+        spack_fc = os.environ['FC']
 
-        kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : True }
-        filter_file('CC="%s"' % spack_cc , 'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
-        filter_file('CXX="%s"'% spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="%s"'% spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="%s"' % spack_fc , 'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)
+        kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
+        filter_file('CC="%s"' % spack_cc, 'CC="%s"' % self.compiler.cc, mpicc, **kwargs)
+        filter_file('CXX="%s"' % spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
+        filter_file('F77="%s"' % spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
+        filter_file('FC="%s"' % spack_fc, 'FC="%s"' % self.compiler.fc, mpif90, **kwargs)

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -82,12 +82,12 @@ class Mumps(Package):
                  'OPTL    = -O ',
                  'OPTC    = -O '])
 
-
         if '+mpi' in self.spec:
+            mpi_provider = spec['mpi'].package
             makefile_conf.extend(
-                ["CC = %s" % join_path(self.spec['mpi'].prefix.bin, 'mpicc'),
-                 "FC = %s" % join_path(self.spec['mpi'].prefix.bin, 'mpif90'),
-                 "FL = %s" % join_path(self.spec['mpi'].prefix.bin, 'mpif90'),
+                ["CC = %s" % mpi_provider.cc_compiler_wrapper,
+                 "FC = %s" % mpi_provider.fc_compiler_wrapper,
+                 "FL = %s" % mpi_provider.fc_compiler_wrapper,
                  "SCALAP = %s" % self.spec['scalapack'].fc_link,
                  "MUMPS_TYPE = par"])
         else:

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -1,10 +1,10 @@
 import os
 
-from spack.provider_contracts import MpiProvider
+from spack.provider_contracts import StandardMpiProvider
 from spack import *
 
 
-class Mvapich2(MpiProvider, Package):
+class Mvapich2(StandardMpiProvider, Package):
     """
     MVAPICH2 is an MPI implementation for Infiniband networks.
     """
@@ -55,22 +55,6 @@ class Mvapich2(MpiProvider, Package):
     ##########
 
     # FIXME : CUDA support is missing
-
-    @property
-    def cc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicc')
-
-    @property
-    def cxx_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicxx')
-
-    @property
-    def f77_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpif77')
-
-    @property
-    def fc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpifort')
 
     def url_for_version(self, version):
         base_url = "http://mvapich.cse.ohio-state.edu/download"

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -1,8 +1,13 @@
-from spack import *
 import os
 
-class Mvapich2(Package):
-    """MVAPICH2 is an MPI implementation for Infiniband networks."""
+from spack.provider_contracts import MpiProvider
+from spack import *
+
+
+class Mvapich2(MpiProvider, Package):
+    """
+    MVAPICH2 is an MPI implementation for Infiniband networks.
+    """
     homepage = "http://mvapich.cse.ohio-state.edu/"
     url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.2b.tar.gz"
 
@@ -50,6 +55,22 @@ class Mvapich2(Package):
     ##########
 
     # FIXME : CUDA support is missing
+
+    @property
+    def cc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicc')
+
+    @property
+    def cxx_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicxx')
+
+    @property
+    def f77_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpif77')
+
+    @property
+    def fc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpifort')
 
     def url_for_version(self, version):
         base_url = "http://mvapich.cse.ohio-state.edu/download"

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -2,10 +2,10 @@ import os
 
 from spack import *
 
-from spack.provider_contracts import MpiProvider
+from spack.provider_contracts import StandardMpiProvider
 
 
-class Openmpi(MpiProvider, Package):
+class Openmpi(StandardMpiProvider, Package):
     """Open MPI is a project combining technologies and resources from
        several other projects (FT-MPI, LA-MPI, LAM/MPI, and PACX-MPI)
        in order to build the best MPI library available. A completely
@@ -39,22 +39,6 @@ class Openmpi(MpiProvider, Package):
     provides('mpi@:3.0', when='@1.7.5:')
 
     depends_on('hwloc')
-
-    @property
-    def cc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicc')
-
-    @property
-    def cxx_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpicxx')
-
-    @property
-    def f77_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpif77')
-
-    @property
-    def fc_compiler_wrapper(self):
-        return join_path(self.prefix.bin, 'mpifort')
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -2,8 +2,10 @@ import os
 
 from spack import *
 
+from spack.provider_contracts import MpiProvider
 
-class Openmpi(Package):
+
+class Openmpi(MpiProvider, Package):
     """Open MPI is a project combining technologies and resources from
        several other projects (FT-MPI, LA-MPI, LAM/MPI, and PACX-MPI)
        in order to build the best MPI library available. A completely
@@ -37,6 +39,22 @@ class Openmpi(Package):
     provides('mpi@:3.0', when='@1.7.5:')
 
     depends_on('hwloc')
+
+    @property
+    def cc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicc')
+
+    @property
+    def cxx_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpicxx')
+
+    @property
+    def f77_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpif77')
+
+    @property
+    def fc_compiler_wrapper(self):
+        return join_path(self.prefix.bin, 'mpifort')
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -1,6 +1,7 @@
 from spack import *
 import os
 
+
 class Scotch(Package):
     """Scotch is a software package for graph and mesh/hypergraph
        partitioning, graph clustering, and sparse matrix ordering."""
@@ -29,8 +30,9 @@ class Scotch(Package):
         makefile_inc.append('CCS       = $(CC)')
 
         if '+mpi' in self.spec:
+            mpi_provider = self.spec['mpi'].package
             makefile_inc.extend([
-                    'CCP       = %s' % os.path.join(self.spec['mpi'].prefix.bin, 'mpicc'),
+                    'CCP       = %s' % mpi_provider.cc_compiler_wrapper,
                     'CCD       = $(CCP)'
                     ])
         else:
@@ -38,8 +40,6 @@ class Scotch(Package):
                     'CCP       = mpicc', # It is set but not used
                     'CCD       = $(CCS)'
                     ])
-
-
 
     def library_build_type(self, makefile_inc, defines):
         makefile_inc.extend([


### PR DESCRIPTION
This PR is just a sketch for a lightweight implementation of a shared interface among providers of the same type. The focus here is on being less invasive as possible while being able to rely on a set of common calls for providers of the same service (e.g. `mpi`). 

The basic ideas are:
- use `ABCMeta` to enforce implementation of a common provider interface
- the provider interface will be used as a mixin at package definition time
- reduce code duplication providing standard implementations

As usual any comment or critique is welcome.