### PR TITLE
Corrected the shared libraries and tests in mumps package

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/mumps-shared.patch
+++ b/var/spack/repos/builtin/packages/mumps/mumps-shared.patch
@@ -1,0 +1,119 @@
+diff -Naur MUMPS_5.0.1/libseq/Makefile MUMPS_5.0.1.new/libseq/Makefile
+--- MUMPS_5.0.1/libseq/Makefile	2015-07-23 19:08:32.000000000 +0200
++++ MUMPS_5.0.1.new/libseq/Makefile	2016-06-07 10:41:16.585179151 +0200
+@@ -8,11 +8,15 @@
+ 
+ include ../Makefile.inc
+ 
+-libmpiseq: libmpiseq$(PLAT)$(LIBEXT)
++libmpiseq: libmpiseq$(PLAT)$(LIBEXT) libmpiseq$(PLAT)$(SHLIBEXT)
+ 
+ libmpiseq$(PLAT)$(LIBEXT): mpi.o mpic.o elapse.o
+ 	$(AR)$@ mpi.o mpic.o elapse.o
+ 	$(RANLIB) $@
++
++libmpiseq$(PLAT)$(SHLIBEXT): mpi.o mpic.o elapse.o
++	$(FC) $(LDFLAGS) $^ -o libmpiseq$(PLAT)$(SHLIBEXT)
++
+ .f.o:
+ 	$(FC) $(OPTF)              -c $*.f $(OUTF)$*.o
+ .c.o:
+diff -Naur MUMPS_5.0.1/Makefile MUMPS_5.0.1.new/Makefile
+--- MUMPS_5.0.1/Makefile	2015-07-23 19:08:29.000000000 +0200
++++ MUMPS_5.0.1.new/Makefile	2016-06-07 10:50:21.863281217 +0200
+@@ -51,7 +51,7 @@
+ dexamples:	d
+ 	(cd examples ; $(MAKE) d)
+ 
+-requiredobj: Makefile.inc $(LIBSEQNEEDED) $(libdir)/libpord$(PLAT)$(LIBEXT)
++requiredobj: Makefile.inc $(LIBSEQNEEDED) $(libdir)/libpord$(PLAT)$(LIBEXT) $(libdir)/libpord$(PLAT)$(SHLIBEXT)
+ 
+ # dummy MPI library (sequential version)
+ 
+@@ -62,16 +62,25 @@
+ $(libdir)/libpord$(PLAT)$(LIBEXT):
+ 	if [ "$(LPORDDIR)" != "" ] ; then \
+ 	  cd $(LPORDDIR); \
+-	  $(MAKE) CC="$(CC)" CFLAGS="$(OPTC)" AR="$(AR)" RANLIB="$(RANLIB)" OUTC="$(OUTC)" LIBEXT=$(LIBEXT); \
++	  $(MAKE) CC="$(CC)" CFLAGS="$(OPTC)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" OUTC="$(OUTC)" LIBEXT=$(LIBEXT) PLAT=$(PLAT) SHLIBEXT=$(SHLIBEXT); \
+ 	fi;
+ 	if [ "$(LPORDDIR)" != "" ] ; then \
+ 	  cp $(LPORDDIR)/libpord$(LIBEXT) $@; \
+ 	fi;
+ 
++$(libdir)/libpord$(PLAT)$(SHLIBEXT):
++	if [ "$(LPORDDIR)" != "" ] ; then \
++	  cd $(LPORDDIR); \
++	  $(MAKE) CC="$(CC)" CFLAGS="$(OPTC)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" OUTC="$(OUTC)" LIBEXT=$(LIBEXT) PLAT=$(PLAT) SHLIBEXT=$(SHLIBEXT) libpord$(PLAT)$(SHLIBEXT); \
++	fi;
++	if [ "$(LPORDDIR)" != "" ] ; then \
++	  cp $(LPORDDIR)/libpord$(PLAT)$(SHLIBEXT) $@; \
++	fi;
++
+ clean:
+ 	(cd src; $(MAKE) clean)
+ 	(cd examples; $(MAKE) clean)
+-	(cd $(libdir); $(RM) *$(PLAT)$(LIBEXT))
++	(cd $(libdir); $(RM) *$(PLAT)$(LIBEXT) *$(PLAT)$(SHLIBEXT))
+ 	(cd libseq; $(MAKE) clean)
+ 	if [ "$(LPORDDIR)" != "" ] ; then \
+ 	  cd $(LPORDDIR); $(MAKE) realclean; \
+diff -Naur MUMPS_5.0.1/PORD/lib/Makefile MUMPS_5.0.1.new/PORD/lib/Makefile
+--- MUMPS_5.0.1/PORD/lib/Makefile	2015-07-23 19:08:29.000000000 +0200
++++ MUMPS_5.0.1.new/PORD/lib/Makefile	2016-06-07 10:49:48.889000958 +0200
+@@ -13,7 +13,7 @@
+ 
+ OBJS = graph.o gbipart.o gbisect.o ddcreate.o ddbisect.o nestdiss.o \
+        multisector.o gelim.o bucket.o tree.o \
+-       symbfac.o interface.o sort.o minpriority.o 
++       symbfac.o interface.o sort.o minpriority.o
+ 
+ # Note: numfac.c read.c mapping.c triangular.c matrix.c kernel.c
+ # were not direcly used by MUMPS and have been removed from the
+@@ -24,12 +24,15 @@
+ .c.o:
+ 	$(CC) $(COPTIONS) -c $*.c $(OUTC)$*.o
+ 
+-libpord$(LIBEXT):$(OBJS)
++libpord$(PLAT)$(LIBEXT):$(OBJS)
+ 	$(AR)$@ $(OBJS)
+ 	$(RANLIB) $@
+ 
++libpord$(PLAT)$(SHLIBEXT): $(OBJS)
++	$(CC) $(LDFLAGS) $(OBJS) -o libpord$(PLAT)$(SHLIBEXT)
++
+ clean:
+ 	rm -f *.o
+ 
+ realclean:
+-	rm -f *.o libpord.a
++	rm -f *.o libpord$(PLAT)$(SHLIBEXT) libpord$(PLAT)$(LIBEXT)
+diff -Naur MUMPS_5.0.1/src/Makefile MUMPS_5.0.1.new/src/Makefile
+--- MUMPS_5.0.1/src/Makefile	2015-07-23 19:08:29.000000000 +0200
++++ MUMPS_5.0.1.new/src/Makefile	2016-06-07 10:40:52.534703722 +0200
+@@ -24,7 +24,10 @@
+ include $(topdir)/Makefile.inc
+ 
+ mumps_lib:    $(libdir)/libmumps_common$(PLAT)$(LIBEXT) \
+-              $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT)
++              $(libdir)/libmumps_common$(PLAT)$(SHLIBEXT) \
++              $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT) \
++              $(libdir)/lib$(ARITH)mumps$(PLAT)$(SHLIBEXT)
++
+ 
+ OBJS_COMMON_MOD = \
+         ana_omp_m.o\
+@@ -162,6 +165,13 @@
+ 	$(AR)$@ $?
+ 	$(RANLIB) $@
+ 
++$(libdir)/libmumps_common$(PLAT)$(SHLIBEXT):	$(OBJS_COMMON_MOD) $(OBJS_COMMON_OTHER)
++	$(FC) $(LDFLAGS) $^ -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBBLAS) $(LIBOTHERS) -o $(libdir)/libmumps_common$(PLAT)$(SHLIBEXT)
++
++
++$(libdir)/lib$(ARITH)mumps$(PLAT)$(SHLIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
++	$(FC) $(LDFLAGS) $^ -L$(libdir) -lmumps_common$(PLAT) $(LORDERINGS) $(LIBS) $(LIBBLAS) $(LIBOTHERS) -o $(libdir)/lib$(ARITH)mumps$(PLAT)$(SHLIBEXT)
++
+ # Dependencies between modules:
+ $(ARITH)mumps_load.o:		$(ARITH)mumps_comm_buffer.o \
+ 				$(ARITH)mumps_struc_def.o \

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -133,7 +133,7 @@ class Mumps(Package):
         if '+mpi' in self.spec:
             makefile_conf.extend(
                 ["CC = %s" % self.spec['mpi'].mpicc,
-                 "FC = %s" % self.spec['mpi'].mpif90,
+                 "FC = %s" % self.spec['mpi'].mpifc,
                  "SCALAP = %s" % self.spec['scalapack'].fc_link,
                  "MUMPS_TYPE = par"])
         else:
@@ -214,17 +214,18 @@ class Mumps(Package):
         # FIXME: use something like numdiff to compare blessed output
         # with the current
         # TODO: test the installed mumps and not the one in stage
-        for t in make_libs:
-            make('{0}examples'.format(t))
-
-        with working_dir('examples'):
+        if '~mpi' in spec:
             for t in make_libs:
-                input_file = 'input_simpletest_{0}'.format(
-                    'real' if t in ['s', 'd'] else 'cmplx')
-                with open(input_file) as input:
-                    test = './{0}simpletest'.format(t)
-                    ret = subprocess.call(test,
-                                          stdin=input)
-                    if ret is not 0:
-                        raise RuntimeError(
-                            'The test {0} did not pass'.format(test))
+                make('{0}examples'.format(t))
+
+            with working_dir('examples'):
+                for t in make_libs:
+                    input_file = 'input_simpletest_{0}'.format(
+                        'real' if t in ['s', 'd'] else 'cmplx')
+                    with open(input_file) as input:
+                        test = './{0}simpletest'.format(t)
+                        ret = subprocess.call(test,
+                                              stdin=input)
+                        if ret is not 0:
+                            raise RuntimeError(
+                                'The test {0} did not pass'.format(test))


### PR DESCRIPTION
This PR add a patch to mumps makfiles to have shared libraries linked with there dependencies.
Which mean applications can link with `-l{s,d,c,z}mumps` only and not with `-l{s,d,c,z}mumps -lmumps_common -lpord -l{all the external dependencies of mumps}` as discussed in #626

I don't like the test that are in the package since the do not test the installed version.
But since there where there I modified them to actually test something. One of them at least was wrong but the return code was never checked. `os.system` does not care on the return code...

I also modified the order of the make target to us parallel build where possible. 