### PR TITLE
refactoring proposal : turn Stage into a context manager

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -25,7 +25,7 @@
 __all__ = ['set_install_permissions', 'install', 'install_tree', 'traverse_tree',
            'expand_user', 'working_dir', 'touch', 'touchp', 'mkdirp',
            'force_remove', 'join_path', 'ancestor', 'can_access', 'filter_file',
-           'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink']
+           'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink', 'remove_dead_links']
 
 import os
 import sys
@@ -235,7 +235,7 @@ def touchp(path):
 def force_symlink(src, dest):
     try:
         os.symlink(src, dest)
-    except OSError, e:
+    except OSError as e:
         os.remove(dest)
         os.symlink(src, dest)
 
@@ -339,3 +339,18 @@ def traverse_tree(source_root, dest_root, rel_path='', **kwargs):
 
     if order == 'post':
         yield (source_path, dest_path)
+
+def remove_dead_links(root):
+    """
+    Removes any dead link that is present in root
+
+    Args:
+        root: path where to search for dead links
+
+    """
+    for file in os.listdir(root):
+        path = join_path(root, file)
+        if os.path.islink(path):
+            real_path = os.path.realpath(path)
+            if not os.path.exists(real_path):
+                os.unlink(path)

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -25,7 +25,7 @@
 __all__ = ['set_install_permissions', 'install', 'install_tree', 'traverse_tree',
            'expand_user', 'working_dir', 'touch', 'touchp', 'mkdirp',
            'force_remove', 'join_path', 'ancestor', 'can_access', 'filter_file',
-           'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink', 'remove_dead_links']
+           'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink', 'remove_dead_links', 'remove_linked_tree']
 
 import os
 import sys
@@ -354,3 +354,19 @@ def remove_dead_links(root):
             real_path = os.path.realpath(path)
             if not os.path.exists(real_path):
                 os.unlink(path)
+
+def remove_linked_tree(path):
+    """
+    Removes a directory and its contents.  If the directory is a symlink, follows the link and removes the real
+    directory before removing the link.
+
+    Args:
+        path: directory to be removed
+
+    """
+    if os.path.exists(path):
+        if os.path.islink(path):
+            shutil.rmtree(os.path.realpath(path), True)
+            os.unlink(path)
+        else:
+            shutil.rmtree(path, True)

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -43,4 +43,4 @@ def clean(parser, args):
     specs = spack.cmd.parse_specs(args.packages, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
-        package.do_clean()
+        package.stage.destroy()

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -168,32 +168,33 @@ def create(path, specs, **kwargs):
         pkg = spec.package
         tty.msg("Adding package {pkg} to mirror".format(pkg=spec.format("$_$@")))
         try:
-            for ii, stage in enumerate(pkg.stage):
-                fetcher = stage.fetcher
-                if ii == 0:
-                    # create a subdirectory for the current package@version
-                    archive_path = os.path.abspath(join_path(mirror_root, mirror_archive_path(spec, fetcher)))
-                    name = spec.format("$_$@")
-                else:
-                    resource = stage.resource
-                    archive_path = join_path(subdir, suggest_archive_basename(resource))
-                    name = "{resource} ({pkg}).".format(resource=resource.name, pkg=spec.format("$_$@"))
-                subdir = os.path.dirname(archive_path)
-                mkdirp(subdir)
+            with pkg.stage:
+                for ii, stage in enumerate(pkg.stage):
+                    fetcher = stage.fetcher
+                    if ii == 0:
+                        # create a subdirectory for the current package@version
+                        archive_path = os.path.abspath(join_path(mirror_root, mirror_archive_path(spec, fetcher)))
+                        name = spec.format("$_$@")
+                    else:
+                        resource = stage.resource
+                        archive_path = join_path(subdir, suggest_archive_basename(resource))
+                        name = "{resource} ({pkg}).".format(resource=resource.name, pkg=spec.format("$_$@"))
+                    subdir = os.path.dirname(archive_path)
+                    mkdirp(subdir)
 
-                if os.path.exists(archive_path):
-                    tty.msg("{name} : already added".format(name=name))
-                else:
-                    everything_already_exists = False
-                    fetcher.fetch()
-                    if not kwargs.get('no_checksum', False):
-                        fetcher.check()
-                        tty.msg("{name} : checksum passed".format(name=name))
+                    if os.path.exists(archive_path):
+                        tty.msg("{name} : already added".format(name=name))
+                    else:
+                        everything_already_exists = False
+                        fetcher.fetch()
+                        if not kwargs.get('no_checksum', False):
+                            fetcher.check()
+                            tty.msg("{name} : checksum passed".format(name=name))
 
-                    # Fetchers have to know how to archive their files.  Use
-                    # that to move/copy/create an archive in the mirror.
-                    fetcher.archive(archive_path)
-                    tty.msg("{name} : added".format(name=name))
+                        # Fetchers have to know how to archive their files.  Use
+                        # that to move/copy/create an archive in the mirror.
+                        fetcher.archive(archive_path)
+                        tty.msg("{name} : added".format(name=name))
 
             if everything_already_exists:
                 present.append(spec)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -291,7 +291,6 @@ class Package(object):
 
     .. code-block:: python
 
-       p.do_clean()              # removes the stage directory entirely
        p.do_restage()            # removes the build directory and
                                  # re-expands the archive.
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -732,7 +732,7 @@ class Package(object):
         # If we encounter an archive that failed to patch, restage it
         # so that we can apply all the patches again.
         if os.path.isfile(bad_file):
-            tty.msg("Patching failed last time.  Restaging.")
+            tty.msg("Patching failed last time. Restaging.")
             self.stage.restage()
 
         self.stage.chdir_to_source()
@@ -912,7 +912,7 @@ class Package(object):
                             % (_hms(self._fetch_time), _hms(build_time), _hms(self._total_time)))
                     print_pkg(self.prefix)
 
