### PR TITLE
[WIP ]Address E302 and F999 in spack create template

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -64,7 +64,9 @@ package_template = string.Template("""\
 # See the spack documentation for more information on building
 # packages.
 #
-from spack import *
+from spack import depends_on, extends, python, version
+from spack import Package
+
 
 class ${class_name}(Package):
     ""\"FIXME: put a proper description of your package here.""\"

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -64,7 +64,8 @@ package_template = string.Template("""\
 # See the spack documentation for more information on building
 # packages.
 #
-from spack import depends_on, extends, python, version
+from spack import depends_on, extends, version
+from spack import configure, cmake, make, python, R
 from spack import Package
 
 


### PR DESCRIPTION
With introducing coding rules, the template should follow it as well.
This fix does not address E203 (spaces before comma), which are used in the formatting of the list of versions.