### PR TITLE
Option to install eigen without dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -42,6 +42,7 @@ class Eigen(Package):
     variant('scotch', default=True, description='Enables scotch backend')
     variant('fftw', default=True, description='Enables FFTW backend')
     variant('suitesparse', default=True, description='Enables SuiteSparse support')
+    variant('mpfr', default=True, description='Enables support for multi-precisions floating points via mpfr')
 
     # TODO : dependency on googlehash, superlu, adolc missing
 
@@ -50,8 +51,8 @@ class Eigen(Package):
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')
-    depends_on('mpfr@2.3.0:')  # Eigen 3.2.7 requires at least 2.3.0
-    depends_on('gmp')
+    depends_on('mpfr@2.3.0:', when="+mpfr")  # Eigen 3.2.7 requires at least 2.3.0
+    depends_on('gmp', when="+mpfr")
 
     def install(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -28,7 +28,9 @@ from spack import *
 
 class Eigen(Package):
     """
-    Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms
+    Eigen is a C++ template library for linear algebra
+
+    Matrices, vectors, numerical solvers, and related algorithms
     """
 
     homepage = 'http://eigen.tuxfamily.org/'
@@ -45,13 +47,12 @@ class Eigen(Package):
     variant('mpfr', default=True, description='Enables support for multi-precisions floating points via mpfr')
 
     # TODO : dependency on googlehash, superlu, adolc missing
-
     depends_on('cmake')
     depends_on('metis@5:', when='+metis')
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')
-    depends_on('mpfr@2.3.0:', when="+mpfr")  # Eigen 3.2.7 requires at least 2.3.0
+    depends_on('mpfr@2.3.0:', when="+mpfr")
     depends_on('gmp', when="+mpfr")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Eigen is a header only library which can be installed without dependencies.
Prior to this pull-request, mpfr and gmp were required dependencies.