### PR TITLE
+ libdrm depends_on libpciaccess.  Use spack provided libpciaccess.

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -2,7 +2,7 @@ from spack import *
 
 class Libdrm(Package):
     """A userspace  library for  accessing the  DRM, direct
-    rendering  manager, on  Linux,  BSD and  other  operating 
+    rendering  manager, on  Linux,  BSD and  other  operating
     systems that support the  ioctl interface."""
 
     homepage = "http://dri.freedesktop.org/libdrm/" # no real website...
@@ -10,6 +10,8 @@ class Libdrm(Package):
 
     version('2.4.59', '105ac7af1afcd742d402ca7b4eb168b6')
     version('2.4.33', '86e4e3debe7087d5404461e0032231c8')
+
+    depends_on('libpciaccess')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)


### PR DESCRIPTION
Running configure w/o optional arguments requires Intel atomics.  If these are found, then pciaccess must also be found.  Choose to use spack's version of libpciaccess.