### PR TITLE
complete lua rework

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -45,11 +45,8 @@ The available directives are:
   * ``resource``
 
 """
-__all__ = ['depends_on', 'extends', 'provides', 'patch', 'version',
-           'variant', 'resource']
 
 import re
-import inspect
 import os.path
 import functools
 
@@ -66,6 +63,9 @@ from spack.variant import Variant
 from spack.spec import Spec, parse_anonymous_spec
 from spack.resource import Resource
 from spack.fetch_strategy import from_kwargs
+
+__all__ = ['depends_on', 'extends', 'provides', 'patch', 'version', 'variant',
+           'resource']
 
 #
 # This is a list of all directives, built up as they are defined in
@@ -122,14 +122,13 @@ class directive(object):
 
     def __init__(self, dicts=None):
         if isinstance(dicts, basestring):
-            dicts = (dicts,)
+            dicts = (dicts, )
         elif type(dicts) not in (list, tuple):
             raise TypeError(
-                "dicts arg must be list, tuple, or string. Found %s"
-                % type(dicts))
+                "dicts arg must be list, tuple, or string. Found %s" %
+                type(dicts))
 
         self.dicts = dicts
-
 
     def ensure_dicts(self, pkg):
         """Ensure that a package has the dicts required by this directive."""
@@ -141,7 +140,6 @@ class directive(object):
             if not isinstance(attr, dict):
                 raise spack.error.SpackError(
                     "Package %s has non-dict %s attribute!" % (pkg, d))
-
 
     def __call__(self, directive_function):
         directives[directive_function.__name__] = self
@@ -259,11 +257,12 @@ def variant(pkg, name, default=False, description=""):
     """Define a variant for the package. Packager can specify a default
     value (on or off) as well as a text description."""
 
-    default     = bool(default)
+    default = bool(default)
     description = str(description).strip()
 
     if not re.match(spack.spec.identifier_re, name):
-        raise DirectiveError("Invalid variant name in %s: '%s'" % (pkg.name, name))
+        raise DirectiveError("Invalid variant name in %s: '%s'" %
+                             (pkg.name, name))
 
     pkg.variants[name] = Variant(default, description)
 
@@ -271,31 +270,37 @@ def variant(pkg, name, default=False, description=""):
 @directive('resources')
 def resource(pkg, **kwargs):
     """
-    Define an external resource to be fetched and staged when building the package. Based on the keywords present in the
-    dictionary the appropriate FetchStrategy will be used for the resource. Resources are fetched and staged in their
-    own folder inside spack stage area, and then linked into the stage area of the package that needs them.
+    Define an external resource to be fetched and staged when building the
+    package. Based on the keywords present in the dictionary the appropriate
+    FetchStrategy will be used for the resource. Resources are fetched and
+    staged in their own folder inside spack stage area, and then linked into
+    the stage area of the package that needs them.
 
     List of recognized keywords:
 
