### PR TITLE
Add `submodules` option for git fetching.

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -604,6 +604,7 @@ Git fetching is enabled with the following parameters to ``version``:
   * ``tag``: name of a tag to fetch.
   * ``branch``: name of a branch to fetch.
   * ``commit``: SHA hash (or prefix) of a commit to fetch.
+  * ``submodules``: Also fetch submodules when checking out this repository.
 
 Only one of ``tag``, ``branch``, or ``commit`` can be used at a time.
 
@@ -659,6 +660,17 @@ Commits
   e.g. you might use the date as the version, as done above.  Or you
   could just use the abbreviated commit hash.  It's up to the package
   author to decide what makes the most sense.
+
+Submodules
+
+  You can supply ``submodules=True`` to cause Spack to fetch submodules
+  along with the repository at fetch time.
+
+  .. code-block:: python
+
+     version('1.0.1', git='https://github.com/example-project/example.git',
+             tag='v1.0.1', submdoules=True)
+
 
 Installing
 ^^^^^^^^^^^^^^

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -366,8 +366,8 @@ class CacheURLFetchStrategy(URLFetchStrategy):
             try:
                 self.check()
             except ChecksumError:
-                # Future fetchers will assume they don't need to download if the
-                # file remains
+                # Future fetchers will assume they don't need to
+                # download if the file remains
                 os.remove(self.archive_file)
                 raise
 
@@ -517,6 +517,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         super(GitFetchStrategy, self).__init__(
             'git', 'tag', 'branch', 'commit', **forwarded_args)
         self._git = None
+        self.submodules = kwargs.get('submodules', False)
 
     @property
     def git_version(self):
@@ -594,6 +595,10 @@ class GitFetchStrategy(VCSFetchStrategy):
                 # see: https://github.com/git/git/commit/19d122b
                 self.git('pull', '--tags', ignore_errors=1)
                 self.git('checkout', self.tag)
+
+        # Init submodules if the user asked for them.
+        if self.submodules:
+            self.git('submodule', 'update', '--init')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')


### PR DESCRIPTION
Resolves #1216.  Allows user to supply `submodules=True` to git fetch.  e.g.:

```python
    version('develop', git='<git url>', branch='master', submodules=True)
```

@willelm: Can you see if this PR meets your needs?