### PR TITLE
Add version 3.3.0 of R and extensions

### DIFF
--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -71,6 +71,7 @@ class R(Package):
     depends_on('tk')
     depends_on('curl')
     depends_on('pcre')
+    depends_on('jdk')
 
     def install(self, spec, prefix):
         rlibdir = join_path(prefix, 'rlib')

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -115,7 +115,7 @@ class R(Package):
         """Called before R modules' install() methods. In most cases,
         extensions will only need to have one line:
             R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' %
-            self.stage.archive_file)"""
+            self.stage.source_path)"""
         # R extension builds can have a global R executable function
         module.R = Executable(join_path(self.spec.prefix.bin, 'R'))
 

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -61,6 +61,7 @@ class R(Package):
     depends_on('icu')
     depends_on('glib')
     depends_on('zlib')
+    depends_on('bzip2')
     depends_on('libtiff')
     depends_on('jpeg')
     depends_on('cairo')

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -22,28 +22,22 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import functools
-import glob
-import inspect
 import os
-import re
-from contextlib import closing
 
-import spack
-from llnl.util.lang import match_predicate
 from spack import *
 from spack.util.environment import *
 
 
 class R(Package):
-    """
-    R is 'GNU S', a freely available language and environment for statistical computing and graphics which provides a
-    wide variety of statistical and graphical techniques: linear and nonlinear modelling, statistical tests, time series
-    analysis, classification, clustering, etc. Please consult the R project homepage for further information.
-    """
+    """R is 'GNU S', a freely available language and environment for
+    statistical computing and graphics which provides a wide variety of
+    statistical and graphical techniques: linear and nonlinear modelling,
+    statistical tests, time series analysis, classification, clustering, etc.
+    Please consult the R project homepage for further information."""
+
     homepage = "https://www.r-project.org"
     url = "http://cran.cnr.berkeley.edu/src/base/R-3/R-3.1.2.tar.gz"
-    
+
     extendable = True
 
     version('3.2.3', '1ba3dac113efab69e706902810cc2970')
@@ -53,7 +47,8 @@ class R(Package):
     version('3.1.3', '53a85b884925aa6b5811dfc361d73fc4')
     version('3.1.2', '3af29ec06704cbd08d4ba8d69250ae74')
 
-    variant('external-lapack', default=False, description='Links to externally installed BLAS/LAPACK')
+    variant('external-lapack', default=False,
+            description='Links to externally installed BLAS/LAPACK')
 
     # Virtual dependencies
     depends_on('blas', when='+external-lapack')
@@ -106,25 +101,24 @@ class R(Package):
         r_libs_path = ':'.join(r_libs_path)
         spack_env.set('R_LIBS', r_libs_path)
 
-        # For run time environment set only the path for extension_spec and prepend it to R_LIBS
+        # For run time environment set only the path for extension_spec and
+        # prepend it to R_LIBS
         if extension_spec.package.extends(self.spec):
-            run_env.prepend_path('R_LIBS', os.path.join(extension_spec.prefix, self.r_lib_dir))
-
+            run_env.prepend_path('R_LIBS', os.path.join(
+                extension_spec.prefix, self.r_lib_dir))
 
     def setup_dependent_package(self, module, ext_spec):
-        """
-        Called before R modules' install() methods.
-
-        In most cases, extensions will only need to have one line::
-
-	R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)
-        """
+        """Called before R modules' install() methods.  In most cases,
+        extensions will only need to have one line:
+            R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' %
+            self.stage.archive_file)"""
         # R extension builds can have a global R executable function
         module.R = Executable(join_path(self.spec.prefix.bin, 'R'))
 
         # Add variable for library directry
         module.r_lib_dir = os.path.join(ext_spec.prefix, self.r_lib_dir)
 
-        # Make the site packages directory for extensions, if it does not exist already.
+        # Make the site packages directory for extensions, if it does not exist
+        # already.
         if ext_spec.package.is_extension:
             mkdirp(module.r_lib_dir)

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -40,6 +40,7 @@ class R(Package):
 
     extendable = True
 
+    version('3.3.0', '5a7506c8813432d1621c9725e86baf7a')
     version('3.2.3', '1ba3dac113efab69e706902810cc2970')
     version('3.2.2', '57cef5c2e210a5454da1979562a10e5b')
     version('3.2.1', 'c2aac8b40f84e08e7f8c9068de9239a3')
@@ -67,6 +68,8 @@ class R(Package):
     depends_on('freetype')
     depends_on('tcl')
     depends_on('tk')
+    depends_on('curl')
+    depends_on('pcre')
 
     def install(self, spec, prefix):
         rlibdir = join_path(prefix, 'rlib')

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -73,15 +73,15 @@ class R(Package):
 
     def install(self, spec, prefix):
         rlibdir = join_path(prefix, 'rlib')
-        options = ['--prefix=%s' % prefix,
-                   '--libdir=%s' % rlibdir,
-                   '--enable-R-shlib',
-                   '--enable-BLAS-shlib',
-                   '--enable-R-framework=no']
+        configure_args = ['--prefix=%s' % prefix,
+                          '--libdir=%s' % rlibdir,
+                          '--enable-R-shlib',
+                          '--enable-BLAS-shlib',
+                          '--enable-R-framework=no']
         if '+external-lapack' in spec:
-            options.extend(['--with-blas', '--with-lapack'])
+            configure_args.extend(['--with-blas', '--with-lapack'])
 
-        configure(*options)
+        configure(*configure_args)
         make()
         make('install')
 
@@ -111,7 +111,7 @@ class R(Package):
                 extension_spec.prefix, self.r_lib_dir))
 
     def setup_dependent_package(self, module, ext_spec):
-        """Called before R modules' install() methods.  In most cases,
+        """Called before R modules' install() methods. In most cases,
         extensions will only need to have one line:
             R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' %
             self.stage.archive_file)"""

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -39,7 +39,8 @@ class Pcre(Package):
     patch("intel.patch")
 
     variant('utf', default=True,
-            description='Enable support for UTF-8/16/32, incompatible with EBCDIC.')
+            description='Enable support for UTF-8/16/32, '
+            'incompatible with EBCDIC.')
 
     def install(self, spec, prefix):
         configure_args = ['--prefix=%s' % prefix]

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -29,6 +29,7 @@ class Pcre(Package):
     """The PCRE package contains Perl Compatible Regular Expression
        libraries. These are useful for implementing regular expression
        pattern matching using the same syntax and semantics as Perl 5."""
