### PR TITLE
Ensure that trilinos and petsc link to appropriate versions of superlu-dist

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -28,8 +28,9 @@ from spack import *
 
 class Petsc(Package):
     """
-    PETSc is a suite of data structures and routines for the scalable (parallel) solution of scientific applications
-    modeled by partial differential equations.
+    PETSc is a suite of data structures and routines for the scalable
+    (parallel) solution of scientific applications modeled by partial
+    differential equations.
     """
 
     homepage = "http://www.mcs.anl.gov/petsc/index.html"
@@ -68,11 +69,13 @@ class Petsc(Package):
 
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('parmetis', when='+metis+mpi')
-    # Hypre does not support complex numbers.
-    # Also PETSc prefer to build it without internal superlu, likely due to conflict in headers
-    # see https://bitbucket.org/petsc/petsc/src/90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config/packages/hypre.py
+    # Hypre does not support complex numbers.  Also PETSc prefer to build it
+    # without internal superlu, likely due to conflict in headers see
+    # https://bitbucket.org/petsc/petsc/src\
+    # /90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config\
+    # /packages/hypre.py
     depends_on('hypre~internal-superlu', when='+hypre+mpi~complex')
-    depends_on('superlu-dist', when='+superlu-dist+mpi')
+    depends_on('superlu-dist@:4.3', when='+superlu-dist+mpi')
     depends_on('mumps+mpi', when='+mumps+mpi')
     depends_on('scalapack', when='+mumps+mpi')
 
@@ -80,17 +83,21 @@ class Petsc(Package):
         if '~mpi' in self.spec:
             compiler_opts = [
                 '--with-cc=%s' % os.environ['CC'],
-                '--with-cxx=%s' % (os.environ['CXX'] if self.compiler.cxx is not None else '0'),
-                '--with-fc=%s' % (os.environ['FC'] if self.compiler.fc is not None else '0'),
+                '--with-cxx=%s' % (os.environ['CXX']
+                                   if self.compiler.cxx is not None else '0'),
+                '--with-fc=%s' % (os.environ['FC']
+                                  if self.compiler.fc is not None else '0'),
                 '--with-mpi=0'
             ]
-            error_message_fmt = '\t{library} support requires "+mpi" to be activated'
+            error_message_fmt = '\t{library} support requires "+mpi" to be ' \
+                                'activated'
 
-            # If mpi is disabled (~mpi), it's an error to have any of these enabled.
-            # This generates a list of any such errors.
+            # If mpi is disabled (~mpi), it's an error to have any of these
+            # enabled.  This generates a list of any such errors.
             errors = [error_message_fmt.format(library=x)
-                      for x in ('hdf5', 'hypre', 'parmetis','mumps','superlu-dist')
-                      if ('+'+x) in self.spec]
+                      for x in ('hdf5', 'hypre', 'parmetis', 'mumps',
+                                'superlu-dist')
+                      if ('+' + x) in self.spec]
             if errors:
                 errors = ['incompatible variants given'] + errors
                 raise RuntimeError('\n'.join(errors))
@@ -105,26 +112,35 @@ class Petsc(Package):
         options = ['--with-ssl=0']
         options.extend(self.mpi_dependent_options())
         options.extend([
-            '--with-precision=%s' % ('double' if '+double' in spec else 'single'),
-            '--with-scalar-type=%s' % ('complex' if '+complex' in spec else 'real'),
+            '--with-precision=%s'
+            % ('double' if '+double' in spec else 'single'),
+            '--with-scalar-type=%s'
+            % ('complex' if '+complex' in spec else 'real'),
             '--with-shared-libraries=%s' % ('1' if '+shared' in spec else '0'),
             '--with-debugging=%s' % ('1' if '+debug' in spec else '0'),
             '--with-blas-lapack-dir=%s' % spec['lapack'].prefix
         ])
         # Activates library support if needed
