### PR TITLE
adding variants to fix openmpi compile with intel

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -105,7 +105,7 @@ concretizer = DefaultConcretizer()
 
 # Version information
 from spack.version import Version
-spack_version = Version("0.9")
+spack_version = Version("0.9.1")
 
 #
 # Executables used by Spack

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -1,0 +1,295 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+'''Produce a "view" of a Spack DAG.
+
+A "view" is file hierarchy representing the union of a number of
+Spack-installed package file hierarchies.  The union is formed from:
+
+- specs resolved from the package names given by the user (the seeds)
+
+- all depenencies of the seeds unless user specifies `--no-depenencies`
+
+- less any specs with names matching the regular expressions given by
+  `--exclude`
+
+The `view` can be built and tore down via a number of methods (the "actions"):
+
+- symlink :: a file system view which is a directory hierarchy that is
+  the union of the hierarchies of the installed packages in the DAG
+  where installed files are referenced via symlinks.
+
+- hardlink :: like the symlink view but hardlinks are used.
+
+- statlink :: a view producing a status report of a symlink or
+  hardlink view.
+
+The file system view concept is imspired by Nix, implemented by
+brett.viren@gmail.com ca 2016.
+
+'''
+# Implementation notes:
+#
+# This is implemented as a visitor pattern on the set of package specs.
+#
+# The command line ACTION maps to a visitor_*() function which takes
+# the set of package specs and any args which may be specific to the
+# ACTION.
+#
+# To add a new view:
+# 1. add a new cmd line args sub parser ACTION
+# 2. add any action-specific options/arguments, most likely a list of specs.
+# 3. add a visitor_MYACTION() function
+# 4. add any visitor_MYALIAS assignments to match any command line aliases
+
+import os
+import re
+import spack
+import spack.cmd
+import llnl.util.tty as tty
+
+description = "Produce a single-rooted directory view of a spec."
+
+
+def setup_parser(sp):
+    setup_parser.parser = sp
+
+    sp.add_argument(
+        '-v', '--verbose', action='store_true', default=False,
+        help="Display verbose output.")
+    sp.add_argument(
+        '-e', '--exclude', action='append', default=[],
+        help="Exclude packages with names matching the given regex pattern.")
+    sp.add_argument(
+        '-d', '--dependencies', choices=['true', 'false', 'yes', 'no'],
+        default='true',
+        help="Follow dependencies.")
+
+    ssp = sp.add_subparsers(metavar='ACTION', dest='action')
+
+    specs_opts = dict(metavar='spec', nargs='+',
+                      help="Seed specs of the packages to view.")
+
+    # The action parameterizes the command but in keeping with Spack
+    # patterns we make it a subcommand.
+    file_system_view_actions = [
+        ssp.add_parser(
+            'symlink', aliases=['add', 'soft'],
+            help='Add package files to a filesystem view via symbolic links.'),
+        ssp.add_parser(
+            'hardlink', aliases=['hard'],
+            help='Add packages files to a filesystem via via hard links.'),
+        ssp.add_parser(
+            'remove', aliases=['rm'],
+            help='Remove packages from a filesystem view.'),
+        ssp.add_parser(
+            'statlink', aliases=['status', 'check'],
+            help='Check status of packages in a filesystem view.')
+    ]
+    # All these options and arguments are common to every action.
+    for act in file_system_view_actions:
+        act.add_argument('path', nargs=1,
+                         help="Path to file system view directory.")
+        act.add_argument('specs', **specs_opts)
+
+    return
+
+
+def assuredir(path):
+    'Assure path exists as a directory'
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+
+def relative_to(prefix, path):
+    'Return end of `path` relative to `prefix`'
+    assert 0 == path.find(prefix)
+    reldir = path[len(prefix):]
+    if reldir.startswith('/'):
+        reldir = reldir[1:]
+    return reldir
+
+
+def transform_path(spec, path, prefix=None):
+    'Return the a relative path corresponding to given path spec.prefix'
+    if os.path.isabs(path):
+        path = relative_to(spec.prefix, path)
+    subdirs = path.split(os.path.sep)
+    if subdirs[0] == '.spack':
+        lst = ['.spack', spec.name] + subdirs[1:]
+        path = os.path.join(*lst)
+    if prefix:
+        path = os.path.join(prefix, path)
+    return path
+
+
+def purge_empty_directories(path):
+    '''Ascend up from the leaves accessible from `path`
+    and remove empty directories.'''
+    for dirpath, subdirs, files in os.walk(path, topdown=False):
+        for sd in subdirs:
+            sdp = os.path.join(dirpath, sd)
+            try:
+                os.rmdir(sdp)
+            except OSError:
+                pass
+
+
+def filter_exclude(specs, exclude):
+    'Filter specs given sequence of exclude regex'
+    to_exclude = [re.compile(e) for e in exclude]
+
+    def exclude(spec):
+        for e in to_exclude:
+            if e.match(spec.name):
+                return True
+        return False
+    return [s for s in specs if not exclude(s)]
+
+
+def flatten(seeds, descend=True):
+    'Normalize and flattend seed specs and descend hiearchy'
+    flat = set()
+    for spec in seeds:
+        if not descend:
+            flat.add(spec)
+            continue
+        flat.update(spec.normalized().traverse())
+    return flat
+
+
+def check_one(spec, path, verbose=False):
+    'Check status of view in path against spec'
+    dotspack = os.path.join(path, '.spack', spec.name)
+    if os.path.exists(os.path.join(dotspack)):
+        tty.info('Package in view: "%s"' % spec.name)
+        return
+    tty.info('Package not in view: "%s"' % spec.name)
+    return
+
+
+def remove_one(spec, path, verbose=False):
+    'Remove any files found in `spec` from `path` and purge empty directories.'
+
+    if not os.path.exists(path):
+        return                  # done, short circuit
+
+    dotspack = transform_path(spec, '.spack', path)
+    if not os.path.exists(dotspack):
+        if verbose:
+            tty.info('Skipping nonexistent package: "%s"' % spec.name)
+        return
+
+    if verbose:
+        tty.info('Removing package: "%s"' % spec.name)
+    for dirpath, dirnames, filenames in os.walk(spec.prefix):
+        if not filenames:
+            continue
+        targdir = transform_path(spec, dirpath, path)
+        for fname in filenames:
+            dst = os.path.join(targdir, fname)
+            if not os.path.exists(dst):
+                continue
+            os.unlink(dst)
+
+
+def link_one(spec, path, link=os.symlink, verbose=False):
+    'Link all files in `spec` into directory `path`.'
+
+    dotspack = transform_path(spec, '.spack', path)
+    if os.path.exists(dotspack):
+        tty.warn('Skipping existing package: "%s"' % spec.name)
+        return
+
+    if verbose:
+        tty.info('Linking package: "%s"' % spec.name)
+    for dirpath, dirnames, filenames in os.walk(spec.prefix):
+        if not filenames:
+            continue        # avoid explicitly making empty dirs
+
+        targdir = transform_path(spec, dirpath, path)
+        assuredir(targdir)
+
+        for fname in filenames:
+            src = os.path.join(dirpath, fname)
+            dst = os.path.join(targdir, fname)
+            if os.path.exists(dst):
+                if '.spack' in dst.split(os.path.sep):
+                    continue    # silence these
+                tty.warn("Skipping existing file: %s" % dst)
+                continue
+            link(src, dst)
+
+
+def visitor_symlink(specs, args):
+    'Symlink all files found in specs'
+    path = args.path[0]
+    assuredir(path)
+    for spec in specs:
+        link_one(spec, path, verbose=args.verbose)
+visitor_add = visitor_symlink
+visitor_soft = visitor_symlink
+
+
+def visitor_hardlink(specs, args):
+    'Hardlink all files found in specs'
+    path = args.path[0]
+    assuredir(path)
+    for spec in specs:
+        link_one(spec, path, os.link, verbose=args.verbose)
+visitor_hard = visitor_hardlink
+
+
+def visitor_remove(specs, args):
+    'Remove all files and directories found in specs from args.path'
+    path = args.path[0]
+    for spec in specs:
+        remove_one(spec, path, verbose=args.verbose)
+    purge_empty_directories(path)
+visitor_rm = visitor_remove
+
+
+def visitor_statlink(specs, args):
+    'Give status of view in args.path relative to specs'
+    path = args.path[0]
+    for spec in specs:
+        check_one(spec, path, verbose=args.verbose)
+visitor_status = visitor_statlink
+visitor_check = visitor_statlink
+
+
+def view(parser, args):
+    'Produce a view of a set of packages.'
+
+    # Process common args
+    seeds = [spack.cmd.disambiguate_spec(s) for s in args.specs]
+    specs = flatten(seeds, args.dependencies.lower() in ['yes', 'true'])
+    specs = filter_exclude(specs, args.exclude)
+
+    # Execute the visitation.
+    try:
+        visitor = globals()['visitor_' + args.action]
+    except KeyError:
+        tty.error('Unknown action: "%s"' % args.action)
+    visitor(specs, args)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -167,6 +167,18 @@ section_schemas = {
                                                         {'type' : 'null' }]},
                                     'fc':  { 'anyOf': [ {'type' : 'string' },
                                                         {'type' : 'null' }]},
