### PR TITLE
Adding `+metis` variant to scotch + changes for esmumps

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/Makefile.esmumps
+++ b/var/spack/repos/builtin/packages/scotch/Makefile.esmumps
@@ -1,5 +1,0 @@
-esmumps				:	scotch
-					(cd esmumps ; $(MAKE) scotch && $(MAKE) install)
-
-ptesmumps			:	ptscotch
-					(cd esmumps ; $(MAKE) ptscotch && $(MAKE) ptinstall)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -59,7 +59,7 @@ class Scotch(Package):
     def url_for_version(self, version):
         return super(Scotch, self).url_for_version(version)
 
-    @when(":6.0.0")
+    @when('@:6.0.0')
     def url_for_version(self, version):
         return '%s/scotch_%s_esmumps.tar.gz' % (Scotch.base_url, version)
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -37,13 +37,18 @@ class Scotch(Package):
     list_url = "http://gforge.inria.fr/frs/?group_id=248"
 
     version('6.0.3', '10b0cc0f184de2de99859eafaca83cfc')
-    version('6.0.0', 'c50d6187462ba801f9a82133ee666e8e')
-    version('5.1.10b', 'f587201d6cf5cf63527182fbfba70753')
+    version('6.0.0', 'ba117428c0a6cd97d0c93e8b872bb3fe')
+    version('5.1.10b', '9b8622b39c141ecaca4a46298486fd99')
+
+    # This must be set for version <= 6.0.0
+    md5_esmumps = { Version('5.1.10b'): 'f587201d6cf5cf63527182fbfba70753',
+                    Version('6.0.0'): 'c50d6187462ba801f9a82133ee666e8e' }
 
     variant('mpi', default=False, description='Activate the compilation of parallel libraries')
     variant('compression', default=True, description='Activate the posibility to use compressed files')
     variant('esmumps', default=False, description='Activate the compilation of esmumps needed by mumps')
     variant('shared', default=True, description='Build a shared version of the library')
+    variant('metis', default=True, description='Build a metis wrapper library library')
 
     depends_on('flex')
     depends_on('bison')
@@ -56,37 +61,19 @@ class Scotch(Package):
     # from the Scotch hosting site.  These alternative archives include a
     # superset of the behavior in their default counterparts, so we choose to
     # always grab these versions for older Scotch versions for simplicity.
-    @when('@:6.0.0')
-    def url_for_version(self, version):
-        return '%s/scotch_%s_esmumps.tar.gz' % (Scotch.base_url, version)
-
-    @when('@6.0.1:')
     def url_for_version(self, version):
         return super(Scotch, self).url_for_version(version)
 
-    # NOTE: Several of the 'esmumps' enabled Scotch releases up to version
-    # 6.0.0 have broken build scripts that don't properly build 'esmumps' as a
-    # separate target, so we need a patch procedure to remove 'esmumps' from
-    # existing targets and to add it as a standalone target.
-    @when('@:6.0.0')
+    @when('+esmumps')
+    def url_for_version(self, version):
+        if version <= Version('6.0.0'):
+            self.versions[version]['md5'] = self.md5_esmumps[version]
+            return '%s/scotch_%s_esmumps.tar.gz' % (Scotch.base_url, version)
+        else:
+            return super(Scotch, self).url_for_version(version)
+
     def patch(self):
-        makefile_path = os.path.join('src', 'Makefile')
-        with open(makefile_path, 'r') as makefile:
-            esmumps_enabled = any(re.search(r'^esmumps(\s*):(.*)$', line)
-                                  for line in makefile.readlines())
-
-        if not esmumps_enabled:
-            mff = FileFilter(makefile_path)
-            mff.filter(r'^.*((esmumps)|(ptesmumps)).*(install).*$', '')
-
-            mfesmumps_dir = os.path.dirname(os.path.realpath(__file__))
-            mfesmumps_path = os.path.join(mfesmumps_dir, 'Makefile.esmumps')
-            with open(makefile_path, 'a') as makefile:
-                makefile.write('\ninclude %s\n' % mfesmumps_path)
-
-    @when('@6.0.1:')
-    def patch(self):
-        pass
+        self.configure()
 
     # NOTE: Configuration of Scotch is achieved by writing a 'Makefile.inc'
     # file that contains all of the configuration variables and their desired
@@ -103,13 +90,13 @@ class Scotch(Package):
         ]
 
         # Library Build Type #
