### PR TITLE
[WIP] Add package for Jupyter and associated kernels

### DIFF
--- a/var/spack/repos/builtin/packages/jupyter_notebook/package.py
+++ b/var/spack/repos/builtin/packages/jupyter_notebook/package.py
@@ -1,0 +1,90 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import subprocess
+
+
+class JupyterNotebook(Package):
+    """A web application that allows you to create and share documents that
+    contain live code, equations, visualizations and explanatory text. Uses
+    include: data cleaning and transformation, numerical simulation,
+    statistical modeling, machine learning and much more."""
+
+    homepage = "http://jupyter.org/"
+    url      = "https://github.com/jupyter/notebook/archive/4.2.1.tar.gz"
+
+    version('4.2.1', '4286f1eaf608257bd69cad4042c7c2fe')
+    version('4.2.0', '136be6b72fe9db7f0269dc7fa5652a62')
+    version('4.1.0', '763ab54b3fc69f6225b9659b6994e756')
+    version('4.0.6', 'd70d8a6d01893f4b64df9edbc0e13b52')
+
+    variant('ipython',         default=True, description='Enable ipython support')
+    # variant('ipywidgets',     default=False,  description='Enable with support')  # NOQA: ignore=E501
+    # variant('ipyparallel',    default=False,  description='Enable with support')  # NOQA: ignore=E501
+    variant('jupyter_console', default=True, description='Enable console support')
+
+    # (Anecdotal) List of sources required to install Jupyer:
+    # http://simnotes.github.io/blog/installing-jupyter-on-hdp-2.3.2/
+
+    def cmd_exists(cmd):
+        try:
+            subprocess.check_output(["which", cmd])
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    if (cmd_exists("bower") is False &
+       cmd_exists("npm") is False &
+       cmd_exists("node") is False):
+        depends_on('node-js',   type='build')
+        depends_on('npm',       type='build')
+
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-setuptools',       type='build')
+    depends_on('py-ipython',          when="+ipython")
+    # depends_on('py-ipyparallel',      when="+ipyparallel")
+    # depends_on('py-ipywidgets',       when="+ipywidgets")
+    depends_on('py-jinja2')
+    depends_on('py-jsonschema')
+    depends_on('py-jupyter_core')
+    depends_on('py-jupyter_client')
+    depends_on('py-jupyter_console',  when="+jupyter_console")
+    depends_on('py-jupyter_nbconvert')
+    depends_on('py-jupyter_nbformat')
+    depends_on('py-matplotlib')
+    depends_on('py-numpy')
+    depends_on('py-pandas')
+    depends_on('py-pygments')
+    depends_on('py-scipy')
+    depends_on('py-scikit-learn')
+    depends_on('py-tornado')
+    depends_on('py-zmq')
+
+    # Unfortunately either bower (preferred?) or npm must be used to install
+    # the remaining dependencies. If bower is in path, this is automatically
+    # invoked from within the setup script. But as a fall-back npm is installed
+    # and will be called if Bower is not present on the system...
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/jupyter_notebook/package.py
+++ b/var/spack/repos/builtin/packages/jupyter_notebook/package.py
@@ -87,4 +87,4 @@ class JupyterNotebook(Package):
     # invoked from within the setup script. But as a fall-back npm is installed
     # and will be called if Bower is not present on the system...
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_console/package.py
@@ -42,4 +42,4 @@ class PyJupyterConsole(Package):
     depends_on('py-jupyter_client')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_console/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyJupyterConsole(Package):
+    """The Jupyter console is a terminal frontend for kernels using the Jupyter
+    protocol."""
+
+    homepage = "http://jupyter.org/"
+    url      = "https://github.com/jupyter/jupyter_console/archive/5.0.0.tar.gz"
+
+    version('5.0.0', '08a9fde32a45c9e2e0b4cec6eca249c2')
+    version('4.1.1', 'a8b077ae0a5c57e9518ac039ad5febb8')
+    version('4.1.0', '9c655076262760bdbeeada9d7f586237')
+    version('4.0.3', '0e928ea261e7f8154698cf69ed4f2459')
+
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-jupyter_core')
+    depends_on('py-jupyter_client')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_core/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_core/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyJupyterCore(Package):
+    """Jupyter core: Core Jupyter functionality."""
+
+    homepage = "http://jupyter.org/"
+    url      = "https://github.com/jupyter/jupyter_core/archive/4.1.0.tar.gz"
+
+    version('4.1.0', 'b7e928f965f68aef13fea1bf9d6384aa')
+    version('4.0.6', '50a73c3a4a8ed047a3674d2b5274cc3b')
+
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-setuptools', type='build')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_core/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_core/package.py
@@ -38,4 +38,4 @@ class PyJupyterCore(Package):
     depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_nbconvert/package.py
