### PR TITLE
Updates to Armadillo package

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -33,11 +33,13 @@ class Armadillo(Package):
     homepage = "http://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-7.200.1.tar.xz"
 
+    version('7.200.2', 'b21585372d67a8876117fd515d8cf0a2')
     version('7.200.1', 'ed86d6df0058979e107502e1fe3e469e')
 
     variant('hdf5', default=False, description='Include HDF5 support')
 
-    depends_on('arpack')
+    depends_on('cmake@2.8:', type='build')
+    depends_on('arpack-ng')  # old arpack causes undefined symbols
     depends_on('blas')
     depends_on('lapack')
     depends_on('superlu@5.2:')
@@ -46,8 +48,8 @@ class Armadillo(Package):
     def install(self, spec, prefix):
         cmake_args = [
             # ARPACK support
-            '-DARPACK_LIBRARY={0}/libarpack.a'.format(
-                spec['arpack'].prefix.lib),
+            '-DARPACK_LIBRARY={0}/libarpack.so'.format(
+                spec['arpack-ng'].prefix.lib),
             # BLAS support
             '-DBLAS_LIBRARY={0}'.format(spec['blas'].blas_shared_lib),
             # LAPACK support

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -48,8 +48,8 @@ class Armadillo(Package):
     def install(self, spec, prefix):
         cmake_args = [
             # ARPACK support
-            '-DARPACK_LIBRARY={0}/libarpack.so'.format(
-                spec['arpack-ng'].prefix.lib),
+            '-DARPACK_LIBRARY={0}/libarpack.{1}'.format(
+                spec['arpack-ng'].prefix.lib, dso_suffix),
             # BLAS support
             '-DBLAS_LIBRARY={0}'.format(spec['blas'].blas_shared_lib),
             # LAPACK support


### PR DESCRIPTION
- Add latest version of Armadillo
- Add cmake build dependency
- Link to arpack-ng instead of arpack (fixes #1299)