### PR TITLE
Put f2py of py-numpy in python ignore list.

### DIFF
--- a/var/spack/repos/builtin/packages/py-bottleneck/package.py
+++ b/var/spack/repos/builtin/packages/py-bottleneck/package.py
@@ -7,7 +7,7 @@ class PyBottleneck(Package):
 
     version('1.0.0', '380fa6f275bd24f27e7cf0e0d752f5d2')
 
-    extends('python', ignore=r'bin/f2py$')
+    extends('python')
     depends_on('py-numpy')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -12,7 +12,7 @@ class PyMatplotlib(Package):
     variant('gui', default=False, description='Enable GUI')
     variant('ipython', default=False, description='Enable ipython support')
 
-    extends('python', ignore=r'bin/nosetests.*$|bin/pbr$|bin/f2py$')
+    extends('python', ignore=r'bin/nosetests.*$|bin/pbr$')
 
     depends_on('py-pyside', when='+gui')
     depends_on('py-ipython', when='+ipython')

--- a/var/spack/repos/builtin/packages/py-numexpr/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr/package.py
@@ -9,7 +9,7 @@ class PyNumexpr(Package):
     version('2.4.6', '17ac6fafc9ea1ce3eb970b9abccb4fbd')
     version('2.5', '84f66cced45ba3e30dcf77a937763aaa')
 
-    extends('python', ignore=r'bin/f2py$')
+    extends('python')
     depends_on('py-numpy')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -10,7 +10,7 @@ class PyPandas(Package):
     version('0.16.1', 'fac4f25748f9610a3e00e765474bdea8')
     version('0.18.0', 'f143762cd7a59815e348adf4308d2cf6')
 
-    extends('python', ignore=r'bin/f2py$')
+    extends('python')
     depends_on('py-dateutil')
     depends_on('py-numpy')
     depends_on('py-setuptools')

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -7,7 +7,7 @@ class PyScikitImage(Package):
 
     version('0.12.3', '04ea833383e0b6ad5f65da21292c25e1')
 
-    extends('python', ignore=r'bin/.*\.py$|bin/f2py$')
+    extends('python', ignore=r'bin/.*\.py$')
 
     depends_on('py-dask')
     depends_on('py-pillow')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -151,6 +151,8 @@ class Python(Package):
             patterns.append(r'setuptools\.pth')
             patterns.append(r'bin/easy_install[^/]*$')
             patterns.append(r'setuptools.*egg$')
+        if ext_pkg.name != 'py-numpy':
+            patterns.append(r'bin/f2py$')
 
         return match_predicate(ignore_arg, patterns)
 


### PR DESCRIPTION
There are many python packages that depend on py-numpy. Each one of
those will have a copy of f2py that will need to be put in the ignore
list for activation. This PR adds f2py to the ignore list in the python
package.py file so that it does not have to be done for each package
that depends on py-numpy. This follows the model of what is done for
py-setuptools.

This PR also removes the f2py ignore expression for python packages
that were using it as it is no longer needed in the individual packages.