### PR TITLE
enhancement : recursive uninstallation of dependent packages

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -149,26 +149,46 @@ customize an installation in :ref:`sec-specs`.
 ``spack uninstall``
 ~~~~~~~~~~~~~~~~~~~~~
 
-To uninstall a package, type ``spack uninstall <package>``.  This will
-completely remove the directory in which the package was installed.
+To uninstall a package, type ``spack uninstall <package>``.  This will ask the user for
+confirmation, and in case will completely remove the directory in which the package was installed.
 
 .. code-block:: sh
 
    spack uninstall mpich
 
 If there are still installed packages that depend on the package to be
-uninstalled, spack will refuse to uninstall it. You can override this
-behavior with ``spack uninstall -f <package>``, but you risk breaking
-other installed packages. In general, it is safer to remove dependent
-packages *before* removing their dependencies.
+uninstalled, spack will refuse to uninstall it.
 
-A line like ``spack uninstall mpich`` may be ambiguous, if multiple
-``mpich`` configurations are installed.  For example, if both
+To uninstall a package and every package that depends on it, you may give the
+`--dependents` option.
+
+.. code-block:: sh
+
+   spack uninstall --dependents mpich
+
+will display a list of all the packages that depends on `mpich` and, upon confirmation,
+will uninstall them in the right order.
+
+A line like
+
+.. code-block:: sh
+
+   spack uninstall mpich
+
+may be ambiguous, if multiple ``mpich`` configurations are installed.  For example, if both
 ``mpich@3.0.2`` and ``mpich@3.1`` are installed, ``mpich`` could refer
 to either one. Because it cannot determine which one to uninstall,
-Spack will ask you to provide a version number to remove the
-ambiguity.  As an example, ``spack uninstall mpich@3.1`` is
-unambiguous in this scenario.
+Spack will ask you either to provide a version number to remove the
+ambiguity or use the ``--all`` option to uninstall all of the matching packages.
+
+You may force uninstall a package with the `--force` option
+
+.. code-block:: sh
+
+   spack uninstall --force mpich
+
+but you risk breaking other installed packages. In general, it is safer to remove dependent
+packages *before* removing their dependencies or use the `--dependents` option.
 
 
 Seeing installed packages

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -40,6 +40,7 @@ error_message = """You can either:
     b) use spack uninstall -a to uninstall ALL matching specs.
 """
 
+
 def ask_for_confirmation(message):
     while True:
         tty.msg(message + '[y/n]')
@@ -122,6 +123,7 @@ def installed_dependents(specs):
     for item in specs:
         lst = [x for x in item.package.installed_dependents if x not in specs]
         if lst:
