### PR TITLE
Octave extensions

### DIFF
--- a/var/spack/repos/builtin/packages/octave-splines/package.py
+++ b/var/spack/repos/builtin/packages/octave-splines/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class OctaveSplines(Package):
+    """Additional spline functions."""
+
+    homepage = "http://octave.sourceforge.net/splines/index.html"
+    url      = "http://downloads.sourceforge.net/octave/splines-1.3.1.tar.gz"
+
+    version('1.3.1', 'f9665d780c37aa6a6e17d1f424c49bdeedb89d1192319a4e39c08784122d18f9')
+
+    extends('octave@3.6.0:')
+
+    def install(self, spec, prefix):
+        Octave('--quiet',
+               '--norc',
+               '--built-in-docstrings-file=/dev/null',
+               '--texi-macros-file=/dev/null',
+               '--eval', 'pkg prefix %s; pkg install %s' %
+               (prefix, self.stage.archive_file))

--- a/var/spack/repos/builtin/packages/octave-splines/package.py
+++ b/var/spack/repos/builtin/packages/octave-splines/package.py
@@ -36,7 +36,7 @@ class OctaveSplines(Package):
     extends('octave@3.6.0:')
 
     def install(self, spec, prefix):
-        Octave('--quiet',
+        octave('--quiet',
                '--norc',
                '--built-in-docstrings-file=/dev/null',
                '--texi-macros-file=/dev/null',

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -36,6 +36,8 @@ class Octave(Package):
     homepage = "https://www.gnu.org/software/octave/"
     url      = "ftp://ftp.gnu.org/gnu/octave/octave-4.0.0.tar.gz"
 
+    extendable = True
+
     version('4.0.2', 'c2a5cacc6e4c52f924739cdf22c2c687')
     version('4.0.0', 'a69f8320a4f20a8480c1b278b1adb799')
 
@@ -212,3 +214,16 @@ class Octave(Package):
 
         make()
         make("install")
+
+    # ========================================================================
+    # Set up environment to make install easy for Octave extensions.
+    # ========================================================================
+
+    def setup_dependent_package(self, module, ext_spec):
+        """Called before Octave modules' install() methods.
+
+        In most cases, extensions will only need to have one line:
+            Octave('--eval', 'pkg install %s' % self.stage.archive_file)
+        """
+        # Octave extension builds can have a global Octave executable function
+        module.Octave = Executable(join_path(self.spec.prefix.bin, 'octave'))

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -223,7 +223,7 @@ class Octave(Package):
         """Called before Octave modules' install() methods.
 
         In most cases, extensions will only need to have one line:
-            Octave('--eval', 'pkg install %s' % self.stage.archive_file)
+            octave('--eval', 'pkg install %s' % self.stage.archive_file)
         """
         # Octave extension builds can have a global Octave executable function
-        module.Octave = Executable(join_path(self.spec.prefix.bin, 'octave'))
+        module.octave = Executable(join_path(self.spec.prefix.bin, 'octave'))


### PR DESCRIPTION
**UPDATE**: does install now, octave seems to pick up the installed package:
```
octave:1> pkg list
Package Name  | Version | Installation directory
--------------+---------+-----------------------
     specfun  |   1.1.0 | /Users/davydden/spack/opt/spack/darwin-elcapitan-x86_64/clang-7.3.0-apple/octave-specfun-1.1.0-z4jrho7a7tnkiflm4d6s373yzpavrj3h/specfun-1.1.0
     splines  |   1.2.7 | /Users/davydden/octave/splines-1.2.7
```

relevant documentation 
https://www.gnu.org/software/octave/doc/v4.0.1/Installing-and-Removing-Packages.html
https://www.gnu.org/software/octave/doc/v4.0.1/Command-Line-Options.html#Command-Line-Options

**TODO if possible**:
- [ ] on uninstallation i need to call `octave --eval pkg uninstall <name>`. Otherwise octave still consider the package to be installed.
 
---------
**outdated:**
I can install packages from Spack's env bash:
```
$ spack env octave-specfun bash
bash-3.2$ octave --texi-macros-file=/dev/null --eval "pkg install /Users/davydden/Downloads/specfun-1.1.0.tar.gz"
```
but i can't make it work from within Spack:
```
$ spack install octave-specfun
==> Installing octave-specfun
==> octave is already installed in /Users/davydden/spack/opt/spack/darwin-elcapitan-x86_64/clang-7.3.0-apple/octave-4.0.2-3odgkplg75v5myrzy3bgyme425p64l4j
==> Already downloaded /Users/davydden/spack/var/spack/stage/octave-specfun-1.1.0-z4jrho7a7tnkiflm4d6s373yzpavrj3h/specfun-1.1.0.tar.gz
==> Already staged octave-specfun-1.1.0-z4jrho7a7tnkiflm4d6s373yzpavrj3h in /Users/davydden/spack/var/spack/stage/octave-specfun-1.1.0-z4jrho7a7tnkiflm4d6s373yzpavrj3h
==> No patches needed for octave-specfun
==> Building octave-specfun
==> Error: Install failed for octave-specfun.  Nothing was installed!
==> Error: Installation process had nonzero exit code : 256
```
whereas from log you see that it did something
```
==> '/Users/davydden/spack/opt/spack/darwin-elcapitan-x86_64/clang-7.3.0-apple/octave-4.0.2-3odgkplg75v5myrzy3bgyme425p64l4j/bin/octave' '--quiet' '--norc' '--built-in-docstrings-file=/dev/null' '--texi-macros-file=/dev/null' '--eval' 'pkg install /Users/davydden/spack/var/spack/stage/octave-specfun-1.1.0-z4jrho7a7tnkiflm4d6s373yzpavrj3h/specfun-1.1.0.tar.gz'
mkoctfile: stripping disabled on this platform
clang: warning: argument unused during compilation: '-pthread'
warning: function /Users/davydden/octave/specfun-1.1.0/ellipke.m shadows a core library function
warning: function /Users/davydden/octave/specfun-1.1.0/erfcinv.m shadows a built-in function
warning: function /Users/davydden/octave/specfun-1.1.0/expint.m shadows a core library function
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-9OPCdN:13: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-9OPCdN:13: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-9OPCdN:13: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'Ci'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-WRdpHY:13: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-WRdpHY:13: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-WRdpHY:13: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'cosint'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-HeNvrN:6: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-HeNvrN:6: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-HeNvrN:6: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'dirac'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-cnbSxE:14: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-cnbSxE:14: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-cnbSxE:14: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'ellipke'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-FGVA9x:6: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-FGVA9x:6: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-FGVA9x:6: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'erfcinv'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-omRfau:13: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-omRfau:13: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-omRfau:13: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'expint'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XeOy1r:13: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XeOy1r:13: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XeOy1r:13: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'expint_E1'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-u0HNCs:13: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-u0HNCs:13: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-u0HNCs:13: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'expint_Ei'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XHmHqv:18: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XHmHqv:18: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-XHmHqv:18: Misplaced }.
warning: doc_cache_create: unusable help text found in file 'heaviside'
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-ai08hV:27: Unknown command `seealso'.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-ai08hV:27: Misplaced {.
/var/folders/5k/sqpp24tx3ylds4fgm13pfht00000gn/T/octave-help-ai08hV:27: Misplaced }.
warning: doc_cache_create:
```
and actually installed the package
```
$ octave
octave:1> pkg list
Package Name  | Version | Installation directory
--------------+---------+-----------------------
     specfun  |   1.1.0 | /Users/davydden/octave/specfun-1.1.0
     splines  |   1.2.7 | /Users/davydden/octave/splines-1.2.7
octave:2>
```

Any advices/ideas?

p.s. ideally fixes https://github.com/LLNL/spack/issues/1111