### PR TITLE
Prevent use of system GTK+

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -137,8 +137,7 @@ class Qt(Package):
                   '-thread',
                   '-shared',
                   '-release',
-                  '-fast',
-                  *self.common_config_args)
+                  '-fast')
 
     @when('@4')
     def configure(self):

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -101,7 +101,7 @@ class Qt(Package):
 
     @property
     def common_config_args(self):
-        return [
+        config_args = [
             '-prefix', self.prefix,
             '-v',
             '-opensource',
@@ -115,7 +115,16 @@ class Qt(Package):
             '-no-openvg',
             '-no-pch',
             # NIS is deprecated in more recent glibc
-            '-no-nis']
+            '-no-nis'
+        ]
+
+        if '+gtk' in self.spec:
+            config_args.append('-gtkstyle')
+        else:
+            config_args.append('-no-gtkstyle')
+
+        return config_args
+
     # Don't disable all the database drivers, but should
     # really get them into spack at some point.
 
@@ -128,8 +137,8 @@ class Qt(Package):
                   '-thread',
                   '-shared',
                   '-release',
-                  '-fast'
-                  )
+                  '-fast',
+                  *self.common_config_args)
 
     @when('@4')
     def configure(self):


### PR DESCRIPTION
As suggested in #704, this should hopefully prevent the use of a system GTK+ when `~gtk` is chosen (the default). I haven't tested it myself, and I'm not familiar with qt, so someone else should test it.

I assume the configure function for version 3 was missing `common_config_args`? If not I can remove it.