### PR TITLE
Wrap the long description of an environment module so it is more readable

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -278,6 +278,6 @@ class TclModule(EnvModule):
         # Long description
         if self.long_description:
             module_file.write('proc ModulesHelp { } {\n')
-            doc = re.sub(r'"', '\"', self.long_description)
-            module_file.write("puts stderr \"%s\"\n" % doc)
+            for line in textwrap.wrap(self.long_description, 72):
+                module_file.write("puts stderr \"%s\"\n" % line)
             module_file.write('}\n\n')


### PR DESCRIPTION
The long description for environment modules was written out as a single line. If the description is truly long then this looks a little messy and hard to read. This PR uses the same logic for `self.long_description` as dotkit does and wraps the text to create multiple lines. This makes the output of `module show` and `module spider` (for Lmod) more readable.