### PR TITLE
libmonitor does not exist at specified location

### DIFF
--- a/var/spack/repos/builtin/packages/libmonitor/package.py
+++ b/var/spack/repos/builtin/packages/libmonitor/package.py
@@ -26,9 +26,9 @@ from spack import *
 
 class Libmonitor(Package):
     """Libmonitor is a library for process and thread control."""
-    homepage = "http://hpctoolkit.org"
+    homepage = "https://github.com/HPCToolkit/libmonitor"
 
-    version('20130218', svn='http://libmonitor.googlecode.com/svn/trunk/', revision=146)
+    version('20130218', git='https://github.com/HPCToolkit/libmonitor.git', commit='4f2311e')
     variant('krellpatch', default=False, description="build with openspeedshop based patch.")
 
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -44,7 +44,10 @@ class Libxcb(Package):
 
     def patch(self):
         filter_file('typedef struct xcb_auth_info_t {', 'typedef struct {', 'src/xcb.h')
-
+        filter_file('NEEDED="pthread-stubs xau >= 0.99.2"',
+                    'NEEDED_CFLAGS=" "; NEEDED_LIBS="-lXau"',
+                    'configure',
+                    when='@1.11')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)


### PR DESCRIPTION
libmonitor does not exist at http://libmonitor.googlecode.com/svn/trunk/

Change location to HPCToolkit version at github. Specify the hash corresponding
to the 20130218 version.