### PR TITLE
Introduce variables for MPI compiler wrappers and document their usage

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1831,6 +1831,23 @@ successfully find ``libdwarf.h`` and ``libdwarf.so``, without the
 packager having to provide ``--with-libdwarf=/path/to/libdwarf`` on
 the command line.
 
+Message Parsing Interface (MPI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is common for high performance computing software/packages to use ``MPI``.
+As a result of conretization, a given package can be built using different
+implementations of MPI such as ``Openmpi``, ``MPICH`` or ``IntelMPI``.
+In some scenarios to configure a package one have to provide it with appropriate MPI
+compiler wrappers such as ``mpicc``, ``mpic++``.
+However different implementations of ``MPI`` may have different names for those
+wrappers.  In order to make package's ``install()`` method indifferent to the
+choice ``MPI`` implementation, each package which implements ``MPI`` sets up
+``self.spec.mpicc``, ``self.spec.mpicxx``, ``self.spec.mpifc`` and ``self.spec.mpif77``
+to point to ``C``, ``C++``, ``Fortran 90`` and ``Fortran 77`` ``MPI`` wrappers.
+Package developers are advised to use these variables, for example ``self.spec['mpi'].mpicc``
+instead of hard-coding ``join_path(self.spec['mpi'].prefix.bin, 'mpicc')`` for
+the reasons outlined above.
+
+
 Forking ``install()``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -54,6 +54,11 @@ class Mpich(Package):
         spack_env.set('MPICH_F90', spack_fc)
         spack_env.set('MPICH_FC', spack_fc)
 
+        self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+        self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
+        self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+        self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+
     def setup_dependent_package(self, module, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
         # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -60,10 +60,6 @@ class Mpich(Package):
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
-        """For dependencies, make mpicc's use spack wrapper."""
-        # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?
-        module.mpicc = join_path(self.prefix.bin, 'mpicc')
-
     def install(self, spec, prefix):
         config_args = ["--prefix=" + prefix,
                        "--enable-shared"]

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -54,12 +54,12 @@ class Mpich(Package):
         spack_env.set('MPICH_F90', spack_fc)
         spack_env.set('MPICH_FC', spack_fc)
 
+    def setup_dependent_package(self, module, dep_spec):
         self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
-    def setup_dependent_package(self, module, dep_spec):
         """For dependencies, make mpicc's use spack wrapper."""
         # FIXME : is this necessary ? Shouldn't this be part of a contract with MPI providers?
         module.mpicc = join_path(self.prefix.bin, 'mpicc')

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -146,6 +146,10 @@ class Mvapich2(Package):
         spack_env.set('MPICH_F77', spack_f77)
         spack_env.set('MPICH_F90', spack_fc)
         spack_env.set('MPICH_FC', spack_fc)
+        self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+        self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
+        self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+        self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     def install(self, spec, prefix):
         # we'll set different configure flags depending on our environment

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -146,6 +146,8 @@ class Mvapich2(Package):
         spack_env.set('MPICH_F77', spack_f77)
         spack_env.set('MPICH_F90', spack_fc)
         spack_env.set('MPICH_FC', spack_fc)
+
+    def setup_dependent_package(self, module, dep_spec):
         self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -45,6 +45,11 @@ class Openmpi(Package):
         spack_env.set('OMPI_FC', spack_fc)
         spack_env.set('OMPI_F77', spack_f77)
 
+        self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+        self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
+        self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+        self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+
 
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -45,6 +45,7 @@ class Openmpi(Package):
         spack_env.set('OMPI_FC', spack_fc)
         spack_env.set('OMPI_F77', spack_f77)
 
+    def setup_dependent_package(self, module, dep_spec):
         self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')

--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -24,10 +24,10 @@ class P4est(Package):
                    '--without-blas',
                    'CPPFLAGS=-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL',
                    'CFLAGS=-O2',
-                   'CC=%s' % join_path(self.spec['mpi'].prefix.bin, 'mpicc'), # TODO: use ENV variables or MPI class wrappers
-                   'CXX=%s' % join_path(self.spec['mpi'].prefix.bin, 'mpic++'),
-                   'FC=%s' % join_path(self.spec['mpi'].prefix.bin, 'mpif90'),
-                   'F77=%s' % join_path(self.spec['mpi'].prefix.bin, 'mpif77'),
+                   'CC=%s'  % self.spec['mpi'].mpicc,
+                   'CXX=%s' % self.spec['mpi'].mpicxx,
+                   'FC=%s'  % self.spec['mpi'].mpifc,
+                   'F77=%s' % self.spec['mpi'].mpif77
                   ]
 
         configure('--prefix=%s' % prefix, *options)


### PR DESCRIPTION
in the spirit of https://github.com/LLNL/spack/pull/657  .

tested with `spack install p4est ^mpich` and `spack install p4est ^openmpi`. Both compile fine.
`p4est ^mpich` have a few failed checks, but it is a separate issue not related to this PR.

@eschnett @alalazo @citibeth @lee218llnl @mathstuf  @tgamblin ping.

fixes https://github.com/LLNL/spack/issues/572 



