### PR TITLE
Bugfix/newarch sys type

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -91,16 +91,10 @@ from spack.util.multiproc import parmap
 import spack.error as serr
 
 
-class InvalidSysTypeError(serr.SpackError):
-    def __init__(self, sys_type):
-        super(InvalidSysTypeError, self).__init__(
-            "Invalid sys_type value for Spack: " + sys_type)
-
-
-class NoSysTypeError(serr.SpackError):
+class NoPlatformError(serr.SpackError):
     def __init__(self):
-        super(NoSysTypeError, self).__init__(
-            "Could not determine sys_type for this machine.")
+        super(NoPlatformError, self).__init__(
+            "Could not determine a platform for this machine.")
 
 
 @key_ordering
@@ -345,14 +339,17 @@ class OperatingSystem(object):
 
 @key_ordering
 class Arch(object):
-    "Architecture is now a class to help with setting attributes"
+    """Architecture is now a class to help with setting attributes.
 
-    def __init__(self, platform=None, platform_os=None, target=None):
-        self.platform = platform
-        if platform and platform_os:
-                platform_os = self.platform.operating_system(platform_os)
-        self.platform_os = platform_os
-        if platform and target:
+    TODO: refactor so that we don't need this class.
+    """
+
+    def __init__(self, plat=None, os=None, target=None):
+        self.platform = plat
+        if plat and os:
+            os = self.platform.operating_system(os)
+        self.platform_os = os
+        if plat and target:
             target = self.platform.target(target)
         self.target = target
 
@@ -409,27 +406,27 @@ class Arch(object):
         return d
 
 
-def _target_from_dict(target_name, platform=None):
+def _target_from_dict(target_name, plat=None):
     """ Creates new instance of target and assigns all the attributes of
         that target from the dictionary
     """
-    if not platform:
-        platform = sys_type()
-    return platform.target(target_name)
+    if not plat:
+        plat = platform()
+    return plat.target(target_name)
 
 
-def _operating_system_from_dict(os_name, platform=None):
+def _operating_system_from_dict(os_name, plat=None):
     """ uses platform's operating system method to grab the constructed
         operating systems that are valid on the platform.
     """
-    if not platform:
-        platform = sys_type()
+    if not plat:
+        plat = platform()
     if isinstance(os_name, dict):
         name = os_name['name']
         version = os_name['version']
-        return platform.operating_system(name+version)
+        return plat.operating_system(name+version)
     else:
-        return platform.operating_system(os_name)
+        return plat.operating_system(os_name)
 
 
 def _platform_from_dict(platform_name):
@@ -504,16 +501,18 @@ def all_platforms():
 
 
 @memoized
-def sys_type():
-    """ Gather a list of all available subclasses of platforms.
-        Sorts the list according to their priority looking. Priority is
-        an arbitrarily set number. Detects platform either using uname or
-        a file path (/opt/cray...)
+def platform():
+    """Detects the platform for this machine.
+
+    Gather a list of all available subclasses of platforms.
+    Sorts the list according to their priority looking. Priority is
+    an arbitrarily set number. Detects platform either using uname or
+    a file path (/opt/cray...)
     """
     # Try to create a Platform object using the config file FIRST
     platform_list = all_platforms()
     platform_list.sort(key=lambda a: a.priority)
 
-    for platform in platform_list:
-        if platform.detect():
-            return platform()
+    for platform_cls in platform_list:
+        if platform_cls.detect():
+            return platform_cls()

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -516,3 +516,20 @@ def platform():
     for platform_cls in platform_list:
         if platform_cls.detect():
             return platform_cls()
+
+
+@memoized
+def sys_type():
+    """Print out the "default" platform-os-target tuple for this machine.
+
+    On machines with only one target OS/target, prints out the
+    platform-os-target for the frontend.  For machines with a frontend
+    and a backend, prints the default backend.
+
+    TODO: replace with use of more explicit methods to get *all* the
+    backends, as client code should really be aware of cross-compiled
+    architectures.
+
+    """
+    arch = Arch(platform(), 'default_os', 'default_target')
+    return str(arch)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -93,7 +93,7 @@ def get_compiler_config(scope=None, init_config=True):
         for compiler in compilers:
             compilers_dict.append(_to_dict(compiler))
         spack.config.update_config('compilers', compilers_dict, scope=scope)
-    
+
     config = spack.config.get_config('compilers', scope=scope)
     # Update the configuration if there are currently no compilers
     # configured.  Avoid updating automatically if there ARE site
@@ -142,8 +142,8 @@ def remove_compiler_from_config(compiler_spec, scope=None):
     """
     compiler_config = get_compiler_config(scope)
     config_length = len(compiler_config)
