### PR TITLE
dealii: set DEAL_II_DIR when loading a module

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -251,3 +251,6 @@ class Dealii(Package):
                 cmake('.')
                 make('release')
                 make('run',parallel=False)
+
+    def setup_environment(self, spack_env, env):
+        env.set('DEAL_II_DIR', self.prefix)


### PR DESCRIPTION
see https://github.com/LLNL/spack/issues/815
thanks to @alalazo for pointing me to the solution.

@tgamblin that should be a no-brainer PR :smile: