### PR TITLE
Fix spack info indentation

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -52,7 +52,7 @@ def print_text_info(pkg):
     print "Safe versions:  "
 
     if not pkg.versions:
-        print("None")
+        print("    None")
     else:
         pad = padder(pkg.versions, 4)
         for v in reversed(sorted(pkg.versions)):
@@ -62,7 +62,7 @@ def print_text_info(pkg):
     print
     print "Variants:"
     if not pkg.variants:
-        print "None"
+        print "    None"
     else:
         pad = padder(pkg.variants, 4)
 


### PR DESCRIPTION
This fixes a very minor indentation bug with packages without any variants or versions that was annoying me.

Before:
```
$ spack info gmp
Package:    gmp
Homepage:   https://gmplib.org

Safe versions:  
    6.1.0     https://gmplib.org/download/gmp/gmp-6.1.0.tar.bz2
    6.0.0a    https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2
    6.0.0     https://gmplib.org/download/gmp/gmp-6.0.0.tar.bz2

Variants:
None

Dependencies:
    None

Virtual packages: 
    None

Description:
    GMP is a free library for arbitrary precision arithmetic, operating on
    signed integers, rational numbers, and floating-point numbers.
```

After:
```
$ spack info gmp
Package:    gmp
Homepage:   https://gmplib.org

Safe versions:  
    6.1.0     https://gmplib.org/download/gmp/gmp-6.1.0.tar.bz2
    6.0.0a    https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2
    6.0.0     https://gmplib.org/download/gmp/gmp-6.0.0.tar.bz2

Variants:
    None

Dependencies:
    None

Virtual packages: 
    None

Description:
    GMP is a free library for arbitrary precision arithmetic, operating on
    signed integers, rational numbers, and floating-point numbers.
```