### PR TITLE
Make R extendable

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -124,10 +124,12 @@ class ConfigureGuesser(object):
         autotools = "configure('--prefix=%s' % prefix)"
         cmake     = "cmake('.', *std_cmake_args)"
         python    = "python('setup.py', 'install', '--prefix=%s' % prefix)"
+        r         = "R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)"
 
         config_lines = ((r'/configure$',      'autotools', autotools),
                         (r'/CMakeLists.txt$', 'cmake',     cmake),
-                        (r'/setup.py$',       'python',    python))
+                        (r'/setup.py$',       'python',    python),
+                        (r'/NAMESPACE$',      'r',         r))
 
         # Peek inside the tarball.
         tar = which('tar')
@@ -271,6 +273,10 @@ def create(parser, args):
     # Prepend 'py-' to python package names, by convention.
     if guesser.build_system == 'python':
         name = 'py-%s' % name
+
+    # Prepend 'r-' to R package names, by convention.
+    if guesser.build_system == 'r':
+        name = 'r-%s' % name
 
     # Create a directory for the new package.
     pkg_path = repo.filename_for_package_name(name)

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -206,6 +206,9 @@ def parse_version_offset(path):
         # e.g. lame-398-1
         (r'-((\d)+-\d)', stem),
 
+        # e.g. foobar_1.2-3
+        (r'_((\d+\.)+\d+(-\d+)?)', stem),
+
         # e.g. foobar-4.5.1
         (r'-((\d+\.)*\d+)$', stem),
 

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -207,7 +207,7 @@ def parse_version_offset(path):
         (r'-((\d)+-\d)', stem),
 
         # e.g. foobar_1.2-3
-        (r'_((\d+\.)+\d+(-\d+)?)', stem),
+        (r'_((\d+\.)+\d+(-\d+)?[a-z]?)', stem),
 
         # e.g. foobar-4.5.1
         (r'-((\d+\.)*\d+)$', stem),

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -50,9 +50,12 @@ class R(Package):
     depends_on('tk')
 
     def install(self, spec, prefix):
+        rlibdir = join_path(prefix, 'rlib')
         options = ['--prefix=%s' % prefix,
+                   '--libdir=%s' % rlibdir,
                    '--enable-R-shlib',
-                   '--enable-BLAS-shlib']
+                   '--enable-BLAS-shlib',
+                   '--enable-R-framework=no']
         if '+external-lapack' in spec:
             options.extend(['--with-blas', '--with-lapack'])
 
@@ -66,7 +69,7 @@ class R(Package):
 
     @property
     def r_lib_dir(self):
-        return os.path.join('lib64', 'R', 'library')
+        return os.path.join('rlib', 'R', 'library')
 
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
         # Set R_LIBS to include the library dir for the

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class RBiocgenerics(Package):
+    """S4 generic functions needed by many Bioconductor packages."""
+    homepage = 'https://www.bioconductor.org/packages/release/bioc/html/BiocGenerics.html'
+    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
+
+    version('0.16.1', 'c2148ffd86fc6f1f819c7f68eb2c744f', expand=False)
+
+    extends('R')
+
+    def install(self, spec, prefix):
+        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -2,6 +2,7 @@ from spack import *
 
 class RBiocgenerics(Package):
     """S4 generic functions needed by many Bioconductor packages."""
+
     homepage = 'https://www.bioconductor.org/packages/release/bioc/html/BiocGenerics.html'
     url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
 

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -1,0 +1,15 @@
+from spack import *
+
+class RAbind(Package):
+    """Combine multidimensional arrays into a single array. This is a generalization of 'cbind' and 'rbind'. Works with vectors, matrices, and higher-dimensional arrays. Also provides functions 'adrop', 'asub', and 'afill' for manipulating, extracting and replacing data in arrays."""
+
+    homepage = "https://cran.r-project.org/"
+    url      = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
+
+    version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5', expand=False)
+
+    extends('R')
+
+    def install(self, spec, prefix):
+
+        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -1,7 +1,10 @@
 from spack import *
 
 class RAbind(Package):
