### PR TITLE
Add parallelization in the build process

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -74,9 +74,10 @@ class MakeExecutable(Executable):
        Note that if the SPACK_NO_PARALLEL_MAKE env var is set it overrides
        everything.
     """
-    def __init__(self, name, jobs):
+    def __init__(self, name, jobs, load):
         super(MakeExecutable, self).__init__(name)
         self.jobs = jobs
+        self.load = load
 
     def __call__(self, *args, **kwargs):
         disable = env_flag(SPACK_NO_PARALLEL_MAKE)
@@ -84,7 +85,8 @@ class MakeExecutable(Executable):
 
         if parallel:
             jobs = "-j%d" % self.jobs
-            args = (jobs,) + args
+            load = "-l%d" % self.load
+            args = (jobs,load) + args
 
         return super(MakeExecutable, self).__call__(*args, **kwargs)
 
@@ -190,6 +192,7 @@ def set_module_variables_for_package(pkg, module):
     """
     # number of jobs spack will to build with.
     jobs = multiprocessing.cpu_count()
+    load = multiprocessing.cpu_count()
     if not pkg.parallel:
         jobs = 1
     elif pkg.make_jobs:
@@ -197,10 +200,11 @@ def set_module_variables_for_package(pkg, module):
 
     m = module
     m.make_jobs = jobs
+    m.make_load = load
 
     # TODO: make these build deps that can be installed if not found.
-    m.make  = MakeExecutable('make', jobs)
-    m.gmake = MakeExecutable('gmake', jobs)
+    m.make  = MakeExecutable('make', jobs, load)
+    m.gmake = MakeExecutable('gmake', jobs, load)
 
     # easy shortcut to os.environ
     m.env = os.environ

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -48,6 +48,9 @@ def setup_parser(subparser):
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
         help="Do not check packages against checksum")
     subparser.add_argument(
+        '-p', '--parallel', action='store_true', dest='build_parallel',
+        help="Whether to do parallel compilation and installation (experimental)")
+    subparser.add_argument(
         '-v', '--verbose', action='store_true', dest='verbose',
         help="Display verbose build output while installing.")
     subparser.add_argument(
@@ -78,4 +81,5 @@ def install(parser, args):
                 ignore_deps=args.ignore_deps,
                 make_jobs=args.jobs,
                 verbose=args.verbose,
-                fake=args.fake)
+                fake=args.fake,
+                build_parallel = args.build_parallel)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -39,6 +39,9 @@ def setup_parser(subparser):
         '-j', '--jobs', action='store', type=int,
         help="Explicitly set number of make jobs.  Default is #cpus.")
     subparser.add_argument(
+        '-l','--load', action='store', type=int,
+        help="Explicitly set maximum load of make. Default is #cpus.")
+    subparser.add_argument(
         '--keep-prefix', action='store_true', dest='keep_prefix',
         help="Don't remove the install prefix if installation fails.")
     subparser.add_argument(
@@ -80,6 +83,7 @@ def install(parser, args):
                 keep_stage=args.keep_stage,
                 ignore_deps=args.ignore_deps,
                 make_jobs=args.jobs,
+                make_load=args.load,
                 verbose=args.verbose,
                 fake=args.fake,
                 build_parallel = args.build_parallel)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -83,22 +83,22 @@ class DoInstallThread(threading.Thread):
   _queue_lock = threading.Lock()
 
   def __init__(self, package, kwargs):
-    threading.Thread.__init__(self)
-    self.package = package
-    self.kwargs = kwargs
-    self.to_wait_for = None
-    # check whether an equivalent thread already exists
-    with DoInstallThread._queue_lock:
-        if package in DoInstallThread._do_install_threads:
-            self.to_wait_for = DoInstallThread._do_install_threads[package]
-        else:
-            DoInstallThread._do_install_threads[package] = self
+      threading.Thread.__init__(self)
+      self.package = package
+      self.kwargs = kwargs
+      self.to_wait_for = None
+      # check whether an equivalent thread already exists
+      with DoInstallThread._queue_lock:
+          if package in DoInstallThread._do_install_threads:
+              self.to_wait_for = DoInstallThread._do_install_threads[package]
+          else:
+              DoInstallThread._do_install_threads[package] = self
 
   def run(self):
