### PR TITLE
Rust

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1,4 +1,4 @@
-##############################################################################
+#
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
@@ -21,7 +21,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+#
 """
 Fetch strategies are used to download source code into a staging area
 in order to build it.  They need to define the following methods:
@@ -75,11 +75,13 @@ def _needs_stage(fun):
 
 
 class FetchStrategy(object):
+
     """Superclass of all fetch strategies."""
     enabled = False  # Non-abstract subclasses should be enabled.
     required_attributes = None  # Attributes required in version() args.
 
     class __metaclass__(type):
+
         """This metaclass registers all fetch strategies in a list."""
 
         def __init__(cls, name, bases, dict):
@@ -126,6 +128,7 @@ class FetchStrategy(object):
 
 @pattern.composite(interface=FetchStrategy)
 class FetchStrategyComposite(object):
+
     """
     Composite for a FetchStrategy object. Implements the GoF composite pattern.
     """
@@ -134,6 +137,7 @@ class FetchStrategyComposite(object):
 
 
 class URLFetchStrategy(FetchStrategy):
+
     """FetchStrategy that pulls source code from a URL for an archive,
        checks the archive against a checksum,and decompresses the archive.
     """
@@ -235,12 +239,13 @@ class URLFetchStrategy(FetchStrategy):
         # redirects properly.
         content_types = re.findall(r'Content-Type:[^\r\n]+', headers)
         if content_types and 'text/html' in content_types[-1]:
-            tty.warn(
-                "The contents of " + self.archive_file + " look like HTML.",
-                "The checksum will likely be bad.  If it is, you can use",
-                "'spack clean <package>' to remove the bad archive, then fix",
-                "your internet gateway issue and install again.")
-
+            tty.warn("The contents of ",
+                     (self.archive_file if self.archive_file is not None
+                      else "the archive"),
+                     " look like HTML.",
+                     "The checksum will likely be bad.  If it is, you can use",
+                     "'spack clean <package>' to remove the bad archive, then",
+                     "fix your internet gateway issue and install again.")
         if save_file:
             os.rename(partial_file, save_file)
 
@@ -353,6 +358,7 @@ class URLFetchStrategy(FetchStrategy):
 
 
 class VCSFetchStrategy(FetchStrategy):
+
     def __init__(self, name, *rev_types, **kwargs):
         super(VCSFetchStrategy, self).__init__()
         self.name = name
@@ -407,6 +413,7 @@ class VCSFetchStrategy(FetchStrategy):
 
 
 class GoFetchStrategy(VCSFetchStrategy):
+
     """
     Fetch strategy that employs the `go get` infrastructure
     Use like this in a package:
@@ -466,6 +473,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
 
 class GitFetchStrategy(VCSFetchStrategy):
+
     """
     Fetch strategy that gets source code from a git repository.
     Use like this in a package:
@@ -586,6 +594,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
 
 class SvnFetchStrategy(VCSFetchStrategy):
+
     """Fetch strategy that gets source code from a subversion repository.
        Use like this in a package:
 
@@ -662,6 +671,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
 
 
 class HgFetchStrategy(VCSFetchStrategy):
