### PR TITLE
Add Psi4 Package

### DIFF
--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -29,6 +29,8 @@ for file in $changed; do
         perl -i -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file
         perl -i -pe 's/^(\s*version\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
         perl -i -pe 's/^(\s*variant\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
+        perl -i -pe 's/^(\s*depends_on\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
+        perl -i -pe 's/^(\s*extends\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
 
         # Exempt '@when' decorated functions from redefinition errors.
         perl -i -pe 's/^(\s*\@when\(.*\).*)$/\1  # NOQA: ignore=F811/' $file

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -25,7 +25,6 @@
 from spack import *
 import spack
 import sys
-
 import os
 
 
@@ -91,6 +90,7 @@ class Boost(Package):
                                 'system',
                                 'test',
                                 'thread',
+                                'timer',
                                 'wave'])
 
     # mpi/python are not installed by default because they pull in many

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -38,13 +38,13 @@ class Psi4(Package):
     variant('mpi', default=True, description='Enable MPI parallelization')
 
     # Required dependencies
-    depends_on('python@2.7:')
-    depends_on('py-numpy')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('cmake@3.0:')
-    depends_on('boost@1.55.0:+chrono+filesystem~mpi+python+regex+serialization+system+timer+thread', when='~mpi')
-    depends_on('boost@1.55.0:+chrono+filesystem+mpi+python+regex+serialization+system+timer+thread', when='+mpi')
+    depends_on('boost+chrono+filesystem~mpi+python+regex+serialization+system+timer+thread', when='~mpi')
+    depends_on('boost+chrono+filesystem+mpi+python+regex+serialization+system+timer+thread', when='+mpi')
+    depends_on('python')
+    depends_on('cmake')
+    depends_on('py-numpy')
 
     # Optional dependencies
     depends_on('mpi', when='+mpi')
@@ -62,17 +62,9 @@ class Psi4(Package):
             '-DLAPACK_LIBRARIES={0}'.format(spec['lapack'].lapack_shared_lib),
             '-DBOOST_INCLUDEDIR={0}'.format(spec['boost'].prefix.include),
             '-DBOOST_LIBRARYDIR={0}'.format(spec['boost'].prefix.lib),
+            '-DENABLE_MPI={0}'.format('ON' if '+mpi' in spec else 'OFF'),
             '-DENABLE_CHEMPS2=OFF'
         ]
-
-        if '+mpi' in spec:
-            cmake_args.extend([
-                '-DENABLE_MPI=ON'
-                #'-DMPI_C_COMPILER={0}'.format(spec['mpi'].mpicc)
-                #'-DMPI_C_INCLUDE_PATH={0}'.format(spec['mpi'].prefix.include),
-            ])
-        else:
-            cmake_args.append('-DENABLE_MPI=OFF')
 
         cmake_args.extend(std_cmake_args)
 
@@ -80,5 +72,5 @@ class Psi4(Package):
             cmake('..', *cmake_args)
 
             make()
-            #ctest()
+            # ctest()
             make('install')

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 
 
 class Psi4(Package):
@@ -74,3 +75,26 @@ class Psi4(Package):
             make()
             # ctest()
             make('install')
