### PR TITLE
[WIP] Add preliminary support for libc & dynamic-linking

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -311,7 +311,7 @@ if [[ -n "$SPACK_DYNAMIC_LINKER" && -e "$SPACK_DYNAMIC_LINKER" ]]; then
     dynamic_linker_dir="$(dirname $SPACK_DYNAMIC_LINKER)"
     if [[ $mode == ccld ]]; then
         $add_rpaths && args=("$dynamic_linker$SPACK_DYNAMIC_LINKER" "${args[@]}")
-        $add_rpaths && args=("-Wl,-rpath=$dynamic_linker_dir" "${args[@]}")
+        $add_rpaths && args=("$rpath$dynamic_linker_dir" "${args[@]}")
     elif [[ $mode == ld ]]; then
         $add_rpaths && args=("--dynamic-linker" "$SPACK_DYNAMIC_LINKER" "${args[@]}")
         $add_rpaths && args=("-rpath" "$dynamic_linker_dir" "${args[@]}")

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -50,6 +50,7 @@ parameters=(
     SPACK_CXX_RPATH_ARG
     SPACK_F77_RPATH_ARG
     SPACK_FC_RPATH_ARG
+    SPACK_CC_DYNAMIC_LINKER_ARG
     SPACK_SHORT_SPEC
 )
 
@@ -161,6 +162,9 @@ fi
 
 # Set up rpath variable according to language.
 eval rpath=\$SPACK_${comp}_RPATH_ARG
+
+# Set up dynamic linker variable according to language.
+eval dynamic_linker=\$SPACK_${comp}_DYNAMIC_LINKER_ARG
 
 # Dump the version and exit if we're in testing mode.
 if [[ $SPACK_TEST_COMMAND == dump-mode ]]; then
@@ -284,6 +288,7 @@ for dep in "${deps[@]}"; do
             args=("-L$dep/lib64" "${args[@]}")
         fi
     fi
+
 done
 
 # Include all -L's and prefix/whatever dirs in rpath
@@ -300,6 +305,18 @@ case "$mode" in
     ld|ccld)
         args=("${args[@]}" ${SPACK_LDLIBS[@]}) ;;
 esac
+
+# Prepend SPACK_DYNAMIC_LINKER & add it's directory to rpath
+if [[ -n "$SPACK_DYNAMIC_LINKER" && -e "$SPACK_DYNAMIC_LINKER" ]]; then
+    dynamic_linker_dir="$(dirname $SPACK_DYNAMIC_LINKER)"
+    if [[ $mode == ccld ]]; then
+        $add_rpaths && args=("$dynamic_linker$SPACK_DYNAMIC_LINKER" "${args[@]}")
+        $add_rpaths && args=("-Wl,-rpath=$dynamic_linker_dir" "${args[@]}")
+    elif [[ $mode == ld ]]; then
+        $add_rpaths && args=("--dynamic-linker" "$SPACK_DYNAMIC_LINKER" "${args[@]}")
+        $add_rpaths && args=("-rpath" "$dynamic_linker_dir" "${args[@]}")
+    fi
+fi
 
 #
 # Unset pesky environment variables that could affect build sanity.

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -108,6 +108,12 @@ class Compiler(object):
     @property
     def fc_rpath_arg(self):
         return '-Wl,-rpath,'