-                except ProcessError, e:
+                except ProcessError as e:
                     # Annotate with location of build log.
                     e.build_log = log_path
                     cleanup()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1138,13 +1138,6 @@ class Package(object):
         """Reverts expanded/checked out source to a pristine state."""
         self.stage.restage()
 
-
-    def do_clean(self):
-        """Removes the package's build stage and source tarball."""
-        if os.path.exists(self.stage.path):
-            self.stage.destroy()
-
-
     def format_doc(self, **kwargs):
         """Wrap doc string at 72 characters and format nicely"""
         indent = kwargs.get('indent', 0)
@@ -1181,7 +1174,7 @@ class Package(object):
         try:
             return spack.util.web.find_versions_of_archive(
                 *self.all_urls, list_url=self.list_url, list_depth=self.list_depth)
-        except spack.error.NoNetworkConnectionError, e:
+        except spack.error.NoNetworkConnectionError as e:
             tty.die("Package.fetch_versions couldn't connect to:",
                     e.url, e.message)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -105,26 +105,10 @@ class Stage(object):
         """
         Entering a stage context will create the stage directory
 
-        If self.tmp_root evaluates to False, the stage directory is created directly under spack.stage_path, otherwise
-        this will attempt to create a stage in a temporary directory and link it into spack.stage_path.
-
-        Spack will use the first writable location in spack.tmp_dirs to create a stage. If there is no valid location
-        in tmp_dirs, fall back to making the stage inside spack.stage_path.
+        Returns:
+            self
         """
-        # Create the top-level stage directory
-        mkdirp(spack.stage_path)
-        remove_dead_links(spack.stage_path)
-        # If a tmp_root exists then create a directory there and then link it in the stage area,
-        # otherwise create the stage directory in self.path
-        if self._need_to_create_path():
-            if self.tmp_root:
-                tmp_dir = tempfile.mkdtemp('', STAGE_PREFIX, self.tmp_root)
-                os.symlink(tmp_dir, self.path)
-            else:
-                mkdirp(self.path)
-        # Make sure we can actually do something with the stage we made.
-        ensure_access(self.path)
-
+        self.create()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -314,8 +298,34 @@ class Stage(object):
         """
         self.fetcher.reset()
 
+    def create(self):
+        """
+        Creates the stage directory
+
+        If self.tmp_root evaluates to False, the stage directory is created directly under spack.stage_path, otherwise
+        this will attempt to create a stage in a temporary directory and link it into spack.stage_path.
+
+        Spack will use the first writable location in spack.tmp_dirs to create a stage. If there is no valid location
+        in tmp_dirs, fall back to making the stage inside spack.stage_path.
+        """
+        # Create the top-level stage directory
+        mkdirp(spack.stage_path)
+        remove_dead_links(spack.stage_path)
+        # If a tmp_root exists then create a directory there and then link it in the stage area,
+        # otherwise create the stage directory in self.path
+        if self._need_to_create_path():
+            if self.tmp_root:
+                tmp_dir = tempfile.mkdtemp('', STAGE_PREFIX, self.tmp_root)
+                os.symlink(tmp_dir, self.path)
+            else:
+                mkdirp(self.path)
+        # Make sure we can actually do something with the stage we made.
+        ensure_access(self.path)
+
     def destroy(self):
-        """Remove this stage directory."""
+        """
+        Removes this stage directory
+        """
         remove_linked_tree(self.path)
 
         # Make sure we don't end up in a removed directory

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -42,33 +42,26 @@ STAGE_PREFIX = 'spack-stage-'
 
 
 class Stage(object):
-    """A Stage object manages a directory where some source code is
-       downloaded and built before being installed.  It handles
-       fetching the source code, either as an archive to be expanded
-       or by checking it out of a repository.  A stage's lifecycle
-       looks like this:
+    """
+    A Stage object is a context manager that handles a directory where some source code is downloaded and built
+    before being installed.  It handles fetching the source code, either as an archive to be expanded or by checking
+    it out of a repository.  A stage's lifecycle looks like this:
 
-       Stage()
-         Constructor creates the stage directory.
-       fetch()
-         Fetch a source archive into the stage.
-       expand_archive()
-         Expand the source archive.
-       <install>
-         Build and install the archive.  This is handled by the Package class.
-       destroy()
-         Remove the stage once the package has been installed.
+    ```
+    with Stage() as stage:  # Context manager creates and destroys the stage directory
+        fetch()  # Fetch a source archive into the stage.
+        expand_archive()  # Expand the source archive.
+        <install>  # Build and install the archive.  This is handled by the Package class.
+    ```
 
-       If spack.use_tmp_stage is True, spack will attempt to create stages
-       in a tmp directory.  Otherwise, stages are created directly in
-       spack.stage_path.
+    If spack.use_tmp_stage is True, spack will attempt to create stages in a tmp directory.
+    Otherwise, stages are created directly in spack.stage_path.
 
-       There are two kinds of stages: named and unnamed.  Named stages can
-       persist between runs of spack, e.g. if you fetched a tarball but
-       didn't finish building it, you won't have to fetch it again.
+    There are two kinds of stages: named and unnamed.  Named stages can persist between runs of spack, e.g. if you
+    fetched a tarball but didn't finish building it, you won't have to fetch it again.
 
-       Unnamed stages are created using standard mkdtemp mechanisms or
-       similar, and are intended to persist for only one run of spack.
+    Unnamed stages are created using standard mkdtemp mechanisms or similar, and are intended to persist for
+    only one run of spack.
     """
 
     def __init__(self, url_or_fetch_strategy, **kwargs):
