### PR TITLE
Improve error message for wrong config section names

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -269,10 +269,10 @@ config_scopes = OrderedDict()
 
 
 def validate_section_name(section):
-    """Raise a ValueError if the section is not a valid section."""
+    """Exit if the section is not a valid section."""
     if section not in section_schemas:
-        raise ValueError("Invalid config section: '%s'.  Options are %s"
-                         % (section, section_schemas))
+        tty.die("Invalid config section: '%s'. Options are: %s"
+                % (section, " ".join(section_schemas.keys())))
 
 
 def extend_with_default(validator_class):


### PR DESCRIPTION
Changes the behaviour towards invalid calls like `spack config edit notExisting` to
```
==> Error: Invalid config section: 'notExisting'. Options are: repos mirrors modules packages compilers
```
instead of 
```
Traceback (most recent call last):
  File "/Users/hegner/spack/bin/spack", line 176, in <module>
    main()
  File "/Users/hegner/spack/bin/spack", line 154, in main
    return_val = command(parser, args)
  File "/Users/hegner/spack/lib/spack/spack/cmd/config.py", line 69, in config
    action[args.config_command](args)
  File "/Users/hegner/spack/lib/spack/spack/cmd/config.py", line 62, in config_edit
    config_file = spack.config.get_config_filename(args.scope, args.section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 526, in get_config_filename
    return scope.get_section_filename(section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 348, in get_section_filename
    validate_section_name(section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 275, in validate_section_name
    % (section, section_schemas))
ValueError: Invalid config section: 'notExisting'.  Options are {'repos': {'additionalProperties': False, 'patternProperties': {'repos:?': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack repository configuration file schema'}, 'mirrors': {'additionalProperties': False, 'patternProperties': {'mirrors:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'type': 'string'}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack mirror configuration file schema'}, 'modules': {'additionalProperties': False, 'patternProperties': {'modules:?': {'default': {}, 'additionalProperties': False, 'type': 'object', 'properties': {'enable': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack module file configuration file schema'}, 'packages': {'additionalProperties': False, 'patternProperties': {'packages:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'default': {}, 'additionalProperties': False, 'type': 'object', 'properties': {'buildable': {'default': True, 'type': 'boolean'}, 'paths': {'default': {}, 'type': 'object'}, 'version': {'default': [], 'items': {'anyOf': [{'type': 'string'}, {'type': 'number'}]}, 'type': 'array'}, 'providers': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}, 'type': 'object'}, 'compiler': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack package configuration file schema'}, 'compilers': {'additionalProperties': False, 'patternProperties': {'compilers:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*@\\w[\\w-]*': {'additionalProperties': False, 'required': ['cc', 'cxx', 'f77', 'fc'], 'type': 'object', 'properties': {'cc': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'cxx': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'f77': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'fc': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}}}}, 'type': 'object'}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack compiler configuration file schema'}}
```