### PR TITLE
enhancement proposal : customization of module files 

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -284,8 +284,8 @@ def setup_package(pkg):
 
     # Allow dependencies to set up environment as well.
     for dependency_spec in pkg.spec.traverse(root=False):
-        dependency_spec.package.module_modifications(pkg.module, dependency_spec, pkg.spec)
-        env.extend(dependency_spec.package.environment_modifications(pkg.spec))
+        dependency_spec.package.modify_module(pkg.module, dependency_spec, pkg.spec)
+        dependency_spec.package.setup_dependent_environment(env, pkg.spec)
     # TODO : implement validation
     #validate(env)
     env.apply_modifications()

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -35,7 +35,7 @@ import sys
 
 import spack
 from llnl.util.filesystem import *
-from spack.environment import EnvironmentModifications, apply_environment_modifications, concatenate_paths
+from spack.environment import EnvironmentModifications, concatenate_paths
 from spack.util.environment import *
 from spack.util.executable import Executable, which
 
@@ -283,10 +283,12 @@ def setup_package(pkg):
         set_module_variables_for_package(pkg, mod)
 
     # Allow dependencies to set up environment as well.
-    for dep_spec in pkg.spec.traverse(root=False):
-        dep_spec.package.module_modifications(pkg.module, dep_spec, pkg.spec)
-        env.extend(dep_spec.package.environment_modifications(pkg.spec))
-    apply_environment_modifications(env)
+    for dependency_spec in pkg.spec.traverse(root=False):
+        dependency_spec.package.module_modifications(pkg.module, dependency_spec, pkg.spec)
+        env.extend(dependency_spec.package.environment_modifications(pkg.spec))
+    # TODO : implement validation
+    #validate(env)
+    env.apply_modifications()
 
 
 def fork(pkg, function):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -3,7 +3,7 @@ This module contains all routines related to setting up the package
 build environment.  All of this is set up by package.py just before
 install() is called.
 
-There are two parts to the bulid environment:
+There are two parts to the build environment:
 
 1. Python build environment (i.e. install() method)
 
@@ -13,7 +13,7 @@ There are two parts to the bulid environment:
    the package's module scope.  Ths allows package writers to call
    them all directly in Package.install() without writing 'self.'
    everywhere.  No, this isn't Pythonic.  Yes, it makes the code more
-   readable and more like the shell script from whcih someone is
+   readable and more like the shell script from which someone is
    likely porting.
 
 2. Build execution environment
@@ -27,17 +27,16 @@ There are two parts to the bulid environment:
 Skimming this module is a nice way to get acquainted with the types of
 calls you can make from within the install() function.
 """
-import os
-import sys
-import shutil
 import multiprocessing
+import os
 import platform
-from llnl.util.filesystem import *
+import shutil
+import sys
 
 import spack
-import spack.compilers as compilers
-from spack.util.executable import Executable, which
+from llnl.util.filesystem import *
 from spack.util.environment import *
+from spack.util.executable import Executable, which
 
 #
 # This can be set by the user to globally disable parallel builds.
@@ -107,18 +106,19 @@ def set_compiler_environment_variables(pkg):
     if compiler.fc:
         os.environ['SPACK_FC']  = compiler.fc
 
-    os.environ['SPACK_COMPILER_SPEC']  = str(pkg.spec.compiler)
+    os.environ['SPACK_COMPILER_SPEC'] = str(pkg.spec.compiler)
 
 
 def set_build_environment_variables(pkg):
-    """This ensures a clean install environment when we build packages.
+    """
+    This ensures a clean install environment when we build packages
     """
     # Add spack build environment path with compiler wrappers first in
     # the path. We add both spack.env_path, which includes default
     # wrappers (cc, c++, f77, f90), AND a subdirectory containing
     # compiler-specific symlinks.  The latter ensures that builds that
     # are sensitive to the *name* of the compiler see the right name
-    # when we're building wtih the wrappers.
+    # when we're building with the wrappers.
     #
     # Conflicts on case-insensitive systems (like "CC" and "cc") are
     # handled by putting one in the <build_env_path>/case-insensitive
@@ -296,23 +296,23 @@ def fork(pkg, function):
            # do stuff
        build_env.fork(pkg, child_fun)
 
-    Forked processes are run with the build environemnt set up by
+    Forked processes are run with the build environment set up by
     spack.build_environment.  This allows package authors to have
-    full control over the environment, etc. without offecting
+    full control over the environment, etc. without affecting
     other builds that might be executed in the same spack call.
 
-    If something goes wrong, the child process is expected toprint
+    If something goes wrong, the child process is expected to print
     the error and the parent process will exit with error as
     well. If things go well, the child exits and the parent
     carries on.
     """
     try:
         pid = os.fork()
-    except OSError, e:
+    except OSError as e:
         raise InstallError("Unable to fork build process: %s" % e)
 
     if pid == 0:
-        # Give the child process the package's build environemnt.
+        # Give the child process the package's build environment.
         setup_package(pkg)
 
         try:
@@ -323,7 +323,7 @@ def fork(pkg, function):
             # which interferes with unit tests.
             os._exit(0)
 
-        except spack.error.SpackError, e:
+        except spack.error.SpackError as e:
             e.die()
 
         except:
@@ -338,8 +338,7 @@ def fork(pkg, function):
         # message.  Just make the parent exit with an error code.
         pid, returncode = os.waitpid(pid, 0)
         if returncode != 0:
-            raise InstallError("Installation process had nonzero exit code."
-                .format(str(returncode)))
+            raise InstallError("Installation process had nonzero exit code.".format(str(returncode)))
 
 
 class InstallError(spack.error.SpackError):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -178,6 +178,7 @@ def set_build_environment_variables(pkg):
 
     return env
 
+
 def set_module_variables_for_package(pkg, m):
     """Populate the module scope of install() with some useful functions.
        This makes things easier for package writers.
@@ -272,7 +273,6 @@ def setup_package(pkg):
     env = EnvironmentModifications()
     env.extend(set_compiler_environment_variables(pkg))
     env.extend(set_build_environment_variables(pkg))
-    apply_environment_modifications(env)
     # If a user makes their own package repo, e.g.
     # spack.repos.mystuff.libelf.Libelf, and they inherit from
     # an existing class like spack.repos.original.libelf.Libelf,
@@ -284,8 +284,9 @@ def setup_package(pkg):
 
     # Allow dependencies to set up environment as well.
     for dep_spec in pkg.spec.traverse(root=False):
-        dep_spec.package.setup_dependent_environment(
-            pkg.module, dep_spec, pkg.spec)
+        env.extend(dep_spec.package.environment_modifications(pkg.module, dep_spec, pkg.spec))
+        dep_spec.package.setup_dependent_environment(pkg.module, dep_spec, pkg.spec)
+    apply_environment_modifications(env)
 
 
 def fork(pkg, function):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -282,9 +282,11 @@ def setup_package(pkg):
     for mod in modules:
         set_module_variables_for_package(pkg, mod)
 
-    # Allow dependencies to set up environment as well.
+    # Allow dependencies to modify the module
     for dependency_spec in pkg.spec.traverse(root=False):
         dependency_spec.package.modify_module(pkg.module, dependency_spec, pkg.spec)
+    # Allow dependencies to set up environment as well
+    for dependency_spec in pkg.spec.traverse(root=False):
         dependency_spec.package.setup_dependent_environment(env, pkg.spec)
     # TODO : implement validation
     #validate(env)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -284,8 +284,8 @@ def setup_package(pkg):
 
     # Allow dependencies to set up environment as well.
     for dep_spec in pkg.spec.traverse(root=False):
-        env.extend(dep_spec.package.environment_modifications(pkg.module, dep_spec, pkg.spec))
-        dep_spec.package.setup_dependent_environment(pkg.module, dep_spec, pkg.spec)
+        dep_spec.package.module_modifications(pkg.module, dep_spec, pkg.spec)
+        env.extend(dep_spec.package.environment_modifications(pkg.spec))
     apply_environment_modifications(env)
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -34,8 +34,9 @@ import shutil
 import sys
 
 import spack
