### PR TITLE
compile cmake with gui support (+qt)

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -76,7 +76,8 @@ class Cmake(Package):
 
         if '+qt' in spec:
             options.append('--qt-gui')
-
+            if spec.satisfies('^xz'):
+	        options.append('--system-liblzma')
         if '+doc' in spec:
             options.append('--sphinx-html')
             options.append('--sphinx-man')


### PR DESCRIPTION
I was trying to build a version of cmake that includes cmake-gui. This requires qt, seems older version
at first attempt, the command 
spack spec cmake +qt %gcc@4.8.2  ^qt@4.8.6 ... return an error:

Input spec
------------------------------
  cmake%gcc@4.8.2+qt
      ^qt@4.8.6

Normalized
------------------------------
  cmake%gcc@4.8.2+qt
      ^qt@4.8.6
          ^dbus
              ^expat
                  ^cmake
          ^glib
              ^libffi
              ^zlib
          ^jpeg
          ^libmng
              ^lcms
                  ^libtiff
                      ^xz
          ^libpng
          ^libxcb
              ^python
                  ^bzip2
                  ^ncurses
                  ^openssl
                  ^readline
                  ^sqlite
              ^xcb-proto
          ^libxml2

Concretized
------------------------------
==> Error: +qt does not satisfy ~qt

I think this is because one indirect dependency of qt is expat that in turn is cmake ...
so my workaround was: 
first build cmake without qt, 
then build expat, then add

  expat:
    paths:
      expat@2.1.0%gcc@4.8.2: linux-x86_64/gcc-4.8.2/expat-2.1.0-6gsgcgu3fpo2wmiropvb7kmy7h7d2jnv
    buildable: false

then the spec can be concretized as expat is dependencies are not searched

now the build builds qt but then cmake does not build as qt has his own xz but 
cmake has the default of building his own as well, then when linking, problems arise.
this is the reason for adding "-system-liblzma" to force cmake to use the same library qt depends on

The mod should affect cmake just when requiring it's gui