### PR TITLE
Added easy site configuration to choose virtual package implementations

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -85,9 +85,10 @@ install_layout = YamlDirectoryLayout(install_path)
 # This controls how things are concretized in spack.
 # Replace it with a subclass if you want different
 # policies.
-#
+
+#choose_hints = {'mpi' : 'openmpi'}
 from spack.concretize import DefaultConcretizer
-concretizer = DefaultConcretizer()
+concretizer = DefaultConcretizer(choose_hints=choose_hints)
 
 # Version information
 from spack.version import Version

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -87,6 +87,7 @@ install_layout = YamlDirectoryLayout(install_path)
 # policies.
 
 #choose_hints = {'mpi' : 'openmpi'}
+choose_hints = {}
 from spack.concretize import DefaultConcretizer
 concretizer = DefaultConcretizer(choose_hints=choose_hints)
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -46,6 +46,9 @@ class DefaultConcretizer(object):
        default concretization strategies, or you can override all of them.
     """
 
+    def __init__(self, choose_hints=dict()):
+        self.choose_hints = choose_hints
+
     def concretize_version(self, spec):
         """If the spec is already concrete, return.  Otherwise take
            the most recent available version, and default to the package's
@@ -191,8 +194,16 @@ class DefaultConcretizer(object):
         assert(providers)
 
         index = spack.spec.index_specs(providers)
-        first_key = sorted(index.keys())[0]
-        latest_version = sorted(index[first_key])[-1]
+        try:
+            # This could fail because:
+            #   a) There is no hint for spec.name (eg: mpi)
+            #   b) The hint for spec.name doesn't correspond to any real provier
+            #      (eg: self.choose_hints['mpi'] == 'sillympi')
+            concrete_versions = index[self.choose_hints[spec.name]]
+        except:
+            concrete_versions = index[sorted(index.keys())[0]]
+
+        latest_version = sorted(concrete_versions)[-1]
         return latest_version
 
 


### PR DESCRIPTION
Added a simple way to configure a site to use a particular choice for virtual packages, while maintainig backwards compatibility.  It may be used by putting in spack/__init__.py, for example:

     choose_hints = {'mpi' : 'openmpi'}
     from spack.concretize import DefaultConcretizer
     concretizer = DefaultConcretizer(choose_hints=choose_hints)

This produces the following result:

    $ spack spec netcdf

    Concretized
    ------------------------------
      netcdf@4.4.0%gcc@4.9.3~fortran~hdf4+mpi=linux-x86_64
          ^curl@7.46.0%gcc@4.9.3=linux-x86_64
              ^zlib@1.2.8%gcc@4.9.3=linux-x86_64
          ^hdf5@1.8.16%gcc@4.9.3~cxx~debug+fortran+mpi+shared~szip~threadsafe+unsupported=linux-x86_64
              ^openmpi@1.10.2%gcc@4.9.3~psm~tm~verbs=linux-x86_64
                  ^hwloc@1.11.2%gcc@4.9.3=linux-x86_64
                      ^libpciaccess@0.13.4%gcc@4.9.3=linux-x86_64
                          ^libtool@2.4.6%gcc@4.9.3=linux-x86_64

on branches efischer/160301-ChooseHints, origin/efischer/160301-ChooseHints
branches efischer/160301-ChooseHints, origin/efischer/160301-ChooseHints
