### PR TITLE
fix boost intel build

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -136,10 +136,8 @@ class Boost(Package):
         return "http://downloads.sourceforge.net/project/boost/boost/%s/boost_%s.tar.bz2" % (dots, underscores)
 
     def determine_toolset(self, spec):
-        if spec.satisfies("arch=darwin-x86_64"):
-            platform = 'darwin'
-            if not spec.satisfies('@1.47:') :
-	        return platform
+        if spec.satisfies("platform=darwin"):
+            return 'darwin'
         else :
             platform = 'linux'
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -147,8 +147,8 @@ class Boost(Package):
                     'icpc': 'intel',
                     'clang++': 'clang'}
 
-        if spec.satisfies('@1.47:') :
-            toolsets['icpc'] += '-'+platform
+        if spec.satisfies('@1.47:'):
+            toolsets['icpc'] += '-' + platform
 
         for cc, toolset in toolsets.iteritems():
             if cc in self.compiler.cxx_names:
@@ -167,8 +167,8 @@ class Boost(Package):
                            join_path(spec['python'].prefix.bin, 'python'))
 
         with open('user-config.jam', 'w') as f:
-            compiler_wrapper = join_path(spack.build_env_path, 'c++')
 #already defined in bottstrap#
+#            compiler_wrapper = join_path(spack.build_env_path, 'c++')
 #            f.write("using {0} : : {1} ;\n".format(boostToolsetId,
 #                    compiler_wrapper))
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -136,12 +136,19 @@ class Boost(Package):
         return "http://downloads.sourceforge.net/project/boost/boost/%s/boost_%s.tar.bz2" % (dots, underscores)
 
     def determine_toolset(self, spec):
-        if spec.satisfies("platform=darwin"):
-            return 'darwin'
+        if spec.satisfies("arch=darwin-x86_64"):
+            platform = 'darwin'
+            if not spec.satisfies('@1.47:') :
+	        return platform
+        else :
+            platform = 'linux'
 
         toolsets = {'g++': 'gcc',
                     'icpc': 'intel',
                     'clang++': 'clang'}
+
+        if spec.satisfies('@1.47:') :
+            toolsets['icpc'] += '-'+platform
 
         for cc, toolset in toolsets.iteritems():
             if cc in self.compiler.cxx_names:
@@ -161,16 +168,17 @@ class Boost(Package):
 
         with open('user-config.jam', 'w') as f:
             compiler_wrapper = join_path(spack.build_env_path, 'c++')
-            f.write("using {0} : : {1} ;\n".format(boostToolsetId,
-                                                   compiler_wrapper))
+#already defined in bottstrap#
+#            f.write("using {0} : : {1} ;\n".format(boostToolsetId,
+#                    compiler_wrapper))
 
             if '+mpi' in spec:
                 f.write('using mpi : %s ;\n' %
                         join_path(spec['mpi'].prefix.bin, 'mpicxx'))
             if '+python' in spec:
                 f.write('using python : %s : %s ;\n' %
-                        (spec['python'].version,
-                         join_path(spec['python'].prefix.bin, 'python')))
+                    (spec['python'].version.up_to(2),
+                    join_path(spec['python'].prefix.bin, 'python')))
 
     def determine_b2_options(self, spec, options):
         if '+debug' in spec:
@@ -202,7 +210,7 @@ class Boost(Package):
                                multithreaded} must be enabled""")
 
         options.extend([
-            'toolset=%s' % self.determine_toolset(spec),
+#already defined in bottstrap#            'toolset=%s' % self.determine_toolset(spec),
             'link=%s' % ','.join(linkTypes),
             '--layout=tagged'])
 


### PR DESCRIPTION
I' m trying to fix boost building with intel compiler, as reported in #535 like:

spack -d --verbose  install --jobs 20   boost@1.58.0+mpi%intel@15.0.2^openmpi@1.8.8

This fix errors related to the toolchain name and to the fact that toolchain was specified in both  bootstrap.sh and at b2.sh command line.

The problem with variants not checked with compatibility for older version and the related one regarding  log file names too long  still remain as I have no idea  how to possibly address 





