### PR TITLE
reindex: preserve 'explicit' flags

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -309,7 +309,11 @@ class Database(object):
                 for spec in directory_layout.all_specs():
                     # Create a spec for each known package and add it.
                     path = directory_layout.path_for_spec(spec)
-                    self._add(spec, path, directory_layout)
+                    old_info = old_data.get(spec.dag_hash())
+                    explicit = False
+                    if old_info is not None:
+                        explicit = old_info.explicit
+                    self._add(spec, path, directory_layout, explicit=explicit)
 
                 self._check_ref_counts()
 


### PR DESCRIPTION
Look up in the old database whether the spec was explicit or not and
preserve it into the new database.

Fixes #1050.

---
Cc: @alalazo 