### PR TITLE
[WIP] Workaround (or permanent fix?) for depends_on(py-numpy)

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -388,6 +388,36 @@ class Package(object):
             spack.repo.get(self.extendee_spec)._check_extendable()
 
 
+    def unique_dependencies(self, spec=None):
+
+        # --------------------------------
+        def walk_dependencies(spec, deps):
+        # see: spec.Spec.traverse()
+            if str(spec.version) == 'system':
+                # No Spack module for system-installed packages
+                return
+
+            for dep in spec.dependencies.values():
+                walk_dependencies(dep, deps)
+
+            deps.append(spec)
+        # --------------------------------
+
+        if spec is None:
+            spec = self.spec
+
+        deps = list()
+        walk_dependencies(spec, deps)
+
+        seen = set()
+        deps_unique = list()
+        for dep in deps:
+            if id(dep) not in seen:
+                deps_unique.append(dep)
+                seen.add(id(dep))
+
+        return deps_unique
+
     @property
     def version(self):
         if not self.spec.versions.concrete:

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -1,0 +1,58 @@
+from spack import *
+import os
+
+class Ibmisc(CMakePackage):
+    """Misc. reusable utilities used by IceBin."""
+
+    homepage = "https://github.com/citibeth/ibmisc"
+    url      = "https://github.com/citibeth/ibmisc/tarball/v0.1.0"
+
+    version('0.1.1', '1bca77795cca96c583dcf75a0c666552')
+    version('0.1.0', '058af1c774b5836a1a71fd10611d80b5')
+
+    variant('everytrace', default=False, description='Report errors through Everytrace')
+    variant('proj', default=True, description='Compile utilities for PROJ.4 library')
+    variant('blitz', default=True, description='Compile utilities for Blitz library')
+    variant('netcdf', default=True, description='Compile utilities for NetCDF library')
+    variant('boost', default=True, description='Compile utilities for Boost library')
+    variant('udunits2', default=True, description='Compile utilities for UDUNITS2 library')
+    variant('googletest', default=True, description='Compile utilities for Google Test library')
+    variant('python', default=True, description='Compile utilities for use with Python/Cython')
+
+    extends('python')
+
+    depends_on('eigen')
+    depends_on('everytrace', when='+everytrace')
+    depends_on('proj', when='+proj')
+    depends_on('blitz', when='+blitz')
+    depends_on('netcdf-cxx4', when='+netcdf')
+    depends_on('udunits2', when='+udunits2')
+    depends_on('googletest', when='+googletest')
+    depends_on('py-cython', when='+python')
+    depends_on('py-numpy', when='+python')
+    depends_on('boost', when='+boost')
+
+    # Build dependencies
+    depends_on('cmake')
+    depends_on('doxygen')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DUSE_EVERYTRACE=%s' % ('YES' if '+everytrace' in spec else 'NO'),
+            '-DUSE_PROJ4=%s' % ('YES' if '+proj' in spec else 'NO'),
+            '-DUSE_BLITZ=%s' % ('YES' if '+blitz' in spec else 'NO'),
+            '-DUSE_NETCDF=%s' % ('YES' if '+netcdf' in spec else 'NO'),
+            '-DUSE_BOOST=%s' % ('YES' if '+boost' in spec else 'NO'),
+            '-DUSE_UDUNITS2=%s' % ('YES' if '+udunits2' in spec else 'NO'),
+            '-DUSE_GTEST=%s' % ('YES' if '+googletest' in spec else 'NO')]
+
+    def install_configure(self):
+
+        py_numpy = self.spec['py-numpy']
+        if 'blas' in py_numpy:
+            LD_LIBRARY_PATH = [join_path(dep.prefix, 'lib')
+                for dep in self.unique_dependencies(py_numpy['blas'])]
+            os.environ['LD_LIBRARY_PATH'] = ':'.join(LD_LIBRARY_PATH)
+
+        super(Ibmisc, self).install_configure()

--- a/var/spack/repos/builtin/packages/icebin/package.py
+++ b/var/spack/repos/builtin/packages/icebin/package.py
@@ -1,0 +1,64 @@
+from spack import *
+
+class Icebin(CMakePackage):
+    """Regridding/Coupling library for GCM + Ice Sheet Model"""
+
+    homepage = "https://github.com/citibeth/icebin"
+    url         = "https://github.com/citibeth/icebin/tarball/v0.1.0"
+
+    version('0.1.0', '1c2769a0cb3531e4086b885dc7a6fd27')
+    version('0.1.1', '986b8b51a2564f9c52156a11642e596c')
+
+    variant('everytrace', default=False, description='Report errors through Everytrace (requires Everytrace)')
+    variant('python', default=True, description='Build Python extension (requires Python, Numpy)')
+    variant('gridgen', default=True, description='Build grid generators (requires CGAL, GMP, MPFR)')
+    variant('coupler', default=True, description='Build the GCM coupler (requires MPI)')
+    variant('pism', default=False, description='Build coupling link with PISM (requires PISM, PETSc)')
+
+    extends('python')
+
+    depends_on('everytrace', when='+everytrace')
+
+    depends_on('python', when='+python')
+    depends_on('py-cython', when='+python')
+    depends_on('py-numpy', when='+python')
+
+    depends_on('cgal', when='+gridgen')
+    depends_on('gmp', when='+gridgen')
+    depends_on('mpfr', when='+gridgen')
+
+    depends_on('mpi', when='+coupler')
+    depends_on('pism~python', when='+coupler+pism')
+    depends_on('petsc', when='+coupler+pism')
+
+    depends_on('boost+filesystem+date_time')
+    depends_on('blitz')
+    depends_on('netcdf-cxx4')
+    depends_on('ibmisc+proj+blitz+netcdf+boost+udunits2+python')
+    depends_on('proj')
+    depends_on('eigen')
+
+
+    # Build dependencies
+    depends_on('cmake')
+    depends_on('doxygen')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DUSE_EVERYTRACE=%s' % ('YES' if '+everytrace' in spec else 'NO'),
+            '-DBUILD_PYTHON=%s' % ('YES' if '+python' in spec else 'NO'),
+            '-DBUILD_GRIDGEN=%s' % ('YES' if '+gridgen' in spec else 'NO'),
+            '-DBUILD_COUPLER=%s' % ('YES' if '+coupler' in spec else 'NO'),
+            '-DUSE_PISM=%s' % ('YES' if '+pism' in spec else 'NO')]
+
+    def install_configure(self):
+
+        # Work around lack of RPATH in Python extensions
+        py_numpy = self.spec['py-numpy']
+        if 'blas' in py_numpy:
+            LD_LIBRARY_PATH = [join_path(dep.prefix, 'lib')
+                for dep in self.unique_dependencies(py_numpy['blas'])]
+            os.environ['LD_LIBRARY_PATH'] = ':'.join(LD_LIBRARY_PATH)
+
+        super(Ibmisc, self).install_configure()

