### PR TITLE
Make install directory a config option

### DIFF
--- a/etc/spack/install.yaml
+++ b/etc/spack/install.yaml
@@ -1,0 +1,8 @@
+# -------------------------------------------------------------------------
+# This is the default spack install setup configuration.
+#
+# Changes to this file will affect all users of this spack install
+# -------------------------------------------------------------------------
+install:
+    path: $spack/opt/spack
+    layout : YamlDirectoryLayout

--- a/lib/spack/docs/site_configuration.rst
+++ b/lib/spack/docs/site_configuration.rst
@@ -3,6 +3,17 @@
 Site configuration
 ===================================
 
+.. _install-area:
+
+Install options
+----------------------------
+
+By default, Spack will install software into ``opt/spack``.
+To set a custom install directory, the option ``path`` in
+``install.yaml`` can be used. This file can be found
+in a Spack installation's ``etc/spack/`` or a user's ``~/.spack/``
+directory.
+
 .. _temp-space:
 
 Temporary space

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -120,7 +120,7 @@ _tmp_user = getpass.getuser()
 _tmp_candidates = (_default_tmp, '/nfs/tmp2', '/tmp', '/var/tmp')
 for path in _tmp_candidates:
     # don't add a second username if it's already unique by user.
-    if not _tmp_user in path:
+    if _tmp_user not in path:
         tmp_dirs.append(join_path(path, '%u', 'spack-stage'))
     else:
         tmp_dirs.append(join_path(path, 'spack-stage'))
@@ -152,12 +152,14 @@ sys_type = None
 # Spack internal code should call 'import spack' and accesses other
 # variables (spack.repo, paths, etc.) directly.
 #
-# TODO: maybe this should be separated out and should go in build_environment.py?
-# TODO: it's not clear where all the stuff that needs to be included in packages
+# TODO: maybe this should be separated out and
+#       should go in build_environment.py?
+# TODO: it's not clear where all the stuff that needs
+#       to be included in packages
 #       should live.  This file is overloaded for spack core vs. for packages.
 #
 __all__ = ['Package', 'Version', 'when', 'ver']
-from spack.package import Package, ExtensionConflictError
+from spack.package import Package
 from spack.version import Version, ver
 from spack.multimethod import when
 
@@ -174,8 +176,8 @@ from spack.util.executable import *
 __all__ += spack.util.executable.__all__
 
 from spack.package import \
-    install_dependency_symlinks, flatten_dependencies, DependencyConflictError, \
-    InstallError, ExternalPackageError
+    install_dependency_symlinks, flatten_dependencies, \
+    DependencyConflictError, InstallError, ExternalPackageError
 __all__ += [
-    'install_dependency_symlinks', 'flatten_dependencies', 'DependencyConflictError',
-    'InstallError', 'ExternalPackageError']
+    'install_dependency_symlinks', 'flatten_dependencies',
+    'DependencyConflictError', 'InstallError', 'ExternalPackageError']

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -49,7 +49,6 @@ share_path     = join_path(spack_root, "share", "spack")
 
 prefix = spack_root
 opt_path       = join_path(prefix, "opt")
-install_path   = join_path(opt_path, "spack")
 etc_path       = join_path(prefix, "etc")
 
 #
@@ -63,23 +62,10 @@ except spack.error.SpackError, e:
     tty.die('while initializing Spack RepoPath:', e.message)
 
 #
-# Set up the installed packages database
-#
-from spack.database import Database
-installed_db = Database(install_path)
-
-#
 # Paths to built-in Spack repositories.
 #
 packages_path      = join_path(repos_path, "builtin")
 mock_packages_path = join_path(repos_path, "builtin.mock")
-
-#
-# This controls how spack lays out install prefixes and
-# stage directories.
-#
-from spack.directory_layout import YamlDirectoryLayout
-install_layout = YamlDirectoryLayout(install_path)
 
 #
 # This controls how packages are sorted when trying to choose

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -39,7 +39,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import *
 from spack.environment import EnvironmentModifications, validate
 from spack.util.environment import *
-from spack.util.executable import Executable, which
+from spack.util.executable import Executable
 
 #
 # This can be set by the user to globally disable parallel builds.

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -34,6 +34,7 @@ import shutil
 import sys
 
 import spack
+import spack.install_area
 import llnl.util.tty as tty
 from llnl.util.filesystem import *
 from spack.environment import EnvironmentModifications, validate
@@ -158,7 +159,7 @@ def set_build_environment_variables(pkg, env):
     env.set(SPACK_PREFIX, pkg.prefix)
 
     # Install root prefix
-    env.set(SPACK_INSTALL, spack.install_path)
+    env.set(SPACK_INSTALL, spack.install_area.path)
 
     # Remove these vars from the environment during build because they
     # can affect how some packages find libraries.  We want to make

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -64,7 +64,6 @@ SPACK_DEBUG_LOG_DIR    = 'SPACK_DEBUG_LOG_DIR'
 dso_suffix = 'dylib' if sys.platform == 'darwin' else 'so'
 
 
