### PR TITLE
Allow py-pillow to link to Spack-built libraries

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -23,77 +23,113 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
+
 
 class PyPillow(Package):
-    """Pillow is the friendly PIL fork by Alex Clark and Contributors. PIL is the Python Imaging Library by Fredrik Lundh and Contributors. The Python Imaging Library (PIL) adds image processing capabilities to your Python interpreter. This library supports many file formats, and provides powerful image processing and graphics capabilities."""
+    """Pillow is a fork of the Python Imaging Library (PIL). It adds image
+    processing capabilities to your Python interpreter. This library supports
+    many file formats, and provides powerful image processing and graphics
+    capabilities."""
 
-    homepage = "https://python-pillow.github.io/"
+    homepage = "https://python-pillow.org/"
     url      = "https://pypi.python.org/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
 
+    version('3.2.0', '7cfd093c11205d9e2ebe3c51dfcad510')
     version('3.0.0', 'fc8ac44e93da09678eac7e30c9b7377d')
-    provides('PIL')
 
     # These defaults correspond to Pillow defaults
-    variant('jpeg', default=True, description='Provide JPEG functionality')
-    variant('zlib', default=True, description='Access to compressed PNGs')
-    variant('tiff', default=False, description='Access to TIFF files')
+    variant('jpeg',     default=True,  description='Provide JPEG functionality')
+    variant('zlib',     default=True,  description='Access to compressed PNGs')
+    variant('tiff',     default=False, description='Access to TIFF files')
     variant('freetype', default=False, description='Font related services')
-    variant('tk', default=False, description='Support for tkinter bitmap and photo images')
-    variant('lcms', default=False, description='Color management')
+    variant('lcms',     default=False, description='Color management')
+    variant('tk',       default=False, description='Support for tkinter bitmap and photo images')
+    variant('jpeg2000', default=False, description='Provide JPEG 2000 functionality')
 
     # Spack does not (yet) support these modes of building
-    # variant('webp', default=False, description='')
-    # variant('webpmux', default=False, description='')
-    # variant('jpeg2000', default=False, description='')
+    # variant('webp',       default=False, description='Provide the WebP format')
+    # variant('webpmux',    default=False, description='WebP metadata, relies on WebP support')
+    # variant('imagequant', default=False, description='Provide improved color quantization')
 
+    provides('PIL')
+
+    # Required dependencies
     extends('python')
-    depends_on('binutils')
     depends_on('py-setuptools')
 
-    depends_on('jpeg', when='+jpeg')   # BUG: It will use the system libjpeg anyway
+    # Recommended dependencies
+    depends_on('jpeg', when='+jpeg')
     depends_on('zlib', when='+zlib')
-    depends_on('tiff', when='+tiff')
-    depends_on('freetype', when='+freetype')
-    depends_on('lcms', when='+lcms')
-    depends_on('tcl', when='+tk')
-    depends_on('tk', when='+tk')
 
-    def install(self, spec, prefix):
-        libpath=[]
+    # Optional dependencies
+    depends_on('libtiff',  when='+tiff')
+    depends_on('freetype', when='+freetype')
+    depends_on('lcms',     when='+lcms')
+    depends_on('tcl',      when='+tk')
+    depends_on('tk',       when='+tk')
+    depends_on('openjpeg', when='+jpeg2000')
+
+    # Spack does not (yet) support these modes of building
+    # depends_on('webp',       when='+webp')
+    # depends_on('webpmux',    when='+webpmux')
+    # depends_on('imagequant', when='+imagequant')
+
+    def patch(self):
+        """Patch setup.py to provide lib and include directories
+        for dependencies."""
+
+        spec = self.spec
+        setup = FileFilter('setup.py')
 
         if '+jpeg' in spec:
-            libpath.append(join_path(spec['jpeg'].prefix, 'lib'))
+            setup.filter('JPEG_ROOT = None',
+                         'JPEG_ROOT = ("{0}", "{1}")'.format(
+                            spec['jpeg'].prefix.lib,
+                            spec['jpeg'].prefix.include))
         if '+zlib' in spec:
-            libpath.append(join_path(spec['zlib'].prefix, 'lib'))
+            setup.filter('ZLIB_ROOT = None',
+                         'ZLIB_ROOT = ("{0}", "{1}")'.format(
+                            spec['zlib'].prefix.lib,
+                            spec['zlib'].prefix.include))
         if '+tiff' in spec:
