### PR TITLE
Update Package : METIS/ParMETIS

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,9 @@
 # - E221: multiple spaces before operator
 # - E241: multiple spaces after ‘,’
 #
+# Let people use terse Python features:
+# - E731 : lambda expressions
+#
 # Spack allows wildcard imports:
 # - F403: disable wildcard import
 #
@@ -16,5 +19,5 @@
 # - F999: name name be undefined or undefined from star imports.
 #
 [flake8]
-ignore = E221,E241,F403,F821,F999
+ignore = E221,E241,E731,F403,F821,F999
 max-line-length = 79

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -128,6 +128,25 @@ class Metis(Package):
         os.system('%s %s 10' % (test_bin('partdmesh'), graph))
         os.system('%s %s' % (test_bin('mesh2dual'), graph))
 
+        # TODO: The following code should replace the testing code in the
+        # block above since it causes installs to fail when one or more of the
+        # Metis tests fail, but it currently doesn't work because the 'mtest',
+        # 'onmetis', and 'partnmesh' tests return error codes that trigger
+        # false positives for failure.
+        """
+        Executable(test_bin('mtest'))(test_graph('4elt.graph'))
+        Executable(test_bin('kmetis'))(test_graph('4elt.graph'), '40')
+        Executable(test_bin('onmetis'))(test_graph('4elt.graph'))
+
+        Executable(test_bin('pmetis'))(test_graph('test.mgraph'), '2')
+        Executable(test_bin('kmetis'))(test_graph('test.mgraph'), '2')
+        Executable(test_bin('kmetis'))(test_graph('test.mgraph'), '5')
+
+        Executable(test_bin('partnmesh'))(test_graph('metis.mesh'), '10')
+        Executable(test_bin('partdmesh'))(test_graph('metis.mesh'), '10')
+        Executable(test_bin('mesh2dual'))(test_graph('metis.mesh'))
+        """
+
     @when('@5:')
     def install(self, spec, prefix):
         options = []

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -94,17 +94,19 @@ class Metis(Package):
             install(sharefile, prefix.share)
 
         if '+shared' in spec:
+            shared_flags = ['-fPIC', '-shared']
             if sys.platform == 'darwin':
-                lib_dsuffix = 'dylib'
-                load_flag = '-Wl,-all_load'
-                no_load_flag = ''
+                shared_suffix = 'dylib'
+                shared_flags.extend(['-Wl,-all_load', 'libmetis.a'])
             else:
-                lib_dsuffix = 'so'
-                load_flag = '-Wl,-whole-archive'
-                no_load_flag = '-Wl,-no-whole-archive'
+                shared_suffix = 'so'
+                shared_flags.extend(['-Wl,-whole-archive', 'libmetis.a',
+                                     '-Wl,-no-whole-archive'])
 