-    * 'when' : (optional) represents the condition upon which the resource is needed
-    * 'destination' : (optional) path where to link the resource. This path must be relative to the main package stage
-    area.
-    * 'placement' : (optional) gives the possibility to fine tune how the resource is linked into the main package stage
-    area.
+    * 'when' : (optional) represents the condition upon which the resource is
+    needed
+    * 'destination' : (optional) path where to link the resource. This path
+    must be relative to the main package stage area.
+    * 'placement' : (optional) gives the possibility to fine tune how the
+    resource is linked into the main package stage area.
     """
     when = kwargs.get('when', pkg.name)
     destination = kwargs.get('destination', "")
     placement = kwargs.get('placement', None)
     # Check if the path is relative
     if os.path.isabs(destination):
-        message = "The destination keyword of a resource directive can't be an absolute path.\n"
+        message = "The destination keyword of a resource directive can't be"
+        " an absolute path.\n"
         message += "\tdestination : '{dest}\n'".format(dest=destination)
         raise RuntimeError(message)
     # Check if the path falls within the main package stage area
     test_path = 'stage_folder_root'
-    normalized_destination = os.path.normpath(join_path(test_path, destination))  # Normalized absolute path
+    normalized_destination = os.path.normpath(join_path(test_path, destination)
+                                              )  # Normalized absolute path
     if test_path not in normalized_destination:
-        message = "The destination folder of a resource must fall within the main package stage directory.\n"
+        message = "The destination folder of a resource must fall within the"
+        " main package stage directory.\n"
         message += "\tdestination : '{dest}'\n".format(dest=destination)
         raise RuntimeError(message)
     when_spec = parse_anonymous_spec(when, pkg.name)
@@ -307,6 +312,7 @@ def resource(pkg, **kwargs):
 
 class DirectiveError(spack.error.SpackError):
     """This is raised when something is wrong with a package directive."""
+
     def __init__(self, directive, message):
         super(DirectiveError, self).__init__(message)
         self.directive = directive
@@ -314,6 +320,7 @@ class DirectiveError(spack.error.SpackError):
 
 class CircularReferenceError(DirectiveError):
     """This is raised when something depends on itself."""
+
     def __init__(self, directive, package):
         super(CircularReferenceError, self).__init__(
             directive,

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -292,7 +292,7 @@ def resource(pkg, **kwargs):
         message += "\tdestination : '{dest}\n'".format(dest=destination)
         raise RuntimeError(message)
     # Check if the path falls within the main package stage area
-    test_path = 'stage_folder_root/'
+    test_path = 'stage_folder_root'
     normalized_destination = os.path.normpath(join_path(test_path, destination))  # Normalized absolute path
     if test_path not in normalized_destination:
         message = "The destination folder of a resource must fall within the main package stage directory.\n"

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -64,7 +64,8 @@ class SetPath(NameValueModifier):
 class AppendPath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(self.separator) if environment_value else []
+        directories = environment_value.split(
+            self.separator) if environment_value else []
         directories.append(os.path.normpath(self.value))
         os.environ[self.name] = self.separator.join(directories)
 
@@ -72,7 +73,8 @@ class AppendPath(NameValueModifier):
 class PrependPath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(self.separator) if environment_value else []
+        directories = environment_value.split(
+            self.separator) if environment_value else []
         directories = [os.path.normpath(self.value)] + directories
         os.environ[self.name] = self.separator.join(directories)
 
@@ -80,9 +82,9 @@ class PrependPath(NameValueModifier):
 class RemovePath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(self.separator) if environment_value else []
-        directories = [os.path.normpath(x)
-                       for x in directories
+        directories = environment_value.split(
+            self.separator) if environment_value else []
+        directories = [os.path.normpath(x) for x in directories
                        if x != os.path.normpath(self.value)]
         os.environ[self.name] = self.separator.join(directories)
 
@@ -257,16 +259,13 @@ def set_or_unset_not_first(variable, changes, errstream):
     Check if we are going to set or unset something after other modifications
     have already been requested
     """
