### PR TITLE
feature : register external packages in the DB

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -465,7 +465,10 @@ def parent_class_modules(cls):
 
 
 def load_external_modules(pkg):
-    """ traverse the spec list and find any specs that have external modules.
+    """Traverse the spec list associated with a package
+    and find any specs that have external modules.
+
+    :param pkg: package under consideration
     """
     for dep in list(pkg.spec.traverse()):
         if dep.external_module:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -99,7 +99,7 @@ class DefaultConcretizer(object):
 
         # Use a sort key to order the results
         return sorted(usable, key=lambda spec: (
-            not (spec.external or spec.external_module),  # prefer externals
+            not spec.external,                            # prefer externals
             pref_key(spec),                               # respect prefs
             spec.name,                                    # group by name
             reverse_order(spec.versions),                 # latest version

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -193,7 +193,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         _check_concrete(spec)
 
         if spec.external:
-            return spec.external
+            return spec.external_path
 
         path = spec.format(self.path_scheme)
         return path

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -31,7 +31,7 @@ from llnl.util.filesystem import join_path, mkdirp
 
 def pre_install(pkg):
     """This hook handles global license setup for licensed software."""
-    if pkg.license_required:
+    if pkg.license_required and not pkg.spec.external:
         set_up_license(pkg)
 
 
@@ -145,7 +145,7 @@ def write_license_file(pkg, license_path):
 def post_install(pkg):
     """This hook symlinks local licenses to the global license for
     licensed software."""
-    if pkg.license_required:
+    if pkg.license_required and not pkg.spec.external:
         symlink_license(pkg)
 
 

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -104,8 +104,12 @@ def filter_shebangs_in_directory(directory, filenames=None):
 
 def post_install(pkg):
     """This hook edits scripts so that they call /bin/bash
-       $spack_prefix/bin/sbang instead of something longer than the
-       shebang limit."""
+    $spack_prefix/bin/sbang instead of something longer than the
+    shebang limit.
+    """
+    if pkg.spec.external:
+        tty.debug('SKIP: shebang filtering [external package]')
+        return
 
     for directory, _, filenames in os.walk(pkg.prefix):
         filter_shebangs_in_directory(directory, filenames)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1531,7 +1531,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 spack.hooks.pre_uninstall(pkg)
 
             # Uninstalling in Spack only requires removing the prefix.
-            if not self.spec.external:
+            if not spec.external:
                 msg = 'Deleting package prefix [{0}]'
                 tty.debug(msg.format(spec.short_spec))
                 spack.store.layout.remove_install_directory(spec)
@@ -1541,9 +1541,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             spack.store.db.remove(spec)
         tty.msg("Successfully uninstalled %s" % spec.short_spec)
 