+            lst = list(set(lst))
             dependents[item] = lst
     return dependents
 

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -62,7 +62,7 @@ def setup_parser(subparser):
              "supplied spec. i.e., if you say uninstall libelf, ALL versions of " +
              "libelf are uninstalled. This is both useful and dangerous, like rm -r.")
     subparser.add_argument(
-        '-r', '--recursive', action='store_true', dest='recursive',
+        '-d', '--dependents', action='store_true', dest='dependents',
         help='Also uninstall any packages that depend on the ones given via command line.'
     )
     subparser.add_argument(
@@ -168,7 +168,7 @@ def uninstall(parser, args):
 
         # Process dependent_list and update uninstall_list
         has_error = False
-        if dependent_list and not args.recursive and not args.force:
+        if dependent_list and not args.dependents and not args.force:
             for spec, lst in dependent_list.items():
                 tty.error("Will not uninstall %s" % spec.format("$_$@$%@$#", color=True))
                 print('')
@@ -176,7 +176,7 @@ def uninstall(parser, args):
                 display_specs(lst, long=True)
                 print('')
                 has_error = True
-        elif args.recursive:
+        elif args.dependents:
             for key, lst in dependent_list.items():
                 uninstall_list.extend(lst)
             uninstall_list = list(set(uninstall_list))

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -23,19 +23,24 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from __future__ import print_function
-import sys
+
 import argparse
+import sys
 
 import llnl.util.tty as tty
-from llnl.util.tty.colify import colify
-
 import spack
 import spack.cmd
 import spack.repository
 from spack.cmd.find import display_specs
 from spack.package import PackageStillNeededError
 
-description="Remove an installed package"
+description = "Remove an installed package"
+
+error_message = """You can either:
+    a) Use a more specific spec, or
+    b) use spack uninstall -a to uninstall ALL matching specs.
+"""
+
 
 def setup_parser(subparser):
     subparser.add_argument(
@@ -44,10 +49,81 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-a', '--all', action='store_true', dest='all',
         help="USE CAREFULLY. Remove ALL installed packages that match each " +
-        "supplied spec. i.e., if you say uninstall libelf, ALL versions of " +
-        "libelf are uninstalled. This is both useful and dangerous, like rm -r.")
+             "supplied spec. i.e., if you say uninstall libelf, ALL versions of " +
+             "libelf are uninstalled. This is both useful and dangerous, like rm -r.")
     subparser.add_argument(
-        'packages', nargs=argparse.REMAINDER, help="specs of packages to uninstall")
+        '-r', '--recursive', action='store_true', dest='recursive',
+        help='Uninstall all the packages that depends on the ones for which we required explicit removal.'
+
+    )
+    subparser.add_argument('packages', nargs=argparse.REMAINDER, help="specs of packages to uninstall")
+
+
+def concretize_specs(specs, allow_multiple_matches=False, force=False):
+    """
+    Returns a list of specs matching the non necessarily concretized specs given from cli
+
+    Args:
+        specs: list of specs to be matched against installed packages
+        allow_multiple_matches : boolean (if True multiple matches for each item in specs are admitted)
+
+    Return:
+        list of specs
+    """
+    specs_from_cli = []  # List of specs that match expressions given via command line
+    has_errors = False
+    for spec in specs:
+        matching = spack.installed_db.query(spec)
+        # For each spec provided, make sure it refers to only one package.
+        # Fail and ask user to be unambiguous if it doesn't
+        if not allow_multiple_matches and len(matching) > 1:
+            tty.error("%s matches multiple packages:" % spec)
+            print()
+            display_specs(matching, long=True)
+            print()
+            has_errors = True
+
+        # No installed package matches the query
+        if len(matching) == 0 and not force:
+            tty.error("%s does not match any installed packages." % spec)
+            has_errors = True
+
+        specs_from_cli.extend(matching)
+    if has_errors:
+        tty.die(error_message)
+
+    return specs_from_cli
+
+
+def installed_dependents(specs):
+    dependents = {}
+    for item in specs:
+        lst = [x for x in item.package.installed_dependents if x not in specs]
+        if lst:
+            dependents[item] = lst
+    return dependents
+
+
+def do_uninstall(specs, force):
+    specs = list(set(specs))  # Make specs unique
+    packages = []
+    for item in specs:
+        try:
+            # should work if package is known to spack
+            packages.append(item.package)
+        except spack.repository.UnknownPackageError as e:
+            # The package.py file has gone away -- but still
+            # want to uninstall.
+            spack.Package(item).do_uninstall(force=True)
+
+    # Sort packages to be uninstalled by the number of installed dependents
+    # This ensures we do things in the right order
+    def num_installed_deps(pkg):
+        return len(pkg.installed_dependents)
+
+    packages.sort(key=num_installed_deps)
+    for item in packages:
+        item.do_uninstall(force=force)
 
 
 def uninstall(parser, args):
@@ -56,50 +132,25 @@ def uninstall(parser, args):
 
     with spack.installed_db.write_transaction():
         specs = spack.cmd.parse_specs(args.packages)
+        # Gets the list of installed specs that match the ones give via cli
+        uninstall_list = concretize_specs(specs, args.all, args.force)  # takes care of '-a' is given in the cli
+        dependent_list = installed_dependents(uninstall_list)  # takes care of '-r'
 
-        # For each spec provided, make sure it refers to only one package.
-        # Fail and ask user to be unambiguous if it doesn't
-        pkgs = []
-        for spec in specs:
-            matching_specs = spack.installed_db.query(spec)
-            if not args.all and len(matching_specs) > 1:
-                tty.error("%s matches multiple packages:" % spec)
-                print()
-                display_specs(matching_specs, long=True)
-                print()
-                print("You can either:")
-                print("  a) Use a more specific spec, or")
-                print("  b) use spack uninstall -a to uninstall ALL matching specs.")
-                sys.exit(1)
-
-            if len(matching_specs) == 0:
-                if args.force: continue
-                tty.die("%s does not match any installed packages." % spec)
-
-            for s in matching_specs:
-                try:
-                    # should work if package is known to spack
-                    pkgs.append(s.package)
-                except spack.repository.UnknownPackageError as e:
-                    # The package.py file has gone away -- but still
-                    # want to uninstall.
-                    spack.Package(s).do_uninstall(force=True)
-
-        # Sort packages to be uninstalled by the number of installed dependents
-        # This ensures we do things in the right order
-        def num_installed_deps(pkg):
-            return len(pkg.installed_dependents)
-        pkgs.sort(key=num_installed_deps)
-
-        # Uninstall packages in order now.
-        for pkg in pkgs:
-            try:
-                pkg.do_uninstall(force=args.force)
-            except PackageStillNeededError as e:
-                tty.error("Will not uninstall %s" % e.spec.format("$_$@$%@$#", color=True))
+        # There are dependents but recursive uninstall wasn't a requirement
+        has_error = False
+        if dependent_list and not args.recursive and not args.force:
+            for spec, lst in dependent_list.items():
+                tty.error("Will not uninstall %s" % spec.format("$_$@$%@$#", color=True))
                 print('')
                 print("The following packages depend on it:")