+import llnl.util.tty as tty
 from llnl.util.filesystem import *
-from spack.environment import EnvironmentModifications, concatenate_paths
+from spack.environment import EnvironmentModifications, concatenate_paths, validate
 from spack.util.environment import *
 from spack.util.executable import Executable, which
 
@@ -288,8 +289,7 @@ def setup_package(pkg):
     # Allow dependencies to set up environment as well
     for dependency_spec in pkg.spec.traverse(root=False):
         dependency_spec.package.setup_dependent_environment(env, pkg.spec)
-    # TODO : implement validation
-    #validate(env)
+    validate(env, tty.warn)
     env.apply_modifications()
 
 

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -80,7 +80,7 @@ def module_find(mtype, spec_array):
     if not os.path.isfile(mod.file_name):
         tty.die("No %s module is installed for %s" % (mtype, spec))
 
-    print mod.use_name
+    print(mod.use_name)
 
 
 def module_refresh():

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -96,9 +96,9 @@ def uninstall(parser, args):
                 pkg.do_uninstall(force=args.force)
             except PackageStillNeededError as e:
                 tty.error("Will not uninstall %s" % e.spec.format("$_$@$%@$#", color=True))
-                print()
+                print('')
                 print("The following packages depend on it:")
                 display_specs(e.dependents, long=True)
-                print()
+                print('')
                 print("You can use spack uninstall -f to force this action.")
                 sys.exit(1)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -79,7 +79,7 @@ def uninstall(parser, args):
                 try:
                     # should work if package is known to spack
                     pkgs.append(s.package)
-                except spack.repository.UnknownPackageError, e:
+                except spack.repository.UnknownPackageError as e:
                     # The package.py file has gone away -- but still
                     # want to uninstall.
                     spack.Package(s).do_uninstall(force=True)
@@ -94,11 +94,11 @@ def uninstall(parser, args):
         for pkg in pkgs:
             try:
                 pkg.do_uninstall(force=args.force)
-            except PackageStillNeededError, e:
+            except PackageStillNeededError as e:
                 tty.error("Will not uninstall %s" % e.spec.format("$_$@$%@$#", color=True))
-                print
-                print "The following packages depend on it:"
+                print()
+                print("The following packages depend on it:")
                 display_specs(e.dependents, long=True)
-                print
-                print "You can use spack uninstall -f to force this action."
+                print()
+                print("You can use spack uninstall -f to force this action.")
                 sys.exit(1)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -150,7 +150,7 @@ class DirectoryLayout(object):
         if os.path.exists(path):
             try:
                 shutil.rmtree(path)
-            except exceptions.OSError, e:
+            except exceptions.OSError as e:
                 raise RemoveFailedError(spec, path, e)
 
         path = os.path.dirname(path)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -73,11 +73,23 @@ class EnvironmentModifications(object):
     Keeps track of requests to modify the current environment
     """
 
-    def __init__(self):
+    def __init__(self, other=None):
         self.env_modifications = []
+        if other is not None:
+            self._check_other(other)
+            self.env_modifications.extend(other.env_modifications)
 
     def __iter__(self):
         return iter(self.env_modifications)
+
+    def extend(self, other):
+        self._check_other(other)
+        self.env_modifications.extend(other.env_modifications)
+
+    @staticmethod
+    def _check_other(other):
+        if not isinstance(other, EnvironmentModifications):
+            raise TypeError('other must be an instance of EnvironmentModifications')
 
     def set_env(self, name, value, **kwargs):
         """
@@ -138,6 +150,9 @@ def validate_environment_modifications(env):
     modifications = collections.defaultdict(list)
     for item in env:
         modifications[item.name].append(item)
+    # TODO : once we organized the modifications into a dictionary that maps an environment variable
+    # TODO : to a list of action to be done on it, we may easily spot inconsistencies and warn the user if
+    # TODO : something suspicious is happening
     return modifications
 
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -146,6 +146,9 @@ class EnvironmentModifications(object):
         self.env_modifications.append(item)
 
 
+def concatenate_paths(paths):
+    return ':'.join(str(item) for item in paths)
+
 def validate_environment_modifications(env):
     modifications = collections.defaultdict(list)
     for item in env:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1,0 +1,157 @@
+import os
+import os.path
+import collections
+
+
+class SetEnv(object):
+    def __init__(self, name, value, **kwargs):
+        self.name = name
+        self.value = value
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def execute(self):
+        os.environ[self.name] = str(self.value)
+
+
+class UnsetEnv(object):
+    def __init__(self, name, **kwargs):
+        self.name = name
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def execute(self):
+        os.environ.pop(self.name, None)  # Avoid throwing if the variable was not set
+
+
+class AppendPath(object):
+    def __init__(self, name, path, **kwargs):
+        self.name = name
+        self.path = path
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def execute(self):
+        environment_value = os.environ.get(self.name, '')
+        directories = environment_value.split(':') if environment_value else []
+        # TODO : Check if this is a valid directory name
+        directories.append(os.path.normpath(self.path))
+        os.environ[self.name] = ':'.join(directories)
+
+
+class PrependPath(object):
+    def __init__(self, name, path, **kwargs):
+        self.name = name
+        self.path = path
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def execute(self):
+        environment_value = os.environ.get(self.name, '')
+        directories = environment_value.split(':') if environment_value else []
+        # TODO : Check if this is a valid directory name
+        directories = [os.path.normpath(self.path)] + directories
+        os.environ[self.name] = ':'.join(directories)
+
+
+class RemovePath(object):
+    def __init__(self, name, path, **kwargs):
+        self.name = name
+        self.path = path
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def execute(self):
+        environment_value = os.environ.get(self.name, '')
+        directories = environment_value.split(':') if environment_value else []
+        directories = [os.path.normpath(x) for x in directories if x != os.path.normpath(self.path)]
+        os.environ[self.name] = ':'.join(directories)
+
+
+class EnvironmentModifications(object):
+    """
+    Keeps track of requests to modify the current environment
+    """
+
+    def __init__(self):
+        self.env_modifications = []
+
+    def __iter__(self):
+        return iter(self.env_modifications)
+
+    def set_env(self, name, value, **kwargs):
+        """
+        Stores in the current object a request to set an environment variable
+
+        Args:
+            name: name of the environment variable to be set
+            value: value of the environment variable
+        """
+        item = SetEnv(name, value, **kwargs)
+        self.env_modifications.append(item)
+
+    def unset_env(self, name, **kwargs):
+        """
+        Stores in the current object a request to unset an environment variable
+
+        Args:
+            name: name of the environment variable to be set
+        """
+        item = UnsetEnv(name, **kwargs)
+        self.env_modifications.append(item)
+
+    def append_path(self, name, path, **kwargs):
+        """
+        Stores in the current object a request to append a path to a path list
+
+        Args:
+            name: name of the path list in the environment
+            path: path to be appended
+        """
+        item = AppendPath(name, path, **kwargs)
+        self.env_modifications.append(item)
+
+    def prepend_path(self, name, path, **kwargs):
+        """
+        Same as `append_path`, but the path is pre-pended
+
+        Args:
+            name: name of the path list in the environment
+            path: path to be pre-pended
+        """
+        item = PrependPath(name, path, **kwargs)
+        self.env_modifications.append(item)
+
+    def remove_path(self, name, path, **kwargs):
+        """
+        Stores in the current object a request to remove a path from a path list
+
+        Args:
+            name: name of the path list in the environment
+            path: path to be removed
+        """
+        item = RemovePath(name, path, **kwargs)
+        self.env_modifications.append(item)
+
+
+def validate_environment_modifications(env):
+    modifications = collections.defaultdict(list)
+    for item in env:
+        modifications[item.name].append(item)
+    return modifications
+
+
+def apply_environment_modifications(env):
+    """
+    Modifies the current environment according to the request in env
+
+    Args:
+        env: object storing modifications to the environment
+    """
+    modifications = validate_environment_modifications(env)
+
+    # Cycle over the environment variables that will be modified
+    for variable, actions in modifications.items():
+        # Execute all the actions in the order they were issued
+        for x in actions:
+            x.execute()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -158,41 +158,43 @@ class EnvironmentModifications(object):
         item = RemovePath(name, path, **kwargs)
         self.env_modifications.append(item)
 