@@ -164,7 +157,7 @@ class Stage(object):
             path = join_path(spack.stage_path, file)
             if os.path.islink(path):
                 real_path = os.path.realpath(path)
-                if not os.path.exists(path):
+                if not os.path.exists(real_path):
                     os.unlink(path)
 
     def _need_to_create_path(self):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -114,15 +114,13 @@ class Stage(object):
         # Create the top-level stage directory
         mkdirp(spack.stage_path)
         remove_dead_links(spack.stage_path)
-
         # If a tmp_root exists then create a directory there and then link it in the stage area,
         # otherwise create the stage directory in self.path
-        if self.tmp_root:
-            if self._need_to_create_path():
+        if self._need_to_create_path():
+            if self.tmp_root:
                 tmp_dir = tempfile.mkdtemp('', STAGE_PREFIX, self.tmp_root)
                 os.symlink(tmp_dir, self.path)
-        else:
-            if self._need_to_create_path():
+            else:
                 mkdirp(self.path)
         # Make sure we can actually do something with the stage we made.
         ensure_access(self.path)
@@ -434,19 +432,6 @@ def ensure_access(file=spack.stage_path):
     """Ensure we can access a directory and die with an error if we can't."""
     if not can_access(file):
         tty.die("Insufficient permissions for %s" % file)
-
-
-def remove_linked_tree(path):
-    """Removes a directory and its contents.  If the directory is a symlink,
-       follows the link and reamoves the real directory before removing the
-       link.
-    """
-    if os.path.exists(path):
-        if os.path.islink(path):
-            shutil.rmtree(os.path.realpath(path), True)
-            os.unlink(path)
-        else:
-            shutil.rmtree(path, True)
 
 
 def purge():

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -246,7 +246,7 @@ class Stage(object):
                 self.fetcher = fetcher
                 self.fetcher.fetch()
                 break
-            except spack.error.SpackError, e:
+            except spack.error.SpackError as e:
                 tty.msg("Fetching from %s failed." % fetcher)
                 tty.debug(e)
                 continue

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -404,10 +404,13 @@ class StageComposite:
         return self[0].path
 
     def __enter__(self):
-        return self[0].__enter__()
+        for item in self:
+            item.__enter__()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return self[0].__exit__(exc_type, exc_val, exc_tb)
+        for item in reversed(self):
+            item.__exit__(exc_type, exc_val, exc_tb)
 
     def chdir_to_source(self):
         return self[0].chdir_to_source()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -22,8 +22,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
-
 import spack
 from spack.spec import Spec, CompilerSpec
 from spack.test.mock_packages_test import *

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -22,13 +22,13 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
-import shutil
 import os
+import shutil
 from tempfile import mkdtemp
-from ordereddict_backport import OrderedDict
+
 import spack
 import spack.config
+from ordereddict_backport import OrderedDict
 from spack.test.mock_packages_test import *
 
 # Some sample compiler config data

--- a/lib/spack/spack/test/configure_guess.py
+++ b/lib/spack/spack/test/configure_guess.py
@@ -23,20 +23,15 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import unittest
 import shutil
 import tempfile
+import unittest
 
 from llnl.util.filesystem import *
-
 from spack.cmd.create import ConfigureGuesser
 from spack.stage import Stage
-
-from spack.fetch_strategy import URLFetchStrategy
-from spack.directory_layout import YamlDirectoryLayout
-from spack.util.executable import which
 from spack.test.mock_packages_test import *
-from spack.test.mock_repo import MockArchive
+from spack.util.executable import which
 
 
 class InstallTest(unittest.TestCase):

--- a/lib/spack/spack/test/configure_guess.py
+++ b/lib/spack/spack/test/configure_guess.py
@@ -52,8 +52,6 @@ class InstallTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
-        if self.stage:
-            self.stage.destroy()
         os.chdir(self.orig_dir)
 
 
