### PR TITLE
Remove more variables from build environment

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -266,6 +266,8 @@ def set_build_environment_variables(pkg, env):
     # can affect how some packages find libraries.  We want to make
     # sure that builds never pull in unintended external dependencies.
     env.unset('LD_LIBRARY_PATH')
+    env.unset('LIBRARY_PATH')
+    env.unset('CPATH')
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
 


### PR DESCRIPTION
Remove the LIBRARY_PATH and CPATH environment variables before building
a package.