### PR TITLE
fix : swiftsim will set git environment variables in the appropriate hook

### DIFF
--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -28,13 +28,6 @@ from spack import *
 import spack.environment
 import llnl.util.tty as tty
 
-# Needed to be able to download from the Durham gitlab repository
-tty.warn('Setting "GIT_SSL_NO_VERIFY=1"')
-tty.warn('This is needed to clone SWIFT repository')
-gitlab_env = spack.environment.EnvironmentModifications()
-gitlab_env.set('GIT_SSL_NO_VERIFY', 1)
-gitlab_env.apply_modifications()
-
 
 class Swiftsim(Package):
     """
@@ -60,6 +53,12 @@ class Swiftsim(Package):
     depends_on('metis')
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('hdf5+mpi', when='+mpi')
+
+    def setup_environment(self, spack_env, run_env):
+        # Needed to be able to download from the Durham gitlab repository
+        tty.warn('Setting "GIT_SSL_NO_VERIFY=1"')
+        tty.warn('This is needed to clone SWIFT repository')
+        spack_env.set('GIT_SSL_NO_VERIFY', 1)
 
     def install(self, spec, prefix):
         # Generate configure from configure.ac

--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -38,7 +38,7 @@ class Swiftsim(Package):
     homepage = 'http://icc.dur.ac.uk/swift/'
     url = 'http://gitlab.cosma.dur.ac.uk/swift/swiftsim/repository/archive.tar.gz?ref=v0.3.0'
 
-    version('0.3.0', git='https://gitlab.cosma.dur.ac.uk/swift/swiftsim.git', tag='v0.3.0')
+    version('0.3.0', git='https://gitlab.cosma.dur.ac.uk/swift/swiftsim.git', commit='254cc1b563b2f88ddcf437b1f71da123bb9db733')
 
     variant('mpi', default=True, description='Enable distributed memory parallelism')
 

--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -25,7 +25,6 @@
 
 from spack import *
 
-import spack.environment
 import llnl.util.tty as tty
 
 


### PR DESCRIPTION
##### Modifications : 
- [x] prevent a warning due to `swiftsim` to ALWAYS be displayed

@tgamblin My bad for this leftover from #1118 