-
 class MakeExecutable(Executable):
     """Special callable executable object for make so the user can
        specify parallel or not on a per-invocation basis.  Using
@@ -93,11 +92,13 @@ class MakeExecutable(Executable):
 def set_compiler_environment_variables(pkg, env):
     assert pkg.spec.concrete
     # Set compiler variables used by CMake and autotools
-    assert all(key in pkg.compiler.link_paths for key in ('cc', 'cxx', 'f77', 'fc'))
+    assert all(key in pkg.compiler.link_paths
+               for key in ('cc', 'cxx', 'f77', 'fc'))
 
     # Populate an object with the list of environment modifications
     # and return it
-    # TODO : add additional kwargs for better diagnostics, like requestor, ttyout, ttyerr, etc.
+    # TODO : add additional kwargs for better diagnostics,
+    #        like requestor, ttyout, ttyerr, etc.
     link_dir = spack.build_env_path
     env.set('CC',  join_path(link_dir, pkg.compiler.link_paths['cc']))
     env.set('CXX', join_path(link_dir, pkg.compiler.link_paths['cxx']))
@@ -140,7 +141,8 @@ def set_build_environment_variables(pkg, env):
     # handled by putting one in the <build_env_path>/case-insensitive
     # directory.  Add that to the path too.
     env_paths = []
-    for item in [spack.build_env_path, join_path(spack.build_env_path, pkg.compiler.name)]:
+    for item in [spack.build_env_path,
+                 join_path(spack.build_env_path, pkg.compiler.name)]:
         env_paths.append(item)
         ci = join_path(item, 'case-insensitive')
         if os.path.isdir(ci):
@@ -153,7 +155,8 @@ def set_build_environment_variables(pkg, env):
     # Prefixes of all of the package's dependencies go in SPACK_DEPENDENCIES
     dep_prefixes = [d.prefix for d in pkg.spec.traverse(root=False)]
     env.set_path(SPACK_DEPENDENCIES, dep_prefixes)
-    env.set_path('CMAKE_PREFIX_PATH', dep_prefixes)  # Add dependencies to CMAKE_PREFIX_PATH
+    # Add dependencies to CMAKE_PREFIX_PATH
+    env.set_path('CMAKE_PREFIX_PATH', dep_prefixes)
 
     # Install prefix
     env.set(SPACK_PREFIX, pkg.prefix)
@@ -169,7 +172,8 @@ def set_build_environment_variables(pkg, env):
     env.unset('DYLD_LIBRARY_PATH')
 
     # Add bin directories from dependencies to the PATH for the build.
-    bin_dirs = reversed(filter(os.path.isdir, ['%s/bin' % prefix for prefix in dep_prefixes]))
+    bin_dirs = reversed(filter(os.path.isdir,
+                        ['%s/bin' % prefix for prefix in dep_prefixes]))
     for item in bin_dirs:
         env.prepend_path('PATH', item)
 
@@ -230,7 +234,8 @@ def set_module_variables_for_package(pkg, module):
 
     # Set up CMake rpath
     m.std_cmake_args.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE')
-    m.std_cmake_args.append('-DCMAKE_INSTALL_RPATH=%s' % ":".join(get_rpaths(pkg)))
+    m.std_cmake_args.append('-DCMAKE_INSTALL_RPATH=%s'
+                            % ":".join(get_rpaths(pkg)))
 
     # Put spack compiler paths in module scope.
     link_dir = spack.build_env_path
@@ -273,13 +278,16 @@ def get_rpaths(pkg):
 
 
 def parent_class_modules(cls):
-    """Get list of super class modules that are all descend from spack.Package"""
+    """
+    Get list of super class modules that are
+    all descend from spack.Package
+    """
     if not issubclass(cls, spack.Package) or issubclass(spack.Package, cls):
         return []
     result = []
     module = sys.modules.get(cls.__module__)
     if module:
-        result = [ module ]
+        result = [module]
     for c in cls.__bases__:
         result.extend(parent_class_modules(c))
     return result
@@ -304,7 +312,8 @@ def setup_package(pkg):
     # throwaway environment, but it is kind of dirty.
     #
     # TODO: Think about how to avoid this fix and do something cleaner.
-    for s in pkg.spec.traverse(): s.package.spec = s
+    for s in pkg.spec.traverse():
+        s.package.spec = s
 
     set_compiler_environment_variables(pkg, spack_env)
     set_build_environment_variables(pkg, spack_env)
@@ -392,7 +401,8 @@ def fork(pkg, function):
         # message.  Just make the parent exit with an error code.
         pid, returncode = os.waitpid(pid, 0)
         if returncode != 0:
-            raise InstallError("Installation process had nonzero exit code.".format(str(returncode)))
+            raise InstallError("Installation process had nonzero exit code."
+                               .format(str(returncode)))
 
 
 class InstallError(spack.error.SpackError):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -32,7 +32,7 @@ from llnl.util.lang import attr_setdefault
 import spack
 import spack.spec
 import spack.config
-
+import spack.install_area
 #
 # Settings for commands that modify configuration
 #
@@ -133,7 +133,7 @@ def elide_list(line_list, max_num=10):
 
 
 def disambiguate_spec(spec):
-    matching_specs = spack.installed_db.query(spec)
+    matching_specs = spack.install_area.db.query(spec)
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -36,7 +36,8 @@ import spack.install_area
 #
 # Settings for commands that modify configuration
 #
-# Commands that modify confguration By default modify the *highest* priority scope.
+# Commands that modify confguration.
+# By default modify the *highest* priority scope.
 default_modify_scope = spack.config.highest_precedence_scope().name
 # Commands that list confguration list *all* scopes by default.
 default_list_scope = None
@@ -71,7 +72,7 @@ def get_module(name):
         module_name, fromlist=[name, SETUP_PARSER, DESCRIPTION],
         level=0)
 
-    attr_setdefault(module, SETUP_PARSER, lambda *args: None) # null-op
+    attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op
     attr_setdefault(module, DESCRIPTION, "")
 
     fn_name = get_cmd_function_name(name)
@@ -101,7 +102,7 @@ def parse_specs(args, **kwargs):
         specs = spack.spec.parse(args)
         for spec in specs:
             if concretize:
-                spec.concretize() # implies normalize
+                spec.concretize()  # implies normalize
             elif normalize:
                 spec.normalize()
 
@@ -127,7 +128,7 @@ def elide_list(line_list, max_num=10):
            [1, 2, 3, '...', 6]
     """
     if len(line_list) > max_num:
-        return line_list[:max_num-1] + ['...'] + line_list[-1:]
+        return line_list[:max_num - 1] + ['...'] + line_list[-1:]
     else:
         return line_list
 
@@ -138,7 +139,7 @@ def disambiguate_spec(spec):
         tty.die("Spec '%s' matches no installed packages." % spec)
 
     elif len(matching_specs) > 1:
-        args =  ["%s matches multiple packages." % spec,
+        args  = ["%s matches multiple packages." % spec,
                  "Matching packages:"]
         args += ["  " + str(s) for s in matching_specs]
         args += ["Use a more specific spec."]

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -27,6 +27,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
+import spack.install_area
 from spack.graph import topological_sort
 
 description = "Deactivate a package extension."
@@ -54,7 +55,7 @@ def deactivate(parser, args):
     if args.all:
         if pkg.extendable:
             tty.msg("Deactivating all extensions of %s" % pkg.spec.short_spec)
-            ext_pkgs = spack.installed_db.installed_extensions_for(spec)
+            ext_pkgs = spack.install_area.db.installed_extensions_for(spec)
 
             for ext_pkg in ext_pkgs:
                 ext_pkg.spec.normalize()

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -32,6 +32,7 @@ from spack.graph import topological_sort
 
 description = "Deactivate a package extension."
 
+
 def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true',
@@ -41,7 +42,8 @@ def setup_parser(subparser):
         help="Deactivate all extensions of an extendable package, or "
         "deactivate an extension AND its dependencies.")
     subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER, help="spec of package extension to deactivate.")
+        'spec', nargs=argparse.REMAINDER,
+        help="spec of package extension to deactivate.")
 
 
 def deactivate(parser, args):
@@ -66,7 +68,8 @@ def deactivate(parser, args):
             if not args.force and not spec.package.activated:
                 tty.die("%s is not activated." % pkg.spec.short_spec)
 
-            tty.msg("Deactivating %s and all dependencies." % pkg.spec.short_spec)
+            tty.msg("Deactivating %s and all dependencies."
+                    % pkg.spec.short_spec)
 
             topo_order = topological_sort(spec)
             index = spec.index()
@@ -80,7 +83,8 @@ def deactivate(parser, args):
                         epkg.do_deactivate(force=args.force)
 
         else:
-            tty.die("spack deactivate --all requires an extendable package or an extension.")
+            tty.die("spack deactivate --all requires an " +
+                    "extendable package or an extension.")
 
     else:
         if not pkg.is_extension:

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -36,6 +36,7 @@ from spack.stage import DIYStage
 
 description = "Do-It-Yourself: build from an existing source directory."
 
+
 def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
@@ -77,14 +78,16 @@ def diy(self, args):
                 return
 
         if not spec.versions.concrete:
-            tty.die("spack diy spec must have a single, concrete version.  Did you forget a package version number?")
+            tty.die("spack diy spec must have a single, concrete version. " +
+                    "Did you forget a package version number?")
 
         spec.concretize()
         package = spack.repo.get(spec)
 
         if package.installed:
             tty.error("Already installed in %s" % package.prefix)
