### PR TITLE
Re-add hwloc as a dependency of openmpi

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -34,6 +34,8 @@ class Openmpi(Package):
     provides('mpi@:2.2', when='@1.6.5')
     provides('mpi@:3.0', when='@1.7.5:')
 
+    depends_on('hwloc')
+
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
@@ -48,6 +50,7 @@ class Openmpi(Package):
 
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,
+                       "--with-hwloc=%s" % spec['hwloc'].prefix,
                        "--enable-shared",
                        "--enable-static"]
 


### PR DESCRIPTION
In #810, I removed OpenMPI's dependency on hwloc because it can be built with an internal hwloc that comes with it. As it turns out, the hwloc that comes with OpenMPI is a bit behind the latest version of hwloc, so it is better to build it with an external package. Thanks for pointing this out @eschnett 