### PR TITLE
Fix preferred providers.

### DIFF
--- a/lib/spack/spack/preferred_packages.py
+++ b/lib/spack/spack/preferred_packages.py
@@ -41,7 +41,7 @@ class PreferredPackages(object):
             pkglist.append('all')
         for pkg in pkglist:
             order = self.preferred.get(pkg, {}).get(component, {})
-            if type(order) is dict:
+            if isinstance(order, dict) and second_key:
                 order = order.get(second_key, {})
             if not order:
                 continue
@@ -89,9 +89,9 @@ class PreferredPackages(object):
     # a and b are considered to match entries in the sorting list if they
     # satisfy the list component.
     def _spec_compare(self, pkgname, component, a, b, reverse_natural_compare, second_key):
-        if not a or not a.concrete:
+        if not a or (not a.concrete and not second_key):
             return -1
-        if not b or not b.concrete:
+        if not b or (not b.concrete and not second_key):
             return 1
         specs = self._spec_for_pkgname(pkgname, component, second_key)
         a_index = None

--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -27,7 +27,6 @@ from contextlib import contextmanager
 
 import StringIO
 import spack.modules
-import unittest
 from spack.test.mock_packages_test import MockPackagesTest
 
 FILE_REGISTRY = collections.defaultdict(StringIO.StringIO)

--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -266,7 +266,7 @@ class TclTests(MockPackagesTest):
 
     def test_blacklist(self):
         spack.modules.CONFIGURATION = configuration_blacklist
-        spec = spack.spec.Spec('mpileaks')
+        spec = spack.spec.Spec('mpileaks ^zmpi')
         content = self.get_modulefile_content(spec)
         self.assertEqual(len([x for x in content if 'is-loaded' in x]), 1)
         self.assertEqual(len([x for x in content if 'module load ' in x]), 1)


### PR DESCRIPTION
Configuring preferred providers via `etc/spack/packages.yaml` does not work. I have configured it as follows:

```
packages:
  all:
    providers:
      mpi: [mpich]
```

Running `spack spec mpi` results in:

```
Concretized
------------------------------
  openmpi@1.10.3%gcc@6.1.1~mxm~pmi~psm~psm2~slurm~sqlite3~thread_multiple~tm~verbs+vt arch=linux-fedora24-x86_64
      ^hwloc@1.11.3%gcc@6.1.1 arch=linux-fedora24-x86_64
          ^libpciaccess@0.13.4%gcc@6.1.1 arch=linux-fedora24-x86_64
              ^libtool@2.4.6%gcc@6.1.1 arch=linux-fedora24-x86_64
                  ^m4@1.4.17%gcc@6.1.1+sigsegv arch=linux-fedora24-x86_64
                      ^libsigsegv@2.10%gcc@6.1.1 arch=linux-fedora24-x86_64
```

After applying my patch, it results in:

```
Concretized
------------------------------
  mpich@3.2%gcc@6.1.1+hydra+pmi~verbs arch=linux-fedora24-x86_64
```

A few words about the patch:
- `isinstance` has to be used because the dictionary is actually a `syaml_dict`.
- When `_spec_compare` is called for `component = 'providers'`, neither `a` nor `b` have a `concrete` value, resulting in `-1` to be returned. I decided to only skip this check if `second_key` is set, which is the case for providers.