### PR TITLE
BBCP

### DIFF
--- a/var/spack/repos/builtin/packages/bbcp/package.py
+++ b/var/spack/repos/builtin/packages/bbcp/package.py
@@ -1,0 +1,17 @@
+from spack import *
+
+class Bbcp(Package):
+    """Securely and quickly copy data from source to target"""
+    homepage = "http://www.slac.stanford.edu/~abh/bbcp/"
+
+    version('git', git='http://www.slac.stanford.edu/~abh/bbcp/bbcp.git', branch="master")
+
+    def install(self, spec, prefix):
+        cd("src")
+        make()
+        # BBCP wants to build the executable in a directory whose name depends on the system type
+        makesname = Executable("../MakeSname")
+        bbcp_executable_path = "../bin/%s/bbcp" % makesname(output=str).rstrip("\n")
+        destination_path = "%s/bin/" % prefix
+        mkdirp(destination_path)
+        install(bbcp_executable_path, destination_path)


### PR DESCRIPTION
This is a parallel copy utility -- slightly smarter than scp, not quite as sophisticated as gridftp/globus.

The default repo at Stanford doesn't support cloning with --depth, so it throws an error, but ends up cloning anyways. 