### PR TITLE
require fortran compilers for Openblas and Openmpi

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -48,6 +48,13 @@ class Openblas(Package):
     patch('make.patch')
 
     def install(self, spec, prefix):
+        # As of 06/2016 there is no mechanism to specify that packages which
+        # depends on Blas/Lapack need C or/and Fortran symbols. For now
+        # require both.
+        if self.compiler.f77 is None:
+            raise InstallError('OpenBLAS requires both C and Fortran ',
+                               'compilers!')
+
         # Configure fails to pick up fortran from FC=/abs/path/to/f77, but
         # works fine with FC=/abs/path/to/gfortran.
         # When mixing compilers make sure that

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -121,6 +121,13 @@ class Openmpi(Package):
             return 'verbs'
 
     def install(self, spec, prefix):
+        # As of 06/2016 there is no mechanism to specify that packages which
+        # depends on MPI need C or/and Fortran implementation. For now
+        # require both.
+        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+            raise InstallError('OpenMPI requires both C and Fortran ',
+                               'compilers!')
+
         config_args = ["--prefix=%s" % prefix,
                        "--with-hwloc=%s" % spec['hwloc'].prefix,
                        "--enable-shared",


### PR DESCRIPTION
this is meant to prevent delayed compiler errors for packages which need MPI/Blas/Lapack with Fortran whereas specific implementations are build without Fortran.

At some point one would need to add an option `+fortran` for virtual packages (mpi, blas, lapack) and propagate it to particular implementations (`openmpi`, `openblas`, `mpich`, etc). Then ifs will change to `if (self.compiler.f77 is None) and ('+fortran' in spec):`. In other words, one would still need those ifs to throw an error.

