### PR TITLE
 Cray XK7 support with multiple Target modules.

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -78,6 +78,7 @@ will be responsible for compiler detection.
 import os
 import imp
 import inspect
+import types
 
 from llnl.util.lang import memoized, list_modules, key_ordering
 from llnl.util.filesystem import join_path
@@ -108,19 +109,25 @@ class Target(object):
     """ Target is the processor of the host machine.
         The host machine may have different front-end and back-end targets,
         especially if it is a Cray machine. The target will have a name and
-        also the module_name (e.g craype-compiler). Targets will also
+        also a module or list of modules (e.g craype-compiler). Targets will also
         recognize which platform they came from using the set_platform method.
         Targets will have compiler finding strategies
     """
 
-    def __init__(self, name, module_name=None):
+    def __init__(self, name, modules=None):
         self.name = name  # case of cray "ivybridge" but if it's x86_64
-        self.module_name = module_name  # craype-ivybridge
+
+        if modules is None:
+            self.modules = modules
+        elif isinstance(modules, types.StringTypes):
+            self.modules = set((modules, ))
+        else:
+            self.modules = set(modules)
 
     # Sets only the platform name to avoid recursiveness
 
     def _cmp_key(self):
-        return (self.name, self.module_name)
+        return (self.name, self.modules)
 
     def __repr__(self):
         return self.__str__()
@@ -150,16 +157,16 @@ class Platform(object):
         self.operating_sys = {}
         self.name = name
 
-    def add_target(self, name, target):
+    def add_target(self, target):
         """Used by the platform specific subclass to list available targets.
         Raises an error if the platform specifies a name
         that is reserved by spack as an alias.
         """
-        if name in ['frontend', 'fe', 'backend', 'be', 'default_target']:
+        if target.name in ['frontend', 'fe', 'backend', 'be', 'default_target']:
             raise ValueError(
                 "%s is a spack reserved alias "
                 "and cannot be the name of a target" % name)
