### PR TITLE
RPATH for blas in py numpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -63,6 +63,7 @@ class PyNumpy(Package):
                 f.write('[DEFAULT]\n')
                 f.write('libraries=%s\n'    % ','.join(libraries))
                 f.write('library_dirs=%s\n' % ':'.join(library_dirs))
+                f.write('rpath=%s\n' % ':'.join(library_dirs))
 
         python('setup.py', 'install', '--prefix=%s' % prefix)
 

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class PyNumpy(Package):
     """NumPy is the fundamental package for scientific computing with Python.
     It contains among other things: a powerful N-dimensional array object,
@@ -37,7 +38,6 @@ class PyNumpy(Package):
     version('1.10.4', 'aed294de0aa1ac7bd3f9745f4f1968ad')
     version('1.9.2',  'a1ed53432dbcd256398898d35bc8e645')
     version('1.9.1',  '78842b73560ec378142665e712ae4ad9')
-
 
     variant('blas',   default=True)
     variant('lapack', default=True)
@@ -66,4 +66,3 @@ class PyNumpy(Package):
                 f.write('rpath=%s\n' % ':'.join(library_dirs))
 
         python('setup.py', 'install', '--prefix=%s' % prefix)
-


### PR DESCRIPTION
In the `site.cfg.example` that is basically the documentation on how to link with blas you can read
```
# runtime_library_dirs/rpath
#       List of directories that contains the libraries that should be 
#       used at runtime, thereby disregarding the LD_LIBRARY_PATH variable.
#       See 'library_dirs' for formatting on different platforms.
#           runtime_library_dirs = /opt/blas/lib:/opt/lapack/lib
#       or equivalently
#           rpath = /opt/blas/lib:/opt/lapack/lib
```

@citibeth this should fix #719 and help for #722
