### PR TITLE
Developer support for CMake-based Projects

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -158,8 +158,8 @@ sys_type = None
 # TODO: it's not clear where all the stuff that needs to be included in packages
 #       should live.  This file is overloaded for spack core vs. for packages.
 #
-__all__ = ['Package', 'Version', 'when', 'ver']
-from spack.package import Package, ExtensionConflictError
+__all__ = ['Package', 'CMakePackage', 'Version', 'when', 'ver']
+from spack.package import Package, CMakePackage, ExtensionConflictError
 from spack.version import Version, ver
 from spack.multimethod import when
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -33,6 +33,7 @@ import shutil
 import multiprocessing
 import platform
 from llnl.util.filesystem import *
+import llnl.util.tty as tty
 
 import spack
 import spack.compilers as compilers
@@ -205,14 +206,7 @@ def set_module_variables_for_package(pkg, m):
     m.cmake = which("cmake")
 
     # standard CMake arguments
-    m.std_cmake_args = ['-DCMAKE_INSTALL_PREFIX=%s' % pkg.prefix,
-                        '-DCMAKE_BUILD_TYPE=RelWithDebInfo']
-    if platform.mac_ver()[0]:
-        m.std_cmake_args.append('-DCMAKE_FIND_FRAMEWORK=LAST')
-
-    # Set up CMake rpath
-    m.std_cmake_args.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE')
-    m.std_cmake_args.append('-DCMAKE_INSTALL_RPATH=%s' % ":".join(get_rpaths(pkg)))
+    m.std_cmake_args = get_std_cmake_args(pkg)
 
     # Emulate some shell commands for convenience
     m.pwd          = os.getcwd
@@ -243,6 +237,18 @@ def get_rpaths(pkg):
                   if os.path.isdir(d.prefix.lib64))
     return rpaths
 
+def get_std_cmake_args(cmake_pkg):
+    # standard CMake arguments
+    ret = ['-DCMAKE_INSTALL_PREFIX=%s' % cmake_pkg.prefix,
+        '-DCMAKE_BUILD_TYPE=RelWithDebInfo']
+    if platform.mac_ver()[0]:
+        ret.append('-DCMAKE_FIND_FRAMEWORK=LAST')
+
+    # Set up CMake rpath
+    ret.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE')
+    ret.append('-DCMAKE_INSTALL_RPATH=%s' % ":".join(get_rpaths(cmake_pkg)))
+
+    return ret
 
 def parent_class_modules(cls):
     """Get list of super class modules that are all descend from spack.Package"""

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -410,7 +410,7 @@ class DIYStage(object):
     def chdir_to_source(self):
         self.chdir()
 
-    def fetch(self):
+    def fetch(self, *args, **kwargs):
         tty.msg("No need to fetch for DIY.")
 
     def check(self):

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -1,0 +1,25 @@
+# Install with:
+#	   spack diy --skip-patch everytrace@devel +fortran +mpi ^openmpi
+
+from spack import *
+import llnl.util.tty as tty
+import os
+
+class Everytrace(CMakePackage):
+	"""Get stack trace EVERY time a program exits."""
+
+	homepage = "https://github.com/citibeth/everytrace"
+	url		 = "https://github.com/citibeth/everytrace/tarball/dev"
+
+	version('devel', '0123456789abcdef0123456789abcdef')
+
+	variant('mpi', default=True, description='Enables MPI parallelism')
+	variant('fortran', default=True, description='Enable use with Fortran programs')
+
+	depends_on('mpi', when='+mpi')
+	depends_on('cmake')
+
+	def config_args(self, spec, prefix):
+		return [
+			'-DUSE_MPI=%s' % 'YES' if '+mpi' in spec else 'NO',
+			'-DUSE_FORTRAN=%s' % 'YES' if '+fortran' in spec else 'NO']


### PR DESCRIPTION
New CMakePackage subclass of Package.  This has two advantages, without breaking backwards compatibility:

1. Boilerplate code in CMake projects can now be eliminated (see everytrace/package.py for details on how it can be done now).

2. The CMakeProject understands a special version 'local', to enlist Spack to help configure CMake properly when developing projects.  Consider the following example for usage, in which Spack is used to set up a build and a module, but not acutally DO the build.

```
     git clone https://github.com/citibeth/everytrace.git
     cd everytrace
     spack diy --skip-patch everytrace@local
     mkdir build
     cd build
     /usr/bin/python ../spconfig.py ..     # Runs cmake with Spack-supplied configuration
     make
     make install        # Installs into spack directory
     spack load everytrace@local   # Spack even makes a module
```

Once you're happy with your project, you can add appropriate version() commands to your package.py, and use Spack normally with it.  To make this work, your project has to cooperate with Spack, as follows:

  a) You need to use CMake (of course).

  b) Your CMakeLists.txt should use the following line, which will ensure that all TRANSITIVE dependencies are added to the include path.  If you're not running with Spack, then this line will do nothing.
       include_directories($ENV{CMAKE_TRANSITIVE_INCLUDE_PATH})

children d2e52340
on branches efischer/develop, origin/efischer/develop
