### PR TITLE
Add Licensed Software Support

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -813,7 +813,7 @@ points to a license server called licman1:
     USE_SERVER
 
 If your package requires the license to install, you can reference the
-location of this global license using ``Package.global_license_file()``.
+location of this global license using ``self.global_license_file``.
 After installation, symlinks for all of the files given in
 ``license_files`` will be created, pointing to this global license.
 If you install a different version or variant of the package, Spack

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -703,6 +703,127 @@ Fetching a revision
 Subversion branches are handled as part of the directory structure, so
 you can check out a branch or tag by changing the ``url``.
 
+
+.. _license:
+
+Licensed software
+------------------------------------------
+
+In order to install licensed software, Spack needs to know a few more
+details about a package. The following class attributes should be defined.
+
+``license_required``
+~~~~~~~~~~~~~~~~~~~~~
+
+Boolean. If set to ``True``, this software requires a license. If set to
+``False``, all of the following attributes will be ignored. Defaults to
+``False``.
+
+``license_comment``
+~~~~~~~~~~~~~~~~~~~~~
+
+String. Contains the symbol used by the license manager to denote a comment.
+Defaults to ``#``.
+
+``license_files``
+~~~~~~~~~~~~~~~~~~~~~
+
+List of strings. These are files that the software searches for when
+looking for a license. All file paths must be relative to the installation
+directory. More complex packages like Intel may require multiple
+licenses for individual components. Defaults to the empty list.
+
+``license_vars``
+~~~~~~~~~~~~~~~~~~~~~
+
+List of strings. Environment variables that can be set to tell the software
+where to look for a license if it is not in the usual location. Defaults
+to the empty list.
+
+``license_url``
+~~~~~~~~~~~~~~~~~~~~~
+
+String. A URL pointing to license setup instructions for the software.
+Defaults to the empty string.
+
+For example, let's take a look at the package for the PGI compilers.
+
+.. code-block:: python
+
+    # Licensing
+    license_required = True
+    license_comment  = '#'
+    license_files    = ['license.dat']
+    license_vars     = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
+    license_url      = 'http://www.pgroup.com/doc/pgiinstall.pdf'
+
+As you can see, PGI requires a license. Its license manager, FlexNet, uses
+the ``#`` symbol to denote a comment. It expects the license file to be
+named ``license.dat`` and to be located directly in the installation prefix.
+If you would like the installation file to be located elsewhere, simply set
+``PGROUPD_LICENSE_FILE`` or ``LM_LICENSE_FILE`` after installation. For
+further instructions on installation and licensing, see the URL provided.
+
+Let's walk through a sample PGI installation to see exactly what Spack is
+and isn't capable of. Since PGI does not provide a download URL, it must
+be downloaded manually. It can either be added to a mirror or located in
+the current directory when ``spack install pgi`` is run. See :ref:`mirrors`
+for instructions on setting up a mirror.
+
+After running ``spack install pgi``, the first thing that will happen is
+Spack will create a global license file located at
+``$SPACK_ROOT/etc/spack/licenses/pgi/license.dat``. It will then open up the
+file using the editor set in ``$EDITOR``, or vi if unset. It will look like
+this:
+
+.. code-block::
+
+    # A license is required to use pgi.
+    #
+    # The recommended solution is to store your license key in this global
+    # license file. After installation, the following symlink(s) will be
+    # added to point to this file (relative to the installation prefix):
+    #
+    #   license.dat
+    #
+    # Alternatively, use one of the following environment variable(s):
+    #
+    #   PGROUPD_LICENSE_FILE
+    #   LM_LICENSE_FILE
+    #
+    # If you choose to store your license in a non-standard location, you may
+    # set one of these variable(s) to the full pathname to the license file, or
+    # port@host if you store your license keys on a dedicated license server.
+    # You will likely want to set this variable in a module file so that it
+    # gets loaded every time someone tries to use pgi.
+    #
+    # For further information on how to acquire a license, please refer to:
+    #
+    #   http://www.pgroup.com/doc/pgiinstall.pdf
+    #
+    # You may enter your license below.
+
+You can add your license directly to this file, or tell FlexNet to use a
+license stored on a separate license server. Here is an example that
+points to a license server called licman1:
+
+.. code-block::
+
+    SERVER licman1.mcs.anl.gov 00163eb7fba5 27200
+    USE_SERVER
+
+If your package requires the license to install, you can reference the
+location of this global license using ``Package.global_license_file()``.
+After installation, symlinks for all of the files given in
+``license_files`` will be created, pointing to this global license.
+If you install a different version or variant of the package, Spack
+will automatically detect and reuse the already existing global license.
+
+If the software you are trying to package doesn't rely on license files,
+Spack will print a warning message, letting the user know that they
+need to set an environment variable or pointing them to installation
+documentation.
+
 .. _patching:
 
 Patches

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -134,4 +134,3 @@ def symlink_license(pkg):
             os.symlink(target, link_name)
             tty.msg("Added local symlink %s to global license file" %
                     link_name)