-                display_specs(e.dependents, long=True)
+                display_specs(lst, long=True)
                 print('')
-                print("You can use spack uninstall -f to force this action.")
-                sys.exit(1)
+                has_error = True
+        elif args.recursive:
+            for key, lst in dependent_list.items():
+                uninstall_list.extend(lst)
+
+        if has_error:
+            tty.die('You can use spack uninstall -f to force this action')
+        # Uninstall everything on the list
+        do_uninstall(uninstall_list, args.force)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from __future__ import print_function
 
-import sys
 import argparse
 
 import llnl.util.tty as tty
@@ -48,8 +47,8 @@ def ask_for_confirmation(message):
         if choice == 'y':
             break
         elif choice == 'n':
-            sys.exit(1)
-        tty.warning('Please reply either "y" or "n"')
+            raise SystemExit('Operation aborted')
+        tty.warn('Please reply either "y" or "n"')
 
 
 def setup_parser(subparser):
@@ -164,7 +163,7 @@ def uninstall(parser, args):
         specs = spack.cmd.parse_specs(args.packages)
         # Gets the list of installed specs that match the ones give via cli
         uninstall_list = concretize_specs(specs, args.all, args.force)  # takes care of '-a' is given in the cli
-        dependent_list = installed_dependents(uninstall_list)  # takes care of '-r'
+        dependent_list = installed_dependents(uninstall_list)  # takes care of '-d'
 
         # Process dependent_list and update uninstall_list
         has_error = False
@@ -182,7 +181,7 @@ def uninstall(parser, args):
             uninstall_list = list(set(uninstall_list))
 
         if has_error:
-            tty.die('You can use spack uninstall -r to uninstall these dependencies as well')
+            tty.die('You can use spack uninstall --dependents to uninstall these dependencies as well')
 
         if not args.yes_to_all:
             tty.msg("The following packages will be uninstalled : ")

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -182,7 +182,7 @@ def uninstall(parser, args):
             uninstall_list = list(set(uninstall_list))
 
         if has_error:
-            tty.die('You can use spack uninstall -f to force this action')
+            tty.die('You can use spack uninstall -r to uninstall these dependencies as well')
 
         if not args.yes_to_all:
             tty.msg("The following packages will be uninstalled : ")

--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -67,7 +67,8 @@ test_names = ['versions',
               'namespace_trie',
               'yaml',
               'sbang',
-              'environment']
+              'environment',
+              'cmd.uninstall']
 
 
 def list_tests():

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -1,0 +1,37 @@
+import spack.test.mock_database
+
+from spack.cmd.uninstall import uninstall
+
+
+class MockArgs(object):
+    def __init__(self, packages, all=False, force=False, recursive=False):
+        self.packages = packages
+        self.all = all
+        self.force = force
+        self.recursive = recursive
+        self.yes_to_all = True
+
+
+class TestUninstall(spack.test.mock_database.MockDatabase):
+    def test_uninstall(self):
+        parser = None
+        # Multiple matches
+        args = MockArgs(['mpileaks'])
+        self.assertRaises(SystemExit, uninstall, parser, args)
+        # Installed dependents
+        args = MockArgs(['libelf'])
+        self.assertRaises(SystemExit, uninstall, parser, args)
+        # Recursive uninstall
+        args = MockArgs(['callpath'], all=True, recursive=True)
+        uninstall(parser, args)
+
+        all_specs = spack.install_layout.all_specs()
+        self.assertEqual(len(all_specs), 7)
+        # query specs with multiple configurations
+        mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
+        callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
+        mpi_specs = [s for s in all_specs if s.satisfies('mpi')]
+
+        self.assertEqual(len(mpileaks_specs), 0)
+        self.assertEqual(len(callpath_specs), 0)
+        self.assertEqual(len(mpi_specs),      3)

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -4,11 +4,11 @@ from spack.cmd.uninstall import uninstall
 
 
 class MockArgs(object):
