### PR TITLE
Add Tkinter support for Python

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -44,6 +44,12 @@ class Tcl(Package):
 
     depends_on('zlib')
 
+    def setup_environment(self, spack_env, env):
+        # When using Tkinter from within spack provided python+tk, python
+        # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
+        env.set('TCL_LIBRARY', join_path(self.prefix.lib, 'tcl{0}'.format(
+                self.spec.version.up_to(2))))
+
     def install(self, spec, prefix):
         with working_dir('unix'):
             configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class Tcl(Package):
     """Tcl (Tool Command Language) is a very powerful but easy to
        learn dynamic programming language, suitable for a very wide
@@ -34,15 +35,16 @@ class Tcl(Package):
        extensible."""
     homepage = "http://www.tcl.tk"
 
-    def url_for_version(self, version):
-        return 'http://prdownloads.sourceforge.net/tcl/tcl%s-src.tar.gz' % version
-
     version('8.6.5', '0e6426a4ca9401825fbc6ecf3d89a326')
     version('8.6.4', 'd7cbb91f1ded1919370a30edd1534304')
     version('8.6.3', 'db382feca91754b7f93da16dc4cdad1f')
     version('8.5.19', '0e6426a4ca9401825fbc6ecf3d89a326')
 
     depends_on('zlib')
+
+    def url_for_version(self, version):
+        base_url = 'http://prdownloads.sourceforge.net/tcl'
+        return '{0}/tcl{1}-src.tar.gz'.format(base_url, version)
 
     def setup_environment(self, spack_env, env):
         # When using Tkinter from within spack provided python+tk, python
@@ -52,6 +54,6 @@ class Tcl(Package):
 
     def install(self, spec, prefix):
         with working_dir('unix'):
-            configure("--prefix=%s" % prefix)
+            configure("--prefix={0}".format(prefix))
             make()
             make("install")

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class Tk(Package):
     """Tk is a graphical user interface toolkit that takes developing
        desktop applications to a higher level than conventional
@@ -33,12 +34,14 @@ class Tk(Package):
        and more."""
     homepage = "http://www.tcl.tk"
 
-    def url_for_version(self, version):
-        return "http://prdownloads.sourceforge.net/tcl/tk%s-src.tar.gz" % version
-
+    version('8.6.5', '11dbbd425c3e0201f20d6a51482ce6c4')
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
 
     depends_on("tcl")
+
+    def url_for_version(self, version):
+        base_url = "http://prdownloads.sourceforge.net/tcl"
+        return "{0}/tk{1}-src.tar.gz".format(base_url, version)
 
     def setup_environment(self, spack_env, env):
         # When using Tkinter from within spack provided python+tk, python
@@ -48,7 +51,7 @@ class Tk(Package):
 
     def install(self, spec, prefix):
         with working_dir('unix'):
-            configure("--prefix=%s" % prefix,
-                      "--with-tcl=%s" % spec['tcl'].prefix.lib)
+            configure("--prefix={0}".format(prefix),
+                      "--with-tcl={0}".format(spec['tcl'].prefix.lib))
             make()
             make("install")

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -40,6 +40,12 @@ class Tk(Package):
 
     depends_on("tcl")
 
+    def setup_environment(self, spack_env, env):
+        # When using Tkinter from within spack provided python+tk, python
+        # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
+        env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
+                self.spec.version.up_to(2))))
+
     def install(self, spec, prefix):
         with working_dir('unix'):
             configure("--prefix=%s" % prefix,


### PR DESCRIPTION
This PR addresses #1024 and adds a `+tk` variant to the Python package. Much of this work was taken from #1039, but that PR has been inactive for a while now, so I opened my own.

The following [Tkinter test instructions](https://wiki.python.org/moin/TkInter) succeeded for me in both Python 2 and 3:
#### Python 2
```
$ python
>>> import _tkinter
>>> import Tkinter
>>> Tkinter._test()
```
#### Python 3
```
$ python3
>>> import _tkinter
>>> import tkinter
>>> tkinter._test()
```
However, the tests only succeeded when I manually set my `TCL_LIBRARY` and `TK_LIBRARY`. If anyone knows a way to RPATH these, let me know.