### PR TITLE
feature : module file generation may be disabled via configuration file

### DIFF
--- a/etc/spack/modules.yaml
+++ b/etc/spack/modules.yaml
@@ -1,0 +1,8 @@
+# -------------------------------------------------------------------------
+# This is the default spack module files generation configuration.
+#
+# Changes to this file will affect all users of this spack install,
+# although users can override these settings in their ~/.spack/modules.yaml.
+# -------------------------------------------------------------------------
+modules:
+  enable: ['tcl', 'dotkit']

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -249,7 +249,7 @@ section_schemas = {
                 'default': {},
                 'additionalProperties': False,
                 'properties': {
-                    'disable': {
+                    'enable': {
                         'type': 'array',
                         'default': [],
                         'items': {

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -237,7 +237,29 @@ section_schemas = {
                                 'type' : 'object',
                                 'default' : {},
                             }
-                        },},},},},}
+                        },},},},},},
+    'modules': {
+        '$schema': 'http://json-schema.org/schema#',
+        'title': 'Spack module file configuration file schema',
+        'type': 'object',
+        'additionalProperties': False,
+        'patternProperties': {
+            r'modules:?': {
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'properties': {
+                    'disable': {
+                        'type': 'array',
+                        'default': [],
+                        'items': {
+                            'type': 'string'
+                        }
+                    }
+                }
+            },
+        },
+    },
 }
 
 """OrderedDict of config scopes keyed by name.
@@ -405,11 +427,11 @@ def _read_config_file(filename, schema):
             validate_section(data, schema)
         return data
 
-    except MarkedYAMLError, e:
+    except MarkedYAMLError as e:
         raise ConfigFileError(
             "Error parsing yaml%s: %s" % (str(e.context_mark), e.problem))
 
-    except IOError, e:
+    except IOError as e:
         raise ConfigFileError(
             "Error reading configuration file %s: %s" % (filename, str(e)))
 

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -124,7 +124,7 @@ class EnvModule(object):
         def __init__(cls, name, bases, dict):
             type.__init__(cls, name, bases, dict)
             if cls.name != 'env_module' and cls.name not in CONFIGURATION['disable']:
-                    module_types[cls.name] = cls
+                module_types[cls.name] = cls
 
     def __init__(self, spec=None):
         self.spec = spec

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -48,6 +48,7 @@ import textwrap
 
 import llnl.util.tty as tty
 import spack
+import spack.config
 from llnl.util.filesystem import join_path, mkdirp
 from spack.environment import *
 
@@ -56,6 +57,13 @@ __all__ = ['EnvModule', 'Dotkit', 'TclModule']
 # Registry of all types of modules.  Entries created by EnvModule's metaclass
 module_types = {}
 
+
+def read_configuration_file():
+    f = spack.config.get_config('modules')
+    f.setdefault('disable', [])  # Default : disable nothing
+    return f
+
+CONFIGURATION = read_configuration_file()
 
 def print_help():
     """For use by commands to tell user how to activate shell support."""
@@ -115,8 +123,8 @@ class EnvModule(object):
     class __metaclass__(type):
         def __init__(cls, name, bases, dict):
             type.__init__(cls, name, bases, dict)
-            if cls.name != 'env_module':
-                module_types[cls.name] = cls
+            if cls.name != 'env_module' and cls.name not in CONFIGURATION['disable']:
+                    module_types[cls.name] = cls
 
     def __init__(self, spec=None):
         self.spec = spec

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -57,13 +57,8 @@ __all__ = ['EnvModule', 'Dotkit', 'TclModule']
 # Registry of all types of modules.  Entries created by EnvModule's metaclass
 module_types = {}
 
+CONFIGURATION = spack.config.get_config('modules')
 
-def read_configuration_file():
-    f = spack.config.get_config('modules')
-    f.setdefault('disable', [])  # Default : disable nothing
-    return f
-
-CONFIGURATION = read_configuration_file()
 
 def print_help():
     """For use by commands to tell user how to activate shell support."""
@@ -123,7 +118,7 @@ class EnvModule(object):
     class __metaclass__(type):
         def __init__(cls, name, bases, dict):
             type.__init__(cls, name, bases, dict)
-            if cls.name != 'env_module' and cls.name not in CONFIGURATION['disable']:
+            if cls.name != 'env_module' and cls.name in CONFIGURATION['enable']:
                 module_types[cls.name] = cls
 
     def __init__(self, spec=None):


### PR DESCRIPTION
##### Rationale
Introduce a configuration file for site-specific customization on module files

##### Modifications :
- [x] introduced a configuration file for module file generators
- [x] added an `enable` keyword to explicitly enable the generation of the module files (defaults to 'tcl' and 'dotkit')

##### Example of use :
```
$ spack config edit modules
```
Add the following lines in the file to enable only `dotkit` file generation:
```
modules::
  enable: ['dotkit']
```