-            tty.msg("Uninstall or try adding a version suffix for this DIY build.")
+            tty.msg("Uninstall or try adding a version suffix " +
+                    "for this DIY build.")
             sys.exit(1)
 
         # Forces the build to run out of the current directory.

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -30,6 +30,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
+import spack.install_area
 from spack.cmd.edit import edit_package
 from spack.stage import DIYStage
 
@@ -62,7 +63,7 @@ def diy(self, args):
         tty.die("spack diy only takes one spec.")
 
     # Take a write lock before checking for existence.
-    with spack.installed_db.write_transaction():
+    with spack.install_area.db.write_transaction():
         spec = specs[0]
         if not spack.repo.exists(spec.name):
             tty.warn("No such package: %s" % spec.name)

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -22,7 +22,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import sys
 import argparse
 
 import llnl.util.tty as tty
@@ -34,6 +33,7 @@ import spack.cmd.find
 import spack.install_area
 
 description = "List extensions for package."
+
 
 def setup_parser(subparser):
     format_group = subparser.add_mutually_exclusive_group()
@@ -48,7 +48,8 @@ def setup_parser(subparser):
         help='Show full dependency DAG of extensions')
 
     subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER, help='Spec of package to list extensions for')
+        'spec', nargs=argparse.REMAINDER,
+        help='Spec of package to list extensions for')
 
 
 def extensions(parser, args):
@@ -86,7 +87,8 @@ def extensions(parser, args):
     #
     # List specs of installed extensions.
     #
-    installed = [s.spec for s in spack.install_area.db.installed_extensions_for(spec)]
+    installed = [s.spec for s in
+                 spack.install_area.db.installed_extensions_for(spec)]
     print
     if not installed:
         tty.msg("None installed.")
@@ -103,4 +105,6 @@ def extensions(parser, args):
         tty.msg("None activated.")
         return
     tty.msg("%d currently activated:" % len(activated))
-    spack.cmd.find.display_specs(activated.values(), mode=args.mode, long=args.long)
+    spack.cmd.find.display_specs(activated.values(),
+                                 mode=args.mode,
+                                 long=args.long)

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -31,6 +31,7 @@ from llnl.util.tty.colify import colify
 import spack
 import spack.cmd
 import spack.cmd.find
+import spack.install_area
 
 description = "List extensions for package."
 
@@ -85,7 +86,7 @@ def extensions(parser, args):
     #
     # List specs of installed extensions.
     #
-    installed = [s.spec for s in spack.installed_db.installed_extensions_for(spec)]
+    installed = [s.spec for s in spack.install_area.db.installed_extensions_for(spec)]
     print
     if not installed:
         tty.msg("None installed.")
@@ -96,7 +97,7 @@ def extensions(parser, args):
     #
     # List specs of activated extensions.
     #
-    activated = spack.install_layout.extension_map(spec)
+    activated = spack.install_area.layout.extension_map(spec)
     print
     if not activated:
         tty.msg("None activated.")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -35,7 +35,7 @@ from llnl.util.lang import *
 
 import spack
 import spack.spec
-
+import spack.install_area
 description ="Find installed spack packages"
 
 def setup_parser(subparser):
@@ -167,9 +167,9 @@ def find(parser, args):
 
     # Get all the specs the user asked for
     if not query_specs:
-        specs = set(spack.installed_db.query(**q_args))
+        specs = set(spack.install_area.db.query(**q_args))
     else:
-        results = [set(spack.installed_db.query(qs, **q_args)) for qs in query_specs]
+        results = [set(spack.install_area.db.query(qs, **q_args)) for qs in query_specs]
         specs = set.union(*results)
 
     if not args.mode:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -23,10 +23,7 @@
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import sys
-import collections
-import itertools
 import argparse
-from StringIO import StringIO
 
 import llnl.util.tty as tty
 from llnl.util.tty.colify import *
@@ -36,7 +33,8 @@ from llnl.util.lang import *
 import spack
 import spack.spec
 import spack.install_area
-description ="Find installed spack packages"
+description = "Find installed spack packages"
+
 
 def setup_parser(subparser):
     format_group = subparser.add_mutually_exclusive_group()
@@ -94,14 +92,15 @@ def display_specs(specs, **kwargs):
 
     # Traverse the index and print out each package
     for i, (architecture, compiler) in enumerate(sorted(index)):
-        if i > 0: print
+        if i > 0:
+            print
 
         header = "%s{%s} / %s{%s}" % (
             spack.spec.architecture_color, architecture,
             spack.spec.compiler_color, compiler)
         tty.hline(colorize(header), char='-')
 
-        specs = index[(architecture,compiler)]
+        specs = index[(architecture, compiler)]
         specs.sort()
 
         nfmt = '.' if namespace else '_'
@@ -137,8 +136,8 @@ def display_specs(specs, **kwargs):
 
         else:
             raise ValueError(
-                "Invalid mode for display_specs: %s. Must be one of (paths, deps, short)." % mode)
-
+                "Invalid mode for display_specs: " +
+                "%s. Must be one of (paths, deps, short)." % mode)
 
 
 def find(parser, args):
@@ -163,13 +162,14 @@ def find(parser, args):
         installed = any
     if args.unknown:
         known = False
-    q_args = { 'installed' : installed, 'known' : known }
+    q_args = {'installed': installed, 'known': known}
 
     # Get all the specs the user asked for
     if not query_specs:
         specs = set(spack.install_area.db.query(**q_args))
     else:
-        results = [set(spack.install_area.db.query(qs, **q_args)) for qs in query_specs]
+        results = [set(spack.install_area.db.query(qs, **q_args))
+                   for qs in query_specs]
         specs = set.union(*results)
 
     if not args.mode:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -28,6 +28,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
+import spack.install_area
 
 description = "Build and install packages"
 
@@ -71,7 +72,7 @@ def install(parser, args):
     specs = spack.cmd.parse_specs(args.packages, concretize=True)
     for spec in specs:
         package = spack.repo.get(spec)
-        with spack.installed_db.write_transaction():
+        with spack.install_area.db.write_transaction():
             package.do_install(
                 keep_prefix=args.keep_prefix,
                 keep_stage=args.keep_stage,

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -32,6 +32,7 @@ import spack.install_area
 
 description = "Build and install packages"
 
+
 def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
@@ -53,9 +54,11 @@ def setup_parser(subparser):
         help="Display verbose build output while installing.")
     subparser.add_argument(
         '--fake', action='store_true', dest='fake',
-        help="Fake install.  Just remove the prefix and touch a fake file in it.")
+        help="Fake install. Just remove the prefix and touch " +
+             "a fake file in it.")
     subparser.add_argument(
-        'packages', nargs=argparse.REMAINDER, help="specs of packages to install")
+        'packages', nargs=argparse.REMAINDER,
+        help="specs of packages to install")
 
 
 def install(parser, args):

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -86,7 +86,8 @@ def module_find(mtype, spec_array):
 def module_refresh():
     """Regenerate all module files for installed packages known to
        spack (some packages may no longer exist)."""
