### PR TITLE
Update Package : Scotch

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/Makefile.esmumps
+++ b/var/spack/repos/builtin/packages/scotch/Makefile.esmumps
@@ -1,0 +1,5 @@
+esmumps				:	scotch
+					(cd esmumps ; $(MAKE) scotch && $(MAKE) install)
+
+ptesmumps			:	ptscotch
+					(cd esmumps ; $(MAKE) ptscotch && $(MAKE) ptinstall)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -4,85 +4,90 @@ import os
 class Scotch(Package):
     """Scotch is a software package for graph and mesh/hypergraph
        partitioning, graph clustering, and sparse matrix ordering."""
+
     homepage = "http://www.labri.fr/perso/pelegrin/scotch/"
-    url      = "http://gforge.inria.fr/frs/download.php/file/34099/scotch_6.0.3.tar.gz"
+    url = "http://gforge.inria.fr/frs/download.php/latestfile/298/scotch_6.0.3.tar.gz"
     list_url = "http://gforge.inria.fr/frs/?group_id=248"
 
     version('6.0.3', '10b0cc0f184de2de99859eafaca83cfc')
+    version('5.1.10b', '9b8622b39c141ecaca4a46298486fd99')
 
     variant('mpi', default=False, description='Activate the compilation of PT-Scotch')
     variant('compression', default=True, description='Activate the posibility to use compressed files')
     variant('esmumps', default=False, description='Activate the compilation of the lib esmumps needed by mumps')
     variant('shared', default=True, description='Build shared libraries')
 
-    depends_on('mpi', when='+mpi')
-    depends_on('zlib', when='+compression')
     depends_on('flex')
     depends_on('bison')
+    depends_on('mpi', when='+mpi')
+    depends_on('zlib', when='+compression')
 
-    def compiler_specifics(self, makefile_inc, defines):
-        if self.compiler.name == 'gcc':
-            defines.append('-Drestrict=__restrict')
-        elif self.compiler.name == 'intel':
-            defines.append('-restrict')
-
-        makefile_inc.append('CCS       = $(CC)')
-
-        if '+mpi' in self.spec:
-            makefile_inc.extend([
-                    'CCP       = %s' % os.path.join(self.spec['mpi'].prefix.bin, 'mpicc'),
-                    'CCD       = $(CCP)'
-                    ])
-        else:
-            makefile_inc.extend([
-                    'CCP       = mpicc', # It is set but not used
-                    'CCD       = $(CCS)'
-                    ])
-
-
-
-    def library_build_type(self, makefile_inc, defines):
-        makefile_inc.extend([
-            'LIB       = .a',
-            'CLIBFLAGS = ',
-            'RANLIB    = ranlib',
-            'AR	       = ar',
-            'ARFLAGS   = -ruv '
-            ])
-
-    @when('+shared')
-    def library_build_type(self, makefile_inc, defines):
-        makefile_inc.extend([
-            'LIB       = .so',
-            'CLIBFLAGS = -shared -fPIC',
-            'RANLIB    = echo',
-            'AR	       = $(CC)',
-            'ARFLAGS   = -shared $(LDFLAGS) -o'
-            ])
-
-    def extra_features(self, makefile_inc, defines):
-        ldflags = []
-        
-        if '+compression' in self.spec:
-            defines.append('-DCOMMON_FILE_COMPRESS_GZ')
-            ldflags.append('-L%s -lz' % (self.spec['zlib'].prefix.lib))
-
-        defines.append('-DCOMMON_PTHREAD')
-        ldflags.append('-lm -lrt -pthread')
-           
-        makefile_inc.append('LDFLAGS   = %s' % ' '.join(ldflags))
+    def validate(self, spec):
+        # NOTE : Scotch v6.0.0 and older have separate tar files for their esmumps-
+        # compatible versions.  In any normal circumstance, it would be better just
+        # to use these tar files since they're more comprehensive, but they
+        # unfortunately have very strange URLs that are non-uniform.  For the time
+        # being, I'm going to just use the '~esmumps' URLs that are uniform for
+        # the sake of simplicity.
+        if spec.satisfies('@:6.0.0') and '+esmumps' in spec:
+            raise RuntimeError('The "+esmumps" variant is only supported for Scotch v6.0.1+.')
 
     def patch(self):
         makefile_inc = []
-        defines = [ 
+        cflags = [
+            '-O3',
             '-DCOMMON_RANDOM_FIXED_SEED',
             '-DSCOTCH_DETERMINISTIC',
             '-DSCOTCH_RENAME',
-            '-DIDXSIZE64' ]
+            '-DIDXSIZE64'
+            ]
 
