### PR TITLE
Use hash to make shorter module and dotkit names, fixes #433

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -194,12 +194,14 @@ class Dotkit(EnvModule):
     @property
     def file_name(self):
         return join_path(Dotkit.path, self.spec.architecture,
-                         self.spec.format('$_$@$%@$+$#.dk'))
+                         '%s.dk' % self.use_name)
 
     @property
     def use_name(self):
-        return self.spec.format('$_$@$%@$+$#')
-
+      return "%s-%s-%s-%s-%s" % (self.spec.name, self.spec.version,
+                                 self.spec.compiler.name,
+                                 self.spec.compiler.version, 
+                                 self.spec.dag_hash())
 
     def _write(self, dk_file):
         # Category
@@ -235,7 +237,10 @@ class TclModule(EnvModule):
 
     @property
     def use_name(self):
-        return self.spec.format('$_$@$%@$+$#')
+      return "%s-%s-%s-%s-%s" % (self.spec.name, self.spec.version,
+                                 self.spec.compiler.name,
+                                 self.spec.compiler.version, 
+                                 self.spec.dag_hash())
 
 
     def _write(self, m_file):


### PR DESCRIPTION
The long dotkit name for boost now looks like:
    boost-1.60.0-gcc-4.9.3-zhhnzppvxlar7owwsi5777qosp4biwz3.dk