### PR TITLE
Update Package : Silo

### DIFF
--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -8,8 +8,8 @@ class Cryptopp(Package):
        public-key encryption (RSA, DSA), and a few obsolete/historical encryption
        algorithms (MD5, Panama)."""
 
-    homepage = "http://www.cryptopp.com/"
-    url      = "http://www.cryptopp.com/cryptopp563.zip"
+    homepage = "http://www.cryptopp.com"
+    base_url = "http://www.cryptopp.com"
 
     version('5.6.3', '3c5b70e2ec98b7a24988734446242d07')
     version('5.6.2', '7ed022585698df48e65ce9218f6c6a67')
@@ -28,4 +28,4 @@ class Cryptopp(Package):
         version_tuple = tuple(v for v in iter(version))
         version_string = reduce(lambda vs, nv: vs + str(nv), version_tuple, "")
 
-        return "%scryptopp%s.zip" % (Cryptopp.homepage, version_string)
+        return '%s/cryptopp%s.zip' % (Cryptopp.base_url, version_string)

--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -25,7 +25,5 @@ class Cryptopp(Package):
         install('libcryptopp.a', prefix.lib)
 
     def url_for_version(self, version):
-        version_tuple = tuple(v for v in iter(version))
-        version_string = reduce(lambda vs, nv: vs + str(nv), version_tuple, "")
-
+        version_string = str(version).replace('.', '')
         return '%s/cryptopp%s.zip' % (Cryptopp.base_url, version_string)

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -5,24 +5,35 @@ class Silo(Package):
        data to binary, disk files."""
 
     homepage = "http://wci.llnl.gov/simulation/computer-codes/silo"
-    url      = "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.8/silo-4.8.tar.gz"
+    base_url = "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo"
 
+    version('4.10.2', '9ceac777a2f2469ac8cef40f4fab49c8')
+    version('4.9', 'a83eda4f06761a86726e918fc55e782a')
     version('4.8', 'b1cbc0e7ec435eb656dc4b53a23663c9')
 
     variant('fortran', default=True, description='Enable Fortran support')
+    variant('silex', default=False, description='Builds Silex, a GUI for viewing Silo files')
 
-    depends_on("hdf5")
+    depends_on('hdf5')
+    depends_on('qt', when='+silex')
 
     def install(self, spec, prefix):
         config_args = [
             '--enable-fortran' if '+fortran' in spec else '--disable-fortran',
+            '--enable-silex' if '+silex' in spec else '--disable-silex',
         ]
 
+        if '+silex' in spec:
+            config_args.append('--with-Qt-dir=%s' % spec['qt'].prefix)
+
         configure(
-            "--prefix=%s" % prefix,
-            "--with-hdf5=%s,%s" % (spec['hdf5'].prefix.include, spec['hdf5'].prefix.lib),
-            "--with-zlib=%s,%s" % (spec['zlib'].prefix.include, spec['zlib'].prefix.lib),
+            '--prefix=%s' % prefix,
+            '--with-hdf5=%s,%s' % (spec['hdf5'].prefix.include, spec['hdf5'].prefix.lib),
+            '--with-zlib=%s,%s' % (spec['zlib'].prefix.include, spec['zlib'].prefix.lib),
             *config_args)
 
         make()
-        make("install")
+        make('install')
+
+    def url_for_version(self, version):
+        return '%s/silo-%s/silo-%s.tar.gz' % (Silo.base_url, version, version)


### PR DESCRIPTION
The changes in this pull request improve the `Silo` package by adding more supported install versions and by adding a `+silex` variant (which allows the installer to toggle whether the `Silo` package's graphical utility will be installed or not).  There are also a few other minor changes to the `Crypto++` package to make its `url_for_version` function a bit more readable using the same techniques to implement `url_for_version` for `Silo`.