+    def group_by_name(self):
+        """
+        Returns a dict of the modifications grouped by variable name
+
+        Returns:
+            dict mapping the environment variable name to the modifications to be done on it
+        """
+        modifications = collections.defaultdict(list)
+        for item in self:
+            modifications[item.name].append(item)
+        return modifications
+
+    def clear(self):
+        """
+        Clears the current list of modifications
+        """
+        self.env_modifications.clear()
+
+    def apply_modifications(self):
+        """
+        Applies the modifications and clears the list
+        """
+        modifications = self.group_by_name()
+        # Apply the modifications to the environment variables one variable at a time
+        for name, actions in sorted(modifications.items()):
+            for x in actions:
+                x.execute()
+
 
 def concatenate_paths(paths):
     """
-    Concatenates an iterable of paths into a column separated string
+    Concatenates an iterable of paths into a  string of column separated paths
 
     Args:
         paths: iterable of paths
 
     Returns:
-        column separated string
+        string
     """
     return ':'.join(str(item) for item in paths)
-
-
-def validate_environment_modifications(env):
-    modifications = collections.defaultdict(list)
-    for item in env:
-        modifications[item.name].append(item)
-    # TODO : once we organized the modifications into a dictionary that maps an environment variable
-    # TODO : to a list of action to be done on it, we may easily spot inconsistencies and warn the user if
-    # TODO : something suspicious is happening
-    return modifications
-
-
-def apply_environment_modifications(env):
-    """
-    Modifies the current environment according to the request in env
-
-    Args:
-        env: object storing modifications to the environment
-    """
-    modifications = validate_environment_modifications(env)
-
-    # Cycle over the environment variables that will be modified
-    for variable, actions in modifications.items():
-        # Execute all the actions in the order they were issued
-        for x in actions:
-            x.execute()

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -178,7 +178,7 @@ class EnvModule(object):
     def process_environment_command(self, env):
         for command in env:
             # FIXME : how should we handle errors here?
-            yield self.formats[type(command)].format(command)
+            yield self.formats[type(command)].format(**command.args)
 
     @property
     def file_name(self):
@@ -203,8 +203,8 @@ class Dotkit(EnvModule):
     path = join_path(spack.share_path, "dotkit")
 
     formats = {
-        PrependPath: 'dk_alter {0.name} {0.path}\n',
-        SetEnv: 'dk_setenv {0.name} {0.value}\n'
+        PrependPath: 'dk_alter {name} {value}\n',
+        SetEnv: 'dk_setenv {name} {value}\n'
     }
 
     @property
@@ -238,8 +238,8 @@ class TclModule(EnvModule):
     path = join_path(spack.share_path, "modules")
 
     formats = {
-        PrependPath: 'prepend-path {0.name} \"{0.path}\"\n',
-        SetEnv: 'setenv {0.name} \"{0.value}\"\n'
+        PrependPath: 'prepend-path {name} \"{value}\"\n',
+        SetEnv: 'setenv {name} \"{value}\"\n'
     }
 
     @property

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -122,10 +122,6 @@ class EnvModule(object):
         self.spec = spec
         self.pkg = spec.package  # Just stored for convenience
 
-        # category in the modules system
-        # TODO: come up with smarter category names.
-        self.category = "spack"
-
         # short description default is just the package + version
         # packages can provide this optional attribute
         self.short_description = spec.format("$_ $@")
@@ -136,6 +132,17 @@ class EnvModule(object):
         self.long_description = None
         if self.spec.package.__doc__:
             self.long_description = re.sub(r'\s+', ' ', self.spec.package.__doc__)
+
+    @property
+    def category(self):
+        # Anything defined at the package level takes precedence
+        if hasattr(self.pkg, 'category'):
+            return self.pkg.category
+        # Extensions
+        for extendee in self.pkg.extendees:
+            return '{extendee} extension'.format(extendee=extendee)
+        # Not very descriptive fallback
+        return 'spack installed package'
 
     # @property
     # def paths(self):

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -177,8 +177,12 @@ class EnvModule(object):
 
     def process_environment_command(self, env):
         for command in env:
-            # FIXME : how should we handle errors here?
-            yield self.formats[type(command)].format(**command.args)
+            try:
+                yield self.formats[type(command)].format(**command.args)
+            except KeyError:
+                tty.warn('Cannot handle command of type {command} : skipping request'.format(command=type(command)))
+                tty.warn('{context} at {filename}:{lineno}'.format(**command.args))
+
 
     @property
     def file_name(self):

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -119,12 +119,12 @@ class EnvModule(object):
                 module_types[cls.name] = cls
 
     def __init__(self, spec=None):
+        self.spec = spec
+        self.pkg = spec.package  # Just stored for convenience
+
         # category in the modules system
         # TODO: come up with smarter category names.
         self.category = "spack"
-
-        self.spec = spec
-        self.pkg = spec.package  # Just stored for convenience
 
         # short description default is just the package + version
         # packages can provide this optional attribute
@@ -161,6 +161,12 @@ class EnvModule(object):
 
         # Environment modifications guessed by inspecting the installation prefix
         env = inspect_path(self.spec.prefix)
+
+        # Let the extendee modify their extensions before asking for package-specific modifications
+        for extendee in self.pkg.extendees:
+            extendee_spec = self.spec[extendee]
+            extendee_spec.package.modify_module(self.pkg, extendee_spec, self.spec)
+
         # Package-specific environment modifications
         self.spec.package.setup_environment(env)
         # TODO : implement site-specific modifications and filters

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -256,7 +256,10 @@ class TclModule(EnvModule):
 
     formats = {
         PrependPath: 'prepend-path {name} \"{value}\"\n',
-        SetEnv: 'setenv {name} \"{value}\"\n'
+        AppendPath: 'append-path {name} \"{value}\"\n',
+        RemovePath: 'remove-path {name} \"{value}\"\n',
+        SetEnv: 'setenv {name} \"{value}\"\n',
+        UnsetEnv: 'unsetenv {name}\n'
     }
 
     @property

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -165,7 +165,7 @@ class EnvModule(object):
         # Let the extendee modify their extensions before asking for package-specific modifications
         for extendee in self.pkg.extendees:
             extendee_spec = self.spec[extendee]
-            extendee_spec.package.modify_module(self.pkg, extendee_spec, self.spec)
+            extendee_spec.package.modify_module(self.pkg.module, extendee_spec, self.spec)
 
         # Package-specific environment modifications
         self.spec.package.setup_environment(env)

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -162,9 +162,8 @@ class EnvModule(object):
         # Environment modifications guessed by inspecting the installation prefix
         env = inspect_path(self.spec.prefix)
         # Package-specific environment modifications
-        # FIXME : decide how to distinguish between calls done in the installation and elsewhere
-        env.extend(self.spec.package.environment_modifications(None))
-        # site_specific = ...`
+        self.spec.package.setup_environment(env)
+        # TODO : implement site-specific modifications and filters
         if not env:
             return
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -979,6 +979,7 @@ class Package(object):
 
     def setup_environment(self, env):
         """
+
         Called before the install() method of dependents.
 
         Return the list of environment modifications needed by dependents (or extensions). Default implementation does

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -984,10 +984,10 @@ class Package(object):
                           fromlist=[self.__class__.__name__])
 
 
-    def environment_modifications(self, module, spec, dependent_spec):
+    def environment_modifications(self, dependent_spec):
         return EnvironmentModifications()
 
-    def setup_dependent_environment(self, module, spec, dependent_spec):
+    def module_modifications(self, module, spec, dependent_spec):
         """Called before the install() method of dependents.
 
         Default implementation does nothing, but this can be

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -985,30 +985,41 @@ class Package(object):
 
 
     def environment_modifications(self, dependent_spec):
