### PR TITLE
feature : finer locking of the db

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -35,15 +35,35 @@ import fileinput
 
 import llnl.util.tty as tty
 
-__all__ = ['set_install_permissions', 'install', 'install_tree',
-           'traverse_tree',
-           'expand_user', 'working_dir', 'touch', 'touchp', 'mkdirp',
-           'force_remove', 'join_path', 'ancestor', 'can_access',
-           'filter_file',
-           'FileFilter', 'change_sed_delimiter', 'is_exe', 'force_symlink',
-           'set_executable', 'copy_mode', 'unset_executable_mode',
-           'remove_dead_links', 'remove_linked_tree', 'find_library_path',
-           'fix_darwin_install_name', 'to_link_flags', 'to_lib_name']
+__all__ = [
+    'FileFilter',
+    'ancestor',
+    'can_access',
+    'change_sed_delimiter',
+    'copy_mode',
+    'expand_user',
+    'filter_file',
+    'find_library_path',
+    'fix_darwin_install_name',
+    'force_remove',
+    'force_symlink',
+    'install',
+    'install_tree',
+    'is_exe',
+    'join_path',
+    'mkdirp',
+    'remove_dead_links',
+    'remove_if_dead_link',
+    'remove_linked_tree',
+    'set_executable',
+    'set_install_permissions',
+    'to_lib_name',
+    'to_link_flags',
+    'touch',
+    'touchp',
+    'traverse_tree',
+    'unset_executable_mode',
+    'working_dir']
 
 
 def filter_file(regex, repl, *filenames, **kwargs):
@@ -384,10 +404,20 @@ def remove_dead_links(root):
     """
     for file in os.listdir(root):
         path = join_path(root, file)
-        if os.path.islink(path):
-            real_path = os.path.realpath(path)
-            if not os.path.exists(real_path):
-                os.unlink(path)
+        remove_if_dead_link(path)
+
+
+def remove_if_dead_link(path):
+    """
+    Removes the argument if it is a dead link, does nothing otherwise
+
+    Args:
+        path: the potential dead link
+    """
+    if os.path.islink(path):
+        real_path = os.path.realpath(path)
+        if not os.path.exists(real_path):
+            os.unlink(path)
 
 
 def remove_linked_tree(path):

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -28,8 +28,12 @@ import errno
 import time
 import socket
 
+import llnl.util.tty as tty
+
+
 __all__ = ['Lock', 'LockTransaction', 'WriteTransaction', 'ReadTransaction',
            'LockError']
+
 
 # Default timeout in seconds, after which locks will raise exceptions.
 _default_timeout = 60
@@ -111,6 +115,7 @@ class Lock(object):
 
         """
         if self._reads == 0 and self._writes == 0:
+            tty.debug('READ LOCK : {0._file_path} [Acquiring]'.format(self))
             self._lock(fcntl.LOCK_SH, timeout)   # can raise LockError.
             self._reads += 1
             return True
@@ -130,6 +135,7 @@ class Lock(object):
 
         """
         if self._writes == 0:
+            tty.debug('WRITE LOCK : {0._file_path} [Acquiring]'.format(self))
             self._lock(fcntl.LOCK_EX, timeout)   # can raise LockError.
             self._writes += 1
             return True
@@ -150,6 +156,7 @@ class Lock(object):
         assert self._reads > 0
 
         if self._reads == 1 and self._writes == 0:
+            tty.debug('READ LOCK : {0._file_path} [Released]'.format(self))
             self._unlock()      # can raise LockError.
             self._reads -= 1
             return True
@@ -170,6 +177,7 @@ class Lock(object):
         assert self._writes > 0
 
         if self._writes == 1 and self._reads == 0:
+            tty.debug('WRITE LOCK : {0._file_path} [Released]'.format(self))
             self._unlock()      # can raise LockError.
             self._writes -= 1
             return True

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -62,42 +62,39 @@ def diy(self, args):
     if len(specs) > 1:
         tty.die("spack diy only takes one spec.")
 
-    # Take a write lock before checking for existence.
-    with spack.installed_db.write_transaction():
-        spec = specs[0]
-        if not spack.repo.exists(spec.name):
-            tty.warn("No such package: %s" % spec.name)
-            create = tty.get_yes_or_no("Create this package?", default=False)
-            if not create:
-                tty.msg("Exiting without creating.")
-                sys.exit(1)
-            else:
-                tty.msg("Running 'spack edit -f %s'" % spec.name)
-                edit_package(spec.name, spack.repo.first_repo(), None, True)
-                return
+    spec = specs[0]
+    if not spack.repo.exists(spec.name):
+        tty.warn("No such package: %s" % spec.name)
+        create = tty.get_yes_or_no("Create this package?", default=False)
+        if not create:
+            tty.msg("Exiting without creating.")
+            sys.exit(1)
+        else:
+            tty.msg("Running 'spack edit -f %s'" % spec.name)
+            edit_package(spec.name, spack.repo.first_repo(), None, True)
+            return
 
         if not spec.versions.concrete:
             tty.die(
                 "spack diy spec must have a single, concrete version. "
                 "Did you forget a package version number?")
 
-        spec.concretize()
-        package = spack.repo.get(spec)
+    spec.concretize()
+    package = spack.repo.get(spec)
 
-        if package.installed:
-            tty.error("Already installed in %s" % package.prefix)
-            tty.msg("Uninstall or try adding a version suffix for this "
-                    "DIY build.")
-            sys.exit(1)
+    if package.installed:
+        tty.error("Already installed in %s" % package.prefix)
+        tty.msg("Uninstall or try adding a version suffix for this DIY build.")
+        sys.exit(1)
 
-        # Forces the build to run out of the current directory.
-        package.stage = DIYStage(os.getcwd())
+    # Forces the build to run out of the current directory.
+    package.stage = DIYStage(os.getcwd())
 
-        # TODO: make this an argument, not a global.
-        spack.do_checksum = False
+    # TODO: make this an argument, not a global.
+    spack.do_checksum = False
 
-        package.do_install(
-            keep_prefix=args.keep_prefix,
-            ignore_deps=args.ignore_deps,
-            verbose=not args.quiet,
-            keep_stage=True)   # don't remove source dir for DIY.
+    package.do_install(
+        keep_prefix=args.keep_prefix,
+        ignore_deps=args.ignore_deps,
+        verbose=not args.quiet,
+        keep_stage=True)   # don't remove source dir for DIY.

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -79,14 +79,13 @@ def install(parser, args):
     specs = spack.cmd.parse_specs(args.packages, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
-        with spack.installed_db.write_transaction():
-            package.do_install(
-                keep_prefix=args.keep_prefix,
-                keep_stage=args.keep_stage,
-                ignore_deps=args.ignore_deps,
-                make_jobs=args.jobs,
-                run_tests=args.run_tests,
-                verbose=args.verbose,
-                fake=args.fake,
-                dirty=args.dirty,
-                explicit=True)
+        package.do_install(
+            keep_prefix=args.keep_prefix,
+            keep_stage=args.keep_stage,
+            ignore_deps=args.ignore_deps,
+            make_jobs=args.jobs,
+            run_tests=args.run_tests,
+            verbose=args.verbose,
+            fake=args.fake,
+            dirty=args.dirty,
+            explicit=True)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -161,40 +161,38 @@ def uninstall(parser, args):
     if not args.packages:
         tty.die("uninstall requires at least one package argument.")
 
-    with spack.installed_db.write_transaction():
-        specs = spack.cmd.parse_specs(args.packages)
-        # Gets the list of installed specs that match the ones give via cli
-        # takes care of '-a' is given in the cli
-        uninstall_list = concretize_specs(specs, args.all, args.force)
-        dependent_list = installed_dependents(
-            uninstall_list)  # takes care of '-d'
+    specs = spack.cmd.parse_specs(args.packages)
+    # Gets the list of installed specs that match the ones give via cli
+    # takes care of '-a' is given in the cli
+    uninstall_list = concretize_specs(specs, args.all, args.force)
+    dependent_list = installed_dependents(uninstall_list)  # takes care of '-d'
 
-        # Process dependent_list and update uninstall_list
-        has_error = False
-        if dependent_list and not args.dependents and not args.force:
-            for spec, lst in dependent_list.items():
-                tty.error("Will not uninstall %s" %
-                          spec.format("$_$@$%@$#", color=True))
-                print('')
-                print("The following packages depend on it:")
-                spack.cmd.display_specs(lst, **display_args)
-                print('')
-                has_error = True
-        elif args.dependents:
-            for key, lst in dependent_list.items():
-                uninstall_list.extend(lst)
-            uninstall_list = list(set(uninstall_list))
-
-        if has_error:
-            tty.die('You can use spack uninstall --dependents '
-                    'to uninstall these dependencies as well')
-
-        if not args.yes_to_all:
-            tty.msg("The following packages will be uninstalled : ")
+    # Process dependent_list and update uninstall_list
+    has_error = False
+    if dependent_list and not args.dependents and not args.force:
+        for spec, lst in dependent_list.items():
+            tty.error("Will not uninstall %s"
+                      % spec.format("$_$@$%@$#", color=True))
             print('')
-            spack.cmd.display_specs(uninstall_list, **display_args)
+            print("The following packages depend on it:")
+            spack.cmd.display_specs(lst, **display_args)
             print('')
-            spack.cmd.ask_for_confirmation('Do you want to proceed ? ')
+            has_error = True
+    elif args.dependents:
+        for key, lst in dependent_list.items():
+            uninstall_list.extend(lst)
+        uninstall_list = list(set(uninstall_list))
 
-        # Uninstall everything on the list
-        do_uninstall(uninstall_list, args.force)
+    if has_error:
+        tty.die('You can use spack uninstall --dependents '
+                'to uninstall these dependencies as well')
+
+    if not args.yes_to_all:
+        tty.msg("The following packages will be uninstalled : ")
+        print('')
+        spack.cmd.display_specs(uninstall_list, **display_args)
+        print('')
+        spack.cmd.ask_for_confirmation('Do you want to proceed ? ')
+
+    # Uninstall everything on the list
+    do_uninstall(uninstall_list, args.force)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -33,7 +33,7 @@ The database serves two purposes:
   2. It will allow us to track external installations as well as lost
      packages and their dependencies.
 
-Prior ot the implementation of this store, a direcotry layout served
+Prior to the implementation of this store, a directory layout served
 as the authoritative database of packages in Spack.  This module
 provides a cache and a sanity checking mechanism for what is in the
 filesystem.
@@ -290,7 +290,7 @@ class Database(object):
                 data[hash_key] = InstallRecord.from_dict(spec, rec)
 
             except Exception as e:
-                tty.warn("Invalid database reecord:",
+                tty.warn("Invalid database record:",
                          "file:  %s" % self._index_path,
                          "hash:  %s" % hash_key,
                          "cause: %s: %s" % (type(e).__name__, str(e)))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -671,7 +671,10 @@ class Package(object):
 
             if not os.path.exists(lock_file):
                 tty.debug('TOUCH FILE : {0}'.format(lock_file))
-                os.makedirs(dirname)
+                try:
+                    os.makedirs(dirname)
+                except OSError:
+                    pass
                 touch(lock_file)
 
             self._prefix_lock = llnl.util.lock.Lock(lock_file)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1258,11 +1258,12 @@ class Package(object):
                 raise PackageStillNeededError(self.spec, dependents)
 
         # Pre-uninstall hook runs first.
-        spack.hooks.pre_uninstall(self)
-
-        # Uninstalling in Spack only requires removing the prefix.
-        self.remove_prefix()
-        spack.installed_db.remove(self.spec)
+        with self._prefix_write_lock():
+            spack.hooks.pre_uninstall(self)
+            # Uninstalling in Spack only requires removing the prefix.
+            self.remove_prefix()
+            #
+            spack.installed_db.remove(self.spec)
         tty.msg("Successfully uninstalled %s" % self.spec.short_spec)
 
         # Once everything else is done, run post install hooks

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -39,8 +39,17 @@ import re
 import textwrap
 import time
 import string
+import contextlib
+from urlparse import urlparse
+from StringIO import StringIO
 
+import llnl.util.lock
 import llnl.util.tty as tty
+from llnl.util.filesystem import *
+from llnl.util.lang import *
+from llnl.util.link_tree import LinkTree
+from llnl.util.tty.log import log_output
+
 import spack
 import spack.build_environment
 import spack.compilers
@@ -52,13 +61,6 @@ import spack.mirror
 import spack.repository
 import spack.url
 import spack.util.web
-
-from urlparse import urlparse
-from StringIO import StringIO
-from llnl.util.filesystem import *
-from llnl.util.lang import *
-from llnl.util.link_tree import LinkTree
-from llnl.util.tty.log import log_output
 from spack.stage import Stage, ResourceStage, StageComposite
 from spack.util.compression import allowed_archive
 from spack.util.environment import dump_environment
@@ -327,6 +329,9 @@ class Package(object):
     def __init__(self, spec):
         # this determines how the package should be built.
         self.spec = spec
+
+        # Lock on the prefix shared resource. Will be set in prefix property
+        self._prefix_lock = None
 
         # Name of package is the name of its module, without the
         # containing module names.
@@ -658,6 +663,22 @@ class Package(object):
         return dependents
 
     @property
+    def prefix_lock(self):
+        if self._prefix_lock is None:
+            dirname = join_path(os.path.dirname(self.spec.prefix), '.locks')
+            basename = os.path.basename(self.spec.prefix)
+            lock_file = join_path(dirname, basename)
+
+            if not os.path.exists(lock_file):
+                tty.debug('TOUCH FILE : {0}'.format(lock_file))
+                os.makedirs(dirname)
+                touch(lock_file)
+
+            self._prefix_lock = llnl.util.lock.Lock(lock_file)
+
+        return self._prefix_lock
+
+    @property
     def prefix(self):
         """Get the prefix into which this package should be installed."""
         return self.spec.prefix
@@ -841,6 +862,22 @@ class Package(object):
         resource_stage_folder = '-'.join(pieces)
         return resource_stage_folder
 
+    @contextlib.contextmanager
+    def _prefix_read_lock(self):
+        try:
+            self.prefix_lock.acquire_read(60)
+            yield self
+        finally:
+            self.prefix_lock.release_read()
+
+    @contextlib.contextmanager
+    def _prefix_write_lock(self):
+        try:
+            self.prefix_lock.acquire_write(60)
+            yield self
+        finally:
+            self.prefix_lock.release_write()
+
     install_phases = set(['configure', 'build', 'install', 'provenance'])
 
     def do_install(self,
@@ -886,14 +923,18 @@ class Package(object):
 
         # Ensure package is not already installed
         layout = spack.install_layout
-        if 'install' in install_phases and layout.check_installed(self.spec):
-            tty.msg("%s is already installed in %s" % (self.name, self.prefix))
-            rec = spack.installed_db.get_record(self.spec)
-            if (not rec.explicit) and explicit:
-                with spack.installed_db.write_transaction():
-                    rec = spack.installed_db.get_record(self.spec)
-                    rec.explicit = True
-            return
+        with self._prefix_read_lock():
+            if ('install' in install_phases and
+                layout.check_installed(self.spec)):
+
+                tty.msg(
+                    "%s is already installed in %s" % (self.name, self.prefix))
+                rec = spack.installed_db.get_record(self.spec)
+                if (not rec.explicit) and explicit:
+                    with spack.installed_db.write_transaction():
+                        rec = spack.installed_db.get_record(self.spec)
+                        rec.explicit = True
+                return
 
         tty.msg("Installing %s" % self.name)
 
@@ -933,7 +974,7 @@ class Package(object):
             self.build_directory = join_path(self.stage.path, 'spack-build')
             self.source_directory = self.stage.source_path
 
-            with self.stage:
+            with contextlib.nested(self.stage, self._prefix_write_lock()):
                 # Run the pre-install hook in the child process after
                 # the directory is created.
                 spack.hooks.pre_install(self)
@@ -1026,8 +1067,9 @@ class Package(object):
                          wrap=False)
             raise
 
-        # note: PARENT of the build process adds the new package to
+        # Note: PARENT of the build process adds the new package to
         # the database, so that we don't need to re-read from file.
+        # Note: add implicitly acquires a write-lock
         spack.installed_db.add(self.spec, self.prefix, explicit=explicit)
 
     def sanity_check_prefix(self):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -159,6 +159,8 @@ class Stage(object):
         if lock:
             self._lock_file = join_path(spack.stage_path, self.name + '.lock')
             if not os.path.exists(self._lock_file):
+                directory, _ = os.path.split(self._lock_file)
+                mkdirp(directory)
                 touch(self._lock_file)
             self._lock = llnl.util.lock.Lock(self._lock_file)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -430,7 +430,8 @@ class Stage(object):
         """
         # Create the top-level stage directory
         mkdirp(spack.stage_path)
