### PR TITLE
Correct shared lib install on Darwin for boost, metis, parmetis

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 from spack import *
-
+import sys
 
 class Metis(Package):
     """
@@ -81,3 +81,9 @@ class Metis(Package):
             cmake(source_directory, *options)
             make()
             make("install")
+
+        # The shared library is not installed correctly on Darwin; correct this
+        if sys.platform == 'darwin':
+            install_name_tool = which('install_name_tool')
+            install_name_tool('-id', join_path(prefix.lib, 'libmetis.dylib'),
+                join_path(prefix.lib, 'libmetis.dylib'))

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 from spack import *
+import sys
 
 # FIXME : lot of code is duplicated from packages/metis/package.py . Inheriting from there may reduce
 # FIXME : the installation rules to just a few lines
@@ -93,3 +94,9 @@ class Parmetis(Package):
             # Parmetis build system doesn't allow for an external metis to be used, but doesn't copy the required
             # metis header either
             install(metis_header, self.prefix.include)
+
+        # The shared library is not installed correctly on Darwin; correct this
+        if sys.platform == 'darwin':
+            install_name_tool = which('install_name_tool')
+            install_name_tool('-id', join_path(prefix.lib, 'libparmetis.dylib'),
+                join_path(prefix.lib, 'libparmetis.dylib'))


### PR DESCRIPTION
Boost, Metis, and Parmetis do not correctly install their shared libraries. The effect is that the equivalent of -rpath isn't working on Darwin. Call "install_name_tool" explicitly to correct this.