### PR TITLE
[Needs Review] Fix conditional extends (BUG #683)

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -163,9 +163,14 @@ class EnvModule(object):
         # package-specific modifications
         spack_env = EnvironmentModifications()
         for item in self.pkg.extendees:
-            package = self.spec[item].package
-            package.setup_dependent_package(self.pkg.module, self.spec)
-            package.setup_dependent_environment(spack_env, env, self.spec)
+            try:
+                package = self.spec[item].package
+                package.setup_dependent_package(self.pkg.module, self.spec)
+                package.setup_dependent_environment(spack_env, env, self.spec)
+            except:
+                # The extends was conditional, so it doesn't count here
+                # eg: extends('python', when='+python')
+                pass
 
         # Package-specific environment modifications
         self.spec.package.setup_environment(spack_env, env)


### PR DESCRIPTION
There have been recent problems with conditional extends, eg:
    extends('python', when='+python')

This seems to fix it for me.  Needs review.