+                                    'fflags':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
+                                    'cppflags':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
+                                    'cflags':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
+                                    'cxxflags':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
+                                    'ldflags':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
+                                    'ldlibs':  { 'anyOf': [ {'type' : 'string' },
+                                                        {'type' : 'null' }]},
                                 },},},},},},},},
 
     'mirrors': {

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -244,38 +244,47 @@ class Dealii(Package):
             print('========= Step-40 Trilinos ==========')
             print('=====================================')
             # change Linear Algebra to Trilinos
-            filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
-                        ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
+            # The below filter_file should be different for versions
+            # before and after 8.4.0
+            if spec.satisfies('@8.4.0:'):
+                filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
+                            ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
+            else:
+                filter_file(r'(#define USE_PETSC_LA.*)',
+                            ('// #define USE_PETSC_LA'), 'step-40.cc')
             if '^trilinos+hypre' in spec:
                 make('release')
                 make('run', parallel=False)
 
-            print('=====================================')
-            print('=== Step-40 Trilinos SuperluDist ====')
-            print('=====================================')
-            # change to direct solvers
-            filter_file(r'(LA::SolverCG solver\(solver_control\);)',  ('TrilinosWrappers::SolverDirect::AdditionalData data(false,"Amesos_Superludist"); TrilinosWrappers::SolverDirect solver(solver_control,data);'), 'step-40.cc')  # NOQA: ignore=E501
-            filter_file(r'(LA::MPI::PreconditionAMG preconditioner;)',
-                        (''), 'step-40.cc')
-            filter_file(r'(LA::MPI::PreconditionAMG::AdditionalData data;)',
-                        (''), 'step-40.cc')
-            filter_file(r'(preconditioner.initialize\(system_matrix, data\);)',
-                        (''), 'step-40.cc')
-            filter_file(r'(solver\.solve \(system_matrix, completely_distributed_solution, system_rhs,)',  ('solver.solve (system_matrix, completely_distributed_solution, system_rhs);'), 'step-40.cc')  # NOQA: ignore=E501
-            filter_file(r'(preconditioner\);)',  (''), 'step-40.cc')
-            if '^trilinos+superlu-dist' in spec:
-                make('release')
-                make('run', paralle=False)
+            # the rest of the tests on step 40 only works for
+            # dealii version 8.4.0 and after
+            if spec.satisfies('@8.4.0:'):
+                print('=====================================')
+                print('=== Step-40 Trilinos SuperluDist ====')
+                print('=====================================')
+                # change to direct solvers
+                filter_file(r'(LA::SolverCG solver\(solver_control\);)',  ('TrilinosWrappers::SolverDirect::AdditionalData data(false,"Amesos_Superludist"); TrilinosWrappers::SolverDirect solver(solver_control,data);'), 'step-40.cc')  # NOQA: ignore=E501
+                filter_file(r'(LA::MPI::PreconditionAMG preconditioner;)',
+                            (''), 'step-40.cc')
+                filter_file(r'(LA::MPI::PreconditionAMG::AdditionalData data;)',
+                            (''), 'step-40.cc')
+                filter_file(r'(preconditioner.initialize\(system_matrix, data\);)',
+                            (''), 'step-40.cc')
+                filter_file(r'(solver\.solve \(system_matrix, completely_distributed_solution, system_rhs,)',  ('solver.solve (system_matrix, completely_distributed_solution, system_rhs);'), 'step-40.cc')  # NOQA: ignore=E501
+                filter_file(r'(preconditioner\);)',  (''), 'step-40.cc')
+                if '^trilinos+superlu-dist' in spec:
+                    make('release')
+                    make('run', paralle=False)
 
-            print('=====================================')
-            print('====== Step-40 Trilinos MUMPS =======')
-            print('=====================================')
-            # switch to Mumps
-            filter_file(r'(Amesos_Superludist)',
-                        ('Amesos_Mumps'), 'step-40.cc')
-            if '^trilinos+mumps' in spec:
-                make('release')
-                make('run', parallel=False)
+                print('=====================================')
+                print('====== Step-40 Trilinos MUMPS =======')
+                print('=====================================')
+                # switch to Mumps
+                filter_file(r'(Amesos_Superludist)',
+                            ('Amesos_Mumps'), 'step-40.cc')
+                if '^trilinos+mumps' in spec:
+                    make('release')
+                    make('run', parallel=False)
 
         print('=====================================')
         print('============ Step-36 ================')

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -1,0 +1,176 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fenics(Package):
+    """FEniCS is organized as a collection of interoperable components
+    that together form the FEniCS Project. These components include
+    the problem-solving environment DOLFIN, the form compiler FFC, the
+    finite element tabulator FIAT, the just-in-time compiler Instant,
+    the code generation interface UFC, the form language UFL and a
+    range of additional components."""
+
+    homepage = "http://fenicsproject.org/"
+    url      = "https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-1.6.0.tar.gz"
+
+    base_url = "https://bitbucket.org/fenics-project/{pkg}/downloads/{pkg}-{version}.tar.gz"  # NOQA: ignore E501
+
+    variant('hdf5',         default=True,  description='Compile with HDF5')
+    variant('parmetis',     default=True,  description='Compile with ParMETIS')
+    variant('scotch',       default=True,  description='Compile with Scotch')
+    variant('petsc',        default=True,  description='Compile with PETSc')
+    variant('slepc',        default=True,  description='Compile with SLEPc')
+    variant('trilinos',     default=True,  description='Compile with Trilinos')
+    variant('suite-sparse', default=True,  description='Compile with SuiteSparse solvers')
+    variant('vtk',          default=False, description='Compile with VTK')
+    variant('qt',           default=False, description='Compile with QT')
+    variant('mpi',          default=True,  description='Enables the distributed memory support')
+    variant('openmp',       default=True,  description='Enables the shared memory support')
+    variant('shared',       default=True,  description='Enables the build of shared libraries')
+    variant('debug',        default=False, description='Builds a debug version of the libraries')
+
+    # not part of spack list for now
+    # variant('petsc4py',     default=True,  description='Uses PETSc4py')
+    # variant('slepc4py',     default=True,  description='Uses SLEPc4py')
+    # variant('pastix',       default=True,  description='Compile with Pastix')
+
+    extends('python')
+
+    depends_on('py-numpy')
+    depends_on('py-ply')
+    depends_on('py-six')
+    depends_on('py-sphinx@1.0.1:', when='+doc')
+    depends_on('eigen@3.2.0:')
+    depends_on('boost')
+    depends_on('mpi', when='+mpi')
+    depends_on('hdf5', when='+hdf5')
+    depends_on('parmetis@4.0.2:^metis+real64', when='+parmetis')
+    depends_on('scotch~metis', when='+scotch~mpi')
+    depends_on('scotch+mpi~metis', when='+scotch+mpi')
+    depends_on('petsc@3.4:', when='+petsc')
+    depends_on('slepc@3.4:', when='+slepc')
+    depends_on('trilinos', when='+trilinos')
+    depends_on('vtk', when='+vtk')
+    depends_on('suite-sparse', when='+suite-sparse')
+    depends_on('qt', when='+qt')
+
+    # This are the build dependencies
+    depends_on('py-setuptools')
+    depends_on('cmake@2.8.12:')
+    depends_on('swig@3.0.3:')
+
+    releases = [
+        {
+            'version': '1.6.0',
+            'md5': '35cb4baf7ab4152a40fb7310b34d5800',
+            'resources': {
+                'ffc': '358faa3e9da62a1b1a717070217b793e',
+                'fiat': 'f4509d05c911fd93cea8d288a78a6c6f',
+                'instant': '5f2522eb032a5bebbad6597b6fe0732a',
+                'ufl': 'c40c5f04eaa847377ab2323122284016',
+            }
+        },
+        {
+            'version': '1.5.0',
+            'md5': '9b589a3534299a5e6d22c13c5eb30bb8',
+            'resources': {
+                'ffc': '343f6d30e7e77d329a400fd8e73e0b63',
+                'fiat': 'da3fa4dd8177bb251e7f68ec9c7cf6c5',
+                'instant': 'b744023ded27ee9df4a8d8c6698c0d58',
+                'ufl': '130d7829cf5a4bd5b52bf6d0955116fd',
+            }
+        },
+    ]
+
+    for release in releases:
+        version(release['version'], release['md5'], url=base_url.format(pkg='dolfin', version=release['version']))
+        for name, md5 in release['resources'].items():
+            resource(name=name,
+                     url=base_url.format(pkg=name, **release),
+                     md5=md5,
+                     destination='depends',
+                     when='@{version}'.format(**release),
+                     placement=name)
+
+    def cmake_is_on(self, option):
+        return 'ON' if option in self.spec else 'OFF'
+
+    def install(self, spec, prefix):
+        for package in ['ufl', 'ffc', 'fiat', 'instant']:
+            with working_dir(join_path('depends', package)):
+                python('setup.py', 'install', '--prefix=%s' % prefix)
+
+        cmake_args = [
+            '-DCMAKE_BUILD_TYPE:STRING={0}'.format(
+                'Debug' if '+debug' in spec else 'RelWithDebInfo'),
+            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
+                self.cmake_is_on('+shared')),
+            '-DDOLFIN_SKIP_BUILD_TESTS:BOOL=ON',
+            '-DDOLFIN_ENABLE_OPENMP:BOOL={0}'.format(
+                self.cmake_is_on('+openmp')),
+            '-DDOLFIN_ENABLE_CHOLMOD:BOOL={0}'.format(
+                self.cmake_is_on('suite-sparse')),
+            '-DDOLFIN_ENABLE_HDF5:BOOL={0}'.format(
+                self.cmake_is_on('hdf5')),
+            '-DDOLFIN_ENABLE_MPI:BOOL={0}'.format(
+                self.cmake_is_on('mpi')),
+            '-DDOLFIN_ENABLE_PARMETIS:BOOL={0}'.format(
+                self.cmake_is_on('parmetis')),
+            '-DDOLFIN_ENABLE_PASTIX:BOOL={0}'.format(
+                self.cmake_is_on('pastix')),
+            '-DDOLFIN_ENABLE_PETSC:BOOL={0}'.format(
+                self.cmake_is_on('petsc')),
+            '-DDOLFIN_ENABLE_PETSC4PY:BOOL={0}'.format(
+                self.cmake_is_on('py-petsc4py')),
+            '-DDOLFIN_ENABLE_PYTHON:BOOL={0}'.format(
+                self.cmake_is_on('python')),
+            '-DDOLFIN_ENABLE_QT:BOOL={0}'.format(
+                self.cmake_is_on('qt')),
+            '-DDOLFIN_ENABLE_SCOTCH:BOOL={0}'.format(
+                self.cmake_is_on('scotch')),
+            '-DDOLFIN_ENABLE_SLEPC:BOOL={0}'.format(
+                self.cmake_is_on('slepc')),
+            '-DDOLFIN_ENABLE_SLEPC4PY:BOOL={0}'.format(
+                self.cmake_is_on('py-slepc4py')),
+            '-DDOLFIN_ENABLE_SPHINX:BOOL={0}'.format(
+                self.cmake_is_on('py-sphinx')),
+            '-DDOLFIN_ENABLE_TRILINOS:BOOL={0}'.format(
+                self.cmake_is_on('trilinos')),
+            '-DDOLFIN_ENABLE_UMFPACK:BOOL={0}'.format(
+                self.cmake_is_on('suite-sparse')),
+            '-DDOLFIN_ENABLE_VTK:BOOL={0}'.format(
+                self.cmake_is_on('vtk')),
+            '-DDOLFIN_ENABLE_ZLIB:BOOL={0}'.format(
+                self.cmake_is_on('zlib')),
+        ]
+
+        cmake_args.extend(std_cmake_args)
+
+        with working_dir('build', create=True):
+            cmake('..', *cmake_args)
+
+            make()
+            make('install')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -38,6 +38,7 @@ class Hdf5(Package):
     list_url = "http://www.hdfgroup.org/ftp/HDF5/releases"
     list_depth = 3
 
