### PR TITLE
MPI : have wrappers set RPATH instead of RUNPATH

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -106,22 +106,13 @@ class Mpich(Package):
         mpif77 = join_path(bin, 'mpif77')
         mpif90 = join_path(bin, 'mpif90')
 
-        spack_cc = env['CC']
-        spack_cxx = env['CXX']
-        spack_f77 = env['F77']
-        spack_fc = env['FC']
-
         # Substitute Spack compile wrappers for the real
         # underlying compiler
         kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
-        filter_file('CC="%s"' % spack_cc,
-                    'CC="%s"' % self.compiler.cc,  mpicc,  **kwargs)
-        filter_file('CXX="%s"' % spack_cxx,
-                    'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="%s"' % spack_f77,
-                    'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="%s"' % spack_fc,
-                    'FC="%s"' % self.compiler.fc,  mpif90, **kwargs)
+        filter_file(env['CC'], self.compiler.cc,  mpicc,  **kwargs)
+        filter_file(env['CXX'], self.compiler.cxx, mpicxx, **kwargs)
+        filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
+        filter_file(env['FC'], self.compiler.fc,  mpif90, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -29,8 +29,8 @@ class Mpich(Package):
     """MPICH is a high performance and widely portable implementation of
        the Message Passing Interface (MPI) standard."""
     homepage = "http://www.mpich.org"
-    url      = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
-    list_url   = "http://www.mpich.org/static/downloads/"
+    url = "http://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz"
+    list_url = "http://www.mpich.org/static/downloads/"
     list_depth = 2
 
     version('3.2',   'f414cfa77099cd1fa1a5ae4e22db508a')
@@ -41,7 +41,8 @@ class Mpich(Package):
     version('3.1',   '5643dd176499bfb7d25079aaff25f2ec')
     version('3.0.4', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
 
-    variant('verbs', default=False, description='Build support for OpenFabrics verbs.')
+    variant('verbs', default=False,
+            description='Build support for OpenFabrics verbs.')
     variant('pmi', default=True, description='Build with PMI support')
     variant('hydra', default=True, description='Build the hydra process manager')
 
@@ -56,9 +57,9 @@ class Mpich(Package):
         spack_env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dep_spec):
-        self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+        self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
-        self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+        self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     def install(self, spec, prefix):
@@ -91,7 +92,6 @@ class Mpich(Package):
 
         self.filter_compilers()
 
-
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.
@@ -101,23 +101,27 @@ class Mpich(Package):
            be bound to whatever compiler they were built with.
         """
         bin = self.prefix.bin
-        mpicc  = join_path(bin, 'mpicc')
+        mpicc = join_path(bin, 'mpicc')
         mpicxx = join_path(bin, 'mpicxx')
         mpif77 = join_path(bin, 'mpif77')
         mpif90 = join_path(bin, 'mpif90')
 
-        spack_cc  = env['CC']
+        spack_cc = env['CC']
         spack_cxx = env['CXX']
         spack_f77 = env['F77']
-        spack_fc  = env['FC']
+        spack_fc = env['FC']
 
         # Substitute Spack compile wrappers for the real
         # underlying compiler
-        kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : True }
-        filter_file('CC="%s"' % spack_cc , 'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
-        filter_file('CXX="%s"'% spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="%s"'% spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="%s"' % spack_fc , 'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)
+        kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
+        filter_file('CC="%s"' % spack_cc,
+                    'CC="%s"' % self.compiler.cc,  mpicc,  **kwargs)
+        filter_file('CXX="%s"' % spack_cxx,
+                    'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
+        filter_file('F77="%s"' % spack_f77,
+                    'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
+        filter_file('FC="%s"' % spack_fc,
+                    'FC="%s"' % self.compiler.fc,  mpif90, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
 class Mpich(Package):
@@ -102,18 +101,25 @@ class Mpich(Package):
            be bound to whatever compiler they were built with.
         """
         bin = self.prefix.bin
-        mpicc  = os.path.join(bin, 'mpicc')
-        mpicxx = os.path.join(bin, 'mpicxx')
-        mpif77 = os.path.join(bin, 'mpif77')
-        mpif90 = os.path.join(bin, 'mpif90')
+        mpicc  = join_path(bin, 'mpicc')
+        mpicxx = join_path(bin, 'mpicxx')
+        mpif77 = join_path(bin, 'mpif77')
+        mpif90 = join_path(bin, 'mpif90')
 
-        spack_cc  = os.environ['CC']
-        spack_cxx = os.environ['CXX']
-        spack_f77 = os.environ['F77']
-        spack_fc  = os.environ['FC']
+        spack_cc  = env['CC']
+        spack_cxx = env['CXX']
+        spack_f77 = env['F77']
+        spack_fc  = env['FC']
 
+        # Substitute Spack compile wrappers for the real
+        # underlying compiler
         kwargs = { 'ignore_absent' : True, 'backup' : False, 'string' : True }
         filter_file('CC="%s"' % spack_cc , 'CC="%s"'  % self.compiler.cc,  mpicc,  **kwargs)
         filter_file('CXX="%s"'% spack_cxx, 'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
         filter_file('F77="%s"'% spack_f77, 'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
         filter_file('FC="%s"' % spack_fc , 'FC="%s"'  % self.compiler.fc,  mpif90, **kwargs)
+
+        # Remove this linking flag if present
+        # (it turns RPATH into RUNPATH)
+        for wrapper in (mpicc, mpicxx, mpif77, mpif90):
+            filter_file('-Wl,--enable-new-dtags', '', wrapper, **kwargs)

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
 class Mvapich2(Package):
@@ -245,15 +244,15 @@ class Mvapich2(Package):
            be bound to whatever compiler they were built with.
         """
         bin = self.prefix.bin
-        mpicc  = os.path.join(bin, 'mpicc')
-        mpicxx = os.path.join(bin, 'mpicxx')
-        mpif77 = os.path.join(bin, 'mpif77')
-        mpif90 = os.path.join(bin, 'mpif90')
+        mpicc  = join_path(bin, 'mpicc')
+        mpicxx = join_path(bin, 'mpicxx')
+        mpif77 = join_path(bin, 'mpif77')
+        mpif90 = join_path(bin, 'mpif90')
 
-        spack_cc  = os.environ['CC']
-        spack_cxx = os.environ['CXX']
-        spack_f77 = os.environ['F77']
-        spack_fc  = os.environ['FC']
+        spack_cc  = env['CC']
+        spack_cxx = env['CXX']
+        spack_f77 = env['F77']
+        spack_fc  = env['FC']
 
         kwargs = {
             'ignore_absent': True,
@@ -261,6 +260,8 @@ class Mvapich2(Package):
             'string': True
         }
 
+        # Substitute Spack compile wrappers for the real
+        # underlying compiler
         filter_file('CC="%s"' % spack_cc,
                     'CC="%s"' % self.compiler.cc, mpicc, **kwargs)
         filter_file('CXX="%s"' % spack_cxx,
@@ -269,3 +270,8 @@ class Mvapich2(Package):
                     'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
         filter_file('FC="%s"' % spack_fc,
                     'FC="%s"' % self.compiler.fc, mpif90, **kwargs)
+
+        # Remove this linking flag if present
+        # (it turns RPATH into RUNPATH)
+        for wrapper in (mpicc, mpicxx, mpif77, mpif90):
+            filter_file('-Wl,--enable-new-dtags', '', wrapper, **kwargs)

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -249,27 +249,13 @@ class Mvapich2(Package):
         mpif77 = join_path(bin, 'mpif77')
         mpif90 = join_path(bin, 'mpif90')
 
-        spack_cc  = env['CC']
-        spack_cxx = env['CXX']
-        spack_f77 = env['F77']
-        spack_fc  = env['FC']
-
-        kwargs = {
-            'ignore_absent': True,
-            'backup': False,
-            'string': True
-        }
-
         # Substitute Spack compile wrappers for the real
         # underlying compiler
-        filter_file('CC="%s"' % spack_cc,
-                    'CC="%s"' % self.compiler.cc, mpicc, **kwargs)
-        filter_file('CXX="%s"' % spack_cxx,
-                    'CXX="%s"' % self.compiler.cxx, mpicxx, **kwargs)
-        filter_file('F77="%s"' % spack_f77,
-                    'F77="%s"' % self.compiler.f77, mpif77, **kwargs)
-        filter_file('FC="%s"' % spack_fc,
-                    'FC="%s"' % self.compiler.fc, mpif90, **kwargs)
+        kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
+        filter_file(env['CC'], self.compiler.cc, mpicc, **kwargs)
+        filter_file(env['CXX'], self.compiler.cxx, mpicxx, **kwargs)
+        filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
+        filter_file(env['FC'], self.compiler.fc, mpif90, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -72,20 +72,27 @@ class Openmpi(Package):
     patch('configure.patch', when="@1.10.0:1.10.1")
 
     variant('psm', default=False, description='Build support for the PSM library.')
-    variant('psm2', default=False, description='Build support for the Intel PSM2 library.')
-    variant('pmi', default=False, description='Build support for PMI-based launchers')
-    variant('verbs', default=_verbs_dir() is not None, description='Build support for OpenFabrics verbs.')
+    variant('psm2', default=False,
+            description='Build support for the Intel PSM2 library.')
+    variant('pmi', default=False,
+            description='Build support for PMI-based launchers')
+    variant('verbs', default=_verbs_dir() is not None,
+            description='Build support for OpenFabrics verbs.')
     variant('mxm', default=False, description='Build Mellanox Messaging support')
 
-    variant('thread_multiple', default=False, description='Enable MPI_THREAD_MULTIPLE support')
+    variant('thread_multiple', default=False,
+            description='Enable MPI_THREAD_MULTIPLE support')
 
     # TODO : variant support for alps, loadleveler  is missing
-    variant('tm', default=False, description='Build TM (Torque, PBSPro, and compatible) support')
-    variant('slurm', default=False, description='Build SLURM scheduler component')
+    variant('tm', default=False,
+            description='Build TM (Torque, PBSPro, and compatible) support')
+    variant('slurm', default=False,
+            description='Build SLURM scheduler component')
 
     variant('sqlite3', default=False, description='Build sqlite3 support')
 
-    variant('vt', default=True, description='Build support for contributed package vt')
+    variant('vt', default=True,
+            description='Build support for contributed package vt')
 
     # TODO : support for CUDA is missing
 
@@ -96,8 +103,7 @@ class Openmpi(Package):
     depends_on('sqlite', when='+sqlite3')
 
     def url_for_version(self, version):
-        return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)
-
+        return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)  # NOQA: ignore=E501
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('OMPI_CC', spack_cc)
@@ -106,14 +112,15 @@ class Openmpi(Package):
         spack_env.set('OMPI_F77', spack_f77)
 
     def setup_dependent_package(self, module, dep_spec):
-        self.spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+        self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
-        self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+        self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     @property
     def verbs(self):
-        # Up through version 1.6, this option was previously named --with-openib
+        # Up through version 1.6, this option was previously named
+        # --with-openib
         if self.spec.satisfies('@:1.6'):
             return 'openib'
         # In version 1.7, it was renamed to be --with-verbs
@@ -135,7 +142,7 @@ class Openmpi(Package):
             '--with-psm2' if '+psm2' in spec else '--without-psm2',
             '--with-mxm' if '+mxm' in spec else '--without-mxm',
             # Other options
-            '--enable-mpi-thread-multiple' if '+thread_multiple' in spec else '--disable-mpi-thread-multiple',
+            '--enable-mpi-thread-multiple' if '+thread_multiple' in spec else '--disable-mpi-thread-multiple',  # NOQA: ignore=E501
             '--with-pmi' if '+pmi' in spec else '--without-pmi',
             '--with-sqlite3' if '+sqlite3' in spec else '--without-sqlite3',
             '--enable-vt' if '+vt' in spec else '--disable-vt'
@@ -153,7 +160,7 @@ class Openmpi(Package):
         # use this for LANL builds, but for LLNL builds, we need:
         #     "--with-platform=contrib/platform/llnl/optimized"
         if self.version == ver("1.6.5") and '+lanl' in spec:
-            config_args.append("--with-platform=contrib/platform/lanl/tlcc2/optimized-nopanasas")
+            config_args.append("--with-platform=contrib/platform/lanl/tlcc2/optimized-nopanasas")  # NOQA: ignore=E501
 
         if not self.compiler.f77 and not self.compiler.fc:
             config_args.append("--enable-mpi-fortran=no")


### PR DESCRIPTION
##### Modifications : 
- [x] removed `-Wl,--enable-new-dtags` from wrappers
- [x] reworked `filter_compilers` in `openmpi/package.py`
- [x] turned `os.environ` into `env` and `os.path.join` into `join_path`

##### Details
I noticed that all the MPI wrappers set `RUNPATH` instead of `RPATH` due to `-Wl,--enable-new-dtags` being present in the wrappers.  This PR filter that flag out of wrappers so that `RPATH` is set correctly.

##### Example
On our clusters : 
```
$ spack load mvapich2
$ mpicc -Wall -Werror main.c
$ objdump -p a.out 

a.out:     file format elf64-x86-64

Program Header:
    PHDR off    0x0000000000000040 vaddr 0x0000000000400040 paddr 0x0000000000400040 align 2**3
         filesz 0x00000000000001c0 memsz 0x00000000000001c0 flags r-x
  INTERP off    0x0000000000000200 vaddr 0x0000000000400200 paddr 0x0000000000400200 align 2**0
         filesz 0x000000000000001c memsz 0x000000000000001c flags r--
    LOAD off    0x0000000000000000 vaddr 0x0000000000400000 paddr 0x0000000000400000 align 2**21
         filesz 0x0000000000000c5c memsz 0x0000000000000c5c flags r-x
    LOAD off    0x0000000000000c60 vaddr 0x0000000000600c60 paddr 0x0000000000600c60 align 2**21
         filesz 0x0000000000000290 memsz 0x0000000000000298 flags rw-
 DYNAMIC off    0x0000000000000c78 vaddr 0x0000000000600c78 paddr 0x0000000000600c78 align 2**3
         filesz 0x0000000000000200 memsz 0x0000000000000200 flags rw-
    NOTE off    0x000000000000021c vaddr 0x000000000040021c paddr 0x000000000040021c align 2**2
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
EH_FRAME off    0x0000000000000b8c vaddr 0x0000000000400b8c paddr 0x0000000000400b8c align 2**2
         filesz 0x000000000000002c memsz 0x000000000000002c flags r--
   STACK off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**4
         filesz 0x0000000000000000 memsz 0x0000000000000000 flags rw-

Dynamic Section:
  NEEDED               libmpi.so.12
  NEEDED               libpmi2.so.0
  NEEDED               libc.so.6
  RUNPATH              /ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/lib:/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/lib64:/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib
  INIT                 0x0000000000400830
  FINI                 0x0000000000400b6c
  INIT_ARRAY           0x0000000000600c60
  INIT_ARRAYSZ         0x0000000000000008
  FINI_ARRAY           0x0000000000600c68
  FINI_ARRAYSZ         0x0000000000000008
  HASH                 0x0000000000400240
  STRTAB               0x00000000004004a0
  SYMTAB               0x00000000004002d8
  STRSZ                0x0000000000000258
  SYMENT               0x0000000000000018
  DEBUG                0x0000000000000000
  PLTGOT               0x0000000000600e80
  PLTRELSZ             0x00000000000000d8
  PLTREL               0x0000000000000007
  JMPREL               0x0000000000400758
  RELA                 0x0000000000400740
  RELASZ               0x0000000000000018
  RELAENT              0x0000000000000018
  VERNEED              0x0000000000400720
  VERNEEDNUM           0x0000000000000001
  VERSYM               0x00000000004006f8

Version References:
  required from libc.so.6:
    0x09691a75 0x00 02 GLIBC_2.2.5

$ mpicc -show
/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/bin/gcc -I/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/include -L/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib -Wl,-rpath -Wl,/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib -Wl,--enable-new-dtags -lmpi -lpmi2

$ /ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/bin/gcc -I/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/include -L/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib -Wl,-rpath -Wl,/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib  -lmpi -lpmi2 main.c

$ objdump -p a.out 

a.out:     file format elf64-x86-64

Program Header:
    PHDR off    0x0000000000000040 vaddr 0x0000000000400040 paddr 0x0000000000400040 align 2**3
         filesz 0x00000000000001c0 memsz 0x00000000000001c0 flags r-x
  INTERP off    0x0000000000000200 vaddr 0x0000000000400200 paddr 0x0000000000400200 align 2**0
         filesz 0x000000000000001c memsz 0x000000000000001c flags r--
    LOAD off    0x0000000000000000 vaddr 0x0000000000400000 paddr 0x0000000000400000 align 2**21
         filesz 0x0000000000000c5c memsz 0x0000000000000c5c flags r-x
    LOAD off    0x0000000000000c60 vaddr 0x0000000000600c60 paddr 0x0000000000600c60 align 2**21
         filesz 0x0000000000000290 memsz 0x0000000000000298 flags rw-
 DYNAMIC off    0x0000000000000c78 vaddr 0x0000000000600c78 paddr 0x0000000000600c78 align 2**3
         filesz 0x0000000000000200 memsz 0x0000000000000200 flags rw-
    NOTE off    0x000000000000021c vaddr 0x000000000040021c paddr 0x000000000040021c align 2**2
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
EH_FRAME off    0x0000000000000b8c vaddr 0x0000000000400b8c paddr 0x0000000000400b8c align 2**2
         filesz 0x000000000000002c memsz 0x000000000000002c flags r--
   STACK off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**4
         filesz 0x0000000000000000 memsz 0x0000000000000000 flags rw-

Dynamic Section:
  NEEDED               libmpi.so.12
  NEEDED               libpmi2.so.0
  NEEDED               libc.so.6
  RPATH                /ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/lib:/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-4.4.7/gcc-5.3.0-eljjnfv6gzibirz5sorgas3bp5okusae/lib64:/ssoft/spack/develop/opt/spack/x86_E5v2_IntelIB/gcc-5.3.0/mvapich2-2.2b-6qz3ze5ipeoe5hq2k7spe37scey6uoxf/lib
  INIT                 0x0000000000400830
  FINI                 0x0000000000400b6c
  INIT_ARRAY           0x0000000000600c60
  INIT_ARRAYSZ         0x0000000000000008
  FINI_ARRAY           0x0000000000600c68
  FINI_ARRAYSZ         0x0000000000000008
  HASH                 0x0000000000400240
  STRTAB               0x00000000004004a0
  SYMTAB               0x00000000004002d8
  STRSZ                0x0000000000000258
  SYMENT               0x0000000000000018
  DEBUG                0x0000000000000000
  PLTGOT               0x0000000000600e80
  PLTRELSZ             0x00000000000000d8
  PLTREL               0x0000000000000007
  JMPREL               0x0000000000400758
  RELA                 0x0000000000400740
  RELASZ               0x0000000000000018
  RELAENT              0x0000000000000018
  VERNEED              0x0000000000400720
  VERNEEDNUM           0x0000000000000001
  VERSYM               0x00000000004006f8

Version References:
  required from libc.so.6:
    0x09691a75 0x00 02 GLIBC_2.2.5

```
