### PR TITLE
Changes to take into account slurm in version @2.1: of mvapich2

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import os
 
+
 class Mvapich2(Package):
     """MVAPICH2 is an MPI implementation for Infiniband networks."""
     homepage = "http://mvapich.cse.ohio-state.edu/"
@@ -43,8 +44,9 @@ class Mvapich2(Package):
     variant('debug', default=False, description='Enables debug information and error messages at run-time')
 
     ##########
-    # TODO : Process managers should be grouped into the same variant, as soon as variant capabilities will be extended
-    # See https://groups.google.com/forum/#!topic/spack/F8-f8B4_0so
+    # TODO : Process managers should be grouped into the same variant,
+    # as soon as variant capabilities will be extended See
+    # https://groups.google.com/forum/#!topic/spack/F8-f8B4_0so
     SLURM = 'slurm'
     HYDRA = 'hydra'
     GFORKER = 'gforker'
@@ -57,7 +59,8 @@ class Mvapich2(Package):
     ##########
 
     ##########
-    # TODO : Network types should be grouped into the same variant, as soon as variant capabilities will be extended
+    # TODO : Network types should be grouped into the same variant, as
+    # soon as variant capabilities will be extended
     PSM = 'psm'
     SOCK = 'sock'
     NEMESISIBTCP = 'nemesisibtcp'
@@ -84,8 +87,8 @@ class Mvapich2(Package):
 
     @staticmethod
     def enabled(x):
-        """
-        Given a variant name returns the string that means the variant is enabled
+        """Given a variant name returns the string that means the variant is
+        enabled
 
         :param x: variant name
         :return:
@@ -93,8 +96,8 @@ class Mvapich2(Package):
         return '+' + x
 
     def set_build_type(self, spec, configure_args):
-        """
-        Appends to configure_args the flags that depends only on the build type (i.e. release or debug)
+        """Appends to configure_args the flags that depends only on the build
+        type (i.e. release or debug)
 
         :param spec: spec
         :param configure_args: list of current configure arguments
@@ -104,7 +107,8 @@ class Mvapich2(Package):
                 "--disable-fast",
                 "--enable-error-checking=runtime",
                 "--enable-error-messages=all",
-                "--enable-g=dbg", "--enable-debuginfo"  # Permits debugging with TotalView
+                # Permits debugging with TotalView
+                "--enable-g=dbg", "--enable-debuginfo"
             ]
         else:
             build_type_options = ["--enable-fast=all"]
@@ -112,16 +116,22 @@ class Mvapich2(Package):
         configure_args.extend(build_type_options)
 
     def set_process_manager(self, spec, configure_args):
-        """
-        Appends to configure_args the flags that will enable the appropriate process managers
+        """Appends to configure_args the flags that will enable the
+        appropriate process managers
 
         :param spec: spec
         :param configure_args: list of current configure arguments
         """
-        # Check that slurm variant is not activated together with other pm variants
-        has_slurm_incompatible_variants = any(self.enabled(x) in spec for x in Mvapich2.SLURM_INCOMPATIBLE_PMS)
-        if self.enabled(Mvapich2.SLURM) in spec and has_slurm_incompatible_variants:
-            raise RuntimeError(" %s : 'slurm' cannot be activated together with other process managers" % self.name)
+        # Check that slurm variant is not activated together with
+        # other pm variants
+        has_slurm_incompatible_variants = \
+            any(self.enabled(x) in spec
+                for x in Mvapich2.SLURM_INCOMPATIBLE_PMS)
+
+        if self.enabled(Mvapich2.SLURM) in spec and \
+           has_slurm_incompatible_variants:
+            raise RuntimeError(" %s : 'slurm' cannot be activated \
+            together with other process managers" % self.name)
 
         process_manager_options = []
         # See: http://slurm.schedmd.com/mpi_guide.html#mvapich2
@@ -139,7 +149,8 @@ class Mvapich2(Package):
 
         elif has_slurm_incompatible_variants:
             pms = []
-            # The variant name is equal to the process manager name in the configuration options
+            # The variant name is equal to the process manager name in
+            # the configuration options
             for x in Mvapich2.SLURM_INCOMPATIBLE_PMS:
                 if self.enabled(x) in spec:
                     pms.append(x)
@@ -155,7 +166,9 @@ class Mvapich2(Package):
             if self.enabled(x) in spec:
                 count += 1
         if count > 1:
-            raise RuntimeError('network variants are mutually exclusive (only one can be selected at a time)')
+            raise RuntimeError('network variants are mutually exclusive \
+            (only one can be selected at a time)')
+
         network_options = []
         # From here on I can suppose that only one variant has been selected
         if self.enabled(Mvapich2.PSM) in spec:
@@ -177,7 +190,7 @@ class Mvapich2(Package):
         if self.enabled(Mvapich2.SLURM) in self.spec and \
            self.version > Version('2.0'):
             run_env.set('SLURM_MPI_TYPE', 'pmi2')
-        
+
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
         spack_env.set('MPICH_CC', spack_cc)
         spack_env.set('MPICH_CXX', spack_cxx)
@@ -190,9 +203,10 @@ class Mvapich2(Package):
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
-    
+
     def install(self, spec, prefix):
-        # we'll set different configure flags depending on our environment
+        # we'll set different configure flags depending on our
+        # environment
         configure_args = [
             "--prefix=%s" % prefix,
             "--enable-shared",
@@ -222,7 +236,6 @@ class Mvapich2(Package):
 
         self.filter_compilers()
 
-
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.
@@ -242,8 +255,17 @@ class Mvapich2(Package):
         spack_f77 = os.environ['F77']
         spack_fc  = os.environ['FC']
 
-        kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : True }
-        filter_file('CC="%s"' % spack_cc , 'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
-        filter_file('CXX="%s"'% spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="%s"'% spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="%s"' % spack_fc , 'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)
+        kwargs = {
+            'ignore_absent': True,
+            'backup': False,
+            'string': True
+        }
+
+        filter_file('CC="%s"' % spack_cc,
+                    'CC="%s"' % self.compiler.cc, mpicc, **kwargs)
+        filter_file('CXX="%s"' % spack_cxx,
+                    'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
+        filter_file('F77="%s"' % spack_f77,
+                    'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
+        filter_file('FC="%s"' % spack_fc,
+                    'FC="%s"' % self.compiler.fc, mpif90, **kwargs)


### PR DESCRIPTION
Sorry for the excessive changes due to the flake8.

The usefull part of this PR is in the options to configure slurm, I used the options given on the slurm website, which means using pmi2, but potentially this should be a variant to be able to choose between pmi or pmi2.