### PR TITLE
Support Bash "-u" mode

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -141,7 +141,7 @@ function _spack_pathadd {
     fi
 
     # Do the actual prepending here.
-    eval "_pa_oldvalue=\$${_pa_varname}"
+    eval "_pa_oldvalue=\${${_pa_varname}:-}"
 
     if [ -d "$_pa_new_path" ] && [[ ":$_pa_oldvalue:" != *":$_pa_new_path:"* ]]; then
         if [ -n "$_pa_oldvalue" ]; then


### PR DESCRIPTION
The command `set -u` in Bash makes it an error to access an undefined variable. I find this useful, and use it often in my scripts to catch typos. By default, undefined variables are assumed to be empty.

Since `setup-env.sh` needs to be sourced, it inherits the `-u` option. This patch makes `setup-env.sh` succeed in `-u` mode, by explicitly using the empty string if a variable is unset.