### PR TITLE
add setuptools version 20.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -11,6 +11,7 @@ class PySetuptools(Package):
     version('19.2', '78353b1f80375ca5e088f4b4627ffe03')
     version('20.5', 'fadc1e1123ddbe31006e5e43e927362b')
     version('20.6.7', '45d6110f3ec14924e44c33411db64fe6')
+    version('20.7.0', '5d12b39bf3e75e80fdce54e44b255615')
 
     extends('python')
 


### PR DESCRIPTION
Just what it says on the tin.  20.5 seems not to have a valid URL anymore, not sure why, but 20.7.0 which is the current pypi version works fine.