-    specs = [s for s in spack.install_area.db.query(installed=True, known=True)]
+    specs = [s for s in spack.install_area.db.query(installed=True,
+                                                    known=True)]
 
     for name, cls in module_types.items():
         tty.msg("Regenerating %s module files." % name)

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -28,6 +28,7 @@ import sys
 
 import llnl.util.tty as tty
 import spack.cmd
+import spack.install_area
 from llnl.util.filesystem import mkdirp
 from spack.modules import module_types
 from spack.util.string import *
@@ -64,7 +65,7 @@ def module_find(mtype, spec_array):
         tty.die("You can only pass one spec.")
     spec = specs[0]
 
-    specs = spack.installed_db.query(spec)
+    specs = spack.install_area.db.query(spec)
     if len(specs) == 0:
         tty.die("No installed packages match spec %s" % spec)
 
@@ -85,7 +86,7 @@ def module_find(mtype, spec_array):
 def module_refresh():
     """Regenerate all module files for installed packages known to
        spack (some packages may no longer exist)."""
-    specs = [s for s in spack.installed_db.query(installed=True, known=True)]
+    specs = [s for s in spack.install_area.db.query(installed=True, known=True)]
 
     for name, cls in module_types.items():
         tty.msg("Regenerating %s module files." % name)

--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -22,7 +22,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import argparse
 import spack
 import spack.install_area
 description = "Rebuild Spack's package database."

--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -24,8 +24,8 @@
 ##############################################################################
 import argparse
 import spack
-
+import spack.install_area
 description = "Rebuild Spack's package database."
 
 def reindex(parser, args):
-    spack.installed_db.reindex(spack.install_layout)
+    spack.install_area.db.reindex(spack.install_area.layout)

--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -27,5 +27,6 @@ import spack
 import spack.install_area
 description = "Rebuild Spack's package database."
 
+
 def reindex(parser, args):
     spack.install_area.db.reindex(spack.install_area.layout)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -59,32 +59,42 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-a', '--all', action='store_true', dest='all',
         help="USE CAREFULLY. Remove ALL installed packages that match each " +
-             "supplied spec. i.e., if you say uninstall libelf, ALL versions of " +
-             "libelf are uninstalled. This is both useful and dangerous, like rm -r.")
+             "supplied spec. i.e., if you say uninstall libelf, " +
+             "ALL versions of libelf are uninstalled. This is both " +
+             "useful and dangerous, like rm -r.")
     subparser.add_argument(
         '-d', '--dependents', action='store_true', dest='dependents',
-        help='Also uninstall any packages that depend on the ones given via command line.'
+        help='Also uninstall any packages that depend on the ones ' +
+             'given via command line.'
     )
     subparser.add_argument(
         '-y', '--yes-to-all', action='store_true', dest='yes_to_all',
-        help='Assume "yes" is the answer to every confirmation asked to the user.'
+        help='Assume "yes" is the answer to every confirmation ' +
+             'asked to the user.'
 
     )
-    subparser.add_argument('packages', nargs=argparse.REMAINDER, help="specs of packages to uninstall")
+    subparser.add_argument(
+        'packages', nargs=argparse.REMAINDER,
+        help="specs of packages to uninstall")
 
 
 def concretize_specs(specs, allow_multiple_matches=False, force=False):
     """
-    Returns a list of specs matching the non necessarily concretized specs given from cli
+    Returns a list of specs matching the non necessarily concretized
+    specs given from cli
 
     Args:
         specs: list of specs to be matched against installed packages
-        allow_multiple_matches : boolean (if True multiple matches for each item in specs are admitted)
+        allow_multiple_matches : boolean (if True multiple matches
+                                          for each item in specs
+                                          are admitted)
 
     Return:
         list of specs
     """
-    specs_from_cli = []  # List of specs that match expressions given via command line
+    #  List of specs that match expressions given via command line
+    specs_from_cli = []
+
     has_errors = False
     for spec in specs:
         matching = spack.install_area.db.query(spec)
@@ -111,7 +121,8 @@ def concretize_specs(specs, allow_multiple_matches=False, force=False):
 
 def installed_dependents(specs):
     """
-    Returns a dictionary that maps a spec with a list of its installed dependents
+    Returns a dictionary that maps a spec with a list of
+    its installed dependents
 
     Args:
         specs: list of specs to be checked for dependents
@@ -163,14 +174,17 @@ def uninstall(parser, args):
     with spack.install_area.db.write_transaction():
         specs = spack.cmd.parse_specs(args.packages)
         # Gets the list of installed specs that match the ones give via cli
-        uninstall_list = concretize_specs(specs, args.all, args.force)  # takes care of '-a' is given in the cli
-        dependent_list = installed_dependents(uninstall_list)  # takes care of '-d'
+        #   takes care of '-a' is given in the cli
+        uninstall_list = concretize_specs(specs, args.all, args.force)
+        #   takes care of '-d'
+        dependent_list = installed_dependents(uninstall_list)
 
         # Process dependent_list and update uninstall_list
         has_error = False
         if dependent_list and not args.dependents and not args.force:
             for spec, lst in dependent_list.items():
-                tty.error("Will not uninstall %s" % spec.format("$_$@$%@$#", color=True))
+                tty.error("Will not uninstall %s"
+                          % spec.format("$_$@$%@$#", color=True))
                 print('')
                 print("The following packages depend on it:")
                 display_specs(lst, long=True)
@@ -182,7 +196,8 @@ def uninstall(parser, args):
             uninstall_list = list(set(uninstall_list))
 
         if has_error:
-            tty.die('You can use spack uninstall --dependents to uninstall these dependencies as well')
+            tty.die('You can use spack uninstall --dependents ' +
+                    'to uninstall these dependencies as well')
 
         if not args.yes_to_all:
             tty.msg("The following packages will be uninstalled : ")

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -29,6 +29,7 @@ import argparse
 import llnl.util.tty as tty
 import spack
 import spack.cmd
+import spack.install_area
 import spack.repository
 from spack.cmd.find import display_specs
 
@@ -86,7 +87,7 @@ def concretize_specs(specs, allow_multiple_matches=False, force=False):
     specs_from_cli = []  # List of specs that match expressions given via command line
     has_errors = False
     for spec in specs:
-        matching = spack.installed_db.query(spec)
+        matching = spack.install_area.db.query(spec)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
@@ -159,7 +160,7 @@ def uninstall(parser, args):
     if not args.packages:
         tty.die("uninstall requires at least one package argument.")
 
-    with spack.installed_db.write_transaction():
+    with spack.install_area.db.write_transaction():
         specs = spack.cmd.parse_specs(args.packages)
         # Gets the list of installed specs that match the ones give via cli
         uninstall_list = concretize_specs(specs, args.all, args.force)  # takes care of '-a' is given in the cli

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -356,6 +356,23 @@ section_schemas = {
             },
         },
     },
+    'install': {
+        '$schema': 'http://json-schema.org/schema#',
+        'title': 'Spack module file configuration file schema',
+        'type': 'object',
+        'additionalProperties': False,
+        'patternProperties': {
+            'install': {
+                'type': 'object',
+                'default' : {},
+                'additionalProperties': False,
+                'properties': {
+                    'path' : { 'type': 'string' },
+                    'layout' : { 'type': 'string' }
+                }
+            },
+        },
+    }
 }
 
 """OrderedDict of config scopes keyed by name.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -51,10 +51,10 @@ from llnl.util.filesystem import *
 from llnl.util.lock import *
 
 import spack.spec
