### PR TITLE
Bash Programmable Completion for Spack

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -176,3 +176,10 @@ _spack_pathadd PATH       "${_sp_prefix%/}/bin"
 _sp_sys_type=$(spack-python -c 'print(spack.architecture.sys_type())')
 _spack_pathadd DK_NODE    "${_sp_share_dir%/}/dotkit/$_sp_sys_type"
 _spack_pathadd MODULEPATH "${_sp_share_dir%/}/modules/$_sp_sys_type"
+
+#
+# Add programmable tab completion for Bash
+#
+if [[ "$SHELL" == *bash ]]; then
+    source $_sp_share_dir/spack-completion.bash
+fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -418,26 +418,188 @@ function _spack_patch {
     fi
 }
 
-#function _spack_pkg {
-#function _spack_providers {
-#function _spack_purge {
-#function _spack_python {
-#function _spack_reindex {
-#function _spack_repo {
-#function _spack_restage {
-#function _spack_spec {
-#function _spack_stage {
-#function _spack_test {
-#function _spack_test-install {
-#function _spack_uninstall {
-#function _spack_unload {
-#function _spack_unuse {
-#function _spack_url-parse {
-#function _spack_urls {
-#function _spack_use {
-#function _spack_versions {
+function _spack_pkg {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "add added diff list removed" -- "$cur"
+    fi
+}
 
+function _spack_pkg_add {
+    # `spack pkg add` has no valid options
+    :
+}
 
