### PR TITLE
Add Mesh Packages: Crypto++, Exodus II, ndiff, TetGen, and Triangle

### DIFF
--- a/var/spack/repos/builtin/packages/Triangle/package.py
+++ b/var/spack/repos/builtin/packages/Triangle/package.py
@@ -1,0 +1,20 @@
+from spack import *
+
+class Triangle(Package):
+    """Triangle is a two-dimensional mesh generator and Delaunay
+       triangulator. Triangle generates exact Delaunay triangulations,
+       constrained Delaunay triangulations, conforming Delaunay
+       triangulations, Voronoi diagrams, and high-quality triangular
+       meshes."""
+
+    homepage = "http://www.cs.cmu.edu/~quake/triangle.html"
+    url      = "http://www.netlib.org/voronoi/triangle.zip"
+
+    version('1.6', '10aff8d7950f5e0e2fb6dd2e340be2c9')
+
+    def install(self, spec, prefix):
+        make()
+        mkdirp(prefix.bin)
+
+        install('triangle', prefix.bin)
+        install('showme', prefix.bin)

--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -1,0 +1,31 @@
+import glob
+from spack import *
+
+class Cryptopp(Package):
+    """Crypto++ is an open-source C++ library of cryptographic schemes. The
+       library supports a number of different cryptography algorithms, including
+       authenticated encryption schemes (GCM, CCM), hash functions (SHA-1, SHA2),
+       public-key encryption (RSA, DSA), and a few obsolete/historical encryption
+       algorithms (MD5, Panama)."""
+
+    homepage = "http://www.cryptopp.com/"
+    url      = "http://www.cryptopp.com/cryptopp563.zip"
+
+    version('5.6.3', '3c5b70e2ec98b7a24988734446242d07')
+    version('5.6.2', '7ed022585698df48e65ce9218f6c6a67')
+
+    def install(self, spec, prefix):
+        make()
+
+        mkdirp(prefix.include)
+        for hfile in glob.glob('*.h*'):
+            install(hfile, prefix.include)
+
+        mkdirp(prefix.lib)
+        install('libcryptopp.a', prefix.lib)
+
+    def url_for_version(self, version):
+        version_tuple = tuple(v for v in iter(version))
+        version_string = reduce(lambda vs, nv: vs + str(nv), version_tuple, "")
+
+        return "%scryptopp%s.zip" % (Cryptopp.homepage, version_string)

--- a/var/spack/repos/builtin/packages/exodusii/exodus-cmake.patch
+++ b/var/spack/repos/builtin/packages/exodusii/exodus-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake-exodus b/cmake-exodus
+index 787fd9d..ed073a2 100755
+--- a/cmake-exodus
++++ b/cmake-exodus
+@@ -1,4 +1,6 @@
+-EXTRA_ARGS=$@
++#!/bin/bash
++
++EXTRA_ARGS=-DSEACASProj_ENABLE_CXX11=OFF
+ 
+ ### Change this to point to the compilers you want to use
+ CC=gcc

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -1,0 +1,49 @@
+from spack import *
+
+# TODO: Add support for a C++11 enabled installation that filters out the
+# TODO: "C++11-Disabled" flag (but only if the spec compiler supports C++11).
+
+# TODO: Add support for parallel installation that uses MPI.
+
+# TODO: Create installation options for NetCDF that support larger page size
+# TODO: suggested by Exodus (see the repository "README" file).
+
+class Exodusii(Package):
+    """Exodus II is a C++/Fortran library developed to store and retrieve data for
+       finite element analyses. It's used for preprocessing (problem definition),
+       postprocessing (results visualization), and data transfer between codes.
+       An Exodus II data file is a random access, machine independent, binary
+       file that is written and read via C, C++, or Fortran API routines."""
+
+    homepage = "https://github.com/gsjaardema/seacas"
+    url      = "https://github.com/gsjaardema/seacas/archive/master.zip"
+
+    version('2016-02-08', git='https://github.com/gsjaardema/seacas.git', commit='dcf3529')
+
+    # TODO: Make this a build dependency once build dependencies are supported
+    # (see: https://github.com/LLNL/spack/pull/378).
+    depends_on('cmake@2.8.7:')
+    depends_on('hdf5+static~mpi')
+    depends_on('netcdf~mpi')
+
+    patch('exodus-cmake.patch')
+
+    def patch(self):
+        ff = FileFilter('cmake-exodus')
+
+        ff.filter('CMAKE_INSTALL_PREFIX:PATH=${ACCESS}',
+            'CMAKE_INSTALL_PREFIX:PATH=%s' % self.spec.prefix, string=True)
+        ff.filter('NetCDF_DIR:PATH=${TPL}',
+            'NetCDF_DIR:PATH=%s' % self.spec['netcdf'].prefix, string=True)
+        ff.filter('HDF5_ROOT:PATH=${TPL}',
+            'HDF5_ROOT:PATH=%s' % self.spec['hdf5'].prefix, string=True)
+
+    def install(self, spec, prefix):
+        mkdirp('build')
+        cd('build')
+
+        cmake_exodus = Executable('../cmake-exodus')
+        cmake_exodus()
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -42,6 +42,7 @@ class Hdf5(Package):
     version('1.8.13', 'c03426e9e77d7766944654280b467289')
 
     variant('debug', default=False, description='Builds a debug version of the library')
