### PR TITLE
Add sanity check paths to packages; fix #505

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -38,6 +38,9 @@ class Libelf(Package):
 
     provides('elf')
 
+    sanity_check_files = ['include/libelf.h']
+    sanity_check_dirs  = ['lib']
+
     def install(self, spec, prefix):
         configure("--prefix=" + prefix,
                   "--enable-shared",


### PR DESCRIPTION
Fix #505: This adds two properties to `Package`: `sanity_check_files` and `sanity_check_dirs`.  They might look like this for libelf:

```python
class Libelf(Package):
    ...
    sanity_check_files = ['include/libelf.h']                                                                                                          
    sanity_check_dirs  = ['lib']
```

Spack will check for the existence and type of these files/directories, and if they're not present, or if they're not files (directories), then Spack will fail the build.

The intent is that you add a few files here that *must* be present for the install to have succeeded.  This should allow you to write sane builds for ill-behaved packages that write to their install directories before the build is complete.