### PR TITLE
[WIP] GEOS Python extension did not compile with Python3.

### DIFF
--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -1,4 +1,5 @@
 from spack import *
+import os
 
 class Geos(Package):
     """GEOS (Geometry Engine - Open Source) is a C++ port of the Java
@@ -10,6 +11,10 @@ class Geos(Package):
     homepage = "http://trac.osgeo.org/geos/"
     url      = "http://download.osgeo.org/geos/geos-3.4.2.tar.bz2"
 
+    # Verison 3.5.0 supports Autotools and CMake
+    version('3.5.0', '136842690be7f504fba46b3c539438dd')
+
+    # Versions through 3.4.2 have CMake, but only Autotools is supported
     version('3.4.2', 'fc5df2d926eb7e67f988a43a92683bae')
     version('3.4.1', '4c930dec44c45c49cd71f3e0931ded7e')
     version('3.4.0', 'e41318fc76b5dc764a69d43ac6b18488')
@@ -21,11 +26,22 @@ class Geos(Package):
     version('3.3.4', '1bb9f14d57ef06ffa41cb1d67acb55a1')
     version('3.3.3', '8454e653d7ecca475153cc88fd1daa26')
 
-    extends('python')
-    depends_on('swig')
+#    # Python3 is not supported.
+#    variant('python', default=False, description='Enable Python support')
+
+#    extends('python', when='+python')
+#    depends_on('python', when='+python')
+#    depends_on('swig', when='+python')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix,
-                  "--enable-python")
+        args = ["--prefix=%s" % prefix]
+#        if '+python' in spec:
+#            os.environ['PYTHON'] = join_path(spec['python'].prefix, 'bin',
+#                'python' if spec['python'].version[:1][0] <= 2 else 'python3')
+#            os.environ['SWIG'] = join_path(spec['swig'].prefix, 'bin', 'swig')
+#
+#            args.append("--enable-python")
+
+        configure(*args)
         make()
         make("install")


### PR DESCRIPTION
The package geos is needed to build py-basemap.  It is not currently used by any other Spack packages.

GEOS comes with a Python option, which builds a Python interface with Swig.  GEOS also comes with an (older) Autotools and a (newer) CMake build.  Only the Autotools build even attempts to build the Swig extension.  And although the extension itself might work with Python3, the configure script crashes if you specify a Python3 interpreter.

It turns out that py-basemap does NOT need the GEOS Swig extension (according to the basemap build instructions at http://matplotlib.org/basemap/users/installing.html  ).   I built GEOS without the Swig extension, and then I built basemap (no problems), and a demo basemap program seems to work.

Unless others object, I recommend we get rid of the '+python' option on GEOS and keep it simple.  I have a feeling the Swig extension has fallen into disuse.