@@ -64,12 +62,12 @@ class InstallTest(unittest.TestCase):
 
         url = 'file://' + join_path(os.getcwd(), 'archive.tar.gz')
         print url
-        self.stage = Stage(url)
-        self.stage.fetch()
+        with Stage(url) as stage:
+            stage.fetch()
 
-        guesser = ConfigureGuesser()
-        guesser(self.stage)
-        self.assertEqual(system, guesser.build_system)
+            guesser = ConfigureGuesser()
+            guesser(stage)
+            self.assertEqual(system, guesser.build_system)
 
 
     def test_python(self):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -26,19 +26,18 @@
 These tests check the database is functioning properly,
 both in memory and in its file
 """
-import tempfile
-import shutil
 import multiprocessing
-
-from llnl.util.lock import *
-from llnl.util.filesystem import join_path
+import shutil
+import tempfile
 
 import spack
+from llnl.util.filesystem import join_path
+from llnl.util.lock import *
+from llnl.util.tty.colify import colify
 from spack.database import Database
 from spack.directory_layout import YamlDirectoryLayout
 from spack.test.mock_packages_test import *
 
-from llnl.util.tty.colify import colify
 
 def _print_ref_counts():
     """Print out all ref counts for the graph used here, for debugging"""

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -25,19 +25,16 @@
 """\
 This test verifies that the Spack directory layout works properly.
 """
-import unittest
-import tempfile
-import shutil
 import os
-
-from llnl.util.filesystem import *
+import shutil
+import tempfile
 
 import spack
-from spack.spec import Spec
-from spack.repository import RepoPath
+from llnl.util.filesystem import *
 from spack.directory_layout import YamlDirectoryLayout
+from spack.repository import RepoPath
+from spack.spec import Spec
 from spack.test.mock_packages_test import *
-
 
 # number of packages to test (to reduce test time)
 max_packages = 10

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -52,18 +52,14 @@ class GitFetchTest(MockPackagesTest):
         spec.concretize()
         self.pkg = spack.repo.get(spec, new=True)
 
-
     def tearDown(self):
         """Destroy the stage space used by this test."""
         super(GitFetchTest, self).tearDown()
         self.repo.destroy()
-        self.pkg.do_clean()
-
 
     def assert_rev(self, rev):
         """Check that the current git revision is equal to the supplied rev."""
         self.assertEqual(self.repo.rev_hash('HEAD'), self.repo.rev_hash(rev))
-
 
     def try_fetch(self, rev, test_file, args):
         """Tries to:

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -23,19 +23,12 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import unittest
-import shutil
-import tempfile
-
-from llnl.util.filesystem import *
 
 import spack
-from spack.version import ver
-from spack.stage import Stage
-from spack.util.executable import which
-
+from llnl.util.filesystem import *
 from spack.test.mock_packages_test import *
 from spack.test.mock_repo import MockGitRepo
+from spack.version import ver
 
 
 class GitFetchTest(MockPackagesTest):

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -76,26 +76,27 @@ class GitFetchTest(MockPackagesTest):
         """
         self.pkg.versions[ver('git')] = args
 
-        self.pkg.do_stage()
-        self.assert_rev(rev)
+        with self.pkg.stage:
+            self.pkg.do_stage()
+            self.assert_rev(rev)
 
-        file_path = join_path(self.pkg.stage.source_path, test_file)
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            file_path = join_path(self.pkg.stage.source_path, test_file)
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        os.unlink(file_path)
-        self.assertFalse(os.path.isfile(file_path))
+            os.unlink(file_path)
+            self.assertFalse(os.path.isfile(file_path))
 
-        untracked_file = 'foobarbaz'
-        touch(untracked_file)
-        self.assertTrue(os.path.isfile(untracked_file))
-        self.pkg.do_restage()
-        self.assertFalse(os.path.isfile(untracked_file))
+            untracked_file = 'foobarbaz'
+            touch(untracked_file)
+            self.assertTrue(os.path.isfile(untracked_file))
+            self.pkg.do_restage()
+            self.assertFalse(os.path.isfile(untracked_file))
 
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        self.assert_rev(rev)
+            self.assert_rev(rev)
 
 
     def test_fetch_master(self):

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -23,16 +23,12 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import unittest
-
-from llnl.util.filesystem import *
-
 import spack
+
 from spack.version import ver
-from spack.stage import Stage
-from spack.util.executable import which
-from spack.test.mock_packages_test import *
 from spack.test.mock_repo import MockHgRepo
+from llnl.util.filesystem import *
+from spack.test.mock_packages_test import *
 
 
 class HgFetchTest(MockPackagesTest):

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -68,26 +68,27 @@ class HgFetchTest(MockPackagesTest):
         """
         self.pkg.versions[ver('hg')] = args
 
-        self.pkg.do_stage()
-        self.assertEqual(self.repo.get_rev(), rev)
+        with self.pkg.stage:
+            self.pkg.do_stage()
+            self.assertEqual(self.repo.get_rev(), rev)
 
-        file_path = join_path(self.pkg.stage.source_path, test_file)
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            file_path = join_path(self.pkg.stage.source_path, test_file)
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        os.unlink(file_path)
-        self.assertFalse(os.path.isfile(file_path))
+            os.unlink(file_path)
+            self.assertFalse(os.path.isfile(file_path))
 
