### PR TITLE
Added version 1.0 of sympy.

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpmath/package.py
+++ b/var/spack/repos/builtin/packages/py-mpmath/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class PyMpmath(Package):
+    """A Python library for arbitrary-precision floating-point arithmetic."""
+    homepage = "http://mpmath.org"
+    url      = "https://pypi.python.org/packages/source/m/mpmath/mpmath-all-0.19.tar.gz"
+
+    version('0.19', 'd1b7e19dd6830d0d7b5e1bc93d46c02c')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-sympy/package.py
+++ b/var/spack/repos/builtin/packages/py-sympy/package.py
@@ -6,8 +6,10 @@ class PySympy(Package):
     url      = "https://pypi.python.org/packages/source/s/sympy/sympy-0.7.6.tar.gz"
 
     version('0.7.6', '3d04753974306d8a13830008e17babca')
+    version('1.0', '43e797de799f00f9e8fd2307dba9fab1')
 
     extends('python')
+    depends_on('py-mpmath', when='@1.0:')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
Beginning with this version, sympy requires the mpmath package. The py-mpmath package is added in this PR to accommodate that.