### PR TITLE
FFTW: openmp needs to be an option for clang build

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -57,6 +57,8 @@ class Fftw(Package):
         if '+openmp' in spec:
             # Note: Apple's Clang does not support OpenMP.
             if spec.satisfies('%clang'):
+              ver = '%s' % self.compiler.version
+              if ver.endswith('-apple'):
                 raise InstallError("Apple's clang does not support OpenMP")
             options.append('--enable-openmp')
         if not self.compiler.f77 or not self.compiler.fc:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -42,7 +42,7 @@ class Fftw(Package):
     variant('float', default=True, description='Produces a single precision version of the library')
     variant('long_double', default=True, description='Produces a long double precision version of the library')
     variant('quad', default=False, description='Produces a quad precision version of the library (works only with GCC and libquadmath)')
-
+    variant('openmp', default=True, description="Enable OpenMP support.")
     variant('mpi', default=False, description='Activate MPI support')
 
     depends_on('mpi', when='+mpi')
@@ -52,8 +52,9 @@ class Fftw(Package):
     def install(self, spec, prefix):
         options = ['--prefix=%s' % prefix,
                    '--enable-shared',
-                   '--enable-threads',
-                   '--enable-openmp']
+                   '--enable-threads']
+        if '+openmp' in spec: 
+            options.append('--enable-openmp')
         if not self.compiler.f77 or not self.compiler.fc:
             options.append("--disable-fortran")
         if '+mpi' in spec:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -53,7 +53,11 @@ class Fftw(Package):
         options = ['--prefix=%s' % prefix,
                    '--enable-shared',
                    '--enable-threads']
-        if '+openmp' in spec: 
+    # Add support for OpenMP
+        if '+openmp' in spec:
+            # Note: Apple's Clang does not support OpenMP.
+            if spec.satisfies('%clang'):
+                raise InstallError("Apple's clang does not support OpenMP")
             options.append('--enable-openmp')
         if not self.compiler.f77 or not self.compiler.fc:
             options.append("--disable-fortran")

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -57,7 +57,7 @@ class Fftw(Package):
         if '+openmp' in spec:
             # Note: Apple's Clang does not support OpenMP.
             if spec.satisfies('%clang'):
-              ver = '%s' % self.compiler.version
+              ver = str(self.compiler.version)
               if ver.endswith('-apple'):
                 raise InstallError("Apple's clang does not support OpenMP")
             options.append('--enable-openmp')

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -42,7 +42,7 @@ class Fftw(Package):
     variant('float', default=True, description='Produces a single precision version of the library')
     variant('long_double', default=True, description='Produces a long double precision version of the library')
     variant('quad', default=False, description='Produces a quad precision version of the library (works only with GCC and libquadmath)')
-    variant('openmp', default=True, description="Enable OpenMP support.")
+    variant('openmp', default=False, description="Enable OpenMP support.")
     variant('mpi', default=False, description='Activate MPI support')
 
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
Add openmp as a variant to fftw so it can be disabled for build with clang on OSX.