-        untracked = 'foobarbaz'
-        touch(untracked)
-        self.assertTrue(os.path.isfile(untracked))
-        self.pkg.do_restage()
-        self.assertFalse(os.path.isfile(untracked))
+            untracked = 'foobarbaz'
+            touch(untracked)
+            self.assertTrue(os.path.isfile(untracked))
+            self.pkg.do_restage()
+            self.assertFalse(os.path.isfile(untracked))
 
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        self.assertEqual(self.repo.get_rev(), rev)
+            self.assertEqual(self.repo.get_rev(), rev)
 
 
     def test_fetch_default(self):

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -49,13 +49,10 @@ class HgFetchTest(MockPackagesTest):
         spec.concretize()
         self.pkg = spack.repo.get(spec, new=True)
 
-
     def tearDown(self):
         """Destroy the stage space used by this test."""
         super(HgFetchTest, self).tearDown()
         self.repo.destroy()
-        self.pkg.do_clean()
-
 
     def try_fetch(self, rev, test_file, args):
         """Tries to:

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -22,18 +22,13 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import os
-import unittest
 import shutil
 import tempfile
 
-from llnl.util.filesystem import *
-
 import spack
-from spack.stage import Stage
-from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
+from llnl.util.filesystem import *
 from spack.directory_layout import YamlDirectoryLayout
-from spack.util.executable import which
+from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
 from spack.test.mock_packages_test import *
 from spack.test.mock_repo import MockArchive
 

--- a/lib/spack/spack/test/link_tree.py
+++ b/lib/spack/spack/test/link_tree.py
@@ -38,6 +38,8 @@ class LinkTreeTest(unittest.TestCase):
 
     def setUp(self):
         self.stage = Stage('link-tree-test')
+        # FIXME : possibly this test needs to be refactored to avoid the explicit call to __enter__ and __exit__
+        self.stage.__enter__()
 
         with working_dir(self.stage.path):
             touchp('source/1')
@@ -51,10 +53,8 @@ class LinkTreeTest(unittest.TestCase):
         source_path = os.path.join(self.stage.path, 'source')
         self.link_tree = LinkTree(source_path)
 
-
     def tearDown(self):
-        if self.stage:
-            self.stage.destroy()
+        self.stage.__exit__(None, None, None)
 
 
     def check_file_link(self, filename):

--- a/lib/spack/spack/test/link_tree.py
+++ b/lib/spack/spack/test/link_tree.py
@@ -24,8 +24,6 @@
 ##############################################################################
 import os
 import unittest
-import shutil
-import tempfile
 
 from llnl.util.filesystem import *
 from llnl.util.link_tree import LinkTree
@@ -38,8 +36,7 @@ class LinkTreeTest(unittest.TestCase):
 
     def setUp(self):
         self.stage = Stage('link-tree-test')
-        # FIXME : possibly this test needs to be refactored to avoid the explicit call to __enter__ and __exit__
-        self.stage.__enter__()
+        self.stage.create()
 
         with working_dir(self.stage.path):
             touchp('source/1')
@@ -54,7 +51,7 @@ class LinkTreeTest(unittest.TestCase):
         self.link_tree = LinkTree(source_path)
 
     def tearDown(self):
-        self.stage.__exit__(None, None, None)
+        self.stage.destroy()
 
 
     def check_file_link(self, filename):

--- a/lib/spack/spack/test/lock.py
+++ b/lib/spack/spack/test/lock.py
@@ -25,15 +25,13 @@
 """
 These tests ensure that our lock works correctly.
 """
-import unittest
-import os
-import tempfile
 import shutil
+import tempfile
+import unittest
 from multiprocessing import Process
 
-from llnl.util.lock import *
 from llnl.util.filesystem import join_path, touch
-
+from llnl.util.lock import *
 from spack.util.multiproc import Barrier
 
 # This is the longest a failed test will take, as the barriers will

--- a/lib/spack/spack/test/make_executable.py
+++ b/lib/spack/spack/test/make_executable.py
@@ -28,13 +28,13 @@ Tests for Spack's built-in parallel make support.
 This just tests whether the right args are getting passed to make.
 """
 import os
-import unittest
-import tempfile
 import shutil
+import tempfile
+import unittest
 
 from llnl.util.filesystem import *
-from spack.util.environment import path_put_first
 from spack.build_environment import MakeExecutable
+from spack.util.environment import path_put_first
 
 
 class MakeExecutableTest(unittest.TestCase):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -104,29 +104,21 @@ class MirrorTest(MockPackagesTest):
 
                     saved_checksum_setting = spack.do_checksum
                     with pkg.stage:
