### PR TITLE
Add OSU Micro-Benchmarks package

### DIFF
--- a/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
@@ -1,0 +1,37 @@
+from spack import *
+
+class OsuMicroBenchmarks(Package):
+    """The Ohio MicroBenchmark suite is a collection of independent MPI
+    message passing performance microbenchmarks developed and written at
+    The Ohio State University. It includes traditional benchmarks and
+    performance measures such as latency, bandwidth and host overhead
+    and can be used for both traditional and GPU-enhanced nodes."""
+
+    homepage = "http://mvapich.cse.ohio-state.edu/benchmarks/"
+    url      = "http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.3.tar.gz"
+
+    version('5.3', '42e22b931d451e8bec31a7424e4adfc2')
+
+    variant('cuda', default=False, description="Enable CUDA support")
+
+    depends_on('mpi')
+    depends_on('cuda', when='+cuda')
+
+
+    def install(self, spec, prefix):
+        config_args = [
+            'CC=%s'  % spec['mpi'].prefix.bin + '/mpicc',
+            'CXX=%s' % spec['mpi'].prefix.bin + '/mpicxx',
+            '--prefix=%s' % prefix
+        ]
+
+        if '+cuda' in spec:
+            config_args.extend([
+                '--enable-cuda',
+                '--with-cuda=%s' % spec['cuda'].prefix,
+            ])
+
+        configure(*config_args)
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/osu-micro-benchmarks/package.py
@@ -22,6 +22,7 @@ class OsuMicroBenchmarks(Package):
         config_args = [
             'CC=%s'  % spec['mpi'].prefix.bin + '/mpicc',
             'CXX=%s' % spec['mpi'].prefix.bin + '/mpicxx',
+            'LDFLAGS=-lrt',
             '--prefix=%s' % prefix
         ]
 


### PR DESCRIPTION
Note: Does not currently build with GCC-5.3.0, but works fine with the latest Intel and PGI compilers. I have contacted the developers about this, so I may add a patch someday. But I don't think that should prevent this from being merged.