+    version('1.10.0-patch1', '9180ff0ef8dc2ef3f61bd37a7404f295')
     version('1.10.0', 'bdc935337ee8282579cd6bc4270ad199')
     version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618', preferred=True)
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -81,9 +81,9 @@ class Openmpi(Package):
 
     # TODO : variant support for alps, loadleveler  is missing
     variant('tm', default=False, description='Build TM (Torque, PBSPro, and compatible) support')
-    # TODO : this is a hack, when variant will allow to specify string, will go away
-    variant('tm_custom', default=False, 
-            description='the tm_custom void module is used to provide PBS installation path')
+    # TODO : this is a hack, to be removed when variant will support string
+    variant('tm_custom', default=False,
+            description='tm_custom void module used for PBS install path')
     variant('slurm', default=False, description='Build SLURM scheduler component')
 
     variant('sqlite3', default=False, description='Build sqlite3 support')
@@ -104,7 +104,6 @@ class Openmpi(Package):
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
 
-
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('OMPI_CC', spack_cc)
         spack_env.set('OMPI_CXX', spack_cxx)
@@ -119,7 +118,7 @@ class Openmpi(Package):
 
     @property
     def verbs(self):
-        # Up through version 1.6, this option was previously named --with-openib
+        # Up through version 1.6, this option was named --with-openib
         if self.spec.satisfies('@:1.6'):
             return 'openib'
         # In version 1.7, it was renamed to be --with-verbs

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -81,9 +81,14 @@ class Openmpi(Package):
 
     # TODO : variant support for alps, loadleveler  is missing
     variant('tm', default=False, description='Build TM (Torque, PBSPro, and compatible) support')
