### PR TITLE
pyside: Updated to work with Python 3.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -6,10 +6,25 @@ class PyPyside(Package):
     homepage = "https://pypi.python.org/pypi/pyside"
     url      = "https://pypi.python.org/packages/source/P/PySide/PySide-1.2.2.tar.gz"
 
-    version('1.2.2', 'c45bc400c8a86d6b35f34c29e379e44d')
+    # This doesn't work, GitHub download isn't the same as the full tarfile.
+    # The tarfile for 1.2.3 was removed from PyPI.
+    # url = "https://github.com/PySide/pyside-setup/tarball/1.2.3"
+
+    # Version 1.2.4 claims to not work with Python 3.5, mostly
+    # because it hasn't been tested.  Otherwise, it's the same as v1.2.3
+    # https://github.com/PySide/pyside-setup/issues/58
+    # Meanwhile, developers have moved onto pyside2 (for Qt5),
+    # and show little interest in certifying PySide 1.2.4 for Python.
+    version('1.2.4', '3cb7174c13bd45e3e8f77638926cb8c0')
+
+    # This is not available from pypi
+    # version('1.2.3', 'fa5d5438b045ede36104bba25a6ccc10')
+
+# v1.2.2 does not work with Python3
+#    version('1.2.2', 'c45bc400c8a86d6b35f34c29e379e44d')
 
     # TODO: make build dependency
-    # depends_on("cmake")
+    depends_on("cmake")
 
     extends('python')
     depends_on('py-setuptools')
@@ -31,12 +46,20 @@ class PyPyside(Package):
                 '"-DCMAKE_INSTALL_RPATH=%s",' % ':'.join(rpath)),
             'setup.py')
 
-        # PySide tries to patch ELF files to remove RPATHs
-        # Disable this and go with the one we set.
+
+        # Convince PySide that it really CAN work with Python 3.5
         filter_file(
-            r'^\s*rpath_cmd\(pyside_path, srcpath\)',
-            r'#rpath_cmd(pyside_path, srcpath)',
-            'pyside_postinstall.py')
+            "'Programming Language :: Python :: 3.4',",
+            "'Programming Language :: Python :: 3.4',\n        'Programming Language :: Python :: 3.5',",
+            'setup.py')
+
+# As of version 1.2.3, PySide removed the post-install script.
+#        # PySide tries to patch ELF files to remove RPATHs
+#        # Disable this and go with the one we set.
+#        filter_file(
+#            r'^\s*rpath_cmd\(pyside_path, srcpath\)',
+#            r'#rpath_cmd(pyside_path, srcpath)',
+#            'pyside_postinstall.py')
 
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Looking for review by @tgamblin who wrote the original code.  Multiple issues are in play here:

1. The old version (1.2.2) does not work with Python3.  It could be retained, but only with a "when=" qualifier requiring Python2.  Alternatively, we could drop it, since v1.2.4 DOES claim to work with Python 2.6 and 2.7.  This is GUI interface code, using a new version not going to change anyone's numerical output.

2. PySide is a "complex" project in which the main project downloads other sub-projects with git magic.  Long an the short of it is... downloading a tarball from git is NOT the same in this case as downloading the tarballs provided at PyPI.  Version 1.2.3 was short-lived (~1 day), and there is no tarball download for it.  It's easiest NOT to try to build that with Spack, since that would require a complex GitHub download procedure.

3. The main improvement of version 1.2.4 is a Python version check that complains and quits if you're using the "wrong" version.  It allows for Python3 up to v3.4, but NOT v3.5.  A GitHub posting indicates that it probably DOES work on v3.5, but the maintainers are not interested in certifying that across all platforms: https://github.com/PySide/pyside-setup/issues/58   Meanwhile, the maintainers seem to have moved on to PySide2, which is for use with Qt5.  I don't expect them to ever certify PySide1 with Python 3.5.

4. The easiest way to get PySide working for Python 3.5 is to patch the `setup.py` file to allow Python 3.5.  Which is what I did.

6. Starting with Version 1.2.3, the PySide post-install script has been eliminated.  I eliminated the patching for it accordingly.  BUT... I don't really understand all the other RPATH machinations going on here, or whether they are still valid with the latest PySide.  This needs review.

The good news is... this all worked for me running Matplotlib with Python 3.5.  So I'm cautiously optimistic that this recipe is basically correct.
