### PR TITLE
Setup environment for Intel Parallel Studio

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -471,6 +471,7 @@ class Dotkit(EnvModule):
     path = join_path(spack.share_path, 'dotkit')
     environment_modifications_formats = {
         PrependPath: 'dk_alter {name} {value}\n',
+        RemovePath: 'dk_unalter {name} {value}\n',
         SetEnv: 'dk_setenv {name} {value}\n'
     }
 

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -184,9 +184,9 @@ class IntelParallelStudio(IntelInstaller):
         run_env.prepend_path('MIC_LD_LIBRARY_PATH',
                              join_path(self.prefix, 'lib', 'mic'))
         run_env.prepend_path('MIC_LIBRARY_PATH',
-                             join_path(self.prefix, 'tbb','lib', 'mic'))
+                             join_path(self.prefix, 'tbb', 'lib', 'mic'))
         run_env.prepend_path('MIC_LD_LIBRARY_PATH',
-                             join_path(self.prefix, 'tbb','lib', 'mic'))
+                             join_path(self.prefix, 'tbb', 'lib', 'mic'))
 
         if self.spec.satisfies('+all'):
             run_env.prepend_path('PATH',
@@ -218,11 +218,14 @@ class IntelParallelStudio(IntelInstaller):
         if (self.spec.satisfies('+all') or self.spec.satisfies('+mpi')) and \
            self.spec.satisfies('@cluster'):
             run_env.prepend_path('PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64', 'bin'))
+                                 join_path(self.prefix, 'mpi', 'intel64',
+                                           'bin'))
             run_env.prepend_path('LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64', 'lib'))
+                                 join_path(self.prefix, 'mpi', 'intel64',
+                                           'lib'))
             run_env.prepend_path('LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64', 'lib'))
+                                 join_path(self.prefix, 'mpi', 'intel64',
+                                           'lib'))
             run_env.prepend_path('LD_LIBRARY_PATH',
                                  join_path(self.prefix, 'mpi', 'mic', 'lib'))
             run_env.prepend_path('MIC_LIBRARY_PATH',
@@ -233,13 +236,15 @@ class IntelParallelStudio(IntelInstaller):
 
         if self.spec.satisfies('+all') or self.spec.satisfies('+mkl'):
             run_env.prepend_path('LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mkl', 'lib', 'intel64'))
+                                 join_path(self.prefix, 'mkl', 'lib',
+                                           'intel64'))
             run_env.prepend_path('LIBRARY_PATH',
-                                 join_path(self.prefix, 'mkl', 'lib', 'intel64'))
+                                 join_path(self.prefix, 'mkl', 'lib',
+                                           'intel64'))
             run_env.prepend_path('CPATH',
                                  join_path(self.prefix, 'mkl', 'include'))
             run_env.prepend_path('MIC_LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mkl','lib', 'mic'))
+                                 join_path(self.prefix, 'mkl', 'lib', 'mic'))
             run_env.set('MKLROOT', join_path(self.prefix, 'mkl'))
 
         if self.spec.satisfies('+all') or self.spec.satisfies('+daal'):
@@ -258,12 +263,13 @@ class IntelParallelStudio(IntelInstaller):
 
         if self.spec.satisfies('+all') or self.spec.satisfies('+ipp'):
             run_env.prepend_path('LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'ipp', 'lib', 'intel64'))
+                                 join_path(self.prefix, 'ipp', 'lib',
+                                           'intel64'))
             run_env.prepend_path('LIBRARY_PATH',
-                                 join_path(self.prefix, 'ipp', 'lib', 'intel64'))
+                                 join_path(self.prefix, 'ipp', 'lib',
+                                           'intel64'))
             run_env.prepend_path('CPATH',
                                  join_path(self.prefix, 'ipp', 'include'))
             run_env.prepend_path('MIC_LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'ipp','lib', 'mic'))
+                                 join_path(self.prefix, 'ipp', 'lib', 'mic'))
             run_env.set('IPPROOT', join_path(self.prefix, 'ipp'))
