### PR TITLE
fix : mpich and mvapich2 will use spack compilers during installation

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -47,12 +47,12 @@ class Mpich(Package):
     provides('mpi@:3.0', when='@3:')
     provides('mpi@:1.3', when='@1:')
 
-    def setup_dependent_environment(self, env, dependent_spec):
-        env.set('MPICH_CC', spack_cc)
-        env.set('MPICH_CXX', spack_cxx)
-        env.set('MPICH_F77', spack_f77)
-        env.set('MPICH_F90', spack_f90)
-        env.set('MPICH_FC', spack_fc)
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('MPICH_CC', spack_cc)
+        spack_env.set('MPICH_CXX', spack_cxx)
+        spack_env.set('MPICH_F77', spack_f77)
+        spack_env.set('MPICH_F90', spack_fc)
+        spack_env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -140,6 +140,13 @@ class Mvapich2(Package):
 
         configure_args.extend(network_options)
 
+    def setup_dependent_environment(self, spack_env, run_env, extension_spec):
+        spack_env.set('MPICH_CC', spack_cc)
+        spack_env.set('MPICH_CXX', spack_cxx)
+        spack_env.set('MPICH_F77', spack_f77)
+        spack_env.set('MPICH_F90', spack_fc)
+        spack_env.set('MPICH_FC', spack_fc)
+
     def install(self, spec, prefix):
         # we'll set different configure flags depending on our environment
         configure_args = [


### PR DESCRIPTION
##### Modifications
- [x] mvapich2 : MPI compiler wrapper will use spack compilers during the installation phase
- [x] mpich : fixed wrong function signature