### PR TITLE
Fix: Add missing dependencies for gmp and eigen

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -45,6 +45,7 @@ class Eigen(Package):
 
     # TODO : dependency on googlehash, superlu, adolc missing
 
+    depends_on('cmake')
     depends_on('metis@5:', when='+metis')
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -35,6 +35,8 @@ class Gmp(Package):
     version('6.0.0a', 'b7ff2d88cae7f8085bd5006096eed470')
     version('6.0.0' , '6ef5869ae735db9995619135bd856b84')
 
+    depends_on("m4")
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()


### PR DESCRIPTION
With reference to [this discussion](https://groups.google.com/forum/#!topic/spack/9JMDwafjBUs)