### PR TITLE
Do not pass "/usr" or "/usr/local" as path to configure

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -142,7 +142,7 @@ class Openmpi(Package):
         ])
         if '+verbs' in spec:
             path = _verbs_dir()
-            if path is not None:
+            if path is not None and path not in ('/usr', '/usr/local'):
                 config_args.append('--with-%s=%s' % (self.verbs, path))
             else:
                 config_args.append('--with-%s' % self.verbs)


### PR DESCRIPTION
Closes #1038.