### PR TITLE
track whether a package was installed "explicitly"

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -58,6 +58,12 @@ def setup_parser(subparser):
         help='Show dependency hashes as well as versions.')
 
     subparser.add_argument(
+        '-e', '--explicit', action='store_true',
+        help='Show only specs that were installed explicitly')
+    subparser.add_argument(
+        '-E', '--implicit', action='store_true',
+        help='Show only specs that were installed as dependencies')
+    subparser.add_argument(
         '-u', '--unknown', action='store_true',
         help='Show only specs Spack does not have a package for.')
     subparser.add_argument(
@@ -163,7 +169,14 @@ def find(parser, args):
         installed = any
     if args.unknown:
         known = False
-    q_args = { 'installed' : installed, 'known' : known }
+
+    explicit = None
+    if args.explicit:
+        explicit = False
+    if args.implicit:
+        explicit = True
+
+    q_args = { 'installed' : installed, 'known' : known, "explicit" : explicit }
 
     # Get all the specs the user asked for
     if not query_specs:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -78,4 +78,5 @@ def install(parser, args):
                 ignore_deps=args.ignore_deps,
                 make_jobs=args.jobs,
                 verbose=args.verbose,
-                fake=args.fake)
+                fake=args.fake,
+                explicit=True)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -857,7 +857,8 @@ class Package(object):
                    skip_patch=False,
                    verbose=False,
                    make_jobs=None,
-                   fake=False):
+                   fake=False,
+                   explicit=False):
         """Called by commands to install a package and its dependencies.
 
         Package implementations should override install() to describe
@@ -995,7 +996,7 @@ class Package(object):
 
         # note: PARENT of the build process adds the new package to
         # the database, so that we don't need to re-read from file.
-        spack.installed_db.add(self.spec, self.prefix)
+        spack.installed_db.add(self.spec, self.prefix, explicit=explicit)
 
     def sanity_check_prefix(self):
         """This function checks whether install succeeded."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -888,6 +888,11 @@ class Package(object):
         # Ensure package is not already installed
         if spack.install_layout.check_installed(self.spec):
             tty.msg("%s is already installed in %s" % (self.name, self.prefix))
+            rec = spack.installed_db.get_record(self.spec)
+            if (not rec.explicit) and explicit:
+                with spack.installed_db.write_transaction():
+                    rec = spack.installed_db.get_record(self.spec)
+                    rec.explicit = True
             return
 
         tty.msg("Installing %s" % self.name)


### PR DESCRIPTION
Adds a new attribute in the database to track whether a package was
installed explicitly or not, where explicitly is the user running `spack
install <package>` and implicitly is it being installed as a dependency.
It also adds arguments to `spack find` to find these packages such that
it should be possible to query the packages that were installed
implicitly and are not currently depended upon any longer.

Related to completing some of the discussions from #457.
