### PR TITLE
Allow setting of LD_LIBRARY_PATH for compilers

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -457,9 +457,9 @@ For compilers, like ``clang``, that do not support Fortran, put
 Once you save the file, the configured compilers will show up in the
 list displayed by ``spack compilers``.
 
-In the exceptional case a compiler requires setting an explicit library
-path, this can bet set in an extra section as either "LD_LIBRARY_PATH" or
-"DYLD_LIBRARY_PATH", depending on your operating system::
+In the exceptional case a compiler requires setting special environment
+variables, like an explicit library path, these can bet set in an extra 
+section in the compiler configuration::
 
     gcc@4.9.3:
         cc: /opt/gcc/bin/gcc

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -457,6 +457,19 @@ For compilers, like ``clang``, that do not support Fortran, put
 Once you save the file, the configured compilers will show up in the
 list displayed by ``spack compilers``.
 
+In the exceptional case a compiler requires setting an explicit library
+path, this can bet set in an extra section as either "LD_LIBRARY_PATH" or
+"DYLD_LIBRARY_PATH", depending on your operating system::
+
+    gcc@4.9.3:
+        cc: /opt/gcc/bin/gcc
+        c++: /opt/gcc/bin/g++
+        f77: /opt/gcc/bin/gfortran
+        fc: /opt/gcc/bin/gfortran
+        environment:
+            set:
+                LD_LIBRARY_PATH : /opt/gcc/lib
+
 
 .. _sec-specs:
 

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -238,6 +238,12 @@ unset LD_RUN_PATH
 unset DYLD_LIBRARY_PATH
 
 #
+# Set library path again if specified explicitly
+#
+LD_LIBRARY_PATH=SPACK_LD_LIBRARY_PATH
+DYLD_LIBRARY_PATH=SPACK_DYLD_LIBRARY_PATH
+
+#
 # Filter '.' and Spack environment directories out of PATH so that
 # this script doesn't just call itself
 #

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -238,10 +238,15 @@ unset LD_RUN_PATH
 unset DYLD_LIBRARY_PATH
 
 #
-# Set library path again if specified explicitly
+# Set paths as defined in the 'environment' section of the compiler config
+#   names are stored in SPACK_ENV_TO_SET
+#   values are stored in SPACK_<varname>
 #
-LD_LIBRARY_PATH=SPACK_LD_LIBRARY_PATH
-DYLD_LIBRARY_PATH=SPACK_DYLD_LIBRARY_PATH
+IFS=':' read -ra varnames <<< "$SPACK_ENV_TO_SET"
+for varname in "${varnames[@]}"; do
+  spack_varname="SPACK_$varname"
+  export $varname=${!spack_varname}
+done
 
 #
 # Filter '.' and Spack environment directories out of PATH so that

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -82,11 +82,6 @@ SPACK_DEBUG            = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC       = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_DIR    = 'SPACK_DEBUG_LOG_DIR'
 
-#
-# This is set in the compilers config file
-#
-LD_LIBRARY_PATH        = "LD_LIBRARY_PATH"
-
 # Platform-specific library suffix.
 dso_suffix = 'dylib' if sys.platform == 'darwin' else 'so'
 
@@ -198,9 +193,10 @@ def set_build_environment_variables(pkg, env):
 
     # Resurrect some of the environment variables if specified for
     # the given compiler
-    if compiler.ld_library_path != "":
-        env.set('LD_LIBRARY_PATH', compiler.ld_library_path)
-        env.set('DYLD_LIBRARY_PATH', compiler.ld_library_path)
+    compiler = pkg.compiler
+    if compiler.LD_LIBRARY_PATH != "":
+        env.set('SPACK_LD_LIBRARY_PATH', compiler.LD_LIBRARY_PATH)
+        env.set('SPACK_DYLD_LIBRARY_PATH', compiler.LD_LIBRARY_PATH)
 
     # Add bin directories from dependencies to the PATH for the build.
     bin_dirs = reversed(filter(os.path.isdir, ['%s/bin' % prefix for prefix in dep_prefixes]))

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -203,6 +203,7 @@ def set_build_environment_variables(pkg, env):
         env_to_set = environment['set']
         for key, value in env_to_set.iteritems():
             env.set('SPACK_%s' % key, value)
+            env.set('%s' % key, value)
         # Let shell know which variables to set
         env_variables = ":".join(env_to_set.keys())
         env.set('SPACK_ENV_TO_SET', env_variables)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -82,6 +82,10 @@ SPACK_DEBUG            = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC       = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_DIR    = 'SPACK_DEBUG_LOG_DIR'
 
