### PR TITLE
Adding latest version in binutils

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -4,10 +4,13 @@ class Binutils(Package):
     """GNU binutils, which contain the linker, assembler, objdump and others"""
     homepage = "http://www.gnu.org/software/binutils/"
 
-    version('2.25', 'd9f3303f802a5b6b0bb73a335ab89d66',url="ftp://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2")
-    version('2.24', 'e0f71a7b2ddab0f8612336ac81d9636b',url="ftp://ftp.gnu.org/gnu/binutils/binutils-2.24.tar.bz2")
-    version('2.23.2', '4f8fa651e35ef262edc01d60fb45702e',url="ftp://ftp.gnu.org/gnu/binutils/binutils-2.23.2.tar.bz2")
-    version('2.20.1', '2b9dc8f2b7dbd5ec5992c6e29de0b764',url="ftp://ftp.gnu.org/gnu/binutils/binutils-2.20.1.tar.bz2")
+    url="https://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
+
+    version('2.26', '64146a0faa3b411ba774f47d41de239f')
+    version('2.25', 'd9f3303f802a5b6b0bb73a335ab89d66')
+    version('2.24', 'e0f71a7b2ddab0f8612336ac81d9636b')
+    version('2.23.2', '4f8fa651e35ef262edc01d60fb45702e')
+    version('2.20.1', '2b9dc8f2b7dbd5ec5992c6e29de0b764')
 
     # Add a patch that creates binutils libiberty_pic.a which is preferred by OpenSpeedShop and cbtf-krell
     variant('krellpatch', default=False, description="build with openspeedshop based patch.")


### PR DESCRIPTION
Adding version 2.26 to have the same version than on debian testing to avoid linking errors with glibc