### PR TITLE
Update Package : Swig

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -22,6 +22,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 from spack import *
 
 class Swig(Package):
@@ -33,14 +34,19 @@ class Swig(Package):
        code. In addition, SWIG provides a variety of customization
        features that let you tailor the wrapping process to suit your
        application."""
-    homepage = "http://www.swig.org"
-    url      = "http://prdownloads.sourceforge.net/swig/swig-3.0.2.tar.gz"
 
+    homepage = "http://www.swig.org"
+    url      = "http://prdownloads.sourceforge.net/swig/swig-3.0.8.tar.gz"
+
+    version('3.0.8', 'c96a1d5ecb13d38604d7e92148c73c97')
     version('3.0.2', '62f9b0d010cef36a13a010dc530d0d41')
+    version('2.0.12', 'c3fb0b2d710cc82ed0154b91e43085a4')
+    version('2.0.2', 'eaf619a4169886923e5f828349504a29')
+    version('1.3.40', '2df766c9e03e02811b1ab4bba1c7b9cc')
 
     depends_on('pcre')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure('--prefix=%s' % prefix)
         make()
-        make("install")
+        make('install')


### PR DESCRIPTION
The changes in this pull request simply augment the Swig package file by adding installation support for a number of the most popular Swig versions.  I've verified that all of these new versions build properly on the CHAOS platform when compiling with gcc@4.7.2.