### PR TITLE
libpng depends on zlib.

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -9,6 +9,8 @@ class Libpng(Package):
     version('1.6.15', '829a256f3de9307731d4f52dc071916d')
     version('1.6.14', '2101b3de1d5f348925990f9aa8405660')
 
+    depends_on('zlib')
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()


### PR DESCRIPTION
I can't build libpng w/o zlib so I added `depends_on('zlib')`.  I suppose most folks have been able to link to a system version of this library, but I need the dependency to be explicit.