### PR TITLE
Dealii, fixed issue with tests

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -244,6 +244,8 @@ class Dealii(Package):
             print('========= Step-40 Trilinos ==========')
             print('=====================================')
             # change Linear Algebra to Trilinos
+	    # The below filter_file should be different for versions
+	    # before and after 8.4.0
             if spec.satisfies('@8.4.0:'):
                 filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
                             ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
@@ -254,6 +256,8 @@ class Dealii(Package):
                 make('release')
                 make('run', parallel=False)
 
+	    # the rest of the tests on step 40 only works for
+	    # dealii version 8.4.0 and after
             if spec.satisfies('@8.4.0:'):
                 print('=====================================')
                 print('=== Step-40 Trilinos SuperluDist ====')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -244,8 +244,8 @@ class Dealii(Package):
             print('========= Step-40 Trilinos ==========')
             print('=====================================')
             # change Linear Algebra to Trilinos
-        # The below filter_file should be different for versions
-        # before and after 8.4.0
+            # The below filter_file should be different for versions
+            # before and after 8.4.0
             if spec.satisfies('@8.4.0:'):
                 filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
                             ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
@@ -256,8 +256,8 @@ class Dealii(Package):
                 make('release')
                 make('run', parallel=False)
 
-        # the rest of the tests on step 40 only works for
-        # dealii version 8.4.0 and after
+            # the rest of the tests on step 40 only works for
+            # dealii version 8.4.0 and after
             if spec.satisfies('@8.4.0:'):
                 print('=====================================')
                 print('=== Step-40 Trilinos SuperluDist ====')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -228,29 +228,33 @@ class Dealii(Package):
 
         # take step-40 which can use both PETSc and Trilinos
         # FIXME: switch step-40 to MPI run
-        if spec.satisfies('@8.4.0:'):
-            with working_dir('examples/step-40'):
-                print('=====================================')
-                print('========== Step-40 PETSc ============')
-                print('=====================================')
-                # list the number of cycles to speed up
-                filter_file(r'(const unsigned int n_cycles = 8;)',
-                            ('const unsigned int n_cycles = 2;'), 'step-40.cc')
-                cmake('.')
-                if '^petsc' in spec:
-                    make('release')
-                    make('run', parallel=False)
-            
-                print('=====================================')
-                print('========= Step-40 Trilinos ==========')
-                print('=====================================')
-                # change Linear Algebra to Trilinos
+        with working_dir('examples/step-40'):
+            print('=====================================')
+            print('========== Step-40 PETSc ============')
+            print('=====================================')
+            # list the number of cycles to speed up
+            filter_file(r'(const unsigned int n_cycles = 8;)',
+                        ('const unsigned int n_cycles = 2;'), 'step-40.cc')
+            cmake('.')
+            if '^petsc' in spec:
+                make('release')
+                make('run', parallel=False)
+
+            print('=====================================')
+            print('========= Step-40 Trilinos ==========')
+            print('=====================================')
+            # change Linear Algebra to Trilinos
+            if spec.satisfies('@8.4.0:'):
                 filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
                             ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
-                if '^trilinos+hypre' in spec:
-                    make('release')
-                    make('run', parallel=False)
+            else:
+                filter_file(r'(#define USE_PETSC_LA.*)',
+                            ('// #define USE_PETSC_LA'), 'step-40.cc')
+            if '^trilinos+hypre' in spec:
+                make('release')
+                make('run', parallel=False)
 
+            if spec.satisfies('@8.4.0:'):
                 print('=====================================')
                 print('=== Step-40 Trilinos SuperluDist ====')
                 print('=====================================')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -228,54 +228,55 @@ class Dealii(Package):
 
         # take step-40 which can use both PETSc and Trilinos
         # FIXME: switch step-40 to MPI run
-        with working_dir('examples/step-40'):
-            print('=====================================')
-            print('========== Step-40 PETSc ============')
-            print('=====================================')
-            # list the number of cycles to speed up
-            filter_file(r'(const unsigned int n_cycles = 8;)',
-                        ('const unsigned int n_cycles = 2;'), 'step-40.cc')
-            cmake('.')
-            if '^petsc' in spec:
-                make('release')
-                make('run', parallel=False)
+        if spec.satisfies('@8.4.0:'):
+            with working_dir('examples/step-40'):
+                print('=====================================')
+                print('========== Step-40 PETSc ============')
+                print('=====================================')
+                # list the number of cycles to speed up
+                filter_file(r'(const unsigned int n_cycles = 8;)',
+                            ('const unsigned int n_cycles = 2;'), 'step-40.cc')
+                cmake('.')
+                if '^petsc' in spec:
+                    make('release')
+                    make('run', parallel=False)
+            
+                print('=====================================')
+                print('========= Step-40 Trilinos ==========')
+                print('=====================================')
+                # change Linear Algebra to Trilinos
+                filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
+                            ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
+                if '^trilinos+hypre' in spec:
+                    make('release')
+                    make('run', parallel=False)
 
