### PR TITLE
Enhancement Proposal: Exempt '@when' Functions from Style Redefinition Errors

### DIFF
--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -21,9 +21,12 @@ fi
 changed=$(git diff --name-only develop... | grep '.py$')
 
 # Exempt url lines in changed packages from overlong line errors.
+# Exempt functions defined with '@when' decorator from redefinition errors.
 for file in $changed; do
     if [[ $file = *package.py ]]; then
-        perl -i~ -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file;
+        cp "$file" "$file~"
+        perl -i -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file
+        perl -i -pe 's/^(\s*\@when\(.*\).*)$/\1  # NOQA: ignore=F811/' $file
     fi
 done
 

--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -20,12 +20,17 @@ fi
 # Check if changed files are flake8 conformant [framework]
 changed=$(git diff --name-only develop... | grep '.py$')
 
-# Exempt url lines in changed packages from overlong line errors.
-# Exempt functions defined with '@when' decorator from redefinition errors.
+# Add approved style exemptions to the changed packages.
 for file in $changed; do
     if [[ $file = *package.py ]]; then
         cp "$file" "$file~"
+
+        # Exempt lines with urls and descriptions from overlong line errors.
         perl -i -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file
+        perl -i -pe 's/^(\s*version\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
+        perl -i -pe 's/^(\s*variant\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
+
+        # Exempt '@when' decorated functions from redefinition errors.
         perl -i -pe 's/^(\s*\@when\(.*\).*)$/\1  # NOQA: ignore=F811/' $file
     fi
 done

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -22,8 +22,10 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import os
+import re
 from spack import *
