### PR TITLE
Fix : PYTHONPATH missing in module files

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -158,13 +158,13 @@ class EnvModule(object):
 
         # Let the extendee modify their extensions before asking for
         # package-specific modifications
-        for extendee in self.pkg.extendees:
-            extendee_spec = self.spec[extendee]
-            extendee_spec.package.setup_dependent_package(
-                self.pkg.module, self.spec)
+        spack_env = EnvironmentModifications()
+        for item in self.pkg.extendees:
+            package = self.spec[item].package
+            package.setup_dependent_package(self.pkg.module, self.spec)
+            package.setup_dependent_environment(spack_env, env, self.spec)
 
         # Package-specific environment modifications
-        spack_env = EnvironmentModifications()
         self.spec.package.setup_environment(spack_env, env)
 
         # TODO : implement site-specific modifications and filters

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -105,7 +105,10 @@ class Python(Package):
 
         pythonpath = ':'.join(python_paths)
         spack_env.set('PYTHONPATH', pythonpath)
-        run_env.set('PYTHONPATH', pythonpath)
+
+        # For run time environment set only the path for extension_spec and prepend it to PYTHONPATH
+        if extension_spec.package.extends(self.spec):
+            run_env.prepend_path('PYTHONPATH', os.path.join(extension_spec.prefix, self.site_packages_dir))
 
 
     def setup_dependent_package(self, module, ext_spec):


### PR DESCRIPTION
##### Modifications : 
- [x] added a call to `Package.setup_dependent_environment` in `modules.py`
- [x] reverted the change in semantics for PYTHONPATH in module files (prepend the path of the loaded package instead of setting the path for it and all the dependencies)