### PR TITLE
Simplify NumPy dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -1,24 +1,43 @@
 from spack import *
 
 class PyNumpy(Package):
-    """array processing for numbers, strings, records, and objects."""
-    homepage = "https://pypi.python.org/pypi/numpy"
+    """NumPy is the fundamental package for scientific computing with Python.
+    It contains among other things: a powerful N-dimensional array object,
+    sophisticated (broadcasting) functions, tools for integrating C/C++ and
+    Fortran code, and useful linear algebra, Fourier transform, and random
+    number capabilities"""
+    homepage = "http://www.numpy.org/"
     url      = "https://pypi.python.org/packages/source/n/numpy/numpy-1.9.1.tar.gz"
 
-    version('1.9.1', '78842b73560ec378142665e712ae4ad9')
-    version('1.9.2', 'a1ed53432dbcd256398898d35bc8e645')
+    version('1.10.4', 'aed294de0aa1ac7bd3f9745f4f1968ad')
+    version('1.9.2',  'a1ed53432dbcd256398898d35bc8e645')
+    version('1.9.1',  '78842b73560ec378142665e712ae4ad9')
 
-    variant('blas', default=True)
+
+    variant('blas',   default=True)
+    variant('lapack', default=True)
 
     extends('python')
     depends_on('py-nose')
-    depends_on('netlib-blas+fpic', when='+blas')
-    depends_on('netlib-lapack+shared', when='+blas')
+    depends_on('blas',   when='+blas')
+    depends_on('lapack', when='+lapack')
 
     def install(self, spec, prefix):
+        libraries    = []
+        library_dirs = []
+
         if '+blas' in spec:
+            libraries.append('blas')
+            library_dirs.append(spec['blas'].prefix.lib)
+        if '+lapack' in spec:
+            libraries.append('lapack')
+            library_dirs.append(spec['lapack'].prefix.lib)
+
+        if '+blas' in spec or '+lapack' in spec:
             with open('site.cfg', 'w') as f:
                 f.write('[DEFAULT]\n')
-                f.write('libraries=lapack,blas\n')
-                f.write('library_dirs=%s/lib:%s/lib\n' % (spec['blas'].prefix, spec['lapack'].prefix))
+                f.write('libraries=%s\n'    % ','.join(libraries))
+                f.write('library_dirs=%s\n' % ':'.join(library_dirs))
+
         python('setup.py', 'install', '--prefix=%s' % prefix)
+

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -2,11 +2,12 @@ from spack import *
 
 class PyScipy(Package):
     """Scientific Library for Python."""
-    homepage = "https://pypi.python.org/pypi/scipy"
+    homepage = "http://www.scipy.org/"
     url      = "https://pypi.python.org/packages/source/s/scipy/scipy-0.15.0.tar.gz"
 
-    version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
+    version('0.17.0', '5ff2971e1ce90e762c59d2cd84837224')
     version('0.15.1', 'be56cd8e60591d6332aac792a5880110')
+    version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
 
     extends('python')
     depends_on('py-nose')


### PR DESCRIPTION
As reported in #418, `spack install scipy` does not work because numpy has such specific dependencies. Previously, the only workaround was to specify `spack install scipy ^netlib-blas+fpic ^netlib-lapack+shared`. This PR addresses the issue by allowing numpy to be built with any blas and lapack implementation.

Newer versions of these packages were added as well. I tried installing openblas@0.2.16, py-numpy@1.9.2, and py-scipy@0.15.1, but when I ran `import scipy.linalg`, I would get the error `_flapack.so: undefined symbol: sgegv_`. Apparently, openblas removed some deprecated symbols that older versions of scipy still depended on. The newest versions do not exhibit this problem.

The url for numpy was broken, so I updated both numpy and scipy to what I thought would be better homepages.

@alalazo: these changes will slightly conflict with #485. How do you feel about my proposed changes?