-    
-    filtered_compiler_config = [comp for comp in compiler_config 
+
+    filtered_compiler_config = [comp for comp in compiler_config
                if spack.spec.CompilerSpec(comp['compiler']['spec']) != compiler_spec]
     # Need a better way for this
     global _cache_config_file
@@ -315,7 +315,7 @@ def all_os_classes():
     """
     classes = []
 
-    platform = spack.architecture.sys_type()
+    platform = spack.architecture.platform()
     for os_class in platform.operating_sys.values():
         classes.append(os_class)
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -221,7 +221,7 @@ class DefaultConcretizer(object):
             if isinstance(spec.root.architecture.platform,spack.architecture.Platform):
                 spec.architecture.platform = spec.root.architecture.platform
         else:
-            spec.architecture.platform = spack.architecture.sys_type()
+            spec.architecture.platform = spack.architecture.platform()
         return True #changed?
 
     def concretize_architecture(self, spec):
@@ -334,7 +334,7 @@ class DefaultConcretizer(object):
         Default specs set at the compiler level will still be added later.
         """
 
-            
+
         if not spec.architecture.platform_os:
             #Although this usually means changed, this means awaiting other changes
             return True
@@ -347,7 +347,7 @@ class DefaultConcretizer(object):
                                and flag in p.compiler_flags))
                 if not flag in spec.compiler_flags or \
                     not (sorted(spec.compiler_flags[flag]) >= sorted(nearest.compiler_flags[flag])):
-                    if flag in spec.compiler_flags: 
+                    if flag in spec.compiler_flags:
                         spec.compiler_flags[flag] = list(set(spec.compiler_flags[flag]) |
                                                          set(nearest.compiler_flags[flag]))
                     else:

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -149,7 +149,7 @@ class when(object):
               @when('arch=chaos_5_x86_64_ib')
               def install(self, prefix):
                   # This will be executed instead of the default install if