-    """Combine multidimensional arrays into a single array. This is a generalization of 'cbind' and 'rbind'. Works with vectors, matrices, and higher-dimensional arrays. Also provides functions 'adrop', 'asub', and 'afill' for manipulating, extracting and replacing data in arrays."""
+    """Combine multidimensional arrays into a single array. This is a
+    generalization of 'cbind' and 'rbind'. Works with vectors, matrices, and
+    higher-dimensional arrays. Also provides functions 'adrop', 'asub', and
+    'afill' for manipulating, extracting and replacing data in arrays."""
 
     homepage = "https://cran.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -1,0 +1,14 @@
+from spack import *
+
+class RFilehash(Package):
+    """Implements a simple key-value style database where character string keys are associated with data values that are stored on the disk. A simple interface is provided for inserting, retrieving, and deleting data from the database. Utilities are provided that allow 'filehash' databases to be treated much like environments and lists are already used in R. These utilities are provided to encourage interactive and exploratory analysis on large datasets. Three different file formats for representing the database are currently available and new formats can easily be incorporated by third parties for use in the 'filehash' framework."""
+
+    homepage = 'https://cran.r-project.org/'
+    url      = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
+
+    version('2.3', '01fffafe09b148ccadc9814c103bdc2f', expand=False)
+
+    extends('R')
+
+    def install(self, spec, prefix):
+        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -1,7 +1,15 @@
 from spack import *
 
 class RFilehash(Package):
-    """Implements a simple key-value style database where character string keys are associated with data values that are stored on the disk. A simple interface is provided for inserting, retrieving, and deleting data from the database. Utilities are provided that allow 'filehash' databases to be treated much like environments and lists are already used in R. These utilities are provided to encourage interactive and exploratory analysis on large datasets. Three different file formats for representing the database are currently available and new formats can easily be incorporated by third parties for use in the 'filehash' framework."""
+    """Implements a simple key-value style database where character string keys
+    are associated with data values that are stored on the disk. A simple
+    interface is provided for inserting, retrieving, and deleting data from the
+    database. Utilities are provided that allow 'filehash' databases to be
+    treated much like environments and lists are already used in R. These
+    utilities are provided to encourage interactive and exploratory analysis on
+    large datasets. Three different file formats for representing the database
+    are currently available and new formats can easily be incorporated by third
+    parties for use in the 'filehash' framework."""
 
     homepage = 'https://cran.r-project.org/'
     url      = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -1,7 +1,11 @@
 from spack import *
 
 class RMagic(Package):
-    """A collection of efficient, vectorized algorithms for the creation and investigation of magic squares and hypercubes, including a variety of functions for the manipulation and analysis of arbitrarily dimensioned arrays."""
+    """A collection of efficient, vectorized algorithms for the creation and
+    investigation of magic squares and hypercubes, including a variety of
+    functions for the manipulation and analysis of arbitrarily dimensioned
+    arrays."""
+
     homepage = "https://cran.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
 

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -1,0 +1,15 @@
+from spack import *
+
+class RMagic(Package):
+    """A collection of efficient, vectorized algorithms for the creation and investigation of magic squares and hypercubes, including a variety of functions for the manipulation and analysis of arbitrarily dimensioned arrays."""
+    homepage = "https://cran.r-project.org/"
+    url      = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
+
+    version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029', expand=False)
+
+    extends('R')
+
+    depends_on('r-abind')
+
+    def install(self, spec, prefix):
+        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)


### PR DESCRIPTION
This PR makes R an extendable package. Along with that, R is recognized as a spack build system so that `spack create` will generate template package files for R packages. Three R packages are in this PR that were used to validate the proper functioning of the extended R as well as to provide the first set of R packages for spack.