-        self.targets[name] = target
+        self.targets[target.name] = target
 
     def target(self, name):
         """This is a getter method for the target dictionary

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -280,8 +280,9 @@ def set_build_environment_variables(pkg, env):
                 #pkg_config_dirs.append(pcdir)
                 env.prepend_path('PKG_CONFIG_PATH',pcdir)
 
-    if pkg.spec.architecture.target.module_name:
-        load_module(pkg.spec.architecture.target.module_name)
+    if pkg.spec.architecture.target.modules:
+        for module in pkg.spec.architecture.target.modules:
+            load_module(module)
 
     return env
 

--- a/lib/spack/spack/platforms/bgq.py
+++ b/lib/spack/spack/platforms/bgq.py
@@ -9,8 +9,8 @@ class Bgq(Platform):
 
     def __init__(self):
         super(Bgq, self).__init__('bgq')
-        self.add_target(self.front_end, Target(self.front_end))
-        self.add_target(self.back_end, Target(self.back_end,))
+        self.add_target(Target(self.front_end))
+        self.add_target(Target(self.back_end,))
 
     @classmethod
     def detect(self):

--- a/lib/spack/spack/platforms/cray_xc.py
+++ b/lib/spack/spack/platforms/cray_xc.py
@@ -31,11 +31,9 @@ class CrayXc(Platform):
 
         # Could switch to use modules and fe targets for front end
         # Currently using compilers by path for front end.
-        self.add_target('sandybridge', Target('sandybridge'))
-        self.add_target('ivybridge', 
-                        Target('ivybridge', 'craype-ivybridge'))
-        self.add_target('haswell', 
-                        Target('haswell','craype-haswell'))         
+        self.add_target(Target('sandybridge'))
+        self.add_target(Target('ivybridge', 'craype-ivybridge'))
+        self.add_target(Target('haswell','craype-haswell'))         
 
         self.add_operating_system('SuSE11', LinuxDistro())
         self.add_operating_system('CNL10', Cnl())

--- a/lib/spack/spack/platforms/cray_xk.py
+++ b/lib/spack/spack/platforms/cray_xk.py
@@ -3,11 +3,11 @@ from spack.architecture import Platform, Target
 from spack.operating_systems.linux_distro import LinuxDistro
 from spack.operating_systems.cnl import Cnl
 
-class CrayXc(Platform):
+class CrayXk(Platform):
     priority    = 20
-    front_end   = 'sandybridge'
-    back_end    = 'ivybridge'
-    default     = 'ivybridge'
+    front_end   = 'istanbul'
+    back_end    = 'interlagos'
+    default     = 'interlagos'
 
     front_os    = "SuSE11"
     back_os     = "CNL10"
@@ -18,29 +18,22 @@ class CrayXc(Platform):
             if we use CRAY_CPU_TARGET as the default. This will ensure
             that if we're on a XC-40 or XC-30 then we can detect the target
         '''
-        super(CrayXc, self).__init__('cray_xc')
+        super(CrayXk, self).__init__('cray_xk')
 
         # Handle the default here so we can check for a key error
         if 'CRAY_CPU_TARGET' in os.environ:
             self.default = os.environ['CRAY_CPU_TARGET']
 
-        # Change the defaults to haswell if we're on an XC40
-        if self.default == 'haswell':
-            self.front_end = self.default
-            self.back_end = self.default
-
         # Could switch to use modules and fe targets for front end
         # Currently using compilers by path for front end.
-        self.add_target('sandybridge', Target('sandybridge'))
-        self.add_target('ivybridge', 
-                        Target('ivybridge', 'craype-ivybridge'))
-        self.add_target('haswell', 
-                        Target('haswell','craype-haswell'))         
+        self.add_target('istanbul', Target('istanbul', 'craype-mc8'))
+        self.add_target('interlagos', 
+                        Target('interlagos', 'craype-interlagos'))
 
         self.add_operating_system('SuSE11', LinuxDistro())
         self.add_operating_system('CNL10', Cnl())
 
     @classmethod
     def detect(self):
-        return 'cray-xc' in os.environ.get('SPACK_PLATFORM', '')
+        return 'cray-xk' in os.environ.get('SPACK_PLATFORM', '')
 

--- a/lib/spack/spack/platforms/cray_xk.py
+++ b/lib/spack/spack/platforms/cray_xk.py
@@ -14,9 +14,8 @@ class CrayXk(Platform):
     default_os  = "CNL10" 
 
     def __init__(self):
-        ''' Since cori doesn't have ivybridge as a front end it's better
-            if we use CRAY_CPU_TARGET as the default. This will ensure
-            that if we're on a XC-40 or XC-30 then we can detect the target
+        ''' Create a Cray XK system platform using CRAY_CPU_TARGET as the
+        default. 
         '''
         super(CrayXk, self).__init__('cray_xk')
 
@@ -26,9 +25,10 @@ class CrayXk(Platform):
 
         # Could switch to use modules and fe targets for front end
         # Currently using compilers by path for front end.
-        self.add_target('istanbul', Target('istanbul', 'craype-mc8'))
-        self.add_target('interlagos', 
-                        Target('interlagos', 'craype-interlagos'))
+        self.add_target(Target('istanbul', {'craype-mc8', 'dynamic-link'}))
+        self.add_target(Target('interlagos', 'craype-interlagos'))
+        self.add_target(Target('interlagos_dynamic',
+                               {'craype-interlagos', 'dynamic-link'}))
 
         self.add_operating_system('SuSE11', LinuxDistro())
         self.add_operating_system('CNL10', Cnl())

--- a/lib/spack/spack/platforms/cray_xk.py
+++ b/lib/spack/spack/platforms/cray_xk.py
@@ -25,10 +25,10 @@ class CrayXk(Platform):
 
         # Could switch to use modules and fe targets for front end
         # Currently using compilers by path for front end.
-        self.add_target(Target('istanbul', {'craype-mc8', 'dynamic-link'}))
+        self.add_target(Target('istanbul', set(('craype-mc8', 'dynamic-link'))))
         self.add_target(Target('interlagos', 'craype-interlagos'))
         self.add_target(Target('interlagos_dynamic',
-                               {'craype-interlagos', 'dynamic-link'}))
+                               set(('craype-interlagos', 'dynamic-link'))))
 
         self.add_operating_system('SuSE11', LinuxDistro())
         self.add_operating_system('CNL10', Cnl())

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -10,9 +10,10 @@ class Darwin(Platform):
 
     def __init__(self):
         super(Darwin, self).__init__('darwin')
-        self.add_target(self.default, Target(self.default))
-        mac_os = MacOs()
 
+        self.add_target(Target(self.default))
+        mac_os = MacOs()
+        
         self.default_os = str(mac_os)
         self.front_os   = str(mac_os)
         self.back_os    = str(mac_os)

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -10,7 +10,7 @@ class Linux(Platform):
 
     def __init__(self):
         super(Linux, self).__init__('linux')
-        self.add_target(self.default, Target(self.default))
+        self.add_target(Target(self.default))
         linux_dist = LinuxDistro()
         self.default_os = str(linux_dist)
         self.front_os = self.default_os

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -15,8 +15,8 @@ class Test(Platform):
 
     def __init__(self):
         super(Test, self).__init__('test')
-        self.add_target(self.default, Target(self.default))
-        self.add_target(self.front_end, Target(self.front_end))
+        self.add_target(Target(self.default))
+        self.add_target(Target(self.front_end))
 
         self.add_operating_system(self.default_os, Cnl())
         linux_dist = LinuxDistro()


### PR DESCRIPTION
This pull request:

1. Adds a platform for Cray XK7 which changes `Platform.detect` for Cray systems to use an environment variable as opposed to the existence of the path `/opt/cray/craype` which is not platform-unique.

1. Allows `Target`s to specify multiple environment modules so that Cray compiler wrapper options (linking style, target architecture, etc) can be modified when using the Cray compiler wrapper to target service nodes vs compute nodes.