### PR TITLE
docbook-xml: replace 'cp -t' with install_tree

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-import glob
 from spack import *
 
 
@@ -35,9 +34,10 @@ class DocbookXml(Package):
     version('4.5', '03083e288e87a7e829e437358da7ef9e')
 
     def install(self, spec, prefix):
-        cp = which('cp')
-
-        install_args = ['-a', '-t', prefix]
-        install_args.extend(glob.glob('*'))
-
-        cp(*install_args)
+        for item in os.listdir('.'):
+            src = os.path.abspath(item)
+            dst = os.path.join(prefix, item)
+            if os.path.isdir(item):
+                install_tree(src, dst, symlinks=True)
+            else:
+                install(src, dst)


### PR DESCRIPTION
'-t' is not supported by the default cp on Mac OS X

replace with install/install_tree

cannot use only a single install_tree since shutil.copytree insists that the dst
directory not exist

Similar issue experienced/fixed in #693 