-        remove_dead_links(spack.stage_path)
+        remove_if_dead_link(self.path)
+
         # If a tmp_root exists then create a directory there and then link it
         # in the stage area, otherwise create the stage directory in self.path
         if self._need_to_create_path():

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -29,6 +29,7 @@ import tempfile
 from urlparse import urljoin
 
 import llnl.util.tty as tty
+import llnl.util.lock
 from llnl.util.filesystem import *
 
 import spack.util.pattern as pattern
@@ -92,8 +93,9 @@ class Stage(object):
     similar, and are intended to persist for only one run of spack.
     """
 
-    def __init__(self, url_or_fetch_strategy,
-                 name=None, mirror_path=None, keep=False, path=None):
+    def __init__(
+            self, url_or_fetch_strategy,
+            name=None, mirror_path=None, keep=False, path=None, lock=True):
         """Create a stage object.
            Parameters:
              url_or_fetch_strategy
@@ -151,6 +153,15 @@ class Stage(object):
         # Flag to decide whether to delete the stage folder on exit or not
         self.keep = keep
 
+        # File lock for the stage directory
+        self._lock_file = None
+        self._lock = None
+        if lock:
+            self._lock_file = join_path(spack.stage_path, self.name + '.lock')
+            if not os.path.exists(self._lock_file):
+                touch(self._lock_file)
+            self._lock = llnl.util.lock.Lock(self._lock_file)
+
     def __enter__(self):
         """
         Entering a stage context will create the stage directory
@@ -158,6 +169,8 @@ class Stage(object):
         Returns:
             self
         """
