### PR TITLE
libtool: add a missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -8,6 +8,8 @@ class Libtool(Package):
     version('2.4.6' , 'addf44b646ddb4e3919805aa88fa7c5e')
     version('2.4.2' , 'd2f3b7d4627e69e13514a40e72a24d50')
 
+    depends_on('m4')
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
 


### PR DESCRIPTION
otherwise:

```
=> Staging archive: /calculate/spack/var/spack/stage/libtool-2.4.6-e4qlvqh6swwfj6ixwhyjbg6ku5zgfvdr/libtool-2.4.6.tar.gz
==> Created stage in /calculate/spack/var/spack/stage/libtool-2.4.6-e4qlvqh6swwfj6ixwhyjbg6ku5zgfvdr
==> No patches needed for libtool
==> Building libtool
==> Error: Command exited with status 1:
./configure --prefix=/calculate/spack/opt/spack/linux-x86_64/gcc-4.8/libtool-2.4.6-e4qlvqh6swwfj6ixwhyjbg6ku5zgfvdr

See build log for details:
 /tmp/root/spack-stage/spack-stage-61j2na/libtool-2.4.6/spack-build.out

/calculate/spack/var/spack/repos/builtin/packages/libtool/package.py:12, in install:
    11       def install(self, spec, prefix):
 >> 12           configure("--prefix=%s" % prefix)
    13
    14           make()
    15           make("install")
==> Error: Installation process had nonzero exit code.

The output from spack-build.out

root@faumcp20:/calculate/spack/bin# cat /tmp/root/spack-stage/spack-stage-61j2na/libtool-2.4.6/spack-build.out
==> ./configure --prefix=/calculate/spack/opt/spack/linux-x86_64/gcc-4.8/libtool-2.4.6-e4qlvqh6swwfj6ixwhyjbg6ku5zgfvdr
## ------------------------- ##
## Configuring libtool 2.4.6 ##
## ------------------------- ##

checking for GNU M4 that supports accurate traces... configure: error: no acceptable m4 could be found in $PATH.
GNU M4 1.4.6 or later is required; 1.4.16 or newer is recommended.
GNU M4 1.4.15 uses a buggy replacement strstr on some systems.
Glibc 2.9 - 2.12 and GNU M4 1.4.11 - 1.4.15 have another strstr bug.
```