+
+    # Default flags used by a compiler to set the dynamic linker
+    @property
+    def cc_dynamic_linker_arg(self):
+        return '-Wl,--dynamic-linker='
+
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv = None
     # Name of module used to switch versions of this compiler

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -317,6 +317,10 @@ class Package(object):
        directories, sanity checks will fail.
     """
     sanity_check_is_dir = []
+    """Path to the  dynamic-linker that should be used when building
+       dependents of this package.
+    """
+    dynamic_linker = None
 
     def __init__(self, spec):
         # this determines how the package should be built.


### PR DESCRIPTION
Despite it adding the appropriate flags to the command, I can't seem to get this to work when compiling python 2.7.11 on our cluster even though I got it working manually (without spack) with a very similar method. Can anyone else get it to work./know what might be the issue?

```
...
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for --enable-universalsdk... no
checking for --with-universal-archs... 32-bit
checking MACHDEP... linux2
checking EXTRAPLATDIR... 
checking for --without-gcc... no
checking for gcc... $SPACK_ROOT/lib/spack/env/gcc/gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... configure: error: in `/tmp/$USER/spack-stage/spack-stage-zA2Itz/Python-2.7.11':
configure: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
See `config.log' for more details
```

and here is the debug dump from the `cc` compiler wrapper:

```
[ccld] /apps/gcc/5.3.0/bin/gcc -Wl,-rpath=$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/glibc-2.17-trpcxsgryqgtsqbp5mvspmibcxyjfg57/lib -Wl,--dynamic-linker=$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/glibc-2.17-trpcxsgryqgtsqbp5mvspmibcxyjfg57/lib/ld-linux-x86-64.so.2 -nostdinc -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/glibc-2.17-trpcxsgryqgtsqbp5mvspmibcxyjfg57/lib -L/apps/gcc/5.3.0/lib64 -Wl,-rpath,/apps/gcc/5.3.0/lib64 -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/python-2.7.11-6usjtxyhy7qecbewxfmjnjeguqffrpme/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/python-2.7.11-6usjtxyhy7qecbewxfmjnjeguqffrpme/lib64 -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/sqlite-3.8.5-qspfldeculrro7tekx7g4ezxrchf6pl7/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/sqlite-3.8.5-qspfldeculrro7tekx7g4ezxrchf6pl7/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/sqlite-3.8.5-qspfldeculrro7tekx7g4ezxrchf6pl7/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/readline-6.3-voguswurxi45eq7siehym4uxhsgfot3u/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/readline-6.3-voguswurxi45eq7siehym4uxhsgfot3u/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/readline-6.3-voguswurxi45eq7siehym4uxhsgfot3u/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/zlib-1.2.8-4smfllshblurbkwmozx7l6sgyz2nmtth/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/zlib-1.2.8-4smfllshblurbkwmozx7l6sgyz2nmtth/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/zlib-1.2.8-4smfllshblurbkwmozx7l6sgyz2nmtth/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/openssl-1.0.2h-zz2clu4raqeao4sy62a65w3xvigyfpxp/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/openssl-1.0.2h-zz2clu4raqeao4sy62a65w3xvigyfpxp/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/openssl-1.0.2h-zz2clu4raqeao4sy62a65w3xvigyfpxp/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/ncurses-6.0-avvusf6rjwxrgvqmkcyxwox4vqj5glzc/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/ncurses-6.0-avvusf6rjwxrgvqmkcyxwox4vqj5glzc/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/ncurses-6.0-avvusf6rjwxrgvqmkcyxwox4vqj5glzc/include -L/usr/lib64 -Wl,-rpath,/usr/lib64 -L/usr/lib -Wl,-rpath,/usr/lib -I/usr/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/bzip2-1.0.6-3njle5iq35prjqqyj7yxxs3pxbhn3d4r/lib -Wl,-rpath,$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/bzip2-1.0.6-3njle5iq35prjqqyj7yxxs3pxbhn3d4r/lib -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/bzip2-1.0.6-3njle5iq35prjqqyj7yxxs3pxbhn3d4r/include -o conftest -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/openssl-1.0.2h-zz2clu4raqeao4sy62a65w3xvigyfpxp/include -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/bzip2-1.0.6-3njle5iq35prjqqyj7yxxs3pxbhn3d4r/include -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/readline-6.3-voguswurxi45eq7siehym4uxhsgfot3u/include -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/ncurses-6.0-avvusf6rjwxrgvqmkcyxwox4vqj5glzc/include -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/sqlite-3.8.5-qspfldeculrro7tekx7g4ezxrchf6pl7/include -I$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/zlib-1.2.8-4smfllshblurbkwmozx7l6sgyz2nmtth/include -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/openssl-1.0.2h-zz2clu4raqeao4sy62a65w3xvigyfpxp/lib -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/bzip2-1.0.6-3njle5iq35prjqqyj7yxxs3pxbhn3d4r/lib -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/readline-6.3-voguswurxi45eq7siehym4uxhsgfot3u/lib -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/ncurses-6.0-avvusf6rjwxrgvqmkcyxwox4vqj5glzc/lib -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/sqlite-3.8.5-qspfldeculrro7tekx7g4ezxrchf6pl7/lib -L$SPACK_ROOT/opt/spack/linux-redhat6-x86_64/gcc-5.3.0/zlib-1.2.8-4smfllshblurbkwmozx7l6sgyz2nmtth/lib conftest.c
```

Also this PR only attempts to add support for ELF... I would have to read up more on how macOS does it... I did try to guard against setting the dynamic-linker on macOS but it probably needs a little more on that front.