-

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -189,10 +189,6 @@ class IntelParallelStudio(IntelInstaller):
                              join_path(self.prefix, 'tbb', 'lib', 'mic'))
 
         if self.spec.satisfies('+all'):
-            run_env.prepend_path('PATH',
-                                 join_path(self.prefix,
-                                           'debugger_{0}'.format(major_ver),
-                                           'gdb', 'intel64_mic', 'bin'))
             run_env.prepend_path('LD_LIBRARY_PATH',
                                  join_path(self.prefix,
                                            'debugger_{0}'.format(major_ver),
@@ -218,21 +214,21 @@ class IntelParallelStudio(IntelInstaller):
         if (self.spec.satisfies('+all') or self.spec.satisfies('+mpi')) and \
            self.spec.satisfies('@cluster'):
             run_env.prepend_path('PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64',
+                                 join_path(self.prefix, 'impi', 'intel64',
                                            'bin'))
             run_env.prepend_path('LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64',
+                                 join_path(self.prefix, 'impi', 'intel64',
                                            'lib'))
             run_env.prepend_path('LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'intel64',
+                                 join_path(self.prefix, 'impi', 'intel64',
                                            'lib'))
             run_env.prepend_path('LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'mic', 'lib'))
+                                 join_path(self.prefix, 'impi', 'mic', 'lib'))
             run_env.prepend_path('MIC_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'mic', 'lib'))
+                                 join_path(self.prefix, 'impi', 'mic', 'lib'))
             run_env.prepend_path('MIC_LD_LIBRARY_PATH',
-                                 join_path(self.prefix, 'mpi', 'mic', 'lib'))
-            run_env.set('I_MPI_ROOT', join_path(self.prefix, 'mpi'))
+                                 join_path(self.prefix, 'impi', 'mic', 'lib'))
+            run_env.set('I_MPI_ROOT', join_path(self.prefix, 'impi'))
 
         if self.spec.satisfies('+all') or self.spec.satisfies('+mkl'):
             run_env.prepend_path('LD_LIBRARY_PATH',

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -66,7 +66,7 @@ PHONEHOME_SEND_USAGE_DATA=no
 CONTINUE_WITH_OPTIONAL_ERROR=yes
 COMPONENTS=%s
 """ % (self.intel_prefix, self.intel_prefix, self.global_license_file,
-       self.intel_components))
+                self.intel_components))
 
         install_script = Executable("./install.sh")
         install_script('--silent', silent_config_filename)
@@ -106,8 +106,8 @@ class Intel(IntelInstaller):
             self.prefix.lib, "intel64", "libimf.a")))[0]
 
         # symlink or copy?
-        os.symlink(self.global_license_file, os.path.join(absbindir,
-                   "license.lic"))
+        os.symlink(self.global_license_file,
+                   os.path.join(absbindir, "license.lic"))
 
         if spec.satisfies('+rpath'):
             for compiler_command in ["icc", "icpc", "ifort"]:
@@ -147,7 +147,6 @@ class Intel(IntelInstaller):
         run_env.prepend_path('MIC_LD_LIBRARY_PATH',
                              join_path(self.prefix, 'lib', 'mic'))
         run_env.prepend_path('MIC_LIBRARY_PATH',
-                             join_path(self.prefix, 'tbb','lib', 'mic'))
+                             join_path(self.prefix, 'tbb', 'lib', 'mic'))
         run_env.prepend_path('MIC_LD_LIBRARY_PATH',
-                             join_path(self.prefix, 'tbb','lib', 'mic'))
-
+                             join_path(self.prefix, 'tbb', 'lib', 'mic'))

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -49,13 +49,6 @@ class IntelInstaller(Package):
 
     def install(self, spec, prefix):
 
-        # Remove the installation DB, otherwise it will try to install into
-        # location of other Intel builds
-        if os.path.exists(os.path.join(os.environ["HOME"], "intel",
-                          "intel_sdp_products.db")):
-            os.remove(os.path.join(os.environ["HOME"], "intel",
-                      "intel_sdp_products.db"))
-
         if not hasattr(self, "intel_prefix"):
             self.intel_prefix = self.prefix
 
@@ -66,12 +59,14 @@ ACCEPT_EULA=accept
 PSET_MODE=install
 CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes
 PSET_INSTALL_DIR=%s
+NONRPM_DB_DIR=%s
 ACTIVATION_LICENSE_FILE=%s
 ACTIVATION_TYPE=license_file
 PHONEHOME_SEND_USAGE_DATA=no
 CONTINUE_WITH_OPTIONAL_ERROR=yes
 COMPONENTS=%s
-""" % (self.intel_prefix, self.global_license_file, self.intel_components))
+""" % (self.intel_prefix, self.intel_prefix, self.global_license_file,
+       self.intel_components))
 
         install_script = Executable("./install.sh")
         install_script('--silent', silent_config_filename)
@@ -123,3 +118,36 @@ class Intel(IntelInstaller):
 
         os.symlink(os.path.join(self.prefix.man, "common", "man1"),
                    os.path.join(self.prefix.man, "man1"))
+
+    def setup_environment(self, spack_env, run_env):
+
+        # Remove paths that were guessed but are incorrect for this package.
+        run_env.remove_path('LIBRARY_PATH',
+                            join_path(self.prefix, 'lib'))
+        run_env.remove_path('LD_LIBRARY_PATH',
+                            join_path(self.prefix, 'lib'))
+        run_env.remove_path('CPATH',
+                            join_path(self.prefix, 'include'))
+
+        # Add the default set of variables
+        run_env.prepend_path('LIBRARY_PATH',
+                             join_path(self.prefix, 'lib', 'intel64'))
+        run_env.prepend_path('LD_LIBRARY_PATH',
+                             join_path(self.prefix, 'lib', 'intel64'))
+        run_env.prepend_path('LIBRARY_PATH',
+                             join_path(self.prefix, 'tbb', 'lib',
+                                       'intel64', 'gcc4.4'))
+        run_env.prepend_path('LD_LIBRARY_PATH',
+                             join_path(self.prefix, 'tbb', 'lib',
+                                       'intel64', 'gcc4.4'))
+        run_env.prepend_path('CPATH',
+                             join_path(self.prefix, 'tbb', 'include'))
+        run_env.prepend_path('MIC_LIBRARY_PATH',
+                             join_path(self.prefix, 'lib', 'mic'))
+        run_env.prepend_path('MIC_LD_LIBRARY_PATH',
+                             join_path(self.prefix, 'lib', 'mic'))
+        run_env.prepend_path('MIC_LIBRARY_PATH',
+                             join_path(self.prefix, 'tbb','lib', 'mic'))
+        run_env.prepend_path('MIC_LD_LIBRARY_PATH',
+                             join_path(self.prefix, 'tbb','lib', 'mic'))
+


### PR DESCRIPTION
Set up the environment for the Intel compilers and tools. This commit
does the following:

- Unset variables that were incorrect from the auto guess prefix
  inspections.
- Add a RemovePath `environment_modifications_formats` for dotkit.
- Set the module environment variables appropriate for the different
  variants.
- Change the component logic so that the '+all' variant works. It was
  getting split by letter and leaving COMPONENTS empty.
- Added a variant checking function.
- Added NONRPM_DB_DIR to the silent.cfg so that the product database
  goes to the installation directory.
- With the product database in prefix the code to remove the product
  database file from the home directory is no longer needed and was
  removed.
- Reformat the 'tools' variant description.

There are probably more variables needed for the '+tools' for the
'professional' product version but I do not have access to that.