-                  # the package's sys_type() is chaos_5_x86_64_ib.
+                  # the package's platform() is chaos_5_x86_64_ib.
 
               @when('arch=bgqos_0")
               def install(self, prefix):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2216,7 +2216,7 @@ class SpecParser(spack.parse.Parser):
         for spec in specs:
             for s in spec.traverse():
                 if s.architecture.os_string or s.architecture.target_string:
-                    s._set_platform(spack.architecture.sys_type())
+                    s._set_platform(spack.architecture.platform())
         return specs
 
     def parse_compiler(self, text):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -5,7 +5,7 @@ import unittest
 import os
 import platform as py_platform
 import spack
-from spack.architecture import *
+import spack.architecture
 from spack.spec import *
 from spack.platforms.cray_xc import CrayXc
 from spack.platforms.linux import Linux
@@ -19,14 +19,14 @@ class ArchitectureTest(MockPackagesTest):
 
     def setUp(self):
         super(ArchitectureTest, self).setUp()
-        self.platform = sys_type()
+        self.platform = spack.architecture.platform()
 
     def tearDown(self):
         super(ArchitectureTest, self).tearDown()
 
     def test_dict_functions_for_architecture(self):
-        arch = Arch()
-        arch.platform = spack.architecture.sys_type()
+        arch = spack.architecture.Arch()
+        arch.platform = spack.architecture.platform()
         arch.platform_os = arch.platform.operating_system('default_os')
         arch.target = arch.platform.target('default_target')
 
@@ -36,18 +36,23 @@ class ArchitectureTest(MockPackagesTest):
 
         self.assertEqual(arch, new_arch)
 
-        self.assertTrue( isinstance(arch, Arch) )
-        self.assertTrue( isinstance(arch.platform, Platform) )
-        self.assertTrue( isinstance(arch.platform_os, OperatingSystem) )
-        self.assertTrue( isinstance(arch.target, Target) )
-        self.assertTrue( isinstance(new_arch, Arch) )
-        self.assertTrue( isinstance(new_arch.platform, Platform) )
-        self.assertTrue( isinstance(new_arch.platform_os, OperatingSystem) )
-        self.assertTrue( isinstance(new_arch.target, Target) )
+        self.assertTrue( isinstance(arch, spack.architecture.Arch) )
+        self.assertTrue( isinstance(arch.platform, spack.architecture.Platform) )
+        self.assertTrue( isinstance(arch.platform_os,
+                                    spack.architecture.OperatingSystem) )
+        self.assertTrue( isinstance(arch.target,
+                                    spack.architecture.Target) )
+        self.assertTrue( isinstance(new_arch, spack.architecture.Arch) )
+        self.assertTrue( isinstance(new_arch.platform,
+                                    spack.architecture.Platform) )
+        self.assertTrue( isinstance(new_arch.platform_os,
+                                    spack.architecture.OperatingSystem) )
+        self.assertTrue( isinstance(new_arch.target,
+                                    spack.architecture.Target) )
 
 
-    def test_sys_type(self):
-        output_platform_class = sys_type()
+    def test_platform(self):
+        output_platform_class = spack.architecture.platform()
         my_arch_class = None
         if os.path.exists('/opt/cray/craype'):
             my_platform_class = CrayXc()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -257,8 +257,8 @@ class ConcretizeTest(MockPackagesTest):
     def test_external_package_module(self):
         # No tcl modules on darwin/linux machines
         # TODO: improved way to check for this.
-        if (spack.architecture.sys_type().name == 'darwin' or
-            spack.architecture.sys_type().name == 'linux'):
+        if (spack.architecture.platform().name == 'darwin' or
+            spack.architecture.platform().name == 'linux'):
             return
 
         spec = Spec('externalmodule')

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -34,7 +34,7 @@ from ordereddict_backport import OrderedDict
 from spack.repository import RepoPath
 from spack.spec import Spec
 
-platform = spack.architecture.sys_type()
+platform = spack.architecture.platform()
 
 linux_os_name = 'debian'
 linux_os_version = '6'
@@ -56,7 +56,7 @@ compilers:
       fc: None
     modules: 'None'
 - compiler:
-    spec: gcc@4.5.0  
+    spec: gcc@4.5.0
     operating_system: {0}{1}
     paths:
       cc: /path/to/gcc
@@ -144,7 +144,7 @@ compilers:
       fc: /path/to/gfortran
     operating_system: elcapitan
     spec: gcc@4.5.0
-    modules: 'None' 
+    modules: 'None'
 - compiler:
     spec: clang@3.3
     operating_system: elcapitan

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -93,7 +93,7 @@ class MultiMethodTest(MockPackagesTest):
 
 
     def test_target_match(self):
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
         targets = platform.targets.values()
         for target in targets[:-1]:
             pkg = spack.repo.get('multimethod target='+target.name)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -242,7 +242,7 @@ class SpecDagTest(MockPackagesTest):
 
 
     def test_unsatisfiable_architecture(self):
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
 
         self.set_pkg_dep('mpileaks', 'mpich platform=test target=be')
         spec = Spec('mpileaks ^mpich platform=test target=fe ^callpath ^dyninst ^libelf ^libdwarf')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -141,7 +141,6 @@ class SpecSematicsTest(MockPackagesTest):
 
 
     def test_satisfies_architecture(self):
-        platform = spack.architecture.sys_type()
         self.check_satisfies(
             'foo platform=test target=frontend os=frontend',
             'platform=test target=frontend os=frontend')
@@ -396,7 +395,7 @@ class SpecSematicsTest(MockPackagesTest):
         self.check_constrain_changed('libelf', 'debug=2')
         self.check_constrain_changed('libelf', 'cppflags="-O3"')
 
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
         self.check_constrain_changed('libelf', 'target='+platform.target('default_target').name)
         self.check_constrain_changed('libelf', 'os='+platform.operating_system('default_os').name)
 
@@ -412,7 +411,7 @@ class SpecSematicsTest(MockPackagesTest):
         self.check_constrain_not_changed('libelf debug=2', 'debug=2')
         self.check_constrain_not_changed('libelf cppflags="-O3"', 'cppflags="-O3"')
 
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
         default_target = platform.target('default_target').name
         self.check_constrain_not_changed('libelf target='+default_target, 'target='+default_target)
 
@@ -425,7 +424,7 @@ class SpecSematicsTest(MockPackagesTest):
         self.check_constrain_changed('libelf^foo', 'libelf^foo+debug')
         self.check_constrain_changed('libelf^foo', 'libelf^foo~debug')
 
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
         default_target = platform.target('default_target').name
         self.check_constrain_changed('libelf^foo', 'libelf^foo target='+default_target)
 
@@ -439,6 +438,6 @@ class SpecSematicsTest(MockPackagesTest):
         self.check_constrain_not_changed('libelf^foo~debug', 'libelf^foo~debug')
         self.check_constrain_not_changed('libelf^foo cppflags="-O3"', 'libelf^foo cppflags="-O3"')
 
-        platform = spack.architecture.sys_type()
+        platform = spack.architecture.platform()
         default_target = platform.target('default_target').name
         self.check_constrain_not_changed('libelf^foo target='+default_target, 'libelf^foo target='+default_target)

--- a/var/spack/repos/builtin.mock/packages/multimethod/package.py
+++ b/var/spack/repos/builtin.mock/packages/multimethod/package.py
@@ -106,17 +106,11 @@ class Multimethod(Package):
     #
     # Make sure we can switch methods on different target
     #
-#    for platform_name in ['cray_xc', 'darwin', 'linux']:
-#        file_path = join_path(spack.platform_path, platform_name)
-#        platform_mod = imp.load_source('spack.platforms', file_path + '.py')
-#        cls = getattr(platform_mod, mod_to_class(platform_name))
-        
-#        platform = cls()
-    platform = spack.architecture.sys_type()
+    platform = spack.architecture.platform()
     targets = platform.targets.values()
     if len(targets) > 1:
         targets = targets[:-1]
-    
+
     for target in targets:
         @when('target='+target.name)
         def different_by_target(self):


### PR DESCRIPTION
Fixes #1075.

- [X] renamed `spack.architecture.sys_type()` to `spack.architecture.platform()`
- [X] added a `spack.architecture.sys_type()` that reports the default platform-os-target string for this machine.
- [X] `spack arch` now prints the full arch string for the default platform-os-target

TBD later:
* Add better programmatic ways to get the available front-end and back-end os-target combinations.
* Figure out a decent policy for modules (module path should probably include all the backends, at least).