-
         if '+shared' in self.spec:
             makefile_inc.extend([
+                # todo change for Darwin systems
                 'LIB       = .so',
                 'CLIBFLAGS = -shared -fPIC',
                 'RANLIB    = echo',
-                'AR	       = $(CC)',
+                'AR	   = $(CC)',
                 'ARFLAGS   = -shared $(LDFLAGS) -o'
             ])
             cflags.append('-fPIC')
@@ -118,7 +105,7 @@ class Scotch(Package):
                 'LIB       = .a',
                 'CLIBFLAGS = ',
                 'RANLIB    = ranlib',
-                'AR	       = ar',
+                'AR	   = ar',
                 'ARFLAGS   = -ruv '
             ])
 
@@ -171,20 +158,34 @@ class Scotch(Package):
                 fh.write('\n'.join(makefile_inc))
 
     def install(self, spec, prefix):
-        self.configure()
-
         targets = ['scotch']
         if '+mpi' in self.spec:
             targets.append('ptscotch')
 
-        if '+esmumps' in self.spec:
-            targets.append('esmumps')
-            if '+mpi' in self.spec:
-                targets.append('ptesmumps')
+        if self.spec.version >= Version('6.0.0'):
+            if '+esmumps' in self.spec:
+                targets.append('esmumps')
+                if '+mpi' in self.spec:
+                    targets.append('ptesmumps')
 
         with working_dir('src'):
             for target in targets:
-                make(target, parallel=(target != 'ptesmumps'))
+                can_make_parallel = not (target == 'ptesmumps'
+                                         or (self.spec.version < Version('6.0.0')
+                                             and target == 'ptscotch'))
+                make(target, parallel=can_make_parallel)
+
+        # It seams easier to remove metis wrappers from the folder that will be installed than
+        # to tweak their Makefiles
+        if '+metis' not in self.spec:
+            with working_dir('lib'):
+                lib_ext = '.so' if '+shared' in self.spec else '.a'
+                force_remove('libscotchmetis{0}'.format(lib_ext))
+                force_remove('libptscotchparmetis{0}'.format(lib_ext))
+
+            with working_dir('include'):
+                force_remove('metis.h')
+                force_remove('parmetis.h')
 
         install_tree('bin', prefix.bin)
         install_tree('lib', prefix.lib)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import re
 from spack import *
 
 
@@ -60,11 +59,9 @@ class Scotch(Package):
     def url_for_version(self, version):
         return super(Scotch, self).url_for_version(version)
 
+    @when(":6.0.0")
     def url_for_version(self, version):
-        if version <= Version('6.0.0'):
-            return '%s/scotch_%s_esmumps.tar.gz' % (Scotch.base_url, version)
-        else:
-            return super(Scotch, self).url_for_version(version)
+        return '%s/scotch_%s_esmumps.tar.gz' % (Scotch.base_url, version)
 
     def patch(self):
         self.configure()
@@ -168,15 +165,16 @@ class Scotch(Package):
                 # version prior to 6.0.0 there is no separated targets force
                 # ptesmumps, this library is built by the ptscotch target. This
                 # should explain the test for the can_make_parallel variable
-                can_make_parallel = not (target == 'ptesmumps'
-                                         or (self.spec.version < Version('6.0.0')
-                                             and target == 'ptscotch'))
+                can_make_parallel = \
+                    not (target == 'ptesmumps' or
+                         (self.spec.version < Version('6.0.0') and
+                          target == 'ptscotch'))
                 make(target, parallel=can_make_parallel)
 
         # todo change this to take into account darwin systems
         lib_ext = '.so' if '+shared' in self.spec else '.a'
-        # It seams easier to remove metis wrappers from the folder that will be installed than
-        # to tweak the Makefiles
+        # It seams easier to remove metis wrappers from the folder that will be
+        # installed than to tweak the Makefiles
         if '+metis' not in self.spec:
             with working_dir('lib'):
                 lib_ext = '.so' if '+shared' in self.spec else '.a'


### PR DESCRIPTION
Adding the `+metis` variant to make optional the installation of the metis.h and parmetis.h files to avoid collision for softwares using both metis and scotch.

I also changes the way esmumps is used to not have to patch the make files of scotch. Just downloading the good file.

I also remove the call of configure from install to follow a remark of @tgamblin  in #231 

@xjrc : I tried to compile the version 5.1.10b and 6.0.0 with +esmumps/~esmumps and +mpi/~mpi
plus some version with +metis/~metis, and did not get any trouble. Can you check if it still works for you.