### PR TITLE
Fetching resources that should not be expanded from mirrors

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -56,7 +56,7 @@ class MockCache(object):
     def store(self, copyCmd, relativeDst):
         pass
 
-    def fetcher(self, targetPath, digest):
+    def fetcher(self, targetPath, digest, **kwargs):
         return MockCacheFetcher()
 
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -170,12 +170,11 @@ class URLFetchStrategy(FetchStrategy):
             tty.msg("Already downloaded %s" % self.archive_file)
             return
 
-        possible_files = self.stage.expected_archive_files
         save_file = None
         partial_file = None
-        if possible_files:
-            save_file = self.stage.expected_archive_files[0]
-            partial_file = self.stage.expected_archive_files[0] + '.part'
+        if self.stage.save_filename:
+            save_file = self.stage.save_filename
+            partial_file = self.stage.save_filename + '.part'
 
         tty.msg("Trying to fetch from %s" % self.url)
 
@@ -858,9 +857,9 @@ class FsCache(object):
         mkdirp(os.path.dirname(dst))
         fetcher.archive(dst)
 
-    def fetcher(self, targetPath, digest):
+    def fetcher(self, targetPath, digest, **kwargs):
         url = "file://" + join_path(self.root, targetPath)
-        return CacheURLFetchStrategy(url, digest)
+        return CacheURLFetchStrategy(url, digest, **kwargs)
 
     def destroy(self):
         shutil.rmtree(self.root, ignore_errors=True)


### PR DESCRIPTION
This is intended to resolve https://github.com/LLNL/spack/issues/1308

It is a WIP on account of the second point below

There are two changes:

* Firstly mirror URL fetchers created in Stage.fetch use the 'expand' member of the default fetcher
* Secondly I felt that the resource retrieved by the mirror should have the same name as if it were retrieved from the web URL (if I make the first change here that still causes a problem WRT https://github.com/LLNL/spack/pull/1233). As far as I could tell this was actually intended with the implementation of Stage.expected_archive_files: it returns the mirror path as well as a path based on the current fetcher. URLFetchStrategy.fetch uses the first expected_archive_files element to choose the output filename for curl (which originally was the path based on the current fetcher URL); the current fetcher is either the default or a mirror so I changed it to reference Stage.default_fetcher (since the non-default case was covered by using the mirror path).

If I was wrong about expected_archive_files I can also modify URLFetchStrategy to optionally save to a specified file and choose that explicitly. If having expectations on the name of the staged file is considered problematic I think this can be handled another way.