### PR TITLE
mpich: disable fortran without a fortran compiler

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -78,6 +78,9 @@ class Mpich(Package):
         if not self.compiler.fc:
             config_args.append("--disable-fc")
 
+        if not self.compiler.fc and not self.compiler.f77:
+            config_args.append("--disable-fortran")
+
         configure(*config_args)
         make()
         make("install")


### PR DESCRIPTION
---
Fixes #240 for machines without a Fortran compiler available.