+        """
+        Called before the install() method of dependents.
+
+        Return the list of environment modifications needed by dependents (or extensions). Default implementation does
+        nothing, but this can be overridden by an extendable package to set up the install environment for its
+        extensions. This is useful if there are some common steps to installing all extensions for a certain package.
+
+        Example :
+
+        1. Installing python modules generally requires `PYTHONPATH` to point to the lib/pythonX.Y/site-packages
+        directory in the module's install prefix.  This could set that variable.
+
+        2. A lot of Qt extensions need `QTDIR` set.  This can be used to do that.
+
+        Args:
+            dependent_spec: dependent (or extension) of this spec
+
+        Returns:
+            instance of environment modifications
+        """
         return EnvironmentModifications()
 
     def module_modifications(self, module, spec, dependent_spec):
-        """Called before the install() method of dependents.
+        """
+        Called before the install() method of dependents.
 
-        Default implementation does nothing, but this can be
-        overridden by an extendable package to set up the install
-        environment for its extensions.  This is useful if there are
-        some common steps to installing all extensions for a
+        Default implementation does nothing, but this can be overridden by an extendable package to set up the module of
+        its extensions. This is useful if there are some common steps to installing all extensions for a
         certain package.
 
-        Some examples:
+        Example :
 
-        1. Installing python modules generally requires PYTHONPATH to
-           point to the lib/pythonX.Y/site-packages directory in the
-           module's install prefix.  This could set that variable.
-
-        2. Extensions often need to invoke the 'python' interpreter
-           from the Python installation being extended.  This routine can
-           put a 'python' Execuable object in the module scope for the
-           extension package to simplify extension installs.
-
-        3. A lot of Qt extensions need QTDIR set.  This can be used to do that.
-
+        1. Extensions often need to invoke the 'python' interpreter from the Python installation being extended.
+        This routine can put a 'python' Executable object in the module scope for the extension package to simplify
+        extension installs.
         """
         pass
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -977,7 +977,7 @@ class Package(object):
                           fromlist=[self.__class__.__name__])
 
 
-    def environment_modifications(self, dependent_spec):
+    def setup_environment(self, env):
         """
         Called before the install() method of dependents.
 
@@ -998,9 +998,12 @@ class Package(object):
         Returns:
             instance of environment modifications
         """
-        return EnvironmentModifications()
+        pass
 
-    def module_modifications(self, module, spec, dependent_spec):
+    def setup_dependent_environment(self, env, dependent_spec):
+        self.setup_environment(env)
+
+    def modify_module(self, module, spec, dependent_spec):
         """
         Called before the install() method of dependents.
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -37,6 +37,7 @@ import os
 import re
 import textwrap
 import time
+import glob
 
 import llnl.util.tty as tty
 import spack
@@ -55,7 +56,6 @@ from llnl.util.filesystem import *
 from llnl.util.lang import *
 from llnl.util.link_tree import LinkTree
 from llnl.util.tty.log import log_output
-from spack.environment import EnvironmentModifications
 from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.compression import allowed_archive
 from spack.util.environment import dump_environment
@@ -1235,6 +1235,15 @@ class Package(object):
         """Get the rpath args as a string, with -Wl,-rpath, for each element."""
         return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
 
+
+class PythonExtension(Package):
+    def setup_dependent_environment(self, env, dependent_spec):
+        pass
+
+    def setup_environment(self, env):
+        site_packages = glob.glob(join_path(self.spec.prefix.lib, "python*/site-packages"))
+        if site_packages:
+            env.prepend_path('PYTHONPATH', site_packages[0])
 
 def validate_package_url(url_string):
     """Determine whether spack can handle a particular URL or not."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -63,6 +63,7 @@ import spack.build_environment
 import spack.url
 import spack.util.web
 import spack.fetch_strategy as fs
+from spack.environment import EnvironmentModifications
 from spack.version import *
 from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.compression import allowed_archive, extension
@@ -982,6 +983,9 @@ class Package(object):
         return __import__(self.__class__.__module__,
                           fromlist=[self.__class__.__name__])
 
+
+    def environment_modifications(self, module, spec, dependent_spec):
+        return EnvironmentModifications()
 
     def setup_dependent_environment(self, module, spec, dependent_spec):
         """Called before the install() method of dependents.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1261,16 +1261,6 @@ class Package(object):
         """Get the rpath args as a string, with -Wl,-rpath, for each element."""
         return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
 
-
-class PythonExtension(Package):
-    def setup_dependent_environment(self, env, dependent_spec):
-        pass
-
-    def setup_environment(self, env):
-        site_packages = glob.glob(join_path(self.spec.prefix.lib, "python*/site-packages"))
-        if site_packages:
-            env.prepend_path('PYTHONPATH', site_packages[0])
-
 def validate_package_url(url_string):
     """Determine whether spack can handle a particular URL or not."""
     url = urlparse(url_string)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -34,41 +34,34 @@ rundown on spack and how it differs from homebrew, look at the
 README.
 """
 import os
-import errno
 import re
-import shutil
-import time
-import itertools
-import subprocess
-import platform as py_platform
-import multiprocessing
-from urlparse import urlparse, urljoin
 import textwrap
-from StringIO import StringIO
+import time
 
 import llnl.util.tty as tty
-from llnl.util.tty.log import log_output
-from llnl.util.link_tree import LinkTree
-from llnl.util.filesystem import *
-from llnl.util.lang import *
-
 import spack
-import spack.error
-import spack.compilers
-import spack.mirror
-import spack.hooks
-import spack.directives
-import spack.repository
 import spack.build_environment
+import spack.compilers
+import spack.directives
+import spack.error
+import spack.fetch_strategy as fs
+import spack.hooks
+import spack.mirror
+import spack.repository
 import spack.url
 import spack.util.web
-import spack.fetch_strategy as fs
+from StringIO import StringIO
+from llnl.util.filesystem import *
+from llnl.util.lang import *
+from llnl.util.link_tree import LinkTree
+from llnl.util.tty.log import log_output
 from spack.environment import EnvironmentModifications
-from spack.version import *
 from spack.stage import Stage, ResourceStage, StageComposite
-from spack.util.compression import allowed_archive, extension
-from spack.util.executable import ProcessError
+from spack.util.compression import allowed_archive
 from spack.util.environment import dump_environment
+from spack.util.executable import ProcessError
+from spack.version import *
+from urlparse import urlparse
 
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -976,32 +976,41 @@ class Package(object):
         return __import__(self.__class__.__module__,
                           fromlist=[self.__class__.__name__])
 
-
     def setup_environment(self, env):
         """
+        Appends in `env` the list of environment modifications needed to use this package outside of spack.
 
+        Default implementation does nothing, but this can be overridden if the package needs a particular environment.
+
+        Example :
+
+        1. A lot of Qt extensions need `QTDIR` set.  This can be used to do that.
+
+        Args:
+            env: list of environment modifications to be updated
+        """
+        pass
+
+    def setup_dependent_environment(self, env, dependent_spec):
+        """
         Called before the install() method of dependents.
 
-        Return the list of environment modifications needed by dependents (or extensions). Default implementation does
-        nothing, but this can be overridden by an extendable package to set up the install environment for its
-        extensions. This is useful if there are some common steps to installing all extensions for a certain package.
+        Appends in `env` the list of environment modifications needed by dependents (or extensions) during the
+        installation of a package. The default implementation delegates to `setup_environment`, but can be overridden
+        if the modifications to the environment happen to be different from the one needed to use the package outside
+        of spack.
+
+        This is useful if there are some common steps to installing all extensions for a certain package.
 
         Example :
 
         1. Installing python modules generally requires `PYTHONPATH` to point to the lib/pythonX.Y/site-packages
         directory in the module's install prefix.  This could set that variable.
 
