### PR TITLE
Add "default" configuration scope.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *~
 .DS_Store
 .idea
-/etc/spack/*
+/etc/spack/*.yaml
 /etc/spackconfig
 /share/spack/dotkit
 /share/spack/modules

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -1,8 +1,17 @@
 # -------------------------------------------------------------------------
-# This is the default spack module files generation configuration.
+# This is the default configuration for Spack's module file generation.
 #
-# Changes to this file will affect all users of this spack install,
-# although users can override these settings in their ~/.spack/modules.yaml.
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/modules.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/modules.yaml
 # -------------------------------------------------------------------------
 modules:
   enable:

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -1,0 +1,21 @@
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  all:
+    providers:
+      mpi: [openmpi, mpich]
+      blas: [openblas]
+      lapack: [openblas]

--- a/etc/spack/defaults/repos.yaml
+++ b/etc/spack/defaults/repos.yaml
@@ -1,0 +1,14 @@
+# -------------------------------------------------------------------------
+# This is the default spack repository configuration. It includes the
+# builtin spack package repository.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/repos.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/repos.yaml
+# -------------------------------------------------------------------------
+repos:
+  - $spack/var/spack/repos/builtin

--- a/etc/spack/repos.yaml
+++ b/etc/spack/repos.yaml
@@ -1,8 +1,0 @@
-# -------------------------------------------------------------------------
-# This is the default spack repository configuration.
-#
-# Changes to this file will affect all users of this spack install,
-# although users can override these settings in their ~/.spack/repos.yaml.
-# -------------------------------------------------------------------------
-repos:
-  - $spack/var/spack/repos/builtin

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -497,8 +497,15 @@ class ConfigScope(object):
         """Empty cached config information."""
         self.sections = {}
 
+"""Default configuration scope is the lowest-level scope. These are
+   versioned with Spack and can be overridden by sites or users."""
+ConfigScope('defaults', os.path.join(spack.etc_path, 'spack', 'defaults'))
 
-ConfigScope('site', os.path.join(spack.etc_path, 'spack')),
+"""Site configuration is per spack instance, for sites or projects.
+   No site-level configs should be checked into spack by default."""
+ConfigScope('site', os.path.join(spack.etc_path, 'spack'))
+
+"""User configuration can override both spack defaults and site config."""
 ConfigScope('user', os.path.expanduser('~/.spack'))
 
 


### PR DESCRIPTION
This implements default concretization preferences for Spack by adding a new configuration scope.  The intent is that defaults should be versioned with Spack but NOT conflict with site preferences. 

- Default scope is versioned with spack and can be overridden by site or user configs.
- Default scope provides sensible default concretization preferences for all of Spack.

TBD in a follow-on PR:
- per-platform concretization scope can be added later (to force a particular MPI on, e.g., Cray systems).
- make `jpeg` a virtual dependency and add an order of preference for its implementations.

@adamjstewart @eschnett @davydden @alalazo: anything missing?