### PR TITLE
Added package for Paradiseo.

### DIFF
--- a/var/spack/repos/builtin/packages/paradiseo/enable_eoserial.patch
+++ b/var/spack/repos/builtin/packages/paradiseo/enable_eoserial.patch
@@ -1,0 +1,14 @@
+diff --git a/eo/src/CMakeLists.txt b/eo/src/CMakeLists.txt
+index b2b445a..d45ddc7 100644
+--- a/eo/src/CMakeLists.txt
++++ b/eo/src/CMakeLists.txt
+@@ -47,7 +47,7 @@ install(DIRECTORY do es ga gp other utils
+ add_subdirectory(es)
+ add_subdirectory(ga)
+ add_subdirectory(utils)
+-#add_subdirectory(serial)
++add_subdirectory(serial) # Required when including <paradiseo/eo/utils/eoTimer.h> , which is need by <paradiseo/eo/mpi/eoMpi.h>
+ 
+ if(ENABLE_PYEO)
+   add_subdirectory(pyeo)
+ 

--- a/var/spack/repos/builtin/packages/paradiseo/fix_osx_detection.patch
+++ b/var/spack/repos/builtin/packages/paradiseo/fix_osx_detection.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Config.cmake b/cmake/Config.cmake
+index 02593ba..d198ca9 100644
+--- a/cmake/Config.cmake
++++ b/cmake/Config.cmake
+@@ -6,7 +6,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+ 
+     # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
+     execute_process (COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
+-    string(REGEX REPLACE "10\\.([0-9]).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
++    string(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+     if(${MACOSX_VERSION} LESS 5)
+         message(FATAL_ERROR "Unsupported version of OS X : ${MACOSX_VERSION_RAW}")
+         return()

--- a/var/spack/repos/builtin/packages/paradiseo/fix_tests.patch
+++ b/var/spack/repos/builtin/packages/paradiseo/fix_tests.patch
@@ -1,0 +1,13 @@
+diff --git a/moeo/test/t-moeo2DMinHypervolumeArchive.cpp b/moeo/test/t-moeo2DMinHypervolumeArchive.cpp
+index 994a9a4..c4ba77b 100644
+--- a/moeo/test/t-moeo2DMinHypervolumeArchive.cpp
++++ b/moeo/test/t-moeo2DMinHypervolumeArchive.cpp
+@@ -41,7 +41,7 @@
+ #include <moeo>
+ #include <cassert>
+ 
+-#include<archive/moeo2DMinHyperVolumeArchive.h>
++#include<archive/moeo2DMinHypervolumeArchive.h>
+ 
+ //-----------------------------------------------------------------------------
+ 

--- a/var/spack/repos/builtin/packages/paradiseo/fix_tutorials.patch
+++ b/var/spack/repos/builtin/packages/paradiseo/fix_tutorials.patch
@@ -1,0 +1,13 @@
+diff --git a/eo/tutorial/Lesson3/exercise3.1.cpp b/eo/tutorial/Lesson3/exercise3.1.cpp
+index dc37479..d178941 100644
+--- a/eo/tutorial/Lesson3/exercise3.1.cpp
++++ b/eo/tutorial/Lesson3/exercise3.1.cpp
+@@ -289,7 +289,7 @@ void main_function(int argc, char **argv)
+     checkpoint.add(fdcStat);
+ 
+     // The Stdout monitor will print parameters to the screen ...
+-    eoStdoutMonitor monitor(false);
++    eoStdoutMonitor monitor;
+ 
+     // when called by the checkpoint (i.e. at every generation)
+     checkpoint.add(monitor);

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -1,0 +1,59 @@
+from spack import *
+import sys
+
+class Paradiseo(Package):
+    """A C++ white-box object-oriented framework dedicated to the reusable design of metaheuristics."""
+    homepage = "http://paradiseo.gforge.inria.fr/"
+
+    # Installing from the development version is a better option at this 
+    # point than using the very old supplied packages
+    version('head', git='https://gforge.inria.fr/git/paradiseo/paradiseo.git')
+    # This is a version that the package formula author has tested successfully.
+    # However, the clone is very large (~1Gb git history). The history in the 
+    # head version has been trimmed significantly.
+    version('dev-safe', git='https://gforge.inria.fr/git/paradiseo/paradiseo.git',
+             commit='dbb8fbe9a786efd4d1c26408ac1883442e7643a6')
+
+    variant('mpi',      default=True,  description='Compile with parallel and distributed metaheuristics module')
+    variant('smp',      default=True,  description='Compile with symmetric multi-processing module ')
+    variant('edo',      default=True,  description='Compile with (Experimental) EDO module')
+    #variant('tests',    default=False, description='Compile with build tests')
+    #variant('doc',      default=False, description='Compile with documentation')
+    variant('debug',    default=False, description='Builds a debug version of the libraries')
+    
+    # Required dependencies
+    depends_on ("cmake")
+    depends_on ("eigen")
+
+    # Optional dependencies
+    depends_on ("mpi", when="+mpi")
+    depends_on ("doxygen", when='+doc')
+    
+    # Patches
+    patch('enable_eoserial.patch')
+    patch('fix_osx_detection.patch')
+    patch('fix_tests.patch')
+    patch('fix_tutorials.patch')
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        options.extend([
+            '-DCMAKE_BUILD_TYPE:STRING=%s' % ('Debug' if '+debug' in spec else 'Release'),
+            '-DINSTALL_TYPE:STRING=MIN',
+            '-DMPI:BOOL=%s' % ('TRUE' if '+mpi' in spec else 'FALSE'),
+            '-DSMP:BOOL=%s' % ('TRUE' if '+smp' in spec else 'FALSE'), # Note: This requires a C++11 compatible compiler
+            '-DEDO:BOOL=%s' % ('TRUE' if '+edo' in spec else 'FALSE'),
+            '-DENABLE_CMAKE_TESTING:BOOL=%s' % ('TRUE' if '+tests' in spec else 'FALSE')
+        ])
+ 
+        with working_dir('spack-build', create=True):
+            # Configure
+            cmake('..', *options)
+
+            # Build, test and install
+            make("VERBOSE=1")
+            if '+tests' in spec:
+                make("test")
+            make("install")


### PR DESCRIPTION
This package mirrors the Homebrew/Linuxbrew package found [here](https://github.com/jppelteret/homebrew-science-extras/blob/master/paradiseo.rb). Unfortunately the source repository and packages are in a bit of a state, so the use of a specific git revision is recommended. Patches have been applied to make it compile on both OS X and Linux.