+    # TODO : this is a hack, when variant will allow to specify string, will go away
+    variant('tm_custom', default=False, 
+            description='the tm_custom void module is used to provide PBS installation path')
     variant('slurm', default=False, description='Build SLURM scheduler component')
 
     variant('sqlite3', default=False, description='Build sqlite3 support')
+    variant('hwloc', default=True, description='Use hwloc')
+    variant('dlopen', default=True, description='Use dlopen')
 
     variant('vt', default=True, description='Build support for contributed package vt')
 
@@ -92,8 +97,9 @@ class Openmpi(Package):
     provides('mpi@:2.2', when='@1.6.5')
     provides('mpi@:3.0', when='@1.7.5:')
 
-    depends_on('hwloc')
+    depends_on('hwloc', when='+hwloc')
     depends_on('sqlite', when='+sqlite3')
+    depends_on('tm', when='+tm_custom')
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
@@ -122,13 +128,14 @@ class Openmpi(Package):
 
     def install(self, spec, prefix):
         config_args = ["--prefix=%s" % prefix,
-                       "--with-hwloc=%s" % spec['hwloc'].prefix,
+                       "--with-hwloc=%s" % spec['hwloc'].prefix if '+hwloc' in spec else '',
                        "--enable-shared",
                        "--enable-static"]
         # Variant based arguments
         config_args.extend([
             # Schedulers
-            '--with-tm' if '+tm' in spec else '--without-tm',
+            '--with-tm' if '+tm' in spec else 
+                '--with-tm=%s' % spec['tm'].prefix if '+tm_custom' in spec else '--without-tm',
             '--with-slurm' if '+slurm' in spec else '--without-slurm',
             # Fabrics
             '--with-psm' if '+psm' in spec else '--without-psm',
@@ -139,6 +146,8 @@ class Openmpi(Package):
             '--with-pmi' if '+pmi' in spec else '--without-pmi',
             '--with-sqlite3' if '+sqlite3' in spec else '--without-sqlite3',
             '--enable-vt' if '+vt' in spec else '--disable-vt'
+            "--with-hwloc=%s" % spec['hwloc'].prefix if '+hwloc' in spec else '', 
+            '--disable-dlopen' if not '+dlopen' in spec else ''
         ])
         if '+verbs' in spec:
             path = _verbs_dir()