-

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -1,0 +1,135 @@
+import os
+
+import spack
+import llnl.util.tty as tty
+from llnl.util.filesystem import join_path
+
+
+def pre_install(pkg):
+    """This hook handles global license setup for licensed software."""
+    if pkg.license_required:
+        set_up_license(pkg)
+
+
+def set_up_license(pkg):
+    """Prompt the user, letting them know that a license is required.
+
+    For packages that rely on license files, a global license file is
+    created and opened for editing.
+
+    For packages that rely on environment variables to point to a
+    license, a warning message is printed.
+
+    For all other packages, documentation on how to set up a license
+    is printed."""
+
+    # If the license can be stored in a file, create one
+    if pkg.license_files:
+        license_path = pkg.global_license_file
+        if not os.path.exists(license_path):
+            # Create a new license file
+            write_license_file(pkg, license_path)
+            # Open up file in user's favorite $EDITOR for editing
+            spack.editor(license_path)
+            tty.msg("Added global license file %s" % license_path)
+        else:
+            # Use already existing license file
+            tty.msg("Found already existing license %s" % license_path)
+
+    # If not a file, what about an environment variable?
+    elif pkg.license_vars:
+        tty.warn("A license is required to use %s. Please set %s to the "
+                 "full pathname to the license file, or port@host if you"
+                 " store your license keys on a dedicated license server" %
+                 (pkg.name, ' or '.join(pkg.license_vars)))
+
+    # If not a file or variable, suggest a website for further info
+    elif pkg.license_url:
+        tty.warn("A license is required to use %s. See %s for details" %
+                (pkg.name, pkg.license_url))
+
+    # If all else fails, you're on your own
+    else:
+        tty.warn("A license is required to use %s" % pkg.name)
+
+
+def write_license_file(pkg, license_path):
+    """Writes empty license file.
+
+    Comments give suggestions on alternative methods of
+    installing a license."""
+
+    comment = pkg.license_comment
+
+    # Global license directory may not already exist
+    if not os.path.exists(os.path.dirname(license_path)):
+        os.makedirs(os.path.dirname(license_path))
+    license = open(license_path, 'w')
+
+    # License files
+    license.write("""\
+{0} A license is required to use {1}.
+{0}
+{0} The recommended solution is to store your license key in this global
+{0} license file. After installation, the following symlink(s) will be
+{0} added to point to this file (relative to the installation prefix):
+{0}
+""".format(comment, pkg.name))
+
+    for filename in pkg.license_files:
+        license.write("{0}\t{1}\n".format(comment, filename))
+
+    license.write("{0}\n".format(comment))
+
+    # Environment variables
+    if pkg.license_vars:
+        license.write("""\
+{0} Alternatively, use one of the following environment variable(s):
+{0}
+""".format(comment))
+
+        for var in pkg.license_vars:
+            license.write("{0}\t{1}\n".format(comment, var))
+
+        license.write("""\
+{0}
+{0} If you choose to store your license in a non-standard location, you may
+{0} set one of these variable(s) to the full pathname to the license file, or
+{0} port@host if you store your license keys on a dedicated license server.
+{0} You will likely want to set this variable in a module file so that it
+{0} gets loaded every time someone tries to use {1}.
+{0}
+""".format(comment, pkg.name))
+
+    # Documentation
+    if pkg.license_url:
+        license.write("""\
+{0} For further information on how to acquire a license, please refer to:
+{0}
+{0}\t{1}
+{0}
+""".format(comment, pkg.license_url))
+
+    license.write("""\
+{0} You may enter your license below.
+
+""".format(comment))
+
+    license.close()
+
+
+def post_install(pkg):
+    """This hook symlinks local licenses to the global license for
+    licensed software."""
+    if pkg.license_required:
+        symlink_license(pkg)
+
+
+def symlink_license(pkg):
+    """Create local symlinks that point to the global license file."""
+    target = pkg.global_license_file
+    for filename in pkg.license_files:
+        link_name = join_path(pkg.prefix, filename)
+        if os.path.exists(target):
+            os.symlink(target, link_name)
+            tty.msg("Added local symlink %s to global license file" % link_name)

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -46,7 +46,7 @@ def set_up_license(pkg):
     # If not a file or variable, suggest a website for further info
     elif pkg.license_url:
         tty.warn("A license is required to use %s. See %s for details" %
-                (pkg.name, pkg.license_url))
+                 (pkg.name, pkg.license_url))
 
     # If all else fails, you're on your own
     else:
@@ -132,4 +132,6 @@ def symlink_license(pkg):
         link_name = join_path(pkg.prefix, filename)
         if os.path.exists(target):
             os.symlink(target, link_name)
