### PR TITLE
Modules in directories and fixes for setup-env.csh

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -195,15 +195,15 @@ class Dotkit(EnvModule):
 
     @property
     def file_name(self):
-        return join_path(Dotkit.path, self.spec.architecture,
+        return join_path(Dotkit.path, self.spec.architecture, self.spec.name,
                          '%s.dk' % self.use_name)
 
     @property
     def use_name(self):
-      return "%s-%s-%s-%s-%s" % (self.spec.name, self.spec.version,
-                                 self.spec.compiler.name,
-                                 self.spec.compiler.version, 
-                                 self.spec.dag_hash())
+      return "%s-%s-%s-%s" % (self.spec.version,
+                              self.spec.compiler.name,
+                              self.spec.compiler.version, 
+                              self.spec.dag_hash())
 
     def _write(self, dk_file):
         # Category
@@ -234,15 +234,15 @@ class TclModule(EnvModule):
 
     @property
     def file_name(self):
-        return join_path(TclModule.path, self.spec.architecture, self.use_name)
+        return join_path(TclModule.path, self.spec.architecture, self.spec.name, self.use_name)
 
 
     @property
     def use_name(self):
-      return "%s-%s-%s-%s-%s" % (self.spec.name, self.spec.version,
-                                 self.spec.compiler.name,
-                                 self.spec.compiler.version, 
-                                 self.spec.dag_hash())
+      return "%s-%s-%s-%s" % (self.spec.version,
+                              self.spec.compiler.name,
+                              self.spec.compiler.version, 
+                              self.spec.dag_hash())
 
 
     def _write(self, m_file):
@@ -259,6 +259,9 @@ class TclModule(EnvModule):
             doc = re.sub(r'"', '\"', self.long_description)
             m_file.write("puts stderr \"%s\"\n" % doc)
             m_file.write('}\n\n')
+
+        # Write out directory based conflict
+        m_file.write('conflict %s\n\n' % self.spec.name)
 
         # Path alterations
         for var, dirs in self.paths.items():

--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -41,6 +41,7 @@ set _sp_subcommand=""
 set _sp_spec=""
 [ $#_sp_args -gt 0 ] && set _sp_subcommand = ($_sp_args[1])
 [ $#_sp_args -gt 1 ] && set _sp_spec = ($_sp_args[2-])
+set _sp_spec_name=`echo $_sp_spec | cut -d@ -f1`
 
 # Figure out what type of module we're running here.
 set _sp_modtype = ""
@@ -67,6 +68,7 @@ case unload:
         set _sp_module_args = $_sp_spec[1]
         shift _sp_spec
         set _sp_spec = ($_sp_spec)
+        set _sp_spec_name=`echo $_sp_spec | cut -d@ -f1`
     endif
 
     # Here the user has run use or unuse with a spec.  Find a matching
@@ -76,25 +78,25 @@ case unload:
         case "use":
             set _sp_full_spec = ( "`\spack $_sp_flags module find dotkit $_sp_spec`" )
             if ( $? == 0 ) then
-                use $_sp_module_args $_sp_full_spec
+                use $_sp_module_args $_sp_spec_name/$_sp_full_spec
             endif
             breaksw
         case "unuse":
             set _sp_full_spec = ( "`\spack $_sp_flags module find dotkit $_sp_spec`" )
             if ( $? == 0 ) then
-                unuse $_sp_module_args $_sp_full_spec
+                unuse $_sp_module_args $_sp_spec_name/$_sp_full_spec
             endif
             breaksw
         case "load":
             set _sp_full_spec = ( "`\spack $_sp_flags module find tcl $_sp_spec`" )
             if ( $? == 0 ) then
-                module load $_sp_module_args $_sp_full_spec
+                module load $_sp_module_args $_sp_spec_name/$_sp_full_spec
             endif
             breaksw
         case "unload":
             set _sp_full_spec = ( "`\spack $_sp_flags module find tcl $_sp_spec`" )
             if ( $? == 0 ) then
-                module unload $_sp_module_args $_sp_full_spec
+                module unload $_sp_module_args $_sp_spec_name/$_sp_full_spec
             endif
             breaksw
     endsw
@@ -107,4 +109,4 @@ endsw
 
 _sp_end:
 unset _sp_args _sp_full_spec _sp_modtype _sp_module_args
-unset _sp_sh_cmd _sp_spec _sp_subcommand _sp_flags
+unset _sp_sh_cmd _sp_spec _sp_spec_name _sp_subcommand _sp_flags

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -40,8 +40,8 @@ if ($?SPACK_ROOT) then
     alias _spack_pathadd 'set _pa_args = (\!*) && source $_spack_share_dir/csh/pathadd.csh'
 
     # Set up modules and dotkit search paths in the user environment
-    # TODO: fix SYS_TYPE to something non-LLNL-specific
-    _spack_pathadd DK_NODE    "$_spack_share_dir/dotkit/$SYS_TYPE"
-    _spack_pathadd MODULEPATH "$_spack_share_dir/modules/$SYS_TYPE"
     _spack_pathadd PATH       "$SPACK_ROOT/bin"
+    set _sp_sys_type=`spack-python -c 'print(spack.architecture.sys_type())'`
+    _spack_pathadd DK_NODE    "$_spack_share_dir/dotkit/$_sp_sys_type"
+    _spack_pathadd MODULEPATH "$_spack_share_dir/modules/$_sp_sys_type"
 endif

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -75,6 +75,7 @@ function spack {
 
     _sp_subcommand=$1; shift
     _sp_spec="$@"
+    _sp_spec_name=$(echo $_sp_spec | cut -d@ -f1)
 
     # Filter out use and unuse.  For any other commands, just run the
     # command.
@@ -94,6 +95,7 @@ function spack {
             if [[ "$1" =~ ^- ]]; then
                 _sp_module_args="$1"; shift
                 _sp_spec="$@"
+                _sp_spec_name=$(echo $_sp_spec | cut -d@ -f1)
             fi
 
             # Here the user has run use or unuse with a spec.  Find a matching
@@ -103,19 +105,19 @@ function spack {
             case $_sp_subcommand in
                 "use")
                     if _sp_full_spec=$(command spack $_sp_flags module find dotkit $_sp_spec); then
-                        use $_sp_module_args $_sp_full_spec
+                        use $_sp_module_args $_sp_spec_name/$_sp_full_spec
                     fi ;;
                 "unuse")
                     if _sp_full_spec=$(command spack $_sp_flags module find dotkit $_sp_spec); then
-                        unuse $_sp_module_args $_sp_full_spec
+                        unuse $_sp_module_args $_sp_spec_name/$_sp_full_spec
                     fi ;;
                 "load")
                     if _sp_full_spec=$(command spack $_sp_flags module find dotkit $_sp_spec); then
-                        module load $_sp_module_args $_sp_full_spec
+                        module load $_sp_module_args $_sp_spec_name/$_sp_full_spec
                     fi ;;
                 "unload")
                     if _sp_full_spec=$(command spack $_sp_flags module find dotkit $_sp_spec); then
-                        module unload $_sp_module_args $_sp_full_spec
+                        module unload $_sp_module_args $_sp_spec_name/$_sp_full_spec
                     fi ;;
             esac
             ;;


### PR DESCRIPTION
This PR puts module files for the same program in the same directory named for the program. This will require the modules to be regenerated,

`spack module refresh`

So, binutils, for example, would be laid out as follows:

```
ls $SPACK_ROOT/share/spack/modules/linux-x86_64/binutils 
2.25-gcc-4.8.5-kby6upoybmx3sz32dpzsalwol3dbx44r  2.25-gcc-5.3.0-6blubrftgydrex3mtrysorgewrg67pbf
```
This is a common scheme for module files and opens up several features.

1. With different builds of the same program in the same directory a conflict can be set up based on directory name.
1. It is possible to set a default version of the package in the directory.
1. In the absence of an explicit default version, the module tool will determine one based on name.
This is where there is an issue with spack generated modules as the dag_hash could wind up playing a role here.
1. If the default is acceptable the module can be loaded with the shortcut name, which is the directory name

I made DotKit have the same structure but I do not know much about DotKit so I do not know if that is appropriate. If not, that could be changed. This requires the spec.name to be available in the setup-env scripts. While I was testing this I took a stab at fixing the csh $SYS_TYPE handling. I tried to make it consistent with the '.sh' version but I may be missing something on that.

The main remaining issue is setting a default value. For the module heuristics the hash will lead to unpredictable settings if the modules can not be distinguished prior to the hash. For manual site specific settings, the hash is not human parsable so I think the naming scheme for module files may need to be tweaked down the road. Here is an example of what lmod sees for binutils on my system.

```
module avail binutils

-------------------------------- /home/gjohnson/spack/share/spack/modules/linux-x86_64 ---------------------------------
   binutils/2.25-gcc-4.8.5-kby6upoybmx3sz32dpzsalwol3dbx44r
   binutils/2.25-gcc-5.3.0-6blubrftgydrex3mtrysorgewrg67pbf (D)

  Where:
   D:  Default Module

Use "module spider" to find all possible modules.
Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
```