### PR TITLE
Add option to disable VT support in openmpi package

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -65,6 +65,8 @@ class Openmpi(Package):
 
     variant('sqlite3', default=False, description='Build sqlite3 support')
 
+    variant('vt', default=True, description='Build support for contributed package vt')
+
     # TODO : support for CUDA is missing
 
     provides('mpi@:2.2', when='@1.6.5')
@@ -116,7 +118,8 @@ class Openmpi(Package):
             # Other options
             '--enable-mpi-thread-multiple' if '+thread_multiple' in spec else '--disable-mpi-thread-multiple',
             '--with-pmi' if '+pmi' in spec else '--without-pmi',
-            '--with-sqlite3' if '+sqlite3' in spec else '--without-sqlite3'
+            '--with-sqlite3' if '+sqlite3' in spec else '--without-sqlite3',
+            '--disable-vt' if '-vt' in spec else '--enable-vt'
         ])
 
         # TODO: use variants for this, e.g. +lanl, +llnl, etc.

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -119,7 +119,7 @@ class Openmpi(Package):
             '--enable-mpi-thread-multiple' if '+thread_multiple' in spec else '--disable-mpi-thread-multiple',
             '--with-pmi' if '+pmi' in spec else '--without-pmi',
             '--with-sqlite3' if '+sqlite3' in spec else '--without-sqlite3',
-            '--disable-vt' if '-vt' in spec else '--enable-vt'
+            '--enable-vt' if '+vt' in spec else '--disable-vt'
         ])
 
         # TODO: use variants for this, e.g. +lanl, +llnl, etc.


### PR DESCRIPTION
Encountered errors building OpenMPI with the PGI compiler. This change adds the ability to pass '-vt' to disable VT support in the OpenMPI package. By default VT support is enabled.