### PR TITLE
xerces-c: update to 3.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -24,8 +24,8 @@ class XercesC(Package):
     """
 
     homepage = "https://xerces.apache.org/xerces-c"
-    url      = "https://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.2.tar.gz"
-    version('3.1.2', '9eb1048939e88d6a7232c67569b23985')
+    url      = "https://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.3.tar.bz2"
+    version('3.1.3', '5e333b55cb43e6b025ddf0e5d0f0fb0d')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix,


### PR DESCRIPTION
The 3.1.2 tarball seems to have gone missing. Also switch to using bz2
rather than gz to reduce the download size.