### PR TITLE
Cleaning the environment breaks on some systems.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -157,9 +157,9 @@ def set_build_environment_variables(pkg, env):
     # Remove these vars from the environment during build because they
     # can affect how some packages find libraries.  We want to make
     # sure that builds never pull in unintended external dependencies.
-    env.unset('LD_LIBRARY_PATH')
-    env.unset('LD_RUN_PATH')
-    env.unset('DYLD_LIBRARY_PATH')
+#    env.unset('LD_LIBRARY_PATH')
+#    env.unset('LD_RUN_PATH')
+#    env.unset('DYLD_LIBRARY_PATH')
 
     # Add bin directories from dependencies to the PATH for the build.
     bin_dirs = reversed(filter(os.path.isdir, ['%s/bin' % prefix for prefix in dep_prefixes]))


### PR DESCRIPTION
Clearing LD_LIBRARY_PATH seemed like a good idea at the time.  BUT... some systems require it.  The backstory:

I'm working on a supercomputer where they've provided a bunch of packages, including GCC.  "module load gcc" sets LD_LIBRARY_PATH, and the compiler doesn't work without it.  I need to use the compiler provided by the module in question, since I don't have a big enough quota to have Spack build GCC for me.  Therefore... in order to get Spack to work, I have to do "module load gcc" in my environment, and then make sure that Spack does NOT muck with LD_LIBRARY_PATH.  Yes, LD_LIBRARY_PATH is evil, but I have to make a deal with the devil here.

It's true that Spack can be polluted by stuff in the user's environment.  But just deleting it can cause problems too.  I think we should either:
   a) Advise users to be careful of what's in their env when they build with Spack
   b) Create .spack/environment.yaml, where we can set up the environment that will be used by Spack.  Or some other similar mechanism.