### PR TITLE
Remove incorrect sanity check for libelf

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -38,8 +38,6 @@ class Libelf(Package):
 
     provides('elf')
 
-    sanity_check_is_file = 'include/libelf.h'
-
     def install(self, spec, prefix):
         configure("--prefix=" + prefix,
                   "--enable-shared",


### PR DESCRIPTION
libelf.h actually resides in include/libelf/libelf.h in the available version. Removed entirely, it in case the location is different in different versions.