-            tty.msg("Added local symlink %s to global license file" % link_name)
+            tty.msg("Added local symlink %s to global license file" %
+                    link_name)
+

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1029,13 +1029,6 @@ class Package(object):
                          os.path.basename(self.license_files[0]))
 
 
-    def local_license_symlink(self):
-        """Returns the path where a local license file is searched for."""
-        if not self.license_files:
-            return
-        return join_path(self.prefix, self.license_files[0])
-
-
     def set_up_license(self):
         """Prompt the user, letting them know that a license is required."""
 
@@ -1086,9 +1079,9 @@ class Package(object):
         license.write("""\
 {0} A license is required to use {1}.
 {0}
-{0} The recommended solution is to store your license key in this file.
-{0} By default, {1} searches the following file(s) for a license key
-{0} (relative to the installation prefix):
+{0} The recommended solution is to store your license key in this global
+{0} license file. After installation, the following symlink(s) will be
+{0} added to point to this file (relative to the installation prefix):
 {0}
 """.format(comment, self.name))
 
@@ -1135,12 +1128,13 @@ class Package(object):
 
 
     def symlink_license(self):
-        """Create a local symlink that points to the global license file."""
-        target    = self.global_license_file()
-        link_name = self.local_license_symlink()
-        if os.path.exists(target):
-            os.symlink(target, link_name)
-            tty.msg("Added local symlink %s to global license file" % link_name)
+        """Create local symlinks that point to the global license file."""
+        target = self.global_license_file()
+        for filename in self.license_files:
+            link_name = join_path(self.prefix, filename)
+            if os.path.exists(target):
+                os.symlink(target, link_name)
+                tty.msg("Added local symlink %s to global license file" % link_name)
 
 
     def do_install_dependencies(self, **kwargs):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1052,7 +1052,7 @@ class Package(object):
 #
 #\t%s
 #
-""" % (self.name, self.name, self.name, '\n#\t'.join(self.license_files)))
+""" % (self.name, self.name, '\n#\t'.join(self.license_files)))
 
         if self.license_vars:
             license.write("""\

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -378,6 +378,9 @@ class Package(object):
         if not hasattr(self, 'license_required'):
             self.license_required = False
 
+        if not hasattr(self, 'license_comment'):
+            self.license_comment = '#'
+
         if not hasattr(self, 'license_files'):
             self.license_files = []
 
@@ -1040,46 +1043,59 @@ class Package(object):
 
 
     def write_license_file(self, license_path):
-        # Use the first file listed in license_files
+        """Writes empty license file.
+
+        Comments give suggestions on alternative methods of installing
+        a license."""
+
+        comment = self.license_comment
         license = open(license_path, 'w')
 
         license.write("""\
-# A license is required to use %s.
-#
-# The recommended solution is to store your license key in this file.
-# By default, %s searches the following file(s) for a license key
-# (relative to the installation prefix):
-#
-#\t%s
-#
-""" % (self.name, self.name, '\n#\t'.join(self.license_files)))
+{0} A license is required to use {1}.
+{0}
+{0} The recommended solution is to store your license key in this file.
+{0} By default, {1} searches the following file(s) for a license key
+{0} (relative to the installation prefix):
+{0}
+""".format(comment, self.name))
+
+        for filename in self.license_files:
+            license.write("{0}\t{1}\n".format(comment, filename))
+
+        license.write("{0}\n".format(comment))
 
         if self.license_vars:
             license.write("""\
-# Alternatively, use one of the following environment variable(s):
-#
-#\t%s
-#
-# If you choose to store your license in a non-standard location, you may
-# set one of these variable(s) to the full pathname to the license file, or
-# port@host if you store your license keys on a dedicated license server.
-# You will likely want to set this variable in a module file so that it
-# gets loaded every time someone tries to use %s.
-#
-""" % ('\n#\t'.join(self.license_vars), self.name))
+{0} Alternatively, use one of the following environment variable(s):
+{0}
+""".format(comment))
+
+            for var in self.license_vars:
+                license.write("{0}\t{1}\n".format(comment, var))
+
+            license.write("""\
+{0}
+{0} If you choose to store your license in a non-standard location, you may
+{0} set one of these variable(s) to the full pathname to the license file, or
+{0} port@host if you store your license keys on a dedicated license server.
+{0} You will likely want to set this variable in a module file so that it
+{0} gets loaded every time someone tries to use {1}.
+{0}
+""".format(comment, self.name))
 
         if self.license_url:
             license.write("""\
-# For further information on how to acquire a license, please refer to:
-#
-#\t%s
-#
-""" % self.license_url)
+{0} For further information on how to acquire a license, please refer to:
+{0}
+{0}\t{1}
+{0}
+""".format(comment, self.license_url))
 
         license.write("""\
-# You may enter your license below.
+{0} You may enter your license below.
 
-""")
+""".format(comment))
 
         license.close()
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1071,6 +1071,7 @@ class Package(object):
         if self.license_url:
             license.write("""\
 # For further information on how to acquire a license, please refer to:
