### PR TITLE
Add mpiseq headers to MUMPS installation (was: Add libexec dir to MUMPS installation)

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -1,5 +1,5 @@
 from spack import *
-import os, sys
+import os, sys, glob
 
 class Mumps(Package):
     """MUMPS: a MUltifrontal Massively Parallel sparse direct Solver"""
@@ -164,10 +164,13 @@ class Mumps(Package):
 
         install_tree('lib', prefix.lib)
         install_tree('include', prefix.include)
-        if '~mpi' in spec:
+
+        if '~mpi' in spec:            
             lib_dsuffix = '.dylib' if sys.platform == 'darwin' else '.so'
             lib_suffix = lib_dsuffix if '+shared' in spec else '.a'
             install('libseq/libmpiseq%s' % lib_suffix, prefix.lib)
+            for f in glob.glob(join_path('libseq','*.h')):
+                install(f, prefix.include)
 
         # FIXME: extend the tests to mpirun -np 2 (or alike) when build with MPI
         # FIXME: use something like numdiff to compare blessed output with the current


### PR DESCRIPTION
Prior to this commit, spack installs a library called `libmpiseq` into
`spec['mumps'].prefix.lib` when it builds MUMPS without MPI. However, it
does not also install the headers corresponding to this library, so it
is impossible to link to this library.

This commit fixes this problem by adding a `libexec` directory to the
MUMPS installation that contains separate `include` and `lib`
subdirectories. The include directory in this subtree contains fake MPI
headers needed when linking libmpiseq in sequential MUMPS to some
software packages (e.g., IPOPT); the headers in
`spec['mumps'].prefix.include` do not contain these headers. Separating
these two directories is important, because the fake MPI headers shadow
MPI headers in functioning MPI implementations. So, if linking
sequential MUMPS to a code that uses MPI outside of MUMPS, one would put
the include directory in `spec['mumps'].prefix.include` in a compiler
header search path. If linking sequential MUMPS to a library like IPOPT
that expects the fake MPI implementation, one would instead put the
include directory in `join_path(spec['mumps'].prefix.libexec,
'include')` in a compiler header search path.