### PR TITLE
Check the installed HDF5 library for consistency

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -25,7 +25,6 @@
 
 from spack import *
 import shutil
-import subprocess
 
 
 class Hdf5(Package):
@@ -177,7 +176,8 @@ HDF5 version {version} {version}
                "-L%s" % join_path(spec.prefix, "lib"), "-lhdf5",
                "-lz")
             try:
-                output = subprocess.check_output("./check")
+                check = Executable('./check')
+                output = check(return_output=True)
             except:
                 output = ""
             success = output == expected

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -171,12 +171,10 @@ HDF5 version {version} {version}
                 cc = which(join_path(spec['mpi'].prefix.bin, "mpicc"))
             else:
                 cc = which('cc')
-            # TODO: Automate these path settings
+            # TODO: Automate these path and library settings
             cc('-c', "-I%s" % join_path(spec.prefix, "include"), "check.c")
             cc('-o', "check", "check.o",
-               # I couldn't make libraries work on Darwin
                "-L%s" % join_path(spec.prefix, "lib"), "-lhdf5",
-               # join_path(spec.prefix, "lib", "libhdf5.a"),
                "-lz")
             try:
                 output = subprocess.check_output("./check")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -24,6 +24,8 @@
 ##############################################################################
 
 from spack import *
+import shutil
+import subprocess
 
 
 class Hdf5(Package):
@@ -114,14 +116,16 @@ class Hdf5(Package):
             # this is not actually a problem.
             extra_args.extend([
                 "--enable-parallel",
-                "CC=%s" % spec['mpi'].prefix.bin + "/mpicc",
+                "CC=%s" % join_path(spec['mpi'].prefix.bin, "mpicc"),
             ])
 
             if '+cxx' in spec:
-                extra_args.append("CXX=%s" % spec['mpi'].prefix.bin + "/mpic++")
+                extra_args.append("CXX=%s" % join_path(spec['mpi'].prefix.bin,
+                                                       "mpic++"))
 
             if '+fortran' in spec:
-                extra_args.append("FC=%s" % spec['mpi'].prefix.bin + "/mpifort")
+                extra_args.append("FC=%s" % join_path(spec['mpi'].prefix.bin,
+                                                      "mpifort"))
 
         if '+szip' in spec:
             extra_args.append("--with-szlib=%s" % spec['szip'].prefix)
@@ -138,6 +142,59 @@ class Hdf5(Package):
             *extra_args)
         make()
         make("install")
+        self.check_install(spec)
+
+    def check_install(self, spec):
+        "Build and run a small program to test the installed HDF5 library"
+        print "Checking HDF5 installation..."
+        checkdir = "spack-check"
+        with working_dir(checkdir, create=True):
+            source = r"""
+#include <hdf5.h>
+#include <assert.h>
+#include <stdio.h>
+int main(int argc, char **argv) {
+  unsigned majnum, minnum, relnum;
+  herr_t herr = H5get_libversion(&majnum, &minnum, &relnum);
+  assert(!herr);
+  printf("HDF5 version %d.%d.%d %u.%u.%u\n", H5_VERS_MAJOR, H5_VERS_MINOR,
+         H5_VERS_RELEASE, majnum, minnum, relnum);
+  return 0;
+}
+"""
+            expected = """\
+HDF5 version {version} {version}
+""".format(version=str(spec.version))
+            with open("check.c", 'w') as f:
+                f.write(source)
+            if '+mpi' in spec:
+                cc = which(join_path(spec['mpi'].prefix.bin, "mpicc"))
+            else:
+                cc = which('cc')
+            # TODO: Automate these path settings
+            cc('-c', "-I%s" % join_path(spec.prefix, "include"), "check.c")
+            cc('-o', "check", "check.o",
+               # I couldn't make libraries work on Darwin
+               "-L%s" % join_path(spec.prefix, "lib"), "-lhdf5",
+               # join_path(spec.prefix, "lib", "libhdf5.a"),
+               "-lz")
+            try:
+                output = subprocess.check_output("./check")
+            except:
+                output = ""
+            success = output == expected
+            if not success:
+                print "Produced output does not match expected output."
+                print "Expected output:"
+                print '-'*80
+                print expected
+                print '-'*80
+                print "Produced output:"
+                print '-'*80
+                print output
+                print '-'*80
+                raise RuntimeError("HDF5 install check failed")
+        shutil.rmtree(checkdir)
 
     def url_for_version(self, version):
         v = str(version)


### PR DESCRIPTION
I added a routine to the HDF5 install script that checks the installed library. This is not the self-check that HDF5 itself can perform as part of its build; rather, this tests whether Spack installed the library in such a way that its customers (other packages etc.) find a self-consistent and usable HDF5 library.

In particular, this routine builds and runs a small C program that uses the HDF5 library, thus checking include, library, and run time path settings. It also checks the version numbers, both via preprocessor constants (from include headers) and via function calls (from the library found at run time), and compares these to the expected version numbers. A mismatch leads to an error.

I think such a system is generically useful for many packages. I'm suggesting to add this to HDF5 as a test balloon, and if it works, it can be cleaned up, made part of Spack, and generally be used for many other packages as well.

As a side node, I think packages could define environment variables that define the list of library names that should be used to link against a library; in this case, HDF5 could define e.g. the equivalent of `HDF5_LIBS='-lhdf5'` or similar. This is just a note, this is not implemented here.