+#
+# This is set in the compilers config file
+#
+LD_LIBRARY_PATH        = "LD_LIBRARY_PATH"
 
 # Platform-specific library suffix.
 dso_suffix = 'dylib' if sys.platform == 'darwin' else 'so'
@@ -145,6 +149,7 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_FC_RPATH_ARG',  compiler.fc_rpath_arg)
 
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
+
     return env
 
 
@@ -190,6 +195,12 @@ def set_build_environment_variables(pkg, env):
     env.unset('LD_LIBRARY_PATH')
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
+
+    # Resurrect some of the environment variables if specified for
+    # the given compiler
+    if compiler.ld_library_path != "":
+        env.set('LD_LIBRARY_PATH', compiler.ld_library_path)
+        env.set('DYLD_LIBRARY_PATH', compiler.ld_library_path)
 
     # Add bin directories from dependencies to the PATH for the build.
     bin_dirs = reversed(filter(os.path.isdir, ['%s/bin' % prefix for prefix in dep_prefixes]))

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -37,6 +37,7 @@ from spack.util.environment import get_path
 
 description = "Manage compilers"
 
+
 def setup_parser(subparser):
     sp = subparser.add_subparsers(
         metavar='SUBCOMMAND', dest='compiler_command')
@@ -44,28 +45,37 @@ def setup_parser(subparser):
     scopes = spack.config.config_scopes
 
     # Find
-    find_parser = sp.add_parser('find', aliases=['add'], help='Search the system for compilers to add to the Spack configuration.')
+    find_parser = sp.add_parser('find', aliases=['add'],
+                                help='Search the system for compilers ' +
+                                     'to add to the Spack configuration.')
     find_parser.add_argument('add_paths', nargs=argparse.REMAINDER)
