### PR TITLE
[WIP] python packages: Added depends_on(binutils) for 

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -13,6 +13,7 @@ class PyCython(Package):
     version('0.21.2', 'd21adb870c75680dc857cd05d41046a4')
 
     extends('python')
+    depends_on('binutils')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -13,6 +13,7 @@ class PyMatplotlib(Package):
     variant('ipython', default=False, description='Enable ipython support')
 
     extends('python', ignore=r'bin/nosetests.*$|bin/pbr$|bin/f2py$')
+    depends_on('binutils')
 
     depends_on('py-pyside', when='+gui')
     depends_on('py-ipython', when='+ipython')

--- a/var/spack/repos/builtin/packages/py-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf/package.py
@@ -8,6 +8,8 @@ class PyNetcdf(Package):
     version('1.2.3.1', '4fc4320d4f2a77b894ebf8da1c9895af')
 
     extends('python')
+    depends_on('binutils')
+
     depends_on('py-numpy')
     depends_on('py-cython')
     depends_on('netcdf')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -19,6 +19,7 @@ class PyNumpy(Package):
     variant('lapack', default=True)
 
     extends('python')
+    depends_on('binutils')
     depends_on('py-nose')
     depends_on('blas',   when='+blas')
     depends_on('lapack', when='+lapack')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -10,6 +10,7 @@ class PyScipy(Package):
     version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
 
     extends('python')
+    depends_on('binutils')
     depends_on('py-nose')
     depends_on('py-numpy+blas+lapack')
 


### PR DESCRIPTION
I'm not sure if this is the right thing, but it solves my problems (for now) on Ubuntu 12.04 (which has a system-installed binutils 2.22).   The problem is that the Ubuntu-supplied ld crashes when linking the packages here.  A newer binutils fixes the problem.  See more detailed description below:

Trying to build some packages (py-numpy, py-cython) causes /usr/bin/ld to crash with an error message asking you to report the bug to GNU.  This is binutils 2.22.  Everyone says, use a newer binutils.

I tried doing this by saying `spack load binutils` before `spack install py-numpy`.  That had no effect.

I got things working by adding `depends('binutils')` to the py-numpy and py-cython packages.  BUT.. I don't think this is really a good solution, because:

1. Is this only a GCC problem?  Would I need to use the different binutils if I installed Intel compilers on my Ubuntu?

2. binutils would seem to be part of the compiler, not something we should have to add as a depends_on() to every package.

3. Once we've added depends_on('binutils') everywhere, most users will want to set binutils to no-build in packages.py

4. It should really be a build-time dependency anyway (this will soon be available with upcoming PR merge).