### PR TITLE
Add additional suffixes for GCC compiler

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -40,7 +40,8 @@ class Gcc(Compiler):
     fc_names = ['gfortran']
 
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
-    suffixes = [r'-mp-\d\.\d']
+    # Homebrew and Linuxes may build gcc with -X, -X.Y suffixes
+    suffixes = [r'-mp-\d\.\d', r'-\d\.\d', r'-\d']
 
     # Named wrapper links within spack.build_env_path
     link_paths = {'cc'  : 'gcc/gcc',


### PR DESCRIPTION
As discussed on the mailing list here:

https://groups.google.com/forum/#!topic/spack/VR6TNzk_N9E

Spack does not pick up Homebrew gcc compilers, and a further personal test also showed it doesn't find multiple installs of gcc compilers on a Linux box (i.e. `/usr/bin/gcc`, `/usr/bin/gcc-4.7`, `/usr/bin/gcc-4.9`).

I think I've traced this to the suffixes used in the `gcc.py` module which only used a regex for MacPorts installs. The PR adds two additional regexes for installs of gcc that use `-MAJOR.MINOR` and `-MAJOR` suffixes. The latter is needed for Homebrew gcc5. 

I've only tested on a Mac with Homebrew in the `PATH` and on my Linux box with multi-gcc in `/usr/bin`, so may well need some tweaking.