### PR TITLE
Add support for NAG's clunky rpath linking

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -175,6 +175,19 @@ fi
 input_command="$@"
 args=("$@")
 
+# Determine appropriate prefix for passing rpaths to the linker
+if [[ $mode == ccld ]]; then
+    if [[ $(basename $0) == nagfor ]]; then
+        # Unlike other compilers, the NAG compiler passes options to GCC, which
+        # then passes them to the linker. Therefore, we need to doubly wrap the
+        # options with '-Wl,-Wl,,'
+        rpath_prefix="-Wl,-Wl,,"
+    else
+        # Wrap the option with '-Wl,' to properly pass it to the linker
+        rpath_prefix="-Wl,"
+    fi
+fi
+
 # Read spack dependencies from the path environment variable
 IFS=':' read -ra deps <<< "$SPACK_DEPENDENCIES"
 for dep in "${deps[@]}"; do
@@ -188,7 +201,7 @@ for dep in "${deps[@]}"; do
     # Prepend lib and RPATH directories
     if [[ -d $dep/lib ]]; then
         if [[ $mode == ccld ]]; then
-            $add_rpaths && args=("-Wl,-rpath,$dep/lib" "${args[@]}")
+            $add_rpaths && args=("$rpath_prefix-rpath,$dep/lib" "${args[@]}")
             args=("-L$dep/lib" "${args[@]}")
         elif [[ $mode == ld ]]; then
             $add_rpaths && args=("-rpath" "$dep/lib" "${args[@]}")
@@ -199,7 +212,7 @@ for dep in "${deps[@]}"; do
     # Prepend lib64 and RPATH directories
     if [[ -d $dep/lib64 ]]; then
         if [[ $mode == ccld ]]; then
-            $add_rpaths && args=("-Wl,-rpath,$dep/lib64" "${args[@]}")
+            $add_rpaths && args=("$rpath_prefix-rpath,$dep/lib64" "${args[@]}")
             args=("-L$dep/lib64" "${args[@]}")
         elif [[ $mode == ld ]]; then
             $add_rpaths && args=("-rpath" "$dep/lib64" "${args[@]}")
@@ -210,7 +223,7 @@ done
 
 # Include all -L's and prefix/whatever dirs in rpath
 if [[ $mode == ccld ]]; then
-    $add_rpaths && args=("-Wl,-rpath,$SPACK_PREFIX/lib" "-Wl,-rpath,$SPACK_PREFIX/lib64" "${args[@]}")
+    $add_rpaths && args=("$rpath_prefix-rpath,$SPACK_PREFIX/lib" "$rpath_prefix-rpath,$SPACK_PREFIX/lib64" "${args[@]}")
 elif [[ $mode == ld ]]; then
     $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib" "-rpath" "$SPACK_PREFIX/lib64" "${args[@]}")
 fi


### PR DESCRIPTION
As discussed in #590, I was having trouble getting the Spack compiler wrappers to work for the NAG Fortran compiler. After doing some digging, I found [this blog](http://baradi09.blogspot.com/2014/08/compiling-openmpi-with-nag-fortran.html) that describes a solution.

Most compilers allow you to send options (like `-rpath`) to the linker by wrapping them with `-Wl,`. NAG is completely backwards, and instead of sending these options to the linker, it first sends them to GCC, which passes them to the linker. If you wrap them normally, NAG passes `-rpath` directly to GCC, resulting in copious error messages like:
```
gcc: error: unrecognized command line option '-rpath'
```
The solution is to doubly wrap rpath arguments with `-Wl,-Wl,,`

I am still unable to build anything with NAG though. I'm going to continue investigating the issue. In the meantime, this PR solves the rpath problem for me.