### PR TITLE
tbb: add 4.4.4; raise InstallError when building 4.4.3 with GCC6.1

### DIFF
--- a/var/spack/repos/builtin/packages/tbb/package.py
+++ b/var/spack/repos/builtin/packages/tbb/package.py
@@ -35,6 +35,7 @@ class Tbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # Only version-specific URL's work for TBB
+    version('4.4.4', 'd4cee5e4ca75cab5181834877738619c56afeb71', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160413oss_src.tgz')
     version('4.4.3', '80707e277f69d9b20eeebdd7a5f5331137868ce1', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160128oss_src_0.tgz')
 
     def coerce_to_spack(self,tbb_build_subdir):
@@ -54,8 +55,10 @@ class Tbb(Package):
                         of.write(l);
 
     def install(self, spec, prefix):
-        #
-        # we need to follow TBB's compiler selection logic to get the proper build + link flags
+        if spec.satisfies('%gcc@6.1:') and spec.satisfies('@:4.4.3'):
+          raise InstallError('Only TBB 4.4.4 and above build with GCC 6.1!')
+
+        # We need to follow TBB's compiler selection logic to get the proper build + link flags
         # but we still need to use spack's compiler wrappers
         # to accomplish this, we do two things:
         #

--- a/var/spack/repos/builtin/packages/tbb/package.py
+++ b/var/spack/repos/builtin/packages/tbb/package.py
@@ -23,8 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 import glob
+
 
 class Tbb(Package):
     """Widely used C++ template library for task parallelism.
@@ -35,38 +35,39 @@ class Tbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # Only version-specific URL's work for TBB
-    version('4.4.4', 'd4cee5e4ca75cab5181834877738619c56afeb71', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160413oss_src.tgz')
-    version('4.4.3', '80707e277f69d9b20eeebdd7a5f5331137868ce1', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160128oss_src_0.tgz')
+    version('4.4.4', 'd4cee5e4ca75cab5181834877738619c56afeb71', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160413oss_src.tgz')    # NOQA: ignore=E501
+    version('4.4.3', '80707e277f69d9b20eeebdd7a5f5331137868ce1', url='https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160128oss_src_0.tgz')  # NOQA: ignore=E501
 
-    def coerce_to_spack(self,tbb_build_subdir):
-        for compiler in ["icc","gcc","clang"]:
-              fs = glob.glob(join_path(tbb_build_subdir,"*.%s.inc" % compiler ))
-              for f in fs:
-                  lines = open(f).readlines()
-                  of = open(f,"w")
-                  for l in lines:
-                      if l.strip().startswith("CPLUS ="):
+    def coerce_to_spack(self, tbb_build_subdir):
+        for compiler in ["icc", "gcc", "clang"]:
+            fs = glob.glob(join_path(tbb_build_subdir,
+                                     "*.%s.inc" % compiler))
+            for f in fs:
+                lines = open(f).readlines()
+                of = open(f, "w")
+                for l in lines:
+                    if l.strip().startswith("CPLUS ="):
                         of.write("# coerced to spack\n")
                         of.write("CPLUS = $(CXX)\n")
-                      elif l.strip().startswith("CPLUS ="):
+                    elif l.strip().startswith("CPLUS ="):
                         of.write("# coerced to spack\n")
                         of.write("CONLY = $(CC)\n")
-                      else:
-                        of.write(l);
+                    else:
+                        of.write(l)
 
     def install(self, spec, prefix):
         if spec.satisfies('%gcc@6.1:') and spec.satisfies('@:4.4.3'):
-          raise InstallError('Only TBB 4.4.4 and above build with GCC 6.1!')
+            raise InstallError('Only TBB 4.4.4 and above build with GCC 6.1!')
 
-        # We need to follow TBB's compiler selection logic to get the proper build + link flags
-        # but we still need to use spack's compiler wrappers
+        # We need to follow TBB's compiler selection logic to get the proper
+        # build + link flags but we still need to use spack's compiler wrappers
         # to accomplish this, we do two things:
         #
-        # * Look at the spack spec to determine which compiler we should pass to tbb's Makefile
+        # * Look at the spack spec to determine which compiler we should pass
+        #   to tbb's Makefile;
         #
         # * patch tbb's build system to use the compiler wrappers (CC, CXX) for
-        #    icc, gcc, clang
-        #    (see coerce_to_spack())
+        #   icc, gcc, clang (see coerce_to_spack());
         #
         self.coerce_to_spack("build")
 
@@ -77,7 +78,6 @@ class Tbb(Package):
         else:
             tbb_compiler = "gcc"
 
-
         mkdirp(prefix)
         mkdirp(prefix.lib)
 
@@ -85,10 +85,10 @@ class Tbb(Package):
         # tbb does not have a configure script or make install target
         # we simply call make, and try to put the pieces together
         #
-        make("compiler=%s"  %(tbb_compiler))
+        make("compiler=%s"  % (tbb_compiler))
 
         # install headers to {prefix}/include
-        install_tree('include',prefix.include)
+        install_tree('include', prefix.include)
 
         # install libs to {prefix}/lib
         tbb_lib_names = ["libtbb",
@@ -97,10 +97,10 @@ class Tbb(Package):
 
         for lib_name in tbb_lib_names:
             # install release libs
-            fs = glob.glob(join_path("build","*release",lib_name + ".*"))
+            fs = glob.glob(join_path("build", "*release", lib_name + ".*"))
             for f in fs:
                 install(f, prefix.lib)
             # install debug libs if they exist
-            fs = glob.glob(join_path("build","*debug",lib_name + "_debug.*"))
+            fs = glob.glob(join_path("build", "*debug", lib_name + "_debug.*"))
             for f in fs:
                 install(f, prefix.lib)


### PR DESCRIPTION
makes `tbb` work with `gcc@6.1`.
fixes https://github.com/LLNL/spack/issues/947