### PR TITLE
Various changes to spack create template

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -50,7 +50,7 @@ from spack.stage import Stage
 description = "Create a new package file from an archive URL"
 
 package_template = string.Template(
-    _copyright + """
+    _copyright + """\
 #
 # This is a template package file for Spack.  We've put "FIXME"
 # next to all the things you'll want to change. Once you've handled
@@ -68,8 +68,10 @@ package_template = string.Template(
 #
 from spack import *
 
+
 class ${class_name}(Package):
     ""\"FIXME: put a proper description of your package here.""\"
+
     # FIXME: add a proper url for your package's homepage here.
     homepage = "http://www.example.com"
     url      = "${url}"
@@ -123,10 +125,10 @@ class ConfigureGuesser(object):
         """Try to guess the type of build system used by the project, and return
            an appropriate configure line.
         """
-        autotools = "configure('--prefix=%s' % prefix)"
+        autotools = "configure('--prefix={0}'.format(prefix))"
         cmake     = "cmake('.', *std_cmake_args)"
-        python    = "python('setup.py', 'install', '--prefix=%s' % prefix)"
-        r         = "R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)"
+        python    = "python('setup.py', 'install', '--prefix={0}'.format(prefix))"
+        r         = "R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir), self.stage.archive_file)"
 
         config_lines = ((r'/configure$',      'autotools', autotools),
                         (r'/CMakeLists.txt$', 'cmake',     cmake),
@@ -214,11 +216,7 @@ def find_repository(spec, args):
 
 def fetch_tarballs(url, name, version):
     """Try to find versions of the supplied archive by scraping the web.
-
-    Prompts the user to select how many to download if many are found.
-
-
-    """
+    Prompts the user to select how many to download if many are found."""
     versions = spack.util.web.find_versions_of_archive(url)
     rkeys = sorted(versions.keys(), reverse=True)
     versions = OrderedDict(zip(rkeys, (versions[v] for v in rkeys)))

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -1,3 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import string
+import os
+import re
+
+from ordereddict_backport import OrderedDict
+import llnl.util.tty as tty
+from llnl.util.filesystem import mkdirp
+
+import spack
+import spack.cmd
+import spack.cmd.checksum
+import spack.url
+import spack.util.web
+from spack.spec import Spec
+from spack.util.naming import *
+from spack.repository import Repo, RepoError
+
+from spack.util.executable import which
+
+
 _copyright = """\
 ##############################################################################
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
@@ -24,28 +69,6 @@ _copyright = """\
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 """
-import string
-import os
-import hashlib
-import re
-
-from ordereddict_backport import OrderedDict
-import llnl.util.tty as tty
-from llnl.util.filesystem import mkdirp
-
-import spack
-import spack.cmd
-import spack.cmd.checksum
-import spack.url
-import spack.util.web
-from spack.spec import Spec
-from spack.util.naming import *
-from spack.repository import Repo, RepoError
-import spack.util.crypto as crypto
-
-from spack.util.executable import which
-from spack.stage import Stage
-
 
 description = "Create a new package file from an archive URL"
 
@@ -122,13 +145,15 @@ def setup_parser(subparser):
 
 class ConfigureGuesser(object):
     def __call__(self, stage):
-        """Try to guess the type of build system used by the project, and return
-           an appropriate configure line.
-        """
+        """Try to guess the type of build system used by the project,
+        and return an appropriate configure line."""
         autotools = "configure('--prefix={0}'.format(prefix))"
         cmake     = "cmake('.', *std_cmake_args)"
-        python    = "python('setup.py', 'install', '--prefix={0}'.format(prefix))"
-        r         = "R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir), self.stage.archive_file)"
+        python    = "python('setup.py', 'install', " \
+                    "'--prefix={0}'.format(prefix))"
+        r         = "R('CMD', 'INSTALL', " \
+                    "'--library={0}'.format(self.module.r_lib_dir), " \
+                    "self.stage.archive_file)"
 
         config_lines = ((r'/configure$',      'autotools', autotools),
                         (r'/CMakeLists.txt$', 'cmake',     cmake),
@@ -149,7 +174,8 @@ class ConfigureGuesser(object):
                 break
         else:
             # None matched -- just put both, with cmake commented out
-            config_line =  "# FIXME: Spack couldn't guess one, so here are some options:\n"
+            config_line  = "# FIXME: Spack couldn't guess one, "
+            config_line += "so here are some options:\n"
             config_line += "        # " + autotools + "\n"
             config_line += "        # " + cmake
             build_system = 'unknown'
@@ -170,10 +196,10 @@ def guess_name_and_version(url, args):
     else:
         try:
             name = spack.url.parse_name(url, version)
-        except spack.url.UndetectableNameError, e:
+        except spack.url.UndetectableNameError:
             # Use a user-supplied name if one is present
-            tty.die("Couldn't guess a name for this package. Try running:", "",
-                    "spack create --name <name> <url>")
+            tty.die("Couldn't guess a name for this package. Try running:",
+                    "", "spack create --name <name> <url>")
 
     if not valid_fully_qualified_module_name(name):
         tty.die("Package name can only contain A-Z, a-z, 0-9, '_' and '-'")
@@ -184,7 +210,8 @@ def guess_name_and_version(url, args):
 def find_repository(spec, args):
     # figure out namespace for spec
     if spec.namespace and args.namespace and spec.namespace != args.namespace:
-        tty.die("Namespaces '%s' and '%s' do not match." % (spec.namespace, args.namespace))
+        tty.die("Namespaces '%s' and '%s' do not match." % (spec.namespace,
+                                                            args.namespace))
 
     if not spec.namespace and args.namespace:
         spec.namespace = args.namespace
@@ -195,8 +222,8 @@ def find_repository(spec, args):
         try:
             repo = Repo(repo_path)
             if spec.namespace and spec.namespace != repo.namespace:
-                tty.die("Can't create package with namespace %s in repo with namespace %s"
-                        % (spec.namespace, repo.namespace))
+                tty.die("Can't create package with namespace %s in repo with "
+                        "namespace %s" % (spec.namespace, repo.namespace))
         except RepoError as e:
             tty.die(str(e))
     else:
@@ -224,11 +251,11 @@ def fetch_tarballs(url, name, version):
     archives_to_fetch = 1
     if not versions:
         # If the fetch failed for some reason, revert to what the user provided
-        versions = { version : url }
+        versions = {version: url}
     elif len(versions) > 1:
         tty.msg("Found %s versions of %s:" % (len(versions), name),
                 *spack.cmd.elide_list(
-                    ["%-10s%s" % (v,u) for v, u in versions.iteritems()]))
+                    ["%-10s%s" % (v, u) for v, u in versions.iteritems()]))
         print
         archives_to_fetch = tty.get_number(
             "Include how many checksums in the package file?",


### PR DESCRIPTION
The main reason I opened this PR is because:
```
from spack import *

class ${class_name}(Package):
```
causes flake8 to be unhappy. I made it two empty lines.

While I was at it, I also changed:
```python
configure('--prefix=%s' % prefix)
```
to
```python
configure('--prefix={0}'.format(prefix))
```
While the former only works in Python 2, the latter works in Python 2.6, 2.7, and 3. The sooner we include this in the template, the sooner we can get people used to using it. Then, converting Spack to Python 3 (hopefully in the distant future) will be a little bit easier.

Let me know if you don't want to include the latter.