### PR TITLE
Bugfix: setting config for list parameters fails

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -548,7 +548,7 @@ def update_config(section, update_data, scope=None):
     if isinstance(update_data, list):
         configuration = update_data
     else:
-        configuration.extend(update_data)
+        configuration.update(update_data)
 
     # read only the requested section's data.
     scope.sections[section] = {section: configuration}

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -545,7 +545,10 @@ def update_config(section, update_data, scope=None):
     # read in the config to ensure we've got current data
     configuration = get_config(section)
 
-    configuration.update(update_data)
+    if isinstance(update_data, list):
+        configuration = update_data
+    else:
+        configuration.extend(update_data)
 
     # read only the requested section's data.
     scope.sections[section] = {section: configuration}

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -129,7 +129,6 @@ from ordereddict_backport import OrderedDict
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
-import copy
 
 import spack
 from spack.error import SpackError
@@ -306,12 +305,13 @@ def extend_with_default(validator_class):
             yield err
 
     return validators.extend(validator_class, {
-        "properties" : set_defaults,
-        "patternProperties" : set_pp_defaults
+        "properties": set_defaults,
+        "patternProperties": set_pp_defaults
     })
 
 
 DefaultSettingValidator = extend_with_default(Draft4Validator)
+
 
 def validate_section(data, schema):
     """Validate data read in from a Spack YAML file.
@@ -347,15 +347,13 @@ class ConfigScope(object):
         validate_section_name(section)
         return os.path.join(self.path, "%s.yaml" % section)
 
-
     def get_section(self, section):
-        if not section in self.sections:
+        if section not in self.sections:
             path   = self.get_section_filename(section)
             schema = section_schemas[section]
             data   = _read_config_file(path, schema)
             self.sections[section] = data
         return self.sections[section]
-
 
     def write_section(self, section):
         filename = self.get_section_filename(section)
@@ -369,7 +367,6 @@ class ConfigScope(object):
             raise ConfigSanityError(e, data)
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError("Error writing to config file: '%s'" % str(e))
-
 
     def clear(self):
         """Empty cached config information."""
@@ -476,7 +473,7 @@ def _merge_yaml(dest, source):
     # Source dict is merged into dest.
     elif they_are(dict):
         for sk, sv in source.iteritems():
-            if not sk in dest:
+            if sk not in dest:
                 dest[sk] = copy.copy(sv)
             else:
                 dest[sk] = _merge_yaml(dest[sk], source[sk])
@@ -590,22 +587,27 @@ def spec_externals(spec):
 def is_spec_buildable(spec):
     """Return true if the spec pkgspec is configured as buildable"""
     allpkgs = get_config('packages')
-    name = spec.name
-    if not spec.name in allpkgs:
+    if spec.name not in allpkgs:
         return True
-    if not 'buildable' in allpkgs[spec.name]:
+    if 'buildable' not in allpkgs[spec.name]:
         return True
     return allpkgs[spec.name]['buildable']
 
 
-class ConfigError(SpackError): pass
-class ConfigFileError(ConfigError): pass
+class ConfigError(SpackError):
+    pass
+
+
+class ConfigFileError(ConfigError):
+    pass
+
 
 def get_path(path, data):
     if path:
         return get_path(path[1:], data[path[0]])
     else:
         return data
+
 
 class ConfigFormatError(ConfigError):
     """Raised when a configuration format does not match its schema."""
@@ -640,6 +642,7 @@ class ConfigFormatError(ConfigError):
 
         message = '%s: %s' % (location, validation_error.message)
         super(ConfigError, self).__init__(message)
+
 
 class ConfigSanityError(ConfigFormatError):
     """Same as ConfigFormatError, raised when config is written by Spack."""

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -72,6 +72,10 @@ b_comps = {
     }
 }
 
+# Some Sample repo data
+repos_low = [ "/some/path" ]
+repos_high = [ "/some/other/path" ]
+
 class ConfigTest(MockPackagesTest):
 
     def setUp(self):
@@ -94,6 +98,12 @@ class ConfigTest(MockPackagesTest):
                 expected = comps[arch][key][c]
                 actual = config[arch][key][c]
                 self.assertEqual(expected, actual)
+
+    def test_write_list_in_memory(self):
+        spack.config.update_config('repos', repos_low, 'test_low_priority')
+        spack.config.update_config('repos', repos_high, 'test_high_priority')
+        config = spack.config.get_config('repos')
+        self.assertEqual(config, repos_high+repos_low)
 
     def test_write_key_in_memory(self):
         # Write b_comps "on top of" a_comps.


### PR DESCRIPTION
PR #775 seems to have broken setting the parameters for lists:
```
 $ spack repo add ../spackintegration/hep-spack
 Traceback (most recent call last):
  File "/build/hegner/spack/bin/spack", line 176, in <module>
    main()
  File "/build/hegner/spack/bin/spack", line 154, in main
    return_val = command(parser, args)
  File "/var/build/hegner/spack/lib/spack/spack/cmd/repo.py", line 174, in repo
    action[args.repo_command](args)
  File "/var/build/hegner/spack/lib/spack/spack/cmd/repo.py", line 109, in repo_add
    spack.config.update_config('repos', repos, args.scope)
  File "/var/build/hegner/spack/lib/spack/spack/config.py", line 548, in update_config
    configuration.update(update_data)
AttributeError: 'syaml_list' object has no attribute 'update'
```
This PR is an attempt to fix it. Seems the wrong place though to do this type logic... 