### PR TITLE
netcdf-cxx4: Update to latest released version 4.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -27,13 +27,16 @@ from spack import *
 class NetcdfCxx4(Package):
     """C++ interface for NetCDF4"""
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
-    url      = "http://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.2.tar.gz"
+    url      = "https://www.github.com/unidata/netcdf-cxx4/tarball/v4.3.0"
 
-    version('4.2', 'd019853802092cf686254aaba165fc81')
+    version('4.3.0', '0dde8b9763eecdafbd69d076e687337e')
+    version('4.2.1', 'd019853802092cf686254aaba165fc81')
 
     depends_on('netcdf')
+    depends_on("autoconf")
 
     def install(self, spec, prefix):
+        which('autoreconf')('-ivf')    # Rebuild to prevent problems of inconsistency in git repo
         configure('--prefix=%s' % prefix)
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class NetcdfCxx4(Package):
     """C++ interface for NetCDF4"""
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
@@ -36,7 +37,8 @@ class NetcdfCxx4(Package):
     depends_on("autoconf")
 
     def install(self, spec, prefix):
-        which('autoreconf')('-ivf')    # Rebuild to prevent problems of inconsistency in git repo
+        # Rebuild to prevent problems of inconsistency in git repo
+        which('autoreconf')('-ivf')
         configure('--prefix=%s' % prefix)
         make()
         make("install")


### PR DESCRIPTION
I switched this to the git repo because:
  a) You can get inter-release versions from it as well, when needed.
  b) The manual process at UCAR of uploading the tarball has not been completed yet.

I also made it re-run autoreconf.  Don't trust configure scripts from git repos, especially if they're from versions inbetween tagged releases.
