### PR TITLE
change of url for mpfr

### DIFF
--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -28,8 +28,9 @@ class Mpfr(Package):
     """The MPFR library is a C library for multiple-precision
        floating-point computations with correct rounding."""
     homepage = "http://www.mpfr.org"
-    url      = "http://www.mpfr.org/mpfr-current/mpfr-3.1.3.tar.bz2"
+    url      = "https://gforge.inria.fr/frs/download.php/latestfile/159/mpfr-3.1.2.tar.bz2"
 
+    version('3.1.4', 'b8a2f6b0e68bef46e53da2ac439e1cf4')
     version('3.1.3', '5fdfa3cfa5c86514ee4a241a1affa138')
     version('3.1.2', 'ee2c3ac63bf0c2359bf08fc3ee094c19')
 


### PR DESCRIPTION
The url used previously worked only for the current release not for older versions.