### PR TITLE
Bugfix - preserve lookup order in PATH when invoking 'spack compiler add'

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -202,6 +202,10 @@ class Compiler(object):
                 return None
 
         successful = [key for key in parmap(check, checks) if key is not None]
+        # The 'successful' list is ordered like the input paths.
+        # Reverse it here so that the dict creation (last insert wins)
+        # does not spoil the intented precedence.
+        successful.reverse()
         return dict(((v, p, s), path) for v, p, s, path in successful)
 
     @classmethod


### PR DESCRIPTION
In case the "same" compiler exists two times in the PATH, spack currently selects the second one, not the first. I stumbled accross this when I had to replace a broken system compiler with a fixed one. Could not convince spack to pick up the new one.  
This fix solves the issue for me.