-    find_parser.add_argument('--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-                            help="Configuration scope to modify.")
+    find_parser.add_argument('--scope', choices=scopes,
+                             default=spack.cmd.default_modify_scope,
+                             help="Configuration scope to modify.")
 
     # Remove
-    remove_parser = sp.add_parser('remove', aliases=['rm'], help='Remove compiler by spec.')
-    remove_parser.add_argument(
-        '-a', '--all', action='store_true', help='Remove ALL compilers that match spec.')
+    remove_parser = sp.add_parser('remove',
+                                  aliases=['rm'],
+                                  help='Remove compiler by spec.')
+    remove_parser.add_argument('-a', '--all',
+                               action='store_true',
+                               help='Remove ALL compilers that match spec.')
     remove_parser.add_argument('compiler_spec')
-    remove_parser.add_argument('--scope', choices=scopes, default=spack.cmd.default_modify_scope,
+    remove_parser.add_argument('--scope', choices=scopes,
+                               default=spack.cmd.default_modify_scope,
                                help="Configuration scope to modify.")
 
     # List
     list_parser = sp.add_parser('list', help='list available compilers')
-    list_parser.add_argument('--scope', choices=scopes, default=spack.cmd.default_list_scope,
+    list_parser.add_argument('--scope', choices=scopes,
+                             default=spack.cmd.default_list_scope,
                              help="Configuration scope to read from.")
 
     # Info
     info_parser = sp.add_parser('info', help='Show compiler paths.')
     info_parser.add_argument('compiler_spec')
-    info_parser.add_argument('--scope', choices=scopes, default=spack.cmd.default_list_scope,
+    info_parser.add_argument('--scope', choices=scopes,
+                             default=spack.cmd.default_list_scope,
                              help="Configuration scope to read from.")
 
 
@@ -77,7 +87,8 @@ def compiler_find(args):
         paths = get_path('PATH')
 
     compilers = [c for c in spack.compilers.find_compilers(*args.add_paths)
-                 if c.spec not in spack.compilers.all_compilers(scope=args.scope)]
+                 if c.spec not in
+                 spack.compilers.all_compilers(scope=args.scope)]
 
     if compilers:
         spack.compilers.add_compilers_to_config(compilers, scope=args.scope)
@@ -99,11 +110,13 @@ def compiler_remove(args):
     elif not args.all and len(compilers) > 1:
         tty.error("Multiple compilers match spec %s. Choose one:" % cspec)
         colify(reversed(sorted([c.spec for c in compilers])), indent=4)
-        tty.msg("Or, you can use `spack compiler remove -a` to remove all of them.")
+        tty.msg("Or, you can use `spack compiler remove -a` " +
+                "to remove all of them.")
         sys.exit(1)
 
     for compiler in compilers:
-        spack.compilers.remove_compiler_from_config(compiler.spec, scope=args.scope)
+        spack.compilers.remove_compiler_from_config(compiler.spec,
+                                                    scope=args.scope)
         tty.msg("Removed compiler %s" % compiler.spec)
 
 
@@ -121,14 +134,20 @@ def compiler_info(args):
             print "\tcxx = %s" % c.cxx
             print "\tf77 = %s" % c.f77
             print "\tfc  = %s" % c.fc
-            if c.ld_library_path != "":
-                print "\tld_library_path = %s" % c.ld_library_path
+            if len(c.environment) != 0:
+                if len(c.environment['set']) != 0:
+                    print "\tenvironment:"
+                    print "\t    set:"
+                    for key, value in c.environment['set'].iteritems():
+                        print "\t        %s = %s" % (key, value)
+
 
 def compiler_list(args):
     tty.msg("Available compilers")
     index = index_by(spack.compilers.all_compilers(scope=args.scope), 'name')
     for i, (name, compilers) in enumerate(index.items()):
-        if i >= 1: print
+        if i >= 1:
+            print
 
         cname = "%s{%s}" % (spack.spec.compiler_color, name)
         tty.hline(colorize(cname), char='-')
@@ -136,10 +155,10 @@ def compiler_list(args):
 
 
 def compiler(parser, args):
-    action = { 'add'    : compiler_find,
-               'find'   : compiler_find,
-               'remove' : compiler_remove,
-               'rm'     : compiler_remove,
-               'info'   : compiler_info,
-               'list'   : compiler_list }
+    action = {'add': compiler_find,
+              'find': compiler_find,
+              'remove': compiler_remove,
+              'rm': compiler_remove,
+              'info': compiler_info,
+              'list': compiler_list}
     action[args.compiler_command](args)

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -121,7 +121,8 @@ def compiler_info(args):
             print "\tcxx = %s" % c.cxx
             print "\tf77 = %s" % c.f77
             print "\tfc  = %s" % c.fc
-
+            if c.ld_library_path != "":
+                print "\tld_library_path = %s" % c.ld_library_path
 
 def compiler_list(args):
     tty.msg("Available compilers")

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -217,8 +217,8 @@ class Compiler(object):
 
                     match = re.match(regex, exe)
                     if match:
-                        key = (full_path,) + match.groups()
-                        checks.append(key)
+                        the_key = (full_path,) + match.groups()
+                        checks.append(the_key)
 
         def check(key):
             try:

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -120,7 +120,7 @@ class Compiler(object):
         self.cxx = check(cxx)
         self.f77 = check(f77)
         self.fc  = check(fc)
-        self.ld_library_path = ld_library_path
+        self.LD_LIBRARY_PATH = ld_library_path
         self.spec = cspec
 
 
@@ -281,7 +281,8 @@ class Compiler(object):
             if ver == 'unknown':
                 continue
 
-            paths = tuple(pn[k] if k in pn else None for pn in dicts)
+            paths = tuple(pn[k] if k in pn else None for pn in dicts) +\
+                    ("",)  # '' is the empty LD_LIBRARY_PATH
             spec = spack.spec.CompilerSpec(cls.name, ver)
 
             if ver in compilers:
@@ -295,9 +296,7 @@ class Compiler(object):
                 # Don't add if it's not an improvement over prev compiler.
                 if newcount <= prevcount:
                     continue
-
             compilers[ver] = cls(spec, *paths)
-
         return list(compilers.values())
 
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -109,7 +109,7 @@ class Compiler(object):
         return '-Wl,-rpath,'
 
 
-    def __init__(self, cspec, cc, cxx, f77, fc):
+    def __init__(self, cspec, cc, cxx, f77, fc, ld_library_path):
         def check(exe):
             if exe is None:
                 return None
@@ -120,7 +120,7 @@ class Compiler(object):
         self.cxx = check(cxx)
         self.f77 = check(f77)
         self.fc  = check(fc)
-
+        self.ld_library_path = ld_library_path
         self.spec = cspec
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -29,7 +29,7 @@ import imp
 import os
 import platform
 
-from llnl.util.lang import memoized, list_modules
+from llnl.util.lang import list_modules
 from llnl.util.filesystem import join_path
 
 import spack
@@ -39,13 +39,11 @@ import spack.config
 import spack.architecture
 
 from spack.util.multiproc import parmap
-from spack.compiler import Compiler
-from spack.util.executable import which
 from spack.util.naming import mod_to_class
 from spack.util.environment import get_path
 
 _imported_compilers_module = 'spack.compilers'
-_required_instance_vars = ['cc', 'cxx', 'f77', 'fc', "LD_LIBRARY_PATH"]
+_required_instance_vars = ['cc', 'cxx', 'f77', 'fc', "environment"]
 
 # TODO: customize order in config file
 if platform.system() == 'Darwin':
@@ -65,7 +63,7 @@ def _auto_compiler_spec(function):
 def _to_dict(compiler):
     """Return a dict version of compiler suitable to insert in YAML."""
     return {
-        str(compiler.spec) : dict(
+        str(compiler.spec): dict(
             (attr, getattr(compiler, attr, None))
             for attr in _required_instance_vars)
     }
@@ -121,7 +119,7 @@ def add_compilers_to_config(compilers, arch=None, scope=None):
             (c, getattr(compiler, c, "None"))
             for c in _required_instance_vars)
 
-    update = { arch : compiler_config }
+    update = {arch: compiler_config}
     spack.config.update_config('compilers', update, scope)
 
 
@@ -139,7 +137,7 @@ def remove_compiler_from_config(compiler_spec, arch=None, scope=None):
 
     compiler_config = get_compiler_config(arch, scope)
     del compiler_config[str(compiler_spec)]
-    update = { arch : compiler_config }
+    update = {arch: compiler_config}
 
     spack.config.update_config('compilers', update, scope)
 
@@ -204,7 +202,7 @@ def find_compilers(*path):
     compiler_lists = parmap(lambda cls: cls.find(*filtered_path), types)
     # ensure all the version calls we made are cached in the parent
     # process, as well.  This speeds up Spack a lot.
-    clist = reduce(lambda x,y: x+y, compiler_lists)
+    clist = reduce(lambda x,  y: x + y, compiler_lists)
     return clist
 
 
@@ -227,7 +225,8 @@ def supported(compiler_spec):
 def find(compiler_spec, arch=None, scope=None):
     """Return specs of available compilers that match the supplied
        compiler spec.  Return an list if nothing found."""
-    return [c for c in all_compilers(arch, scope) if c.satisfies(compiler_spec)]
+    return [c for c in all_compilers(arch, scope)
+            if c.satisfies(compiler_spec)]
 
 
 @_auto_compiler_spec
@@ -296,4 +295,5 @@ class InvalidCompilerConfigurationError(spack.error.SpackError):
 
 class NoCompilersError(spack.error.SpackError):
     def __init__(self):
-        super(NoCompilersError, self).__init__("Spack could not find any compilers!")
+        super(NoCompilersError, self).__init__("Spack could not " +
+                                               "find any compilers!")

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -45,7 +45,7 @@ from spack.util.naming import mod_to_class
 from spack.util.environment import get_path
 
 _imported_compilers_module = 'spack.compilers'
-_required_instance_vars = ['cc', 'cxx', 'f77', 'fc']
+_required_instance_vars = ['cc', 'cxx', 'f77', 'fc', "LD_LIBRARY_PATH"]
 
 # TODO: customize order in config file
 if platform.system() == 'Darwin':

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -86,9 +86,7 @@ def get_compiler_config(arch=None, scope=None):
         for compiler in compilers:
             config[arch].update(_to_dict(compiler))
         spack.config.update_config('compilers', config, scope=scope)
-
     config = spack.config.get_config('compilers', scope=scope)
-
     # Update the configuration if there are currently no compilers
     # configured.  Avoid updating automatically if there ARE site
     # compilers configured but no user ones.
@@ -204,7 +202,6 @@ def find_compilers(*path):
     # the overhead of spelunking all these directories.
     types = all_compiler_types()
     compiler_lists = parmap(lambda cls: cls.find(*filtered_path), types)
-
     # ensure all the version calls we made are cached in the parent
     # process, as well.  This speeds up Spack a lot.
     clist = reduce(lambda x,y: x+y, compiler_lists)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -159,6 +159,8 @@ section_schemas = {
                                 'additionalProperties': False,
                                 'required': ['cc', 'cxx', 'f77', 'fc'],
                                 'properties': {
+                                    'LD_LIBRARY_PATH' : {"type" : "string",
+                                                         "default": ""},
                                     'cc':  { 'anyOf': [ {'type' : 'string' },
                                                         {'type' : 'null' }]},
                                     'cxx': { 'anyOf': [ {'type' : 'string' },

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -173,11 +173,11 @@ section_schemas = {
                                         'additionalProperties': False,
                                         'properties' : {
                                             'set': {
-                                                 'type': 'object',
-                                                 'additionalProperties' : False,
-                                                 'properties' : {
-                                                     'LD_LIBRARY_PATH' : {'type' : 'string'},
-                                                     'DYLD_LIBRARY_PATH' : {'type' : 'string'}
+                                                'type': 'object',
+                                                 'patternProperties': {
+                                                      r'\w[\w-]*': {  # key
+                                                      'type': 'string'
+                                                      }
                                                   }
                                              }
                                          }

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -159,8 +159,6 @@ section_schemas = {
                                 'additionalProperties': False,
                                 'required': ['cc', 'cxx', 'f77', 'fc'],
                                 'properties': {
-                                    'LD_LIBRARY_PATH' : {"type" : "string",
-                                                         "default": ""},
                                     'cc':  { 'anyOf': [ {'type' : 'string' },
                                                         {'type' : 'null' }]},
                                     'cxx': { 'anyOf': [ {'type' : 'string' },
@@ -169,6 +167,21 @@ section_schemas = {
                                                         {'type' : 'null' }]},
                                     'fc':  { 'anyOf': [ {'type' : 'string' },
                                                         {'type' : 'null' }]},
+                                    'environment': {
+                                        'type': 'object',
+                                        'default': {},
+                                        'additionalProperties': False,
+                                        'properties' : {
+                                            'set': {
+                                                 'type': 'object',
+                                                 'additionalProperties' : False,
+                                                 'properties' : {
+                                                     'LD_LIBRARY_PATH' : {'type' : 'string'},
+                                                     'DYLD_LIBRARY_PATH' : {'type' : 'string'}
+                                                  }
+                                             }
+                                         }
+                                    }
                                 },},},},},},},},
 
     'mirrors': {

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -42,13 +42,14 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
-      LD_LIBRARY_PATH : empty/dir
+      environment:
+        set:
+          LD_LIBRARY_PATH : empty/dir
     gcc@4.5.0:
       cc: /path/to/gcc
       cxx: /path/to/g++
       f77: /path/to/gfortran
       fc: /path/to/gfortran
-      LD_LIBRARY_PATH : empty/dir
 """
 
 mock_packages_config = """\
@@ -63,6 +64,7 @@ packages:
       externalvirtual@2.0%clang@3.3: /path/to/external_virtual_clang
       externalvirtual@1.0%gcc@4.5.0: /path/to/external_virtual_gcc
 """
+
 
 class MockPackagesTest(unittest.TestCase):
     def initmock(self):
@@ -81,7 +83,8 @@ class MockPackagesTest(unittest.TestCase):
         self.mock_user_config = os.path.join(self.temp_config, 'user')
         mkdirp(self.mock_site_config)
         mkdirp(self.mock_user_config)
-        for confs in [('compilers.yaml', mock_compiler_config), ('packages.yaml', mock_packages_config)]:
+        for confs in [('compilers.yaml', mock_compiler_config),
+                      ('packages.yaml', mock_packages_config)]:
             conf_yaml = os.path.join(self.mock_site_config, confs[0])
             with open(conf_yaml, 'w') as f:
                 f.write(confs[1])
@@ -95,7 +98,6 @@ class MockPackagesTest(unittest.TestCase):
         # Store changes to the package's dependencies so we can
         # restore later.
         self.saved_deps = {}
-
 
     def set_pkg_dep(self, pkg_name, spec):
         """Alters dependence information for a package.
@@ -111,8 +113,7 @@ class MockPackagesTest(unittest.TestCase):
             self.saved_deps[pkg_name] = (pkg, pkg.dependencies.copy())
 
         # Change dep spec
-        pkg.dependencies[spec.name] = { Spec(pkg_name) : spec }
-
+        pkg.dependencies[spec.name] = {Spec(pkg_name): spec}
 
     def cleanmock(self):
         """Restore the real packages path after any test."""
@@ -126,10 +127,8 @@ class MockPackagesTest(unittest.TestCase):
             pkg.dependencies.clear()
             pkg.dependencies.update(deps)
 
-
     def setUp(self):
         self.initmock()
-
 
     def tearDown(self):
         self.cleanmock()

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -42,11 +42,13 @@ compilers:
       cxx: /path/to/clang++
       f77: None
       fc: None
+      LD_LIBRARY_PATH : empty/dir
     gcc@4.5.0:
       cc: /path/to/gcc
       cxx: /path/to/g++
       f77: /path/to/gfortran
       fc: /path/to/gfortran
+      LD_LIBRARY_PATH : empty/dir
 """
 
 mock_packages_config = """\


### PR DESCRIPTION
As mentioned in issue #332 this adds the possiblity to specify an LD_LIBRARY_PATH in compilers.yaml

```
gcc@4.4.7:
    cc  = /usr/bin/gcc
    cxx = /usr/bin/g++
    f77 = /usr/bin/gfortran
    fc  = /usr/bin/gfortran
    ld_library_path = /what/ever/you/need
```

If considered useful, I will clean up and document. 
