### PR TITLE
Improve shell integration.

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -101,7 +101,7 @@ function spack {
             _sp_subcommand_args=""
             _sp_module_args=""
             while [[ "$1" =~ ^- ]]; do
-                if [ "$1" = "-r" ]; then
+                if [ "$1" = "-r" -o "$1" = "--dependencies" ]; then
                     _sp_subcommand_args="$_sp_subcommand_args $1"
                 else
                     _sp_module_args="$_sp_module_args $1"


### PR DESCRIPTION
This PR improves several points about the shell integration:
1. It enables sh emulation for Zsh because Zsh does not do word splitting by default, causing several errors.
2. It correctly handles multiple arguments passed to the underlying module command (replacing an if clause with a while loop).
3. It allows loading and unloading modules recursively (that is, with dependencies). This is done by explicitly filtering out `-r` when parsing the arguments and passing it to `module find`.

For example, executing `spack load -r bison` without any loaded modules results in this:
```
Currently Loaded Modulefiles:
  1) libsigsegv-2.10-gcc-6.1.1-y4dr4zikeo635x3y7azfzohjcvbmww45
  2) m4-1.4.17-gcc-6.1.1-dgqy3coqt6qi5oxs3gm5aplhbgn734l4
  3) bison-3.0.4-gcc-6.1.1-g7wd2yi7sbkbgxnxx6ybe7bgcb6g5lwl
```