### PR TITLE
Added new Cython version; old versions don't work with Python3.

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -1,19 +1,3 @@
-# FIXME:
-# This is a template package file for Spack.  We've conveniently
-# put "FIXME" labels next to all the things you'll want to change.
-#
-# Once you've edited all the FIXME's, delete this whole message,
-# save this file, and test out your package like this:
-#
-#     spack install googletest
-#
-# You can always get back here to change things with:
-#
-#     spack edit googletest
-#
-# See the spack documentation for more information on building
-# packages.
-#
 from spack import *
 
 class Googletest(Package):

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -1,0 +1,40 @@
+# FIXME:
+# This is a template package file for Spack.  We've conveniently
+# put "FIXME" labels next to all the things you'll want to change.
+#
+# Once you've edited all the FIXME's, delete this whole message,
+# save this file, and test out your package like this:
+#
+#     spack install googletest
+#
+# You can always get back here to change things with:
+#
+#     spack edit googletest
+#
+# See the spack documentation for more information on building
+# packages.
+#
+from spack import *
+
+class Googletest(Package):
+    """Google test framework for C++.  Also called gtest."""
+    homepage = "https://github.com/google/googletest"
+    url      = "https://github.com/google/googletest/tarball/release-1.7.0"
+
+    version('1.7.0', '5eaf03ed925a47b37c8e1d559eb19bc4')
+
+    depends_on("cmake")
+
+    def install(self, spec, prefix):
+        which('cmake')('.', *std_cmake_args)
+
+        make()
+
+        # Google Test doesn't have a make install
+        # We have to do our own install here.
+	install_tree('include', prefix.include)
+
+        mkdirp(prefix.lib)
+	install('./libgtest.a', '%s' % prefix.lib)
+	install('./libgtest_main.a', '%s' % prefix.lib)
+

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -3,10 +3,13 @@ from spack import *
 class PyCython(Package):
     """The Cython compiler for writing C extensions for the Python language."""
     homepage = "https://pypi.python.org/pypi/cython"
-    url      = "https://pypi.python.org/packages/source/C/Cython/cython-0.22.tar.gz"
+    url      = "https://pypi.python.org/packages/source/C/Cython/Cython-0.22.tar.gz"
 
-    version('0.21.2', 'd21adb870c75680dc857cd05d41046a4')
+    version('0.23.4', '157df1f69bcec6b56fd97e0f2e057f6e')
+
+    # These versions contain illegal Python3 code...
     version('0.22', '1ae25add4ef7b63ee9b4af697300d6b6')
+    version('0.21.2', 'd21adb870c75680dc857cd05d41046a4')
 
     extends('python')
 

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -5,6 +5,7 @@ class PyCython(Package):
     homepage = "https://pypi.python.org/pypi/cython"
     url      = "https://pypi.python.org/packages/source/C/Cython/Cython-0.22.tar.gz"
 
+    version('0.23.5', '66b62989a67c55af016c916da36e7514')
     version('0.23.4', '157df1f69bcec6b56fd97e0f2e057f6e')
 
     # These versions contain illegal Python3 code...


### PR DESCRIPTION
Older versions had a Python3 compatibility bug that's since been fixed upstream.