-    if self.to_wait_for:
-      self.to_wait_for.join()
-    else:
-      self.package.do_install(**self.kwargs)
+      if self.to_wait_for:
+          self.to_wait_for.join()
+      else:
+          self.package.do_install(**self.kwargs)
 
 
 class Package(object):
@@ -1024,12 +1024,12 @@ class Package(object):
         deptasks = []
         for dep in self.spec.dependencies.values():
             task = DoInstallThread(dep.package, kwargs)
-            if (kwargs["build_parallel"]==False):
+            if kwargs["build_parallel"]==False:
                 task.start()
                 task.join()
             else:
                 deptasks.append(task)
-        if (kwargs["build_parallel"]==True):
+        if kwargs["build_parallel"]==True:
             for task in deptasks:
                 task.start()
             for task in deptasks:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1023,13 +1023,15 @@ class Package(object):
         # Pass along paths of dependencies here
         deptasks = []
         for dep in self.spec.dependencies.values():
-            deptasks.append(DoInstallThread(dep.package, kwargs))
-            print "adding dep", dep
-        for task in deptasks:
-            task.start()
-            if not kwargs["build_parallel"]:
+            task = DoInstallThread(dep.package, kwargs)
+            if (kwargs["build_parallel"]==False):
+                task.start()
                 task.join()
-        if  kwargs["build_parallel"]:
+            else:
+                deptasks.append(task)
+        if (kwargs["build_parallel"]==True):
+            for task in deptasks:
+                task.start()
             for task in deptasks:
                 task.join()
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -343,6 +343,9 @@ class Package(object):
     """# jobs to use for parallel make. If set, overrides default of ncpus."""
     make_jobs = None
 
+    """# load to use for parallel make. If set, overrides default of ncpus."""
+    make_load = None
+
     """Most packages are NOT extendable.  Set to True if you want extensions."""
     extendable = False
 
@@ -869,7 +872,8 @@ class Package(object):
 
     def do_install(self,
                    keep_prefix=False,  keep_stage=False, ignore_deps=False,
-                   skip_patch=False, verbose=False, make_jobs=None, fake=False, build_parallel=False):
+                   skip_patch=False, verbose=False, make_jobs=None, make_load=None,
+                   fake=False, build_parallel=False):
         """Called by commands to install a package and its dependencies.
 
         Package implementations should override install() to describe
@@ -885,6 +889,7 @@ class Package(object):
         skip_patch     -- Skip patch stage of build if True.
         verbose        -- Display verbose build output (by default, suppresses it)
         make_jobs      -- Number of make jobs to use for install.  Default is ncpus.
+        make_load      -- Maximum load of parallel make. Default is ncpus.
         build_parallel -- Whether to build dependencies in parallel
         """
         if not self.spec.concrete:
@@ -907,10 +912,11 @@ class Package(object):
             self.do_install_dependencies(
                 keep_prefix=keep_prefix, keep_stage=keep_stage, ignore_deps=ignore_deps,
                 fake=fake, skip_patch=skip_patch, verbose=verbose, make_jobs=make_jobs, 
-                build_parallel = build_parallel)
+                make_load = make_load, build_parallel = build_parallel)
 
         # Set parallelism before starting build.
         self.make_jobs = make_jobs
+        self.make_load = make_load
 
         # Then install the package itself.
         def build_process():

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -98,7 +98,7 @@ class DoInstallThread(threading.Thread):
     if self.to_wait_for:
       self.to_wait_for.join()
     else:
-      self.package.do_install(self.kwargs)
+      self.package.do_install(**self.kwargs)
 
 
 class Package(object):
@@ -1024,6 +1024,7 @@ class Package(object):
         deptasks = []
         for dep in self.spec.dependencies.values():
             deptasks.append(DoInstallThread(dep.package, kwargs))
