### PR TITLE
Created flatten_dependencies function

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -175,5 +175,5 @@ import spack.util.executable
 from spack.util.executable import *
 __all__ += spack.util.executable.__all__
 
-from spack.package import flat_install, flatten_dependencies, DependencyConflictError
-__all__ += ['flat_install', 'flatten_dependencies', 'DependencyConflictError']
+from spack.package import install_dependency_symlinks, flatten_dependencies, DependencyConflictError
+__all__ += ['install_dependency_symlinks', 'flatten_dependencies', 'DependencyConflictError']

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -174,3 +174,6 @@ __all__ += spack.directives.__all__
 import spack.util.executable
 from spack.util.executable import *
 __all__ += spack.util.executable.__all__
+
+from spack.package import flat_install, flatten_dependencies, DependencyConflictError
+__all__ += ['flat_install', 'flatten_dependencies', 'DependencyConflictError']

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -132,23 +132,6 @@ class DirectoryLayout(object):
         raise NotImplementedError()
 
 
-    def flatten_dependencies(self, spec, flat_dir):
-        """Make each dependency of spec present in dir via symlink."""
-        for dep in spec.traverse(root=False):
-            name = dep.name
-
-            dep_path = self.path_for_spec(dep)
-            dep_files = LinkTree(dep_path)
-
-            os.mkdir(flat_dir+'/'+name)
-
-            conflict = dep_files.find_conflict(flat_dir+'/'+name)
-            if conflict:
-                raise DependencyConflictError(conflict)
-
-            dep_files.merge(flat_dir+'/'+name)
-
-
     def path_for_spec(self, spec):
         """Return an absolute path from the root to a directory for the spec."""
         _check_concrete(spec)
@@ -498,10 +481,3 @@ class NoSuchExtensionError(DirectoryLayoutError):
         super(NoSuchExtensionError, self).__init__(
             "%s cannot be removed from %s because it's not activated."% (
                 ext_spec.short_spec, spec.short_spec))
-
-class DependencyConflictError(SpackError):
-    """Raised when the dependencies cannot be flattened as asked for."""
-    def __init__(self, conflict):
-        super(DependencyConflictError, self).__init__(
-            "%s conflicts with another file in the flattened directory." %(
-                conflict))

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -33,6 +33,7 @@ import yaml
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import join_path, mkdirp
+from llnl.util.link_tree import *
 
 from spack.spec import Spec
 from spack.error import SpackError
@@ -129,6 +130,23 @@ class DirectoryLayout(object):
     def remove_extension(self, spec, ext_spec):
         """Remove from the list of currently installed extensions."""
         raise NotImplementedError()
+
+
+    def flatten_dependencies(self, spec, flat_dir):
+        """Make each dependency of spec present in dir via symlink."""
+        for dep in spec.traverse(root=False):
+            name = dep.name
+
+            dep_path = self.path_for_spec(dep)
+            dep_files = LinkTree(dep_path)
+
+            os.mkdir(flat_dir+'/'+name)
+
+            conflict = dep_files.find_conflict(flat_dir+'/'+name)
+            if conflict:
+                raise DependencyConflictError(conflict)
+
+            dep_files.merge(flat_dir+'/'+name)
 
 
     def path_for_spec(self, spec):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -33,7 +33,6 @@ import yaml
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import join_path, mkdirp
-from llnl.util.link_tree import *
 
 from spack.spec import Spec
 from spack.error import SpackError

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -498,3 +498,10 @@ class NoSuchExtensionError(DirectoryLayoutError):
         super(NoSuchExtensionError, self).__init__(
             "%s cannot be removed from %s because it's not activated."% (
                 ext_spec.short_spec, spec.short_spec))
+
+class DependencyConflictError(SpackError):
+    """Raised when the dependencies cannot be flattened as asked for."""
+    def __init__(self, conflict):
+        super(DependencyConflictError, self).__init__(
+            "%s conflicts with another file in the flattened directory." %(
+                conflict))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1211,10 +1211,9 @@ class Package(object):
         return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
 
 
-def flat_install(pkg, spec, prefix):
+def install_dependency_symlinks(pkg, spec, prefix):
     """Execute a dummy install and flatten dependencies"""
-    os.mkdir(prefix+'/libs')
-    flatten_dependencies(spec, prefix+'/libs')
+    flatten_dependencies(spec, prefix)
 
 def flatten_dependencies(spec, flat_dir):
     """Make each dependency of spec present in dir via symlink."""


### PR DESCRIPTION
Packages can use the spack.install_layout.flatten_dependencies function to create a symlink directory containing all of their dependencies.

Use cases:
1) Packages with hacky builds that require all of their dependencies to be in one directory
2) Dummy packages used to manage all of the dependencies for a tool under development. The dummy package can then localize all of the dependencies to be built against manually for development. 