-        for library in ('metis', 'boost', 'hdf5', 'hypre', 'parmetis','mumps','scalapack'):
+        for library in ('metis', 'boost', 'hdf5', 'hypre', 'parmetis',
+                        'mumps', 'scalapack'):
             options.append(
-                '--with-{library}={value}'.format(library=library, value=('1' if library in spec else '0'))
+                '--with-{library}={value}'.format(
+                    library=library, value=('1' if library in spec else '0'))
             )
             if library in spec:
                 options.append(
-                    '--with-{library}-dir={path}'.format(library=library, path=spec[library].prefix)
+                    '--with-{library}-dir={path}'.format(
+                        library=library, path=spec[library].prefix)
                 )
-        # PETSc does not pick up SuperluDist from the dir as they look for superlu_dist_4.1.a
+        # PETSc does not pick up SuperluDist from the dir as they look for
+        # superlu_dist_4.1.a
         if 'superlu-dist' in spec:
             options.extend([
-                '--with-superlu_dist-include=%s' % spec['superlu-dist'].prefix.include,
-                '--with-superlu_dist-lib=%s' % join_path(spec['superlu-dist'].prefix.lib, 'libsuperlu_dist.a'),
+                '--with-superlu_dist-include=%s'
+                % spec['superlu-dist'].prefix.include,
+                '--with-superlu_dist-lib=%s'
+                % join_path(spec['superlu-dist'].prefix.lib,
+                            'libsuperlu_dist.a'),
                 '--with-superlu_dist=1'
             ])
         else:

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -71,9 +71,7 @@ class Petsc(Package):
     depends_on('parmetis', when='+metis+mpi')
     # Hypre does not support complex numbers.  Also PETSc prefer to build it
     # without internal superlu, likely due to conflict in headers see
-    # https://bitbucket.org/petsc/petsc/src\
-    # /90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config\
-    # /packages/hypre.py
+    # https://bitbucket.org/petsc/petsc/src/90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config/packages/hypre.py  # NOQA: ignore=E501
     depends_on('hypre~internal-superlu', when='+hypre+mpi~complex')
     depends_on('superlu-dist@:4.3', when='+superlu-dist+mpi')
     depends_on('mumps+mpi', when='+mumps+mpi')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -23,18 +23,25 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os, sys, glob
+import os
+import sys
 
-# Trilinos is complicated to build, as an inspiration a couple of links to other repositories which build it:
-# https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild/easyblocks/t/trilinos.py#L111
-# https://github.com/koecher/candi/blob/master/deal.II-toolchain/packages/trilinos.package
-# https://gitlab.com/configurations/cluster-config/blob/master/trilinos.sh
-# https://github.com/Homebrew/homebrew-science/blob/master/trilinos.rb
+# Trilinos is complicated to build, as an inspiration a couple of links to
+# other repositories which build it:
+# - https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild\
+#   /easyblocks/t/trilinos.py#L111
+# - https://github.com/koecher/candi/blob/master/deal.II-toolchain/packages\
+#   /trilinos.package
+# - https://gitlab.com/configurations/cluster-config/blob/master/trilinos.sh
+# - https://github.com/Homebrew/homebrew-science/blob/master/trilinos.rb
 # and some relevant documentation/examples:
-# https://github.com/trilinos/Trilinos/issues/175
+# - https://github.com/trilinos/Trilinos/issues/175
+
+
 class Trilinos(Package):
