### PR TITLE
libpciaccess cannot be built with PGI compilers

### DIFF
--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -12,8 +12,8 @@ class Libpciaccess(Package):
     depends_on('libtool')
 
     def install(self, spec, prefix):
-        # libpciaccess does not support OS X
-        if spec.satisfies('=darwin-x86_64'):
+        # libpciaccess does not support OS X or PGI compilers
+        if spec.satisfies('=darwin-x86_64') or spec.satisfies('%pgi'):
             # create a dummy directory
             mkdir(prefix.lib)
             return


### PR DESCRIPTION
I don't think libpciaccess can be built with PGI compilers. The only way I was able to build OpenMPI was to trick Spack into thinking I installed libpciaccess as was done for Darwin in #257. If anyone can figure out how to build libpciaccess with PGI I will be more than happy to close this PR.

See https://groups.google.com/forum/#!topic/spack/JX2hsOyXSdk for the relevant discussion. Thanks to @eschnett for the suggestion.