### PR TITLE
Metis and suitesparse fixes

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -174,6 +174,19 @@ class Dealii(Package):
             make('release')
             make('run',parallel=False)
 
+        # An example which uses Metis + PETSc
+        # FIXME: switch step-18 to MPI
+        with working_dir('examples/step-18'):
+            print('=====================================')
+            print('============= Step-18 ===============')
+            print('=====================================')
+            # list the number of cycles to speed up
+            filter_file(r'(end_time = 10;)',  ('end_time = 3;'), 'step-18.cc')
+            if '^petsc' in spec and '^metis' in spec:
+                cmake('.')
+                make('release')
+                make('run',parallel=False)
+
         # take step-40 which can use both PETSc and Trilinos
         # FIXME: switch step-40 to MPI run
         with working_dir('examples/step-40'):

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -23,8 +23,10 @@ class Dealii(Package):
 
     # required dependencies, light version
     depends_on ("blas")
-    depends_on ("boost",     when='~mpi')
-    depends_on ("boost+mpi", when='+mpi')
+    # Boost 1.58 is blacklisted, see https://github.com/dealii/dealii/issues/1591
+    # require at least 1.59
+    depends_on ("boost@1.59.0:",     when='~mpi')
+    depends_on ("boost@1.59.0:+mpi", when='+mpi')
     depends_on ("bzip2")
     depends_on ("cmake")
     depends_on ("lapack")

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -10,13 +10,18 @@ class SuiteSparse(Package):
 
     version('4.5.1', 'f0ea9aad8d2d1ffec66a5b6bfeff5319')
 
-    variant('tbb', default=True, description='Build with Intel TBB')
+    # FIXME: (see below)
+    # variant('tbb', default=True, description='Build with Intel TBB')
 
     depends_on('blas')
     depends_on('lapack')
 
     depends_on('metis@5.1.0', when='@4.5.1')
-    depends_on('tbb', when='+tbb')
+    # FIXME:
+    # in @4.5.1. TBB support in SPQR seems to be broken as TBB-related linkng flags
+    # does not seem to be used, which leads to linking errors on Linux.
+    # Try re-enabling in future versions.
+    # depends_on('tbb', when='+tbb')
 
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -10,10 +10,13 @@ class SuiteSparse(Package):
 
     version('4.5.1', 'f0ea9aad8d2d1ffec66a5b6bfeff5319')
 
+    variant('tbb', default=True, description='Build with Intel TBB')
+
     depends_on('blas')
     depends_on('lapack')
 
     depends_on('metis@5.1.0', when='@4.5.1')
+    depends_on('tbb', when='+tbb')
 
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned
@@ -21,16 +24,35 @@ class SuiteSparse(Package):
         # with a lot of convoluted logic in it.
         # Any kind of customization will need to go through filtering of that file
 
-        # FIXME : this actually uses the current workaround
-        # FIXME : (blas / lapack always provide libblas and liblapack as aliases)
-        make('install', 'INSTALL=%s' % prefix,
+        make_args = ['INSTALL=%s' % prefix]
 
-             # inject Spack compiler wrappers
+        # inject Spack compiler wrappers
+        make_args.extend([
              'AUTOCC=no',
              'CC=cc',
              'CXX=c++',
              'F77=f77',
+        ])
 
-             # BLAS arguments require path to libraries
-             'BLAS=-lblas',
-             'LAPACK=-llapack')
+        # use Spack's metis in CHOLMOD/Partition module,
+        # otherwise internal Metis will be compiled
+        make_args.extend([
+             'MY_METIS_LIB=-L%s -lmetis' % spec['metis'].prefix.lib,
+             'MY_METIS_INC=%s' % spec['metis'].prefix.include,
+        ])
+
+        # Intel TBB in SuiteSparseQR
+        if '+tbb' in spec:
+            make_args.extend([
+                'SPQR_CONFIG=-DHAVE_TBB',
+                'TBB=-L%s -ltbb' % spec['tbb'].prefix.lib,
+            ])
+
+        # BLAS arguments require path to libraries
+        # FIXME : (blas / lapack always provide libblas and liblapack as aliases)
+        make_args.extend([
+            'BLAS=-lblas',
+            'LAPACK=-llapack'
+        ])
+
+        make('install', *make_args)


### PR DESCRIPTION
first, fix `metis` with clang 7.3.0 (credits to Homebrew guys) and add some tests.
second, fix an ugly bug where `suite-sparse` was build with internal `metis` (also cleanup suite-sparse build). That, i believe, lead to symbol collision for libraries which are build against both `metis` and `suite-sparse` (like `dealii`) and eventually resulted in Metis errors on OSX when calling `METIS_PartGraphKway` or `METIS_PartGraphRecursive`. Finally, add another test to `dealii` which uses `metis`.

Tested on OSX 10.11.4. with Clang 7.3.0.