-    def __init__(self, packages, all=False, force=False, recursive=False):
+    def __init__(self, packages, all=False, force=False, dependents=False):
         self.packages = packages
         self.all = all
         self.force = force
-        self.recursive = recursive
+        self.dependents = dependents
         self.yes_to_all = True
 
 
@@ -22,7 +22,7 @@ class TestUninstall(spack.test.mock_database.MockDatabase):
         args = MockArgs(['libelf'])
         self.assertRaises(SystemExit, uninstall, parser, args)
         # Recursive uninstall
-        args = MockArgs(['callpath'], all=True, recursive=True)
+        args = MockArgs(['callpath'], all=True, dependents=True)
         uninstall(parser, args)
 
         all_specs = spack.install_layout.all_specs()

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -28,16 +28,12 @@ both in memory and in its file
 """
 import os.path
 import multiprocessing
-import shutil
-import tempfile
 
 import spack
 from llnl.util.filesystem import join_path
 from llnl.util.lock import *
 from llnl.util.tty.colify import colify
-from spack.database import Database
-from spack.directory_layout import YamlDirectoryLayout
-from spack.test.mock_packages_test import *
+from spack.test.mock_database import MockDatabase
 
 
 def _print_ref_counts():
@@ -75,80 +71,7 @@ def _print_ref_counts():
     colify(recs, cols=3)
 
 
-class DatabaseTest(MockPackagesTest):
-
-    def _mock_install(self, spec):
-        s = Spec(spec)
-        s.concretize()
-        pkg = spack.repo.get(s)
-        pkg.do_install(fake=True)
-
-
-    def _mock_remove(self, spec):
-        specs = spack.installed_db.query(spec)
-        assert(len(specs) == 1)
-        spec = specs[0]
-        spec.package.do_uninstall(spec)
-
-
-    def setUp(self):
-        super(DatabaseTest, self).setUp()
-        #
-        # TODO: make the mockup below easier.
-        #
-
-        # Make a fake install directory
-        self.install_path = tempfile.mkdtemp()
-        self.spack_install_path = spack.install_path
-        spack.install_path = self.install_path
-
-        self.install_layout = YamlDirectoryLayout(self.install_path)
-        self.spack_install_layout = spack.install_layout
-        spack.install_layout = self.install_layout
-
-        # Make fake database and fake install directory.
-        self.installed_db = Database(self.install_path)
-        self.spack_installed_db = spack.installed_db
-        spack.installed_db = self.installed_db
-
-        # make a mock database with some packages installed note that
-        # the ref count for dyninst here will be 3, as it's recycled
-        # across each install.
-        #
-        # Here is what the mock DB looks like:
-        #
-        # o  mpileaks     o  mpileaks'    o  mpileaks''
-        # |\              |\              |\
-        # | o  callpath   | o  callpath'  | o  callpath''
-        # |/|             |/|             |/|
-        # o |  mpich      o |  mpich2     o |  zmpi
-        #   |               |             o |  fake
-        #   |               |               |
-        #   |               |______________/
-        #   | .____________/
-        #   |/
-        #   o  dyninst
-        #   |\
-        #   | o  libdwarf
-        #   |/
-        #   o  libelf
-        #
-
-        # Transaction used to avoid repeated writes.
-        with spack.installed_db.write_transaction():
-            self._mock_install('mpileaks ^mpich')
-            self._mock_install('mpileaks ^mpich2')
-            self._mock_install('mpileaks ^zmpi')
-
-
-    def tearDown(self):
-        super(DatabaseTest, self).tearDown()
-        shutil.rmtree(self.install_path)
-        spack.install_path = self.spack_install_path
-        spack.install_layout = self.spack_install_layout
-        spack.installed_db = self.spack_installed_db
-
-
+class DatabaseTest(MockDatabase):
     def test_005_db_exists(self):
         """Make sure db cache file exists after creating."""
         index_file = join_path(self.install_path, '.spack-db', 'index.yaml')
@@ -156,7 +79,6 @@ class DatabaseTest(MockPackagesTest):
 
         self.assertTrue(os.path.exists(index_file))
         self.assertTrue(os.path.exists(lock_file))
-
 
     def test_010_all_install_sanity(self):
         """Ensure that the install layout reflects what we think it does."""

--- a/lib/spack/spack/test/mock_database.py
+++ b/lib/spack/spack/test/mock_database.py
@@ -1,0 +1,78 @@
+import shutil
+import tempfile
+
+import spack
+from spack.spec import Spec
+from spack.database import Database
+from spack.directory_layout import YamlDirectoryLayout
+from spack.test.mock_packages_test import MockPackagesTest
+
+
+class MockDatabase(MockPackagesTest):
+    def _mock_install(self, spec):
+        s = Spec(spec)
+        s.concretize()
+        pkg = spack.repo.get(s)
+        pkg.do_install(fake=True)
+
+    def _mock_remove(self, spec):
+        specs = spack.installed_db.query(spec)
+        assert(len(specs) == 1)
+        spec = specs[0]
+        spec.package.do_uninstall(spec)
+
+    def setUp(self):
+        super(MockDatabase, self).setUp()
+        #
+        # TODO: make the mockup below easier.
+        #
+
+        # Make a fake install directory
+        self.install_path = tempfile.mkdtemp()
+        self.spack_install_path = spack.install_path
+        spack.install_path = self.install_path
+
+        self.install_layout = YamlDirectoryLayout(self.install_path)
+        self.spack_install_layout = spack.install_layout
+        spack.install_layout = self.install_layout
+
+        # Make fake database and fake install directory.
+        self.installed_db = Database(self.install_path)
+        self.spack_installed_db = spack.installed_db
+        spack.installed_db = self.installed_db
+
+        # make a mock database with some packages installed note that
+        # the ref count for dyninst here will be 3, as it's recycled
+        # across each install.
+        #
+        # Here is what the mock DB looks like:
+        #
+        # o  mpileaks     o  mpileaks'    o  mpileaks''
+        # |\              |\              |\
+        # | o  callpath   | o  callpath'  | o  callpath''
+        # |/|             |/|             |/|
+        # o |  mpich      o |  mpich2     o |  zmpi
+        #   |               |             o |  fake
+        #   |               |               |
+        #   |               |______________/
+        #   | .____________/
+        #   |/
+        #   o  dyninst
+        #   |\
+        #   | o  libdwarf
+        #   |/
+        #   o  libelf
+        #
+
+        # Transaction used to avoid repeated writes.
+        with spack.installed_db.write_transaction():
+            self._mock_install('mpileaks ^mpich')
+            self._mock_install('mpileaks ^mpich2')
+            self._mock_install('mpileaks ^zmpi')
+
+    def tearDown(self):
+        super(MockDatabase, self).tearDown()
+        shutil.rmtree(self.install_path)
+        spack.install_path = self.spack_install_path
+        spack.install_layout = self.spack_install_layout
+        spack.installed_db = self.spack_installed_db


### PR DESCRIPTION
##### Modifications : 
- [x] added `--dependents` option to uninstall
- [x] always prompt user for confirmation
- [x] add tests for regression on the command
- [x] updated documentation

##### Notes : 
This is meant to address #651 . Any comment or bug report on the PR is welcome.

##### Example : 
```
$ spack find
==> 8 installed packages.
-- linux-x86_64 / gcc@4.8 ---------------------------------------
bzip2@1.0.6  ncurses@6.0  openssl@1.0.2g  python@2.7.11  python@3.5.1  readline@6.3  sqlite@3.8.5  zlib@1.2.8

$ spack uninstall python
==> Error: python matches multiple packages:

-- linux-x86_64 / gcc@4.8 ---------------------------------------
nk2wnn4 python@2.7.11  7hxo5t5 python@3.5.1

==> Error: You can either:
    a) Use a more specific spec, or
    b) use spack uninstall -a to uninstall ALL matching specs.

$ spack uninstall -a python zlib
==> Error: Will not uninstall zlib@1.2.8%gcc@4.8-pdtswcf

The following packages depend on it:
-- linux-x86_64 / gcc@4.8 ---------------------------------------
3trgywi openssl@1.0.2g

==> Error: You can use spack uninstall -f to force this action

$ spack uninstall -a -d python zlib
==> The following packages will be uninstalled : 

-- linux-x86_64 / gcc@4.8 ---------------------------------------
3trgywi openssl@1.0.2g  nk2wnn4 python@2.7.11  7hxo5t5 python@3.5.1  pdtswcf zlib@1.2.8

==> Do you want to proceed ? [y/n]
y
==> Successfully uninstalled python@2.7.11%gcc@4.8=linux-x86_64-nk2wnn4
==> Successfully uninstalled python@3.5.1%gcc@4.8=linux-x86_64-7hxo5t5
==> Successfully uninstalled openssl@1.0.2g%gcc@4.8=linux-x86_64-3trgywi
==> Successfully uninstalled zlib@1.2.8%gcc@4.8=linux-x86_64-pdtswcf
```