### PR TITLE
metis 4.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -40,7 +40,7 @@ class Dealii(Package):
     depends_on ("arpack-ng+mpi", when='+arpack+mpi')
     depends_on ("doxygen", when='+doc')
     depends_on ("hdf5+mpi~cxx", when='+hdf5+mpi') #FIXME NetCDF declares dependency with ~cxx, why?
-    depends_on ("metis", when='+metis')
+    depends_on ("metis@5:", when='+metis')
     depends_on ("netcdf+mpi", when="+netcdf+mpi")
     depends_on ("netcdf-cxx", when='+netcdf+mpi')
     depends_on ("oce", when='+oce')

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -45,7 +45,7 @@ class Eigen(Package):
 
     # TODO : dependency on googlehash, superlu, adolc missing
 
-    depends_on('metis', when='+metis')
+    depends_on('metis@5:', when='+metis')
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 from spack import *
-import glob,sys
+import glob, sys, os
 
 class Metis(Package):
     """
@@ -37,6 +37,8 @@ class Metis(Package):
     url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz"
 
     version('5.1.0', '5465e67079419a69e0116de24fce58fe')
+    version('4.0.3', '5efa35de80703c1b2c4d0de080fafbcf4e0d363a21149a1ad2f96e0144841a55',
+            url='http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz')
 
     variant('shared', default=True, description='Enables the build of shared libraries')
     variant('debug', default=False, description='Builds the library in debug mode')
@@ -45,12 +47,85 @@ class Metis(Package):
     variant('idx64', default=False, description='Use int64_t as default index type')
     variant('double', default=False, description='Use double precision floating point types')
 
-    depends_on('cmake @2.8:')  # build-time dependency
-
+    depends_on('cmake @2.8:', when='@5:')  # build-time dependency
     depends_on('gdb', when='+gdb')
 
-    patch('install_gklib_defs_rename.patch')
+    patch('install_gklib_defs_rename.patch', when='@5:')
 
+
+    @when('@4:4.0.3')
+    def install(self, spec, prefix):
+
+        if '+gdb' in spec:
+            raise InstallError('gdb support not implemented in METIS 4!')
+        if '+idx64' in spec:
+            raise InstallError('idx64 option not implemented in METIS 4!')
+        if '+double' in spec:
+            raise InstallError('double option not implemented for METIS 4!')
+
+        options = ['COPTIONS=-fPIC']
+        if '+debug' in spec:
+            options.append('OPTFLAGS=-g -O0')
+        make(*options)
+
+        mkdir(prefix.bin)
+        for x in ('pmetis', 'kmetis', 'oemetis', 'onmetis', 'partnmesh',
+                  'partdmesh', 'mesh2nodal', 'mesh2dual', 'graphchk'):
+            install(x, prefix.bin)
+
+        mkdir(prefix.lib)
+        install('libmetis.a', prefix.lib)
+
+        mkdir(prefix.include)
+        for h in glob.glob(join_path('Lib', '*.h')):
+            install(h, prefix.include)
+
+        mkdir(prefix.share)
+        for f in (join_path(*p)
+                  for p in (('Programs', 'io.c'),
+                            ('Test','mtest.c'),
+                            ('Graphs','4elt.graph'),
+                            ('Graphs', 'metis.mesh'),
+                            ('Graphs', 'test.mgraph'))):
+            install(f, prefix.share)
+
+        if '+shared' in spec:
+            if sys.platform == 'darwin':
+                lib_dsuffix = 'dylib'
+                load_flag = '-Wl,-all_load'
+                no_load_flag = ''
+            else:
+                lib_dsuffix = 'so'
+                load_flag = '-Wl,-whole-archive'
+                no_load_flag = '-Wl,-no-whole-archive'
+
+            os.system(spack_cc + ' -fPIC -shared ' + load_flag +
+                      ' libmetis.a ' + no_load_flag + ' -o libmetis.' +
+                      lib_dsuffix)
+            install('libmetis.' + lib_dsuffix, prefix.lib)
+
+        # Set up and run tests on installation
+        symlink(join_path(prefix.share, 'io.c'), 'io.c')
+        symlink(join_path(prefix.share, 'mtest.c'), 'mtest.c')
+        os.system(spack_cc + ' -I%s' % prefix.include + ' -c io.c')
+        os.system(spack_cc + ' -I%s' % prefix.include +
+                  ' -L%s' % prefix.lib + ' -lmetis mtest.c io.o -o mtest')
+        _4eltgraph = join_path(prefix.share, '4elt.graph')
+        test_mgraph = join_path(prefix.share, 'test.mgraph')
+        metis_mesh = join_path(prefix.share, 'metis.mesh')
+        kmetis = join_path(prefix.bin, 'kmetis')
+        os.system('./mtest ' + _4eltgraph)
+        os.system(kmetis + ' ' + _4eltgraph + ' 40')
+        os.system(join_path(prefix.bin, 'onmetis') + ' ' + _4eltgraph)
+        os.system(join_path(prefix.bin, 'pmetis') + ' ' + test_mgraph + ' 2')
+        os.system(kmetis + ' ' + test_mgraph + ' 2')
+        os.system(kmetis + ' ' + test_mgraph + ' 5')
+        os.system(join_path(prefix.bin, 'partnmesh') + metis_mesh + ' 10')
+        os.system(join_path(prefix.bin, 'partdmesh') + metis_mesh + ' 10')
+        os.system(join_path(prefix.bin, 'mesh2dual') + metis_mesh)
+
+
+    @when('@5:')
     def install(self, spec, prefix):
 
         options = []

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -23,7 +23,7 @@ class Mumps(Package):
 
     depends_on('scotch + esmumps', when='~ptscotch+scotch')
     depends_on('scotch + esmumps + mpi', when='+ptscotch')
-    depends_on('metis', when='+metis')
+    depends_on('metis@5:', when='+metis')
     depends_on('parmetis', when="+parmetis")
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -44,7 +44,7 @@ class Parmetis(Package):
     depends_on('mpi')
 
     patch('enable_external_metis.patch')
-    depends_on('metis')
+    depends_on('metis@5:')
 
     # bug fixes from PETSc developers
     # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -40,7 +40,7 @@ class Petsc(Package):
 
     # Other dependencies
     depends_on('boost', when='+boost')
-    depends_on('metis', when='+metis')
+    depends_on('metis@5:', when='+metis')
 
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('parmetis', when='+metis+mpi')

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -15,7 +15,7 @@ class SuperluDist(Package):
     depends_on ('blas')
     depends_on ('lapack')
     depends_on ('parmetis')
-    depends_on ('metis')
+    depends_on ('metis@5:')
 
     def install(self, spec, prefix):
         makefile_inc = []

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -42,7 +42,7 @@ class Trilinos(Package):
     depends_on('matio')
     depends_on('glm')
     depends_on('swig')
-    depends_on('metis',when='+metis')
+    depends_on('metis@5:',when='+metis')
     depends_on('suite-sparse',when='+suite-sparse')
 
     # MPI related dependencies


### PR DESCRIPTION
Add version 4.0.3 to metis package. Attempted to implement reasonable
versions of all variants declared for metis@5.1.0; some of these do
not have analogues in metis@4.0.3, and errors are raised accordingly.