+
     """
     Fetch strategy that gets source code from a Mercurial repository.
     Use like this in a package:
@@ -806,11 +816,13 @@ def for_package_version(pkg, version):
 
 
 class FetchError(spack.error.SpackError):
+
     def __init__(self, msg, long_msg=None):
         super(FetchError, self).__init__(msg, long_msg)
 
 
 class FailedDownloadError(FetchError):
+
     """Raised wen a download fails."""
 
     def __init__(self, url, msg=""):
@@ -820,16 +832,19 @@ class FailedDownloadError(FetchError):
 
 
 class NoArchiveFileError(FetchError):
+
     def __init__(self, msg, long_msg):
         super(NoArchiveFileError, self).__init__(msg, long_msg)
 
 
 class NoDigestError(FetchError):
+
     def __init__(self, msg, long_msg=None):
         super(NoDigestError, self).__init__(msg, long_msg)
 
 
 class InvalidArgsError(FetchError):
+
     def __init__(self, pkg, version):
         msg = ("Could not construct a fetch strategy for package %s at "
                "version %s")
@@ -838,6 +853,7 @@ class InvalidArgsError(FetchError):
 
 
 class ChecksumError(FetchError):
+
     """Raised when archive fails to checksum."""
 
     def __init__(self, message, long_msg=None):
@@ -845,6 +861,7 @@ class ChecksumError(FetchError):
 
 
 class NoStageError(FetchError):
+
     """Raised when fetch operations are called before set_stage()."""
 
     def __init__(self, method):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os, shutil
+import os, glob
 
 
 class Llvm(Package):
@@ -46,7 +46,9 @@ class Llvm(Package):
     variant('libcxx', default=True, description="Build the LLVM C++ standard library")
     variant('compiler-rt', default=True, description="Build the LLVM compiler runtime, including sanitizers")
     variant('gold', default=True, description="Add support for LTO with the gold linker plugin")
-
+    variant('shared_libs', default=False, description="Build all components as shared libraries, faster, less memory to build, less stable")
+    variant('link_dylib', default=False, description="Build and link the libLLVM shared library rather than static")
+    variant('all_targets', default=True, description="Build all supported targets, default targets <current arch>,NVPTX,AMDGPU,CppBackend")
 
     # Build dependency
     depends_on('cmake @2.8.12.2:')
@@ -257,6 +259,28 @@ class Llvm(Package):
         if '+compiler-rt' not in spec:
             cmake_args.append('-DLLVM_EXTERNAL_COMPILER_RT_BUILD:Bool=OFF')
 
+        if '+shared_libs' in spec:
+            cmake_args.append('-DBUILD_SHARED_LIBS:Bool=ON')
+
+        if '+link_dylib' in spec:
+            cmake_args.append('-DLLVM_LINK_LLVM_DYLIB:Bool=ON')
+
+        if '+all_targets' not in spec: # all is default on cmake
+            targets = ['CppBackend', 'NVPTX', 'AMDGPU']
+            if 'x86' in spec.architecture.lower():
+                targets.append('X86')
+            elif 'arm' in spec.architecture.lower():
+                targets.append('ARM')
+            elif 'aarch64' in spec.architecture.lower():
+                targets.append('AArch64')
+            elif 'sparc' in spec.architecture.lower():
+                targets.append('sparc')
+            elif ('ppc' in spec.architecture.lower() or
+                  'power' in spec.architecture.lower()):
+                targets.append('PowerPC')
+
+            cmake_args.append('-DLLVM_TARGETS_TO_BUILD:Bool=' + ';'.join(targets))
+
         if  '+clang' not in spec:
             if '+clang_extra' in spec:
                 raise SpackException('The clang_extra variant requires the clang variant to be selected')
@@ -267,7 +291,5 @@ class Llvm(Package):
             cmake(*cmake_args)
             make()
             make("install")
-            query_path = os.path.join('bin', 'clang-query')
-            # Manually install clang-query, because llvm doesn't...
-            if os.path.exists(query_path):
-                shutil.copy(query_path, os.path.join(prefix, 'bin'))
+            cp = which('cp')
+            cp('-a', 'bin/', prefix)

--- a/var/spack/repos/builtin/packages/rust-bindgen/package.py
+++ b/var/spack/repos/builtin/packages/rust-bindgen/package.py
@@ -7,6 +7,8 @@ class RustBindgen(Package):
     homepage = "http://www.rust-lang.org"
     url = "https://github.com/crabtw/rust-bindgen"
 
+    version('0.16', tag='0.16', git='https://github.com/crabtw/rust-bindgen')
+
     extends("rust")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/rust-bindgen/package.py
+++ b/var/spack/repos/builtin/packages/rust-bindgen/package.py
@@ -10,6 +10,9 @@ class RustBindgen(Package):
     version('0.16', tag='0.16', git='https://github.com/crabtw/rust-bindgen')
 
     extends("rust")
+    depends_on("llvm")
 
     def install(self, spec, prefix):
-        cargo('install', '--root', prefix)
+        env = dict(os.environ)
+        env['LIBCLANG_PATH'] = os.path.join(spec['llvm'].prefix, 'lib')
+        cargo('install', '--root', prefix, env=env)

--- a/var/spack/repos/builtin/packages/rust-bindgen/package.py
+++ b/var/spack/repos/builtin/packages/rust-bindgen/package.py
@@ -1,0 +1,13 @@
+from spack import *
+import os
+
+
+class RustBindgen(Package):
+    """The rust programming language toolchain"""
+    homepage = "http://www.rust-lang.org"
+    url = "https://github.com/crabtw/rust-bindgen"
+
+    extends("rust")
+
+    def install(self, spec, prefix):
+        cargo('install', '--root', prefix)

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -21,6 +21,7 @@ class Rust(Package):
     extendable = True
 
     # Rust
+    depends_on("llvm")
     depends_on("curl")
     depends_on("git")
     depends_on("cmake")
@@ -30,8 +31,8 @@ class Rust(Package):
     depends_on("openssl")
 
     def install(self, spec, prefix):
-        get_submodules()
-        configure('--prefix=%s' % prefix)
+        configure('--prefix=%s' % prefix,
+                  '--llvm-root=' + spec['llvm'].prefix)
 
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -1,0 +1,62 @@
+from spack import *
+import os
+
+
+def get_submodules():
+    git = which('git')
+    git('submodule', 'update', '--init', '--recursive')
+
+class Rust(Package):
+    """The rust programming language toolchain"""
+    homepage = "http://www.rust-lang.org"
+    url = "https://github.com/rust-lang/rust"
+
+    version('1.8.0', tag='1.8.0', git="https://github.com/rust-lang/rust")
+
+    resource(name='cargo',
+             git="https://github.com/rust-lang/cargo.git",
+             tag='0.10.0',
+             destination='cargo')
+
+    extendable = True
+
+    # Rust
+    depends_on("curl")
+    depends_on("git")
+    depends_on("cmake")
+    depends_on("python@:2.8")
+
+    # Cargo
+    depends_on("openssl")
+
+    def install(self, spec, prefix):
+        get_submodules()
+        configure('--prefix=%s' % prefix)
+
+        make()
+        make("install")
+
+        # Install cargo, rust package manager
+        with working_dir(os.path.join('cargo', 'cargo')):
+            get_submodules()
+            configure('--prefix=' + prefix,
+                      '--local-rust-root=' + prefix)
+
+            make()
+            make("install")
+
+    def setup_dependent_package(self, module, ext_spec):
+        """
+        Called before python modules' install() methods.
+
+        In most cases, extensions will only need to have one or two lines::
+
+            cargo('build')
+            cargo('install', '--root', prefix)
+
+        or
+
+            cargo('install', '--root', prefix)
+        """
+        # Rust extension builds can have a global cargo executable function
+        module.cargo = Executable(join_path(self.spec.prefix.bin, 'cargo'))


### PR DESCRIPTION
Adds a rust package to build the rustc compiler as well as the cargo build manager, which provides a cargo command for extension packages.  This is meant to be used somewhat like the go package, where packages may not actually grab all of their dependencies through spack, but rather grab their static build-time dependencies independently and create a standalone result installed as a normal spack package.

Since this depends on llvm, and llvm takes centuries to build all targets with static linkage, this also adds variants for various of the time-saving build options to llvm.