--- a/var/spack/repos/builtin/packages/py-ply/package.py
+++ b/var/spack/repos/builtin/packages/py-ply/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPly(Package):
+    """PLY is nothing more than a straightforward lex/yacc implementation."""
+    homepage = "http://www.dabeaz.com/ply"
+    url      = "http://www.dabeaz.com/ply/ply-3.8.tar.gz"
+
+    version('3.8', '94726411496c52c87c2b9429b12d5c50')
+
+    extends('python')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/tetgen/package.py
+++ b/var/spack/repos/builtin/packages/tetgen/package.py
@@ -24,16 +24,19 @@
 ##############################################################################
 from spack import *
 
+
 class Tetgen(Package):
-    """TetGen is a program and library that can be used to generate tetrahedral
-       meshes for given 3D polyhedral domains. TetGen generates exact constrained
-       Delaunay tetrahedralizations, boundary conforming Delaunay meshes, and
-       Voronoi paritions."""
+    """TetGen is a program and library that can be used to generate
+       tetrahedral meshes for given 3D polyhedral domains. TetGen
+       generates exact constrained Delaunay tetrahedralizations,
+       boundary conforming Delaunay meshes, and Voronoi paritions.
+    """
 
     homepage = "http://www.tetgen.org"
     url      = "http://www.tetgen.org/files/tetgen1.4.3.tar.gz"
 
     version('1.4.3', 'd6a4bcdde2ac804f7ec66c29dcb63c18')
