### PR TITLE
Use the site_packages_dir from the Python class

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
 class Libxml2(Package):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -43,9 +43,6 @@ class Libxml2(Package):
 
     def install(self, spec, prefix):
         if '+python' in spec:
-            site_packages_dir = os.path.join(prefix,
-                                             'lib/python%s/site-packages' %
-                                             (spec['python'].version.up_to(2)))
             python_args = ["--with-python=%s" % spec['python'].prefix,
                            "--with-python-install-dir=%s" % site_packages_dir]
         else:


### PR DESCRIPTION
It is not necessary to set site_packages_dir in this package as it is
already provided by the Python package class.