### PR TITLE
Add missing m4 dependency to bison

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -10,6 +10,8 @@ class Bison(Package):
 
     version('3.0.4', 'a586e11cd4aff49c3ff6d3b6a4c9ccf8')
 
+    depends_on("m4")
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
 


### PR DESCRIPTION
Bison requires m4. Compilation fails if the system m4 is too old.