### PR TITLE
Disabled Vulnerable Git Versions

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -5,14 +5,22 @@ class Git(Package):
        system designed to handle everything from small to very large
        projects with speed and efficiency."""
     homepage = "http://git-scm.com"
-    url      = "https://www.kernel.org/pub/software/scm/git/git-2.2.1.tar.gz"
+    url      = "https://github.com/git/git/tarball/v2.7.1"
 
-    version('2.6.3', 'b711be7628a4a2c25f38d859ee81b423')
-    version('2.6.2', 'da293290da69f45a86a311ad3cd43dc8')
-    version('2.6.1', '4c62ee9c5991fe93d99cf2a6b68397fd')
-    version('2.6.0', 'eb76a07148d94802a1745d759716a57e')
-    version('2.5.4', '3eca2390cf1fa698b48e2a233563a76b')
-    version('2.2.1', 'ff41fdb094eed1ec430aed8ee9b9849c')
+    version('2.8.0-rc2', 'c2cf9f2cc70e35f2fafbaf9258f82e4c')
+    version('2.7.3', 'fa1c008b56618c355a32ba4a678305f6')
+    version('2.7.1', 'bf0706b433a8dedd27a63a72f9a66060')
+
+
+    # See here for info on vulnerable Git versions:
+    # http://www.theregister.co.uk/2016/03/16/git_server_client_patch_now/
+    # All the following are vulnerable
+    #version('2.6.3', 'b711be7628a4a2c25f38d859ee81b423')
+    #version('2.6.2', 'da293290da69f45a86a311ad3cd43dc8')
+    #version('2.6.1', '4c62ee9c5991fe93d99cf2a6b68397fd')
+    #version('2.6.0', 'eb76a07148d94802a1745d759716a57e')
+    #version('2.5.4', '3eca2390cf1fa698b48e2a233563a76b')
+    #version('2.2.1', 'ff41fdb094eed1ec430aed8ee9b9849c')
 
 
     # Git compiles with curl support by default on but if your system
@@ -24,6 +32,7 @@ class Git(Package):
     variant("expat", default=False, description="Add the internal support of expat for https push")
 
     depends_on("openssl")
+    depends_on("autoconf")
     depends_on("curl", when="+curl")
     depends_on("expat", when="+expat")
 
@@ -47,6 +56,7 @@ class Git(Package):
         if '+expat' in spec:
             configure_args.append("--with-expat=%s" % spec['expat'].prefix)
 
+        which('autoreconf')('-i')
         configure(*configure_args)
         make()
         make("install")


### PR DESCRIPTION
Versions 2.7.1--2.7.3 fix one of two vulnerabilities.

The only version of git known to be completely non-vulnerable is 2.8, which is not yet released.  This package will now install 2.8.0-rc2 by default --- assuming that a RC version is better than one known to be vulnerable.

There is currently no tarball download for v2.8.0-rc2.  Instead, it is downloaded directly from GitHub.  Additional autoconf dependency was added to create the ./configure script, which is normally only available in distributed tarballs.  The added dependency is no problem for Spack.