### PR TITLE
Fix compile issues with new libpng versions and qt3 builds by using a…

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -8,6 +8,9 @@ class Libpng(Package):
     version('1.6.16', '1a4ad377919ab15b54f6cb6a3ae2622d')
     version('1.6.15', '829a256f3de9307731d4f52dc071916d')
     version('1.6.14', '2101b3de1d5f348925990f9aa8405660')
+    version('1.5.26', '3ca98347a5541a2dad55cd6d07ee60a9')
+    version('1.4.19', '89bcbc4fc8b31f4a403906cf4f662330')
+    version('1.2.56', '9508fc59d10a1ffadd9aae35116c19ee')
 
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -29,7 +29,8 @@ class Qt(Package):
     depends_on("zlib")
     depends_on("dbus", when='@4:')
     depends_on("libtiff")
-    depends_on("libpng")
+    depends_on("libpng@1.2.56", when='@3')
+    depends_on("libpng", when='@4:')
     depends_on("libmng")
     depends_on("jpeg")
 
@@ -120,6 +121,8 @@ class Qt(Package):
 
     @when('@3')
     def configure(self):
+        # An user report that this was necessary to link Qt3 on ubuntu
+        os.environ['LD_LIBRARY_PATH'] = os.getcwd()+'/lib' 
         configure('-prefix', self.prefix,
                   '-v',
                   '-thread',


### PR DESCRIPTION
…n older version of libpng.  In libpng, make older versions available.   We are trying to match the libpng that existed when qt3 was in its prime.   Three users have reported seeing that the newer versions of libpng were causing API mismatches with the qt3 code causing compile errors resulting in qt3 failing to build.