### PR TITLE
atlas : provides both 'blas' and 'lapack'

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -27,6 +27,8 @@ class Atlas(Package):
     provides('blas')
     provides('lapack')
 
+    parallel = False
+
     def patch(self):
         # Disable thread check.  LLNL's environment does not allow
         # disabling of CPU throttling in a way that ATLAS actually

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -1,31 +1,34 @@
 from spack import *
 from spack.util.executable import Executable
-import os
+import os.path
 
 class Atlas(Package):
     """
-    Automatically Tuned Linear Algebra Software, generic shared
-    ATLAS is an approach for the automatic generation and optimization of
-    numerical software. Currently ATLAS supplies optimized versions for the
-    complete set of linear algebra kernels known as the Basic Linear Algebra
-    Subroutines (BLAS), and a subset of the linear algebra routines in the
-    LAPACK library.
+    Automatically Tuned Linear Algebra Software, generic shared ATLAS is an approach for the automatic generation and
+    optimization of numerical software. Currently ATLAS supplies optimized versions for the complete set of linear
+    algebra kernels known as the Basic Linear Algebra Subroutines (BLAS), and a subset of the linear algebra routines
+    in the LAPACK library.
     """
     homepage = "http://math-atlas.sourceforge.net/"
 
+    version('3.10.2', 'a4e21f343dec8f22e7415e339f09f6da',
+            url='http://downloads.sourceforge.net/project/math-atlas/Stable/3.10.2/atlas3.10.2.tar.bz2', preferred=True)
+    resource(name='lapack',
+             url='http://www.netlib.org/lapack/lapack-3.5.0.tgz',
+             md5='b1d3e3e425b2e44a06760ff173104bdf',
+             destination='spack-resource-lapack',
+             when='@3:')
+
     version('3.11.34', '0b6c5389c095c4c8785fd0f724ec6825',
             url='http://sourceforge.net/projects/math-atlas/files/Developer%20%28unstable%29/3.11.34/atlas3.11.34.tar.bz2/download')
-    version('3.10.2', 'a4e21f343dec8f22e7415e339f09f6da',
-            url='http://downloads.sourceforge.net/project/math-atlas/Stable/3.10.2/atlas3.10.2.tar.bz2')
 
-    # TODO: make this provide BLAS once it works better.  Create a way
-    # TODO: to mark "beta" packages and require explicit invocation.
+    variant('shared', default=True, description='Builds shared library')
 
-    # provides('blas')
-
+    provides('blas')
+    provides('lapack')
 
     def patch(self):
-        # Disable thraed check.  LLNL's environment does not allow
+        # Disable thread check.  LLNL's environment does not allow
         # disabling of CPU throttling in a way that ATLAS actually
         # understands.
         filter_file(r'^\s+if \(thrchk\) exit\(1\);', 'if (0) exit(1);',
@@ -33,26 +36,21 @@ class Atlas(Package):
         # TODO: investigate a better way to add the check back in
         # TODO: using, say, MSRs.  Or move this to a variant.
 
-    @when('@:3.10')
     def install(self, spec, prefix):
-        with working_dir('ATLAS-Build', create=True):
+
+        options = []
+        if '+shared' in spec:
+            options.append('--shared')
+
+        # Lapack resource
+        lapack_stage = self.stage[1]
+        lapack_tarfile = os.path.basename(lapack_stage.fetcher.url)
+        lapack_tarfile_path = join_path(lapack_stage.path, lapack_tarfile)
+        options.append('--with-netlib-lapack-tarfile=%s' % lapack_tarfile_path)
+
+        with working_dir('spack-build', create=True):
             configure = Executable('../configure')
-            configure('--prefix=%s' % prefix, '-C', 'ic', 'cc', '-C', 'if', 'f77', "--dylibs")
-            make()
-            make('check')
-            make('ptcheck')
-            make('time')
-            make("install")
-
-
-    def install(self, spec, prefix):
-        with working_dir('ATLAS-Build', create=True):
-            configure = Executable('../configure')
-            configure('--incdir=%s' % prefix.include,
-                      '--libdir=%s' % prefix.lib,
-                      '--cc=cc',
-                      "--shared")
-
+            configure('--prefix=%s' % prefix, *options)
             make()
             make('check')
             make('ptcheck')


### PR DESCRIPTION
Modifications : 
- [x] atlas provides both 'blas' and 'lapack'
- [x] added resource to build full lapack API

Still to be done:
- decide how to export the information on the library to be linked (serial or threaded). Should possibly be part of a different PR (see #436 for a sketch on a possible idea on how to do that).