### PR TITLE
Bugfix/github1196 specify preferred variants

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -142,8 +142,9 @@ Here's an example packages.yaml file that sets preferred packages:
 .. code-block:: sh
 
     packages:
-      dyninst:
+      opencv:
         compiler: [gcc@4.9]
+        variants: +debug
       gperftools:
         version: [2.2, 2.4, 2.3]
       all:
@@ -153,17 +154,17 @@ Here's an example packages.yaml file that sets preferred packages:
 
 
 At a high level, this example is specifying how packages should be
-concretized.  The dyninst package should prefer using gcc 4.9.
-The gperftools package should prefer version
+concretized.  The opencv package should prefer using gcc 4.9 and
+be built with debug options.  The gperftools package should prefer version
 2.2 over 2.4.  Every package on the system should prefer mvapich for
-its MPI and gcc 4.4.7 (except for Dyninst, which overrides this by preferring gcc 4.9).
+its MPI and gcc 4.4.7 (except for opencv, which overrides this by preferring gcc 4.9).
 These options are used to fill in implicit defaults.  Any of them can be overwritten
 on the command line if explicitly requested.
 
 Each packages.yaml file begins with the string ``packages:`` and
 package names are specified on the next level. The special string ``all``
 applies settings to each package. Underneath each package name is
-one or more components: ``compiler``, ``version``,
+one or more components: ``compiler``, ``variants``, ``version``,
 or ``providers``.  Each component has an ordered list of spec
 ``constraints``, with earlier entries in the list being preferred over
 later entries.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -254,13 +254,18 @@ class DefaultConcretizer(object):
 
     def concretize_variants(self, spec):
         """If the spec already has variants filled in, return.  Otherwise, add
-           the default variants from the package specification.
+           the user preferences from packages.yaml or the default variants from
+           the package specification.
         """
         changed = False
+        preferred_variants = spack.pkgsort.spec_preferred_variants(spec.package_class.name)
         for name, variant in spec.package_class.variants.items():
             if name not in spec.variants:
-                spec.variants[name] = spack.spec.VariantSpec(name, variant.default)
                 changed = True
+                if name in preferred_variants:
+                    spec.variants[name] = preferred_variants.get(name)
+                else:
+                    spec.variants[name] = spack.spec.VariantSpec(name, variant.default)
         return changed
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -257,7 +257,13 @@ section_schemas = {
                             'paths': {
                                 'type' : 'object',
                                 'default' : {},
-                            }
+                             },
+                            'variants': {
+                                'oneOf' : [
+                                    { 'type' : 'string' },
+                                    { 'type' : 'array',
+                                      'items' : { 'type' : 'string' } },
+                                    ], },
                         },},},},},},
 
     'modules': {

--- a/lib/spack/spack/preferred_packages.py
+++ b/lib/spack/spack/preferred_packages.py
@@ -158,6 +158,13 @@ class PreferredPackages(object):
         return bool(self._order_for_package(pkgname, 'providers',
                     provider_str, False))
 
+    def spec_preferred_variants(self, pkgname):
+        """Return a VariantMap of preferred variants and their values"""
+        variants = self.preferred.get(pkgname, {}).get('variants', '')
+        if not isinstance(variants, basestring):
+            variants = "".join(variants)
+        return spack.spec.Spec(pkgname + variants).variants
+
     def version_compare(self, pkgname, a, b):
         """Return less-than-0, 0, or greater than 0 if version a of pkgname is
            respectively less-than, equal-to, or greater-than version b of


### PR DESCRIPTION
This fix is intended to resolve #1196. This uses the following format for packages.yaml:
```
packages:
  python:
    variants: +ucs4
  octave:
    variants: +fftw+curl+qt
```
which was the format in the original documentation, and conforms to the usual spec form.