-                        try:
-                            # Stage the archive from the mirror and cd to it.
-                            spack.do_checksum = False
-                            pkg.do_stage(mirror_only=True)
-
-                            # Compare the original repo with the expanded archive
-                            original_path = mock_repo.path
-                            if 'svn' in name:
-                                # have to check out the svn repo to compare.
-                                original_path = join_path(mock_repo.path, 'checked_out')
-                                svn('checkout', mock_repo.url, original_path)
-
-                            dcmp = dircmp(original_path, pkg.stage.source_path)
-
-                            # make sure there are no new files in the expanded tarball
-                            self.assertFalse(dcmp.right_only)
-
-                            # and that all original files are present.
-                            self.assertTrue(all(l in exclude for l in dcmp.left_only))
-
-                        finally:
-                            spack.do_checksum = saved_checksum_setting
-                            pkg.do_clean()
+                        # Stage the archive from the mirror and cd to it.
+                        spack.do_checksum = False
+                        pkg.do_stage(mirror_only=True)
+                        # Compare the original repo with the expanded archive
+                        original_path = mock_repo.path
+                        if 'svn' in name:
+                            # have to check out the svn repo to compare.
+                            original_path = join_path(mock_repo.path, 'checked_out')
+                            svn('checkout', mock_repo.url, original_path)
+                        dcmp = dircmp(original_path, pkg.stage.source_path)
+                        # make sure there are no new files in the expanded tarball
+                        self.assertFalse(dcmp.right_only)
+                        # and that all original files are present.
+                        self.assertTrue(all(l in exclude for l in dcmp.left_only))
+                        spack.do_checksum = saved_checksum_setting
 
 
     def test_git_mirror(self):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -74,14 +74,14 @@ class MirrorTest(MockPackagesTest):
 
 
     def check_mirror(self):
-        stage = Stage('spack-mirror-test')
-        mirror_root = join_path(stage.path, 'test-mirror')
+        with Stage('spack-mirror-test') as stage:
+            mirror_root = join_path(stage.path, 'test-mirror')
 
-        # register mirror with spack config
-        mirrors = { 'spack-mirror-test' : 'file://' + mirror_root }
-        spack.config.update_config('mirrors', mirrors)
+            # register mirror with spack config
+            mirrors = { 'spack-mirror-test' : 'file://' + mirror_root }
+            spack.config.update_config('mirrors', mirrors)
 
-        try:
+
             os.chdir(stage.path)
             spack.mirror.create(
                 mirror_root, self.repos, no_checksum=True)
@@ -97,38 +97,36 @@ class MirrorTest(MockPackagesTest):
                 files = os.listdir(subdir)
                 self.assertEqual(len(files), 1)
 
-            # Now try to fetch each package.
-            for name, mock_repo in self.repos.items():
-                spec = Spec(name).concretized()
-                pkg = spec.package
+                # Now try to fetch each package.
+                for name, mock_repo in self.repos.items():
+                    spec = Spec(name).concretized()
+                    pkg = spec.package
 
-                pkg._stage = None
-                saved_checksum_setting = spack.do_checksum
-                try:
-                    # Stage the archive from the mirror and cd to it.
-                    spack.do_checksum = False
-                    pkg.do_stage(mirror_only=True)
+                    saved_checksum_setting = spack.do_checksum
+                    with pkg.stage:
+                        try:
+                            # Stage the archive from the mirror and cd to it.
+                            spack.do_checksum = False
+                            pkg.do_stage(mirror_only=True)
 
-                    # Compare the original repo with the expanded archive
-                    original_path = mock_repo.path
-                    if 'svn' in name:
-                        # have to check out the svn repo to compare.
-                        original_path = join_path(mock_repo.path, 'checked_out')
-                        svn('checkout', mock_repo.url, original_path)
+                            # Compare the original repo with the expanded archive
+                            original_path = mock_repo.path
+                            if 'svn' in name:
+                                # have to check out the svn repo to compare.
+                                original_path = join_path(mock_repo.path, 'checked_out')
+                                svn('checkout', mock_repo.url, original_path)
 
-                    dcmp = dircmp(original_path, pkg.stage.source_path)
+                            dcmp = dircmp(original_path, pkg.stage.source_path)
 
-                    # make sure there are no new files in the expanded tarball
-                    self.assertFalse(dcmp.right_only)
+                            # make sure there are no new files in the expanded tarball
+                            self.assertFalse(dcmp.right_only)
 
-                    # and that all original files are present.
-                    self.assertTrue(all(l in exclude for l in dcmp.left_only))
+                            # and that all original files are present.
+                            self.assertTrue(all(l in exclude for l in dcmp.left_only))
 
-                finally:
-                    spack.do_checksum = saved_checksum_setting
-                    pkg.do_clean()
-        finally:
-            stage.destroy()
+                        finally:
+                            spack.do_checksum = saved_checksum_setting
+                            pkg.do_clean()
 
 
     def test_git_mirror(self):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -23,11 +23,10 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-from filecmp import dircmp
-
 import spack
 import spack.mirror
-from spack.util.compression import decompressor_for
+
+from filecmp import dircmp
 from spack.test.mock_packages_test import *
 from spack.test.mock_repo import *
 

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -22,17 +22,15 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import sys
 import os
 import shutil
-import unittest
 import tempfile
-from ordereddict_backport import OrderedDict
-
-from llnl.util.filesystem import mkdirp
+import unittest
 
 import spack
 import spack.config
+from llnl.util.filesystem import mkdirp
+from ordereddict_backport import OrderedDict
 from spack.repository import RepoPath
 from spack.spec import Spec
 