+import spack.install_area
 from spack.version import Version
-from spack.spec import Spec
 from spack.error import SpackError
-from spack.repository import UnknownPackageError
+import spack.repository
 
 # DB goes in this directory underneath the root
 _db_dirname = '.spack-db'
@@ -204,7 +204,7 @@ class Database(object):
         spec_dict = installs[hash_key]['spec']
 
         # Build spec from dict first.
-        spec = Spec.from_node_dict(spec_dict)
+        spec = spack.spec.Spec.from_node_dict(spec_dict)
 
         # Add dependencies from other records in the install DB to
         # form a full spec.
@@ -367,7 +367,7 @@ class Database(object):
         else:
             # The file doesn't exist, try to traverse the directory.
             # reindex() takes its own write lock, so no lock here.
-            self.reindex(spack.install_layout)
+            self.reindex(spack.install_area.layout)
 
 
     def _add(self, spec, path, directory_layout=None):
@@ -507,7 +507,7 @@ class Database(object):
             try:
                 if s.package.extends(extendee_spec):
                     yield s.package
-            except UnknownPackageError as e:
+            except spack.repository.UnknownPackageError as e:
                 continue
             # skips unknown packages
             # TODO: conditional way to do this instead of catching exceptions

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -40,7 +40,6 @@ filesystem.
 
 """
 import os
-import time
 import socket
 
 import yaml

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -34,7 +34,7 @@ import yaml
 import llnl.util.tty as tty
 from llnl.util.filesystem import join_path, mkdirp
 
-from spack.spec import Spec
+import spack.spec
 from spack.error import SpackError
 
 
@@ -225,7 +225,7 @@ class YamlDirectoryLayout(DirectoryLayout):
     def read_spec(self, path):
         """Read the contents of a file and parse them as a spec"""
         with open(path) as f:
-            spec = Spec.from_yaml(f)
+            spec = spack.spec.Spec.from_yaml(f)
 
         # Specs read from actual installations are always concrete
         spec._mark_concrete()

--- a/lib/spack/spack/install_area.py
+++ b/lib/spack/spack/install_area.py
@@ -1,0 +1,37 @@
+__author__ = "Benedikt Hegner (CERN)"
+
+import spack
+import re
+
+import llnl.util.tty as tty
+from llnl.util.filesystem import *
+
+#
+# Read in the config
+#
+import spack.config
+config = spack.config.get_config("install")
+
+#
+# Set up the install path
+#
+path = re.sub(r'^\$spack', spack.prefix, config['path'])
+
+#
+# Set up the installed packages database
+#
+from spack.database import Database
+db = Database(path)
+
+#
+# This controls how spack lays out install prefixes and
+# stage directories.
+#
+import spack.directory_layout
+
+try:
+    layout_name = config["layout"]
+    layout_class = getattr(spack.directory_layout,layout_name)
+    layout = layout_class(path)
+except:
+     tty.die("Invalid install directory layout %s chosen." %layout_name)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -577,7 +577,8 @@ class Package(object):
     @property
     def activated(self):
         if not self.is_extension:
-            raise ValueError("is_extension called on package that is not an extension.")
+            raise ValueError("is_extension called on package " +
+                             "that is not an extension.")
         exts = spack.install_area.layout.extension_map(self.extendee_spec)
         return (self.name in exts) and (exts[self.name] == self.spec)
 
@@ -1185,7 +1186,6 @@ class Package(object):
         spack.install_area.layout.check_extension_conflict(
             self.extendee_spec, self.spec)
 
-
         # Activate any package dependencies that are also extensions.
         if not force:
             for spec in self.spec.traverse(root=False):
@@ -1246,7 +1246,8 @@ class Package(object):
         # redundant activation check -- makes SURE the spec is not
         # still activated even if something was wrong above.
         if self.activated:
-            spack.install_area.layout.remove_extension(self.extendee_spec, self.spec)
+            spack.install_area.layout.remove_extension(self.extendee_spec,
+                                                       self.spec)
 
         tty.msg("Deactivated extension %s for %s"
                 % (self.spec.short_spec,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -41,6 +41,7 @@ import time
 import llnl.util.tty as tty
 import spack
 import spack.build_environment
+import spack.install_area
 import spack.compilers
 import spack.directives
 import spack.error
@@ -576,9 +577,8 @@ class Package(object):
     @property
     def activated(self):
         if not self.is_extension:
-            raise ValueError(
-                "is_extension called on package that is not an extension.")
-        exts = spack.install_layout.extension_map(self.extendee_spec)
+            raise ValueError("is_extension called on package that is not an extension.")
+        exts = spack.install_area.layout.extension_map(self.extendee_spec)
         return (self.name in exts) and (exts[self.name] == self.spec)
 
     def preorder_traversal(self, visited=None, **kwargs):
@@ -636,7 +636,7 @@ class Package(object):
         TODO: move this method to database.py?
         """
         dependents = []
-        for spec in spack.installed_db.query():
+        for spec in spack.install_area.db.query():
             if self.name == spec.name:
                 continue
             for dep in spec.traverse():
@@ -672,7 +672,7 @@ class Package(object):
         Removes the prefix for a package along with any empty parent
         directories
         """
-        spack.install_layout.remove_install_directory(self.spec)
+        spack.install_area.layout.remove_install_directory(self.spec)
 
     def do_fetch(self, mirror_only=False):
         """
@@ -859,7 +859,7 @@ class Package(object):
             return
 
         # Ensure package is not already installed
-        if spack.install_layout.check_installed(self.spec):
+        if spack.install_area.layout.check_installed(self.spec):
             tty.msg("%s is already installed in %s" % (self.name, self.prefix))
             return
 
@@ -926,12 +926,10 @@ class Package(object):
                     self.sanity_check_prefix()
 
                     # Copy provenance into the install directory on success
-                    log_install_path = spack.install_layout.build_log_path(
-                        self.spec)
-                    env_install_path = spack.install_layout.build_env_path(
-                        self.spec)
-                    packages_dir = spack.install_layout.build_packages_path(
-                        self.spec)
+                    layout =  spack.install_area.layout
+                    log_install_path = layout.build_log_path(self.spec)
+                    env_install_path = layout.build_env_path(self.spec)
+                    packages_dir     = layout.build_packages_path(self.spec)
 
                     install(log_path, log_install_path)
                     install(env_path, env_install_path)
@@ -952,7 +950,7 @@ class Package(object):
 
         try:
             # Create the install prefix and fork the build process.
-            spack.install_layout.create_install_directory(self.spec)
+            spack.install_area.layout.create_install_directory(self.spec)
             spack.build_environment.fork(self, build_process)
         except:
             # remove the install prefix if anything went wrong during install.
@@ -968,7 +966,7 @@ class Package(object):
 
         # note: PARENT of the build process adds the new package to
         # the database, so that we don't need to re-read from file.
-        spack.installed_db.add(self.spec, self.prefix)
+        spack.install_area.db.add(self.spec, self.prefix)
 
     def sanity_check_prefix(self):
         """This function checks whether install succeeded."""
