### PR TITLE
Enhancement Proposal: Make Python Spack Installs Ignore User Configuration

### DIFF
--- a/share/spack/csh/convert-pyext.sh
+++ b/share/spack/csh/convert-pyext.sh
@@ -1,0 +1,5 @@
+#!/bin/bash --noprofile
+PYEXT_REGEX=".*/.*/package.py"
+
+find var/spack/repos/builtin/packages/ -type f -regextype sed -regex ${PYEXT_REGEX} -exec \
+    sed -i 's/python('\''setup.py'\'', /setup_py(/' {} \;

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -24,8 +24,11 @@
 ##############################################################################
 from spack import *
 
+
 class PySetuptools(Package):
-    """Easily download, build, install, upgrade, and uninstall Python packages."""
+    """A Python utility that aids in the process of downloading, building,
+       upgrading, installing, and uninstalling Python packages."""
+
     homepage = "https://pypi.python.org/pypi/setuptools"
     url      = "https://pypi.python.org/packages/source/s/setuptools/setuptools-11.3.tar.gz"
 
@@ -40,4 +43,4 @@ class PySetuptools(Package):
     extends('python')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -101,32 +101,13 @@ class Python(Package):
         # Rest of install is pretty standard except setup.py needs to
         # be able to read the CPPFLAGS and LDFLAGS as it scans for the
         # library and headers to build
-        include_dirs = [
-            spec['openssl'].prefix.include,  spec['bzip2'].prefix.include,
-            spec['readline'].prefix.include, spec['ncurses'].prefix.include,
-            spec['sqlite'].prefix.include,   spec['zlib'].prefix.include
-        ]
-
-        library_dirs = [
-            spec['openssl'].prefix.lib,  spec['bzip2'].prefix.lib,
-            spec['readline'].prefix.lib, spec['ncurses'].prefix.lib,
-            spec['sqlite'].prefix.lib,   spec['zlib'].prefix.lib
-        ]
-
-        if '+tk' in spec:
-            include_dirs.extend([
-                spec['tk'].prefix.include, spec['tcl'].prefix.include
-            ])
-            library_dirs.extend([
-                spec['tk'].prefix.lib, spec['tcl'].prefix.lib
-            ])
-
+        dep_pfxs = [dspec.prefix for dspec in spec.dependencies('link')]
         config_args = [
-            "--prefix={0}".format(prefix),
-            "--with-threads",
-            "--enable-shared",
-            "CPPFLAGS=-I{0}".format(" -I".join(include_dirs)),
-            "LDFLAGS=-L{0}".format(" -L".join(library_dirs))
+            '--prefix={0}'.format(prefix),
+            '--with-threads',
+            '--enable-shared',
+            'CPPFLAGS=-I{0}'.format(' -I'.join(dp.include for dp in dep_pfxs)),
+            'LDFLAGS=-L{0}'.format(' -L'.join(dp.lib for dp in dep_pfxs)),
         ]
 
         if '+ucs4' in spec:
@@ -142,9 +123,8 @@ class Python(Package):
             config_args.append('--without-ensurepip')
 
         configure(*config_args)
-
         make()
-        make("install")
+        make('install')
 
         self.filter_compilers(spec, prefix)
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -27,6 +27,7 @@ import re
 from contextlib import closing
 
 import spack
+import llnl.util.tty as tty
 from llnl.util.lang import match_predicate
 from spack import *
 from spack.util.environment import *
@@ -72,9 +73,29 @@ class Python(Package):
     depends_on("tk",  when="+tk")
     depends_on("tcl", when="+tk")
 
+    @when('@2.7,3.4:')
+    def patch(self):
+        # NOTE: Python's default installation procedure makes it possible for a
+        # user's local configurations to change the Spack installation.  In
+        # order to prevent this behavior for a full installation, we must
+        # modify the installation script so that it ignores user files.
+        ff = FileFilter('Makefile.pre.in')
+        ff.filter(
+            r'^(.*)setup\.py(.*)((build)|(install))(.*)$',
+            r'\1setup.py\2 --no-user-cfg \3\6'
+        )
+
     def install(self, spec, prefix):
+        # TODO: The '--no-user-cfg' option for Python installation is only in
+        # Python v2.7 and v3.4+ (see https://bugs.python.org/issue1180) and
+        # adding support for ignoring user configuration will require
+        # significant changes to this package for other Python versions.
+        if not spec.satisfies('@2.7,3.4:'):
+            tty.warn(('Python v{0} may not install properly if Python '
+                      'user configurations are present.').format(self.version))
+
         # Need this to allow python build to find the Python installation.
-        env['PYTHONHOME'] = prefix
+        env['PYTHONHOME'], env['PYTHONPATH'] = prefix, prefix
         env['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
         # Rest of install is pretty standard except setup.py needs to
@@ -193,6 +214,8 @@ class Python(Package):
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
         """Set PYTHONPATH to include site-packages dir for the
         extension and any other python extensions it depends on."""
+        pythonhome = self.prefix
+        spack_env.set('PYTHONHOME', pythonhome)
 
         python_paths = []
         for d in extension_spec.traverse(deptype=nolink, deptype_query='run'):
@@ -214,15 +237,14 @@ class Python(Package):
 
         In most cases, extensions will only need to have one line::
 
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))"""
+        setup_py('install', '--prefix={0}'.format(prefix))"""
+        python_path = join_path(
+            self.spec.prefix.bin,
+            'python{0}'.format('3' if self.spec.satisfies('@3') else '')
+        )
 