-            print('=====================================')
-            print('========= Step-40 Trilinos ==========')
-            print('=====================================')
-            # change Linear Algebra to Trilinos
-            filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
-                        ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
-            if '^trilinos+hypre' in spec:
-                make('release')
-                make('run', parallel=False)
+                print('=====================================')
+                print('=== Step-40 Trilinos SuperluDist ====')
+                print('=====================================')
+                # change to direct solvers
+                filter_file(r'(LA::SolverCG solver\(solver_control\);)',  ('TrilinosWrappers::SolverDirect::AdditionalData data(false,"Amesos_Superludist"); TrilinosWrappers::SolverDirect solver(solver_control,data);'), 'step-40.cc')  # NOQA: ignore=E501
+                filter_file(r'(LA::MPI::PreconditionAMG preconditioner;)',
+                            (''), 'step-40.cc')
+                filter_file(r'(LA::MPI::PreconditionAMG::AdditionalData data;)',
+                            (''), 'step-40.cc')
+                filter_file(r'(preconditioner.initialize\(system_matrix, data\);)',
+                            (''), 'step-40.cc')
+                filter_file(r'(solver\.solve \(system_matrix, completely_distributed_solution, system_rhs,)',  ('solver.solve (system_matrix, completely_distributed_solution, system_rhs);'), 'step-40.cc')  # NOQA: ignore=E501
+                filter_file(r'(preconditioner\);)',  (''), 'step-40.cc')
+                if '^trilinos+superlu-dist' in spec:
+                    make('release')
+                    make('run', paralle=False)
 
-            print('=====================================')
-            print('=== Step-40 Trilinos SuperluDist ====')
-            print('=====================================')
-            # change to direct solvers
-            filter_file(r'(LA::SolverCG solver\(solver_control\);)',  ('TrilinosWrappers::SolverDirect::AdditionalData data(false,"Amesos_Superludist"); TrilinosWrappers::SolverDirect solver(solver_control,data);'), 'step-40.cc')  # NOQA: ignore=E501
-            filter_file(r'(LA::MPI::PreconditionAMG preconditioner;)',
-                        (''), 'step-40.cc')
-            filter_file(r'(LA::MPI::PreconditionAMG::AdditionalData data;)',
-                        (''), 'step-40.cc')
-            filter_file(r'(preconditioner.initialize\(system_matrix, data\);)',
-                        (''), 'step-40.cc')
-            filter_file(r'(solver\.solve \(system_matrix, completely_distributed_solution, system_rhs,)',  ('solver.solve (system_matrix, completely_distributed_solution, system_rhs);'), 'step-40.cc')  # NOQA: ignore=E501
-            filter_file(r'(preconditioner\);)',  (''), 'step-40.cc')
-            if '^trilinos+superlu-dist' in spec:
-                make('release')
-                make('run', paralle=False)
-
-            print('=====================================')
-            print('====== Step-40 Trilinos MUMPS =======')
-            print('=====================================')
-            # switch to Mumps
-            filter_file(r'(Amesos_Superludist)',
-                        ('Amesos_Mumps'), 'step-40.cc')
-            if '^trilinos+mumps' in spec:
-                make('release')
-                make('run', parallel=False)
+                print('=====================================')
+                print('====== Step-40 Trilinos MUMPS =======')
+                print('=====================================')
+                # switch to Mumps
+                filter_file(r'(Amesos_Superludist)',
+                            ('Amesos_Mumps'), 'step-40.cc')
+                if '^trilinos+mumps' in spec:
+                    make('release')
+                    make('run', parallel=False)
 
         print('=====================================')
         print('============ Step-36 ================')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -244,8 +244,8 @@ class Dealii(Package):
             print('========= Step-40 Trilinos ==========')
             print('=====================================')
             # change Linear Algebra to Trilinos
-	    # The below filter_file should be different for versions
-	    # before and after 8.4.0
+        # The below filter_file should be different for versions
+        # before and after 8.4.0
             if spec.satisfies('@8.4.0:'):
                 filter_file(r'(\/\/ #define FORCE_USE_OF_TRILINOS.*)',
                             ('#define FORCE_USE_OF_TRILINOS'), 'step-40.cc')
@@ -256,8 +256,8 @@ class Dealii(Package):
                 make('release')
                 make('run', parallel=False)
 
-	    # the rest of the tests on step 40 only works for
-	    # dealii version 8.4.0 and after
+        # the rest of the tests on step 40 only works for
+        # dealii version 8.4.0 and after
             if spec.satisfies('@8.4.0:'):
                 print('=====================================')
                 print('=== Step-40 Trilinos SuperluDist ====')


### PR DESCRIPTION
When compiling dealii version 8.3.0 or lower, the test “step-40” doesn’t compile.

I updated the package file and specified that test case “step-40” is only to be run when using dealii
version 8.4.0 or later