+    version('1.5.0', '3b9fd9cdec121e52527b0308f7aad5c1', url='http://www.tetgen.org/1.5/src/tetgen1.5.0.tar.gz')
 
     # TODO: Make this a build dependency once build dependencies are supported
     # (see: https://github.com/LLNL/spack/pull/378).

--- a/var/spack/repos/builtin/packages/tm/package.py
+++ b/var/spack/repos/builtin/packages/tm/package.py
@@ -1,0 +1,22 @@
+from spack import *
+
+class Tm(Package):
+    """This is Torque / PBS"""
+    homepage = "http://www.adaptivecomputing.com/"
+    url      = "http://www.adaptivecomputing.com/download/torque/torque-6.0.1-1456945733_daea91b.tar.gz"
+
+    version('6.0.1', '2b958e9f5d200641e6fc9564977aecc5')
+
+    def install(self, spec, prefix):
+        print "install not implemented"
+        #configure("--prefix=%s" % prefix)
+        #make()
+        #make("install")
+##############################################################
+# these lines should be added to etc/spack/packages.yaml
+#  tm:
+#    version: [system]
+#    paths:
+#      tm@system: /cineca/sysprod/pbs/12.3.0.143517
+#    buildable: false
+


### PR DESCRIPTION
These more variant are needed to build with our custom intel 15 installation  on my machine a working opnmpi lib that can be useb by imb like:

spack install -v -j 20 test_imb%intel@15 ^openmpi~dlopen~hwloc+verbs+tm_custom

it refers to tag09