### PR TITLE
fix cmake on OSX: missing dependency openssl

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -42,6 +42,7 @@ class Cmake(Package):
     variant('doc', default=False, description='Enables the generation of html and man page documentation')
 
     depends_on('ncurses', when='+ncurses')
+    depends_on('openssl')
     depends_on('qt', when='+qt')
     depends_on('python@2.7.11:', when='+doc')
     depends_on('py-sphinx', when='+doc')


### PR DESCRIPTION
taken from https://github.com/LLNL/spack/pull/563