+
+        self.filter_compilers()
+
+    def filter_compilers(self):
+        """Run after install to tell the configuration files to
+        use the compilers that Spack built the package with.
+
+        If this isn't done, they'll have PLUGIN_CXX set to
+        Spack's generic cxx. We want it to be bound to
+        whatever compiler it was built with."""
+
+        kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
+
+        cc_files  = ['bin/psi4-config']
+        cxx_files = ['bin/psi4-config', 'include/psi4/psiconfig.h']
+
+        for filename in cc_files:
+            filter_file(os.environ['CC'], self.compiler.cc,
+                        os.path.join(self.prefix, filename), **kwargs)
+
+        for filename in cxx_files:
+            filter_file(os.environ['CXX'], self.compiler.cxx,
+                        os.path.join(self.prefix, filename), **kwargs)

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -1,0 +1,84 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Psi4(Package):
+    """Psi4 is an open-source suite of ab initio quantum chemistry
+    programs designed for efficient, high-accuracy simulations of
+    a variety of molecular properties."""
+
+    homepage = "http://www.psicode.org/"
+    url      = "https://github.com/psi4/psi4/archive/0.5.tar.gz"
+
+    version('0.5', '53041b8a9be3958384171d0d22f9fdd0')
+
+    variant('mpi', default=True, description='Enable MPI parallelization')
+
+    # Required dependencies
+    depends_on('python@2.7:')
+    depends_on('py-numpy')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('cmake@3.0:')
+    depends_on('boost@1.55.0:+chrono+filesystem~mpi+python+regex+serialization+system+timer+thread', when='~mpi')
+    depends_on('boost@1.55.0:+chrono+filesystem+mpi+python+regex+serialization+system+timer+thread', when='+mpi')
+
+    # Optional dependencies
+    depends_on('mpi', when='+mpi')
+    # TODO: add packages for these
+    # depends_on('perl')
+    # depends_on('erd')
+    # depends_on('pcm-solver')
+    # depends_on('chemps2')
+
+    def install(self, spec, prefix):
+        cmake_args = [
+            '-DBLAS_TYPE={0}'.format(spec['blas'].name.upper()),
+            '-DBLAS_LIBRARIES={0}'.format(spec['blas'].blas_shared_lib),
+            '-DLAPACK_TYPE={0}'.format(spec['lapack'].name.upper()),
+            '-DLAPACK_LIBRARIES={0}'.format(spec['lapack'].lapack_shared_lib),
+            '-DBOOST_INCLUDEDIR={0}'.format(spec['boost'].prefix.include),
+            '-DBOOST_LIBRARYDIR={0}'.format(spec['boost'].prefix.lib),
+            '-DENABLE_CHEMPS2=OFF'
+        ]
+
+        if '+mpi' in spec:
+            cmake_args.extend([
+                '-DENABLE_MPI=ON'
+                #'-DMPI_C_COMPILER={0}'.format(spec['mpi'].mpicc)
+                #'-DMPI_C_INCLUDE_PATH={0}'.format(spec['mpi'].prefix.include),
+            ])
+        else:
+            cmake_args.append('-DENABLE_MPI=OFF')
+
+        cmake_args.extend(std_cmake_args)
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *cmake_args)
+
+            make()
+            #ctest()
+            make('install')


### PR DESCRIPTION
The serial version compiles without any trouble. However, when I try to build the parallel version, I'm seeing the following linking errors:

```
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::detail::broadcast_impl<double>(boost::mpi::communicator const&, double*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::detail::all_gather_impl<double>(boost::mpi::communicator const&, double const*, int, double*, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/all_gather.hpp:31: undefined reference to `MPI_Allgather'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::array_irecv_impl<double>(int, int, double*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1637: undefined reference to `MPI_Irecv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::irecv_impl<double>(int, int, double&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1599: undefined reference to `MPI_Irecv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::status boost::mpi::communicator::array_recv_impl<double>(int, int, double*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1239: undefined reference to `MPI_Recv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::status boost::mpi::communicator::recv_impl<double>(int, int, double&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1204: undefined reference to `MPI_Recv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::array_irecv_impl<int>(int, int, int*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1637: undefined reference to `MPI_Irecv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::irecv_impl<int>(int, int, int&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1599: undefined reference to `MPI_Irecv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::status boost::mpi::communicator::array_recv_impl<int>(int, int, int*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1239: undefined reference to `MPI_Recv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::status boost::mpi::communicator::recv_impl<int>(int, int, int&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1204: undefined reference to `MPI_Recv'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::array_isend_impl<int>(int, int, int const*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1359: undefined reference to `MPI_Isend'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::isend_impl<int>(int, int, int const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1324: undefined reference to `MPI_Isend'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::communicator::array_send_impl<int>(int, int, int const*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1171: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::communicator::send_impl<int>(int, int, int const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1139: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::array_isend_impl<double>(int, int, double const*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1359: undefined reference to `MPI_Isend'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `boost::mpi::request boost::mpi::communicator::isend_impl<double>(int, int, double const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1324: undefined reference to `MPI_Isend'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::communicator::array_send_impl<double>(int, int, double const*, int, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1171: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(LibParallelHelper.cc.o): In function `void boost::mpi::communicator::send_impl<double>(int, int, double const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1139: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(DynamicScheduler.cc.o): In function `boost::mpi::status boost::mpi::communicator::recv_impl<int>(int, int, int&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1204: undefined reference to `MPI_Recv'
../../../lib/libparallel2.a(DynamicScheduler.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libparallel2.a(DynamicScheduler.cc.o): In function `void boost::mpi::communicator::send_impl<int>(int, int, int const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1139: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(MasterTools.cc.o): In function `void boost::mpi::communicator::send_impl<unsigned int>(int, int, unsigned int const&, mpl_::bool_<true>) const':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/communicator.hpp:1139: undefined reference to `MPI_Send'
../../../lib/libparallel2.a(TaskStatistics.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(toclen.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(toclen.cc.o): In function `void boost::mpi::detail::broadcast_impl<unsigned long>(boost::mpi::communicator const&, unsigned long*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(close.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(open.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::status::cancelled() const':
communicator.cpp:(.text+0x333): undefined reference to `MPI_Test_cancelled'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::communicator(int const&, boost::mpi::comm_create_kind)':
communicator.cpp:(.text+0x428): undefined reference to `MPI_Comm_dup'
communicator.cpp:(.text+0x49c): undefined reference to `MPI_Comm_set_errhandler'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::communicator(boost::mpi::communicator const&, boost::mpi::group const&)':
communicator.cpp:(.text+0x6dc): undefined reference to `MPI_Comm_create'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::size() const':
communicator.cpp:(.text+0x845): undefined reference to `MPI_Comm_size'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::rank() const':
communicator.cpp:(.text+0x8b5): undefined reference to `MPI_Comm_rank'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::group() const':
communicator.cpp:(.text+0x928): undefined reference to `MPI_Comm_group'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::send(int, int) const':
communicator.cpp:(.text+0x9af): undefined reference to `MPI_Send'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::recv(int, int) const':
communicator.cpp:(.text+0xa2e): undefined reference to `MPI_Recv'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::iprobe(int, int) const':
communicator.cpp:(.text+0xaad): undefined reference to `MPI_Iprobe'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::probe(int, int) const':
communicator.cpp:(.text+0xb65): undefined reference to `MPI_Probe'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::barrier() const':
communicator.cpp:(.text+0xbd0): undefined reference to `MPI_Barrier'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::split(int, int) const':
communicator.cpp:(.text+0xc47): undefined reference to `MPI_Comm_split'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::as_intercommunicator() const':
communicator.cpp:(.text+0xdc2): undefined reference to `MPI_Comm_test_inter'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::as_graph_communicator() const':
communicator.cpp:(.text+0xef4): undefined reference to `MPI_Topo_test'
communicator.cpp:(.text+0xf40): undefined reference to `MPI_Topo_test'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::has_cartesian_topology() const':
communicator.cpp:(.text+0x1195): undefined reference to `MPI_Topo_test'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::abort(int) const':
communicator.cpp:(.text+0x1200): undefined reference to `MPI_Abort'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `void boost::mpi::communicator::send<boost::mpi::content>(int, int, boost::mpi::content const&) const':
communicator.cpp:(.text+0x1272): undefined reference to `MPI_Send'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::status boost::mpi::communicator::recv<boost::mpi::content const>(int, int, boost::mpi::content const&) const':
communicator.cpp:(.text+0x12f1): undefined reference to `MPI_Recv'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::request boost::mpi::communicator::isend<boost::mpi::content>(int, int, boost::mpi::content const&) const':
communicator.cpp:(.text+0x1389): undefined reference to `MPI_Isend'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::isend(int, int) const':
communicator.cpp:(.text+0x1441): undefined reference to `MPI_Isend'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::request boost::mpi::communicator::irecv<boost::mpi::packed_skeleton_iarchive>(int, int, boost::mpi::packed_skeleton_iarchive&) const':
communicator.cpp:(.text+0x15af): undefined reference to `MPI_Irecv'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::request boost::mpi::communicator::irecv<boost::mpi::content const>(int, int, boost::mpi::content const&) const':
communicator.cpp:(.text+0x1799): undefined reference to `MPI_Irecv'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::irecv(int, int) const':
communicator.cpp:(.text+0x1851): undefined reference to `MPI_Irecv'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::operator==(boost::mpi::communicator const&, boost::mpi::communicator const&)':
communicator.cpp:(.text+0x18ef): undefined reference to `MPI_Comm_compare'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::split(int) const':
communicator.cpp:(.text+0x1985): undefined reference to `MPI_Comm_rank'
communicator.cpp:(.text+0x19ae): undefined reference to `MPI_Comm_split'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::mpi::communicator::comm_free::operator()(int*) const [clone .isra.47]':
communicator.cpp:(.text.unlikely+0x36): undefined reference to `MPI_Finalized'
communicator.cpp:(.text.unlikely+0x64): undefined reference to `MPI_Comm_free'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::detail::sp_counted_impl_pd<int*, boost::mpi::communicator::comm_free>::dispose()':
communicator.cpp:(.text._ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi12communicator9comm_freeEE7disposeEv[_ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi12communicator9comm_freeEE7disposeEv]+0xf): undefined reference to `MPI_Finalized'
communicator.cpp:(.text._ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi12communicator9comm_freeEE7disposeEv[_ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi12communicator9comm_freeEE7disposeEv]+0x23): undefined reference to `MPI_Comm_free'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `std::vector<char, boost::mpi::allocator<char> >::_M_default_append(unsigned long)':
communicator.cpp:(.text._ZNSt6vectorIcN5boost3mpi9allocatorIcEEE17_M_default_appendEm[_ZNSt6vectorIcN5boost3mpi9allocatorIcEEE17_M_default_appendEm]+0xd3): undefined reference to `MPI_Free_mem'
communicator.cpp:(.text._ZNSt6vectorIcN5boost3mpi9allocatorIcEEE17_M_default_appendEm[_ZNSt6vectorIcN5boost3mpi9allocatorIcEEE17_M_default_appendEm]+0x10e): undefined reference to `MPI_Alloc_mem'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(communicator.o): In function `boost::optional<boost::mpi::status> boost::mpi::request::handle_serialized_irecv<boost::mpi::packed_iarchive>(boost::mpi::request*, boost::mpi::request::request_action)':
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x5d): undefined reference to `MPI_Wait'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0xdf): undefined reference to `MPI_Wait'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x148): undefined reference to `MPI_Irecv'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x1c3): undefined reference to `MPI_Test'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x29f): undefined reference to `MPI_Test'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x320): undefined reference to `MPI_Irecv'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x4b0): undefined reference to `MPI_Free_mem'
communicator.cpp:(.text._ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE[_ZN5boost3mpi7request23handle_serialized_irecvINS0_15packed_iarchiveEEENS_8optionalINS0_6statusEEEPS1_NS1_14request_actionE]+0x58c): undefined reference to `MPI_Alloc_mem'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::group::group(int const&, bool)':
group.cpp:(.text+0x1b0): undefined reference to `MPI_Finalized'
group.cpp:(.text+0x1c3): undefined reference to `MPI_Group_free'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::group::rank() const':
group.cpp:(.text+0x268): undefined reference to `MPI_Group_rank'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::group::size() const':
group.cpp:(.text+0x2e5): undefined reference to `MPI_Group_size'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::operator==(boost::mpi::group const&, boost::mpi::group const&)':
group.cpp:(.text+0x35f): undefined reference to `MPI_Group_compare'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::operator|(boost::mpi::group const&, boost::mpi::group const&)':
group.cpp:(.text+0x3f4): undefined reference to `MPI_Group_union'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::operator&(boost::mpi::group const&, boost::mpi::group const&)':
group.cpp:(.text+0x494): undefined reference to `MPI_Group_intersection'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::operator-(boost::mpi::group const&, boost::mpi::group const&)':
group.cpp:(.text+0x534): undefined reference to `MPI_Group_difference'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `int* boost::mpi::group::translate_ranks<int*, int*>(int*, int*, boost::mpi::group const&, int*)':
group.cpp:(.text+0x5e4): undefined reference to `MPI_Group_translate_ranks'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::group boost::mpi::group::include<int*>(int*, int*)':
group.cpp:(.text+0x674): undefined reference to `MPI_Group_incl'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::mpi::group boost::mpi::group::exclude<int*>(int*, int*)':
group.cpp:(.text+0x704): undefined reference to `MPI_Group_excl'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(group.o): In function `boost::detail::sp_counted_impl_pd<int*, boost::mpi::group::group_free>::dispose()':
group.cpp:(.text._ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi5group10group_freeEE7disposeEv[_ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi5group10group_freeEE7disposeEv]+0xf): undefined reference to `MPI_Finalized'
group.cpp:(.text._ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi5group10group_freeEE7disposeEv[_ZN5boost6detail18sp_counted_impl_pdIPiNS_3mpi5group10group_freeEE7disposeEv]+0x23): undefined reference to `MPI_Group_free'
../../../lib/libpsio.a(rw.cc.o): In function `void boost::mpi::detail::broadcast_impl<char>(boost::mpi::communicator const&, char*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(rw.cc.o): In function `void boost::mpi::detail::broadcast_impl<unsigned long>(boost::mpi::communicator const&, unsigned long*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
../../../lib/libpsio.a(volseek.cc.o): In function `void boost::mpi::detail::broadcast_impl<int>(boost::mpi::communicator const&, int*, int, int, mpl_::bool_<true>)':
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/include/boost/mpi/collectives/broadcast.hpp:96: undefined reference to `MPI_Bcast'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::abort(int)':
environment.cpp:(.text+0x21d): undefined reference to `MPI_Abort'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::initialized()':
environment.cpp:(.text+0x26b): undefined reference to `MPI_Initialized'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::finalized()':
environment.cpp:(.text+0x2cb): undefined reference to `MPI_Finalized'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::max_tag()':
environment.cpp:(.text+0x342): undefined reference to `MPI_Attr_get'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::host_rank()':
environment.cpp:(.text+0x3b5): undefined reference to `MPI_Attr_get'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::io_rank()':
environment.cpp:(.text+0x445): undefined reference to `MPI_Attr_get'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::processor_name[abi:cxx11]()':
environment.cpp:(.text+0x4c7): undefined reference to `MPI_Get_processor_name'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::thread_level()':
environment.cpp:(.text+0x59b): undefined reference to `MPI_Query_thread'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::is_main_thread()':
environment.cpp:(.text+0x5eb): undefined reference to `MPI_Is_thread_main'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::collectives_tag()':
environment.cpp:(.text+0x662): undefined reference to `MPI_Attr_get'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::~environment()':
environment.cpp:(.text+0x6d2): undefined reference to `MPI_Finalized'
environment.cpp:(.text+0x6fe): undefined reference to `MPI_Finalize'
environment.cpp:(.text+0x733): undefined reference to `MPI_Abort'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::environment(int&, char**&, bool)':
environment.cpp:(.text+0x7ad): undefined reference to `MPI_Initialized'
environment.cpp:(.text+0x7c4): undefined reference to `MPI_Init'
environment.cpp:(.text+0x7da): undefined reference to `MPI_Errhandler_set'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::environment(bool)':
environment.cpp:(.text+0x855): undefined reference to `MPI_Initialized'
environment.cpp:(.text+0x86a): undefined reference to `MPI_Init'
environment.cpp:(.text+0x880): undefined reference to `MPI_Errhandler_set'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::environment(boost::mpi::threading::level, bool)':
environment.cpp:(.text+0x8ff): undefined reference to `MPI_Initialized'
environment.cpp:(.text+0x91b): undefined reference to `MPI_Init_thread'
environment.cpp:(.text+0x931): undefined reference to `MPI_Errhandler_set'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(environment.o): In function `boost::mpi::environment::environment(int&, char**&, boost::mpi::threading::level, bool)':
environment.cpp:(.text+0x9bb): undefined reference to `MPI_Initialized'
environment.cpp:(.text+0x9da): undefined reference to `MPI_Init_thread'
environment.cpp:(.text+0x9f0): undefined reference to `MPI_Errhandler_set'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(mpi_datatype_cache.o): In function `boost::mpi::detail::mpi_datatype_map::clear()':
mpi_datatype_cache.cpp:(.text+0x1c7): undefined reference to `MPI_Finalized'
mpi_datatype_cache.cpp:(.text+0x1f5): undefined reference to `MPI_Type_free'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(mpi_datatype_cache.o): In function `boost::mpi::detail::mpi_datatype_map::~mpi_datatype_map()':
mpi_datatype_cache.cpp:(.text+0x269): undefined reference to `MPI_Finalized'
mpi_datatype_cache.cpp:(.text+0x295): undefined reference to `MPI_Type_free'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(point_to_point.o): In function `boost::mpi::detail::packed_archive_send(int, int, int, boost::mpi::packed_oarchive const&)':
point_to_point.cpp:(.text+0x41): undefined reference to `MPI_Send'
point_to_point.cpp:(.text+0x69): undefined reference to `MPI_Send'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(point_to_point.o): In function `boost::mpi::detail::packed_archive_isend(int, int, int, boost::mpi::packed_oarchive const&, int*, int)':
point_to_point.cpp:(.text+0x113): undefined reference to `MPI_Isend'
point_to_point.cpp:(.text+0x147): undefined reference to `MPI_Isend'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(point_to_point.o): In function `boost::mpi::detail::packed_archive_isend(int, int, int, boost::mpi::packed_iarchive const&, int*, int)':
point_to_point.cpp:(.text+0x1f3): undefined reference to `MPI_Isend'
point_to_point.cpp:(.text+0x227): undefined reference to `MPI_Isend'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(point_to_point.o): In function `boost::mpi::detail::packed_archive_recv(int, int, int, boost::mpi::packed_iarchive&, MPI_Status&)':
point_to_point.cpp:(.text+0x2c1): undefined reference to `MPI_Recv'
point_to_point.cpp:(.text+0x318): undefined reference to `MPI_Recv'
point_to_point.cpp:(.text+0x40a): undefined reference to `MPI_Free_mem'
point_to_point.cpp:(.text+0x4a7): undefined reference to `MPI_Alloc_mem'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(request.o): In function `boost::mpi::request::wait()':
request.cpp:(.text+0x82): undefined reference to `MPI_Waitall'
request.cpp:(.text+0xd4): undefined reference to `MPI_Wait'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(request.o): In function `boost::mpi::request::test()':
request.cpp:(.text+0x201): undefined reference to `MPI_Testall'
request.cpp:(.text+0x283): undefined reference to `MPI_Test'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(request.o): In function `boost::mpi::request::cancel()':
request.cpp:(.text+0x38e): undefined reference to `MPI_Cancel'
request.cpp:(.text+0x3a9): undefined reference to `MPI_Cancel'
/blues/gpfs/home/software/spack/opt/spack/linux-x86_64/gcc-6.1.0/boost-1.61.0-deyw7xs6bmycmara46vfwnd3xnpbivxe/lib/libboost_mpi-mt.a(exception.o): In function `boost::mpi::exception::exception(char const*, int)':
exception.cpp:(.text+0xaf): undefined reference to `MPI_Error_string'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/psi4] Error 1
make[1]: *** [src/bin/psi4/CMakeFiles/psi4.dir/all] Error 2
make: *** [all] Error 2
```

Any idea what's going on here? Looks like a boost+mpi problem.