### PR TITLE
Bug fix : issues in `md5` and `checksum` commands

### DIFF
--- a/lib/spack/spack/cmd/md5.py
+++ b/lib/spack/spack/cmd/md5.py
@@ -22,51 +22,51 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import os
 import argparse
 import hashlib
-
-from contextlib import contextmanager
+import os
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import *
-
 import spack.util.crypto
 from spack.stage import Stage, FailedDownloadError
 
 description = "Calculate md5 checksums for files/urls."
 
-@contextmanager
-def stager(url):
-    _cwd = os.getcwd()
-    _stager = Stage(url)
-    try:
-        _stager.fetch()
-        yield _stager
-    except FailedDownloadError:
-        tty.msg("Failed to fetch %s" % url)
-    finally:
-        _stager.destroy()
-        os.chdir(_cwd) # the Stage class changes the current working dir so it has to be restored
 
 def setup_parser(subparser):
     setup_parser.parser = subparser
     subparser.add_argument('files', nargs=argparse.REMAINDER,
                            help="Files to checksum.")
 
+
+def compute_md5_checksum(url):
+    if not os.path.isfile(url):
+        with Stage(url) as stage:
+            stage.fetch()
+            value = spack.util.crypto.checksum(hashlib.md5, stage.archive_file)
+    else:
+        value = spack.util.crypto.checksum(hashlib.md5, url)
+    return value
+
+
 def md5(parser, args):
     if not args.files:
         setup_parser.parser.print_help()
         return 1
 
-    for f in args.files:
-        if not os.path.isfile(f):
-            with stager(f) as stage:
-                checksum = spack.util.crypto.checksum(hashlib.md5, stage.archive_file)
-                print "%s  %s" % (checksum, f)
-        else:
-            if not can_access(f):
-                tty.die("Cannot read file: %s" % f)
+    results = []
+    for url in args.files:
+        try:
+            checksum = compute_md5_checksum(url)
+            results.append((checksum, url))
+        except FailedDownloadError as e:
+            tty.warn("Failed to fetch %s" % url)
+            tty.warn("%s" % e)
+        except IOError as e:
+            tty.warn("Error when reading %s" % url)
+            tty.warn("%s" % e)
 
-            checksum = spack.util.crypto.checksum(hashlib.md5, f)
-            print "%s  %s" % (checksum, f)
+    # Dump the MD5s at last without interleaving them with downloads
+    tty.msg("Number of MD5 check-sums computed: %s " % len(results))
+    for checksum, url in results:
+        tty.msg("%s  %s" % (checksum, url))

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -50,4 +50,6 @@ def stage(parser, args):
     specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
-        package.do_stage()
+        with package.stage as stage:
+            stage.delete_on_exit = False
+            package.do_stage()

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -438,6 +438,7 @@ class StageComposite:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for item in reversed(self):
+            item.delete_on_exit = getattr(self, 'delete_on_exit', True)
             item.__exit__(exc_type, exc_val, exc_tb)
 
     def chdir_to_source(self):


### PR DESCRIPTION
The issues are similar to the ones solved in ad103dcafa652a839590f5fce28b2e2ce3b5a56d and were introduced by (my) stage refactoring. 

@tgamblin : if you think it may be better, I could remove the explicit call to create in `_make_stage` and use the stage as a context manager in `fetch`, `stage`, etc. I'll also try to have a look in another PR how hard it is to write regression tests for these issues.