-    indexes = [ii
-               for ii, item in enumerate(changes)
+    indexes = [ii for ii, item in enumerate(changes)
                if ii != 0 and type(item) in [SetEnv, UnsetEnv]]
     if indexes:
         good = '\t    \t{context} at {filename}:{lineno}'
         nogood = '\t--->\t{context} at {filename}:{lineno}'
         message = 'Suspicious requests to set or unset the variable \'{var}\' found'  # NOQA: ignore=E501
-        errstream(
-            message.format(
-                var=variable))
+        errstream(message.format(var=variable))
         for ii, item in enumerate(changes):
             print_format = nogood if ii in indexes else good
             errstream(print_format.format(**item.args))

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -241,12 +241,14 @@ class EnvironmentModifications(object):
                 x.execute()
 
 
-def concatenate_paths(paths, separator=';'):
+def concatenate_paths(paths, separator=':'):
     """
-    Concatenates an iterable of paths into a  string of column separated paths
+    Concatenates an iterable of paths into a string of paths separated by
+    separator, defaulting to colon
 
     Args:
         paths: iterable of paths
+        separator: the separator to use, default ':'
 
     Returns:
         string

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -39,7 +39,8 @@ class NameValueModifier(object):
     def __init__(self, name, value, **kwargs):
         self.name = name
         self.value = value
-        self.args = {'name': name, 'value': value}
+        self.separator = kwargs.get('separator', ':')
+        self.args = {'name': name, 'value': value, 'delim': self.separator}
         self.args.update(kwargs)
 
 
@@ -56,34 +57,34 @@ class UnsetEnv(NameModifier):
 
 class SetPath(NameValueModifier):
     def execute(self):
-        string_path = concatenate_paths(self.value)
+        string_path = concatenate_paths(self.value, separator=self.separator)
         os.environ[self.name] = string_path
 
 
 class AppendPath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(':') if environment_value else []
+        directories = environment_value.split(self.separator) if environment_value else []
         directories.append(os.path.normpath(self.value))
-        os.environ[self.name] = ':'.join(directories)
+        os.environ[self.name] = self.separator.join(directories)
 
 
 class PrependPath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(':') if environment_value else []
+        directories = environment_value.split(self.separator) if environment_value else []
         directories = [os.path.normpath(self.value)] + directories
-        os.environ[self.name] = ':'.join(directories)
+        os.environ[self.name] = self.separator.join(directories)
 
 
 class RemovePath(NameValueModifier):
     def execute(self):
         environment_value = os.environ.get(self.name, '')
-        directories = environment_value.split(':') if environment_value else []
+        directories = environment_value.split(self.separator) if environment_value else []
         directories = [os.path.normpath(x)
                        for x in directories
                        if x != os.path.normpath(self.value)]
-        os.environ[self.name] = ':'.join(directories)
+        os.environ[self.name] = self.separator.join(directories)
 
 
 class EnvironmentModifications(object):
@@ -238,7 +239,7 @@ class EnvironmentModifications(object):
                 x.execute()
 
 
-def concatenate_paths(paths):
+def concatenate_paths(paths, separator=';'):
     """
     Concatenates an iterable of paths into a  string of column separated paths
 
@@ -248,7 +249,7 @@ def concatenate_paths(paths):
     Returns:
         string
     """
-    return ':'.join(str(item) for item in paths)
+    return separator.join(str(item) for item in paths)
 
 
 def set_or_unset_not_first(variable, changes, errstream):

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -485,9 +485,10 @@ class TclModule(EnvModule):
     path = join_path(spack.share_path, "modules")
 
     environment_modifications_formats = {
-        PrependPath: 'prepend-path {name} \"{value}\"\n',
-        AppendPath: 'append-path {name} \"{value}\"\n',
-        RemovePath: 'remove-path {name} \"{value}\"\n',
+    formats = {
+        PrependPath: 'prepend-path --delim "{delim}" {name} \"{value}\"\n',
+        AppendPath: 'append-path   --delim "{delim}" {name} \"{value}\"\n',
+        RemovePath: 'remove-path   --delim "{delim}" {name} \"{value}\"\n',
         SetEnv: 'setenv {name} \"{value}\"\n',
         UnsetEnv: 'unsetenv {name}\n'
     }

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -485,7 +485,6 @@ class TclModule(EnvModule):
     path = join_path(spack.share_path, "modules")
 
     environment_modifications_formats = {
-    formats = {
         PrependPath: 'prepend-path --delim "{delim}" {name} \"{value}\"\n',
         AppendPath: 'append-path   --delim "{delim}" {name} \"{value}\"\n',
         RemovePath: 'remove-path   --delim "{delim}" {name} \"{value}\"\n',

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -1,6 +1,7 @@
 from spack import *
 import glob
 
+
 class LuaLuaposix(Package):
     """Lua posix bindings, including ncurses"""
     homepage = "https://github.com/luaposix/luaposix/"

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -13,5 +13,4 @@ class LuaLuaposix(Package):
 
     def install(self, spec, prefix):
         rockspec = glob.glob('luaposix-*.rockspec')
-        print rockspec
         luarocks('--tree=' + prefix, 'install', rockspec[0])

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -1,0 +1,16 @@
+from spack import *
+import glob
+
+class LuaLuaposix(Package):
+    """Lua posix bindings, including ncurses"""
+    homepage = "https://github.com/luaposix/luaposix/"
+    url      = "https://github.com/luaposix/luaposix/archive/release-v33.4.0.tar.gz"
+
+    version('33.4.0', 'b36ff049095f28752caeb0b46144516c')
+
+    extends("lua")
+
+    def install(self, spec, prefix):
+        rockspec = glob.glob('luaposix-*.rockspec')
+        print rockspec
+        luarocks('--tree=' + prefix, 'install', rockspec[0])

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -25,10 +25,11 @@
 from spack import *
 import os
 
+
 class Lua(Package):
     """ The Lua programming language interpreter and library """
     homepage = "http://www.lua.org"
-    url      = "http://www.lua.org/ftp/lua-5.1.5.tar.gz"
+    url = "http://www.lua.org/ftp/lua-5.1.5.tar.gz"
 
     version('5.3.2', '33278c2ab5ee3c1a875be8d55c1ca2a1')
     version('5.3.1', '797adacada8d85761c079390ff1d9961')
@@ -47,11 +48,12 @@ class Lua(Package):
     depends_on('ncurses')
     depends_on('readline')
 
-    resource(name="luarocks",
-             url="https://keplerproject.github.io/luarocks/releases/luarocks-2.3.0.tar.gz",
-             md5="a38126684cf42b7d0e7a3c7cf485defb",
-             destination="luarocks",
-             placement='luarocks')
+    resource(
+        name="luarocks",
+        url="https://keplerproject.github.io/luarocks/releases/luarocks-2.3.0.tar.gz",
+        md5="a38126684cf42b7d0e7a3c7cf485defb",
+        destination="luarocks",
+        placement='luarocks')
 
     def install(self, spec, prefix):
         if spec.satisfies("=darwin-i686") or spec.satisfies("=darwin-x86_64"):
@@ -59,15 +61,13 @@ class Lua(Package):
         else:
             target = 'linux'
         make('INSTALL_TOP=%s' % prefix,
-             'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib,
-             target)
+             'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib, target)
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib,
              'install')
 
-        with working_dir(os.path.join('luarocks','luarocks')):
-            configure('--prefix=' + prefix,
-                      '--with-lua=' + prefix)
+        with working_dir(os.path.join('luarocks', 'luarocks')):
+            configure('--prefix=' + prefix, '--with-lua=' + prefix)
             make('build')
             make('install')
 
@@ -77,8 +77,7 @@ class Lua(Package):
         cpaths.append(os.path.join(path, '?.so'))
 
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
-        lua_paths = [
-                ]
+        lua_paths = []
         for d in extension_spec.traverse():
             if d.package.extends(self.spec):
                 lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
@@ -91,31 +90,41 @@ class Lua(Package):
                 self.append_paths(lua_patterns, lua_cpatterns, p)
 
         # Always add this package's paths
-        for p in ( os.path.join(self.spec.prefix, self.lua_lib_dir), os.path.join(self.spec.prefix, self.lua_share_dir)):
+        for p in (os.path.join(self.spec.prefix, self.lua_lib_dir),
+                  os.path.join(self.spec.prefix, self.lua_share_dir)):
             self.append_paths(lua_patterns, lua_cpatterns, p)
-
 
         spack_env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
         spack_env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
 
         # For run time environment set only the path for extension_spec and prepend it to LUAPATH
         if extension_spec.package.extends(self.spec):
-            run_env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')
-            run_env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
-            # run_env.prepend_path('LUA_PATH',  os.path.join(extension_spec.prefix, self.lua_lib_dir, '?.lua'), separator=';')
-            # run_env.prepend_path('LUA_PATH',  os.path.join(extension_spec.prefix, self.lua_lib_dir, '?', 'init.lua'), separator=';')
-            # run_env.prepend_path('LUA_CPATH', os.path.join(extension_spec.prefix, self.lua_lib_dir, '?.so'), separator=';')
+            run_env.prepend_path('LUA_PATH', ';'.join(lua_patterns),
+                                 separator=';')
+            run_env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns),
+                                 separator=';')
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'), separator=';')
-        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_share_dir, '?', 'init.lua'), separator=';')
-        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_lib_dir, '?.lua'), separator=';')
-        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'), separator=';')
-        run_env.prepend_path('LUA_CPATH', os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'), separator=';')
+        run_env.prepend_path('LUA_PATH', os.path.join(
+            self.spec.prefix, self.lua_share_dir, '?.lua'),
+                             separator=';')
+        run_env.prepend_path('LUA_PATH', os.path.join(
+            self.spec.prefix, self.lua_share_dir, '?', 'init.lua'),
+                             separator=';')
+        run_env.prepend_path('LUA_PATH', os.path.join(
+            self.spec.prefix, self.lua_lib_dir, '?.lua'),
+                             separator=';')
+        run_env.prepend_path('LUA_PATH', os.path.join(
+            self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'),
+                             separator=';')
+        run_env.prepend_path('LUA_CPATH', os.path.join(
+            self.spec.prefix, self.lua_lib_dir, '?.so'),
+                             separator=';')
 
     @property
     def lua_lib_dir(self):
         return os.path.join('lib', 'lua', '%d.%d' % self.version[:2])
+
     @property
     def lua_share_dir(self):
         return os.path.join('share', 'lua', '%d.%d' % self.version[:2])
@@ -130,5 +139,5 @@ class Lua(Package):
         """
         # Lua extension builds can have lua and luarocks executable functions
         module.lua = Executable(join_path(self.spec.prefix.bin, 'lua'))
-        module.luarocks = Executable(join_path(self.spec.prefix.bin, 'luarocks'))
-
+        module.luarocks = Executable(join_path(self.spec.prefix.bin,
+                                               'luarocks'))

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -62,9 +62,18 @@ class Lua(Package):
         else:
             target = 'linux'
         make('INSTALL_TOP=%s' % prefix,
-             'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib, target)
+             'MYLDFLAGS=-L%s -L%s ' % (
+                 spec['readline'].prefix.lib,
+                 spec['ncurses'].prefix.lib
+                 ),
+             'MYLIBS=-lncurses',
+             target)
         make('INSTALL_TOP=%s' % prefix,
-             'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib,
+             'MYLDFLAGS=-L%s -L%s ' % (
+                 spec['readline'].prefix.lib,
+                 spec['ncurses'].prefix.lib
+                 ),
+             'MYLIBS=-lncurses',
              'install')
 
         with working_dir(os.path.join('luarocks', 'luarocks')):

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -64,15 +64,13 @@ class Lua(Package):
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -L%s ' % (
                  spec['readline'].prefix.lib,
-                 spec['ncurses'].prefix.lib
-                 ),
+                 spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
              target)
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -L%s ' % (
                  spec['readline'].prefix.lib,