+
     homepage = "http://www.pcre.org"""
     url      = "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.36.tar.bz2"
 
@@ -37,7 +38,14 @@ class Pcre(Package):
 
     patch("intel.patch")
 
+    variant('utf', default=True,
+            description='Enable support for UTF-8/16/32, incompatible with EBCDIC.')
+
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure_args = ['--prefix=%s' % prefix]
+        if '+utf' in spec:
+            configure_args.append('--enable-utf')
+
+        configure(*configure_args)
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -28,8 +28,8 @@ from spack import *
 class RBiocgenerics(Package):
     """S4 generic functions needed by many Bioconductor packages."""
 
-    homepage = 'https://www.bioconductor.org/packages/release/bioc/html/BiocGenerics.html'
-    url = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
+    homepage = 'https://bioconductor.org/packages/BiocGenerics/'
+    url = 'https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.18.0.tar.gz'
 
     version('0.18.0', 'baaff00eb2c2b15396fed2f7f43e634c', expand=False)
 

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -29,12 +29,15 @@ class RBiocgenerics(Package):
     """S4 generic functions needed by many Bioconductor packages."""
 
     homepage = 'https://bioconductor.org/packages/BiocGenerics/'
-    url = 'https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.18.0.tar.gz'
-
-    version('0.18.0', 'baaff00eb2c2b15396fed2f7f43e634c', expand=False)
+    version('bioc-3.3',
+            git='https://github.com/Bioconductor-mirror/BiocGenerics.git',
+            branch='release-3.3')
+    version('bioc-3.2',
+            git='https://github.com/Bioconductor-mirror/BiocGenerics.git',
+            branch='release-3.2')
 
     extends('R')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.archive_file)
+          self.module.r_lib_dir, '%s' % self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -31,7 +31,7 @@ class RBiocgenerics(Package):
     homepage = 'https://www.bioconductor.org/packages/release/bioc/html/BiocGenerics.html'
     url = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
 
-    version('0.16.1', 'c2148ffd86fc6f1f819c7f68eb2c744f', expand=False)
+    version('0.18.0', 'baaff00eb2c2b15396fed2f7f43e634c', expand=False)
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -24,15 +24,17 @@
 ##############################################################################
 from spack import *
 
+
 class RBiocgenerics(Package):
     """S4 generic functions needed by many Bioconductor packages."""
 
     homepage = 'https://www.bioconductor.org/packages/release/bioc/html/BiocGenerics.html'
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
+    url = "https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.16.1.tar.gz"
 
     version('0.16.1', 'c2148ffd86fc6f1f819c7f68eb2c744f', expand=False)
 
     extends('R')
 
     def install(self, spec, prefix):
