### PR TITLE
Fix #1019 - cannot create mirror for git spec

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -307,9 +307,6 @@ class URLFetchStrategy(FetchStrategy):
         if not self.archive_file:
             raise NoArchiveFileError("Cannot call archive() before fetching.")
 
-        if not extension(destination) == extension(self.archive_file):
-            raise ValueError("Cannot archive without matching extensions.")
-
         shutil.move(self.archive_file, destination)
 
     @_needs_stage


### PR DESCRIPTION
As discussed in #1019, it seems like checking the extensions of the archive is rather brittle and superfluous especially since we do a checksum anyway...