-    """The Trilinos Project is an effort to develop algorithms and enabling technologies within an object-oriented
-    software framework for the solution of large-scale, complex multi-physics engineering and scientific problems.
+    """The Trilinos Project is an effort to develop algorithms and enabling
+    technologies within an object-oriented software framework for the solution
+    of large-scale, complex multi-physics engineering and scientific problems.
     A unique design feature of Trilinos is its focus on packages.
     """
     homepage = "https://trilinos.org/"
@@ -54,7 +61,8 @@ class Trilinos(Package):
     variant('hypre',        default=True,  description='Compile with Hypre preconditioner')
     variant('hdf5',         default=True,  description='Compile with HDF5')
     variant('suite-sparse', default=True,  description='Compile with SuiteSparse solvers')
-    # not everyone has py-numpy activated, keep it disabled by default to avoid configure errors
+    # not everyone has py-numpy activated, keep it disabled by default to avoid
+    # configure errors
     variant('python',       default=False, description='Build python wrappers')
     variant('shared',       default=True,  description='Enables the build of shared libraries')
     variant('debug',        default=False, description='Builds a debug version of the libraries')
@@ -66,37 +74,40 @@ class Trilinos(Package):
     depends_on('matio')
     depends_on('glm')
     depends_on('swig')
-    depends_on('metis@5:',when='+metis')
-    depends_on('suite-sparse',when='+suite-sparse')
+    depends_on('metis@5:', when='+metis')
+    depends_on('suite-sparse', when='+suite-sparse')
 
     # MPI related dependencies
     depends_on('mpi')
     depends_on('netcdf+mpi')
-    depends_on('parmetis',when='+metis')
-    # Trilinos' Tribits config system is limited which makes it
-    # very tricky to link Amesos with static MUMPS, see
-    # https://trilinos.org/docs/dev/packages/amesos2/doc/html/classAmesos2_1_1MUMPS.html
-    # One could work it out by getting linking flags from mpif90 --showme:link (or alike)
-    # and adding results to -DTrilinos_EXTRA_LINK_FLAGS
-    # together with Blas and Lapack and ScaLAPACK and Blacs and -lgfortran and
-    # it may work at the end. But let's avoid all this by simply using shared libs
-    depends_on('mumps@5.0:+mpi+shared',when='+mumps')
-    depends_on('scalapack',when='+mumps')
-    depends_on('superlu-dist',when='+superlu-dist')
-    depends_on('hypre~internal-superlu',when='+hypre')
-    depends_on('hdf5+mpi',when='+hdf5')
+    depends_on('parmetis', when='+metis')
+    # Trilinos' Tribits config system is limited which makes it very tricky to
+    # link Amesos with static MUMPS, see
+    # https://trilinos.org/docs/dev/packages/amesos2/doc/html/\
+    # classAmesos2_1_1MUMPS.html One could work it out by getting linking flags
+    # from mpif90 --showme:link (or alike) and adding results to
+    # -DTrilinos_EXTRA_LINK_FLAGS together with Blas and Lapack and ScaLAPACK
+    # and Blacs and -lgfortran and it may work at the end. But let's avoid all
+    # this by simply using shared libs
+    depends_on('mumps@5.0:+mpi+shared', when='+mumps')
+    depends_on('scalapack', when='+mumps')
+    depends_on('superlu-dist@:4.3', when='@:12.6.1+superlu-dist')
+    depends_on('superlu-dist', when='@12.6.2:+superlu-dist')
+    depends_on('hypre~internal-superlu', when='+hypre')
+    depends_on('hdf5+mpi', when='+hdf5')
 
-    depends_on('python',when='+python')
+    depends_on('python', when='+python')
 
     patch('umfpack_from_suitesparse.patch')
 
     # check that the combination of variants makes sense
     def variants_check(self):
         if '+superlu-dist' in self.spec and self.spec.satisfies('@:11.4.3'):
-            # For Trilinos v11 we need to force SuperLUDist=OFF,
-            # since only the deprecated SuperLUDist v3.3 together with an Amesos patch
-            # is working.
-            raise RuntimeError('The superlu-dist variant can only be used with Trilinos @12.0.1:')
+            # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
+            # deprecated SuperLUDist v3.3 together with an Amesos patch is
+            # working.
+            raise RuntimeError('The superlu-dist variant can only be used '
+                               'with Trilinos @12.0.1:')
 
     def install(self, spec, prefix):
         self.variants_check()
@@ -111,49 +122,66 @@ class Trilinos(Package):
                         '-DTrilinos_VERBOSE_CONFIGURE:BOOL=OFF',
                         '-DTrilinos_ENABLE_TESTS:BOOL=OFF',
                         '-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF',
-                        '-DCMAKE_BUILD_TYPE:STRING=%s' % ('DEBUG' if '+debug' in spec else 'RELEASE'),
-                        '-DBUILD_SHARED_LIBS:BOOL=%s' % ('ON' if '+shared' in spec else 'OFF'),
+                        '-DCMAKE_BUILD_TYPE:STRING=%s'
+                        % ('DEBUG' if '+debug' in spec else 'RELEASE'),
+                        '-DBUILD_SHARED_LIBS:BOOL=%s'
+                        % ('ON' if '+shared' in spec else 'OFF'),
                         '-DTPL_ENABLE_MPI:BOOL=ON',
                         '-DMPI_BASE_DIR:PATH=%s' % spec['mpi'].prefix,
                         '-DTPL_ENABLE_BLAS=ON',
-                        '-DBLAS_LIBRARY_NAMES=blas', # FIXME: don't hardcode names
+                        # FIXME: don't hardcode names (blas, lapack)
+                        '-DBLAS_LIBRARY_NAMES=blas',
                         '-DBLAS_LIBRARY_DIRS=%s' % spec['blas'].prefix.lib,
                         '-DTPL_ENABLE_LAPACK=ON',
                         '-DLAPACK_LIBRARY_NAMES=lapack',
                         '-DLAPACK_LIBRARY_DIRS=%s' % spec['lapack'].prefix,
                         '-DTPL_ENABLE_Boost:BOOL=ON',
-                        '-DBoost_INCLUDE_DIRS:PATH=%s' % spec['boost'].prefix.include,
-                        '-DBoost_LIBRARY_DIRS:PATH=%s' % spec['boost'].prefix.lib,
+                        '-DBoost_INCLUDE_DIRS:PATH=%s'
+                        % spec['boost'].prefix.include,
+                        '-DBoost_LIBRARY_DIRS:PATH=%s'
+                        % spec['boost'].prefix.lib,
                         '-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON',
                         '-DTrilinos_ENABLE_CXX11:BOOL=ON',
                         '-DTPL_ENABLE_Netcdf:BOOL=ON',
-                        '-DTPL_ENABLE_HYPRE:BOOL=%s' % ('ON' if '+hypre' in spec else 'OFF'),
-                        '-DTPL_ENABLE_HDF5:BOOL=%s' % ('ON' if '+hdf5' in spec else 'OFF'),
+                        '-DTPL_ENABLE_HYPRE:BOOL=%s'
+                        % ('ON' if '+hypre' in spec else 'OFF'),
+                        '-DTPL_ENABLE_HDF5:BOOL=%s'
+                        % ('ON' if '+hdf5' in spec else 'OFF'),
                         ])
 
         # Fortran lib
-        libgfortran = os.path.dirname (os.popen('%s --print-file-name libgfortran.a' % join_path(mpi_bin,'mpif90') ).read())
+        libgfortran = os.path.dirname(os.popen(
+            '%s --print-file-name libgfortran.a'
+            % join_path(mpi_bin, 'mpif90')).read())
         options.extend([
-            '-DTrilinos_EXTRA_LINK_FLAGS:STRING=-L%s/ -lgfortran' % libgfortran,
+            '-DTrilinos_EXTRA_LINK_FLAGS:STRING=-L%s/ -lgfortran'
+            % libgfortran,
             '-DTrilinos_ENABLE_Fortran=ON'
         ])
 
         # for build-debug only:
-        #options.extend([
+        # options.extend([
         #   '-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE'
-        #])
+        # ])
 
         # suite-sparse related
         if '+suite-sparse' in spec:
             options.extend([
-                '-DTPL_ENABLE_Cholmod:BOOL=OFF', # FIXME: Trilinos seems to be looking for static libs only, patch CMake TPL file?
-                #'-DTPL_ENABLE_Cholmod:BOOL=ON',
-                #'-DCholmod_LIBRARY_DIRS:PATH=%s' % spec['suite-sparse'].prefix.lib,
-                #'-DCholmod_INCLUDE_DIRS:PATH=%s' % spec['suite-sparse'].prefix.include,
+                # FIXME: Trilinos seems to be looking for static libs only,
+                # patch CMake TPL file?
+                '-DTPL_ENABLE_Cholmod:BOOL=OFF',
+                # '-DTPL_ENABLE_Cholmod:BOOL=ON',
+                # '-DCholmod_LIBRARY_DIRS:PATH=%s'
+                # % spec['suite-sparse'].prefix.lib,
+                # '-DCholmod_INCLUDE_DIRS:PATH=%s'
+                # % spec['suite-sparse'].prefix.include,
                 '-DTPL_ENABLE_UMFPACK:BOOL=ON',
-                '-DUMFPACK_LIBRARY_DIRS:PATH=%s' % spec['suite-sparse'].prefix.lib,
-                '-DUMFPACK_INCLUDE_DIRS:PATH=%s' % spec['suite-sparse'].prefix.include,
-                '-DUMFPACK_LIBRARY_NAMES=umfpack;amd;colamd;cholmod;suitesparseconfig'
+                '-DUMFPACK_LIBRARY_DIRS:PATH=%s'
+                % spec['suite-sparse'].prefix.lib,
+                '-DUMFPACK_INCLUDE_DIRS:PATH=%s'
+                % spec['suite-sparse'].prefix.include,
+                '-DUMFPACK_LIBRARY_NAMES=umfpack;amd;colamd;cholmod;'
+                'suitesparseconfig'
             ])
         else:
             options.extend([
@@ -169,9 +197,11 @@ class Trilinos(Package):
                 '-DMETIS_LIBRARY_NAMES=metis',
                 '-DTPL_METIS_INCLUDE_DIRS=%s' % spec['metis'].prefix.include,
                 '-DTPL_ENABLE_ParMETIS:BOOL=ON',
-                '-DParMETIS_LIBRARY_DIRS=%s;%s' % (spec['parmetis'].prefix.lib,spec['metis'].prefix.lib),
+                '-DParMETIS_LIBRARY_DIRS=%s;%s'
+                % (spec['parmetis'].prefix.lib, spec['metis'].prefix.lib),
                 '-DParMETIS_LIBRARY_NAMES=parmetis;metis',
-                '-DTPL_ParMETIS_INCLUDE_DIRS=%s' % spec['parmetis'].prefix.include
+                '-DTPL_ParMETIS_INCLUDE_DIRS=%s'
+                % spec['parmetis'].prefix.include
             ])
         else:
             options.extend([
@@ -184,11 +214,14 @@ class Trilinos(Package):
             options.extend([
                 '-DTPL_ENABLE_MUMPS:BOOL=ON',
                 '-DMUMPS_LIBRARY_DIRS=%s' % spec['mumps'].prefix.lib,
-                '-DMUMPS_LIBRARY_NAMES=dmumps;mumps_common;pord', # order is important!
+                # order is important!
+                '-DMUMPS_LIBRARY_NAMES=dmumps;mumps_common;pord',
                 '-DTPL_ENABLE_SCALAPACK:BOOL=ON',
-                '-DSCALAPACK_LIBRARY_NAMES=scalapack' # FIXME: for MKL it's mkl_scalapack_lp64;mkl_blacs_mpich_lp64
+                # FIXME: for MKL it's mkl_scalapack_lp64;mkl_blacs_mpich_lp64
+                '-DSCALAPACK_LIBRARY_NAMES=scalapack'
             ])
-            # see https://github.com/trilinos/Trilinos/blob/master/packages/amesos/README-MUMPS
+            # see https://github.com/trilinos/Trilinos/blob/master/packages\
+            #     /amesos/README-MUMPS
             cxx_flags.extend([
                 '-DMUMPS_5_0'
             ])
@@ -201,16 +234,20 @@ class Trilinos(Package):
         # superlu-dist:
         if '+superlu-dist' in spec:
             # Amesos, conflicting types of double and complex SLU_D
-            # see https://trilinos.org/pipermail/trilinos-users/2015-March/004731.html
-            # and https://trilinos.org/pipermail/trilinos-users/2015-March/004802.html
+            # see https://trilinos.org/pipermail/trilinos-users/2015-March\
+            #     /004731.html
+            # and https://trilinos.org/pipermail/trilinos-users/2015-March\
+            #     /004802.html
             options.extend([
                 '-DTeuchos_ENABLE_COMPLEX:BOOL=OFF',
                 '-DKokkosTSQR_ENABLE_Complex:BOOL=OFF'
             ])
             options.extend([
                 '-DTPL_ENABLE_SuperLUDist:BOOL=ON',
-                '-DSuperLUDist_LIBRARY_DIRS=%s' % spec['superlu-dist'].prefix.lib,
-                '-DSuperLUDist_INCLUDE_DIRS=%s' % spec['superlu-dist'].prefix.include
+                '-DSuperLUDist_LIBRARY_DIRS=%s'
+                % spec['superlu-dist'].prefix.lib,
+                '-DSuperLUDist_INCLUDE_DIRS=%s'
+                % spec['superlu-dist'].prefix.include
             ])
             if spec.satisfies('^superlu-dist@4.0:'):
                 options.extend([
@@ -220,7 +257,6 @@ class Trilinos(Package):
             options.extend([
                 '-DTPL_ENABLE_SuperLUDist:BOOL=OFF',
             ])
-
 
         # python
         if '+python' in spec:
@@ -248,23 +284,27 @@ class Trilinos(Package):
                 '-DTrilinos_ENABLE_FEI=OFF'
             ])
 
-
         with working_dir('spack-build', create=True):
             cmake('..', *options)
             make()
             make('install')
 
-            # When trilinos is built with Python, libpytrilinos is included through
-            # cmake configure files. Namely, Trilinos_LIBRARIES in TrilinosConfig.cmake
-            # contains pytrilinos. This leads to a run-time error:
-            # Symbol not found: _PyBool_Type
-            # and prevents Trilinos to be used in any C++ code, which links executable
-            # against the libraries listed in Trilinos_LIBRARIES.
-            # See https://github.com/Homebrew/homebrew-science/issues/2148#issuecomment-103614509
-            # A workaround it to remove PyTrilinos from the COMPONENTS_LIST :
+            # When trilinos is built with Python, libpytrilinos is included
+            # through cmake configure files. Namely, Trilinos_LIBRARIES in
+            # TrilinosConfig.cmake contains pytrilinos. This leads to a
+            # run-time error: Symbol not found: _PyBool_Type and prevents
+            # Trilinos to be used in any C++ code, which links executable
+            # against the libraries listed in Trilinos_LIBRARIES.  See
+            # https://github.com/Homebrew/homebrew-science/issues\
+            # /2148#issuecomment-103614509 A workaround it to remove PyTrilinos
+            # from the COMPONENTS_LIST :
             if '+python' in self.spec:
-                filter_file(r'(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)',  (r'\1\3'),  '%s/cmake/Trilinos/TrilinosConfig.cmake' % prefix.lib)
+                filter_file(r'(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)',
+                            (r'\1\3'),
+                            '%s/cmake/Trilinos/TrilinosConfig.cmake'
+                            % prefix.lib)
 
-            # The shared libraries are not installed correctly on Darwin; correct this
+            # The shared libraries are not installed correctly on Darwin;
+            # correct this
             if (sys.platform == 'darwin') and ('+shared' in spec):
                 fix_darwin_install_name(prefix.lib)

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -28,10 +28,8 @@ import sys
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
-# - https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild\
-#   /easyblocks/t/trilinos.py#L111
-# - https://github.com/koecher/candi/blob/master/deal.II-toolchain/packages\
-#   /trilinos.package
+# - https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild/easyblocks/t/trilinos.py#L111  # NOQA: ignore=E501
+# - https://github.com/koecher/candi/blob/master/deal.II-toolchain/packages/trilinos.package  # NOQA: ignore=E501
 # - https://gitlab.com/configurations/cluster-config/blob/master/trilinos.sh
 # - https://github.com/Homebrew/homebrew-science/blob/master/trilinos.rb
 # and some relevant documentation/examples:
@@ -83,12 +81,11 @@ class Trilinos(Package):
     depends_on('parmetis', when='+metis')
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see
-    # https://trilinos.org/docs/dev/packages/amesos2/doc/html/\
-    # classAmesos2_1_1MUMPS.html One could work it out by getting linking flags
-    # from mpif90 --showme:link (or alike) and adding results to
-    # -DTrilinos_EXTRA_LINK_FLAGS together with Blas and Lapack and ScaLAPACK
-    # and Blacs and -lgfortran and it may work at the end. But let's avoid all
-    # this by simply using shared libs
+    # https://trilinos.org/docs/dev/packages/amesos2/doc/html/classAmesos2_1_1MUMPS.html  # NOQA: ignore=E501
+    # One could work it out by getting linking flags from mpif90 --showme:link
+    # (or alike) and adding results to -DTrilinos_EXTRA_LINK_FLAGS together
+    # with Blas and Lapack and ScaLAPACK and Blacs and -lgfortran and it may
+    # work at the end. But let's avoid all this by simply using shared libs
     depends_on('mumps@5.0:+mpi+shared', when='+mumps')
     depends_on('scalapack', when='+mumps')
     depends_on('superlu-dist@:4.3', when='@:12.6.1+superlu-dist')
@@ -220,8 +217,7 @@ class Trilinos(Package):
                 # FIXME: for MKL it's mkl_scalapack_lp64;mkl_blacs_mpich_lp64
                 '-DSCALAPACK_LIBRARY_NAMES=scalapack'
             ])
-            # see https://github.com/trilinos/Trilinos/blob/master/packages\
-            #     /amesos/README-MUMPS
+            # see https://github.com/trilinos/Trilinos/blob/master/packages/amesos/README-MUMPS  # NOQA: ignore=E501
             cxx_flags.extend([
                 '-DMUMPS_5_0'
             ])
@@ -234,10 +230,8 @@ class Trilinos(Package):
         # superlu-dist:
         if '+superlu-dist' in spec:
             # Amesos, conflicting types of double and complex SLU_D
-            # see https://trilinos.org/pipermail/trilinos-users/2015-March\
-            #     /004731.html
-            # and https://trilinos.org/pipermail/trilinos-users/2015-March\
-            #     /004802.html
+            # see https://trilinos.org/pipermail/trilinos-users/2015-March/004731.html  # NOQA: ignore=E501
+            # and https://trilinos.org/pipermail/trilinos-users/2015-March/004802.html  # NOQA: ignore=E501
             options.extend([
                 '-DTeuchos_ENABLE_COMPLEX:BOOL=OFF',
                 '-DKokkosTSQR_ENABLE_Complex:BOOL=OFF'
@@ -295,9 +289,8 @@ class Trilinos(Package):
             # run-time error: Symbol not found: _PyBool_Type and prevents
             # Trilinos to be used in any C++ code, which links executable
             # against the libraries listed in Trilinos_LIBRARIES.  See
-            # https://github.com/Homebrew/homebrew-science/issues\
-            # /2148#issuecomment-103614509 A workaround it to remove PyTrilinos
-            # from the COMPONENTS_LIST :
+            # https://github.com/Homebrew/homebrew-science/issues/2148#issuecomment-103614509  # NOQA: ignore=E501
+            # A workaround it to remove PyTrilinos from the COMPONENTS_LIST :
             if '+python' in self.spec:
                 filter_file(r'(SET\(COMPONENTS_LIST.*)(PyTrilinos;)(.*)',
                             (r'\1\3'),


### PR DESCRIPTION
- Prevent petsc from linking to superlu-dist@5 since this version of superlu-dist is not currently supported by petsc.
- Prevent trilinos versions prior to 12.6.2 from linking to superlu-dist@5.
- Fix formatting to meet pep8 requirements.

- fixes #901 