### PR TITLE
Feature Proposal : Fetcher Configuration

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -356,6 +356,22 @@ section_schemas = {
             },
         },
     },
+
+    'fetchers': {
+        '$schema': 'http://json-schema.org/schema#',
+        'title': 'Spack archive fetcher configuration file schema',
+        'type': 'object',
+        'additionalProperties': False,
+        'patternProperties': {
+            r'fetchers:?': {
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'properties': {
+                    'show_status': {
+                        'type': 'boolean',
+                        'default': True},},},},},
+
 }
 
 """OrderedDict of config scopes keyed by name.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -50,6 +50,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import *
 import spack
 import spack.error
+import spack.config
 import spack.util.crypto as crypto
 from spack.util.executable import *
 from spack.util.string import *
@@ -170,6 +171,8 @@ class URLFetchStrategy(FetchStrategy):
             tty.msg("Already downloaded %s" % self.archive_file)
             return
 
+        fetch_config = spack.config.get_config('fetchers')
+
         possible_files = self.stage.expected_archive_files
         save_file = None
         partial_file = None
@@ -195,10 +198,10 @@ class URLFetchStrategy(FetchStrategy):
             self.url,
         ]
 
-        if sys.stdout.isatty():
+        if sys.stdout.isatty() and fetch_config.get('show_status', True):
             curl_args.append('-#')  # status bar when using a tty
         else:
-            curl_args.append('-sS')  # just errors when not.
+            curl_args.append('-sS')  # just errors when not
 
         # Run curl but grab the mime type from the http headers
         headers = spack.curl(*curl_args, output=str, fail_on_error=False)


### PR DESCRIPTION
The changes in this pull request add preliminary support for configuring the utilities that Spack uses in order to fetch archives from the web.  This preliminary support includes the following features:

- The addition of `fetchers.yaml` as the recognized configuration file for Spack fetchers.
- The `show_status` configuration option, which can be used to specify whether or not Spack displays a progress bar when downloading archives (useful since the progress bar for `curl` is broken in many environments).

I'm hoping to extend this set of configuration options sometime soon to make it possible to configure Spack's default archive fetcher (i.e. adding an option like `fetcher: (curl|wget|...)`).  Other configuration options could also be added to solve the problems discussed in #69 and  #895.

Please let me know if there are any problems with this implementation or any improvements that I can make to it!