### PR TITLE
cmake package: add variant for openssl support

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -43,6 +43,7 @@ class Cmake(Package):
     variant('doc', default=False, description='Enables the generation of html and man page documentation')
 
     depends_on('ncurses', when='+ncurses')
+    depends_on('openssl', when='+openssl')
     depends_on('qt', when='+qt')
     depends_on('python@2.7.11:', when='+doc')
     depends_on('py-sphinx', when='+doc')

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -38,6 +38,7 @@ class Cmake(Package):
     version('2.8.10.2', '097278785da7182ec0aea8769d06860c')
 
     variant('ncurses', default=True, description='Enables the build of the ncurses gui')
+    variant('openssl', default=True, description="Enables CMake's OpenSSL features")
     variant('qt', default=False, description='Enables the build of cmake-gui')
     variant('doc', default=False, description='Enables the generation of html and man page documentation')
 
@@ -77,8 +78,9 @@ class Cmake(Package):
             options.append('--sphinx-html')
             options.append('--sphinx-man')
 
-        options.append('--')
-        options.append('-DCMAKE_USE_OPENSSL=ON')
+        if '+openssl' in spec:
+            options.append('--')
+            options.append('-DCMAKE_USE_OPENSSL=ON')
 
         configure(*options)
         make()


### PR DESCRIPTION
The openssl variant defaults to true to preserve spack's
current CMake configuration, which is using OpenSSL.
