### PR TITLE
Paraview new version

### DIFF
--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -225,7 +225,7 @@ def parse_version_offset(path):
         (r'_((\d+\.)+\d+[a-z]?)[.]orig$', stem),
 
         # e.g. http://www.openssl.org/source/openssl-0.9.8s.tar.gz
-        (r'-([^-]+(-alpha|-beta)?)', stem),
+        (r'-v?([^-]+(-alpha|-beta)?)', stem),
 
         # e.g. astyle_1.23_macosx.tar.gz
         (r'_([^_]+(_alpha|_beta)?)', stem),

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -2,9 +2,11 @@ from spack import *
 
 class Paraview(Package):
     homepage = 'http://www.paraview.org'
-    url      = 'http://www.paraview.org/files/v4.4/ParaView-v4.4.0-source.tar.gz'
+    url      = 'http://www.paraview.org/files/v5.0/ParaView-v'
+    _url_str = 'http://www.paraview.org/files/v%s/ParaView-v%s-source.tar.gz'
 
-    version('4.4.0', 'fa1569857dd680ebb4d7ff89c2227378', url='http://www.paraview.org/files/v4.4/ParaView-v4.4.0-source.tar.gz')
+    version('4.4.0', 'fa1569857dd680ebb4d7ff89c2227378')
+    version('5.0.0', '4598f0b421460c8bbc635c9a1c3bdbee')
 
     variant('python', default=False, description='Enable Python support')
 
@@ -25,8 +27,8 @@ class Paraview(Package):
 
     depends_on('bzip2')
     depends_on('freetype')
-    depends_on('hdf5')
     depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5~mpi', when='~mpi')
     depends_on('jpeg')
     depends_on('libpng')
     depends_on('libtiff')
@@ -35,6 +37,11 @@ class Paraview(Package):
     #depends_on('protobuf') # version mismatches?
     #depends_on('sqlite') # external version not supported
     depends_on('zlib')
+    
+    def url_for_version(self, version):
+        """Handle ParaView version-based custom URLs."""
+        return self._url_str % (version.up_to(2), version)
+    
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):


### PR DESCRIPTION
This just add paraview 5.0 and add url generation.
tested with command
paraview@5.0.0+qt+python+tcl+opengl2%gcc@4.8.2 ^netcdf -mpi
Try to fix spack versions paraview results by getting rid of initial v.
Still it does not seem that url_for_version is used to find  all the available paraview versions