### PR TITLE
Allow Nag compiler to set rpaths differently.

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -46,6 +46,10 @@ SPACK_PREFIX
 SPACK_ENV_PATH
 SPACK_DEBUG_LOG_DIR
 SPACK_COMPILER_SPEC
+SPACK_CC_RPATH_ARG
+SPACK_CXX_RPATH_ARG
+SPACK_F77_RPATH_ARG
+SPACK_FC_RPATH_ARG
 SPACK_SHORT_SPEC"
 
 # The compiler input variables are checked for sanity later:
@@ -85,6 +89,7 @@ done
 #    ccld    compile & link
 
 command=$(basename "$0")
+comp=CC
 case "$command" in
     cpp)
         mode=cpp
@@ -92,18 +97,22 @@ case "$command" in
     cc|c89|c99|gcc|clang|icc|pgcc|xlc)
         command="$SPACK_CC"
         language="C"
+        comp=CC
         ;;
     c++|CC|g++|clang++|icpc|pgc++|xlc++)
         command="$SPACK_CXX"
         language="C++"
+        comp=CXX
         ;;
     f90|fc|f95|gfortran|ifort|pgfortran|xlf90|nagfor)
         command="$SPACK_FC"
         language="Fortran 90"
+        comp=FC
         ;;
     f77|gfortran|ifort|pgfortran|xlf|nagfor)
         command="$SPACK_F77"
         language="Fortran 77"
+        comp=F77
         ;;
     ld)
         mode=ld
@@ -140,6 +149,12 @@ if [[ -z $mode ]]; then
             break
         fi
     done
+fi
+
+# Set up rpath variable according to language.
+eval rpath=\$SPACK_${comp}_RPATH_ARG
+if [[ $rpath != *%s* ]]; then
+    die "SPACK_${comp}_RPATH_ARG must contain '%s' for parameter substitution."
 fi
 
 # Dump the version and exit if we're in testing mode.
@@ -188,7 +203,7 @@ for dep in "${deps[@]}"; do
     # Prepend lib and RPATH directories
     if [[ -d $dep/lib ]]; then
         if [[ $mode == ccld ]]; then
-            $add_rpaths && args=("-Wl,-rpath,$dep/lib" "${args[@]}")
+            $add_rpaths && args=(${rpath/\%s/$dep\/lib} "${args[@]}")
             args=("-L$dep/lib" "${args[@]}")
         elif [[ $mode == ld ]]; then
             $add_rpaths && args=("-rpath" "$dep/lib" "${args[@]}")
@@ -199,7 +214,7 @@ for dep in "${deps[@]}"; do
     # Prepend lib64 and RPATH directories
     if [[ -d $dep/lib64 ]]; then
         if [[ $mode == ccld ]]; then
-            $add_rpaths && args=("-Wl,-rpath,$dep/lib64" "${args[@]}")
+            $add_rpaths && args=(${rpath/\%s/$dep\/lib64} "${args[@]}")
             args=("-L$dep/lib64" "${args[@]}")
         elif [[ $mode == ld ]]; then
             $add_rpaths && args=("-rpath" "$dep/lib64" "${args[@]}")
@@ -210,7 +225,7 @@ done
 
 # Include all -L's and prefix/whatever dirs in rpath
 if [[ $mode == ccld ]]; then
-    $add_rpaths && args=("-Wl,-rpath,$SPACK_PREFIX/lib" "-Wl,-rpath,$SPACK_PREFIX/lib64" "${args[@]}")
+    $add_rpaths && args=(${rpath/\%s/$SPACK_PREFIX\/lib} ${rpath/\%s/$SPACK_PREFIX\/lib64} "${args[@]}")
 elif [[ $mode == ld ]]; then
     $add_rpaths && args=("-rpath" "$SPACK_PREFIX/lib" "-rpath" "$SPACK_PREFIX/lib64" "${args[@]}")
 fi

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -114,6 +114,11 @@ def set_compiler_environment_variables(pkg, env):
     if compiler.fc:
         env.set('SPACK_FC', compiler.fc)
 
+    env.set('SPACK_CC_RPATH_ARG',  compiler.cc_rpath_arg)
+    env.set('SPACK_CXX_RPATH_ARG', compiler.cxx_rpath_arg)
+    env.set('SPACK_F77_RPATH_ARG', compiler.f77_rpath_arg)
+    env.set('SPACK_FC_RPATH_ARG',  compiler.fc_rpath_arg)
+
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
     return env
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -91,8 +91,11 @@ class Compiler(object):
     # version suffix for gcc.
     suffixes = [r'-.*']
 
-    # Names of generic arguments used by this compiler
-    arg_rpath   = '-Wl,-rpath,%s'
+    # How to set an rpath with this compiler
+    cc_rpath_arg  = '-Wl,-rpath,%s'
+    cxx_rpath_arg = cc_rpath_arg
+    f77_rpath_arg = cc_rpath_arg
+    fc_rpath_arg  = cc_rpath_arg
 
     # argument used to get C++11 options
     cxx11_flag = "-std=c++11"

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -20,6 +20,10 @@ class Nag(Compiler):
                    'f77' : 'nag/nagfor',
                    'fc'  : 'nag/nagfor' }
 
+    # Needs double -Wl for rpaths.
+    f77_rpath_arg = '-Wl,-Wl,-rpath,%s'
+    fc_rpath_arg = f77_rpath_arg
+
     @classmethod
     def default_version(self, comp):
         """The '-V' option works for nag compilers.

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -67,6 +67,11 @@ class CompilerTest(unittest.TestCase):
         os.environ['SPACK_COMPILER_SPEC'] = "gcc@4.4.7"
         os.environ['SPACK_SHORT_SPEC'] = "foo@1.2"
 
+        os.environ['SPACK_CC_RPATH_ARG']  = "-Wl,-rpath,%s"
+        os.environ['SPACK_CXX_RPATH_ARG'] = "-Wl,-rpath,%s"
+        os.environ['SPACK_F77_RPATH_ARG'] = "-Wl,-rpath,%s"
+        os.environ['SPACK_FC_RPATH_ARG']  = "-Wl,-rpath,%s"
+
         # Make some fake dependencies
         self.tmp_deps = tempfile.mkdtemp()
         self.dep1 = join_path(self.tmp_deps, 'dep1')
@@ -218,4 +223,3 @@ class CompilerTest(unittest.TestCase):
                       '-rpath ' + self.dep1 + '/lib ' +
 
                       ' '.join(test_command))
-


### PR DESCRIPTION
Resolves #748.

@adamjstewart: can you test this?  It should allow nag to set RPATHs in its weird way.