### PR TITLE
Package serf also depends on zlib.

### DIFF
--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -36,6 +36,7 @@ class Serf(Package):
     depends_on('scons')
     depends_on('expat')
     depends_on('openssl')
+    depends_on('zlib')
 
     def install(self, spec, prefix):
         scons = which("scons")
@@ -44,8 +45,10 @@ class Serf(Package):
         options.append('APR=%s' % spec['apr'].prefix)
         options.append('APU=%s' % spec['apr-util'].prefix)
         options.append('OPENSSL=%s' % spec['openssl'].prefix)
-        options.append('LINKFLAGS=-L%s/lib' % spec['expat'].prefix)
-        options.append('CPPFLAGS=-I%s/include' % spec['expat'].prefix)
+        options.append('LINKFLAGS=-L%s/lib -L%s/lib' %
+                       ( spec['expat'].prefix, spec['zlib'].prefix ))
+        options.append('CPPFLAGS=-I%s/include -I%s/include' %
+                       ( spec['expat'].prefix, spec['zlib'].prefix ))
 
         scons(*options)
         scons('install')

--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -24,8 +24,10 @@
 ##############################################################################
 from spack import *
 
+
 class Serf(Package):
-    """Apache Serf - a high performance C-based HTTP client library built upon the Apache Portable Runtime (APR) library"""
+    """Apache Serf - a high performance C-based HTTP client library
+    built upon the Apache Portable Runtime (APR) library"""
     homepage  = 'https://serf.apache.org/'
     url       = 'https://archive.apache.org/dist/serf/serf-1.3.8.tar.bz2'
 
@@ -46,9 +48,9 @@ class Serf(Package):
         options.append('APU=%s' % spec['apr-util'].prefix)
         options.append('OPENSSL=%s' % spec['openssl'].prefix)
         options.append('LINKFLAGS=-L%s/lib -L%s/lib' %
-                       ( spec['expat'].prefix, spec['zlib'].prefix ))
+                       (spec['expat'].prefix, spec['zlib'].prefix))
         options.append('CPPFLAGS=-I%s/include -I%s/include' %
-                       ( spec['expat'].prefix, spec['zlib'].prefix ))
+                       (spec['expat'].prefix, spec['zlib'].prefix))
 
         scons(*options)
         scons('install')


### PR DESCRIPTION
- Add zlib as a required dependency.
- Point scons build system to the spack provided zlib installation.

I was unable to build serf without this change.  Using the develop branch from 2016-06-09:

```
git clone git@github.com:LLNL/spack.git
cd spack
export SPACK_ROOT=`pwd`
export PATH=`pwd`/bin:$PATH
spack compiler add
spack install serf
...
==> Error: Installation process had nonzero exit code.
```