### PR TITLE
Added deprecation warning to netcdf-cxx

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -1,7 +1,11 @@
 from spack import *
 
 class NetcdfCxx(Package):
-    """C++ compatibility bindings for NetCDF"""
+    “””Deprecated C++ compatibility bindings for NetCDF.
+    These do NOT read or write NetCDF-4 files, and are no longer
+    maintained by Unidata.  Developers should migrate to current
+    NetCDF C++ bindings, in Spack package netcdf-cxx4.”””
+
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "http://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx-4.2.tar.gz"
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -1,10 +1,10 @@
 from spack import *
 
 class NetcdfCxx(Package):
-    “””Deprecated C++ compatibility bindings for NetCDF.
+    """Deprecated C++ compatibility bindings for NetCDF.
     These do NOT read or write NetCDF-4 files, and are no longer
     maintained by Unidata.  Developers should migrate to current
-    NetCDF C++ bindings, in Spack package netcdf-cxx4.”””
+    NetCDF C++ bindings, in Spack package netcdf-cxx4."""
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "http://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx-4.2.tar.gz"


### PR DESCRIPTION
The netcdf-cxx package is deprecated by Unidata.  Added this information as a comment in package.py.