-        2. A lot of Qt extensions need `QTDIR` set.  This can be used to do that.
-
         Args:
+            env: list of environment modifications to be updated
             dependent_spec: dependent (or extension) of this spec
-
-        Returns:
-            instance of environment modifications
         """
-        pass
-
-    def setup_dependent_environment(self, env, dependent_spec):
         self.setup_environment(env)
 
     def modify_module(self, module, spec, dependent_spec):
@@ -1020,11 +1029,9 @@ class Package(object):
         """
         pass
 
-
     def install(self, spec, prefix):
         """Package implementations override this with their own build configuration."""
         raise InstallError("Package %s provides no install method!" % self.name)
-
 
     def do_uninstall(self, force=False):
         if not self.installed:

--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -66,7 +66,8 @@ test_names = ['versions',
               'database',
               'namespace_trie',
               'yaml',
-              'sbang']
+              'sbang',
+              'environment']
 
 
 def list_tests():

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -26,6 +26,7 @@
 These tests check the database is functioning properly,
 both in memory and in its file
 """
+import os.path
 import multiprocessing
 import shutil
 import tempfile

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -62,4 +62,4 @@ class EnvironmentTest(unittest.TestCase):
         copy_construct = EnvironmentModifications(env)
         self.assertEqual(len(copy_construct), 2)
         for x, y in zip(env, copy_construct):
-            self.assertIs(x, y)
+            assert x is y

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -53,7 +53,7 @@ class EnvironmentTest(unittest.TestCase):
         env = EnvironmentModifications()
         env.set_env('A', 'dummy value', who='Pkg1')
         for x in env:
-            assert hasattr(x, 'who')
+            assert 'who' in x.args
         env.apply_modifications()
         self.assertEqual('dummy value', os.environ['A'])
 

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -48,3 +48,12 @@ class EnvironmentTest(unittest.TestCase):
         self.assertEqual('/path/first:/path/middle:/path/last', os.environ['EMPTY_PATH_LIST'])
         self.assertEqual('/path/first:/path/middle:/path/last', os.environ['NEWLY_CREATED_PATH_LIST'])
         self.assertEqual('/a/b:/a/c:/a/d:/f/g', os.environ['REMOVE_PATH_LIST'])
+
+    def test_extra_arguments(self):
+        env = EnvironmentModifications()
+        env.set_env('A', 'dummy value', who='Pkg1')
+        apply_environment_modifications(env)
+        self.assertEqual('dummy value', os.environ['A'])
+
+    def test_copy(self):
+        pass

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -1,0 +1,50 @@
+import unittest
+import os
+from spack.environment import EnvironmentModifications, apply_environment_modifications
+
+
+class EnvironmentTest(unittest.TestCase):
+    def setUp(self):
+        os.environ.clear()
+        os.environ['UNSET_ME'] = 'foo'
+        os.environ['EMPTY_PATH_LIST'] = ''
+        os.environ['PATH_LIST'] = '/path/second:/path/third'
+        os.environ['REMOVE_PATH_LIST'] = '/a/b:/duplicate:/a/c:/remove/this:/a/d:/duplicate/:/f/g'
+
+    def test_set_env(self):
+        env = EnvironmentModifications()
+        env.set_env('A', 'dummy value')
+        env.set_env('B', 3)
+        apply_environment_modifications(env)
+        self.assertEqual('dummy value', os.environ['A'])
+        self.assertEqual(str(3), os.environ['B'])
+
+    def test_unset_env(self):
+        env = EnvironmentModifications()
+        self.assertEqual('foo', os.environ['UNSET_ME'])
+        env.unset_env('UNSET_ME')
+        apply_environment_modifications(env)
+        self.assertRaises(KeyError, os.environ.__getitem__, 'UNSET_ME')
+
+    def test_path_manipulation(self):
+        env = EnvironmentModifications()
+
+        env.append_path('PATH_LIST', '/path/last')
+        env.prepend_path('PATH_LIST', '/path/first')
+
+        env.append_path('EMPTY_PATH_LIST', '/path/middle')
+        env.append_path('EMPTY_PATH_LIST', '/path/last')
+        env.prepend_path('EMPTY_PATH_LIST', '/path/first')
+
+        env.append_path('NEWLY_CREATED_PATH_LIST', '/path/middle')
+        env.append_path('NEWLY_CREATED_PATH_LIST', '/path/last')
+        env.prepend_path('NEWLY_CREATED_PATH_LIST', '/path/first')
+
+        env.remove_path('REMOVE_PATH_LIST', '/remove/this')
+        env.remove_path('REMOVE_PATH_LIST', '/duplicate/')
+
+        apply_environment_modifications(env)
+        self.assertEqual('/path/first:/path/second:/path/third:/path/last', os.environ['PATH_LIST'])
+        self.assertEqual('/path/first:/path/middle:/path/last', os.environ['EMPTY_PATH_LIST'])
+        self.assertEqual('/path/first:/path/middle:/path/last', os.environ['NEWLY_CREATED_PATH_LIST'])
+        self.assertEqual('/a/b:/a/c:/a/d:/f/g', os.environ['REMOVE_PATH_LIST'])

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from spack.environment import EnvironmentModifications, apply_environment_modifications
+from spack.environment import EnvironmentModifications
 
 
 class EnvironmentTest(unittest.TestCase):
@@ -15,7 +15,7 @@ class EnvironmentTest(unittest.TestCase):
         env = EnvironmentModifications()
         env.set_env('A', 'dummy value')
         env.set_env('B', 3)
-        apply_environment_modifications(env)
+        env.apply_modifications()
         self.assertEqual('dummy value', os.environ['A'])
         self.assertEqual(str(3), os.environ['B'])
 
@@ -23,7 +23,7 @@ class EnvironmentTest(unittest.TestCase):
         env = EnvironmentModifications()
         self.assertEqual('foo', os.environ['UNSET_ME'])
         env.unset_env('UNSET_ME')
-        apply_environment_modifications(env)
+        env.apply_modifications()
         self.assertRaises(KeyError, os.environ.__getitem__, 'UNSET_ME')
 
     def test_path_manipulation(self):
@@ -43,7 +43,7 @@ class EnvironmentTest(unittest.TestCase):
         env.remove_path('REMOVE_PATH_LIST', '/remove/this')
         env.remove_path('REMOVE_PATH_LIST', '/duplicate/')
 
-        apply_environment_modifications(env)
+        env.apply_modifications()
         self.assertEqual('/path/first:/path/second:/path/third:/path/last', os.environ['PATH_LIST'])
         self.assertEqual('/path/first:/path/middle:/path/last', os.environ['EMPTY_PATH_LIST'])
         self.assertEqual('/path/first:/path/middle:/path/last', os.environ['NEWLY_CREATED_PATH_LIST'])
@@ -52,7 +52,9 @@ class EnvironmentTest(unittest.TestCase):
     def test_extra_arguments(self):
         env = EnvironmentModifications()
         env.set_env('A', 'dummy value', who='Pkg1')
-        apply_environment_modifications(env)
+        for x in env:
+            assert hasattr(x, 'who')
+        env.apply_modifications()
         self.assertEqual('dummy value', os.environ['A'])
 
     def test_extend(self):

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -55,5 +55,11 @@ class EnvironmentTest(unittest.TestCase):
         apply_environment_modifications(env)
         self.assertEqual('dummy value', os.environ['A'])
 
-    def test_copy(self):
-        pass
+    def test_extend(self):
+        env = EnvironmentModifications()
+        env.set_env('A', 'dummy value')
+        env.set_env('B', 3)
+        copy_construct = EnvironmentModifications(env)
+        self.assertEqual(len(copy_construct), 2)
+        for x, y in zip(env, copy_construct):
+            self.assertIs(x, y)

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -40,13 +40,11 @@ def env_flag(name):
     return False
 
 
-# FIXME : remove this function ?
 def path_set(var_name, directories):
     path_str = ":".join(str(dir) for dir in directories)
     os.environ[var_name] = path_str
 
 
-# FIXME : remove this function ?
 def path_put_first(var_name, directories):
     """Puts the provided directories first in the path, adding them
        if they're not already there.

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -40,11 +40,13 @@ def env_flag(name):
     return False
 
 