--- a/var/spack/repos/builtin/packages/py-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf/package.py
@@ -1,4 +1,23 @@
 from spack import *
+import os
+
+
+# --------------------------------------
+def walk_dependencies(spec, deps):
+# see: spec.Spec.traverse()
+    if str(spec.version) == 'system':
+        # No Spack module for system-installed packages
+        return
+
+    for dep in spec.dependencies.values():
+        walk_dependencies(dep, deps)
+
+    deps.append(spec)
+
+
+
+# --------------------------------------
+
 
 class PyNetcdf(Package):
     """Python interface to the netCDF Library."""
@@ -13,4 +32,26 @@ class PyNetcdf(Package):
     depends_on('netcdf')
 
     def install(self, spec, prefix):
+
+        # ---- Set up LD_LIBRARY_PATH coming from py-numpy:blas
+        # (because py-numpy isn't built with RPATH)
+        # Our install process imports numpy, and that needs to work.
+        deps = list()
+        py_numpy = spec['py-numpy']
+        if 'blas' in py_numpy:
+            walk_dependencies(spec['py-numpy']['blas'], deps)
+
+        seen = set()
+        deps_unique = list()
+        for dep in deps:
+            if id(dep) not in seen:
+                deps_unique.append(dep)
+                seen.add(id(dep))
+
+        LD_LIBRARY_PATH = []
+        for dep in deps_unique:
+            LD_LIBRARY_PATH.append(join_path(dep.prefix, 'lib'))
+        # --------------------------------
+
+        os.environ['LD_LIBRARY_PATH'] = ':'.join(LD_LIBRARY_PATH)
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf/package.py
@@ -2,23 +2,6 @@ from spack import *
 import os
 
 
-# --------------------------------------
-def walk_dependencies(spec, deps):
-# see: spec.Spec.traverse()
-    if str(spec.version) == 'system':
-        # No Spack module for system-installed packages
-        return
-
-    for dep in spec.dependencies.values():
-        walk_dependencies(dep, deps)
-
-    deps.append(spec)
-
-
-
-# --------------------------------------
-
-
 class PyNetcdf(Package):
     """Python interface to the netCDF Library."""
     homepage = "http://unidata.github.io/netcdf4-python"
@@ -33,25 +16,11 @@ class PyNetcdf(Package):
 
     def install(self, spec, prefix):
 
-        # ---- Set up LD_LIBRARY_PATH coming from py-numpy:blas
-        # (because py-numpy isn't built with RPATH)
-        # Our install process imports numpy, and that needs to work.
-        deps = list()
-        py_numpy = spec['py-numpy']
+        # Work around lack of RPATH in Python extensions
+        py_numpy = self.spec['py-numpy']
         if 'blas' in py_numpy:
-            walk_dependencies(spec['py-numpy']['blas'], deps)
+            LD_LIBRARY_PATH = [join_path(dep.prefix, 'lib')
+                for dep in self.unique_dependencies(py_numpy['blas'])]
+            os.environ['LD_LIBRARY_PATH'] = ':'.join(LD_LIBRARY_PATH)
 
-        seen = set()
-        deps_unique = list()
-        for dep in deps:
-            if id(dep) not in seen:
-                deps_unique.append(dep)
-                seen.add(id(dep))
-
-        LD_LIBRARY_PATH = []
-        for dep in deps_unique:
-            LD_LIBRARY_PATH.append(join_path(dep.prefix, 'lib'))
-        # --------------------------------
-
-        os.environ['LD_LIBRARY_PATH'] = ':'.join(LD_LIBRARY_PATH)
         python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
I merged today from develop, and it broke anything that depends_on('py-numpy').  I believe these used to work.  But now I have to set LD_LIBRARY_PATH to point to Numpy (or else `python3 -c numpy` won't find libopenblas.so).

The most likely reason for this problem is that OpenBLAS builds a shared object (previously I was using ATLAS, I believe with static library).  That has uncovered a latent problem, that Python extensions (eg, those built in py-numpy) do not use RPATH (and thus cannot find libopenblas.so).  Or... maybe this problem with Python libs was introduced in the last two weeks.  Or maybe with 
refactoring of build_environment on March 21?

Seeking advice...

See: https://github.com/LLNL/spack/issues/719