+function _spack_pkg_added {
+    # `spack pkg added` has no valid options
+    :
+}
+
+function _spack_pkg_diff {
+    # `spack pkg diff` has no valid options
+    :
+}
+
+function _spack_pkg_list {
+    # `spack pkg list` has no valid options
+    :
+}
+
+function _spack_pkg_removed {
+    # `spack pkg removed` has no valid options
+    :
+}
+
+function _spack_providers {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "blas elf lapack mpe mpi scalapack" -- "$cur"
+    fi
+}
+
+function _spack_purge {
+    compgen -W "-h --help" -- "$cur"
+}
+
+function _spack_python {
+    if $list_options
+    then
+        compgen -W "-h --help -c" -- "$cur"
+    else
+        compgen -o filenames -- "$cur"
+    fi
+}
+
+function _spack_reindex {
+    compgen -W "-h --help" -- "$cur"
+}
+
+function _spack_repo {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "add create list remove" -- "$cur"
+    fi
+}
+
+function _spack_repo_add {
+    # `spack repo add` has no valid options
+    :
+}
+
+function _spack_repo_create {
+    # `spack repo create` has no valid options
+    :
+}
+
+function _spack_repo_list {
+    # `spack repo list` has no valid options
+    :
+}
+
+function _spack_repo_remove {
+    compgen -W "$(_repos)" -- "$cur"
+}
+
+function _spack_restage {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_spec {
+    if $list_options
+    then
+        compgen -W "-h --help -i --ids" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_stage {
+    if $list_options
+    then
+        compgen -W "-h --help -n --no-checksum" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_test {
+    # TODO: What does this subcommand even do?
+    compgen -W "-h --help -l --list --createXmlOutput --xmlOutputDir
+                -v --verbose" -- "$cur"
+}
+
+function _spack_test-install {
+    if $list_options
+    then
+        compgen -W "-h --help -j --jobs -n --no-checksum -o --output" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_uninstall {
+    if $list_options
+    then
+        compgen -W "-h --help -f --force -a --all" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
+function _spack_unload {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)"
+    fi
+}
+
+function _spack_unuse {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)"
+    fi
+}
+
+function _spack_url-parse {
+    compgen -W "-h --help -s --spider" -- "$cur"
+}
+
+function _spack_urls {
+    compgen -W "-h --help -c --color -e --extrapolation" -- "$cur"
+}
+
+function _spack_use {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
+function _spack_versions {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
 
 function _subcommands {
     spack help | grep "^    [a-z]" | awk '{print $1}'
@@ -457,6 +619,10 @@ function _installed_compilers {
 
 function _mirrors {
     spack mirror list | awk '{print $1}'
+}
+
+function _repos {
+    spack repo list
 }
 
 function test_vars {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -32,7 +32,7 @@ function _bash_completion_spack {
     # Options will be listed by a subfunction named after non-flag arguments.
     # For example, `spack -d install []` will call _spack_install
     # and `spack compiler add []` will call _spack_compiler_add
-    subfunction=$(IFS=_; echo "_${COMP_WORDS_NO_FLAGS[@]}")
+    subfunction=$(IFS='_'; echo "_${COMP_WORDS_NO_FLAGS[*]}")
 
     # However, the word containing the current cursor position needs to be
     # added regardless of whether or not it is a flag. This allows us to
@@ -80,13 +80,15 @@ function _bash_completion_spack {
     local cur=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS]}
     local prev=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS-1]}
 
-    #test_vars
+    test_vars
 
-    COMPREPLY=($($subcommand))
+    # TODO: Make sure function exists before calling it
+    COMPREPLY=($($subfunction))
 }
 
 function _spack {
     if $list_options
+    then
         compgen -W "-h --help -d --debug -D --pdb -k --insecure -m --mock -p
                     --profile -v --verbose -V --version" -- "$cur"
     else
@@ -141,7 +143,7 @@ function _spack_checksum {
 function _spack_clean {
     if $list_options
     then
-        compgen -W "-h --help"
+        compgen -W "-h --help" -- "$cur"
     else
         compgen -W "$(_available_packages)" -- "$cur"
     fi
@@ -152,7 +154,7 @@ function _spack_compiler {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "add remove list info"
+        compgen -W "add info list remove" -- "$cur"
     fi
 }
 
@@ -160,15 +162,16 @@ function _spack_compiler_add {
     compgen -o dirnames -- "$cur"
 }
 
-function _spack_compiler_remove {
+function _spack_compiler_info {
     compgen -W "$(_installed_compilers)" -- "$cur"
 }
 
 function _spack_compiler_list {
     # `spack compiler list` has no valid options
+    :
 }
 
-function _spack_compiler_info {
+function _spack_compiler_remove {
     compgen -W "$(_installed_compilers)" -- "$cur"
 }
 
@@ -181,16 +184,16 @@ function _spack_config {
     then
         compgen -W "-h --help --user --site" -- "$cur"
     else
-        compgen -W "edit get"
+        compgen -W "edit get" -- "$cur"
     fi
 }
 
 function _spack_config_edit {
-    compgen -W "compilers mirrors" # TODO: more?
+    compgen -W "compilers mirrors" -- "$cur" # TODO: more?
 }
 
 function _spack_config_get {
-    compgen -W "compilers mirrors" # TODO: more?
+    compgen -W "compilers mirrors" -- "$cur" # TODO: more?
 }
 
 function _spack_create {
@@ -211,7 +214,7 @@ function _spack_deactivate {
 function _spack_dependents {
     if $list_options
     then
-        compgen -W "-h --help"
+        compgen -W "-h --help" -- "$cur"
     else
         compgen -W "$(_available_packages)" -- "$cur"
     fi
@@ -315,36 +318,124 @@ function _spack_install {
         compgen -W "-h --help -i --ignore-dependencies -j --jobs --keep-prefix
                     --keep-stage -n --no-checksum -v --verbose --fake" -- "$cur"
     else
-        compgen -W "$(_spack_available_packages)" -- "$cur"
+        compgen -W "$(_available_packages)" -- "$cur"
     fi
 }
 
 function _spack_list {
+    if $list_options
+    then
+        compgen -W "-h --help -i --insensitive" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
 function _spack_load {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
 function _spack_location {
+    if $list_options
+    then
+        compgen -W "-h --help -m --module-dir -r --spack-root -i --install-dir
+                    -p --package-dir -P --packages -s --stage-dir -S --stages
+                    -b --build-dir" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
 function _spack_md5 {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -o filenames -- "$cur"
+    fi
+}
+
 function _spack_mirror {
+    if $list_options
+    then
+        compgen -W "-h --help -n --no-checksum" -- "$cur"
+    else
+        compgen -W "add create list remove" -- "$cur"
+    fi
+}
+
+function _spack_mirror_add {
+    compgen -o dirnames -- "$cur"
+}
+
+function _spack_mirror_create {
+    compgen -W "$(_available_packages)" -- "$cur"
+}
+
+function _spack_mirror_list {
+    # `spack mirror list` has no valid options
+    :
+}
+
+function _spack_mirror_remove {
+    compgen -W "$(_mirrors)" -- "$cur"
+}
+
 function _spack_module {
+    if $list_compilers
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "find refresh" -- "$cur"
+    fi
+}
+
+function _spack_module_find {
+    # `spack module find` has no valid options
+    :
+}
+
+function _spack_module_refresh {
+    # `spack module refresh` has no valid arguments
+    :
+}
+
 function _spack_package-list {
+    compgen -W "-h --help" -- "$cur"
+}
+
 function _spack_patch {
-function _spack_pkg {
-function _spack_providers {
-function _spack_purge {
-function _spack_python {
-function _spack_reindex {
-function _spack_repo {
-function _spack_restage {
-function _spack_spec {
-function _spack_stage {
-function _spack_test {
-function _spack_test-install {
-function _spack_uninstall {
-function _spack_unload {
-function _spack_unuse {
-function _spack_url-parse {
-function _spack_urls {
-function _spack_use {
-function _spack_versions {
+    if $list_options
+    then
+        compgen -W "-h --help -n --no-checksum" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+#function _spack_pkg {
+#function _spack_providers {
+#function _spack_purge {
+#function _spack_python {
+#function _spack_reindex {
+#function _spack_repo {
+#function _spack_restage {
+#function _spack_spec {
+#function _spack_stage {
+#function _spack_test {
+#function _spack_test-install {
+#function _spack_uninstall {
+#function _spack_unload {
+#function _spack_unuse {
+#function _spack_url-parse {
+#function _spack_urls {
+#function _spack_use {
+#function _spack_versions {
 
 
 
@@ -364,26 +455,31 @@ function _installed_compilers {
     spack compilers | grep -v "^--"
 }
 
+function _mirrors {
+    spack mirror list | awk '{print $1}'
+}
+
 function test_vars {
-    echo "-----------------------------------------------------"            >> ~/temp
-    echo "Full line:                '$COMP_LINE'"                           >> ~/temp
-    echo                                                                    >> ~/temp
-    echo "Word list w/ flags:       $(pretty_print COMP_WORDS[@])"          >> ~/temp
-    echo "# words w/ flags:         '${#COMP_WORDS[@]}'"                    >> ~/temp
-    echo "Cursor index w/ flags:    '$COMP_CWORD'"                          >> ~/temp
-    echo                                                                    >> ~/temp
-    echo "Word list w/out flags:    $(pretty_print COMP_WORDS_NO_FLAGS[@])" >> ~/temp
-    echo "# words w/out flags:      '${#COMP_WORDS_NO_FLAGS[@]}'"           >> ~/temp
-    echo "Cursor index w/out flags: '$COMP_CWORD_NO_FLAGS'"                 >> ~/temp
-    echo                                                                    >> ~/temp
+    echo "-----------------------------------------------------"            >> temp
+    echo "Full line:                '$COMP_LINE'"                           >> temp
+    echo                                                                    >> temp
+    echo "Word list w/ flags:       $(pretty_print COMP_WORDS[@])"          >> temp
+    echo "# words w/ flags:         '${#COMP_WORDS[@]}'"                    >> temp
+    echo "Cursor index w/ flags:    '$COMP_CWORD'"                          >> temp
+    echo                                                                    >> temp
+    echo "Word list w/out flags:    $(pretty_print COMP_WORDS_NO_FLAGS[@])" >> temp
+    echo "# words w/out flags:      '${#COMP_WORDS_NO_FLAGS[@]}'"           >> temp
+    echo "Cursor index w/out flags: '$COMP_CWORD_NO_FLAGS'"                 >> temp
+    echo                                                                    >> temp
+    echo "Subfunction:              '$subfunction'"                         >> temp
     if $list_options
     then
-        echo "List options:             'True'"  >> ~/temp
+        echo "List options:             'True'"  >> temp
     else
-        echo "List options:             'False'" >> ~/temp
+        echo "List options:             'False'" >> temp
     fi
-    echo "Current word:             '$cur'"  >> ~/temp
-    echo "Previous word:            '$prev'" >> ~/temp
+    echo "Current word:             '$cur'"  >> temp
+    echo "Previous word:            '$prev'" >> temp
 }
 
 # Pretty-prints one or more arrays

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 
+# The following global variables are used/set by Bash programmable completion
+#     COMP_CWORD: An index into ${COMP_WORDS} of the word containing the
+#                 current cursor position
+#     COMP_LINE:  The current command line
+#     COMP_WORDS: an array containing individual command arguments typed so far
+#     COMPREPLY:  an array containing possible completions as a result of your
+#                 function
 
+# Bash programmable completion for Spack
 function _bash_completion_spack {
-    # Bash programmable completion for Spack
-    #
-    # The following variables are useful for Bash completion:
-    #     COMP_CWORD: An index into ${COMP_WORDS} of the word containing the current cursor position
-    #     COMP_KEY:   The key (or final key of a key sequence) used to invoke the current completion function
-    #     COMP_LINE:  The current command line
-    #     COMP_POINT: The index of the current cursor position relative to the beginning of the current command
-    #     COMP_TYPE:  Set to an integer value corresponding to the type of completion attempted
-    #     COMP_WORDS: an array containing individual command arguments typed so far
-    #     COMPREPLY:  an array containing possible completions as a result of your function
-
     # In all following examples, let the cursor be denoted by brackets, i.e. []
 
     # For our purposes, flags should not affect tab completion. For instance,
-    # `spack install []` and `spack -d install []` should both give the same
+    # `spack install []` and `spack -d install --jobs 8 []` should both give the same
     # possible completions. Therefore, we need to ignore any flags in COMP_WORDS.
     local COMP_WORDS_NO_FLAGS=()
     local index=0
@@ -32,7 +29,7 @@ function _bash_completion_spack {
     # Options will be listed by a subfunction named after non-flag arguments.
     # For example, `spack -d install []` will call _spack_install
     # and `spack compiler add []` will call _spack_compiler_add
-    subfunction=$(IFS='_'; echo "_${COMP_WORDS_NO_FLAGS[*]}")
+    local subfunction=$(IFS='_'; echo "_${COMP_WORDS_NO_FLAGS[*]}")
 
     # However, the word containing the current cursor position needs to be
     # added regardless of whether or not it is a flag. This allows us to
@@ -60,14 +57,11 @@ function _bash_completion_spack {
         list_options=true
     fi
 
-
-
-    # TODO:
     # In general, when envoking tab completion, the user is not expecting to
     # see optional flags mixed in with subcommands or package names. Tab
-    # completion is used by the lazy and by those who are bad at spelling.
+    # completion is used by those who are either lazy or just bad at spelling.
     # If someone doesn't remember what flag to use, seeing single letter flags
-    # in their results won't help them, and they should consult the
+    # in their results won't help them, and they should instead consult the
     # documentation. However, if the user explicitly declares that they are
     # looking for a flag, we can certainly help them out.
     #     `spack install -[]`
@@ -80,10 +74,13 @@ function _bash_completion_spack {
     local cur=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS]}
     local prev=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS-1]}
 
-    test_vars
+    #test_vars
 
-    # TODO: Make sure function exists before calling it
-    COMPREPLY=($($subfunction))
+    # Make sure function exists before calling it
+    if [[ "$(type -t $subfunction)" == "function" ]]
+    then
+        COMPREPLY=($($subfunction))
+    fi
 }
 
 function _spack {
@@ -127,7 +124,7 @@ function _spack_cd {
                     -p --package-dir -P --packages -s --stage-dir -S --stages
                     -b --build-dir" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -136,7 +133,7 @@ function _spack_checksum {
     then
         compgen -W "-h --help --keep-stage" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -145,7 +142,7 @@ function _spack_clean {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -216,7 +213,7 @@ function _spack_dependents {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -226,7 +223,7 @@ function _spack_diy {
         compgen -W "-h --help -i --ignore-dependencies --keep-prefix
                     --skip-patch" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -241,7 +238,7 @@ function _spack_edit {
         compgen -W "-h --help -f --force -c --command -t --test -m --module
                     -r --repo -N --namespace" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -250,7 +247,7 @@ function _spack_env {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -270,7 +267,7 @@ function _spack_fetch {
         compgen -W "-h --help -n --no-checksum -m --missing
                     -D --dependencies" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -290,7 +287,7 @@ function _spack_graph {
     then
         compgen -W "-h --help --ascii --dot --concretize" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -308,7 +305,7 @@ function _spack_info {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -318,7 +315,7 @@ function _spack_install {
         compgen -W "-h --help -i --ignore-dependencies -j --jobs --keep-prefix
                     --keep-stage -n --no-checksum -v --verbose --fake" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -327,7 +324,7 @@ function _spack_list {
     then
         compgen -W "-h --help -i --insensitive" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -347,7 +344,7 @@ function _spack_location {
                     -p --package-dir -P --packages -s --stage-dir -S --stages
                     -b --build-dir" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -374,7 +371,7 @@ function _spack_mirror_add {
 }
 
 function _spack_mirror_create {
-    compgen -W "$(_available_packages)" -- "$cur"
+    compgen -W "$(_all_packages)" -- "$cur"
 }
 
 function _spack_mirror_list {
@@ -414,7 +411,7 @@ function _spack_patch {
     then
         compgen -W "-h --help -n --no-checksum" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -511,7 +508,7 @@ function _spack_restage {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -520,7 +517,7 @@ function _spack_spec {
     then
         compgen -W "-h --help -i --ids" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -529,7 +526,7 @@ function _spack_stage {
     then
         compgen -W "-h --help -n --no-checksum" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -544,7 +541,7 @@ function _spack_test-install {
     then
         compgen -W "-h --help -j --jobs -n --no-checksum -o --output" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -597,7 +594,7 @@ function _spack_versions {
     then
         compgen -W "-h --help" -- "$cur"
     else
-        compgen -W "$(_available_packages)" -- "$cur"
+        compgen -W "$(_all_packages)" -- "$cur"
     fi
 }
 
@@ -605,12 +602,13 @@ function _subcommands {
     spack help | grep "^    [a-z]" | awk '{print $1}'
 }
 
-function _available_packages {
+function _all_packages {
     spack list
 }
 
 function _installed_packages {
-    spack find | grep -v "^--"
+    # Perl one-liner used to strip out color codes
+    spack find | grep -v "^--" | perl -pe 's/\e\[?.*?[\@-~]//g'
 }
 
 function _installed_compilers {
@@ -622,7 +620,7 @@ function _mirrors {
 }
 
 function _repos {
-    spack repo list
+    spack repo list | awk '{print $1}'
 }
 
 function test_vars {
@@ -661,7 +659,5 @@ function pretty_print {
     done
 }
 
-
 complete -F _bash_completion_spack spack
-
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -612,7 +612,7 @@ function _installed_packages {
 }
 
 function _installed_compilers {
-    spack compilers | grep -v "^--"
+    spack compilers | egrep -v "^(-|=)"
 }
 
 function _mirrors {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+
+
+function _bash_completion_spack {
+    # Bash programmable completion for Spack
+    #
+    # The following variables are useful for Bash completion:
+    #     COMP_CWORD: An index into ${COMP_WORDS} of the word containing the current cursor position
+    #     COMP_KEY:   The key (or final key of a key sequence) used to invoke the current completion function
+    #     COMP_LINE:  The current command line
+    #     COMP_POINT: The index of the current cursor position relative to the beginning of the current command
+    #     COMP_TYPE:  Set to an integer value corresponding to the type of completion attempted
+    #     COMP_WORDS: an array containing individual command arguments typed so far
+    #     COMPREPLY:  an array containing possible completions as a result of your function
+
+    # In all following examples, let the cursor be denoted by brackets, i.e. []
+
+    # For our purposes, flags should not affect tab completion. For instance,
+    # `spack install []` and `spack -d install []` should both give the same
+    # possible completions. Therefore, we need to ignore any flags in COMP_WORDS.
+    local COMP_WORDS_NO_FLAGS=()
+    local index=0
+    while [[ "$index" -lt "$COMP_CWORD" ]]
+    do
+        if [[ "${COMP_WORDS[$index]}" == [a-z]* ]]
+        then
+            COMP_WORDS_NO_FLAGS+=("${COMP_WORDS[$index]}")
+        fi
+        let index++
+    done
+
+    # Options will be listed by a subfunction named after non-flag arguments.
+    # For example, `spack -d install []` will call _spack_install
+    # and `spack compiler add []` will call _spack_compiler_add
+    subfunction=$(IFS=_; echo "_${COMP_WORDS_NO_FLAGS[@]}")
+
+    # However, the word containing the current cursor position needs to be
+    # added regardless of whether or not it is a flag. This allows us to
+    # complete something like `spack install --keep-st[]`
+    COMP_WORDS_NO_FLAGS+=("${COMP_WORDS[$COMP_CWORD]}")
+
+    # Since we have removed all words after COMP_CWORD, we can safely assume
+    # that COMP_CWORD_NO_FLAGS is simply the index of the last element
+    local COMP_CWORD_NO_FLAGS=$(( ${#COMP_WORDS_NO_FLAGS[@]} - 1 ))
+
+    # There is no guarantee that the cursor is at the end of the command line
+    # when tab completion is envoked. For example, in the following situation:
+    #     `spack -d [] install`
+    # if the user presses the TAB key, a list of valid flags should be listed.
+    # Note that we cannot simply ignore everything after the cursor. In the
+    # previous scenario, the user should expect to see a list of flags, but
+    # not of other subcommands. Obviously, `spack -d list install` would be
+    # invalid syntax. To accomplish this, we use the variable list_options
+    # which is true if the current word starts with '-' or if the cursor is
+    # not at the end of the line.
+    local list_options=false
+    if [[ "${COMP_WORDS[$COMP_CWORD]}" == -* || \
+          "$COMP_CWORD" -ne "${#COMP_WORDS[@]}-1" ]]
+    then
+        list_options=true
+    fi
+
+
+
+    # TODO:
+    # In general, when envoking tab completion, the user is not expecting to
+    # see optional flags mixed in with subcommands or package names. Tab
+    # completion is used by the lazy and by those who are bad at spelling.
+    # If someone doesn't remember what flag to use, seeing single letter flags
+    # in their results won't help them, and they should consult the
+    # documentation. However, if the user explicitly declares that they are
+    # looking for a flag, we can certainly help them out.
+    #     `spack install -[]`
+    # and
+    #     `spack install --[]`
+    # should list all flags and long flags, respectively. Furthermore, if a
+    # subcommand has no non-flag completions, such as `spack arch []`, it
+    # should list flag completions.
+
+    local cur=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS]}
+    local prev=${COMP_WORDS_NO_FLAGS[$COMP_CWORD_NO_FLAGS-1]}
+
+    #test_vars
+
+    COMPREPLY=($($subcommand))
+}
+
+function _spack {
+    if $list_options
+        compgen -W "-h --help -d --debug -D --pdb -k --insecure -m --mock -p
+                    --profile -v --verbose -V --version" -- "$cur"
+    else
+        compgen -W "$(_subcommands)" -- "$cur"
+    fi
+}
+
+function _spack_activate {
+    if $list_options
+    then
+        compgen -W "-h --help -f --force" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
+function _spack_arch {
+    # `spack arch` has no non-flag options
+    # Always list options
+    compgen -W "-h --help" -- "$cur"
+}
+
+function _spack_bootstrap {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -o dirnames -- "$cur"
+    fi
+}
+
+function _spack_cd {
+    if $list_options
+    then
+        compgen -W "-h --help -m --module-dir -r --spack-root -i --install-dir
+                    -p --package-dir -P --packages -s --stage-dir -S --stages
+                    -b --build-dir" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_checksum {
+    if $list_options
+    then
+        compgen -W "-h --help --keep-stage" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_clean {
+    if $list_options
+    then
+        compgen -W "-h --help"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_compiler {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "add remove list info"
+    fi
+}
+
+function _spack_compiler_add {
+    compgen -o dirnames -- "$cur"
+}
+
+function _spack_compiler_remove {
+    compgen -W "$(_installed_compilers)" -- "$cur"
+}
+
+function _spack_compiler_list {
+    # `spack compiler list` has no valid options
+}
+
+function _spack_compiler_info {
+    compgen -W "$(_installed_compilers)" -- "$cur"
+}
+
+function _spack_compilers {
+    compgen -W "-h --help --scope" -- "$cur"
+}
+
+function _spack_config {
+    if $list_options
+    then
+        compgen -W "-h --help --user --site" -- "$cur"
+    else
+        compgen -W "edit get"
+    fi
+}
+
+function _spack_config_edit {
+    compgen -W "compilers mirrors" # TODO: more?
+}
+
+function _spack_config_get {
+    compgen -W "compilers mirrors" # TODO: more?
+}
+
+function _spack_create {
+    # You can't complet a URL. Just list options
+    compgen -W "-h --help --keep-stage -n --name -r --repo -N --namespace
+                -f --force" -- "$cur"
+}
+
+function _spack_deactivate {
+    if $list_options
+    then
+        compgen -W "-h --help -f --force -a --all" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
+function _spack_dependents {
+    if $list_options
+    then
+        compgen -W "-h --help"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_diy {
+    if $list_options
+    then
+        compgen -W "-h --help -i --ignore-dependencies --keep-prefix
+                    --skip-patch" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_doc {
+    # TODO: What does this function even do?
+    compgen -W "-h --help" -- "$cur"
+}
+
+function _spack_edit {
+    if $list_options
+    then
+        compgen -W "-h --help -f --force -c --command -t --test -m --module
+                    -r --repo -N --namespace" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_env {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_extensions {
+    if $list_options
+    then
+        compgen -W "-h --help -l --long -p --paths -d --deps" -- "$cur"
+    else
+        # TODO: Is Python currently the only package that can be extended?
+        compgen -W "python" -- "$cur"
+    fi
+}
+
+function _spack_fetch {
+    if $list_options
+    then
+        compgen -W "-h --help -n --no-checksum -m --missing
+                    -D --dependencies" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_find {
+    if $list_options
+    then
+        compgen -W "-h --help -s --short -p --paths -d --deps -l --long
+                    -L --very-long -u --unknown -m --missing -M --only-missing
+                    -N --namespace" -- "$cur"
+    else
+        compgen -W "$(_installed_packages)" -- "$cur"
+    fi
+}
+
+function _spack_graph {
+    if $list_options
+    then
+        compgen -W "-h --help --ascii --dot --concretize" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_help {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_subcommands)" -- "$cur"
+    fi
+}
+
+function _spack_info {
+    if $list_options
+    then
+        compgen -W "-h --help" -- "$cur"
+    else
+        compgen -W "$(_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_install {
+    if $list_options
+    then
+        compgen -W "-h --help -i --ignore-dependencies -j --jobs --keep-prefix
+                    --keep-stage -n --no-checksum -v --verbose --fake" -- "$cur"
+    else
+        compgen -W "$(_spack_available_packages)" -- "$cur"
+    fi
+}
+
+function _spack_list {
+function _spack_load {
+function _spack_location {
+function _spack_md5 {
+function _spack_mirror {
+function _spack_module {
+function _spack_package-list {
+function _spack_patch {
+function _spack_pkg {
+function _spack_providers {
+function _spack_purge {
+function _spack_python {
+function _spack_reindex {
+function _spack_repo {
+function _spack_restage {
+function _spack_spec {
+function _spack_stage {
+function _spack_test {
+function _spack_test-install {
+function _spack_uninstall {
+function _spack_unload {
+function _spack_unuse {
+function _spack_url-parse {
+function _spack_urls {
+function _spack_use {
+function _spack_versions {
+
+
+
+function _subcommands {
+    spack help | grep "^    [a-z]" | awk '{print $1}'
+}
+
+function _available_packages {
+    spack list
+}
+
+function _installed_packages {
+    spack find | grep -v "^--"
+}
+
+function _installed_compilers {
+    spack compilers | grep -v "^--"
+}
+
+function test_vars {
+    echo "-----------------------------------------------------"            >> ~/temp
+    echo "Full line:                '$COMP_LINE'"                           >> ~/temp
+    echo                                                                    >> ~/temp
+    echo "Word list w/ flags:       $(pretty_print COMP_WORDS[@])"          >> ~/temp
+    echo "# words w/ flags:         '${#COMP_WORDS[@]}'"                    >> ~/temp
+    echo "Cursor index w/ flags:    '$COMP_CWORD'"                          >> ~/temp
+    echo                                                                    >> ~/temp
+    echo "Word list w/out flags:    $(pretty_print COMP_WORDS_NO_FLAGS[@])" >> ~/temp
+    echo "# words w/out flags:      '${#COMP_WORDS_NO_FLAGS[@]}'"           >> ~/temp
+    echo "Cursor index w/out flags: '$COMP_CWORD_NO_FLAGS'"                 >> ~/temp
+    echo                                                                    >> ~/temp
+    if $list_options
+    then
+        echo "List options:             'True'"  >> ~/temp
+    else
+        echo "List options:             'False'" >> ~/temp
+    fi
+    echo "Current word:             '$cur'"  >> ~/temp
+    echo "Previous word:            '$prev'" >> ~/temp
+}
+
+# Pretty-prints one or more arrays
+# Syntax: pretty_print array1[@] ...
+function pretty_print {
+    for arg in $@
+    do
+        local array=("${!arg}")
+        echo -n "$arg: ["
+        printf   "'%s'" "${array[0]}"
+        printf ", '%s'" "${array[@]:1}"
+        echo "]"
+    done
+}
+
+
+complete -F _bash_completion_spack spack
+
+

--- a/var/spack/repos/builtin/packages/py-argcomplete/package.py
+++ b/var/spack/repos/builtin/packages/py-argcomplete/package.py
@@ -1,0 +1,14 @@
+from spack import *
+
+class PyArgcomplete(Package):
+    """Bash tab completion for argparse."""
+
+    homepage = "https://pypi.python.org/pypi/argcomplete"
+    url      = "https://pypi.python.org/packages/source/a/argcomplete/argcomplete-1.1.0.tar.gz"
+
+    version('1.1.0', '07504963b54e6af8aa8c51a4913bbbe3')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
Do you have trouble remembering the ordering for `spack config edit compilers`? Do you have to run `spack list 'py-*'` before installing any Python package because you can't remember the spelling of `py-mysqldb1`? Don't you wish you could just tab-to-complete everything? Allow me to introduce Bash Programmable Completion for Spack!

To add tab completion, simply source setup-env.sh from a Bash shell. Here is an example session. In the following examples, let the cursor be denoted by brackets, i.e. [], and assume that the user presses <kbd>TAB</kbd><kbd>TAB</kbd> at the cursor position:

```bash
$ spack []
activate      create        find          mirror        repo          url-parse
arch          deactivate    graph         module        restage       urls
bootstrap     dependents    help          package-list  spec          use
cd            diy           info          patch         stage         versions
checksum      doc           install       pkg           test          
clean         edit          list          providers     test-install  
compiler      env           load          purge         uninstall     
compilers     extensions    location      python        unload        
config        fetch         md5           reindex       unuse         
$ spack con[]
$ spack config []
edit  get   
$ spack config e[]
$ spack config edit []
compilers  mirrors    
$ spack config edit c[]
$ spack config edit compilers  # the full command
```

```bash
$ spack in[]
info     install  
$ spack ins[]
$ spack install []
Display all 320 possibilities? (y or n)  # lists all 320 available packages
$ spack install py-[]
py-astropy           py-mako              py-pmw               py-scikit-learn
py-basemap           py-matplotlib        py-pychecker         py-scipy
py-biopython         py-mock              py-pycparser         py-setuptools
py-blessings         py-mpi4py            py-pyelftools        py-shiboken
py-cffi              py-mx                py-pygments          py-sip
py-coverage          py-mysqldb1          py-pylint            py-six
py-cython            py-nose              py-pypar             py-sphinx
py-dateutil          py-numexpr           py-pyparsing         py-sympy
py-epydoc            py-numpy             py-pyqt              py-tappy
py-funcsigs          py-pandas            py-pyside            py-twisted
py-genders           py-pbr               py-pytables          py-urwid
py-gnuplot           py-periodictable     py-python-daemon     py-virtualenv
py-h5py              py-pexpect           py-pytz              py-wheel
py-ipython           py-phonopy           py-pyyaml            py-yapf
py-libxml2           py-pil               py-rpy2              
py-lockfile          py-pillow            py-scientificpython  
$ spack install py-numpy []
$ spack install --[] py-numpy  # whoops, forgot to add an option
--fake                 --ignore-dependencies  --keep-prefix          --no-checksum
--help                 --jobs                 --keep-stage           --verbose
$ spack install --v[] py-numpy
$ spack install --verbose[] py-numpy  # the complete command
```