--- a/lib/spack/spack/test/mock_repo.py
+++ b/lib/spack/spack/test/mock_repo.py
@@ -26,12 +26,8 @@ import os
 import shutil
 
 from llnl.util.filesystem import *
-
-import spack
-from spack.version import ver
 from spack.stage import Stage
 from spack.util.executable import which
-
 
 #
 # VCS Systems used by mock repo code.

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -25,14 +25,11 @@
 """
 Test for multi_method dispatch.
 """
-import unittest
 
 import spack
 from spack.multimethod import *
-from spack.version import *
-from spack.spec import Spec
-from spack.multimethod import when
 from spack.test.mock_packages_test import *
+from spack.version import *
 
 
 class MultiMethodTest(MockPackagesTest):

--- a/lib/spack/spack/test/namespace_trie.py
+++ b/lib/spack/spack/test/namespace_trie.py
@@ -23,6 +23,7 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import unittest
+
 from spack.util.naming import NamespaceTrie
 
 

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -22,10 +22,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
 
-import spack
-from spack.spec import Spec, CompilerSpec
+from spack.spec import Spec
 from spack.test.mock_packages_test import *
 
 class ConcretizeTest(MockPackagesTest):

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -75,20 +75,30 @@ class PackagesTest(MockPackagesTest):
     #
 
     def test_import_package(self):
-        pass
+        import spack.pkg.builtin.mock.mpich
 
 
     def test_import_package_as(self):
-        pass
+        import spack.pkg.builtin.mock.mpich as mp
 
 
     def test_import_class_from_package(self):
-        pass
+        from spack.pkg.builtin.mock.mpich import Mpich
 
 
     def test_import_module_from_package(self):
-        pass
+        from spack.pkg.builtin.mock import mpich
 
 
     def test_import_namespace_container_modules(self):
-        pass
+        import spack.pkg
+        import spack.pkg as p
+        from spack import pkg
+
+        import spack.pkg.builtin
+        import spack.pkg.builtin as b
+        from spack.pkg import builtin
+
+        import spack.pkg.builtin.mock
+        import spack.pkg.builtin.mock as m
+        from spack.pkg.builtin import mock

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -22,14 +22,12 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
-
-from llnl.util.filesystem import join_path
 
 import spack
+from llnl.util.filesystem import join_path
 from spack.repository import Repo
-from spack.util.naming import mod_to_class
 from spack.test.mock_packages_test import *
+from spack.util.naming import mod_to_class
 
 
 class PackagesTest(MockPackagesTest):
@@ -77,30 +75,20 @@ class PackagesTest(MockPackagesTest):
     #
 
     def test_import_package(self):
-        import spack.pkg.builtin.mock.mpich
+        pass
 
 
     def test_import_package_as(self):
-        import spack.pkg.builtin.mock.mpich as mp
+        pass
 
 
     def test_import_class_from_package(self):
-        from spack.pkg.builtin.mock.mpich import Mpich
+        pass
 
 
     def test_import_module_from_package(self):
-        from spack.pkg.builtin.mock import mpich
+        pass
 
 
     def test_import_namespace_container_modules(self):
-        import spack.pkg
-        import spack.pkg as p
-        from spack import pkg
-
-        import spack.pkg.builtin
-        import spack.pkg.builtin as b
-        from spack.pkg import builtin
-
-        import spack.pkg.builtin.mock
-        import spack.pkg.builtin.mock as m
-        from spack.pkg.builtin import mock
+        pass

