### PR TITLE
Fix typo in Octave variant suitesparse

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -61,7 +61,7 @@ class Octave(Package):
     variant('qrupdate',   default=False)
     variant('qscintilla', default=False)
     variant('qt',         default=False)
-    variant('suiteparse', default=False)
+    variant('suitesparse', default=False)
     variant('zlib',       default=False)
 
     # Required dependencies


### PR DESCRIPTION
Fix a typo in the Octave variant name, it was called `suiteparse` but was later referenced using:
```
depends_on('suite-sparse', when='+suitesparse')
```
