### PR TITLE
Update NetCDF to version 4.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -33,6 +33,7 @@ class Netcdf(Package):
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.tar.gz"
 
+    version('4.4.1', '7843e35b661c99e1d49e60791d5072d8')
     version('4.4.0', 'cffda0cbd97fdb3a06e9274f7aef438e')
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -48,8 +48,10 @@ class Netcdf(Package):
 
     # Required for NetCDF-4 support
     depends_on("zlib")
-    depends_on("hdf5+mpi", when='+mpi')
-    depends_on("hdf5~mpi", when='~mpi')
+    depends_on('hdf5@:1.8+mpi', when='@:4.4.0+mpi')
+    depends_on('hdf5+mpi', when='@4.4.1:+mpi')
+    depends_on('hdf5@:1.8~mpi', when='@:4.4.0~mpi')
+    depends_on('hdf5~mpi', when='@4.4.1:~mpi')
 
     def install(self, spec, prefix):
         # Environment variables


### PR DESCRIPTION
This version supports HDF5 1.10 in a backward-compatible manner.