--- a/lib/spack/spack/test/python_version.py
+++ b/lib/spack/spack/test/python_version.py
@@ -28,12 +28,11 @@ This test ensures that all Spack files are Python version 2.6 or less.
 Spack was originally 2.7, but enough systems in 2014 are still using
 2.6 on their frontend nodes that we need 2.6 to get adopted.
 """
-import unittest
 import os
 import re
+import unittest
 
 import llnl.util.tty as tty
-
 import pyqver2
 import spack
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -31,8 +31,6 @@ You can find the dummy packages here::
 import spack
 import spack.package
 
-from llnl.util.lang import list_modules
-
 from spack.spec import Spec
 from spack.test.mock_packages_test import *
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -22,7 +22,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
 from spack.spec import *
 from spack.test.mock_packages_test import *
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -23,9 +23,10 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import unittest
+
 import spack.spec
-from spack.spec import *
 from spack.parse import Token
+from spack.spec import *
 
 # Sample output for a complex lexing.
 complex_lex = [Token(ID, 'mvapich_foo'),

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -25,15 +25,13 @@
 """\
 Test that the Stage class works correctly.
 """
-import unittest
-import shutil
 import os
-import getpass
+import shutil
+import unittest
 from contextlib import *
 
-from llnl.util.filesystem import *
-
 import spack
+from llnl.util.filesystem import *
 from spack.stage import Stage
 from spack.util.executable import which
 

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -24,18 +24,12 @@
 ##############################################################################
 import os
 import re
-import unittest
-import shutil
-import tempfile
-
-from llnl.util.filesystem import *
-
 import spack
-from spack.version import ver
-from spack.stage import Stage
-from spack.util.executable import which
-from spack.test.mock_packages_test import *
+
 from spack.test.mock_repo import svn, MockSvnRepo
+from spack.version import ver
+from spack.test.mock_packages_test import *
+from llnl.util.filesystem import *
 
 
 class SvnFetchTest(MockPackagesTest):

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -51,13 +51,10 @@ class SvnFetchTest(MockPackagesTest):
         spec.concretize()
         self.pkg = spack.repo.get(spec, new=True)
 
-
     def tearDown(self):
         """Destroy the stage space used by this test."""
         super(SvnFetchTest, self).tearDown()
         self.repo.destroy()
-        self.pkg.do_clean()
-
 
     def assert_rev(self, rev):
         """Check that the current revision is equal to the supplied rev."""
@@ -69,7 +66,6 @@ class SvnFetchTest(MockPackagesTest):
                 if match:
                     return match.group(1)
         self.assertEqual(get_rev(), rev)
-
 
     def try_fetch(self, rev, test_file, args):
         """Tries to:

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -82,26 +82,27 @@ class SvnFetchTest(MockPackagesTest):
         """
         self.pkg.versions[ver('svn')] = args
 
-        self.pkg.do_stage()
-        self.assert_rev(rev)
+        with self.pkg.stage:
+            self.pkg.do_stage()
+            self.assert_rev(rev)
 
-        file_path = join_path(self.pkg.stage.source_path, test_file)
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            file_path = join_path(self.pkg.stage.source_path, test_file)
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        os.unlink(file_path)
-        self.assertFalse(os.path.isfile(file_path))
+            os.unlink(file_path)
+            self.assertFalse(os.path.isfile(file_path))
 
-        untracked = 'foobarbaz'
-        touch(untracked)
-        self.assertTrue(os.path.isfile(untracked))
-        self.pkg.do_restage()
-        self.assertFalse(os.path.isfile(untracked))
+            untracked = 'foobarbaz'
+            touch(untracked)
+            self.assertTrue(os.path.isfile(untracked))
+            self.pkg.do_restage()
+            self.assertFalse(os.path.isfile(untracked))
 
-        self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
-        self.assertTrue(os.path.isfile(file_path))
+            self.assertTrue(os.path.isdir(self.pkg.stage.source_path))
+            self.assertTrue(os.path.isfile(file_path))
 
-        self.assert_rev(rev)
+            self.assert_rev(rev)
 
 
     def test_fetch_default(self):

--- a/lib/spack/spack/test/tally_plugin.py
+++ b/lib/spack/spack/test/tally_plugin.py
@@ -22,9 +22,9 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from nose.plugins import Plugin
-
 import os
+
+from nose.plugins import Plugin
 
 class Tally(Plugin):
     name = 'tally'

--- a/lib/spack/spack/test/unit_install.py
+++ b/lib/spack/spack/test/unit_install.py
@@ -22,10 +22,11 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import unittest
 import itertools
+import unittest
 
 import spack
+
 test_install = __import__("spack.cmd.test-install",
     fromlist=["BuildId", "create_test_output", "TestResult"])
 

--- a/lib/spack/spack/test/url_extrapolate.py
+++ b/lib/spack/spack/test/url_extrapolate.py
@@ -25,10 +25,7 @@
 """\
 Tests ability of spack to extrapolate URL versions from existing versions.
 """
-import spack
 import spack.url as url
-from spack.spec import Spec
-from spack.version import ver
 from spack.test.mock_packages_test import *
 
 

--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -27,8 +27,8 @@ This file has a bunch of versions tests taken from the excellent version
 detection in Homebrew.
 """
 import unittest
+
 import spack.url as url
-from pprint import pprint
 
 
 class UrlParseTest(unittest.TestCase):

--- a/lib/spack/spack/test/url_substitution.py
+++ b/lib/spack/spack/test/url_substitution.py
@@ -27,7 +27,6 @@ This test does sanity checks on substituting new versions into URLs
 """
 import unittest
 
-import spack
 import spack.url as url
 
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -28,6 +28,7 @@ We try to maintain compatibility with RPM's version semantics
 where it makes sense.
 """
 import unittest
+
 from spack.version import *
 
 

--- a/lib/spack/spack/test/yaml.py
+++ b/lib/spack/spack/test/yaml.py
@@ -26,6 +26,7 @@
 Test Spack's custom YAML format.
 """
 import unittest
+
 import spack.util.spack_yaml as syaml
 
 test_file = """\


### PR DESCRIPTION
Modifications:
- [x] Stage is now a context manager
- [x] `package.do_install`, `mirror.create` and the tests have been updated accordingly
- [x] `_setup` has been removed from Stage, its logic has been simplified and is now part of `__enter__`
- [x] `Stage._cleanup_dead_links` and `remove_link_tree` have been moved to `llnl.util.filesytsem`
- [x] removed `Package.do_clean`

@tgamblin this goes in the direction of cleaning a bit `Stage` and `FetchStrategy`. I guess the best way to proceed is to submit a moderately small PR like this at a time. Just let me know if you prefer something different (like a long-term refactoring branch or similar)