-        # Python extension builds can have a global python executable function
-        if Version("3.0.0") <= self.version < Version("4.0.0"):
-            module.python = Executable(join_path(self.spec.prefix.bin,
-                                                 'python3'))
-        else:
-            module.python = Executable(join_path(self.spec.prefix.bin,
-                                                 'python'))
+        module.python = Executable(python_path)
+        module.setup_py = Executable(python_path + ' setup.py --no-user-cfg')
 
         # Add variables for lib/pythonX.Y and lib/pythonX.Y/site-packages dirs.
         module.python_lib_dir     = join_path(ext_spec.prefix,


### PR DESCRIPTION
Python's build system provides a lot of room for granular levels of customization through the use and application of [user, system, and distribution configuration files](https://docs.python.org/2/install/index.html#distutils-configuration-files).  While these files are very useful for customizing Python builds, they tend to negatively impact Spack's installation processes for Python and Python extensions by adding unwanted configuration options (which can alter the destinations of Spack's installs).  In order to allow Spack installations of Python libraries to coexist with these files, a solution must be implemented that allows Spack's install scripts to ignore these configuration files and all external install scripts that use Spack's Python to acknowledge them.

I've outlined a few potential solutions to this problem below:
- **Add `--no-user-cfg` to Each Python Extension's Install Command**: This solution will require changing the most files, but will necessitate zero additional changes to Spack's infrastructure or the Python package.  This solution is potentially undesirable because it requires authors for Python extension packages to acknowledge and properly account for the the fact that user configuration needs to be ignored.
- **Add `python_setup` Function to Python Extensions**: This solution involves adding new function to Python extension modules that sets up extension files while ignoring user configurations (i.e. something that invokes `python setup.py --no-user-cfg [setup-instruction] [arguments]`).  This solution avoids the majority of the acknowledgement problems of the previous solution (authors will still have to remember to call `python_setup` instead of `python('setup.py', 'install')`), but still requires that all the Python extension install scripts be updated.
- **Pre-Install `setup.cfg` into Each Python Extension's Install Directory**: This solution involves taking advantage of [Python's hierarchy of configuration files](https://docs.python.org/2/install/index.html#location-and-names-of-config-files) to override user and system options.  No Python extension packages need to be modified in this solution, but the Python package will need to install a file into each extension package's install directory (probably similar to the `Package.setup_dependent_package` function but occurring after the staging process for the dependent begins).  Additionally, due to a bug in Python's configuration capture functionality, this method will require a nontrivial patch to be applied to the Python `distutils` source code (which is probably not portable to versions of Python outside of 2.7).

If anyone has any thoughts about the methods that I've outlined or has any alternative solutions (especially frequent users of the Python package like @alalazo, @citibeth, @glennpj, @tgamblin), please let me know!  Given that each solution will require some fairly significant changes to Spack's Python packages, I'd like some input before I start writing anything major.  Thanks!