+        if self._lock is not None:
+            self._lock.acquire_write(timeout=60)
         self.create()
         return self
 
@@ -178,6 +191,9 @@ class Stage(object):
         # Delete when there are no exceptions, unless asked to keep.
         if exc_type is None and not self.keep:
             self.destroy()
+
+        if self._lock is not None:
+            self._lock.release_write()
 
     def _need_to_create_path(self):
         """Makes sure nothing weird has happened since the last time we


### PR DESCRIPTION
##### Modifications
- [x] removed global db locks from `install`, `uninstall` and `diy`
- [x] added lock for stage directory (an exclusive lock is taken as part of the `Stage` context manager)
- [x] added lock for prefix directory (an exclusive lock is taken during `Package.do_install`)
- [x] debug output shows locks acquire and release

##### Install and uninstall are not mutually exclusive
This means that if : 
```
spack uninstall ...
``` 
is run concurrently with 
```
spack install ...
```
the former command may cause the latter to fail (the same way an administrator can `sudo rm ...` something that another admin is about to use)

##### Debug output shows acquire and release
```
$ spack -d install  python@3:
==> Reading config file /home/mculpo/.spack/compilers.yaml
==> TOUCH FILE : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2 [Acquiring]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2 [Released]
==> Installing python
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/bzip2-1.0.6-i6a7grcnt5wwn6i3rjh2al25ypwtlyhz [Acquiring]
==> bzip2 is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/bzip2-1.0.6-i6a7grcnt5wwn6i3rjh2al25ypwtlyhz
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/bzip2-1.0.6-i6a7grcnt5wwn6i3rjh2al25ypwtlyhz [Released]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/ncurses-6.0-faybomf54bbh376q54ztgfsrqxa7vavk [Acquiring]
==> ncurses is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/ncurses-6.0-faybomf54bbh376q54ztgfsrqxa7vavk
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/ncurses-6.0-faybomf54bbh376q54ztgfsrqxa7vavk [Released]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/zlib-1.2.8-rv427lhuk7qeq5fh67f36dxq3z22bpu4 [Acquiring]
==> zlib is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/zlib-1.2.8-rv427lhuk7qeq5fh67f36dxq3z22bpu4
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/zlib-1.2.8-rv427lhuk7qeq5fh67f36dxq3z22bpu4 [Released]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/openssl-1.0.2h-d7ykxud2ghnusqhwdzagnpx7inboix75 [Acquiring]
==> openssl is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/openssl-1.0.2h-d7ykxud2ghnusqhwdzagnpx7inboix75
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/openssl-1.0.2h-d7ykxud2ghnusqhwdzagnpx7inboix75 [Released]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/sqlite-3.8.5-5ivjx67knpt477vxen6p6xc73fdq22na [Acquiring]
==> sqlite is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/sqlite-3.8.5-5ivjx67knpt477vxen6p6xc73fdq22na
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/sqlite-3.8.5-5ivjx67knpt477vxen6p6xc73fdq22na [Released]
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/readline-6.3-ie3abif7kh64o7it4lntlcj2wkygqxvf [Acquiring]
==> readline is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/readline-6.3-ie3abif7kh64o7it4lntlcj2wkygqxvf
==> READ LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/readline-6.3-ie3abif7kh64o7it4lntlcj2wkygqxvf [Released]
==> Reading config file /home/mculpo/.spack/mirrors.yaml
==> Trying to fetch from file:///home/mculpo/production/spack-mirror/python/python-3.5.1.tgz
==> /usr/bin/curl -C - -o /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/python-3.5.1.tgz.part -f -D - -L file:///home/mculpo/production/spack-mirror/python/python-3.5.1.tgz -#
######################################################################## 100,0%
==> Staging archive: /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/python-3.5.1.tgz
==> /bin/tar -xf /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/python-3.5.1.tgz
==> Created stage in /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2
==> No patches needed for python
==> Building python
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2.lock [Acquiring]
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2 [Acquiring]
==> Installing /tmp/mculpo/spack-stage/spack-stage-_bO_kd/Python-3.5.1/spack-build.out to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/build.out
==> Installing /tmp/mculpo/spack-stage/spack-stage-_bO_kd/Python-3.5.1/spack-build.env to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/build.env
==> Installing /home/mculpo/PycharmProjects/spack/var/spack/repos/builtin/packages/python/package.py to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/python
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/bzip2-1.0.6-i6a7grcnt5wwn6i3rjh2al25ypwtlyhz/.spack/repos/builtin/packages/bzip2 to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/bzip2
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/ncurses-6.0-faybomf54bbh376q54ztgfsrqxa7vavk/.spack/repos/builtin/packages/ncurses to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/ncurses
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/openssl-1.0.2h-d7ykxud2ghnusqhwdzagnpx7inboix75/.spack/repos/builtin/packages/openssl to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/openssl
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/zlib-1.2.8-rv427lhuk7qeq5fh67f36dxq3z22bpu4/.spack/repos/builtin/packages/zlib to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/zlib
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/readline-6.3-ie3abif7kh64o7it4lntlcj2wkygqxvf/.spack/repos/builtin/packages/readline to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/readline
==> Installing /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/sqlite-3.8.5-5ivjx67knpt477vxen6p6xc73fdq22na/.spack/repos/builtin/packages/sqlite to /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/.spack/repos/builtin/packages/sqlite
==> Warning: Patched overly long shebang in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/bin/idle3.5
==> Warning: Patched overly long shebang in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/bin/pyvenv-3.5
==> Warning: Patched overly long shebang in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/bin/pydoc3.5
==> Warning: Patched overly long shebang in /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2/bin/2to3-3.5
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/.locks/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2 [Released]
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/var/spack/stage/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2.lock [Released]
==> Successfully installed python
  Fetch: 0.06s.  Build: 2m 33.03s.  Total: 2m 33.08s.
[+] /home/mculpo/PycharmProjects/spack/opt/spack/linux-x86_64/gcc-6.1.0/python-3.5.1-wxwrgojeiacr4ckh3jnrqrsi4o5a7jg2
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/.spack-db/lock [Acquiring]
==> WRITE LOCK : /home/mculpo/PycharmProjects/spack/opt/spack/.spack-db/lock [Released]
```

---------

@tgamblin @adamjstewart @hegner As we need this with high priority, and there's much request for this feature (see #636), I thought it was better to share what I am doing early in the development to avoid duplicate work.