### PR TITLE
+ Add version 5.0 download for SuperLU_DIST.

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -6,6 +6,7 @@ class SuperluDist(Package):
     homepage = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/"
     url      = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_4.1.tar.gz"
 
+    version('5.0.0', '2b53baf1b0ddbd9fcf724992577f0670')
     version('4.3', 'ee66c84e37b4f7cc557771ccc3dc43ae')
     version('4.2', 'ae9fafae161f775fbac6eba11e530a65')
     version('4.1', '4edee38cc29f687bd0c8eb361096a455')

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -7,7 +7,8 @@ class SuperluDist(Package):
     url      = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_4.1.tar.gz"
 
     version('5.0.0', '2b53baf1b0ddbd9fcf724992577f0670')
-    version('4.3', 'ee66c84e37b4f7cc557771ccc3dc43ae')
+    # default to version 4.3 since petsc and trilinos are not tested with 5.0.
+    version('4.3', 'ee66c84e37b4f7cc557771ccc3dc43ae', preferred=True)
     version('4.2', 'ae9fafae161f775fbac6eba11e530a65')
     version('4.1', '4edee38cc29f687bd0c8eb361096a455')
     version('4.0', 'c0b98b611df227ae050bc1635c6940e0')


### PR DESCRIPTION
SuperLU_DIST version 5.0.0 was released April 8.  Add option to download and build.