### PR TITLE
Add MPI environment variables to packages

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -50,6 +50,11 @@ class Mpich(Package):
     provides('mpi@:1.3', when='@1:')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
+        spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
+        spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+        spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+
         spack_env.set('MPICH_CC', spack_cc)
         spack_env.set('MPICH_CXX', spack_cxx)
         spack_env.set('MPICH_F77', spack_f77)

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -191,6 +191,11 @@ class Mvapich2(Package):
             run_env.set('SLURM_MPI_TYPE', 'pmi2')
 
     def setup_dependent_environment(self, spack_env, run_env, extension_spec):
+        spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
+        spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx'))
+        spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+        spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+
         spack_env.set('MPICH_CC', spack_cc)
         spack_env.set('MPICH_CXX', spack_cxx)
         spack_env.set('MPICH_F77', spack_f77)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -109,6 +109,11 @@ class Openmpi(Package):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (version.up_to(2), version)  # NOQA: ignore=E501
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
+        spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
+        spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+        spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+
         spack_env.set('OMPI_CC', spack_cc)
         spack_env.set('OMPI_CXX', spack_cxx)
         spack_env.set('OMPI_FC', spack_fc)


### PR DESCRIPTION
This PR solves #991, thanks to the brilliant @alalazo! `parallel-netcdf` wouldn't build for me with Intel and OpenMPI without these environment variables set. It's probably a good idea to have them in all MPI packages.