### PR TITLE
[WIP] Sample CMakePackages (Everytrace)

### DIFF
--- a/var/spack/repos/builtin/packages/ettest/package.py
+++ b/var/spack/repos/builtin/packages/ettest/package.py
@@ -1,0 +1,21 @@
+from spack import *
+import llnl.util.tty as tty
+import os
+
+class Ettest(CMakePackage):
+    """Get stack trace EVERY time a program exits."""
+
+    homepage = "https://github.com/citibeth/ettest"
+    version('develop', git='https://github.com/citibeth/ettest.git', branch='develop')
+
+    depends_on('cmake')
+    depends_on('everytrace+mpi+fortran')
+
+    # Currently the only MPI this everytrace works with.
+    depends_on('openmpi')
+
+    def configure_args(self):
+        return []
+
+    def setup_environment(self, spack_env, env):
+        env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -1,0 +1,30 @@
+# Install with:
+#      spack diy --skip-patch everytrace@devel +fortran +mpi ^openmpi
+
+from spack import *
+import llnl.util.tty as tty
+import os
+
+class Everytrace(CMakePackage):
+    """Get stack trace EVERY time a program exits."""
+
+    homepage = "https://github.com/citibeth/everytrace"
+    url          = "https://github.com/citibeth/everytrace/tarball/0.2.0"
+
+    version('0.2.0', '2af0e5b6255064d5191accebaa70d222')
+    version('develop', git='https://github.com/citibeth/everytrace.git', branch='develop')
+
+    variant('mpi', default=True, description='Enables MPI parallelism')
+    variant('fortran', default=True, description='Enable use with Fortran programs')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('cmake')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DUSE_MPI=%s' % ('YES' if '+mpi' in spec else 'NO'),
+            '-DUSE_FORTRAN=%s' % ('YES' if '+fortran' in spec else 'NO')]
+
+    def setup_environment(self, spack_env, env):
+        env.prepend_path('PATH', join_path(self.prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -12,7 +12,7 @@ class Everytrace(CMakePackage):
     url          = "https://github.com/citibeth/everytrace/tarball/0.2.0"
 
     version('0.2.0', '2af0e5b6255064d5191accebaa70d222')
-    version('develop', git='https://github.com/citibeth/everytrace.git', branch='develop')
+    version('develop', git='https://github.com/citibeth/everytrace.git', branch='develop', preferred=True)
 
     variant('mpi', default=True, description='Enables MPI parallelism')
     variant('fortran', default=True, description='Enable use with Fortran programs')


### PR DESCRIPTION
Sample packages using CMakePackage base calss.
Try:
```
$ spack install ettest
$ spack load ettest
$ test_et_cf
_EVERYTRACE_ REFERENCE "/home2/rpfische/spack/opt/spack/linux-x86_64/gcc-4.9.3/ettest-develop-ri4ud3fvicijbbvjovmotisnvtxagy36/lib/libettestlib_cf.so" 0x7f2d57725f60
xxx Exit type (null)
_EVERYTRACE_: Caught signal 11 (SIGSEGV)
_EVERYTRACE_ DUMP: Exiting with return code: 11
#0  0x7f2d561522a2
#1  0x7f2d57524246
#2  0x7f2d5752429d
#3  0x7f2d5697466f
#4  0x7f2d577260f4
#5  0x400de1
#6  0x7f2d56960b14
#7  0x400e18
#8  0xffffffffffffffff
```

The segfault and stacktrace are correct.