### PR TITLE
Add tk variant for python. This provides the Tkinter python module.

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -80,11 +80,6 @@ class Python(Package):
         ldflags += ' -L%s/lib -L%s/lib' % (
             spec['sqlite'].prefix, spec['zlib'].prefix)
         if '+tk' in spec:
-            configure_args.extend([
-                '--with-tcltk-includes=-I%s/include -I%s/include' % (
-                    spec['tk'].prefix, spec['tcl'].prefix),
-                '--with-tcltk-libs=%s/lib %s/lib' % (
-                    spec['tk'].prefix, spec['tcl'].prefix)])
             cppflags += ' -I%s/include -I%s/include' % (
                 spec['tk'].prefix, spec['tcl'].prefix)
             ldflags += ' -L%s/lib -L%s/lib' % (

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -22,9 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import functools
-import glob
-import inspect
 import os
 import re
 from contextlib import closing
@@ -73,15 +70,15 @@ class Python(Package):
                                '--enable-shared'])
 
         cppflags = '-I%s/include -I%s/include -I%s/include -I%s/include' % (
-                       spec['openssl'].prefix, spec['bzip2'].prefix,
+            spec['openssl'].prefix, spec['bzip2'].prefix,
             spec['readline'].prefix, spec['ncurses'].prefix)
         cppflags += ' -I%s/include -I%s/include' % (
             spec['sqlite'].prefix, spec['zlib'].prefix)
         ldflags = '-L%s/lib -L%s/lib -L%s/lib -L%s/lib' % (
-                       spec['openssl'].prefix, spec['bzip2'].prefix,
+            spec['openssl'].prefix, spec['bzip2'].prefix,
             spec['readline'].prefix, spec['ncurses'].prefix)
         ldflags += ' -L%s/lib -L%s/lib' % (
-                       spec['sqlite'].prefix, spec['zlib'].prefix)
+            spec['sqlite'].prefix, spec['zlib'].prefix)
         if '+tk' in spec:
             configure_args.extend([
                 '--with-tcltk-includes=-I%s/include -I%s/include' % (
@@ -95,6 +92,7 @@ class Python(Package):
 
         configure_args.extend(['CPPFLAGS=%s' % cppflags,
                                'LDFLAGS=%s' % ldflags])
+
         if spec.satisfies('@3:'):
             configure_args.extend(['--without-ensurepip'])
         configure(*configure_args)
@@ -105,16 +103,19 @@ class Python(Package):
         # building site packages outside of spack
         filter_file(r'([/s]=?)([\S=]*)/lib/spack/env(/[^\s/]*)?/(\S*)(\s)',
                     (r'\4\5'),
-                    join_path(prefix.lib, 'python%d.%d' % self.version[:2], '_sysconfigdata.py'))
+                    join_path(prefix.lib, 'python%d.%d' % self.version[:2],
+                              '_sysconfigdata.py'))
 
         python3_version = ''
         if spec.satisfies('@3:'):
             python3_version = '-%d.%dm' % self.version[:2]
-        makefile_filepath = join_path(prefix.lib, 'python%d.%d' % self.version[:2], 'config%s' % python3_version, 'Makefile')
+        makefile_filepath = join_path(prefix.lib,
+                                      'python%d.%d' % self.version[:2],
+                                      'config%s' % python3_version,
+                                      'Makefile')
         filter_file(r'([/s]=?)([\S=]*)/lib/spack/env(/[^\s/]*)?/(\S*)(\s)',
                     (r'\4\5'),
                     makefile_filepath)
-
 
     # ========================================================================
     # Set up environment to make install easy for python extensions.
@@ -124,33 +125,34 @@ class Python(Package):
     def python_lib_dir(self):
         return os.path.join('lib', 'python%d.%d' % self.version[:2])
 
-
     @property
     def python_include_dir(self):
         return os.path.join('include', 'python%d.%d' % self.version[:2])
-
 
     @property
     def site_packages_dir(self):
         return os.path.join(self.python_lib_dir, 'site-packages')
 
-
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
         # TODO: do this only for actual extensions.
 
-        # Set PYTHONPATH to include site-packages dir for the
-        # extension and any other python extensions it depends on.
+        # Set PYTHONPATH to include site-packages dir for the extension and any
+        # other python extensions it depends on.
         python_paths = []
         for d in extension_spec.traverse():
             if d.package.extends(self.spec):
-                python_paths.append(os.path.join(d.prefix, self.site_packages_dir))
+                python_paths.append(os.path.join(d.prefix,
+                                                 self.site_packages_dir))
 
         pythonpath = ':'.join(python_paths)
         spack_env.set('PYTHONPATH', pythonpath)
 
-        # For run time environment set only the path for extension_spec and prepend it to PYTHONPATH
+        # For run time environment set only the path for extension_spec and
+        # prepend it to PYTHONPATH
         if extension_spec.package.extends(self.spec):
-            run_env.prepend_path('PYTHONPATH', os.path.join(extension_spec.prefix, self.site_packages_dir))
+            run_env.prepend_path('PYTHONPATH',
+                                 os.path.join(extension_spec.prefix,
+                                              self.site_packages_dir))
 
         # In the future, to build a package that depends on python with
         # Tkinter, it may be necessary to set TCL_LIBRARY and TK_LIBRARY in the
@@ -158,7 +160,7 @@ class Python(Package):
         # if '+tk' in spec:
         #     spack_env.set('TCL_LIBRARY', spec('tcl').prefix.lib+"/tcl%s"
         #                   % (version.up_to(2),spec('tcl').version))
-        #     speck_env.set('TK_LIBRARY', spec('tk').prefix.lib+"/tk%s"
+        #     spack_env.set('TK_LIBRARY', spec('tk').prefix.lib+"/tk%s"
         #                   % (version.up_to(2),spec('tk').version))
 
     def setup_dependent_package(self, module, ext_spec):
@@ -170,17 +172,24 @@ class Python(Package):
         python('setup.py', 'install', '--prefix=%s' % prefix)
         """
         # Python extension builds can have a global python executable function
-        if self.version >= Version("3.0.0") and self.version < Version("4.0.0"):
-            module.python = Executable(join_path(self.spec.prefix.bin, 'python3'))
+        if ((self.version >= Version("3.0.0") and
+             self.version < Version("4.0.0"))):
+            module.python = Executable(join_path(self.spec.prefix.bin,
+                                                 'python3'))
         else:
-            module.python = Executable(join_path(self.spec.prefix.bin, 'python'))
+            module.python = Executable(join_path(self.spec.prefix.bin,
+                                                 'python'))
 
         # Add variables for lib/pythonX.Y and lib/pythonX.Y/site-packages dirs.
-        module.python_lib_dir     = os.path.join(ext_spec.prefix, self.python_lib_dir)
-        module.python_include_dir = os.path.join(ext_spec.prefix, self.python_include_dir)
-        module.site_packages_dir  = os.path.join(ext_spec.prefix, self.site_packages_dir)
+        module.python_lib_dir     = os.path.join(ext_spec.prefix,
+                                                 self.python_lib_dir)
+        module.python_include_dir = os.path.join(ext_spec.prefix,
+                                                 self.python_include_dir)
+        module.site_packages_dir  = os.path.join(ext_spec.prefix,
+                                                 self.site_packages_dir)
 
-        # Make the site packages directory for extensions, if it does not exist already.
+        # Make the site packages directory for extensions, if it does not exist
+        # already.
         if ext_spec.package.is_extension:
             mkdirp(module.site_packages_dir)
 
@@ -206,11 +215,11 @@ class Python(Package):
 
         return match_predicate(ignore_arg, patterns)
 
-
     def write_easy_install_pth(self, exts):
         paths = []
         for ext in sorted(exts.values()):
-            ext_site_packages = os.path.join(ext.prefix, self.site_packages_dir)
+            ext_site_packages = os.path.join(ext.prefix,
+                                             self.site_packages_dir)
             easy_pth = "%s/easy-install.pth" % ext_site_packages
 
             if not os.path.isfile(easy_pth):
@@ -221,10 +230,13 @@ class Python(Package):
                     line = line.rstrip()
 
                     # Skip lines matching these criteria
-                    if not line: continue
-                    if re.search(r'^(import|#)', line): continue
-                    if (ext.name != 'py-setuptools' and
-                        re.search(r'setuptools.*egg$', line)): continue
+                    if not line:
+                        continue
+                    if re.search(r'^(import|#)', line):
+                        continue
+                    if ((ext.name != 'py-setuptools' and
+                         re.search(r'setuptools.*egg$', line))):
+                        continue
 
                     paths.append(line)
 
@@ -240,12 +252,13 @@ class Python(Package):
                 f.write("import sys; sys.__plen = len(sys.path)\n")
                 for path in paths:
                     f.write("%s\n" % path)
-                f.write("import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; "
-                        "p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)\n")
-
+                f.write("import sys; new=sys.path[sys.__plen:]; "
+                        "del sys.path[sys.__plen:]; "
+                        "p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; "
+                        "sys.__egginsert = p+len(new)\n")
 
     def activate(self, ext_pkg, **args):
-        ignore=self.python_ignore(ext_pkg, args)
+        ignore = self.python_ignore(ext_pkg, args)
         args.update(ignore=ignore)
 
         super(Python, self).activate(ext_pkg, **args)
@@ -253,7 +266,6 @@ class Python(Package):
         exts = spack.install_layout.extension_map(self.spec)
         exts[ext_pkg.name] = ext_pkg.spec
         self.write_easy_install_pth(exts)
-
 
     def deactivate(self, ext_pkg, **args):
         args.update(ignore=self.python_ignore(ext_pkg, args))

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class Tcl(Package):
     """Tcl (Tool Command Language) is a very powerful but easy to
        learn dynamic programming language, suitable for a very wide
@@ -49,3 +50,9 @@ class Tcl(Package):
             configure("--prefix=%s" % prefix)
             make()
             make("install")
+
+    # When using Tkinter from within spack provided python+tk, python
+    # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
+    def setup_environment(self, spack_env, env):
+        env.set('TCL_LIBRARY', self.prefix.lib + "/tcl%s" %
+                Version(self.spec.version).up_to(2))

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -36,7 +36,9 @@ class Tcl(Package):
     homepage = "http://www.tcl.tk"
 
     def url_for_version(self, version):
-        return 'http://prdownloads.sourceforge.net/tcl/tcl%s-src.tar.gz' % version
+        return (
+            'http://prdownloads.sourceforge.net/tcl/tcl%s-src.tar.gz' %
+            version)
 
     version('8.6.5', '0e6426a4ca9401825fbc6ecf3d89a326')
     version('8.6.4', 'd7cbb91f1ded1919370a30edd1534304')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -35,7 +35,9 @@ class Tk(Package):
     homepage = "http://www.tcl.tk"
 
     def url_for_version(self, version):
-        return "http://prdownloads.sourceforge.net/tcl/tk%s-src.tar.gz" % version
+        return (
+            "http://prdownloads.sourceforge.net/tcl/tk%s-src.tar.gz" %
+            version)
 
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
 

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class Tk(Package):
     """Tk is a graphical user interface toolkit that takes developing
        desktop applications to a higher level than conventional
@@ -46,3 +47,9 @@ class Tk(Package):
                       "--with-tcl=%s" % spec['tcl'].prefix.lib)
             make()
             make("install")
+
+    # When using Tkinter from within spack provided python+tk, python
+    # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
+    def setup_environment(self, spack_env, env):
+        env.set('TK_LIBRARY', self.prefix.lib + "/tk%s" %
+                Version(self.spec.version).up_to(2))


### PR DESCRIPTION
+ Register 'tk' variant (default=False so existing behavior is unmodified).
+ Add dependencies on tcl and tk if +tk in found in the spec.
+ Add configure options to enable discovery of Tcl/Tk during the python build.
+ Update formatting to meet flake8 requirements:
  - Mostly this involved splitting long lines and removing extra blank lines. I
    did have a little trouble with E125 and E129 (continuation line does not
    distinguish itself from the next logical line). In the end, I added an extra
    set of parenthesis so that the continuation line indent didn't line up
    exactly with the conditional body.
+ Fixes #1024