### PR TITLE
[WIP] Speed up with targeted memoization

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -102,7 +102,7 @@ class DefaultConcretizer(object):
         return usable
 
 
-    def choose_virtual_or_external(self, spec):
+    def __choose_virtual_or_external(self, spec):
         """Given a list of candidate virtual and external packages, try to
            find one that is most ABI compatible.
         """
@@ -130,6 +130,13 @@ class DefaultConcretizer(object):
         # Pull the candidates back out and return them in order
         candidates = [c for s,l,c in keys]
         return candidates
+
+    _memoize_choose_virtual_or_external = dict()
+    def choose_virtual_or_external(self, spec):
+        key = id(spec)
+        if key not in self._memoize_choose_virtual_or_external:
+            self._memoize_choose_virtual_or_external[key] = self.__choose_virtual_or_external(spec)
+        return self._memoize_choose_virtual_or_external[key]
 
 
     def concretize_version(self, spec):
@@ -269,7 +276,7 @@ class DefaultConcretizer(object):
         return True  # things changed.
 
 
-def find_spec(spec, condition):
+def __find_spec(spec, condition):
     """Searches the dag from spec in an intelligent order and looks
        for a spec that matches a condition"""
     # First search parents, then search children
@@ -294,6 +301,12 @@ def find_spec(spec, condition):
 
     return None   # Nothing matched the condition.
 
+_memoize_find_spec = dict()
+def find_spec(spec, condition):
+    key = (id(spec), condition)
+    if key not in _memoize_find_spec:
+        _memoize_find_spec[key] = __find_spec(spec, condition)
+    return _memoize_find_spec[key]
 
 def cmp_specs(lhs, rhs):
     # Package name sort order is not configurable, always goes alphabetical

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -834,6 +834,7 @@ class Package(object):
 
 
     def do_install(self,
+                   force=False,
                    keep_prefix=False,  keep_stage=False, ignore_deps=False,
                    skip_patch=False, verbose=False, make_jobs=None, fake=False):
         """Called by commands to install a package and its dependencies.
@@ -842,6 +843,7 @@ class Package(object):
         their build process.
 
         Args:
+        force       -- Overwrite existing install directory if present (top level package only)
         keep_prefix -- Keep install prefix on failure. By default, destroys it.
         keep_stage  -- By default, stage is destroyed only if there are no
                        exceptions during build. Set to True to keep the stage
@@ -942,6 +944,8 @@ class Package(object):
             print_pkg(self.prefix)
 
         try:
+            if force:
+                spack.install_layout.remove_install_directory(self.spec)
             # Create the install prefix and fork the build process.
             spack.install_layout.create_install_directory(self.spec)
             spack.build_environment.fork(self, build_process)
@@ -958,7 +962,8 @@ class Package(object):
 
         # note: PARENT of the build process adds the new package to
         # the database, so that we don't need to re-read from file.
-        spack.installed_db.add(self.spec, self.prefix)
+        if 'db' in install_phases:
+            spack.installed_db.add(self.spec, self.prefix)
 
 
     def sanity_check_prefix(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1375,7 +1375,7 @@ class Spec(object):
         except SpecError:
             return parse_anonymous_spec(spec_like, self.name)
 
-    def __satisfies(self, other, deps=True, strict=False):
+    def satisfies(self, other, deps=True, strict=False):
         """Determine if this spec satisfies all constraints of another.
 
         There are two senses for satisfies:
@@ -1439,12 +1439,12 @@ class Spec(object):
         else:
             return True
 
-    _memoize_satisfies = dict()
-    def satisfies(self, other, deps=True, strict=False):
-        key = (other, deps, strict)
-        if key not in self._memoize_satisfies:
-            self._memoize_satisfies[key] = self.__satisfies(other, deps=deps, strict=strict)
-        return self._memoize_satisfies[key]
+#    _memoize_satisfies = dict()
+#    def satisfies(self, other, deps=True, strict=False):
+#        key = (other, deps, strict)
+#        if key not in self._memoize_satisfies:
+#            self._memoize_satisfies[key] = self.__satisfies(other, deps=deps, strict=strict)
+#        return self._memoize_satisfies[key]
 
 
     def satisfies_dependencies(self, other, strict=False):


### PR DESCRIPTION
I added a few memoizations to avoid re-doing work again and again.  Not that this is how things should be in the end... but it DOES speed me up from 30 seconds to 15 for a simple "spack spec" command.

On my run...

It's true, virtual dependencies are taking a lot of time.  _expand_virtual_packages() is only called 3 times.  But then ProviderIndex() is instantiated 738 (!) times.  Overall, 6838 specs are created --- FAR MORE than there are specs in the entire repo!

I suspect that speedup will happen through some more targeted re-use of objects.  Among other things, it looks like the same Spec is being instantiated multiple times.  And we shouldn't have to instantiate ProviderIndex 738 times.

In the meantime, I've shaved down the pain for myself somewhat.