+            print "adding dep", dep
         for task in deptasks:
             task.start()
             if not kwargs["build_parallel"]:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -66,6 +66,40 @@ from urlparse import urlparse
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
 
+import threading
+
+class DoInstallThread(threading.Thread):
+  """
+  This is a lightweight thread class to take care of executing
+  do_install calls in parallel.
+
+  To avoid the same package to be build multiple times,
+  the queued builds are being recorded. If a package thread finds
+  its target package already being in the queue, it just waits for
+  the other thread to finish.
+
+  """
+  _do_install_threads = {}
+  _queue_lock = threading.Lock()
+
+  def __init__(self, package, kwargs):
+    threading.Thread.__init__(self)
+    self.package = package
+    self.kwargs = kwargs
+    self.to_wait_for = None
+    # check whether an equivalent thread already exists
+    with DoInstallThread._queue_lock:
+        if package in DoInstallThread._do_install_threads:
+            self.to_wait_for = DoInstallThread._do_install_threads[package]
+        else:
+            DoInstallThread._do_install_threads[package] = self
+
+  def run(self):
+    if self.to_wait_for:
+      self.to_wait_for.join()
+    else:
+      self.package.do_install(self.kwargs)
+
 
 class Package(object):
     """This is the superclass for all spack packages.
@@ -835,22 +869,23 @@ class Package(object):
 
     def do_install(self,
                    keep_prefix=False,  keep_stage=False, ignore_deps=False,
-                   skip_patch=False, verbose=False, make_jobs=None, fake=False):
+                   skip_patch=False, verbose=False, make_jobs=None, fake=False, build_parallel=False):
         """Called by commands to install a package and its dependencies.
 
         Package implementations should override install() to describe
         their build process.
 
         Args:
-        keep_prefix -- Keep install prefix on failure. By default, destroys it.
-        keep_stage  -- By default, stage is destroyed only if there are no
-                       exceptions during build. Set to True to keep the stage
-                       even with exceptions.
-        ignore_deps -- Do not install dependencies before installing this package.
-        fake        -- Don't really build -- install fake stub files instead.
-        skip_patch  -- Skip patch stage of build if True.
-        verbose     -- Display verbose build output (by default, suppresses it)
-        make_jobs   -- Number of make jobs to use for install.  Default is ncpus.
+        keep_prefix    -- Keep install prefix on failure. By default, destroys it.
+        keep_stage     -- By default, stage is destroyed only if there are no
+                          exceptions during build. Set to True to keep the stage
+                          even with exceptions.
+        ignore_deps    -- Do not install dependencies before installing this package.
+        fake           -- Don't really build -- install fake stub files instead.
+        skip_patch     -- Skip patch stage of build if True.
+        verbose        -- Display verbose build output (by default, suppresses it)
+        make_jobs      -- Number of make jobs to use for install.  Default is ncpus.
+        build_parallel -- Whether to build dependencies in parallel
         """
         if not self.spec.concrete:
             raise ValueError("Can only install concrete packages.")
@@ -871,7 +906,8 @@ class Package(object):
         if not ignore_deps:
             self.do_install_dependencies(
                 keep_prefix=keep_prefix, keep_stage=keep_stage, ignore_deps=ignore_deps,
-                fake=fake, skip_patch=skip_patch, verbose=verbose, make_jobs=make_jobs)
+                fake=fake, skip_patch=skip_patch, verbose=verbose, make_jobs=make_jobs, 
+                build_parallel = build_parallel)
 
         # Set parallelism before starting build.
         self.make_jobs = make_jobs
@@ -985,9 +1021,16 @@ class Package(object):
 
     def do_install_dependencies(self, **kwargs):
         # Pass along paths of dependencies here
+        deptasks = []
         for dep in self.spec.dependencies.values():
-            dep.package.do_install(**kwargs)
-
+            deptasks.append(DoInstallThread(dep.package, kwargs))
+        for task in deptasks:
+            task.start()
+            if not kwargs["build_parallel"]:
+                task.join()
+        if  kwargs["build_parallel"]:
+            for task in deptasks:
+                task.join()
 
     @property
     def build_log_path(self):

--- a/lib/spack/spack/test/make_executable.py
+++ b/lib/spack/spack/test/make_executable.py
@@ -55,31 +55,31 @@ class MakeExecutableTest(unittest.TestCase):
 
 
     def test_make_normal(self):
-        make = MakeExecutable('make', 8)
-        self.assertEqual(make(output=str).strip(), '-j8')
-        self.assertEqual(make('install', output=str).strip(), '-j8 install')
+        make = MakeExecutable('make', 8, 7)
+        self.assertEqual(make(output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', output=str).strip(), '-j8 -l7 install')
 
 
     def test_make_explicit(self):
-        make = MakeExecutable('make', 8)
-        self.assertEqual(make(parallel=True, output=str).strip(), '-j8')
-        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 install')
+        make = MakeExecutable('make', 8, 7)
+        self.assertEqual(make(parallel=True, output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 -l7 install')
 
 
     def test_make_one_job(self):
-        make = MakeExecutable('make', 1)
+        make = MakeExecutable('make', 1, 1)
         self.assertEqual(make(output=str).strip(), '')
         self.assertEqual(make('install', output=str).strip(), 'install')
 
 
     def test_make_parallel_false(self):
-        make = MakeExecutable('make', 8)
+        make = MakeExecutable('make', 8, 7)
         self.assertEqual(make(parallel=False, output=str).strip(), '')
         self.assertEqual(make('install', parallel=False, output=str).strip(), 'install')
 
 
     def test_make_parallel_disabled(self):
-        make = MakeExecutable('make', 8)
+        make = MakeExecutable('make', 8, 7)
 
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'true'
         self.assertEqual(make(output=str).strip(), '')
@@ -91,18 +91,18 @@ class MakeExecutableTest(unittest.TestCase):
 
         # These don't disable (false and random string)
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'false'
-        self.assertEqual(make(output=str).strip(), '-j8')
-        self.assertEqual(make('install', output=str).strip(), '-j8 install')
+        self.assertEqual(make(output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', output=str).strip(), '-j8 -l7 install')
 
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'foobar'
-        self.assertEqual(make(output=str).strip(), '-j8')
-        self.assertEqual(make('install', output=str).strip(), '-j8 install')
+        self.assertEqual(make(output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', output=str).strip(), '-j8 -l7 install')
 
         del os.environ['SPACK_NO_PARALLEL_MAKE']
 
 
     def test_make_parallel_precedence(self):
-        make = MakeExecutable('make', 8)
+        make = MakeExecutable('make', 8, 7)
 
         # These should work
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'true'
@@ -115,11 +115,11 @@ class MakeExecutableTest(unittest.TestCase):
 
         # These don't disable (false and random string)
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'false'
-        self.assertEqual(make(parallel=True, output=str).strip(), '-j8')
-        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 install')
+        self.assertEqual(make(parallel=True, output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 -l7 install')
 
         os.environ['SPACK_NO_PARALLEL_MAKE'] = 'foobar'
-        self.assertEqual(make(parallel=True, output=str).strip(), '-j8')
-        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 install')
+        self.assertEqual(make(parallel=True, output=str).strip(), '-j8 -l7')
+        self.assertEqual(make('install', parallel=True, output=str).strip(), '-j8 -l7 install')
 
         del os.environ['SPACK_NO_PARALLEL_MAKE']


### PR DESCRIPTION
This PR adds a trivial implementation of building the dependencies of a given package in parallel, using
`spack install --parallel <target>`

It spawns each a thread per dependency. As the CPU time is spent outside Python this should be sufficient for a significant speedup. Concerning thread-safety I currently rely on
- the GIL for all Python code
- the separation of environments via os.fork for the actual build processes
- an explicit handling to avoid building the same package multiple times

As I have no idea which implicit assumptions I break (how does `extends` behave?), I marked this feature as _experimental_ in the help message. Will be a long way to completion I suppose.
