### PR TITLE
Get glib to compile with gcc-6.1

### DIFF
--- a/var/spack/repos/builtin/packages/glib/g_date_strftime.patch
+++ b/var/spack/repos/builtin/packages/glib/g_date_strftime.patch
@@ -1,0 +1,34 @@
+From 00148329967adb196138372771052a3f606a6ea3 Mon Sep 17 00:00:00 2001
+From: coypu <coypu@sdf.org>
+Date: Wed, 2 Mar 2016 19:43:10 +0200
+Subject: [PATCH 2/2] gdate: Suppress string format literal warning
+
+Newer versions of GCC emit an error here, but we know it's safe.
+https://bugzilla.gnome.org/761550
+---
+ glib/gdate.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/glib/gdate.c b/glib/gdate.c
+index 4aece02..92c34d2 100644
+--- a/glib/gdate.c
++++ b/glib/gdate.c
+@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *d,
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
+@@ -2549,3 +2552,5 @@ g_date_strftime (gchar       *s,
+   return retval;
+ #endif
+ }
++
++#pragma GCC diagnostic pop
+-- 
+2.7.1
+

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -25,20 +25,23 @@
 from spack import *
 import sys
 
+
 class Glib(Package):
     """The GLib package contains a low-level libraries useful for
        providing data structure handling for C, portability wrappers
        and interfaces for such runtime functionality as an event loop,
        threads, dynamic loading and an object system."""
     homepage = "https://developer.gnome.org/glib/"
-    url      = "http://ftp.gnome.org/pub/gnome/sources/glib/2.42/glib-2.42.1.tar.xz"
+    url = "http://ftp.gnome.org/pub/gnome/sources/glib/2.42/glib-2.42.1.tar.xz"
 
     version('2.42.1', '89c4119e50e767d3532158605ee9121a')
 
     depends_on("libffi")
     depends_on("zlib")
     depends_on("pkg-config")
-    depends_on('gettext', sys.platform=='darwin')
+    depends_on('gettext', sys.platform == 'darwin')
+
+    patch('g_date_strftime.patch')
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -41,6 +41,7 @@ class Glib(Package):
     depends_on("pkg-config")
     depends_on('gettext', sys.platform == 'darwin')
 
+    # The following patch is needed for gcc-6.1
     patch('g_date_strftime.patch')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This commit adds a patch to fix the case where gcc-6.1 emits an error
for string format literal that was a warning in previous versions of
gcc. The patch reference is
https://bugzilla.gnome.org/show_bug.cgi?id=761550

Also ran the package file through autopep8.