### PR TITLE
GMsh: Fix binary linking against its own libraries

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -62,7 +62,9 @@ class Gmsh(Package):
 
         build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path
-        
+
+        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
+
         # Prevent GMsh from using its own strange directory structure on OSX
         options.append('-DENABLE_OS_SPECIFIC_INSTALL=OFF')
 


### PR DESCRIPTION
GMsh binary now links against full path name of libraries. This fixes
problems, such as `dyld: Library not loaded: libGmsh.2.11.dylib`, when
running the executable.