### PR TITLE
find : add unit tests

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -180,6 +180,29 @@ def display_specs(specs, **kwargs):
                 "deps, short)." % mode)  # NOQA: ignore=E501
 
 
+def query_arguments(args):
+    # Check arguments
+    if args.explicit and args.implicit:
+        tty.error('You can\'t pass -E and -e options simultaneously.')
+        raise SystemExit(1)
+
+    # Set up query arguments.
+    installed, known = True, any
+    if args.only_missing:
+        installed = False
+    elif args.missing:
+        installed = any
+    if args.unknown:
+        known = False
+    explicit = any
+    if args.explicit:
+        explicit = True
+    if args.implicit:
+        explicit = False
+    q_args = {'installed': installed, 'known': known, "explicit": explicit}
+    return q_args
+
+
 def find(parser, args):
     # Filter out specs that don't exist.
     query_specs = spack.cmd.parse_specs(args.query_specs)
@@ -194,22 +217,7 @@ def find(parser, args):
         if not query_specs:
             return
 
-    # Set up query arguments.
-    installed, known = True, any
-    if args.only_missing:
-        installed = False
-    elif args.missing:
-        installed = any
-    if args.unknown:
-        known = False
-
-    explicit = any
-    if args.explicit:
-        explicit = False
-    if args.implicit:
-        explicit = True
-
-    q_args = {'installed': installed, 'known': known, "explicit": explicit}
+    q_args = query_arguments(args)
 
     # Get all the specs the user asked for
     if not query_specs:
@@ -229,3 +237,4 @@ def find(parser, args):
                   long=args.long,
                   very_long=args.very_long,
                   show_flags=args.show_flags)
+

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -237,4 +237,3 @@ def find(parser, args):
                   long=args.long,
                   very_long=args.very_long,
                   show_flags=args.show_flags)
-

--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -38,7 +38,7 @@ test_names = ['versions', 'url_parse', 'url_substitution', 'packages', 'stage',
               'svn_fetch', 'hg_fetch', 'mirror', 'modules', 'url_extrapolate',
               'cc', 'link_tree', 'spec_yaml', 'optional_deps',
               'make_executable', 'configure_guess', 'lock', 'database',
-              'namespace_trie', 'yaml', 'sbang', 'environment',
+              'namespace_trie', 'yaml', 'sbang', 'environment', 'cmd.find',
               'cmd.uninstall', 'cmd.test_install']
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+
+import spack.cmd.find
+import unittest
+
+
+class Bunch(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class FindTest(unittest.TestCase):
+    def test_query_arguments(self):
+        query_arguments = spack.cmd.find.query_arguments
+        # Default arguments
+        args = Bunch(only_missing=False, missing=False, unknown=False, explicit=False, implicit=False)
+        q_args = query_arguments(args)
+        self.assertTrue('installed' in q_args)
+        self.assertTrue('known' in q_args)
+        self.assertTrue('explicit' in q_args)
+        self.assertEqual(q_args['installed'], True)
+        self.assertEqual(q_args['known'], any)
+        self.assertEqual(q_args['explicit'], any)
+        # Check that explicit works correctly
+        args.explicit = True
+        q_args = query_arguments(args)
+        self.assertEqual(q_args['explicit'], True)
+        args.explicit = False
+        args.implicit = True
+        q_args = query_arguments(args)
+        self.assertEqual(q_args['explicit'], False)
+        args.explicit = True
+        self.assertRaises(SystemExit, query_arguments, args)

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -29,15 +29,18 @@ import unittest
 
 
 class Bunch(object):
+
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
 
 class FindTest(unittest.TestCase):
+
     def test_query_arguments(self):
         query_arguments = spack.cmd.find.query_arguments
         # Default arguments
-        args = Bunch(only_missing=False, missing=False, unknown=False, explicit=False, implicit=False)
+        args = Bunch(only_missing=False, missing=False,
+                     unknown=False, explicit=False, implicit=False)
         q_args = query_arguments(args)
         self.assertTrue('installed' in q_args)
         self.assertTrue('known' in q_args)


### PR DESCRIPTION
Modifications : 
- [x] unit tests for #968 
- [x] if `spack find` is given both `-E` and `-e` print an error and exit with 1
- [x] fixes a non reported bug for the explicit option showing the opposite of what you requested