### PR TITLE
Fixed issues with hypre:

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -1,4 +1,5 @@
 from spack import *
+import os
 
 class Hypre(Package):
     """Hypre is a library of high performance preconditioners that
@@ -8,7 +9,10 @@ class Hypre(Package):
     homepage = "http://computation.llnl.gov/project/linear_solvers/software.php"
     url      = "http://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz"
 
+    version('2.10.1', 'dc048c4cabb3cd549af72591474ad674')
     version('2.10.0b', '768be38793a35bb5d055905b271f5b8e')
+
+    variant('shared', default=True, description="Build shared library version (disables static library)")
 
     depends_on("mpi")
     depends_on("blas")
@@ -17,16 +21,26 @@ class Hypre(Package):
     def install(self, spec, prefix):
         blas_dir = spec['blas'].prefix
         lapack_dir = spec['lapack'].prefix
+        mpi_dir = spec['mpi'].prefix
+
+        os.environ['CC'] = os.path.join(mpi_dir, 'bin', 'mpicc')
+        os.environ['CXX'] = os.path.join(mpi_dir, 'bin', 'mpicxx')
+        os.environ['F77'] = os.path.join(mpi_dir, 'bin', 'mpif77')
+
+
+        configure_args = [
+                "--prefix=%s" % prefix,
+                "--with-lapack-libs=lapack",
+                "--with-lapack-lib-dirs=%s/lib" % lapack_dir,
+                "--with-blas-libs=blas",
+                "--with-blas-lib-dirs=%s/lib" % blas_dir]
+        if '+shared' in self.spec:
+            configure_args.append("--enable-shared")
 
         # Hypre's source is staged under ./src so we'll have to manually
         # cd into it.
         with working_dir("src"):
-            configure(
-                "--prefix=%s" % prefix,
-                "--with-blas-libs=blas",
-                "--with-blas-lib-dirs=%s/lib" % blas_dir,
-                "--with-lapack-libs=\"lapack blas\"",
-                "--with-lapack-lib-dirs=%s/lib" % lapack_dir,
-                "--with-MPI")
+            configure(*configure_args)
+
             make()
             make("install")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -11,8 +11,11 @@ class Petsc(Package):
     version('3.5.3', 'd4fd2734661e89f18ac6014b5dd1ef2f')
     version('3.5.2', 'ad170802b3b058b5deb9cd1f968e7e13')
     version('3.5.1', 'a557e029711ebf425544e117ffa44d8f')
+    version('3.4.4', '7edbc68aa6d8d6a3295dd5f6c2f6979d')
 
-    depends_on("python @2.6:2.9")   # requires Python for building
+    variant('shared', default=True, description="Build shared library version")
+
+    depends_on("python @2.6:2.7")   # requires Python for building
 
     depends_on("boost")
     depends_on("blas")
@@ -33,7 +36,7 @@ class Petsc(Package):
                   "--with-metis-dir=%s"              % spec['metis'].prefix,
                   "--with-hdf5-dir=%s"               % spec['hdf5'].prefix,
                   "--with-mpi-dir=%s"                % spec['mpi'].prefix,
-                  "--with-shared-libraries=0")
+                  "--with-shared-libraries=%d"       % (1 if '+shared' in self.spec else 0))
 
         # PETSc has its own way of doing parallel make.
         make('MAKE_NP=%s' % make_jobs, parallel=False)


### PR DESCRIPTION
Fixes problems with hyper package.

1. --with-lapack-lib was wrong.
2. --with-MPI was wrong; set env vars for MPI wrappers instead.
3. Added version 2.10.1
4. Added shared library variant (True by default).  Hypre can build shared or static libraries, but not both in the same build.