### PR TITLE
libxcb: Added comments on two dependencies Spack does not yet know ho…

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -14,6 +14,9 @@ class Libxcb(Package):
     depends_on("python")
     depends_on("xcb-proto")
 
+    # depends_on('pthread')    # Ubuntu: apt-get install libpthread-stubs0-dev
+    # depends_on('xau')        # Ubuntu: apt-get install libxau-dev
+
     def patch(self):
         filter_file('typedef struct xcb_auth_info_t {', 'typedef struct {', 'src/xcb.h')
 


### PR DESCRIPTION
It would be nice to be able to depends_on() things that don't yet exist (but are assumed to be system-installed).  Until that point, we do so in comments.