### PR TITLE
Update Package : Silo

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -1,19 +1,28 @@
 from spack import *
 
 class Silo(Package):
-    """Silo is a library for reading and writing a wide variety of scientific data to binary, disk files."""
+    """Silo is a library for reading and writing a wide variety of scientific
+       data to binary, disk files."""
 
     homepage = "http://wci.llnl.gov/simulation/computer-codes/silo"
     url      = "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.8/silo-4.8.tar.gz"
 
-    #version('4.9', 'a83eda4f06761a86726e918fc55e782a')
     version('4.8', 'b1cbc0e7ec435eb656dc4b53a23663c9')
 
-    depends_on("hdf5@:1.8.12")
+    variant('fortran', default=True, description='Enable Fortran support')
+
+    depends_on("hdf5")
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix,
-                  "--with-hdf5=%s" %spec['hdf5'].prefix)
+        config_args = [
+            '--enable-fortran' if '+fortran' in spec else '--disable-fortran',
+        ]
+
+        configure(
+            "--prefix=%s" % prefix,
+            "--with-hdf5=%s,%s" % (spec['hdf5'].prefix.include, spec['hdf5'].prefix.lib),
+            "--with-zlib=%s,%s" % (spec['zlib'].prefix.include, spec['zlib'].prefix.lib),
+            *config_args)
 
         make()
         make("install")


### PR DESCRIPTION
The changes in this pull request update the `silo` package by adding a `+fortran` variant and by improving the dependency locations set during the configuration step.  I've tested out these changes with the `+fortran` variant both enabled and disabled and they seem to work just fine for me.  Please let me know if there any problems with these changes!