-        self.library_build_type(makefile_inc, defines)
-        self.compiler_specifics(makefile_inc, defines)
-        self.extra_features(makefile_inc, defines)
+        ## Library Build Type ##
+
+        if '+shared' in self.spec:
+            makefile_inc.extend([
+                'LIB       = .so',
+                'CLIBFLAGS = -shared -fPIC',
+                'RANLIB    = echo',
+                'AR	       = $(CC)',
+                'ARFLAGS   = -shared $(LDFLAGS) -o'
+                ])
+            cflags.append('-fPIC')
+        else:
+            makefile_inc.extend([
+                'LIB       = .a',
+                'CLIBFLAGS = ',
+                'RANLIB    = ranlib',
+                'AR	       = ar',
+                'ARFLAGS   = -ruv '
+                ])
+
+        ## Compiler-Specific Options ##
+
+        if self.compiler.name == 'gcc':
+            cflags.append('-Drestrict=__restrict')
+        elif self.compiler.name == 'intel':
+            cflags.append('-restrict')
+
+        makefile_inc.append('CCS       = $(CC)')
+        makefile_inc.append('CCP       = %s' %
+            (os.path.join(self.spec['mpi'].prefix.bin, 'mpicc') if '+mpi' in self.spec else 'mpicc'))
+        makefile_inc.append('CCD       = $(CCS)')
+
+        ## Extra Features ##
+
+        ldflags = []
+
+        if '+compression' in self.spec:
+            cflags.append('-DCOMMON_FILE_COMPRESS_GZ')
+            ldflags.append('-L%s -lz' % (self.spec['zlib'].prefix.lib))
+
+        cflags.append('-DCOMMON_PTHREAD')
+        ldflags.append('-lm -lrt -pthread')
+
+        makefile_inc.append('LDFLAGS   = %s' % ' '.join(ldflags))
+
+        ## General Features ##
 
         makefile_inc.extend([
             'EXE       =',
@@ -93,18 +98,19 @@ class Scotch(Package):
             'MKDIR     = mkdir',
             'MV        = mv',
             'CP        = cp',
-            'CFLAGS    = -O3 %s' % (' '.join(defines)),
+            'CFLAGS    = %s' % ' '.join(cflags),
             'LEX       = %s -Pscotchyy -olex.yy.c' % os.path.join(self.spec['flex'].prefix.bin , 'flex'),
             'YACC      = %s -pscotchyy -y -b y' %    os.path.join(self.spec['bison'].prefix.bin, 'bison'),
-            'prefix    = %s' % self.prefix,
-            ''
+            'prefix    = %s' % self.prefix
             ])
 
         with working_dir('src'):
             with open('Makefile.inc', 'w') as fh:
                 fh.write('\n'.join(makefile_inc))
-            
+
     def install(self, spec, prefix):
+        self.validate(spec)
+
         targets = ['scotch']
         if '+mpi' in self.spec:
             targets.append('ptscotch')
@@ -115,12 +121,10 @@ class Scotch(Package):
                 targets.append('ptesmumps')
 
         with working_dir('src'):
-            for app in targets:
-                make(app, parallel=(not app=='ptesmumps'))
+            for target in targets:
+                make(target, parallel=(target!='ptesmumps'))
 
-        
         install_tree('bin', prefix.bin)
         install_tree('lib', prefix.lib)
         install_tree('include', prefix.include)
         install_tree('man/man1', prefix.share_man1)
-

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -103,7 +103,7 @@ class Scotch(Package):
 
         makefile_inc.append('CCS       = $(CC)')
         makefile_inc.append('CCP       = %s' %
-            (os.path.join(self.spec['mpi'].prefix.bin, 'mpicc') if '+mpi' in self.spec else 'mpicc'))
+            (self.spec['mpi'].mpicc if '+mpi' in self.spec else 'mpicc'))
         makefile_inc.append('CCD       = $(CCS)')
 
         ## Extra Features ##


### PR DESCRIPTION
The changes in this pull request make the following changes to the Scotch package:

- Fix a bug that was causing shared library usage to fail when linking with another application.
- Update the repository URL to allow for more general version downloading.
- Add installation support for version 5.1.10b.
- Clean up the installation file to make it a bit easier to follow and modify.

I've verified that the `+mpi` and `+shared` installation variants for both versions 6.0.3 and 5.1.10b compile and can be linked with external code on CHAOS when compiling with gcc@4.7.2.

Sidebar Below:

At first glance, it looks like I made some heavy modifications to this package, but really the majority of the changes consist of rearrangements of existing code segments.  I decided to change the code in this way to make it (what I believe to be) easier to read.  Eliminating a lot of the one-off function calls makes it easier for me to see exactly what the `Scotch.patch` function is doing.  If others prefer the previous implementation, I have no objections to reverting it; I just thought I'd try to improve the package a bit while I was making some changes.