+#
 #\t%s
 #
 """ % self.license_url)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -407,7 +407,6 @@ class Package(object):
         return join_path(global_license_dir, self.name,
                          os.path.basename(self.license_files[0]))
 
-
     @property
     def version(self):
         if not self.spec.versions.concrete:
@@ -1021,7 +1020,6 @@ class Package(object):
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)
 
-
     def do_install_dependencies(self, **kwargs):
         # Pass along paths of dependencies here
         for dep in self.spec.dependencies.values():
@@ -1349,11 +1347,9 @@ class Package(object):
     def rpath(self):
         """Get the rpath this package links with, as a list of paths."""
         rpaths = [self.prefix.lib, self.prefix.lib64]
-        rpaths.extend(d.prefix.lib
-                      for d in self.spec.traverse(root=False)
+        rpaths.extend(d.prefix.lib for d in self.spec.traverse(root=False)
                       if os.path.isdir(d.prefix.lib))
-        rpaths.extend(d.prefix.lib64
-                      for d in self.spec.traverse(root=False)
+        rpaths.extend(d.prefix.lib64 for d in self.spec.traverse(root=False)
                       if os.path.isdir(d.prefix.lib64))
         return rpaths
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -374,6 +374,19 @@ class Package(object):
         if not hasattr(self, 'list_depth'):
             self.list_depth = 1
 
+        # Set default licensing information
+        if not hasattr(self, 'license_required'):
+            self.license_required = False
+
+        if not hasattr(self, 'license_files'):
+            self.license_files = []
+
+        if not hasattr(self, 'license_vars'):
+            self.license_vars = []
+
+        if not hasattr(self, 'license_url'):
+            self.license_url = None
+
         # Set up some internal variables for timing.
         self._fetch_time = 0.0
         self._total_time = 0.0

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -13,10 +13,10 @@ class AllineaForge(Package):
 
     # Licensing
     license_required = True
-    license_comment  = '#'
-    license_files    = ['licences/Licence']
-    license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
-    license_url      = 'http://www.allinea.com/user-guide/forge/Installation.html'
+    license_comment = '#'
+    license_files = ['licences/Licence']
+    license_vars = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
+    license_url = 'http://www.allinea.com/user-guide/forge/Installation.html'
 
     def url_for_version(self, version):
         # TODO: add support for other architectures/distributions

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -1,5 +1,6 @@
 from spack import *
 
+
 class AllineaForge(Package):
     """Allinea Forge is the complete toolsuite for software development - with
     everything needed to debug, profile, optimize, edit and build C, C++ and
@@ -17,12 +18,10 @@ class AllineaForge(Package):
     license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
     license_url      = 'http://www.allinea.com/user-guide/forge/Installation.html'
 
-
     def url_for_version(self, version):
         # TODO: add support for other architectures/distributions
         url = "http://content.allinea.com/downloads/"
         return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
-
 
     def install(self, spec, prefix):
         textinstall = which('textinstall.sh')

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -1,0 +1,29 @@
+from spack import *
+
+class AllineaForge(Package):
+    """Allinea Forge is the complete toolsuite for software development - with
+    everything needed to debug, profile, optimize, edit and build C, C++ and
+    Fortran applications on Linux for high performance - from single threads
+    through to complex parallel HPC codes with MPI, OpenMP, threads or CUDA."""
+
+    homepage = "http://www.allinea.com/products/develop-allinea-forge"
+
+    version('6.0.4', 'df7f769975048477a36f208d0cd57d7e')
+
+    # Licensing
+    license_required = True
+    license_comment  = '#'
+    license_files    = ['licences/Licence']
+    license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
+    license_url      = 'http://www.allinea.com/user-guide/forge/Installation.html'
+
+
+    def url_for_version(self, version):
+        # TODO: add support for other architectures/distributions
+        url = "http://content.allinea.com/downloads/"
+        return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
+
+
+    def install(self, spec, prefix):
+        textinstall = which('textinstall.sh')
+        textinstall('--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/allinea-reports/package.py
+++ b/var/spack/repos/builtin/packages/allinea-reports/package.py
@@ -1,9 +1,11 @@
 from spack import *
 
+
 class AllineaReports(Package):
     """Allinea Performance Reports are the most effective way to characterize
-    and understand the performance of HPC application runs. One single-page HTML
-    report elegantly answers a range of vital questions for any HPC site"""
+    and understand the performance of HPC application runs. One single-page
+    HTML report elegantly answers a range of vital questions for any HPC site
+    """
 
     homepage = "http://www.allinea.com/products/allinea-performance-reports"
 
@@ -16,12 +18,10 @@ class AllineaReports(Package):
     license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
     license_url      = 'http://www.allinea.com/user-guide/reports/Installation.html'
 
-
     def url_for_version(self, version):
         # TODO: add support for other architectures/distributions
         url = "http://content.allinea.com/downloads/"
         return url + "allinea-reports-%s-Redhat-6.0-x86_64.tar" % version
-
 
     def install(self, spec, prefix):
         textinstall = which('textinstall.sh')

--- a/var/spack/repos/builtin/packages/allinea-reports/package.py
+++ b/var/spack/repos/builtin/packages/allinea-reports/package.py
@@ -13,10 +13,10 @@ class AllineaReports(Package):
 
     # Licensing
     license_required = True
-    license_comment  = '#'
-    license_files    = ['licences/Licence']
-    license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
-    license_url      = 'http://www.allinea.com/user-guide/reports/Installation.html'
+    license_comment = '#'
+    license_files = ['licences/Licence']
+    license_vars = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
+    license_url = 'http://www.allinea.com/user-guide/reports/Installation.html'
 
     def url_for_version(self, version):
         # TODO: add support for other architectures/distributions

--- a/var/spack/repos/builtin/packages/allinea-reports/package.py
+++ b/var/spack/repos/builtin/packages/allinea-reports/package.py
@@ -1,0 +1,28 @@
+from spack import *
+
+class AllineaReports(Package):
+    """Allinea Performance Reports are the most effective way to characterize
+    and understand the performance of HPC application runs. One single-page HTML
+    report elegantly answers a range of vital questions for any HPC site"""
+
+    homepage = "http://www.allinea.com/products/allinea-performance-reports"
+
+    version('6.0.4', '3f13b08a32682737bc05246fbb2fcc77')
+
+    # Licensing
+    license_required = True
+    license_comment  = '#'
+    license_files    = ['licences/Licence']
+    license_vars     = ['ALLINEA_LICENCE_FILE', 'ALLINEA_LICENSE_FILE']
+    license_url      = 'http://www.allinea.com/user-guide/reports/Installation.html'
+
+
+    def url_for_version(self, version):
+        # TODO: add support for other architectures/distributions
+        url = "http://content.allinea.com/downloads/"
+        return url + "allinea-reports-%s-Redhat-6.0-x86_64.tar" % version
+
+
+    def install(self, spec, prefix):
+        textinstall = which('textinstall.sh')
+        textinstall('--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -11,10 +11,10 @@ class Nag(Package):
 
     # Licensing
     license_required = True
-    license_comment  = '!'
-    license_files    = ['lib/nag.key']
-    license_vars     = ['NAG_KUSARI_FILE']
-    license_url      = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
+    license_comment = '!'
+    license_files = ['lib/nag.key']
+    license_vars = ['NAG_KUSARI_FILE']
+    license_url = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
 
     def url_for_version(self, version):
         # TODO: url and checksum are architecture dependent

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -1,6 +1,7 @@
 from spack import *
 import os
 
+
 class Nag(Package):
     """The NAG Fortran Compiler."""
     homepage = "http://www.nag.com/nagware/np.asp"
@@ -15,13 +16,11 @@ class Nag(Package):
     license_vars     = ['NAG_KUSARI_FILE']
     license_url      = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
 
-
     def url_for_version(self, version):
         # TODO: url and checksum are architecture dependent
         # TODO: We currently only support x86_64
         return 'http://www.nag.com/downloads/impl/npl6a%sna_amd64.tgz' % \
-                str(version).replace('.', '')
-
+               str(version).replace('.', '')
 
     def install(self, spec, prefix):
         # Set installation directories

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -1,0 +1,26 @@
+from spack import *
+import os
+
+class Nag(Package):
+    """The NAG Fortran Compiler."""
+    homepage = "http://www.nag.com/nagware/np.asp"
+
+    version('6.1', '1e29d9d435b7ccc2842a320150b28ba4',
+            url='http://www.nag.com/downloads/impl/npl6a61na_amd64.tgz')
+
+    # Licensing
+    license_required = True
+    license_files    = ['lib/nag.key',
+                        'lib/nag.licence',
+                        'lib/nagware.licence']
+    license_vars     = ['NAG_KUSARI_FILE']
+    license_url      = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
+
+    def install(self, spec, prefix):
+        # Set installation directories
+        os.environ['INSTALL_TO_BINDIR'] = prefix.bin
+        os.environ['INSTALL_TO_LIBDIR'] = prefix.lib
+        os.environ['INSTALL_TO_MANDIR'] = prefix + '/share/man/man'
+
+        # Run install script
+        os.system('./INSTALLU.sh')

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -5,16 +5,25 @@ class Nag(Package):
     """The NAG Fortran Compiler."""
     homepage = "http://www.nag.com/nagware/np.asp"
 
-    version('6.1', '1e29d9d435b7ccc2842a320150b28ba4',
-            url='http://www.nag.com/downloads/impl/npl6a61na_amd64.tgz')
+    version('6.1', '1e29d9d435b7ccc2842a320150b28ba4')
+    version('6.0', '3fa1e7f7b51ef8a23e6c687cdcad9f96')
 
     # Licensing
     license_required = True
+    license_comment  = '!'
     license_files    = ['lib/nag.key',
                         'lib/nag.licence',
                         'lib/nagware.licence']
     license_vars     = ['NAG_KUSARI_FILE']
     license_url      = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
+
+
+    def url_for_version(self, version):
+        # TODO: url and checksum are architecture dependent
+        # TODO: We currently only support x86_64
+        return 'http://www.nag.com/downloads/impl/npl6a%sna_amd64.tgz' % \
+                str(version).replace('.', '')
+
 
     def install(self, spec, prefix):
         # Set installation directories

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -11,9 +11,7 @@ class Nag(Package):
     # Licensing
     license_required = True
     license_comment  = '!'
-    license_files    = ['lib/nag.key',
-                        'lib/nag.licence',
-                        'lib/nagware.licence']
+    license_files    = ['lib/nag.key']
     license_vars     = ['NAG_KUSARI_FILE']
     license_url      = 'http://www.nag.com/doc/inun/np61/lin-mac/klicence.txt'
 

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -1,6 +1,7 @@
 from spack import *
 import os
 
+
 class Pgi(Package):
     """PGI optimizing multi-core x64 compilers for Linux, MacOS & Windows
     with support for debugging and profiling of local MPI processes.
@@ -18,12 +19,18 @@ class Pgi(Package):
 
     version('16.3', '618cb7ddbc57d4e4ed1f21a0ab25f427')
 
-    variant('network', default=True,  description="Perform a network install")
-    variant('single',  default=False, description="Perform a single system install")
-    variant('nvidia',  default=False, description="Enable installation of optional NVIDIA components, such as CUDA")
-    variant('amd',     default=False, description="Enable installation of optional AMD components")
-    variant('java',    default=False, description="Enable installation of Java Runtime Environment")
-    variant('mpi',     default=False, description="Enable installation of Open MPI")
+    variant('network', default=True,
+        description="Perform a network install")
+    variant('single',  default=False,
+        description="Perform a single system install")
+    variant('nvidia',  default=False,
+        description="Enable installation of optional NVIDIA components")
+    variant('amd',     default=False,
+        description="Enable installation of optional AMD components")
+    variant('java',    default=False,
+        description="Enable installation of Java Runtime Environment")
+    variant('mpi',     default=False,
+        description="Enable installation of Open MPI")
 
     # Licensing
     license_required = True
@@ -31,7 +38,6 @@ class Pgi(Package):
     license_files    = ['license.dat']
     license_vars     = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
     license_url      = 'http://www.pgroup.com/doc/pgiinstall.pdf'
-
 
     def install(self, spec, prefix):
         # Enable the silent installation feature
@@ -41,12 +47,13 @@ class Pgi(Package):
 
         if '+network' in spec and '~single' in spec:
             os.environ['PGI_INSTALL_TYPE'] = "network"
-            os.environ['PGI_INSTALL_LOCAL_DIR'] = "%s/%s/share_objects" % (prefix, self.version)
+            os.environ['PGI_INSTALL_LOCAL_DIR'] = "%s/%s/share_objects" % \
+                (prefix, self.version)
         elif '+single' in spec and '~network' in spec:
             os.environ['PGI_INSTALL_TYPE'] = "single"
         else:
-            msg  = 'You must choose either a network install or a single system install.\n'
-            msg += 'You cannot choose both.'
+            msg  = 'You must choose either a network install or a single '
+            msg += 'system install.\nYou cannot choose both.'
             raise RuntimeError(msg)
 
         if '+nvidia' in spec:

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -27,6 +27,7 @@ class Pgi(Package):
 
     # Licensing
     license_required = True
+    license_comment  = '#'
     license_files    = ['license.dat']
     license_vars     = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
     license_url      = 'http://www.pgroup.com/doc/pgiinstall.pdf'

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -1,6 +1,4 @@
 from spack import *
-import spack
-import llnl.util.tty as tty
 import os
 
 class Pgi(Package):
@@ -27,46 +25,18 @@ class Pgi(Package):
     variant('java',    default=False, description="Enable installation of Java Runtime Environment")
     variant('mpi',     default=False, description="Enable installation of Open MPI")
 
-
-    def set_up_license(self, prefix):
-        license_path = "%s/license.dat" % prefix
-
-        with open(license_path, "w") as license:
-            license.write("""\
-# The PGI compilers require a license to use. There are two ways to set this up.
-#
-# 1.    (Recommended) Store your license key in this license.dat file. Example:
-#
-#       SERVER <hostname> 0123456789ab 27000
-#       DAEMON pgroupd
-#       PACKAGE PGI2015-<PGI_PIN> pgroupd <subscription end date>  A13AB920D570 \\
-#       <...>
-#       6167 7015 3F05 9C37 2315 ACDF 1B73 DAA9 FBAE"
-#
-# 2.    Use the environment variable PGROUPD_LICENSE_FILE or LM_LICENSE_FILE.
-#
-#       If you choose to store your license in a non-standard location, you may
-#       set either one of these variables to a full pathname to the license
-#       file, or port@host if you store your license keys on a dedicated
-#       license server. You will likely want to set this variable in a module
-#       file so that it gets loaded every time someone wants to use PGI.
-#
-# For further information on how to acquire a license, please refer to:
-# http://www.pgroup.com/doc/pgiinstall.pdf
-#
-# You may enter your license below.
-
-""")
-
-        #spack.editor(license_path)
-        tty.msg("Set up license file %s" % license_path)
+    # Licensing
+    license_required = True
+    license_files    = ['license.dat']
+    license_vars     = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
+    license_url      = 'http://www.pgroup.com/doc/pgiinstall.pdf'
 
 
     def install(self, spec, prefix):
         # Enable the silent installation feature
         os.environ['PGI_SILENT'] = "true"
         os.environ['PGI_ACCEPT_EULA'] = "accept"
-        os.environ['PGI_INSTALL_DIR'] = "%s" % prefix
+        os.environ['PGI_INSTALL_DIR'] = prefix
 
         if '+network' in spec and '~single' in spec:
             os.environ['PGI_INSTALL_TYPE'] = "network"
@@ -92,6 +62,3 @@ class Pgi(Package):
 
         # Run install script
         os.system("./install")
-
-        # Prompt user to set up license file
-        self.set_up_license(prefix)

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -1,0 +1,97 @@
+from spack import *
+import spack
+import llnl.util.tty as tty
+import os
+
+class Pgi(Package):
+    """PGI optimizing multi-core x64 compilers for Linux, MacOS & Windows
+    with support for debugging and profiling of local MPI processes.
+
+    Note: The PGI compilers are licensed software. You will need to create
+    an account on the PGI homepage and download PGI yourself. Once the download
+    finishes, rename the file (which may contain information such as the
+    architecture) to the format: pgi-<version>.tar.gz. Spack will search your
+    current directory for a file of this format. Alternatively, add this
+    file to a mirror so that Spack can find it. For instructions on how to
+    set up a mirror, see http://software.llnl.gov/spack/mirrors.html"""
+
+    homepage = "http://www.pgroup.com/"
+    url      = "file://%s/pgi-16.3.tar.gz" % os.getcwd()
+
+    version('16.3', '618cb7ddbc57d4e4ed1f21a0ab25f427')
+
+    variant('network', default=True,  description="Perform a network install")
+    variant('single',  default=False, description="Perform a single system install")
+    variant('nvidia',  default=False, description="Enable installation of optional NVIDIA components, such as CUDA")
+    variant('amd',     default=False, description="Enable installation of optional AMD components")
+    variant('java',    default=False, description="Enable installation of Java Runtime Environment")
+    variant('mpi',     default=False, description="Enable installation of Open MPI")
+
+
+    def set_up_license(self, prefix):
+        license_path = "%s/license.dat" % prefix
+
+        with open(license_path, "w") as license:
+            license.write("""\
+# The PGI compilers require a license to use. There are two ways to set this up.
+#
+# 1.    (Recommended) Store your license key in this license.dat file. Example:
+#
+#       SERVER <hostname> 0123456789ab 27000
+#       DAEMON pgroupd
+#       PACKAGE PGI2015-<PGI_PIN> pgroupd <subscription end date>  A13AB920D570 \\
+#       <...>
+#       6167 7015 3F05 9C37 2315 ACDF 1B73 DAA9 FBAE"
+#
+# 2.    Use the environment variable PGROUPD_LICENSE_FILE or LM_LICENSE_FILE.
+#
+#       If you choose to store your license in a non-standard location, you may
+#       set either one of these variables to a full pathname to the license
+#       file, or port@host if you store your license keys on a dedicated
+#       license server. You will likely want to set this variable in a module
+#       file so that it gets loaded every time someone wants to use PGI.
+#
+# For further information on how to acquire a license, please refer to:
+# http://www.pgroup.com/doc/pgiinstall.pdf
+#
+# You may enter your license below.
+
+""")
+
+        spack.editor(license_path)
+        tty.message("Set up license file %s" % license_path)
+
+
+    def install(self, spec, prefix):
+        # Enable the silent installation feature
+        os.environ['PGI_SILENT'] = "true"
+        os.environ['PGI_ACCEPT_EULA'] = "accept"
+        os.environ['PGI_INSTALL_DIR'] = "%s" % prefix
+
+        if '+network' in spec and '~single' in spec:
+            os.environ['PGI_INSTALL_TYPE'] = "network"
+            os.environ['PGI_INSTALL_LOCAL_DIR'] = "%s/%s/share_objects" % (prefix, self.version)
+        elif '+single' in spec and '~network' in spec:
+            os.environ['PGI_INSTALL_TYPE'] = "single"
+        else:
+            msg  = 'You must choose either a network install or a single system install.\n'
+            msg += 'You cannot choose both.'
+            raise RuntimeError(msg)
+
+        if '+nvidia' in spec:
+            os.environ['PGI_INSTALL_NVIDIA'] = "true"
+
+        if '+amd' in spec:
+            os.environ['PGI_INSTALL_AMD'] = "true"
+
+        if '+java' in spec:
+            os.environ['PGI_INSTALL_JAVA'] = "true"
+
+        if '+mpi' in spec:
+            os.environ['PGI_INSTALL_MPI'] = "true"
+
+        # Run install script
+        os.system("./install")
+
+        # Prompt user to set up license file
+        self.set_up_license(prefix)

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -58,8 +58,8 @@ class Pgi(Package):
 
 """)
 
-        spack.editor(license_path)
-        tty.message("Set up license file %s" % license_path)
+        #spack.editor(license_path)
+        tty.msg("Set up license file %s" % license_path)
 
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -15,29 +15,29 @@ class Pgi(Package):
     set up a mirror, see http://software.llnl.gov/spack/mirrors.html"""
 
     homepage = "http://www.pgroup.com/"
-    url      = "file://%s/pgi-16.3.tar.gz" % os.getcwd()
+    url = "file://%s/pgi-16.3.tar.gz" % os.getcwd()
 
     version('16.3', '618cb7ddbc57d4e4ed1f21a0ab25f427')
 
     variant('network', default=True,
-        description="Perform a network install")
+            description="Perform a network install")
     variant('single',  default=False,
-        description="Perform a single system install")
+            description="Perform a single system install")
     variant('nvidia',  default=False,
-        description="Enable installation of optional NVIDIA components")
+            description="Enable installation of optional NVIDIA components")
     variant('amd',     default=False,
-        description="Enable installation of optional AMD components")
+            description="Enable installation of optional AMD components")
     variant('java',    default=False,
-        description="Enable installation of Java Runtime Environment")
+            description="Enable installation of Java Runtime Environment")
     variant('mpi',     default=False,
-        description="Enable installation of Open MPI")
+            description="Enable installation of Open MPI")
 
     # Licensing
     license_required = True
