### PR TITLE
Scikit

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -9,5 +9,7 @@ class PyDask(Package):
 
     extends('python')
 
+    depends_on('py-setuptools')
+
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class PyDask(Package):
+    """Minimal task scheduling abstraction"""
+    homepage = "https://github.com/dask/dask/"
+    url      = "https://pypi.python.org/packages/source/d/dask/dask-0.8.1.tar.gz"
+
+    version('0.8.1', '5dd8e3a3823b3bc62c9a6d192e2cb5b4')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-decorator/package.py
+++ b/var/spack/repos/builtin/packages/py-decorator/package.py
@@ -9,5 +9,7 @@ class PyDecorator(Package):
 
     extends('python')
 
+    depends_on('py-setuptools')
+
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-decorator/package.py
+++ b/var/spack/repos/builtin/packages/py-decorator/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class PyDecorator(Package):
+    """The aim of the decorator module it to simplify the usage of decorators for the average programmer, and to popularize decorators by showing various non-trivial examples."""
+    homepage = "https://github.com/micheles/decorator"
+    url      = "https://pypi.python.org/packages/source/d/decorator/decorator-4.0.9.tar.gz"
+
+    version('4.0.9', 'f12c5651ccd707e12a0abaa4f76cd69a')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -1,0 +1,15 @@
+from spack import *
+
+class PyNetworkx(Package):
+    """NetworkX is a Python package for the creation, manipulation, and study of the structure, dynamics, and functions of complex networks."""
+    homepage = "http://networkx.github.io/"
+    url      = "https://pypi.python.org/packages/source/n/networkx/networkx-1.11.tar.gz"
+
+    version('1.11', '6ef584a879e9163013e9a762e1cf7cd1')
+
+    extends('python')
+
+    depends_on('py-decorator')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -1,0 +1,20 @@
+from spack import *
+
+class PyScikitImage(Package):
+    """Image processing algorithms for SciPy, including IO, morphology, filtering, warping, color manipulation, object detection, etc."""
+    homepage = "http://scikit-image.org/"
+    url      = "https://pypi.python.org/packages/source/s/scikit-image/scikit-image-0.12.3.tar.gz"
+
+    version('0.12.3', '04ea833383e0b6ad5f65da21292c25e1')
+
+    extends('python', ignore=r'bin/.*\.py$|bin/f2py$')
+
+    depends_on('py-dask')
+    depends_on('py-pillow')
+    depends_on('py-networkx')
+    depends_on('py-six')
+    depends_on('py-scipy')
+    depends_on('py-matplotlib')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -11,5 +11,9 @@ class PyScikitLearn(Package):
 
     extends('python')
 
+    depends_on('py-setuptools')
+    depends_on('py-numpy')
+    depends_on('py-scipy')
+
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -7,6 +7,7 @@ class PyScikitLearn(Package):
 
     version('0.15.2', 'd9822ad0238e17b382a3c756ea94fe0d')
     version('0.16.1', '363ddda501e3b6b61726aa40b8dbdb7e')
+    version('0.17.1', 'a2f8b877e6d99b1ed737144f5a478dfc')
 
     extends('python')
 


### PR DESCRIPTION
This PR adds py-scikit-learn-0.17.1 and adds py-scikit-image along with new dependent packages.

@tgamblin 
Scikit-image depends on py-pillow which creates several '*.py' scripts in the bin directory. As was noticed with numpy dependencies, those binaries/scripts get copied to the bin directory the scikit-image package. This means that those need to be added to the `ignore` parameter of `extends`. In this case, scikit-image also creates a program in bin (no '.py' extension) which needs to be linked during activation. This was accomplished with the regex in the ignore parameter but this does not feel right. Should the next version of scikit-image create a '.py' script in bin then the regex will not be correct any longer. It seems like spack needs something that will automatically add scripts in the bin directory to the ignore list once they have been activated so that it does not have to be done at the package level.