### PR TITLE
Don't set PETSC_DIR

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -113,7 +113,3 @@ class Petsc(Package):
         # PETSc has its own way of doing parallel make.
         make('MAKE_NP=%s' % make_jobs, parallel=False)
         make("install")
-
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        # set up PETSC_DIR for everyone using PETSc package
-        spack_env.set('PETSC_DIR', self.prefix)


### PR DESCRIPTION
Setting PETSC_DIR this way breaks building PETSc; apparently, this also sets PETSC_DIR while building PETSc, and this doesn't work.

Why is the location of PETSc exported via an environment variable anyway? Spack should have a mechanism for this (modules?), and if it doesn't, such a mechanism should be introduced. Otherwise, each package should have such a function and export its location.