+# FIXME : remove this function ?
 def path_set(var_name, directories):
     path_str = ":".join(str(dir) for dir in directories)
     os.environ[var_name] = path_str
 
 
+# FIXME : remove this function ?
 def path_put_first(var_name, directories):
     """Puts the provided directories first in the path, adding them
        if they're not already there.
@@ -57,12 +59,6 @@ def path_put_first(var_name, directories):
 
     new_path = tuple(directories) + tuple(path)
     path_set(var_name, new_path)
-
-
-def pop_keys(dictionary, *keys):
-    for key in keys:
-        if key in dictionary:
-            dictionary.pop(key)
 
 
 def dump_environment(path):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -64,5 +64,5 @@ def path_put_first(var_name, directories):
 def dump_environment(path):
     """Dump the current environment out to a file."""
     with open(path, 'w') as env_file:
-        for key,val in sorted(os.environ.items()):
+        for key, val in sorted(os.environ.items()):
             env_file.write("%s=%s\n" % (key, val))

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -47,30 +47,21 @@ class Mpich(Package):
     provides('mpi@:3.0', when='@3:')
     provides('mpi@:1.3', when='@1:')
 
-    def environment_modifications(self, dependent_spec):
-        env = super(Mpich, self).environment_modifications(dependent_spec)
+    def setup_environment(self, env):
+        env.set_env('MPICH_CC', self.compiler.cc)
+        env.set_env('MPICH_CXX', self.compiler.cxx)
+        env.set_env('MPICH_F77', self.compiler.f77)
+        env.set_env('MPICH_F90', self.compiler.fc)
+        env.set_env('MPICH_FC', self.compiler.fc)
 
-        if dependent_spec is None:
-            # We are not using compiler wrappers
-            cc = self.compiler.cc
-            cxx = self.compiler.cxx
-            f77 = self.compiler.f77
-            f90 = fc = self.compiler.fc
-        else:
-            # Spack compiler wrappers
-            cc = os.environ['CC']
-            cxx = os.environ['CXX']
-            f77 = os.environ['F77']
-            f90 = fc = os.environ['FC']
+    def setup_dependent_environment(self, env, dependent_spec):
+        env.set_env('MPICH_CC', spack_cc)
+        env.set_env('MPICH_CXX', spack_cxx)
+        env.set_env('MPICH_F77', spack_f77)
+        env.set_env('MPICH_F90', spack_f90)
+        env.set_env('MPICH_FC', spack_fc)
 
-        env.set_env('MPICH_CC', cc)
-        env.set_env('MPICH_CXX', cxx)
-        env.set_env('MPICH_F77', f77)
-        env.set_env('MPICH_F90', f90)
-        env.set_env('MPICH_FC', fc)
-        return env
-
-    def module_modifications(self, module, spec, dep_spec):
+    def modify_module(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
         # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?
         module.mpicc = join_path(self.prefix.bin, 'mpicc')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import os
 
+
 class Mpich(Package):
     """MPICH is a high performance and widely portable implementation of
        the Message Passing Interface (MPI) standard."""
@@ -48,11 +49,25 @@ class Mpich(Package):
 
     def environment_modifications(self, dependent_spec):
         env = super(Mpich, self).environment_modifications(dependent_spec)
-        env.set_env('MPICH_CC', os.environ['CC'])
-        env.set_env('MPICH_CXX', os.environ['CXX'])
-        env.set_env('MPICH_F77', os.environ['F77'])
-        env.set_env('MPICH_F90', os.environ['FC'])
-        env.set_env('MPICH_FC', os.environ['FC'])
+
+        if dependent_spec is None:
+            # We are not using compiler wrappers
+            cc = self.compiler.cc
+            cxx = self.compiler.cxx
+            f77 = self.compiler.f77
+            f90 = fc = self.compiler.fc
+        else:
+            # Spack compiler wrappers
+            cc = os.environ['CC']
+            cxx = os.environ['CXX']
+            f77 = os.environ['F77']
+            f90 = fc = os.environ['FC']
+
+        env.set_env('MPICH_CC', cc)
+        env.set_env('MPICH_CXX', cxx)
+        env.set_env('MPICH_F77', f77)
+        env.set_env('MPICH_F90', f90)
+        env.set_env('MPICH_FC', fc)
         return env
 
     def module_modifications(self, module, spec, dep_spec):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -46,8 +46,8 @@ class Mpich(Package):
     provides('mpi@:3.0', when='@3:')
     provides('mpi@:1.3', when='@1:')
 
-    def environment_modifications(self, module, spec, dependent_spec):
-        env = super(Mpich, self).environment_modifications(module, spec, dependent_spec)
+    def environment_modifications(self, dependent_spec):
+        env = super(Mpich, self).environment_modifications(dependent_spec)
         env.set_env('MPICH_CC', os.environ['CC'])
         env.set_env('MPICH_CXX', os.environ['CXX'])
         env.set_env('MPICH_F77', os.environ['F77'])
@@ -55,7 +55,7 @@ class Mpich(Package):
         env.set_env('MPICH_FC', os.environ['FC'])
         return env
 
-    def setup_dependent_environment(self, module, spec, dep_spec):
+    def module_modifications(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
         # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?
         module.mpicc = join_path(self.prefix.bin, 'mpicc')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -46,14 +46,18 @@ class Mpich(Package):
     provides('mpi@:3.0', when='@3:')
     provides('mpi@:1.3', when='@1:')
 
+    def environment_modifications(self, module, spec, dependent_spec):
+        env = super(Mpich, self).environment_modifications(module, spec, dependent_spec)
+        env.set_env('MPICH_CC', os.environ['CC'])
+        env.set_env('MPICH_CXX', os.environ['CXX'])
+        env.set_env('MPICH_F77', os.environ['F77'])
+        env.set_env('MPICH_F90', os.environ['FC'])
+        env.set_env('MPICH_FC', os.environ['FC'])
+        return env
+
     def setup_dependent_environment(self, module, spec, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
-        os.environ['MPICH_CC']  = os.environ['CC']
-        os.environ['MPICH_CXX'] = os.environ['CXX']
-        os.environ['MPICH_F77'] = os.environ['F77']
-        os.environ['MPICH_F90'] = os.environ['FC']
-        os.environ['MPICH_FC'] = os.environ['FC']
-
+        # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?
         module.mpicc = join_path(self.prefix.bin, 'mpicc')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -123,7 +123,7 @@ class Mvapich2(Package):
                 count += 1
         if count > 1:
             raise RuntimeError('network variants are mutually exclusive (only one can be selected at a time)')
-
+        network_options = []
         # From here on I can suppose that only one variant has been selected
         if self.enabled(Mvapich2.PSM) in spec:
             network_options = ["--with-device=ch3:psm"]

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -40,7 +40,7 @@ class NetlibScalapack(Package):
             make()
             make("install")
 
-    def setup_dependent_environment(self, module, spec, dependent_spec):
+    def module_modifications(self, module, spec, dependent_spec):
         # TODO treat OS that are not Linux...
         lib_suffix = '.so' if '+shared' in spec['scalapack'] else '.a'
 

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -46,5 +46,4 @@ class NetlibScalapack(Package):
 
         spec['scalapack'].fc_link = '-L%s -lscalapack' % spec['scalapack'].prefix.lib
         spec['scalapack'].cc_link = spec['scalapack'].fc_link
-        spec['scalapack'].libraries = [join_path(spec['scalapack'].prefix.lib,
-                                                 'libscalapack%s' % lib_suffix)]
+        spec['scalapack'].libraries = [join_path(spec['scalapack'].prefix.lib, 'libscalapack%s' % lib_suffix)]

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -40,7 +40,7 @@ class NetlibScalapack(Package):
             make()
             make("install")
 
-    def module_modifications(self, module, spec, dependent_spec):
+    def modify_module(self, module, spec, dependent_spec):
         # TODO treat OS that are not Linux...
         lib_suffix = '.so' if '+shared' in spec['scalapack'] else '.a'
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -41,8 +41,8 @@ class Openmpi(Package):
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
 
-    def environment_modifications(self, module, spec, dependent_spec):
-        env = super(Openmpi, self).environment_modifications(module, spec, dependent_spec)
+    def environment_modifications(self, dependent_spec):
+        env = super(Openmpi, self).environment_modifications(dependent_spec)
         # FIXME : the compilers should point to the current wrappers, not to generic cc etc.
         env.set_env('OMPI_CC', 'cc')
         env.set_env('OMPI_CXX', 'c++')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -41,14 +41,17 @@ class Openmpi(Package):
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
 
-    def environment_modifications(self, dependent_spec):
-        env = super(Openmpi, self).environment_modifications(dependent_spec)
-        # FIXME : the compilers should point to the current wrappers, not to generic cc etc.
-        env.set_env('OMPI_CC', 'cc')
-        env.set_env('OMPI_CXX', 'c++')
-        env.set_env('OMPI_FC', 'f90')
-        env.set_env('OMPI_F77', 'f77')
-        return env
+    def setup_environment(self, env):
+        env.set_env('OMPI_CC', self.compiler.cc)
+        env.set_env('OMPI_CXX', self.compiler.cxx)
+        env.set_env('OMPI_FC', self.compiler.fc)
+        env.set_env('OMPI_F77', self.compiler.f77)
+
+    def setup_dependent_environment(self, env, dependent_spec):
+        env.set_env('OMPI_CC', spack_cc)
+        env.set_env('OMPI_CXX', spack_cxx)
+        env.set_env('OMPI_FC', spack_fc)
+        env.set_env('OMPI_F77', spack_f77)
 
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -41,12 +41,14 @@ class Openmpi(Package):
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
 
-    def setup_dependent_environment(self, module, spec, dep_spec):
-        """For dependencies, make mpicc's use spack wrapper."""
-        os.environ['OMPI_CC'] = 'cc'
-        os.environ['OMPI_CXX'] = 'c++'
-        os.environ['OMPI_FC'] = 'f90'
-        os.environ['OMPI_F77'] = 'f77'
+    def environment_modifications(self, module, spec, dependent_spec):
+        env = super(Openmpi, self).environment_modifications(module, spec, dependent_spec)
+        # FIXME : the compilers should point to the current wrappers, not to generic cc etc.
+        env.set_env('OMPI_CC', 'cc')
+        env.set_env('OMPI_CXX', 'c++')
+        env.set_env('OMPI_FC', 'f90')
+        env.set_env('OMPI_F77', 'f77')
+        return env
 
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -1,4 +1,4 @@
-import urllib2
+import urllib
 import llnl.util.tty as tty
 
 from spack import *
