### PR TITLE
ninja: fix installation on OS X

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -16,7 +16,7 @@ class Ninja(Package):
 
         cp = which('cp')
 
-        bindir = os.path.join(prefix, 'bin')
+        bindir = os.path.join(prefix, 'bin/')
         mkdir(bindir)
-        cp('-a', '-t', bindir, 'ninja')
-        cp('-ra', 'misc', prefix)
+        cp('-a', 'ninja', bindir)
+        cp('-a', 'misc', prefix)


### PR DESCRIPTION
The cp -t flag is a GNU-ism. Instead, add a trailing slash to bindir to
ensure that it is not treated as a file.

---
@tgamblin 