### PR TITLE
[WIP] spec['mpi'].run and petsc tests fixes

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -66,6 +66,7 @@ class Mpich(Package):
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
         self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        self.spec.run = Executable(join_path(self.prefix.bin, 'mpirun'))
 
     def install(self, spec, prefix):
         config_args = ["--prefix=" + prefix,

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -207,6 +207,10 @@ class Mvapich2(Package):
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
         self.spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        if 'slurm' in self.spec:
+            self.spec.run = which('srun')
+        else:
+            self.spec.run = Executable(join_path(self.prefix.bin, 'mpirun'))
 
     def install(self, spec, prefix):
         # we'll set different configure flags depending on our

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -124,6 +124,10 @@ class Openmpi(Package):
         self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
         self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
         self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        if 'slurm' in self.spec:
+            self.spec.run = which('srun')
+        else:
+            self.spec.run = Executable(join_path(self.prefix.bin, 'mpirun'))
 
     def setup_environment(self, spack_env, run_env):
         # As of 06/2016 there is no mechanism to specify that packages which


### PR DESCRIPTION
fix issue reported in https://github.com/LLNL/spack/pull/1145#issuecomment-229714840 by introducing `self.spec['mpi'].run`. Tested on macOS with Openmpi.

@nrichart: please see if this fixes your issue.
@adamjstewart @alalazo: ping.