### PR TITLE
executable: quote arguments

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -144,7 +144,7 @@ class Executable(object):
 
         cmd = self.exe + list(args)
 
-        cmd_line = ' '.join(cmd)
+        cmd_line = "'%s'" % "' '".join(map(lambda arg: arg.replace("'", "'\"'\"'"), cmd))
         tty.debug(cmd_line)
 
         try:


### PR DESCRIPTION
This allows command line arguments with spaces to be shown. The quoting
madness is because a single quote cannot appear within a single quoted
argument on the command line. To do so, you have to stop the single
quote argument, double quote the single quote, then open the single
quote again:

    $ echo 'before'"'"'after'
    before'after

Fixes #174