### PR TITLE
modules: Do not force suffixes to be separated by '-'

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -294,9 +294,9 @@ class EnvModule(object):
         for constraint, suffix in configuration.get('suffixes', {}).items():
             if constraint in self.spec:
                 suffixes.append(suffix)
+        name = ''.join(suffixes)
         # Always append the hash to make the module file unique
-        suffixes.append(self.spec.dag_hash())
-        name = '-'.join(suffixes)
+        name += '-' + self.spec.dag_hash()
         return name
 
     @property


### PR DESCRIPTION
This small change allows the user to choose their own style for suffix separator .

It enables configs like:

``` yaml
...
all:
  suffixes:
    +mpi: +mpi
```

or like the original behavior:

``` yaml
...
all:
  suffixes:
    +mpi: -mpi
```

etc.

I know this small change is potentially "breaking" in that some people might have to add `-` to their configs but I think it is worth it in the long run.