+    variant('static', default=False, description='Builds a static executable version of the library')
 
     variant('cxx', default=True, description='Enable C++ support')
     variant('fortran', default=True, description='Enable Fortran support')
@@ -77,6 +78,9 @@ class Hdf5(Package):
             extra_args.append('--enable-debug=all')
         else:
             extra_args.append('--enable-production')
+
+        if '+static' in spec:
+            extra_args.append('--enable-static-exec')
 
         if '+unsupported' in spec:
             extra_args.append("--enable-unsupported")

--- a/var/spack/repos/builtin/packages/ndiff/package.py
+++ b/var/spack/repos/builtin/packages/ndiff/package.py
@@ -1,0 +1,21 @@
+from spack import *
+
+class Ndiff(Package):
+    """The ndiff tool is a binary utility that compares putatively similar files
+       while ignoring small numeric differernces. This utility is most often used
+       to compare files containing a lot of floating-point numeric data that
+       may be slightly different due to numeric error."""
+
+    homepage = "http://ftp.math.utah.edu/pub/ndiff/"
+    url      = "http://ftp.math.utah.edu/pub/ndiff/ndiff-2.00.tar.gz"
+
+    version('2.00', '885548b4dc26e72c5455bebb5ba6c16d')
+    version('1.00', 'f41ffe5d12f36cd36b6311acf46eccdc')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+
+        mkdirp(prefix.bin)
+        mkdirp('%s/lib' % prefix.share)
+
+        make('install-exe', 'install-shrlib')

--- a/var/spack/repos/builtin/packages/tetgen/package.py
+++ b/var/spack/repos/builtin/packages/tetgen/package.py
@@ -1,0 +1,28 @@
+from spack import *
+
+class Tetgen(Package):
+    """TetGen is a program and library that can be used to generate tetrahedral
+       meshes for given 3D polyhedral domains. TetGen generates exact constrained
+       Delaunay tetrahedralizations, boundary conforming Delaunay meshes, and
+       Voronoi paritions."""
+
+    homepage = "http://www.tetgen.org"
+    url      = "http://www.tetgen.org/files/tetgen1.4.3.tar.gz"
+
+    version('1.4.3', 'd6a4bcdde2ac804f7ec66c29dcb63c18')
+
+    # TODO: Make this a build dependency once build dependencies are supported
+    # (see: https://github.com/LLNL/spack/pull/378).
+    depends_on('cmake@2.8.7:', when='@1.5.0:')
+
+    def install(self, spec, prefix):
+        make('tetgen', 'tetlib')
+
+        mkdirp(prefix.bin)
+        install('tetgen', prefix.bin)
+
+        mkdirp(prefix.include)
+        install('tetgen.h', prefix.include)
+
+        mkdirp(prefix.lib)
+        install('libtet.a', prefix.lib)


### PR DESCRIPTION
The changes in the pull request add the following meshing packages to Spack's built-in package list:

- **[Crypto++](http://cryptopp.com/)**: A C++ library that implements a number of functions that are useful for cryptography.
- **[Exodus II](https://github.com/gsjaardema/seacas)**: A C++ library developed by Sandia to help with the storing and loading of meshes used for finite element analysis.
- **[ndiff](http://ftp.math.utah.edu/pub/ndiff/)**: A diff-like tool that can be used to diff files that may have slight numerical differences.
- **[TetGen](http://wias-berlin.de/software/tetgen/)**: A C++ library that can generate tetrahedra for any closed solid given a triangulated set of that solid's boundary surfaces.
- **[Triangle](https://www.cs.cmu.edu/~quake/triangle.html)**: A C/C++ library that generates triangulated surfaces for any given closed and planar boundary.

Please let me know if there are any problems with these package implementations.