### PR TITLE
Fix format of explanation of an example & question

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -543,11 +543,12 @@ More formally, a spec consists of the following pieces:
 * ``+`` or ``-`` or ``~`` Optional variant specifiers (``+debug``,
   ``-qt``, or ``~qt``) for boolean variants
 * ``name=<value>`` Optional variant specifiers that are not restricted to
-boolean variants
+  boolean variants
 * ``name=<value>`` Optional compiler flag specifiers. Valid flag names are
-``cflags``, ``cxxflags``, ``fflags``, ``cppflags``, ``ldflags``, and ``ldlibs``.
+  ``cflags``, ``cxxflags``, ``fflags``, ``cppflags``, ``ldflags``, and ``ldlibs``.
 * ``target=<value> os=<value>`` Optional architecture specifier 
-(``target=haswell os=CNL10``) * ``^`` Dependency specs (``^callpath@1.1``)
+  (``target=haswell os=CNL10``)
+* ``^`` Dependency specs (``^callpath@1.1``)
 
 There are two things to notice here.  The first is that specs are
 recursively defined.  That is, each dependency after ``^`` is a spec


### PR DESCRIPTION
This list was not formatted correctly on [the ReadTheDocs site](http://software.llnl.gov/spack/basic_usage.html#specs-dependencies).

I'm not a .rst expert, but I think that it was improperly indented.

The example includes an `arch=...` string but *arch* is not listed in the valid compiler flag specifiers or architecture specifiers.  Should it be, or is it considered an "optional variant specifier?