-        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)
+        R('CMD', 'INSTALL', '--library=%s' %
+          self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-BiocGenerics/package.py
@@ -38,6 +38,19 @@ class RBiocgenerics(Package):
 
     extends('R')
 
+    def validate(self, spec):
+        """
+        Checks that the version of R is appropriate for the Bioconductor
+        version.
+        """
+        if spec.satisfies('@bioc-3.3'):
+            if not spec.satisfies('^R@3.3.0:3.3.9'):
+                raise InstallError('Must use R-3.3 for Bioconductor-3.3')
+        elif spec.satisfies('@bioc-3.2'):
+            if not spec.satisfies('^R@3.2.0:3.2.9'):
+                raise InstallError('Must use R-3.2 for Bioconductor-3.2')
+
     def install(self, spec, prefix):
+        self.validate(spec)
         R('CMD', 'INSTALL', '--library=%s' %
           self.module.r_lib_dir, '%s' % self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -34,11 +34,11 @@ class RAbind(Package):
     homepage = "https://cran.r-project.org/"
     url = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
 
-    version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5', expand=False)
+    version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5')
 
     extends('R')
 
     def install(self, spec, prefix):
 
         R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.archive_file)
+          self.module.r_lib_dir, '%s' % self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class RAbind(Package):
     """Combine multidimensional arrays into a single array. This is a
     generalization of 'cbind' and 'rbind'. Works with vectors, matrices, and
@@ -31,7 +32,7 @@ class RAbind(Package):
     'afill' for manipulating, extracting and replacing data in arrays."""
 
     homepage = "https://cran.r-project.org/"
-    url      = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
+    url = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
 
     version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5', expand=False)
 
@@ -39,4 +40,5 @@ class RAbind(Package):
 
     def install(self, spec, prefix):
 
-        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)
+        R('CMD', 'INSTALL', '--library=%s' %
+          self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -32,13 +32,13 @@ class RAbind(Package):
     'afill' for manipulating, extracting and replacing data in arrays."""
 
     homepage = "https://cran.r-project.org/"
-    url = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/abind"
 
     version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5')
 
     extends('R')
 
     def install(self, spec, prefix):
-
-        R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.source_path)
+        R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),
+          self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -37,12 +37,13 @@ class RFilehash(Package):
     parties for use in the 'filehash' framework."""
 
     homepage = 'https://cran.r-project.org/'
-    url = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/filehash"
 
     version('2.3', '01fffafe09b148ccadc9814c103bdc2f')
 
     extends('R')
 
     def install(self, spec, prefix):
-        R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.source_path)
+        R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),
+          self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -39,10 +39,10 @@ class RFilehash(Package):
     homepage = 'https://cran.r-project.org/'
     url = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
 
-    version('2.3', '01fffafe09b148ccadc9814c103bdc2f', expand=False)
+    version('2.3', '01fffafe09b148ccadc9814c103bdc2f')
 
     extends('R')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.archive_file)
+          self.module.r_lib_dir, '%s' % self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class RFilehash(Package):
     """Implements a simple key-value style database where character string keys
     are associated with data values that are stored on the disk. A simple
@@ -36,11 +37,12 @@ class RFilehash(Package):
     parties for use in the 'filehash' framework."""
 
     homepage = 'https://cran.r-project.org/'
-    url      = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
+    url = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
 
     version('2.3', '01fffafe09b148ccadc9814c103bdc2f', expand=False)
 
     extends('R')
 
     def install(self, spec, prefix):
-        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)
+        R('CMD', 'INSTALL', '--library=%s' %
+          self.module.r_lib_dir, '%s' % self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -32,7 +32,8 @@ class RMagic(Package):
     arrays."""
 
     homepage = "https://cran.r-project.org/"
-    url = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/magic"
 
     version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029')
 
@@ -41,5 +42,5 @@ class RMagic(Package):
     depends_on('r-abind')
 
     def install(self, spec, prefix):
-        R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.source_path)
+        R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),
+          self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -34,7 +34,7 @@ class RMagic(Package):
     homepage = "https://cran.r-project.org/"
     url = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
 
-    version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029', expand=False)
+    version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029')
 
     extends('R')
 
@@ -42,4 +42,4 @@ class RMagic(Package):
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library=%s' %
-          self.module.r_lib_dir, '%s' % self.stage.archive_file)
+          self.module.r_lib_dir, '%s' % self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class RMagic(Package):
     """A collection of efficient, vectorized algorithms for the creation and
     investigation of magic squares and hypercubes, including a variety of
@@ -31,7 +32,7 @@ class RMagic(Package):
     arrays."""
 
     homepage = "https://cran.r-project.org/"
-    url      = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
+    url = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
 
     version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029', expand=False)
 
@@ -40,4 +41,5 @@ class RMagic(Package):
     depends_on('r-abind')
 
     def install(self, spec, prefix):
-        R('CMD', 'INSTALL', '--library=%s' % self.module.r_lib_dir, '%s' % self.stage.archive_file)
+        R('CMD', 'INSTALL', '--library=%s' %
+          self.module.r_lib_dir, '%s' % self.stage.archive_file)


### PR DESCRIPTION
This PR updates the version of R to 3.3.0. It also runs it and the existing R extensions through autopep8. This PR also adds curl and pcre dependencies. In the case of pcre, this PR adds a 'utf' variant to the pcre package, set to True by default.

The BiocGenerics package was updated. This is a BioConductor package and the issue is that the bioconductor repositories only maintain the latest versions. I am not sure what the best way is to handle that in spack. There could potentially be plenty of bioconductor packages so it may be best to treat them in a different way from other R packages. There is a bioconductor installer that will manage the packages but it does not really fit the "spack way".