### PR TITLE
Make HDF5 1.10 the default version again

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -40,7 +40,7 @@ class Hdf5(Package):
 
     version('1.10.0-patch1', '9180ff0ef8dc2ef3f61bd37a7404f295')
     version('1.10.0', 'bdc935337ee8282579cd6bc4270ad199')
-    version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618', preferred=True)
+    version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618')
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
     version('1.8.13', 'c03426e9e77d7766944654280b467289')
 

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -36,9 +36,8 @@ class Netcdf(Package):
     version('4.4.0', 'cffda0cbd97fdb3a06e9274f7aef438e')
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 
-    variant('mpi',     default=True,  description='Enables MPI parallelism')
-    variant('hdf4',    default=False, description='Enable HDF4 support')
-    variant('hdf5_18', default=True,  description='Build against HDF5 1.8')
+    variant('mpi',  default=True,  description='Enables MPI parallelism')
+    variant('hdf4', default=False, description='Enable HDF4 support')
 
     depends_on("m4", type='build')
     depends_on("hdf", when='+hdf4')
@@ -48,9 +47,8 @@ class Netcdf(Package):
 
     # Required for NetCDF-4 support
     depends_on("zlib")
-    depends_on("hdf5@:1.8.999", when='+hdf5_18')
-    depends_on("hdf5+mpi", when='+mpi')
-    depends_on("hdf5~mpi", when='~mpi')
+    depends_on("hdf5@:1.8+mpi", when='+mpi')
+    depends_on("hdf5@:1.8~mpi", when='~mpi')
 
     def install(self, spec, prefix):
         # Environment variables

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -36,8 +36,9 @@ class Netcdf(Package):
     version('4.4.0', 'cffda0cbd97fdb3a06e9274f7aef438e')
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 
-    variant('mpi',  default=True,  description='Enables MPI parallelism')
-    variant('hdf4', default=False, description='Enable HDF4 support')
+    variant('mpi',     default=True,  description='Enables MPI parallelism')
+    variant('hdf4',    default=False, description='Enable HDF4 support')
+    variant('hdf5_18', default=True,  description='Build against HDF5 1.8')
 
     depends_on("m4", type='build')
     depends_on("hdf", when='+hdf4')
@@ -47,6 +48,7 @@ class Netcdf(Package):
 
     # Required for NetCDF-4 support
     depends_on("zlib")
+    depends_on("hdf5@:1.8.999", when='+hdf5_18')
     depends_on("hdf5+mpi", when='+mpi')
     depends_on("hdf5~mpi", when='~mpi')
 


### PR DESCRIPTION
Add code to NetCDF to require HDF5 1.8 by default, so that the default behaviour when installing NetCDF does not change.

This moves the version requirement from HDF5 to NetCDF where it originates. (I believe the NetCDF community does not want to use HDF5 1.10 features by default because of backward compatibility.) Instead of making a choice for the default of all HDF5 package users, this patch makes this choice only for the NetCDF package.