### PR TITLE
+ On some systems, Dia also requires intltool.

### DIFF
--- a/var/spack/repos/builtin/packages/dia/package.py
+++ b/var/spack/repos/builtin/packages/dia/package.py
@@ -7,6 +7,7 @@ class Dia(Package):
 
     version('0.97.3',    '0e744a0f6a6c4cb6a089e4d955392c3c')
 
+    depends_on('intltool')
     depends_on('gtkplus@2.6.0:')
     depends_on('cairo')
     #depends_on('libart') # optional dependency, not yet supported by spack.

--- a/var/spack/repos/builtin/packages/intltool/package.py
+++ b/var/spack/repos/builtin/packages/intltool/package.py
@@ -1,0 +1,19 @@
+from spack import *
+
+class Intltool(Package):
+    """intltool is a set of tools to centralize translation of many different file formats using GNU gettext-compatible PO files."""
+    homepage  = 'https://freedesktop.org/wiki/Software/intltool/'
+
+    version('0.51.0',    '12e517cac2b57a0121cda351570f1e63')
+
+    def url_for_version(self, version):
+        """Handle version-based custom URLs."""
+        return 'https://launchpad.net/intltool/trunk/%s/+download/intltool-%s.tar.gz' % (version, version)
+
+    def install(self, spec, prefix):
+
+        # configure, build, install:
+        options = ['--prefix=%s' % prefix ]
+        configure(*options)
+        make()
+        make('install')


### PR DESCRIPTION
- Added a new package 'intltool.'
- Make dia depend on intltool.