-    license_comment  = '#'
-    license_files    = ['license.dat']
-    license_vars     = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
-    license_url      = 'http://www.pgroup.com/doc/pgiinstall.pdf'
+    license_comment = '#'
+    license_files = ['license.dat']
+    license_vars = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
+    license_url = 'http://www.pgroup.com/doc/pgiinstall.pdf'
 
     def install(self, spec, prefix):
         # Enable the silent installation feature


### PR DESCRIPTION
With this package, users will be able to install and use PGI compilers with ease. They will still have to download the file manually since you need to create an account and login. But the build is automated, and Spack walks you through the license setup. Spack can locate the package in two ways: it will find the file if it is in the user's current directory and it will find it if it is in a mirror.

See #553 for a previous conversation regarding the installation of licensed software.

Remaining potential problems to tackle:

1. ~~Currently the installation hangs at `spack.editor(license_path)`. It installs the software properly and writes to license.dat, but doesn't open an editor like `spack create` does. Guess that's what I get for trying to be fancy. Also, `tty.msg()` prints to `spack-build.out`. Is there a way to get it to print to STDOUT?~~

2. Technically, PGI depends on the Linux Standard Base (lsb). We don't have it installed here and PGI builds fine, but the installation raises a warning when it is not present. Another warning message is raised when GCC can't find a 32-bit C library. I'm not sure how easy it would be to write a package for lsb since it seems to be dependent on the architecture.

3. There is no single PGI compiler source code. PGI offers many compilers, including C/C++/Fortran, CUDA, and Visual Fortran. Downloads are further divided into 64-bit/32-bit and Linux/OS X/Windows. Luckily they all seem to have the same installation process? But they will all have different checksums and filenames. For example, the checksum I added is for PGI Accelerator Fortran/C/C++ Server, 64-bit, Linux, Full. The downloaded file was named `pgilinux-2016-163-x86_64.tar.gz`. I think it's safe to require users to rename this file to `pgi-16.3.tar.gz`, but they will have to install with `--no-checksum` unless we can find a way to add a list of checksums for a single version.

4. PGI refers to the version as 16.3, but when Spack extracts the version with `pgcc -V`, it gets 16.3-0. I believe PGI numbers updates with the dash number. Should we add this to the version I used? Should we remove this from Spack's PGI version regex?

5. I would like the `+network` variant to be enabled on Linux by default. But network installations don't work on OS X. The `+single` variant should be enabled by default on Darwin instead.

6. Should we even provide the variants to allow users to build NVIDIA, AMD, JRE, and MPI?

7. Minor annoyance, but is there a way to preserve the empty line in the package description? Or is there a better place to put the note about downloading the file?