-            libpath.append(join_path(spec['tiff'].prefix, 'lib'))
+            setup.filter('TIFF_ROOT = None',
+                         'TIFF_ROOT = ("{0}", "{1}")'.format(
+                            spec['libtiff'].prefix.lib,
+                            spec['libtiff'].prefix.include))
         if '+freetype' in spec:
-            libpath.append(join_path(spec['freetype'].prefix, 'lib'))
+            setup.filter('FREETYPE_ROOT = None',
+                         'FREETYPE_ROOT = ("{0}", "{1}")'.format(
+                            spec['freetype'].prefix.lib,
+                            spec['freetype'].prefix.include))
         if '+lcms' in spec:
-            libpath.append(join_path(spec['lcms'].prefix, 'lib'))
+            setup.filter('LCMS_ROOT = None',
+                         'LCMS_ROOT = ("{0}", "{1}")'.format(
+                            spec['lcms'].prefix.lib,
+                            spec['lcms'].prefix.include))
+        if '+tk' in spec:
+            setup.filter('TCL_ROOT = None',
+                         'TCL_ROOT = ("{0}", "{1}")'.format(
+                            spec['tcl'].prefix.lib,
+                            spec['tcl'].prefix.include))
+        if '+jpeg2000' in spec:
+            setup.filter('JPEG2K_ROOT = None',
+                         'JPEG2K_ROOT = ("{0}", "{1}")'.format(
+                            spec['openjpeg'].prefix.lib,
+                            spec['openjpeg'].prefix.include))
 
-        # This has not been tested, and likely needs some other treatment.
-        #if '+tk' in spec:
-        #    libpath.append(join_path(spec['tcl'].prefix, 'lib'))
-        #    libpath.append(join_path(spec['tk'].prefix, 'lib'))
+    def install(self, spec, prefix):
+        build_args = [
+            '--{0}-jpeg'.format('enable' if '+jpeg' in spec else 'disable'),
+            '--{0}-zlib'.format('enable' if '+zlib' in spec else 'disable'),
+            '--{0}-tiff'.format('enable' if '+tiff' in spec else 'disable'),
+            '--{0}-freetype'.format(
+                'enable' if '+freetype' in spec else 'disable'),
+            '--{0}-lcms'.format('enable' if '+lcms' in spec else 'disable'),
+            '--{0}-tk'.format('enable' if '+tk' in spec else 'disable'),
+            '--{0}-tcl'.format('enable' if '+tk' in spec else 'disable'),
+            '--{0}-jpeg2000'.format(
+                'enable' if '+jpeg2000' in spec else 'disable')
+        ]
 
-        # -------- Building
-        cmd = ['build_ext',
-            '--%s-jpeg' % ('enable' if '+jpeg' in spec else 'disable'),
-            '--%s-zlib' % ('enable' if '+zlib' in spec else 'disable'),
-            '--%s-tiff' % ('enable' if '+tiff' in spec else 'disable'),
-            '--%s-freetype' % ('enable' if '+freetype' in spec else 'disable'),
-            '--%s-lcms' % ('enable' if '+lcms' in spec else 'disable'),
-            '-L'+':'.join(libpath)    # NOTE: This does not make it find libjpeg
-            ]
-
-        #if '+tk' in spec:
-        #    cmd.extend(['--enable-tcl', '--enable-tk'])
-        #else:
-        #    cmd.extend(['--disable-tcl', '--disable-tk'])
-
-        # --------- Installation
-        cmd.extend(['install', '--prefix=%s' % prefix])
-
-        python('setup.py', *cmd)
+        python('setup.py', 'build_ext', *build_args)
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))


### PR DESCRIPTION
Previously, py-pillow linked to the system libraries instead of the Spack-built libraries. This PR fixes that.

Note that this solution is actually [recommended by the developers](https://pillow.readthedocs.io/en/latest/installation.html#external-libraries):
> If the prerequisites are installed in the standard library locations for your machine (e.g. `/usr` or `/usr/local`), no additional configuration should be required. If they are installed in a non-standard location, you may need to configure setuptools to use those locations by editing `setup.py` or `setup.cfg`, or by adding environment variables on the command line:
>
> ```$ CFLAGS="-I/usr/pkg/include" pip install pillow```

I actually tried using environment variables but to no avail. Hacking `setup.py` is also the [solution that Homebrew uses](https://github.com/Homebrew/homebrew-python/blob/master/pillow.rb).

@citibeth: You were the last person to edit py-pillow. Can you confirm that this solution works for you?

Note that I'm still having trouble getting it to link to Tcl/Tk. Any solutions are welcome.