@@ -40,4 +40,4 @@ class PyJupyterNbconvert(Package):
     depends_on('py-jupyter_core')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_nbconvert/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyJupyterNbconvert(Package):
+    """The nbconvert tool allows you to convert a Jupyter .ipynb notebook
+    document file into another static format including HTML, LaTeX, PDF,
+    Markdown, reStructuredText, and more."""
+
+    homepage = "http://jupyter.org/"
+    url      = "https://github.com/jupyter/nbconvert/archive/4.2.0.tar.gz"
+
+    version('4.2.0', '8bd88771cc00f575d5edcd0b5197f964')
+
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-pycurl', type='build')
+    depends_on('py-jupyter_core')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_nbformat/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_nbformat/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyJupyterNbformat(Package):
+    """Reference implementation of the Jupyter Notebook format."""
+
+    homepage = "http://jupyter.org/"
+    url      = "https://github.com/jupyter/nbformat/archive/4.0.1.tar.gz"
+
+    version('4.0.1', 'ab7172e517c9d561c0c01eef5631b4c8')
+
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-jupyter_core')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jupyter_nbformat/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter_nbformat/package.py
@@ -37,4 +37,4 @@ class PyJupyterNbformat(Package):
     depends_on('py-jupyter_core')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix={0}'.format(prefix))
+        setup_py('install', '--prefix={0}'.format(prefix))


### PR DESCRIPTION
[List of packages](https://jupyter.readthedocs.io/en/latest/projects/content-projects.html#how-do-i-decide-which-packages-i-need)

Depends on:
- [ ] #1439
- [ ] #1440
- [ ] #1435

[Jupyter core](https://github.com/jupyter/jupyter_core)
- [x] Builds on OSX
- [ ] Builds on Linux

[Jupyter notebook](https://github.com/jupyter/notebook)
- [x] Builds on OSX
- [ ] Runs on OSX
- [x] Builds on Linux
- [ ] Runs on Linux

[Jupyter console](https://github.com/jupyter/jupyter_console)
- [x] Builds on OSX
- [ ] Runs on OSX
- [ ] Builds on Linux
- [ ] Runs on Linux

[Jupyter qt-console](https://github.com/jupyter/qtconsole)
- [ ] Builds on OSX
- [ ] Runs on OSX
- [ ] Builds on Linux
- [ ] Runs on Linux

[Available kernels](https://jupyter.readthedocs.io/en/latest/projects/subprojects.html?highlight=jupyterhub#kernels)  (build/check):
- [x] iPython (core package)
- [ ] ipywidgets
- [ ] ipyparallel

[Additional iPython kernels](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages)
- [ ] Bash
- [ ] Gnuplot
- [ ] [Maxima-Jupyter](https://github.com/robert-dodier/maxima-jupyter)

[Utilities](https://jupyter.readthedocs.io/en/latest/projects/subprojects.html?highlight=jupyterhub#formatting-and-conversion)

[nbconvert](https://github.com/jupyter/nbconvert)
- [ ] Builds on OSX (issue getting py-pycurl to download required css files)
```
running css
Failed, trying again with PycURL to avoid outdated SSL.
Failed to download css from https://cdn.jupyter.org/notebook/4.1.0/style/style.min.css: (60, 'SSL certificate problem: unable to get local issuer certificate')
```
- [ ] Builds on Linux

[nbformat](https://github.com/jupyter/nbformat)
- [x] Builds on OSX
- [ ] Builds on Linux

Other tasks
- [ ] Dummy package to that collects the Jupyter software suite?
- [ ] Appease the flake master

Note: I have no familiarity with Jupyter as of yet, so I'm just working this out as I go along.
![What's going on?](http://i1.kym-cdn.com/photos/images/facebook/000/234/739/fa5.jpg)
