### PR TITLE
Features/blas lapack hardening

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -27,7 +27,7 @@ __all__ = ['set_install_permissions', 'install', 'install_tree', 'traverse_tree'
            'force_remove', 'join_path', 'ancestor', 'can_access', 'filter_file',
            'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink',
            'set_executable', 'copy_mode', 'unset_executable_mode',
-           'remove_dead_links', 'remove_linked_tree']
+           'remove_dead_links', 'remove_linked_tree', 'find_library_path']
 
 import os
 import sys
@@ -392,3 +392,18 @@ def remove_linked_tree(path):
             os.unlink(path)
         else:
             shutil.rmtree(path, True)
+
+
+def find_library_path(libname, *paths):
+    """Searches for a file called <libname> in each path.
+
+    Return:
+      directory where the library was found, if found.  None otherwise.
+
+    """
+    for path in paths:
+        library = join_path(path, libname)
+        if os.path.exists(library):
+            return path
+    return None
+

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -59,6 +59,11 @@ SPACK_SHORT_SPEC       = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_DIR    = 'SPACK_DEBUG_LOG_DIR'
 
 
+# Platform-specific library suffix.
+dso_suffix = 'dylib' if sys.platform == 'darwin' else 'so'
+
+
+
 class MakeExecutable(Executable):
     """Special callable executable object for make so the user can
        specify parallel or not on a per-invocation basis.  Using
@@ -245,6 +250,9 @@ def set_module_variables_for_package(pkg, module):
     # Useful directories within the prefix are encapsulated in
     # a Prefix object.
     m.prefix  = pkg.prefix
+
+    # Platform-specific library suffix.
+    m.dso_suffix = dso_suffix
 
 
 def get_rpaths(pkg):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -926,6 +926,9 @@ class Package(object):
                      install(env_path, env_install_path)
                      dump_packages(self.spec, packages_dir)
 
+                # Run post install hooks before build stage is removed.
+                spack.hooks.post_install(self)
+
             # Stop timer.
             self._total_time = time.time() - start_time
             build_time = self._total_time - self._fetch_time
@@ -953,9 +956,6 @@ class Package(object):
         # note: PARENT of the build process adds the new package to
         # the database, so that we don't need to re-read from file.
         spack.installed_db.add(self.spec, self.prefix)
-
-        # Once everything else is done, run post install hooks
-        spack.hooks.post_install(self)
 
 
     def sanity_check_prefix(self):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -1,5 +1,6 @@
 from spack import *
 import sys
+import os
 
 class Openblas(Package):
     """OpenBLAS: An optimized BLAS library"""
@@ -10,29 +11,60 @@ class Openblas(Package):
     version('0.2.16', 'fef46ab92463bdbb1479dcec594ef6dc')
     version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
 
+    variant('shared', default=True, description="Build shared libraries as well as static libs.")
+
     # virtual dependency
     provides('blas')
     provides('lapack')
 
+
     def install(self, spec, prefix):
-        extra=[]
+        make_defs = ['CC=%s' % spack_cc,
+                     'FC=%s' % spack_fc]
+
+        make_targets = ['libs', 'netlib']
+
+        # Build shared if variant is set.
+        if '+shared' in spec:
+            make_targets += ['shared']
+        else:
+            make_defs += ['NO_SHARED=1']
+
+        # fix missing _dggsvd_ and _sggsvd_
         if spec.satisfies('@0.2.16'):
-            extra.extend([
-                'BUILD_LAPACK_DEPRECATED=1' # fix missing _dggsvd_ and _sggsvd_
-            ])
+            make_defs += ['BUILD_LAPACK_DEPRECATED=1']
 
-        make('libs', 'netlib', 'shared', 'CC=cc', 'FC=f77',*extra)
-        make("tests")
-        make('install', "PREFIX='%s'" % prefix)
+        make_args = make_defs + make_targets
+        make(*make_args)
 
-        lib_dsuffix = 'dylib' if sys.platform == 'darwin' else 'so'
+        make("tests", *make_defs)
+
+        # no quotes around prefix (spack doesn't use a shell)
+        make('install', "PREFIX=%s" % prefix, *make_defs)
+
         # Blas virtual package should provide blas.a and libblas.a
         with working_dir(prefix.lib):
             symlink('libopenblas.a', 'blas.a')
             symlink('libopenblas.a', 'libblas.a')
-            symlink('libopenblas.%s' % lib_dsuffix, 'libblas.%s' % lib_dsuffix)
+            if '+shared' in spec:
+                symlink('libopenblas.%s' % dso_suffix, 'libblas.%s' % dso_suffix)
 
         # Lapack virtual package should provide liblapack.a
         with working_dir(prefix.lib):
             symlink('libopenblas.a', 'liblapack.a')
-            symlink('libopenblas.%s' % lib_dsuffix, 'liblapack.%s' % lib_dsuffix)
+            if '+shared' in spec:
+                symlink('libopenblas.%s' % dso_suffix, 'liblapack.%s' % dso_suffix)
+
+
+    def setup_dependent_package(self, module, dspec):
+        # This is WIP for a prototype interface for virtual packages.
+        # We can update this as more builds start depending on BLAS/LAPACK.
+        libdir = find_library_path('libopenblas.a', self.prefix.lib64, self.prefix.lib)
+
+        self.spec.blas_static_lib   = join_path(libdir, 'libopenblas.a')
+        self.spec.lapack_static_lib = self.spec.blas_static_lib
+
+        if '+shared' in self.spec:
+            self.spec.blas_shared_lib   = join_path(libdir, 'libopenblas.%s' % dso_suffix)
+            self.spec.lapack_shared_lib = self.spec.blas_shared_lib
+

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -11,9 +11,15 @@ class PyScipy(Package):
 
     extends('python')
     depends_on('py-nose')
-    depends_on('py-numpy')
-    depends_on('blas')
-    depends_on('lapack')
+    depends_on('py-numpy+blas+lapack')
 
     def install(self, spec, prefix):
+        if 'atlas' in spec:
+            # libatlas.so actually isn't always installed, but this
+            # seems to make the build autodetect things correctly.
+            env['ATLAS'] = join_path(spec['atlas'].prefix.lib, 'libatlas.' + dso_suffix)
+        else:
+            env['BLAS']   = spec['blas'].blas_shared_lib
+            env['LAPACK'] = spec['lapack'].lapack_shared_lib
+
         python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
@citibeth @eschnett @alalazo @davydden @lee218llnl 

I attempted to harden the `py-scipy` builds a bit.  In particular, the following now work on our RHEL6 environment:

```bash
spack install py-numpy ^openblas
spack install py-numpy ^netlib-lapack
spack install py-numpy ^atlas
```

This is an attempt to make the builds do the "right thing" by default.

I also started some conventions for passing around bias lib information via `spec` attributes in `setup_dependent_package`. I do not think it is sufficient just to symlink `libblas` and `liblapack` -- Atlas in particular has a particuarly crazy library layout so I think it needs a bit more than this.  scipy at least does a good job of detecting it and linking the right stuff.

Other stuff:
* py-scipy now builds with netlib-lapack, openblas, and atlas.
* started a convention for passing lib info from blas/lapack implementations.

* Improved netlib-lapack:
    * Also build static libs when `shared` variant is enabled.
    * Enable CBLAS  build
        * needed minor patch to build correctly.

* Added `shared` variant to OpenBLAS.
    * Made OpenBLAS build properly shared and static.

Still testing on El Capitan and working out some test issues, but most of the changes are there.

Feedback welcome.