### PR TITLE
modify compiler commands in python config files, fix for #431

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -55,6 +55,20 @@ class Python(Package):
         make()
         make("install")
 
+        # Modify compiler paths in configuration files. This is necessary for
+        # building site packages outside of spack
+        filter_file(r'([/s]=?)([\S=]*)/lib/spack/env(/[^\s/]*)?/(\S*)(\s)',
+                    (r'\4\5'),
+                    join_path(prefix.lib, 'python%d.%d' % self.version[:2], '_sysconfigdata.py'))
+
+        python3_version = ''
+        if spec.satisfies('@3:'):
+            python3_version = '-%d.%dm' % self.version[:2]
+        makefile_filepath = join_path(prefix.lib, 'python%d.%d' % self.version[:2], 'config%s' % python3_version, 'Makefile')
+        filter_file(r'([/s]=?)([\S=]*)/lib/spack/env(/[^\s/]*)?/(\S*)(\s)',
+                    (r'\4\5'),
+                    makefile_filepath)
+
 
     # ========================================================================
     # Set up environment to make install easy for python extensions.


### PR DESCRIPTION
My regex-fu is not particularly strong, so I don't know if this is the most elegant/robust solution, however, this appears to fix issue #431. I able to build compiled site-packages, such as numpy and scipy, both via spack and manually outside of spack.