### PR TITLE
Updates to run-flake8 test

### DIFF
--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -18,7 +18,7 @@ if [[ ! $flake8 ]]; then
 fi
 
 # Check if changed files are flake8 conformant [framework]
-changed=$(git diff --name-only develop... | grep '.py$')
+changed=$(git diff --name-only --find-renames develop... | grep '.py$')
 
 # Add approved style exemptions to the changed packages.
 for file in $changed; do
@@ -26,6 +26,7 @@ for file in $changed; do
         cp "$file" "$file~"
 
         # Exempt lines with urls and descriptions from overlong line errors.
+        perl -i -pe 's/^(\s*homepage\s*=.*)$/\1  # NOQA: ignore=E501/' $file
         perl -i -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file
         perl -i -pe 's/^(\s*version\(.*\).*)$/\1  # NOQA: ignore=E501/' $file
         perl -i -pe 's/^(\s*variant\(.*\).*)$/\1  # NOQA: ignore=E501/' $file


### PR DESCRIPTION
Previously, if you renamed a file using `git mv`, the run-flake8 test would get confused because you changed the old file, but the old file no longer exists by that name. Adding the `--find-renames` flag to `git diff` solves this and only lists the new file name. See #1171.

This PR also excludes homepage from the line length check. See #1230.