### PR TITLE
Automatically add deptype to newly created packages

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -142,9 +142,9 @@ class ConfigureGuesser(object):
         # Build dependencies and extensions
         dependenciesDict = {
             'autotools': "# depends_on('foo')",
-            'cmake':     "depends_on('cmake')",
-            'scons':     "depends_on('scons')",
-            'python':    "extends('python')",
+            'cmake':     "depends_on('cmake', type='build')",
+            'scons':     "depends_on('scons', type='build')",
+            'python':    "extends('python', type=nolink)",
             'R':         "extends('R')",
             'unknown':   "# depends_on('foo')"
         }


### PR DESCRIPTION
Now when you create a new CMake package, it will automatically add CMake as a `build` dependency.

Is `nolink` a good default for Python packages?