### PR TITLE
Add share/man to prefix inspections.

### DIFF
--- a/etc/spack/modules.yaml
+++ b/etc/spack/modules.yaml
@@ -13,6 +13,8 @@ modules:
       - PATH
     man:
       - MANPATH
+    share/man:
+      - MANPATH
     lib:
       - LIBRARY_PATH
       - LD_LIBRARY_PATH


### PR DESCRIPTION
The share/man path should be in prefix_inspections for MANPATH as
share/man is a common location for manual pages.