### PR TITLE
Gmsh -- various fixes

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -27,11 +27,13 @@ from spack import *
 
 class Gmsh(Package):
     """
-    Gmsh is a free 3D finite element grid generator with a built-in CAD engine and post-processor. Its design goal is
-    to provide a fast, light and user-friendly meshing tool with parametric input and advanced visualization
-    capabilities. Gmsh is built around four modules: geometry, mesh, solver and post-processing. The specification of
-    any input to these modules is done either interactively using the graphical user interface or in ASCII text files
-    using Gmsh's own scripting language.
+    Gmsh is a free 3D finite element grid generator with a built-in CAD engine
+    and post-processor. Its design goal is to provide a fast, light and
+    user-friendly meshing tool with parametric input and advanced visualization
+    capabilities. Gmsh is built around four modules: geometry, mesh, solver and
+    post-processing. The specification of any input to these modules is done
+    either interactively using the graphical user interface or in ASCII text
+    files using Gmsh's own scripting language.
     """
     homepage = 'http://gmsh.info'
     url = 'http://gmsh.info/src/gmsh-2.11.0-source.tgz'
@@ -54,7 +56,8 @@ class Gmsh(Package):
     depends_on('cmake@2.8:')
     depends_on('gmp')
     depends_on('mpi',  when='+mpi')
-    depends_on('fltk', when='+fltk')  # Assumes OpenGL with GLU is already provided by the system
+    # Assumes OpenGL with GLU is already provided by the system:
+    depends_on('fltk', when='+fltk')
     depends_on('hdf5', when='+hdf5')
     depends_on('oce',  when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
@@ -63,9 +66,10 @@ class Gmsh(Package):
     depends_on('zlib',  when='+compression')
 
     def install(self, spec, prefix):
-
         options = []
         options.extend(std_cmake_args)
+
+        # Make sure native file dialogs are used
         options.extend(['-DENABLE_NATIVE_FILE_CHOOSER=ON'])
 
         build_directory = join_path(self.stage.path, 'spack-build')
@@ -76,7 +80,7 @@ class Gmsh(Package):
         # Prevent GMsh from using its own strange directory structure on OSX
         options.append('-DENABLE_OS_SPECIFIC_INSTALL=OFF')
 
-        # Make sure GMSH picks up correct blas-lapack by providing linker flags:
+        # Make sure GMSH picks up correct BlasLapack by providing linker flags
         options.append('-DBLAS_LAPACK_LIBRARIES=%s %s' %
                        (to_link_flags(spec['lapack'].lapack_shared_lib),
                         to_link_flags(spec['blas'].blas_shared_lib)))
@@ -99,7 +103,6 @@ class Gmsh(Package):
         if '+petsc' in spec:
             env['PETSC_DIR'] = self.spec['petsc'].prefix
             options.extend(['-DENABLE_PETSC=ON'])
-            #env['PETSC_ARCH'] = "real"
         else:
             options.extend(['-DENABLE_PETSC=OFF'])
 
@@ -110,10 +113,12 @@ class Gmsh(Package):
             options.extend(['-DENABLE_SLEPC=OFF'])
 
         if '+shared' in spec:
+            # Builds dynamic executable and installs shared library
             options.extend(['-DENABLE_BUILD_SHARED:BOOL=ON',
-                            '-DENABLE_BUILD_DYNAMIC:BOOL=ON'])  # Builds dynamic executable and installs shared library
+                            '-DENABLE_BUILD_DYNAMIC:BOOL=ON'])
         else:
-            options.append('-DENABLE_BUILD_LIB:BOOL=ON')  # Builds and installs static library
+            # Builds and installs static library
+            options.append('-DENABLE_BUILD_LIB:BOOL=ON')
 
         if '+debug' in spec:
             options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')


### PR DESCRIPTION
(i) add new version
(ii) add OCE, PETSc and SLEPc as dependencies
(iii) fix Blas/Lapack configuration
(iv) disable internal Metis which does not compile

Tested on macOS with `spack install gmsh+petsc+mpi+slepc+oce ^petsc@3.6.4+boost ^boost+python+mpi ^slepc@3.6.3`.

fixes https://github.com/LLNL/spack/issues/1129

@jppelteret 