-                 spec['ncurses'].prefix.lib
-                 ),
+                 spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
              'install')
 

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -42,8 +42,16 @@ class Lua(Package):
     version('5.1.4', 'd0870f2de55d59c1c8419f36e8fac150')
     version('5.1.3', 'a70a8dfaa150e047866dc01a46272599')
 
+    extendable = True
+
     depends_on('ncurses')
     depends_on('readline')
+
+    resource(name="luarocks",
+             url="https://keplerproject.github.io/luarocks/releases/luarocks-2.3.0.tar.gz",
+             md5="a38126684cf42b7d0e7a3c7cf485defb",
+             destination="luarocks",
+             placement='luarocks')
 
     def install(self, spec, prefix):
         if spec.satisfies("=darwin-i686") or spec.satisfies("=darwin-x86_64"):
@@ -56,3 +64,71 @@ class Lua(Package):
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -lncurses' % spec['ncurses'].prefix.lib,
              'install')
+
+        with working_dir(os.path.join('luarocks','luarocks')):
+            configure('--prefix=' + prefix,
+                      '--with-lua=' + prefix)
+            make('build')
+            make('install')
+
+    def append_paths(self, paths, cpaths, path):
+        paths.append(os.path.join(path, '?.lua'))
+        paths.append(os.path.join(path, '?', 'init.lua'))
+        cpaths.append(os.path.join(path, '?.so'))
+
+    def setup_dependent_environment(self, spack_env, run_env, extension_spec):
+        lua_paths = [
+                ]
+        for d in extension_spec.traverse():
+            if d.package.extends(self.spec):
+                lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
+                lua_paths.append(os.path.join(d.prefix, self.lua_share_dir))
+
+        lua_patterns = []
+        lua_cpatterns = []
+        for p in lua_paths:
+            if os.path.isdir(p):
+                self.append_paths(lua_patterns, lua_cpatterns, p)
+
+        # Always add this package's paths
+        for p in ( os.path.join(self.spec.prefix, self.lua_lib_dir), os.path.join(self.spec.prefix, self.lua_share_dir)):
+            self.append_paths(lua_patterns, lua_cpatterns, p)
+
+
+        spack_env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
+        spack_env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
+
+        # For run time environment set only the path for extension_spec and prepend it to LUAPATH
+        if extension_spec.package.extends(self.spec):
+            run_env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')
+            run_env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
+            # run_env.prepend_path('LUA_PATH',  os.path.join(extension_spec.prefix, self.lua_lib_dir, '?.lua'), separator=';')
+            # run_env.prepend_path('LUA_PATH',  os.path.join(extension_spec.prefix, self.lua_lib_dir, '?', 'init.lua'), separator=';')
+            # run_env.prepend_path('LUA_CPATH', os.path.join(extension_spec.prefix, self.lua_lib_dir, '?.so'), separator=';')
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'), separator=';')
+        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_share_dir, '?', 'init.lua'), separator=';')
+        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_lib_dir, '?.lua'), separator=';')
+        run_env.prepend_path('LUA_PATH',  os.path.join(self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'), separator=';')
+        run_env.prepend_path('LUA_CPATH', os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'), separator=';')
+
+    @property
+    def lua_lib_dir(self):
+        return os.path.join('lib', 'lua', '%d.%d' % self.version[:2])
+    @property
+    def lua_share_dir(self):
+        return os.path.join('share', 'lua', '%d.%d' % self.version[:2])
+
+    def setup_dependent_package(self, module, ext_spec):
+        """
+        Called before lua modules's install() methods.
+
+        In most cases, extensions will only need to have two lines::
+
+        luarocks('--tree=' + prefix, 'install', rock_spec_path)
+        """
+        # Lua extension builds can have lua and luarocks executable functions
+        module.lua = Executable(join_path(self.spec.prefix.bin, 'lua'))
+        module.luarocks = Executable(join_path(self.spec.prefix.bin, 'luarocks'))
+

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -50,7 +50,8 @@ class Lua(Package):
 
     resource(
         name="luarocks",
-        url="https://keplerproject.github.io/luarocks/releases/luarocks-2.3.0.tar.gz",
+        url="https://keplerproject.github.io/luarocks/releases/"
+        "luarocks-2.3.0.tar.gz",
         md5="a38126684cf42b7d0e7a3c7cf485defb",
         destination="luarocks",
         placement='luarocks')
@@ -97,7 +98,8 @@ class Lua(Package):
         spack_env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
         spack_env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
 
-        # For run time environment set only the path for extension_spec and prepend it to LUAPATH
+        # For run time environment set only the path for extension_spec and
+        # prepend it to LUAPATH
         if extension_spec.package.extends(self.spec):
             run_env.prepend_path('LUA_PATH', ';'.join(lua_patterns),
                                  separator=';')
@@ -105,21 +107,26 @@ class Lua(Package):
                                  separator=';')
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('LUA_PATH', os.path.join(
-            self.spec.prefix, self.lua_share_dir, '?.lua'),
-                             separator=';')
-        run_env.prepend_path('LUA_PATH', os.path.join(
-            self.spec.prefix, self.lua_share_dir, '?', 'init.lua'),
-                             separator=';')
-        run_env.prepend_path('LUA_PATH', os.path.join(
-            self.spec.prefix, self.lua_lib_dir, '?.lua'),
-                             separator=';')
-        run_env.prepend_path('LUA_PATH', os.path.join(
-            self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'),
-                             separator=';')
-        run_env.prepend_path('LUA_CPATH', os.path.join(
-            self.spec.prefix, self.lua_lib_dir, '?.so'),
-                             separator=';')
+        run_env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'),
+            separator=';')
+        run_env.prepend_path(
+            'LUA_PATH', os.path.join(self.spec.prefix, self.lua_share_dir, '?',
+                                     'init.lua'),
+            separator=';')
+        run_env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?.lua'),
+            separator=';')
+        run_env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'),
+            separator=';')
+        run_env.prepend_path(
+            'LUA_CPATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'),
+            separator=';')
 
     @property
     def lua_lib_dir(self):


### PR DESCRIPTION
This PR completely reworks handling of lua and lua extension packages.  In fact, it should *never* be necessary to use `activate` on a lua package.  The new version installs both lua and luarocks together, and uses them to provide lua and luarocks spack commands.  It also sets LUA_PATH and LUA_CPATH appropriately for lua and all packages installed by it.  The biggest advantage of pulling luarocks into the lua package, rather than leaving it to the side, is that it can be used as a nearly universal build command for released lua projects, most now just need `luarocks('--tree=' + prefix, 'install', rockspeck_path)` in their install method.

The downside: I still don't have a good way to handle the lua/luajit duality.  This will work for all regular luas, but luajit will not find these modules, as they're installed in interpreter versioned paths.  If anyone knows a way to have two interpreters provide a language and allow extensions from the same set of child packages, I would appreciate a hint.