### PR TITLE
Use Executable to set script for Intel compiler installation

### DIFF
--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -73,7 +73,7 @@ CONTINUE_WITH_OPTIONAL_ERROR=yes
 COMPONENTS=%s
 """ % (self.intel_prefix, self.global_license_file, self.intel_components))
 
-        install_script = which("install.sh")
+        install_script = Executable("./install.sh")
         install_script('--silent', silent_config_filename)
 
 


### PR DESCRIPTION
Use `Executable("./install.sh")` to set `install_script`. This allows it
to work when the current directory is not on the PATH.