-            ccompile('-fPIC', '-shared', load_flag, 'libmetis.a', no_load_flag,
-                     '-o', '%s/libmetis.%s' % (prefix.lib, lib_dsuffix))
+            shared_out = '%s/libmetis.%s' % (prefix.lib, shared_suffix)
+            shared_flags.extend(['-o', shared_out])
+
+            ccompile(*shared_flags)
 
         # Set up and run tests on installation
         ccompile('-I%s' % prefix.include, '-L%s' % prefix.lib,
@@ -128,7 +130,7 @@ class Metis(Package):
         os.system('%s %s 10' % (test_bin('partdmesh'), graph))
         os.system('%s %s' % (test_bin('mesh2dual'), graph))
 
-        # TODO: The following code should replace the testing code in the
+        # FIXME: The following code should replace the testing code in the
         # block above since it causes installs to fail when one or more of the
         # Metis tests fail, but it currently doesn't work because the 'mtest',
         # 'onmetis', and 'partnmesh' tests return error codes that trigger

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -31,10 +31,12 @@ class Parmetis(Package):
     ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured
     graphs, meshes, and for computing fill-reducing orderings of sparse matrices.
     """
+
     homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
-    url = 'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz'
+    base_url = 'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis'
 
     version('4.0.3', 'f69c479586bf6bb7aff6a9bc0c739628')
+    version('4.0.2', '0912a953da5bb9b5e5e10542298ffdce')
 
     variant('shared', default=True, description='Enables the build of shared libraries')
     variant('debug', default=False, description='Builds the library in debug mode')
@@ -42,17 +44,18 @@ class Parmetis(Package):
 
     depends_on('cmake @2.8:')  # build dependency
     depends_on('mpi')
-
-    patch('enable_external_metis.patch')
     depends_on('metis@5:')
 
+    patch('enable_external_metis.patch')
     # bug fixes from PETSc developers
     # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/
     patch('pkg-parmetis-1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b.patch')
     # https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/
     patch('pkg-parmetis-82409d68aa1d6cbc70740d0f35024aae17f7d5cb.patch')
 
-    depends_on('gdb', when='+gdb')
+    def url_for_version(self, version):
+        version_dir = 'OLD/' if version < Version('3.2.0') else ''
+        return '%s/%sparmetis-%s.tar.gz' % (Parmetis.base_url, version_dir, version)
 
     def install(self, spec, prefix):
         options = []
@@ -71,18 +74,15 @@ class Parmetis(Package):
 
         if '+shared' in spec:
             options.append('-DSHARED:BOOL=ON')
-
         if '+debug' in spec:
-            options.extend(['-DDEBUG:BOOL=ON',
-                            '-DCMAKE_BUILD_TYPE:STRING=Debug'])
-
+            options.extend(['-DDEBUG:BOOL=ON', '-DCMAKE_BUILD_TYPE:STRING=Debug'])
         if '+gdb' in spec:
             options.append('-DGDB:BOOL=ON')
 
         with working_dir(build_directory, create=True):
             cmake(source_directory, *options)
             make()
-            make("install")
+            make('install')
 
             # The shared library is not installed correctly on Darwin; correct this
             if (sys.platform == 'darwin') and ('+shared' in spec):

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -65,12 +65,10 @@ class Parmetis(Package):
         source_directory = self.stage.source_path
         metis_source = join_path(source_directory, 'metis')
 
-        # FIXME : Once a contract is defined, MPI compilers should be retrieved indirectly via spec['mpi'] in case
-        # FIXME : they use a non-standard name
         options.extend(['-DGKLIB_PATH:PATH={metis_source}/GKlib'.format(metis_source=spec['metis'].prefix.include),
                         '-DMETIS_PATH:PATH={metis_source}'.format(metis_source=spec['metis'].prefix),
-                        '-DCMAKE_C_COMPILER:STRING=mpicc',
-                        '-DCMAKE_CXX_COMPILER:STRING=mpicxx'])
+                        '-DCMAKE_C_COMPILER:STRING={mpicc}'.format(mpicc=spec['mpi'].mpicc),
+                        '-DCMAKE_CXX_COMPILER:STRING={mpicxx}'.format(mpicxx=spec['mpi'].mpicxx)])
 
         if '+shared' in spec:
             options.append('-DSHARED:BOOL=ON')

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -26,11 +26,11 @@
 from spack import *
 import sys
 
+
 class Parmetis(Package):
-    """
-    ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured
-    graphs, meshes, and for computing fill-reducing orderings of sparse matrices.
-    """
+    """ParMETIS is an MPI-based parallel library that implements a variety of
+       algorithms for partitioning unstructured graphs, meshes, and for
+       computing fill-reducing orderings of sparse matrices."""
 
     homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
     base_url = 'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis'
@@ -42,20 +42,20 @@ class Parmetis(Package):
     variant('debug', default=False, description='Builds the library in debug mode')
     variant('gdb', default=False, description='Enables gdb support')
 
-    depends_on('cmake @2.8:')  # build dependency
+    depends_on('cmake@2.8:')  # build dependency
     depends_on('mpi')
     depends_on('metis@5:')
 
     patch('enable_external_metis.patch')
     # bug fixes from PETSc developers
-    # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/
+    # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/  # NOQA: ignore=E501
     patch('pkg-parmetis-1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b.patch')
-    # https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/
+    # https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/  # NOQA: ignore=E501
     patch('pkg-parmetis-82409d68aa1d6cbc70740d0f35024aae17f7d5cb.patch')
 
     def url_for_version(self, version):
-        version_dir = 'OLD/' if version < Version('3.2.0') else ''
-        return '%s/%sparmetis-%s.tar.gz' % (Parmetis.base_url, version_dir, version)
+        verdir = 'OLD/' if version < Version('3.2.0') else ''
+        return '%s/%sparmetis-%s.tar.gz' % (Parmetis.base_url, verdir, version)
 
     def install(self, spec, prefix):
         options = []
@@ -63,17 +63,19 @@ class Parmetis(Package):
 
         build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path
-        metis_source = join_path(source_directory, 'metis')
 
-        options.extend(['-DGKLIB_PATH:PATH={metis_source}/GKlib'.format(metis_source=spec['metis'].prefix.include),
-                        '-DMETIS_PATH:PATH={metis_source}'.format(metis_source=spec['metis'].prefix),
-                        '-DCMAKE_C_COMPILER:STRING={mpicc}'.format(mpicc=spec['mpi'].mpicc),
-                        '-DCMAKE_CXX_COMPILER:STRING={mpicxx}'.format(mpicxx=spec['mpi'].mpicxx)])
+        options.extend([
+            '-DGKLIB_PATH:PATH=%s/GKlib' % spec['metis'].prefix.include,
+            '-DMETIS_PATH:PATH=%s' % spec['metis'].prefix,
+            '-DCMAKE_C_COMPILER:STRING=%s' % spec['mpi'].mpicc,
+            '-DCMAKE_CXX_COMPILER:STRING=%s' % spec['mpi'].mpicxx
+        ])
 
         if '+shared' in spec:
             options.append('-DSHARED:BOOL=ON')
         if '+debug' in spec:
-            options.extend(['-DDEBUG:BOOL=ON', '-DCMAKE_BUILD_TYPE:STRING=Debug'])
+            options.extend(['-DDEBUG:BOOL=ON',
+                            '-DCMAKE_BUILD_TYPE:STRING=Debug'])
         if '+gdb' in spec:
             options.append('-DGDB:BOOL=ON')
 
@@ -82,6 +84,6 @@ class Parmetis(Package):
             make()
             make('install')
 
-            # The shared library is not installed correctly on Darwin; correct this
+            # The shared library is not installed correctly on Darwin; fix this
             if (sys.platform == 'darwin') and ('+shared' in spec):
                 fix_darwin_install_name(prefix.lib)


### PR DESCRIPTION
The changes in this pull request make the following changes to the `metis` and `parmetis` packages:

- Add installation support for package versions `metis@5.0.2` and `parmetis@4.0.2`.
- Add a `url_for_version` function to each package to remove the need for per-version urls.
- Change the `metis+double` variant to `metis+real64` to improve naming consistency with the `metis+idx64` variant.
- Remove an unnecessary dependency in `metis` on the `gdb` package.
- Improve the `metis@4` installation method by adding support for working with staged archives, fixing a few Linux installation errors, and adding better install error handling.
- Update the code in these packages to conform to PEP8 standards.

I've verified that the `metis@4.0.3/5.0.2+/~shared` and `parmetis@4.0.2+/~shared` variants of these packages compile and install properly on CHAOS when compiling with `gcc@4.7.2`.

@goxberry, @davydden : Could you both verify that your installation variants for `metis` and `parmetis` still work before this PR is merged?  Thanks in advance for your help and please let me know if you have feedback on these changes.