### PR TITLE
Disable -Werror

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -29,6 +29,7 @@ class Binutils(Package):
         configure_args = [
             '--prefix=%s' % prefix,
             '--disable-dependency-tracking',
+            '--disable-werror',
             '--enable-interwork',
             '--enable-multilib',
             '--enable-shared',


### PR DESCRIPTION
This leads to problems if new compiler versions report new kinds of warnings.