### PR TITLE
Remove mechanism that auto-accepts Oracle license agreements without …

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -31,26 +31,25 @@ from spack import *
 
 class Jdk(Package):
     """The Java Development Kit (JDK) released by Oracle Corporation
-       in the form of a binary product aimed at Java developers."""
+       in the form of a binary product aimed at Java developers.
+
+      For legal reasons, Spack is not able to auto-download this tarball.
+      To install, do as follows:
+        1. Set up a Spack mirror.
+        2. Manually download the JDK tarball and put it in the Spack mirror.
+        3. Run `spack install`.
+    """
     homepage = "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
-    # Oracle requires that you accept their License Agreement in order
-    # to access the Java packages in download.oracle.com. In order to
-    # automate this process, we need to utilize these additional curl
-    # commandline options.
-    #
-    # See http://stackoverflow.com/questions/10268583/how-to-automate-download-and-installation-of-java-jdk-on-linux
-    curl_options = [
-        '-j',  # junk cookies
-        '-H',  # specify required License Agreement cookie
-        'Cookie: oraclelicense=accept-securebackup-cookie']
 
-    version('8u66-linux-x64', '88f31f3d642c3287134297b8c10e61bf',
+    version('8u66', '88f31f3d642c3287134297b8c10e61bf',
             url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz",
             curl_options=curl_options)
-    version('8u92-linux-x64', '65a1cc17ea362453a6e0eb4f13be76e4',
+    version('8u92', '65a1cc17ea362453a6e0eb4f13be76e4',
             url="http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz",
             curl_options=curl_options)
+
+    provides('java@8')
 
     def install(self, spec, prefix):
         distutils.dir_util.copy_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -40,12 +40,11 @@ class Jdk(Package):
         3. Run `spack install`.
     """
     homepage = "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
-    url = "file://%s/jdk-8u66-linux-x64.tar.gz" % os.getcwd()
 
     version('8u66', '88f31f3d642c3287134297b8c10e61bf',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz")
+            url="file://%s/jdk-8u66-linux-x64.tar.gz" % os.getcwd())
     version('8u92', '65a1cc17ea362453a6e0eb4f13be76e4',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz")
+            url="file://%s/jdk-8u92-linux-x64.tar.gz" % os.getcwd())
 
     provides('java@8')
 

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -25,6 +25,7 @@
 #
 # Author: Justin Too <too1@llnl.gov>
 #
+import os
 import distutils.dir_util
 from spack import *
 

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -41,7 +41,6 @@ class Jdk(Package):
     """
     homepage = "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
-
     version('8u66', '88f31f3d642c3287134297b8c10e61bf',
             url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz",
             curl_options=curl_options)

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -40,6 +40,7 @@ class Jdk(Package):
         3. Run `spack install`.
     """
     homepage = "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
+    url = "file://%s/jdk-8u66-linux-x64.tar.gz" % os.getcwd()
 
     version('8u66', '88f31f3d642c3287134297b8c10e61bf',
             url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz")

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -42,11 +42,9 @@ class Jdk(Package):
     homepage = "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
     version('8u66', '88f31f3d642c3287134297b8c10e61bf',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz",
-            curl_options=curl_options)
+            url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz")
     version('8u92', '65a1cc17ea362453a6e0eb4f13be76e4',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz",
-            curl_options=curl_options)
+            url="http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz")
 
     provides('java@8')
 


### PR DESCRIPTION
…user's consent or approval.  Removed because it could cause legal liability for users and LLNL.

Added virtual dependency `java`.

TODO later:
- Add better documentation on how to deal with licensed-binary installs like this one, using Spack mirrors.
- Add a real IcedTea build.
