### PR TITLE
Build Subversion with HTTP/S support

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -1,0 +1,13 @@
+from spack import *
+
+class Scons(Package):
+    """SCons is a software construction tool"""
+    homepage = "http://scons.org"
+    url      = "http://downloads.sourceforge.net/project/scons/scons/2.5.0/scons-2.5.0.tar.gz"
+
+    version('2.5.0', '9e00fa0df8f5ca5c5f5975b40e0ed354')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+class Serf(Package):
+    """Apache Serf - a high performance C-based HTTP client library built upon the Apache Portable Runtime (APR) library"""
+    homepage  = 'https://serf.apache.org/'
+    url       = 'https://archive.apache.org/dist/serf/serf-1.3.8.tar.bz2'
+
+    version('1.3.8',     '1d45425ca324336ce2f4ae7d7b4cfbc5567c5446')
+
+    depends_on('apr')
+    depends_on('apr-util')
+    depends_on('scons')
+    depends_on('expat')
+    depends_on('openssl')
+
+    def install(self, spec, prefix):
+        scons = which("scons")
+
+        options = ['PREFIX=%s' % prefix]
+        options.append('APR=%s' % spec['apr'].prefix)
+        options.append('APU=%s' % spec['apr-util'].prefix)
+        options.append('OPENSSL=%s' % spec['openssl'].prefix)
+        options.append('LINKFLAGS=-L%s/lib' % spec['expat'].prefix)
+        options.append('CPPFLAGS=-I%s/include' % spec['expat'].prefix)
+
+        scons(*options)
+        scons('install')

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -37,6 +37,7 @@ class Subversion(Package):
     depends_on('apr-util')
     depends_on('zlib')
     depends_on('sqlite')
+    depends_on('serf')
 
     # Optional: We need swig if we want the Perl, Python or Ruby
     # bindings.
@@ -54,6 +55,7 @@ class Subversion(Package):
         options.append('--with-apr-util=%s' % spec['apr-util'].prefix)
         options.append('--with-zlib=%s' % spec['zlib'].prefix)
         options.append('--with-sqlite=%s' % spec['sqlite'].prefix)
+        options.append('--with-serf=%s' % spec['serf'].prefix)
         #options.append('--with-swig=%s' % spec['swig'].prefix)
 
         configure(*options)


### PR DESCRIPTION
## PR to allow subversion to access http/s repos.

Subversion can interact with http/s repositories if you build it with Apache Serf. Serf requires Scons as its build utility instead of CMake or Autoconf.

I did not make this optional, because it is a fairly common use case for our users, but if y'all think it should be an optional dependency, I will be happy to fix it.

:smile: 