@@ -988,7 +986,7 @@ class Package(object):
         check_paths(self.sanity_check_is_dir, 'directory', os.path.isdir)
 
         installed = set(os.listdir(self.prefix))
-        installed.difference_update(spack.install_layout.hidden_file_paths)
+        installed.difference_update(spack.install_area.layout.hidden_file_paths)
         if not installed:
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)
@@ -1001,7 +999,7 @@ class Package(object):
     @property
     def build_log_path(self):
         if self.installed:
-            return spack.install_layout.build_log_path(self.spec)
+            return spack.install_area.layout.build_log_path(self.spec)
         else:
             return join_path(self.stage.source_path, 'spack-build.out')
 
@@ -1149,7 +1147,7 @@ class Package(object):
 
         # Uninstalling in Spack only requires removing the prefix.
         self.remove_prefix()
-        spack.installed_db.remove(self.spec)
+        spack.install_area.db.remove(self.spec)
         tty.msg("Successfully uninstalled %s" % self.spec.short_spec)
 
         # Once everything else is done, run post install hooks
@@ -1183,8 +1181,9 @@ class Package(object):
         """
         self._sanity_check_extension()
 
-        spack.install_layout.check_extension_conflict(self.extendee_spec,
-                                                      self.spec)
+        spack.install_area.layout.check_extension_conflict(
+            self.extendee_spec, self.spec)
+
 
         # Activate any package dependencies that are also extensions.
         if not force:
@@ -1195,9 +1194,9 @@ class Package(object):
 
         self.extendee_spec.package.activate(self, **self.extendee_args)
 
-        spack.install_layout.add_extension(self.extendee_spec, self.spec)
-        tty.msg("Activated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        spack.install_area.layout.add_extension(self.extendee_spec, self.spec)
+        tty.msg("Activated extension %s for %s"
+                % (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
 
     def activate(self, extension, **kwargs):
         """Symlinks all files from the extension into extendee's install dir.
@@ -1210,7 +1209,7 @@ class Package(object):
         """
 
         def ignore(filename):
-            return (filename in spack.install_layout.hidden_file_paths or
+            return (filename in spack.install_area.layout.hidden_file_paths or
                     kwargs.get('ignore', lambda f: False)(filename))
 
         tree = LinkTree(extension.prefix)
@@ -1228,9 +1227,9 @@ class Package(object):
         # Allow a force deactivate to happen.  This can unlink
         # spurious files if something was corrupted.
         if not force:
-            spack.install_layout.check_activated(self.extendee_spec, self.spec)
+            spack.install_area.layout.check_activated(self.extendee_spec, self.spec)
 
-            activated = spack.install_layout.extension_map(self.extendee_spec)
+            activated = spack.install_area.layout.extension_map(self.extendee_spec)
             for name, aspec in activated.items():
                 if aspec == self.spec:
                     continue
@@ -1245,11 +1244,10 @@ class Package(object):
         # redundant activation check -- makes SURE the spec is not
         # still activated even if something was wrong above.
         if self.activated:
-            spack.install_layout.remove_extension(self.extendee_spec,
-                                                  self.spec)
+            spack.install_area.layout.remove_extension(self.extendee_spec, self.spec)
 
-        tty.msg("Deactivated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        tty.msg("Deactivated extension %s for %s"
+                % (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
 
     def deactivate(self, extension, **kwargs):
         """Unlinks all files from extension out of this package's install dir.
@@ -1262,7 +1260,7 @@ class Package(object):
         """
 
         def ignore(filename):
-            return (filename in spack.install_layout.hidden_file_paths or
+            return (filename in spack.install_area.layout.hidden_file_paths or
                     kwargs.get('ignore', lambda f: False)(filename))
 
         tree = LinkTree(extension.prefix)
@@ -1346,7 +1344,7 @@ def flatten_dependencies(spec, flat_dir):
     for dep in spec.traverse(root=False):
         name = dep.name
 
-        dep_path = spack.install_layout.path_for_spec(dep)
+        dep_path = spack.install_area.layout.path_for_spec(dep)
         dep_files = LinkTree(dep_path)
 
         os.mkdir(flat_dir + '/' + name)
@@ -1385,7 +1383,7 @@ def dump_packages(spec, path):
         if node is not spec:
             # Locate the dependency package in the install tree and find
             # its provenance information.
-            source = spack.install_layout.build_packages_path(node)
+            source = spack.install_area.layout.build_packages_path(node)
             source_repo_root = join_path(source, node.namespace)
 
             # There's no provenance installed for the source package.  Skip it.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -670,7 +670,7 @@ class Package(object):
     def remove_prefix(self):
         """
         Removes the prefix for a package along with any empty parent
-        directories
+        directories.
         """
         spack.install_area.layout.remove_install_directory(self.spec)
 
@@ -926,7 +926,7 @@ class Package(object):
                     self.sanity_check_prefix()
 
                     # Copy provenance into the install directory on success
-                    layout =  spack.install_area.layout
+                    layout = spack.install_area.layout
                     log_install_path = layout.build_log_path(self.spec)
                     env_install_path = layout.build_env_path(self.spec)
                     packages_dir     = layout.build_packages_path(self.spec)
@@ -986,7 +986,8 @@ class Package(object):
         check_paths(self.sanity_check_is_dir, 'directory', os.path.isdir)
 
         installed = set(os.listdir(self.prefix))
-        installed.difference_update(spack.install_area.layout.hidden_file_paths)
+        installed.difference_update(
+            spack.install_area.layout.hidden_file_paths)
         if not installed:
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)
@@ -1196,7 +1197,8 @@ class Package(object):
 
         spack.install_area.layout.add_extension(self.extendee_spec, self.spec)
         tty.msg("Activated extension %s for %s"
-                % (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+                % (self.spec.short_spec,
+                   self.extendee_spec.format("$_$@$+$%@")))
 
     def activate(self, extension, **kwargs):
         """Symlinks all files from the extension into extendee's install dir.
@@ -1227,9 +1229,9 @@ class Package(object):
         # Allow a force deactivate to happen.  This can unlink
         # spurious files if something was corrupted.
         if not force:
-            spack.install_area.layout.check_activated(self.extendee_spec, self.spec)
-
-            activated = spack.install_area.layout.extension_map(self.extendee_spec)
+            layout = spack.install_area.layout
+            layout.check_activated(self.extendee_spec, self.spec)
+            activated = layout.extension_map(self.extendee_spec)
             for name, aspec in activated.items():
                 if aspec == self.spec:
                     continue
