### PR TITLE
fix name collision in svn-based resources

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -296,8 +296,9 @@ def resource(pkg, **kwargs):
         raise RuntimeError(message)
     when_spec = parse_anonymous_spec(when, pkg.name)
     resources = pkg.resources.setdefault(when_spec, [])
-    fetcher = from_kwargs(**kwargs)
     name = kwargs.get('name')
+    del kwargs['name'] # name stripped to avoid collisions in svn and git fetch strategy init methods
+    fetcher = from_kwargs(**kwargs)
     resources.append(Resource(name, fetcher, destination, placement))
 
 


### PR DESCRIPTION
When a name is specified for a resource, it was mistakenly passed along
to the fetch strategy which found itself with two different values for
the name keyword argument when either git or SVN-backed resources were
instantiated.  This just removes the name keyword argument from the list
before passing it to the fetch strategy.