### PR TITLE
Disable OpenBLAS's overriding of our "make -jN" option

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/make.patch
+++ b/var/spack/repos/builtin/packages/openblas/make.patch
@@ -1,0 +1,35 @@
+diff --git a/Makefile.system b/Makefile.system
+index b89f60e..2dbdad0 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -139,6 +139,10 @@ NO_PARALLEL_MAKE=0
+ endif
+ GETARCH_FLAGS  += -DNO_PARALLEL_MAKE=$(NO_PARALLEL_MAKE)
+ 
++ifdef MAKE_NO_J
++GETARCH_FLAGS += -DMAKE_NO_J=$(MAKE_NO_J)
++endif
++
+ ifdef MAKE_NB_JOBS
+ GETARCH_FLAGS += -DMAKE_NB_JOBS=$(MAKE_NB_JOBS)
+ endif
+diff --git a/getarch.c b/getarch.c
+index f9c49e6..dffad70 100644
+--- a/getarch.c
++++ b/getarch.c
+@@ -1012,6 +1012,7 @@ int main(int argc, char *argv[]){
+ #endif
+ #endif
+ 
++#ifndef MAKE_NO_J
+ #ifdef MAKE_NB_JOBS
+     printf("MAKE += -j %d\n", MAKE_NB_JOBS);
+ #elif NO_PARALLEL_MAKE==1
+@@ -1021,6 +1022,7 @@ int main(int argc, char *argv[]){
+     printf("MAKE += -j %d\n", get_num_cores());
+ #endif
+ #endif
++#endif
+ 
+     break;
+ 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -19,13 +19,15 @@ class Openblas(Package):
     provides('blas')
     provides('lapack')
 
+    patch('make.patch')
 
     def install(self, spec, prefix):
         # Openblas is picky about compilers. Configure fails with
         # FC=/abs/path/to/f77, whereas FC=f77 works fine.
         # To circumvent this, provide basename only:
         make_defs = ['CC=%s' % os.path.basename(spack_cc),
-                     'FC=%s' % os.path.basename(spack_f77)]
+                     'FC=%s' % os.path.basename(spack_f77),
+                     'MAKE_NO_J=1']
 
         make_targets = ['libs', 'netlib']
 


### PR DESCRIPTION
By default, OpenBLAS overrides the "make -jN" option. This patch disables this overriding.