### PR TITLE
Make MockPackagesTest use a different module location.

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -454,7 +454,6 @@ class EnvModule(object):
 
 class Dotkit(EnvModule):
     name = 'dotkit'
-    path = join_path(spack.share_path, "dotkit")
 
     environment_modifications_formats = {
         PrependPath: 'dk_alter {name} {value}\n',
@@ -467,7 +466,7 @@ class Dotkit(EnvModule):
 
     @property
     def file_name(self):
-        return join_path(Dotkit.path, self.spec.architecture,
+        return join_path(spack.share_path, "dotkit", self.spec.architecture,
                          '%s.dk' % self.use_name)
 
     @property
@@ -495,7 +494,6 @@ class Dotkit(EnvModule):
 
 class TclModule(EnvModule):
     name = 'tcl'
-    path = join_path(spack.share_path, "modules")
 
     environment_modifications_formats = {
         PrependPath: 'prepend-path --delim "{delim}" {name} \"{value}\"\n',
@@ -516,7 +514,7 @@ class TclModule(EnvModule):
 
     @property
     def file_name(self):
-        return join_path(TclModule.path, self.spec.architecture, self.use_name)
+        return join_path(spack.share_path, "modules", self.spec.architecture, self.use_name)
 
     @property
     def header(self):

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -56,7 +56,7 @@ compilers:
       fc: None
     modules: 'None'
 - compiler:
-    spec: gcc@4.5.0  
+    spec: gcc@4.5.0
     operating_system: {0}{1}
     paths:
       cc: /path/to/gcc
@@ -144,7 +144,7 @@ compilers:
       fc: /path/to/gfortran
     operating_system: elcapitan
     spec: gcc@4.5.0
-    modules: 'None' 
+    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: elcapitan
@@ -201,6 +201,10 @@ class MockPackagesTest(unittest.TestCase):
         spack.config.ConfigScope('site', self.mock_site_config)
         spack.config.ConfigScope('user', self.mock_user_config)
 
+        # Keep tests from interfering with the actual module path.
+        self.real_share_path = spack.share_path
+        spack.share_path = tempfile.mkdtemp()
+
         # Store changes to the package's dependencies so we can
         # restore later.
         self.saved_deps = {}
@@ -234,6 +238,9 @@ class MockPackagesTest(unittest.TestCase):
         for pkg_name, (pkg, deps) in self.saved_deps.items():
             pkg.dependencies.clear()
             pkg.dependencies.update(deps)
+
+        shutil.rmtree(spack.share_path, ignore_errors=True)
+        spack.share_path = self.real_share_path
 
 
     def setUp(self):

--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -148,7 +148,7 @@ configuration_suffix = {
 }
 
 
-class HelperFunctionsTests(unittest.TestCase):
+class HelperFunctionsTests(MockPackagesTest):
 
     def test_update_dictionary_extending_list(self):
         target = {


### PR DESCRIPTION
- ensures anything tests create is blown away.

@alalazo: here's another test pollution fix.  Can you look at this one to make sure the change to the `path` variable didn't change anything?