### PR TITLE
Add CUDA and HOOMD-blue packages

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -16,9 +16,12 @@ class Cuda(Package):
     see http://software.llnl.gov/spack/mirrors.html"""
 
     homepage = "http://www.nvidia.com/object/cuda_home_new.html"
-    url      = "file://%s/cuda_7.5.18_linux.run" % os.getcwd()
 
-    version('7.5.18', '4b3bcecf0dfc35928a0898793cf3e4c6', expand=False)
+    version('7.5.18', '4b3bcecf0dfc35928a0898793cf3e4c6', expand=False,
+            url="file://%s/cuda_7.5.18_linux.run"    % os.getcwd())
+    version('6.5.14', '90b1b8f77313600cc294d9271741f4da', expand=False,
+            url="file://%s/cuda_6.5.14_linux_64.run" % os.getcwd())
+
 
     def install(self, spec, prefix):
         runfile = glob(os.path.join(self.stage.path, 'cuda*.run'))[0]
@@ -27,15 +30,13 @@ class Cuda(Package):
         runfile = which(runfile)
 
         # Note: NVIDIA does not officially support many newer versions of compilers.
-        # For example, on CentOS 6, you must use GCC 4.4.7 or older.
-        # The --override flag disables these checks. See:
+        # For example, on CentOS 6, you must use GCC 4.4.7 or older. See:
         # http://docs.nvidia.com/cuda/cuda-installation-guide-linux/#system-requirements
         # for details.
 
         runfile(
             '--silent',   # disable interactive prompts
             '--verbose',  # create verbose log file
-            '--override', # ignore compiler checks
             '--toolkit',  # install CUDA Toolkit
             '--toolkitpath=%s' % prefix
         )

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -1,0 +1,42 @@
+from spack import *
+from glob import glob
+import os
+
+class Cuda(Package):
+    """CUDA is a parallel computing platform and programming model invented by
+    NVIDIA. It enables dramatic increases in computing performance by harnessing
+    the power of the graphics processing unit (GPU).
+
+    Note: NVIDIA does not provide a download URL for CUDA so you will need to
+    download it yourself. Go to https://developer.nvidia.com/cuda-downloads
+    and select your Operating System, Architecture, Distribution, and Version.
+    For the Installer Type, select runfile and click Download. Spack will search
+    your current directory for this file. Alternatively, add this file to a
+    mirror so that Spack can find it. For instructions on how to set up a mirror,
+    see http://software.llnl.gov/spack/mirrors.html"""
+
+    homepage = "http://www.nvidia.com/object/cuda_home_new.html"
+    url      = "file://%s/cuda_7.5.18_linux.run" % os.getcwd()
+
+    version('7.5.18', '4b3bcecf0dfc35928a0898793cf3e4c6', expand=False)
+
+    def install(self, spec, prefix):
+        runfile = glob(os.path.join(self.stage.path, 'cuda*.run'))[0]
+        chmod = which('chmod')
+        chmod('+x', runfile)
+        runfile = which(runfile)
+
+        # Note: NVIDIA does not officially support many newer versions of compilers.
+        # For example, on CentOS 6, you must use GCC 4.4.7 or older.
+        # The --override flag disables these checks. See:
+        # http://docs.nvidia.com/cuda/cuda-installation-guide-linux/#system-requirements
+        # for details.
+
+        runfile(
+            '--silent',   # disable interactive prompts
+            '--verbose',  # create verbose log file
+            '--override', # ignore compiler checks
+            '--toolkit',  # install CUDA Toolkit
+            '--toolkitpath=%s' % prefix
+        )
+

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -13,7 +13,11 @@ class Cuda(Package):
     For the Installer Type, select runfile and click Download. Spack will search
     your current directory for this file. Alternatively, add this file to a
     mirror so that Spack can find it. For instructions on how to set up a mirror,
-    see http://software.llnl.gov/spack/mirrors.html"""
+    see http://software.llnl.gov/spack/mirrors.html
+
+    Note: This package does not currently install the drivers necessary to run
+    CUDA. These will need to be installed manually. See:
+    http://docs.nvidia.com/cuda/cuda-getting-started-guide-for-linux for details."""
 
     homepage = "http://www.nvidia.com/object/cuda_home_new.html"
 

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -49,10 +49,14 @@ class HoomdBlue(Package):
             cmake_args.append('-DENABLE_CUDA=OFF')
 
         # CUDA-aware MPI library support
-        if '+cuda' in spec and '+mpi' in spec:
-            cmake_args.append('-DENABLE_MPI_CUDA=ON')
-        else:
-            cmake_args.append('-DENABLE_MPI_CUDA=OFF')
+        #if '+cuda' in spec and '+mpi' in spec:
+        #    cmake_args.append('-DENABLE_MPI_CUDA=ON')
+        #else:
+        #    cmake_args.append('-DENABLE_MPI_CUDA=OFF')
+
+        # There may be a bug in the MPI-CUDA code. See:
+        # https://groups.google.com/forum/#!msg/hoomd-users/2griTESmc5I/E69s_M5fDwAJ
+        cmake_args.append('-DENABLE_MPI_CUDA=OFF')
 
         # Documentation
         if '+doc' in spec:
@@ -64,4 +68,5 @@ class HoomdBlue(Package):
         cmake('.', *cmake_args)
 
         make()
+        make("test")
         make("install")

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -1,0 +1,67 @@
+from spack import *
+import os
+
+class HoomdBlue(Package):
+    """HOOMD-blue is a general-purpose particle simulation toolkit. It scales
+    from a single CPU core to thousands of GPUs.
+
+    You define particle initial conditions and interactions in a high-level
+    python script. Then tell HOOMD-blue how you want to execute the job and it
+    takes care of the rest. Python job scripts give you unlimited flexibility
+    to create custom initialization routines, control simulation parameters,
+    and perform in situ analysis."""
+
+    homepage = "https://codeblue.umich.edu/hoomd-blue/index.html"
+    url      = "https://bitbucket.org/glotzer/hoomd-blue/get/v1.3.3.tar.bz2"
+
+    version('1.3.3', '1469ef4531dc14b579c0acddbfe6a273')
+
+    variant('mpi',  default=False, description='Compile with MPI enabled')
+    variant('cuda', default=False, description='Compile with CUDA Toolkit')
+    variant('doc',  default=False, description='Generate documentation')
+
+    extends('python')
+    depends_on('py-numpy')
+    depends_on('boost+python')
+    depends_on('cmake')
+    depends_on('mpi', when='+mpi')
+    depends_on('cuda', when='+cuda')
+    depends_on('doxygen', when='+doc')
+
+    def install(self, spec, prefix):
+
+        cmake_args = [
+            '-DPYTHON_EXECUTABLE=%s/python' % spec['python'].prefix.bin,
+            '-DBOOST_ROOT=%s'               % spec['boost' ].prefix
+        ]
+
+        # MPI support
+        if '+mpi' in spec:
+            os.environ['MPI_HOME'] = spec['mpi'].prefix
+            cmake_args.append('-DENABLE_MPI=ON')
+        else:
+            cmake_args.append('-DENABLE_MPI=OFF')
+
+        # CUDA support
+        if '+cuda' in spec:
+            cmake_args.append('-DENABLE_CUDA=ON')
+        else:
+            cmake_args.append('-DENABLE_CUDA=OFF')
+
+        # CUDA-aware MPI library support
+        if '+cuda' in spec and '+mpi' in spec:
+            cmake_args.append('-DENABLE_MPI_CUDA=ON')
+        else:
+            cmake_args.append('-DENABLE_MPI_CUDA=OFF')
+
+        # Documentation
+        if '+doc' in spec:
+            cmake_args.append('-DENABLE_DOXYGEN=ON')
+        else:
+            cmake_args.append('-DENABLE_DOXYGEN=OFF')
+
+        cmake_args.extend(std_cmake_args)
+        cmake('.', *cmake_args)
+
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -16,9 +16,9 @@ class HoomdBlue(Package):
 
     version('1.3.3', '1469ef4531dc14b579c0acddbfe6a273')
 
-    variant('mpi',  default=False, description='Compile with MPI enabled')
-    variant('cuda', default=False, description='Compile with CUDA Toolkit')
-    variant('doc',  default=False, description='Generate documentation')
+    variant('mpi',  default=True, description='Compile with MPI enabled')
+    variant('cuda', default=True, description='Compile with CUDA Toolkit')
+    variant('doc',  default=True, description='Generate documentation')
 
     extends('python')
     depends_on('py-numpy')
@@ -56,6 +56,7 @@ class HoomdBlue(Package):
 
         # There may be a bug in the MPI-CUDA code. See:
         # https://groups.google.com/forum/#!msg/hoomd-users/2griTESmc5I/E69s_M5fDwAJ
+        # This prevented "make test" from passing for me.
         cmake_args.append('-DENABLE_MPI_CUDA=OFF')
 
         # Documentation


### PR DESCRIPTION
This pull request adds a package for CUDA. At first glance, the following packages can now be modified to add CUDA support:

- cbtf-argonavis
- cbtf-krell
- mvapich2
- openspeedshop
- opencv

I'm not familiar with most of these packages, so I'll let someone else add CUDA support to these after this gets merged.

#### Potential improvements that can be made:

Similar to #558, the runfile download must be done manually. What would be really cool would be to override whatever function attempts fetching and add a try/catch statement. If the package cannot be found (in this case meaning it is not in the current directory or in a mirror), then prompt the user letting them know that it needs to be manually downloaded.

This package does not handle driver installation. As far as I know, this needs to be done manually by disabling the Nouveau drivers and rebooting into text-mode (see [CUDA Installation Guide](http://docs.nvidia.com/cuda/cuda-getting-started-guide-for-linux/#runfile-installation)). Perhaps I could add a `+driver` variant that handles the driver installation as long as the user is already in text-mode.

CUDA also suffers from the same problem as #558, in which the filename depends not only on the version but also on the platform and architecture. We could require users to rename the file without those, but the checksum will still be different.