-            # TODO: refactor hooks to use specs, not packages.
-            if pkg is not None:
-                spack.hooks.post_uninstall(pkg)
+        # TODO: refactor hooks to use specs, not packages.
+        if pkg is not None:
+            spack.hooks.post_uninstall(pkg)
 
         tty.msg("Successfully uninstalled %s" % spec.short_spec)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1089,8 +1089,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             the user, False if it was pulled in as a dependency of an explicit
             package.
         """
-        message = '{s.name}@{s.version} : externally installed in {path}'
-        tty.msg(message.format(s=self, path=self.spec.external))
+        if self.spec.external_module:
+            message = '{s.name}@{s.version} : has external module in {module}'
+            tty.msg(message.format(s=self, module=self.spec.external_module))
+            message = '{s.name}@{s.version} : is actually installed in {path}'
+            tty.msg(message.format(s=self, path=self.spec.external_path))
+        else:
+            message = '{s.name}@{s.version} : externally installed in {path}'
+            tty.msg(message.format(s=self, path=self.spec.external_path))
         try:
             # Check if the package was already registered in the DB
             # If this is the case, then just exit

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1081,6 +1081,34 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             with spack.store.db.prefix_write_lock(self.spec):
                 yield
 
+    def _process_external_package(self, explicit):
+        """Helper function to process external packages. It runs post install
+        hooks and registers the package in the DB.
+
+        :param bool explicit: True if the package was requested explicitly by
+            the user, False if it was pulled in as a dependency of an explicit
+            package.
+        """
+        message = '{s.name}@{s.version} : externally installed in {path}'
+        tty.msg(message.format(s=self, path=self.spec.external))
+        try:
+            # Check if the package was already registered in the DB
+            # If this is the case, then just exit
+            spack.store.db.get_record(self.spec)
+            message = '{s.name}@{s.version} : already registered in DB'
+            tty.msg(message.format(s=self))
+        except KeyError:
+            # If not register it and generate the module file
+            # For external packages we just need to run
+            # post-install hooks to generate module files
+            message = '{s.name}@{s.version} : generating module file'
+            tty.msg(message.format(s=self))
+            spack.hooks.post_install(self)
+            # Add to the DB
+            message = '{s.name}@{s.version} : registering into DB'
+            tty.msg(message.format(s=self))
+            spack.store.db.add(self.spec, None, explicit=explicit)
+
     def do_install(self,
                    keep_prefix=False,
                    keep_stage=False,
@@ -1121,11 +1149,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             raise ValueError("Can only install concrete packages: %s."
                              % self.spec.name)
 
-        # No installation needed if package is external
+        # For external packages the workflow is simplified, and basically
+        # consists in module file generation and registration in the DB
         if self.spec.external:
-            tty.msg("%s is externally installed in %s" %
-                    (self.name, self.spec.external))
-            return
+            return self._process_external_package(explicit)
 
         # Ensure package is not already installed
         layout = spack.store.layout
@@ -1135,8 +1162,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 tty.msg(
                     "Continuing from partial install of %s" % self.name)
             elif layout.check_installed(self.spec):
-                tty.msg(
-                    "%s is already installed in %s" % (self.name, self.prefix))
+                msg= '{0.name} is already installed in {0.prefix}'
+                tty.msg(msg.format(self))
                 rec = spack.store.db.get_record(self.spec)
                 if (not rec.explicit) and explicit:
                     with spack.store.db.write_transaction():
@@ -1150,10 +1177,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         self._do_install_pop_kwargs(kwargs)
 
-        tty.msg("Installing %s" % self.name)
-
         # First, install dependencies recursively.
         if install_deps:
+            tty.debug('Installing {0} dependencies'.format(self.name))
             for dep in self.spec.dependencies():
                 dep.package.do_install(
                     keep_prefix=keep_prefix,
@@ -1167,6 +1193,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                     dirty=dirty,
                     **kwargs
                 )
+
+        tty.msg('Installing %s' % self.name)
 
         # Set run_tests flag before starting build.
         self.run_tests = run_tests
@@ -1265,7 +1293,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             # Fork a child to do the actual installation
             spack.build_environment.fork(self, build_process, dirty=dirty)
             # If we installed then we should keep the prefix
-            keep_prefix = True if self.last_phase is None else keep_prefix
+            keep_prefix = self.last_phase is None or keep_prefix
             # note: PARENT of the build process adds the new package to
             # the database, so that we don't need to re-read from file.
             spack.store.db.add(
@@ -1490,8 +1518,15 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 spack.hooks.pre_uninstall(pkg)
 
             # Uninstalling in Spack only requires removing the prefix.
-            spack.store.layout.remove_install_directory(spec)
+            if not self.spec.external:
+                msg = 'Deleting package prefix [{0}]'
+                tty.debug(msg.format(spec.short_spec))
+                spack.store.layout.remove_install_directory(spec)
+            # Delete DB entry
+            msg = 'Deleting DB entry [{0}]'
+            tty.debug(msg.format(spec.short_spec))
             spack.store.db.remove(spec)
+        tty.msg("Successfully uninstalled %s" % spec.short_spec)
 
             # TODO: refactor hooks to use specs, not packages.
             if pkg is not None:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1179,7 +1179,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 tty.msg(
                     "Continuing from partial install of %s" % self.name)
             elif layout.check_installed(self.spec):
-                msg= '{0.name} is already installed in {0.prefix}'
+                msg = '{0.name} is already installed in {0.prefix}'
                 tty.msg(msg.format(self))
                 rec = spack.store.db.get_record(self.spec)
                 return self._update_explicit_entry_in_db(rec, explicit)

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -29,6 +29,7 @@ from llnl.util.lang import classproperty
 
 import spack
 import spack.error
+from spack.util.path import canonicalize_path
 from spack.version import *
 
 
@@ -215,7 +216,8 @@ def spec_externals(spec):
             # skip entries without paths (avoid creating extra Specs)
             continue
 
-        external_spec = spack.spec.Spec(external_spec, external=path)
+        external_spec = spack.spec.Spec(external_spec,
+                                        external_path=canonicalize_path(path))
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 
@@ -223,10 +225,8 @@ def spec_externals(spec):
         if not module:
             continue
 
-        path = get_path_from_module(module)
-
         external_spec = spack.spec.Spec(
-            external_spec, external=path, external_module=module)
+            external_spec, external_module=module)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -200,7 +200,7 @@ def spec_externals(spec):
     """Return a list of external specs (w/external directory path filled in),
        one for each known external installation."""
     # break circular import.
-    from spack.build_environment import get_path_from_module
+    from spack.build_environment import get_path_from_module  # noqa: F401
 
     allpkgs = get_packages_config()
     name = spec.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -954,7 +954,7 @@ class Spec(object):
         self._concrete = kwargs.get('concrete', False)
 
         # Allow a spec to be constructed with an external path.
-        self.external  = kwargs.get('external', None)
+        self.external = kwargs.get('external', None)
         self.external_module = kwargs.get('external_module', None)
 
         # This allows users to construct a spec DAG with literals.
@@ -1349,6 +1349,13 @@ class Spec(object):
         if params:
             d['parameters'] = params
 
+        d['external'] = False
+        if self.external:
+            d['external'] = {
+                'path': self.external,
+                'module': bool(self.external_module)
+            }
+
         # TODO: restore build dependencies here once we have less picky
         # TODO: concretization.
         deps = self.dependencies_dict(deptype=('link', 'run'))
@@ -1411,6 +1418,16 @@ class Spec(object):
                 spec.variants[name] = VariantSpec(name, value)
             for name in FlagMap.valid_compiler_flags():
                 spec.compiler_flags[name] = []
+
+        if 'external' in node:
+            spec.external = None
+            if node['external']:
+                spec.external = node['external']['path']
+                spec.external_module = node['external']['module']
+                if spec.external_module is False:
+                    spec.external_module = None
+        else:
+            spec.external = None
 
         # Don't read dependencies here; from_node_dict() is used by
         # from_yaml() to read the root *and* each dependency spec.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1349,7 +1349,6 @@ class Spec(object):
         if params:
             d['parameters'] = params
 
-        d['external'] = False
         if self.external:
             d['external'] = {
                 'path': self.external,
@@ -1421,6 +1420,10 @@ class Spec(object):
 
         if 'external' in node:
             spec.external = None
+            # This conditional is needed because sometimes this function is
+            # called with a node already constructed that contains a 'versions'
+            # and 'external' field. Related to virtual packages provider
+            # indexes.
             if node['external']:
                 spec.external = node['external']['path']
                 spec.external_module = node['external']['module']

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -954,7 +954,7 @@ class Spec(object):
         self._concrete = kwargs.get('concrete', False)
 
         # Allow a spec to be constructed with an external path.
-        self.external = kwargs.get('external', None)
+        self.external_path = kwargs.get('external_path', None)
         self.external_module = kwargs.get('external_module', None)
 
         # This allows users to construct a spec DAG with literals.
@@ -975,6 +975,10 @@ class Spec(object):
             spec = dep if isinstance(dep, Spec) else Spec(dep)
             self._add_dependency(spec, deptypes)
             deptypes = ()
+
+    @property
+    def external(self):
+        return bool(self.external_path) or bool(self.external_module)
 
     def get_dependency(self, name):
         dep = self._dependencies.get(name)
@@ -1351,7 +1355,7 @@ class Spec(object):
 
         if self.external:
             d['external'] = {
-                'path': self.external,
+                'path': self.external_path,
                 'module': bool(self.external_module)
             }
 
@@ -1419,18 +1423,20 @@ class Spec(object):
                 spec.compiler_flags[name] = []
 
         if 'external' in node:
-            spec.external = None
+            spec.external_path = None
+            spec.external_module = None
             # This conditional is needed because sometimes this function is
             # called with a node already constructed that contains a 'versions'
             # and 'external' field. Related to virtual packages provider
             # indexes.
             if node['external']:
-                spec.external = node['external']['path']
+                spec.external_path = node['external']['path']
                 spec.external_module = node['external']['module']
                 if spec.external_module is False:
                     spec.external_module = None
         else:
-            spec.external = None
+            spec.external_path = None
+            spec.external_module = None
 
         # Don't read dependencies here; from_node_dict() is used by
         # from_yaml() to read the root *and* each dependency spec.
@@ -1598,6 +1604,8 @@ class Spec(object):
             done = True
             for spec in list(self.traverse()):
                 replacement = None
+                if spec.external:
+                    continue
                 if spec.virtual:
                     replacement = self._find_provider(spec, self_index)
                     if replacement:
@@ -1634,7 +1642,7 @@ class Spec(object):
                             continue
 
                 # If replacement is external then trim the dependencies
-                if replacement.external or replacement.external_module:
+                if replacement.external:
                     if (spec._dependencies):
                         changed = True
                         spec._dependencies = DependencyMap()
@@ -1652,7 +1660,8 @@ class Spec(object):
                         feq(replacement.architecture, spec.architecture) and
                         feq(replacement._dependencies, spec._dependencies) and
                         feq(replacement.variants, spec.variants) and
-                        feq(replacement.external, spec.external) and
+                        feq(replacement.external_path,
+                            spec.external_path) and
                         feq(replacement.external_module,
                             spec.external_module)):
                     continue
@@ -1711,14 +1720,14 @@ class Spec(object):
             if s.namespace is None:
                 s.namespace = spack.repo.repo_for_pkg(s.name).namespace
 
-        for s in self.traverse(root=False):
+        for s in self.traverse():
             if s.external_module:
                 compiler = spack.compilers.compiler_for_spec(
                     s.compiler, s.architecture)
                 for mod in compiler.modules:
                     load_module(mod)
 
-                s.external = get_path_from_module(s.external_module)
+                s.external_path = get_path_from_module(s.external_module)
 
         # Mark everything in the spec as concrete, as well.
         self._mark_concrete()
@@ -1939,7 +1948,7 @@ class Spec(object):
 
         # if we descend into a virtual spec, there's nothing more
         # to normalize.  Concretize will finish resolving it later.
-        if self.virtual or self.external or self.external_module:
+        if self.virtual or self.external:
             return False
 
         # Combine constraints from package deps with constraints from
@@ -2345,7 +2354,7 @@ class Spec(object):
                        self.variants != other.variants and
                        self._normal != other._normal and
                        self.concrete != other.concrete and
-                       self.external != other.external and
+                       self.external_path != other.external_path and
                        self.external_module != other.external_module and
                        self.compiler_flags != other.compiler_flags)
 
@@ -2361,7 +2370,7 @@ class Spec(object):
         self.compiler_flags = other.compiler_flags.copy()
         self.variants = other.variants.copy()
         self.variants.spec = self
-        self.external = other.external
+        self.external_path = other.external_path
         self.external_module = other.external_module
         self.namespace = other.namespace
 
@@ -3008,7 +3017,7 @@ class SpecParser(spack.parse.Parser):
         spec.variants = VariantMap(spec)
         spec.architecture = None
         spec.compiler = None
-        spec.external = None
+        spec.external_path = None
         spec.external_module = None
         spec.compiler_flags = FlagMap(spec)
         spec._dependents = DependencyMap()

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -53,7 +53,7 @@ def test_uninstall(database):
     uninstall(parser, args)
 
     all_specs = spack.store.layout.all_specs()
-    assert len(all_specs) == 7
+    assert len(all_specs) == 8
     # query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
     callpath_specs = [s for s in all_specs if s.satisfies('callpath')]

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -293,7 +293,7 @@ class TestConcretize(object):
     def test_external_package(self):
         spec = Spec('externaltool%gcc')
         spec.concretize()
-        assert spec['externaltool'].external == '/path/to/external_tool'
+        assert spec['externaltool'].external_path == '/path/to/external_tool'
         assert 'externalprereq' not in spec
         assert spec['externaltool'].compiler.satisfies('gcc')
 
@@ -322,8 +322,8 @@ class TestConcretize(object):
     def test_external_and_virtual(self):
         spec = Spec('externaltest')
         spec.concretize()
-        assert spec['externaltool'].external == '/path/to/external_tool'
-        assert spec['stuff'].external == '/path/to/external_virtual_gcc'
+        assert spec['externaltool'].external_path == '/path/to/external_tool'
+        assert spec['stuff'].external_path == '/path/to/external_virtual_gcc'
         assert spec['externaltool'].compiler.satisfies('gcc')
         assert spec['stuff'].compiler.satisfies('gcc')
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -170,4 +170,4 @@ mpich:
         # ensure that once config is in place, external is used
         spec = Spec('mpi')
         spec.concretize()
-        assert spec['mpich'].external == '/dummy/path'
+        assert spec['mpich'].external_path == '/dummy/path'

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -252,6 +252,7 @@ def database(tmpdir_factory, builtin_mock, config):
             _install('mpileaks ^mpich')
             _install('mpileaks ^mpich2')
             _install('mpileaks ^zmpi')
+            _install('externaltest')
 
     t = Database(
         real=real,
@@ -265,6 +266,7 @@ def database(tmpdir_factory, builtin_mock, config):
         t.install('mpileaks ^mpich')
         t.install('mpileaks ^mpich2')
         t.install('mpileaks ^zmpi')
+        t.install('externaltest')
 
     yield t
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -86,11 +86,17 @@ def _check_merkleiness():
 
 def _check_db_sanity(install_db):
     """Utiilty function to check db against install layout."""
-    expected = sorted(spack.store.layout.all_specs())
+    pkg_in_layout = sorted(spack.store.layout.all_specs())
     actual = sorted(install_db.query())
 
-    assert len(expected) == len(actual)
-    for e, a in zip(expected, actual):
+    externals = sorted([x for x in actual if x.external is not None])
+    nexpected = len(pkg_in_layout) + len(externals)
+
+    assert nexpected == len(actual)
+
+    non_external_in_db = sorted([x for x in actual if x.external is None])
+
+    for e, a in zip(pkg_in_layout, non_external_in_db):
         assert e == a
 
     _check_merkleiness()
@@ -127,7 +133,7 @@ def test_005_db_exists(database):
 def test_010_all_install_sanity(database):
     """Ensure that the install layout reflects what we think it does."""
     all_specs = spack.store.layout.all_specs()
-    assert len(all_specs) == 13
+    assert len(all_specs) == 14
 
     # Query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
@@ -207,7 +213,7 @@ def test_050_basic_query(database):
     """Ensure querying database is consistent with what is installed."""
     install_db = database.mock.db
     # query everything
-    assert len(spack.store.db.query()) == 13
+    assert len(spack.store.db.query()) == 16
 
     # query specs with multiple configurations
     mpileaks_specs = install_db.query('mpileaks')
@@ -365,3 +371,19 @@ def test_110_no_write_with_exception_on_install(database):
     # reload DB and make sure cmake was not written.
     with install_db.read_transaction():
         assert install_db.query('cmake', installed=any) == []
+
+
+def test_external_entries_in_db(database):
+    install_db = database.mock.db
+    rec = install_db.get_record('mpileaks ^zmpi')
+    assert rec.spec.external is None
+    assert rec.spec.external_module is None
+    rec = install_db.get_record('externaltool')
+    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_module is None
+    assert rec.explicit is False
+    rec.spec.package.do_install(fake=True, explicit=True)
+    rec = install_db.get_record('externaltool')
+    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_module is None
+    assert rec.explicit is True

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -375,13 +375,16 @@ def test_110_no_write_with_exception_on_install(database):
 
 def test_external_entries_in_db(database):
     install_db = database.mock.db
+
     rec = install_db.get_record('mpileaks ^zmpi')
     assert rec.spec.external is None
     assert rec.spec.external_module is None
+
     rec = install_db.get_record('externaltool')
     assert rec.spec.external == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is False
+
     rec.spec.package.do_install(fake=True, explicit=True)
     rec = install_db.get_record('externaltool')
     assert rec.spec.external == '/path/to/external_tool'

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -89,12 +89,12 @@ def _check_db_sanity(install_db):
     pkg_in_layout = sorted(spack.store.layout.all_specs())
     actual = sorted(install_db.query())
 
-    externals = sorted([x for x in actual if x.external is True])
+    externals = sorted([x for x in actual if x.external])
     nexpected = len(pkg_in_layout) + len(externals)
 
     assert nexpected == len(actual)
 
-    non_external_in_db = sorted([x for x in actual if x.external is False])
+    non_external_in_db = sorted([x for x in actual if not x.external])
 
     for e, a in zip(pkg_in_layout, non_external_in_db):
         assert e == a

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -89,12 +89,12 @@ def _check_db_sanity(install_db):
     pkg_in_layout = sorted(spack.store.layout.all_specs())
     actual = sorted(install_db.query())
 
-    externals = sorted([x for x in actual if x.external is not None])
+    externals = sorted([x for x in actual if x.external is True])
     nexpected = len(pkg_in_layout) + len(externals)
 
     assert nexpected == len(actual)
 
-    non_external_in_db = sorted([x for x in actual if x.external is None])
+    non_external_in_db = sorted([x for x in actual if x.external is False])
 
     for e, a in zip(pkg_in_layout, non_external_in_db):
         assert e == a
@@ -377,16 +377,16 @@ def test_external_entries_in_db(database):
     install_db = database.mock.db
 
     rec = install_db.get_record('mpileaks ^zmpi')
-    assert rec.spec.external is None
+    assert rec.spec.external_path is None
     assert rec.spec.external_module is None
 
     rec = install_db.get_record('externaltool')
-    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is False
 
     rec.spec.package.do_install(fake=True, explicit=True)
     rec = install_db.get_record('externaltool')
-    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is True

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -52,6 +52,16 @@ def test_normal_spec(builtin_mock):
     check_yaml_round_trip(spec)
 
 
+def test_external_spec(config, builtin_mock):
+    spec = Spec('externaltool')
+    spec.concretize()
+    check_yaml_round_trip(spec)
+
+    spec = Spec('externaltest')
+    spec.concretize()
+    check_yaml_round_trip(spec)
+
+
 def test_ambiguous_version_spec(builtin_mock):
     spec = Spec('mpileaks@1.0:5.0,6.1,7.3+debug~opt')
     spec.normalize()


### PR DESCRIPTION
##### Modifications
- [x] external packages are registered in the db and generate module files
- [x] added an attribute `external` to each spec in the DB entry
- [x] added unit tests to stress the new feature

fixes #1066