### PR TITLE
modules.yaml: use the right envvar for pkg-config

### DIFF
--- a/etc/spack/modules.yaml
+++ b/etc/spack/modules.yaml
@@ -22,8 +22,8 @@ modules:
     include:
       - CPATH
     lib/pkgconfig:
-      - PKGCONFIG
+      - PKG_CONFIG_PATH
     lib64/pkgconfig:
-      - PKGCONFIG
+      - PKG_CONFIG_PATH
     '':
       - CMAKE_PREFIX_PATH


### PR DESCRIPTION
Fixes #1072.

---
@eschnett 