### PR TITLE
--run-tests install argument and petsc fixes

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -55,6 +55,10 @@ def setup_parser(subparser):
         help="Fake install.  Just remove the prefix and touch a fake file in it.")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER, help="specs of packages to install")
+    subparser.add_argument(
+        '--run-tests', action='store_true', dest='run_tests',
+        help="Run tests during installation of a package.")
+
 
 
 def install(parser, args):
@@ -77,6 +81,7 @@ def install(parser, args):
                 keep_stage=args.keep_stage,
                 ignore_deps=args.ignore_deps,
                 make_jobs=args.jobs,
+                run_tests=args.run_tests,
                 verbose=args.verbose,
                 fake=args.fake,
                 explicit=True)

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -154,7 +154,7 @@ class Petsc(Package):
                 env['PETSC_DIR'] = self.prefix
                 cc = Executable(spec['mpi'].mpicc)
                 cc('ex50.c', '-I%s' % prefix.include, '-L%s' % prefix.lib,
-                   '-lpetsc', '-o', 'ex50')
+                   '-lpetsc', '-lm', '-o', 'ex50')
                 run = Executable(join_path(spec['mpi'].prefix.bin, 'mpirun'))
                 run('ex50', '-da_grid_x', '4', '-da_grid_y', '4')
                 if 'superlu-dist' in spec:

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -149,20 +149,22 @@ class Petsc(Package):
         make("install")
 
         # solve Poisson equation in 2D to make sure nothing is broken:
-        with working_dir('src/ksp/ksp/examples/tutorials'):
-            cc = os.environ['CC'] if '~mpi' in self.spec else self.spec['mpi'].mpicc  # NOQA: ignore=E501
-            os.system('%s ex50.c -I%s -L%s -lpetsc -o ex50' % (
-                cc, prefix.include, prefix.lib))
-            ex50 = Executable('./ex50')
-            ex50('-da_grid_x', '4', '-da_grid_y', '4')
-            if 'superlu-dist' in spec:
-                ex50('-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'lu', '-pc_factor_mat_solver_package', 'superlu_dist')  # NOQA: ignore=E501
+        if ('mpi' in spec) and self.run_tests:
+            with working_dir('src/ksp/ksp/examples/tutorials'):
+                env['PETSC_DIR'] = self.prefix
+                cc = Executable(spec['mpi'].mpicc)
+                cc('ex50.c', '-I%s' % prefix.include, '-L%s' % prefix.lib,
+                   '-lpetsc', '-o', 'ex50')
+                run = Executable(join_path(spec['mpi'].prefix.bin, 'mpirun'))
+                run('ex50', '-da_grid_x', '4', '-da_grid_y', '4')
+                if 'superlu-dist' in spec:
+                    run('ex50', '-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'lu', '-pc_factor_mat_solver_package', 'superlu_dist')  # NOQA: ignore=E501
 
-            if 'mumps' in spec:
-                ex50('-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'lu', '-pc_factor_mat_solver_package', 'mumps')  # NOQA: ignore=E501
+                if 'mumps' in spec:
+                    run('ex50', '-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'lu', '-pc_factor_mat_solver_package', 'mumps')  # NOQA: ignore=E501
 
-            if 'hypre' in spec:
-                ex50('-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'hypre', '-pc_hypre_type', 'boomeramg')  # NOQA: ignore=E501
+                if 'hypre' in spec:
+                    run('ex50', '-da_grid_x', '4', '-da_grid_y', '4', '-pc_type', 'hypre', '-pc_hypre_type', 'boomeramg')  # NOQA: ignore=E501
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up PETSC_DIR for everyone using PETSc package


### PR DESCRIPTION
Implements `--no-tests` argument as discussed here https://github.com/LLNL/spack/issues/169 and fixes the issue reported https://github.com/LLNL/spack/pull/1145#issuecomment-229714840 by allowing to skip small tests.

tested on macOS.

@adamjstewart @alalazo @mathstuf: ping.