### PR TITLE
(bugfix) fixed typo of spec --> raw_spec

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -108,7 +108,7 @@ def module_find(mtype, flags, spec_array):
             tty.die("No installed packages match spec %s" % raw_spec)
 
         if len(specs) > 1:
-            tty.error("Multiple matches for spec %s.  Choose one:" % spec)
+            tty.error("Multiple matches for spec %s.  Choose one:" % raw_spec)
             for s in specs:
                 sys.stderr.write(s.tree(color=True))
             sys.exit(1)


### PR DESCRIPTION
`spec` is not defined when used. becomes a problem when multiple versions exist.