@@ -37,22 +37,17 @@ class Openssl(Package):
             version_number = '.'.join([str(x) for x in version[:-1]])
             older_url = older.format(version_number=version_number, version_full=version)
             latest_url = latest.format(version=version)
-            try:
-                response = urllib2.urlopen(latest.format(version=version), timeout=5)
-                if response.getcode() == 404:
-                    openssl_url = older_url
-                    # Checks if we already warned the user for this particular version of OpenSSL.
-                    # If not we display a warning message and mark this version
-                    if not warnings_given_to_user.get(version, False):
-                        tty.warn('This installation depends on an old version of OpenSSL, which may have known security issues. ')
-                        tty.warn('Consider updating to the latest version of this package.')
-                        tty.warn('More details at {homepage}'.format(homepage=Openssl.homepage))
-                        warnings_given_to_user[version] = True
-                else:
-                    openssl_url = latest_url
-            except urllib2.URLError:
-                tty.warn('Cannot connect to network to retrieve OpenSSL version. Using default url.')
-                warnings_given_to_user[version] = True
+            response = urllib.urlopen(latest.format(version=version))
+            if response.getcode() == 404:
+                openssl_url = older_url
+                # Checks if we already warned the user for this particular version of OpenSSL.
+                # If not we display a warning message and mark this version
+                if not warnings_given_to_user.get(version, False):
+                    tty.warn('This installation depends on an old version of OpenSSL, which may have known security issues. ')
+                    tty.warn('Consider updating to the latest version of this package.')
+                    tty.warn('More details at {homepage}'.format(homepage=Openssl.homepage))
+                    warnings_given_to_user[version] = True
+            else:
                 openssl_url = latest_url
             # Store the computed URL
             openssl_urls[version] = openssl_url

--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -1,6 +1,7 @@
 from spack import *
+from spack.package import PythonExtension
 
-class PyNose(Package):
+class PyNose(PythonExtension):
     """nose extends the test loading and running features of unittest,
     making it easier to write, find and run tests."""
 

--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -1,12 +1,12 @@
 from spack import *
-from spack.package import PythonExtension
 
-class PyNose(PythonExtension):
+
+class PyNose(Package):
     """nose extends the test loading and running features of unittest,
     making it easier to write, find and run tests."""
 
     homepage = "https://pypi.python.org/pypi/nose"
-    url      = "https://pypi.python.org/packages/source/n/nose/nose-1.3.4.tar.gz"
+    url = "https://pypi.python.org/packages/source/n/nose/nose-1.3.4.tar.gz"
 
     version('1.3.4', '6ed7169887580ddc9a8e16048d38274d')
     version('1.3.6', '0ca546d81ca8309080fc80cb389e7a16')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -89,19 +89,17 @@ class Python(Package):
     def site_packages_dir(self):
         return os.path.join(self.python_lib_dir, 'site-packages')
 
-
-    def environment_modifications(self, module, spec, dependent_spec):
-        env = super(Python, self).environment_modifications(module, spec, dependent_spec)
+    def environment_modifications(self, extension_spec):
+        env = super(Python, self).environment_modifications(extension_spec)
         # Set PYTHONPATH to include site-packages dir for the
         # extension and any other python extensions it depends on.
         python_paths = []
-        for d in ext_spec.traverse():
+        for d in extension_spec.traverse():
             if d.package.extends(self.spec):
                 python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
         env.set_env['PYTHONPATH'] = ':'.join(python_paths)
 
-
-    def setup_dependent_environment(self, module, spec, ext_spec):
+    def module_modifications(self, module, spec, ext_spec):
         """Called before python modules' install() methods.
 
         In most cases, extensions will only need to have one line::

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -95,7 +95,7 @@ class Python(Package):
         for d in extension_spec.traverse():
             if d.package.extends(self.spec):
                 python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
-        env.set_env['PYTHONPATH'] = ':'.join(python_paths)
+        env.set_env('PYTHONPATH', ':'.join(python_paths))
 
     def modify_module(self, module, spec, ext_spec):
         """

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -98,6 +98,7 @@ class Python(Package):
             if d.package.extends(self.spec):
                 python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
         env.set_env['PYTHONPATH'] = ':'.join(python_paths)
