### PR TITLE
The lmod package should depend_on('tcl')

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/fix_tclsh_paths.patch
+++ b/var/spack/repos/builtin/packages/lmod/fix_tclsh_paths.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.in	2016-07-21 13:03:27.861000000 -0400
++++ b/Makefile.in	2016-07-21 13:03:58.416000000 -0400
+@@ -197,6 +197,7 @@
+ 	        -e 's|@colorize@|$(COLORIZE)|g'                       	   	  \
+ 	        -e 's|@duplicate_paths@|$(DUPLICATE_PATHS)|g'      	   	  \
+ 	        -e 's|@allow_tcl_mfiles@|$(ALLOW_TCL_MFILES)|g'      	   	  \
++	        -e 's|@path_to_tclsh@|$(PATH_TO_TCLSH)|g'	      	   	  \
+ 	        -e 's|@mpath_avail@|$(MPATH_AVAIL)|g'            	   	  \
+ 	        -e 's|@short_time@|$(SHORT_TIME)|g'                   	   	  \
+ 	        -e 's|@cacheDirs@|$(SPIDER_CACHE_DIRS)|g'             	   	  \

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -44,7 +44,7 @@ class Lmod(Package):
     depends_on('lua@5.2:')
     depends_on('lua-luaposix', type=nolink)
     depends_on('lua-luafilesystem', type=nolink)
-    depends_on('tcl')
+    depends_on('tcl', type=nolink)
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-
+from glob import glob
 
 class Lmod(Package):
     """
@@ -53,6 +53,15 @@ class Lmod(Package):
             self.stage.path, 'Lmod-{version}', 'src', '?.lua')
         spack_env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
+
+    patch('fix_tclsh_paths.patch')
+    def patch(self):
+        """The tcl scripts should use the tclsh that was discovered
+           by the configure script.  Touch up their #! lines so that the
+           sed in the Makefile's install step has something to work on.
+           Requires the change in the associated patch file.fg"""
+        for tclscript in glob('src/*.tcl'):
+            filter_file(r'^#!.*tclsh', '#!@path_to_tclsh@', tclscript)
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -25,6 +25,7 @@
 from spack import *
 from glob import glob
 
+
 class Lmod(Package):
     """
     Lmod is a Lua based module system that easily handles the MODULEPATH
@@ -55,6 +56,7 @@ class Lmod(Package):
             version=self.version), separator=';')
 
     patch('fix_tclsh_paths.patch')
+
     def patch(self):
         """The tcl scripts should use the tclsh that was discovered
            by the configure script.  Touch up their #! lines so that the

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -44,6 +44,7 @@ class Lmod(Package):
     depends_on('lua@5.2:')
     depends_on('lua-luaposix', type=nolink)
     depends_on('lua-luafilesystem', type=nolink)
+    depends_on('tcl')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -57,3 +57,5 @@ class Tcl(Package):
             configure("--prefix={0}".format(prefix))
             make()
             make("install")
+        with working_dir(prefix.bin):
+            symlink('tclsh{0}'.format(self.version.up_to(2)), 'tclsh')


### PR DESCRIPTION
The lmod package needs a tclsh.  Up until now it just assumed
that one was available on the system.

This change adds a depends_on('tcl') to the lmod package.

The tcl package installs a tclsh script with an embedded version
number (e.g. tclsh8.6) but the lmod configuration looks for tclsh.
This change extends the tcl package to symlink tclshX.Y to tclsh in
the tcl package bin directory.

Closes #1257.