-import os, re
+
 
 class Scotch(Package):
     """Scotch is a software package for graph and mesh/hypergraph
@@ -38,10 +40,14 @@ class Scotch(Package):
     version('6.0.0', 'c50d6187462ba801f9a82133ee666e8e')
     version('5.1.10b', 'f587201d6cf5cf63527182fbfba70753')
 
-    variant('mpi', default=False, description='Activate the compilation of PT-Scotch')
-    variant('compression', default=True, description='Activate the posibility to use compressed files')
-    variant('esmumps', default=False, description='Activate the compilation of the lib esmumps needed by mumps')
-    variant('shared', default=True, description='Build shared libraries')
+    variant('mpi', default=False,
+            description='Activate the compilation of parallel libraries')
+    variant('compression', default=True,
+            description='Activate the posibility to use compressed files')
+    variant('esmumps', default=False,
+            description='Activate the compilation of esmumps needed by mumps')
+    variant('shared', default=True,
+            description='Build a shared version of the library')
 
     depends_on('flex')
     depends_on('bison')
@@ -51,7 +57,7 @@ class Scotch(Package):
     # NOTE: Versions of Scotch up to version 6.0.0 don't include support for
     # building with 'esmumps' in their default packages.  In order to enable
     # support for this feature, we must grab the 'esmumps' enabled archives
-    # from the Scotch hosting site.  These alternative archives include a strict
+    # from the Scotch hosting site.  These alternative archives include a
     # superset of the behavior in their default counterparts, so we choose to
     # always grab these versions for older Scotch versions for simplicity.
     @when('@:6.0.0')
@@ -62,32 +68,34 @@ class Scotch(Package):
     def url_for_version(self, version):
         return super(Scotch, self).url_for_version(version)
 
-    # NOTE: Several of the 'esmumps' enabled Scotch releases up to version 6.0.0
-    # have broken build scripts that don't properly build 'esmumps' as a separate
-    # target, so we need a patch procedure to remove 'esmumps' from existing targets
-    # and to add it as a standalone target.
+    # NOTE: Several of the 'esmumps' enabled Scotch releases up to version
+    # 6.0.0 have broken build scripts that don't properly build 'esmumps' as a
+    # separate target, so we need a patch procedure to remove 'esmumps' from
+    # existing targets and to add it as a standalone target.
     @when('@:6.0.0')
     def patch(self):
         makefile_path = os.path.join('src', 'Makefile')
         with open(makefile_path, 'r') as makefile:
-            esmumps_enabled = any(re.search(r'^esmumps(\s*):(.*)$', line) for line in makefile.readlines())
+            esmumps_enabled = any(re.search(r'^esmumps(\s*):(.*)$', line)
+                                  for line in makefile.readlines())
 
         if not esmumps_enabled:
             mff = FileFilter(makefile_path)
             mff.filter(r'^.*((esmumps)|(ptesmumps)).*(install).*$', '')
 
-            makefile_esmumps_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Makefile.esmumps')
+            mfesmumps_dir = os.path.dirname(os.path.realpath(__file__))
+            mfesmumps_path = os.path.join(mfesmumps_dir, 'Makefile.esmumps')
             with open(makefile_path, 'a') as makefile:
-                makefile.write('\ninclude %s\n' % makefile_esmumps_path)
+                makefile.write('\ninclude %s\n' % mfesmumps_path)
 
     @when('@6.0.1:')
     def patch(self):
         pass
 
-    # NOTE: Configuration of Scotch is achieved by writing a 'Makefile.inc' file
-    # that contains all of the configuration variables and their desired values
-    # for the installation.  This function writes this file based on the given
-    # installation variants.
+    # NOTE: Configuration of Scotch is achieved by writing a 'Makefile.inc'
+    # file that contains all of the configuration variables and their desired
+    # values for the installation.  This function writes this file based on
+    # the given installation variants.
     def configure(self):
         makefile_inc = []
         cflags = [
@@ -96,9 +104,9 @@ class Scotch(Package):
             '-DSCOTCH_DETERMINISTIC',
             '-DSCOTCH_RENAME',
             '-DIDXSIZE64'
-            ]
+        ]
 
-        ## Library Build Type ##
+        # Library Build Type #
 
         if '+shared' in self.spec:
             makefile_inc.extend([
@@ -107,7 +115,7 @@ class Scotch(Package):
                 'RANLIB    = echo',
                 'AR	       = $(CC)',
                 'ARFLAGS   = -shared $(LDFLAGS) -o'
-                ])
+            ])
             cflags.append('-fPIC')
         else:
             makefile_inc.extend([
@@ -116,21 +124,21 @@ class Scotch(Package):
                 'RANLIB    = ranlib',
                 'AR	       = ar',
                 'ARFLAGS   = -ruv '
-                ])
+            ])
 
-        ## Compiler-Specific Options ##
+        # Compiler-Specific Options #
 
         if self.compiler.name == 'gcc':
             cflags.append('-Drestrict=__restrict')
         elif self.compiler.name == 'intel':
             cflags.append('-restrict')
 
+        mpicc_path = self.spec['mpi'].mpicc if '+mpi' in self.spec else 'mpicc'
         makefile_inc.append('CCS       = $(CC)')
-        makefile_inc.append('CCP       = %s' %
-            (self.spec['mpi'].mpicc if '+mpi' in self.spec else 'mpicc'))
+        makefile_inc.append('CCP       = %s' % mpicc_path)
         makefile_inc.append('CCD       = $(CCS)')
 
-        ## Extra Features ##
+        # Extra Features #
 
         ldflags = []
 
@@ -143,8 +151,10 @@ class Scotch(Package):
 
         makefile_inc.append('LDFLAGS   = %s' % ' '.join(ldflags))
 
-        ## General Features ##
+        # General Features #
 
+        flex_path = os.path.join(self.spec['flex'].prefix.bin, 'flex')
+        bison_path = os.path.join(self.spec['bison'].prefix.bin, 'bison')
         makefile_inc.extend([
             'EXE       =',
             'OBJ       = .o',
@@ -155,10 +165,10 @@ class Scotch(Package):
             'MV        = mv',
             'CP        = cp',
             'CFLAGS    = %s' % ' '.join(cflags),
-            'LEX       = %s -Pscotchyy -olex.yy.c' % os.path.join(self.spec['flex'].prefix.bin , 'flex'),
-            'YACC      = %s -pscotchyy -y -b y' %    os.path.join(self.spec['bison'].prefix.bin, 'bison'),
+            'LEX       = %s -Pscotchyy -olex.yy.c' % flex_path,
+            'YACC      = %s -pscotchyy -y -b y' % bison_path,
             'prefix    = %s' % self.prefix
-            ])
+        ])
 
         with working_dir('src'):
             with open('Makefile.inc', 'w') as fh:
@@ -178,7 +188,7 @@ class Scotch(Package):
 
         with working_dir('src'):
             for target in targets:
-                make(target, parallel=(target!='ptesmumps'))
+                make(target, parallel=(target != 'ptesmumps'))
 
         install_tree('bin', prefix.bin)
         install_tree('lib', prefix.lib)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -40,14 +40,10 @@ class Scotch(Package):
     version('6.0.0', 'c50d6187462ba801f9a82133ee666e8e')
     version('5.1.10b', 'f587201d6cf5cf63527182fbfba70753')
 
-    variant('mpi', default=False,
-            description='Activate the compilation of parallel libraries')
-    variant('compression', default=True,
-            description='Activate the posibility to use compressed files')
-    variant('esmumps', default=False,
-            description='Activate the compilation of esmumps needed by mumps')
-    variant('shared', default=True,
-            description='Build a shared version of the library')
+    variant('mpi', default=False, description='Activate the compilation of parallel libraries')
+    variant('compression', default=True, description='Activate the posibility to use compressed files')
+    variant('esmumps', default=False, description='Activate the compilation of esmumps needed by mumps')
+    variant('shared', default=True, description='Build a shared version of the library')
 
     depends_on('flex')
     depends_on('bison')


### PR DESCRIPTION
The changes in this pull request simply modify the style checking script to exempt functions defined with the `@when` decorator from redefinition errors.  These changes have been tested on the `scotch` package, which uses this decorator in multiple locations.  In order to accomplish this testing, the `scotch` package has also been updated to conform to Spack's style standards.