### PR TITLE
Bugfix/GitHub 502: Error: No spec file found at path

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -16,4 +16,4 @@ class Pango(Package):
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()
-        make("install")
+        make("install", parallel=False)


### PR DESCRIPTION
Fixes #502.

- Fix bug introduced during merge of stage refactor.
  - install prefix was not created before build_environment.fork()
    - build_environment.fork() calls setup_dependent_environment
    - python's setup_dependent_environment can inadvertently create
      the install prefix before directory_layout expects it.

- Clean up Package.do_install:
  - simplify control flow: parent process now entirely responsible for
    creating/destroying the install prefix. cleanup is now in one place.
  - Hoisting cleanup out of the child improves nesting of try/catch in
    `real_work`.
  - `real_work` renamed to `build_process`

- also fixes race in `pango` install.