@@ -1247,7 +1249,8 @@ class Package(object):
             spack.install_area.layout.remove_extension(self.extendee_spec, self.spec)
 
         tty.msg("Deactivated extension %s for %s"
-                % (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+                % (self.spec.short_spec,
+                   self.extendee_spec.format("$_$@$+$%@")))
 
     def deactivate(self, extension, **kwargs):
         """Unlinks all files from extension out of this package's install dir.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -104,6 +104,7 @@ from llnl.util.lang import *
 from llnl.util.tty.color import *
 
 import spack
+import spack.install_area
 import spack.parse
 import spack.error
 import spack.compilers as compilers
@@ -657,7 +658,7 @@ class Spec(object):
 
     @property
     def prefix(self):
-        return Prefix(spack.install_layout.path_for_spec(self))
+        return Prefix(spack.install_area.layout.path_for_spec(self))
 
 
     def dag_hash(self, length=None):
@@ -1805,7 +1806,7 @@ class Spec(object):
                 elif named_str == 'SPACK_ROOT':
                     out.write(fmt % spack.prefix)
                 elif named_str == 'SPACK_INSTALL':
-                    out.write(fmt % spack.install_path)
+                    out.write(fmt % spack.install_area.path)
 
                 named = False
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -1,5 +1,5 @@
 import spack.test.mock_database
-
+import spack.install_area
 from spack.cmd.uninstall import uninstall
 
 
@@ -25,7 +25,7 @@ class TestUninstall(spack.test.mock_database.MockDatabase):
         args = MockArgs(['callpath'], all=True, dependents=True)
         uninstall(parser, args)
 
-        all_specs = spack.install_layout.all_specs()
+        all_specs = spack.install_area.layout.all_specs()
         self.assertEqual(len(all_specs), 7)
         # query specs with multiple configurations
         mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -89,26 +89,28 @@ class DatabaseTest(MockDatabase):
         # query specs with multiple configurations
         mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
         callpath_specs = [s for s in all_specs if s.satisfies('callpath')]
-        mpi_specs =      [s for s in all_specs if s.satisfies('mpi')]
+        mpi_specs      = [s for s in all_specs if s.satisfies('mpi')]
 
         self.assertEqual(len(mpileaks_specs), 3)
         self.assertEqual(len(callpath_specs), 3)
         self.assertEqual(len(mpi_specs),      3)
 
         # query specs with single configurations
-        dyninst_specs =  [s for s in all_specs if s.satisfies('dyninst')]
+        dyninst_specs  = [s for s in all_specs if s.satisfies('dyninst')]
         libdwarf_specs = [s for s in all_specs if s.satisfies('libdwarf')]
-        libelf_specs =   [s for s in all_specs if s.satisfies('libelf')]
+        libelf_specs   = [s for s in all_specs if s.satisfies('libelf')]
 
         self.assertEqual(len(dyninst_specs),  1)
         self.assertEqual(len(libdwarf_specs), 1)
         self.assertEqual(len(libelf_specs),   1)
 
         # Query by dependency
-        self.assertEqual(len([s for s in all_specs if s.satisfies('mpileaks ^mpich')]),  1)
-        self.assertEqual(len([s for s in all_specs if s.satisfies('mpileaks ^mpich2')]), 1)
-        self.assertEqual(len([s for s in all_specs if s.satisfies('mpileaks ^zmpi')]),   1)
-
+        self.assertEqual(
+            len([s for s in all_specs if s.satisfies('mpileaks ^mpich')]),  1)
+        self.assertEqual(
+            len([s for s in all_specs if s.satisfies('mpileaks ^mpich2')]), 1)
+        self.assertEqual(
+            len([s for s in all_specs if s.satisfies('mpileaks ^zmpi')]),   1)
 
     def test_015_write_and_read(self):
         # write and read DB
@@ -123,7 +125,6 @@ class DatabaseTest(MockDatabase):
             self.assertEqual(new_rec.path,      rec.path)
             self.assertEqual(new_rec.installed, rec.installed)
 
-
     def _check_db_sanity(self):
         """Utiilty function to check db against install layout."""
         expected = sorted(spack.install_area.layout.all_specs())
@@ -133,11 +134,9 @@ class DatabaseTest(MockDatabase):
         for e, a in zip(expected, actual):
             self.assertEqual(e, a)
 
-
     def test_020_db_sanity(self):
         """Make sure query() returns what's actually in the db."""
         self._check_db_sanity()
-
 
     def test_030_db_sanity_from_another_process(self):
         def read_and_modify():
@@ -153,30 +152,31 @@ class DatabaseTest(MockDatabase):
         with self.installed_db.read_transaction():
             self.assertEqual(len(self.installed_db.query('mpileaks ^zmpi')), 0)
 
-
     def test_040_ref_counts(self):
         """Ensure that we got ref counts right when we read the DB."""
         self.installed_db._check_ref_counts()
 
-
     def test_050_basic_query(self):
-        """Ensure that querying the database is consistent with what is installed."""
+        """
+        Ensure that querying the database is consistent
+         with what is installed.
+        """
         # query everything
         self.assertEqual(len(spack.install_area.db.query()), 13)
 
         # query specs with multiple configurations
         mpileaks_specs = self.installed_db.query('mpileaks')
         callpath_specs = self.installed_db.query('callpath')
-        mpi_specs =      self.installed_db.query('mpi')
+        mpi_specs      = self.installed_db.query('mpi')
 
         self.assertEqual(len(mpileaks_specs), 3)
         self.assertEqual(len(callpath_specs), 3)
         self.assertEqual(len(mpi_specs),      3)
 
         # query specs with single configurations
-        dyninst_specs =  self.installed_db.query('dyninst')
+        dyninst_specs  = self.installed_db.query('dyninst')
         libdwarf_specs = self.installed_db.query('libdwarf')
-        libelf_specs =   self.installed_db.query('libelf')
+        libelf_specs   = self.installed_db.query('libelf')
 
         self.assertEqual(len(dyninst_specs),  1)
         self.assertEqual(len(libdwarf_specs), 1)
@@ -186,7 +186,6 @@ class DatabaseTest(MockDatabase):
         self.assertEqual(len(self.installed_db.query('mpileaks ^mpich')),  1)
         self.assertEqual(len(self.installed_db.query('mpileaks ^mpich2')), 1)
         self.assertEqual(len(self.installed_db.query('mpileaks ^zmpi')),   1)
-
 
     def _check_remove_and_add_package(self, spec):
         """Remove a spec from the DB, then add it and make sure everything's
@@ -216,14 +215,11 @@ class DatabaseTest(MockDatabase):
         self._check_db_sanity()
         self.installed_db._check_ref_counts()
 
-
     def test_060_remove_and_add_root_package(self):
         self._check_remove_and_add_package('mpileaks ^mpich')
 
-
     def test_070_remove_and_add_dependency_package(self):
         self._check_remove_and_add_package('dyninst')
-
 
     def test_080_root_ref_counts(self):
         rec = self.installed_db.get_record('mpileaks ^mpich')
@@ -232,22 +228,25 @@ class DatabaseTest(MockDatabase):
         self.installed_db.remove('mpileaks ^mpich')
 
         # record no longer in DB
-        self.assertEqual(self.installed_db.query('mpileaks ^mpich', installed=any), [])
+        self.assertEqual(
+            self.installed_db.query('mpileaks ^mpich', installed=any), [])
 
         # record's deps have updated ref_counts
-        self.assertEqual(self.installed_db.get_record('callpath ^mpich').ref_count, 0)
+        self.assertEqual(
+            self.installed_db.get_record('callpath ^mpich').ref_count, 0)
         self.assertEqual(self.installed_db.get_record('mpich').ref_count, 1)
 
         # put the spec back
         self.installed_db.add(rec.spec, rec.path)
 
         # record is present again
-        self.assertEqual(len(self.installed_db.query('mpileaks ^mpich', installed=any)), 1)
+        self.assertEqual(len(self.installed_db.query('mpileaks ^mpich',
+                                                     installed=any)), 1)
 
         # dependencies have ref counts updated
-        self.assertEqual(self.installed_db.get_record('callpath ^mpich').ref_count, 1)
+        self.assertEqual(
+            self.installed_db.get_record('callpath ^mpich').ref_count, 1)
         self.assertEqual(self.installed_db.get_record('mpich').ref_count, 2)
-
 
     def test_090_non_root_ref_counts(self):
         mpileaks_mpich_rec = self.installed_db.get_record('mpileaks ^mpich')
@@ -257,19 +256,25 @@ class DatabaseTest(MockDatabase):
         self.installed_db.remove('callpath ^mpich')
 
         # record still in DB but marked uninstalled
-        self.assertEqual(self.installed_db.query('callpath ^mpich', installed=True), [])
-        self.assertEqual(len(self.installed_db.query('callpath ^mpich', installed=any)), 1)
+        self.assertEqual(self.installed_db.query('callpath ^mpich',
+                                                 installed=True), [])
+        self.assertEqual(len(self.installed_db.query('callpath ^mpich',
+                                                     installed=any)), 1)
 
         # record and its deps have same ref_counts
-        self.assertEqual(self.installed_db.get_record('callpath ^mpich', installed=any).ref_count, 1)
+        self.assertEqual(
+            self.installed_db.get_record('callpath ^mpich',
+                                         installed=any).ref_count, 1)
         self.assertEqual(self.installed_db.get_record('mpich').ref_count, 2)
 
         # remove only dependent of uninstalled callpath record
         self.installed_db.remove('mpileaks ^mpich')
 
         # record and parent are completely gone.
-        self.assertEqual(self.installed_db.query('mpileaks ^mpich', installed=any), [])
-        self.assertEqual(self.installed_db.query('callpath ^mpich', installed=any), [])
+        self.assertEqual(self.installed_db.query('mpileaks ^mpich',
+                                                 installed=any), [])
+        self.assertEqual(self.installed_db.query('callpath ^mpich',
+                                                 installed=any), [])
 
         # mpich ref count updated properly.
         mpich_rec = self.installed_db.get_record('mpich')

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 
 import spack
+import spack.install_area
 from llnl.util.filesystem import *
 from spack.directory_layout import YamlDirectoryLayout
 from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
@@ -48,8 +49,8 @@ class InstallTest(MockPackagesTest):
         # Use a fake install directory to avoid conflicts bt/w
         # installed pkgs and mock packages.
         self.tmpdir = tempfile.mkdtemp()
-        self.orig_layout = spack.install_layout
-        spack.install_layout = YamlDirectoryLayout(self.tmpdir)
+        self.orig_layout = spack.install_area.layout
+        spack.install_area.layout = YamlDirectoryLayout(self.tmpdir)
 
 
     def tearDown(self):
@@ -60,7 +61,7 @@ class InstallTest(MockPackagesTest):
         spack.do_checksum = True
 
         # restore spack's layout.
-        spack.install_layout = self.orig_layout
+        spack.install_area.layout = self.orig_layout
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
 
@@ -90,7 +91,7 @@ class InstallTest(MockPackagesTest):
             raise
 
 
-    def test_install_environment(self):
+    def test_install_area(self):
         spec = Spec('cmake-client').concretized()
 
         for s in spec.traverse():

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -52,7 +52,6 @@ class InstallTest(MockPackagesTest):
         self.orig_layout = spack.install_area.layout
         spack.install_area.layout = YamlDirectoryLayout(self.tmpdir)
 
-
     def tearDown(self):
         super(InstallTest, self).tearDown()
         self.repo.destroy()
@@ -64,13 +63,11 @@ class InstallTest(MockPackagesTest):
         spack.install_area.layout = self.orig_layout
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-
     def fake_fetchify(self, pkg):
         """Fake the URL for a package so it downloads from a file."""
         fetcher = FetchStrategyComposite()
         fetcher.append(URLFetchStrategy(self.repo.url))
         pkg.fetcher = fetcher
-
 
     def ztest_install_and_uninstall(self):
         # Get a basic concrete spec for the trivial install package.
@@ -89,7 +86,6 @@ class InstallTest(MockPackagesTest):
         except Exception, e:
             pkg.remove_prefix()
             raise
-
 
     def test_install_area(self):
         spec = Spec('cmake-client').concretized()

--- a/lib/spack/spack/test/mock_database.py
+++ b/lib/spack/spack/test/mock_database.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 
 import spack
+import spack.install_area
 from spack.spec import Spec
 from spack.database import Database
 from spack.directory_layout import YamlDirectoryLayout
@@ -16,7 +17,7 @@ class MockDatabase(MockPackagesTest):
         pkg.do_install(fake=True)
 
     def _mock_remove(self, spec):
-        specs = spack.installed_db.query(spec)
+        specs = spack.install_area.db.query(spec)
         assert len(specs) == 1
         spec = specs[0]
         spec.package.do_uninstall(spec)
@@ -29,17 +30,17 @@ class MockDatabase(MockPackagesTest):
 
         # Make a fake install directory
         self.install_path = tempfile.mkdtemp()
-        self.spack_install_path = spack.install_path
-        spack.install_path = self.install_path
+        self.spack_install_path = spack.install_area.path
+        spack.install_area.path = self.install_path
 
         self.install_layout = YamlDirectoryLayout(self.install_path)
-        self.spack_install_layout = spack.install_layout
-        spack.install_layout = self.install_layout
+        self.spack_install_layout = spack.install_area.layout
+        spack.install_area.layout = self.install_layout
 
         # Make fake database and fake install directory.
         self.installed_db = Database(self.install_path)
-        self.spack_installed_db = spack.installed_db
-        spack.installed_db = self.installed_db
+        self.spack_installed_db = spack.install_area.db
+        spack.install_area.db = self.installed_db
 
         # make a mock database with some packages installed note that
         # the ref count for dyninst here will be 3, as it's recycled
@@ -65,16 +66,16 @@ class MockDatabase(MockPackagesTest):
         #
 
         # Transaction used to avoid repeated writes.
-        with spack.installed_db.write_transaction():
+        with spack.install_area.db.write_transaction():
             self._mock_install('mpileaks ^mpich')
             self._mock_install('mpileaks ^mpich2')
             self._mock_install('mpileaks ^zmpi')
 
     def tearDown(self):
-        for spec in spack.installed_db.query():
+        for spec in spack.install_area.db.query():
             spec.package.do_uninstall(spec)
         super(MockDatabase, self).tearDown()
         shutil.rmtree(self.install_path)
-        spack.install_path = self.spack_install_path
-        spack.install_layout = self.spack_install_layout
-        spack.installed_db = self.spack_installed_db
+        spack.install_area.path = self.spack_install_path
+        spack.install_area.layout = self.spack_install_layout
+        spack.install_area.db = self.spack_installed_db


### PR DESCRIPTION
This PR refactors the settings for the install area into a separate install_area.py and makes the location of this area a configurable. Even though there is only one layout currently, the directory_layout has been made a config option as well.