### PR TITLE
Update Package : Zoltan

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -36,7 +36,7 @@ class Zoltan(Package):
         ]
 
         if '+shared' in spec:
-            config_args.append('--with-ar=%s -shared $(LDFLAGS) -o' % self.compiler.cxx)
+            config_args.append('--with-ar=$(CXX) -shared $(LDFLAGS) -o')
             config_args.append('RANLIB=echo')
             config_cflags.append('-fPIC')
 


### PR DESCRIPTION
The changes in this pull request make the following changes to the Zoltan package:

- Implement the standard `+shared` and `+debug` variants.
- Add support for two more Zoltan versions: v3.6 and v3.8.

I've verified that the new `+shared` variant works both with and without the `+mpi` variant and that these combinations compile and can be linked with external code for versions v3.3 and v3.83 on CHAOS when compiling with gcc@4.7.2.  I've also verified that the new versions (i.e. v3.6 and v3.8) compile with the standard package variants in the same architecture/compiler environment.