+        return env
 
     def module_modifications(self, module, spec, ext_spec):
         """Called before python modules' install() methods.

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -91,13 +91,14 @@ class Python(Package):
 
     def environment_modifications(self, extension_spec):
         env = super(Python, self).environment_modifications(extension_spec)
-        # Set PYTHONPATH to include site-packages dir for the
-        # extension and any other python extensions it depends on.
-        python_paths = []
-        for d in extension_spec.traverse():
-            if d.package.extends(self.spec):
-                python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
-        env.set_env['PYTHONPATH'] = ':'.join(python_paths)
+        if extension_spec is not None:
+            # Set PYTHONPATH to include site-packages dir for the
+            # extension and any other python extensions it depends on.
+            python_paths = []
+            for d in extension_spec.traverse():
+                if d.package.extends(self.spec):
+                    python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
+            env.set_env['PYTHONPATH'] = ':'.join(python_paths)
         return env
 
     def module_modifications(self, module, spec, ext_spec):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -89,24 +89,21 @@ class Python(Package):
     def site_packages_dir(self):
         return os.path.join(self.python_lib_dir, 'site-packages')
 
-    def environment_modifications(self, extension_spec):
-        env = super(Python, self).environment_modifications(extension_spec)
-        if extension_spec is not None:
-            # Set PYTHONPATH to include site-packages dir for the
-            # extension and any other python extensions it depends on.
-            python_paths = []
-            for d in extension_spec.traverse():
-                if d.package.extends(self.spec):
-                    python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
-            env.set_env['PYTHONPATH'] = ':'.join(python_paths)
-        return env
+    def setup_dependent_environment(self, env, extension_spec):
+        # Set PYTHONPATH to include site-packages dir for the extension and any other python extensions it depends on.
+        python_paths = []
+        for d in extension_spec.traverse():
+            if d.package.extends(self.spec):
+                python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
+        env.set_env['PYTHONPATH'] = ':'.join(python_paths)
 
-    def module_modifications(self, module, spec, ext_spec):
-        """Called before python modules' install() methods.
+    def modify_module(self, module, spec, ext_spec):
+        """
+        Called before python modules' install() methods.
 
         In most cases, extensions will only need to have one line::
 
-            python('setup.py', 'install', '--prefix=%s' % prefix)
+        python('setup.py', 'install', '--prefix=%s' % prefix)
         """
         # Python extension builds can have a global python executable function
         if self.version >= Version("3.0.0") and self.version < Version("4.0.0"):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -90,6 +90,17 @@ class Python(Package):
         return os.path.join(self.python_lib_dir, 'site-packages')
 
 
+    def environment_modifications(self, module, spec, dependent_spec):
+        env = super(Python, self).environment_modifications(module, spec, dependent_spec)
+        # Set PYTHONPATH to include site-packages dir for the
+        # extension and any other python extensions it depends on.
+        python_paths = []
+        for d in ext_spec.traverse():
+            if d.package.extends(self.spec):
+                python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
+        env.set_env['PYTHONPATH'] = ':'.join(python_paths)
+
+
     def setup_dependent_environment(self, module, spec, ext_spec):
         """Called before python modules' install() methods.
 
@@ -110,15 +121,6 @@ class Python(Package):
 
         # Make the site packages directory if it does not exist already.
         mkdirp(module.site_packages_dir)
-
-        # Set PYTHONPATH to include site-packages dir for the
-        # extension and any other python extensions it depends on.
-        python_paths = []
-        for d in ext_spec.traverse():
-            if d.package.extends(self.spec):
-                python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
-        os.environ['PYTHONPATH'] = ':'.join(python_paths)
-
 
     # ========================================================================
     # Handle specifics of activating and deactivating python modules.

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -55,10 +55,8 @@ class Qt(Package):
     depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb")
 
-    def environment_modifications(self, dependent_spec):
-        env = super(Qt, self).environment_modifications(dependent_spec)
+    def setup_environment(self, env):
         env.set_env['QTDIR'] = self.prefix
-        return env
 
     def patch(self):
         if self.spec.satisfies('@4'):

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -52,11 +52,8 @@ class Qt(Package):
     depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb")
 
-    def environment_modifications(self, module, spec, dep_spec):
-        """
-        Dependencies of Qt find it using the QTDIR environment variable
-        """
-        env = super(Qt, self).environment_modifications(module, spec, dep_spec)
+    def environment_modifications(self, dependent_spec):
+        env = super(Qt, self).environment_modifications(dependent_spec)
         env.set_env['QTDIR'] = self.prefix
         return env
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -52,11 +52,13 @@ class Qt(Package):
     depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb")
 
-
-    def setup_dependent_environment(self, module, spec, dep_spec):
-        """Dependencies of Qt find it using the QTDIR environment variable."""
-        os.environ['QTDIR'] = self.prefix
-
+    def environment_modifications(self, module, spec, dep_spec):
+        """
+        Dependencies of Qt find it using the QTDIR environment variable
+        """
+        env = super(Qt, self).environment_modifications(module, spec, dep_spec)
+        env.set_env['QTDIR'] = self.prefix
+        return env
 
     def patch(self):
         if self.spec.satisfies('@4'):

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -1,6 +1,5 @@
 from spack import *
-import spack
-import os
+
 
 class Ruby(Package):
     """A dynamic, open source programming language with a focus on 
@@ -18,19 +17,19 @@ class Ruby(Package):
         make()
         make("install")
 
-    def environment_modifications(self, module, spec, ext_spec):
-        env = super(Ruby, self).environment_modifications(module, spec, ext_spec)
+    def environment_modifications(self, extension_spec):
+        env = super(Ruby, self).environment_modifications(extension_spec)
         # Set GEM_PATH to include dependent gem directories
         ruby_paths = []
-        for d in ext_spec.traverse():
+        for d in extension_spec.traverse():
             if d.package.extends(self.spec):
                 ruby_paths.append(d.prefix)
         env.set_env('GEM_PATH', concatenate_paths(ruby_paths))
         # The actual installation path for this gem
-        env.set_env('GEM_HOME', ext_spec.prefix)
+        env.set_env('GEM_HOME', extension_spec.prefix)
         return env
 
-    def setup_dependent_environment(self, module, spec, ext_spec):
+    def module_modifications(self, module, spec, ext_spec):
         """Called before ruby modules' install() methods.  Sets GEM_HOME
         and GEM_PATH to values appropriate for the package being built.
 

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -17,8 +17,7 @@ class Ruby(Package):
         make()
         make("install")
 
-    def environment_modifications(self, extension_spec):
-        env = super(Ruby, self).environment_modifications(extension_spec)
+    def setup_dependent_environment(self, env, extension_spec):
         # Set GEM_PATH to include dependent gem directories
         ruby_paths = []
         for d in extension_spec.traverse():
@@ -27,9 +26,8 @@ class Ruby(Package):
         env.set_env('GEM_PATH', concatenate_paths(ruby_paths))
         # The actual installation path for this gem
         env.set_env('GEM_HOME', extension_spec.prefix)
-        return env
 
-    def module_modifications(self, module, spec, ext_spec):
+    def modify_module(self, module, spec, ext_spec):
         """Called before ruby modules' install() methods.  Sets GEM_HOME
         and GEM_PATH to values appropriate for the package being built.
 


### PR DESCRIPTION
##### Objective 
Being able to customize what gets written in a module file

##### TLDR
Currently the modifications that gets written in a module file are:

- generic modifications to some list of paths in the environment

These modifications are obtained inspecting `pkg.prefix` according to the same set of rules for every package. I would like to extend this process allowing:

- package-specific modifications to the environment (this PR)
- site-specific modifications via a configuration file (a subsequent PR)

##### Current Status
- [x] class that manages environment modifications during both installation and module file creation (module + unit tests)
- [x] environment variables set in a package are written to tcl or dotkit module files
- [x] polished the interface that package maintainers will need to use
- [x] validation of environment modifications (i.e. detect conflicting changes to the same variable issued by different packages)

##### Examples of use
1. `openmpi` and `mpich` packages in this PR set the environment variables for compiler wrappers differently depending on whether they are used as a dependency during an installation or outside of spack via module files

##### Details
The biggest change done in this PR is the introduction of a class (`EnvironmentModifications`) to manage environment modifications both during install and module file creation. An object of this class is essentially a FIFO queue containing requests to modify the environment. Those requests can be executed at a later time and from a scope other than where they were created (in which case the environment is modified and the list is cleared.) 

Alternatively the requests can be inspected and processed. This is what is done during module file creation when each module file writer (`TclModule`, `Dotkit`) maps each single request to a formatted line and writes that line to a file.

An interesting side effect of this design is the possibility to inspect the whole set of requests done by different packages before applying them. This could permit to reveal inconsistencies (e.g.  variables that are set by a package and unset by another) and output diagnostic messages to the user.