### PR TITLE
gitignore: don't require opt to be a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /var/spack/stage
 /var/spack/cache
 *.pyc
-/opt/
+/opt
 *~
 .DS_Store
 .idea


### PR DESCRIPTION
I use a symlink to make it easy to swap out.