### PR TITLE
Improve distribution detection

### DIFF
--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -2,6 +2,7 @@ import re
 import platform as py_platform
 from spack.architecture import OperatingSystem
 
+
 class LinuxDistro(OperatingSystem):
     """ This class will represent the autodetected operating system
         for a Linux System. Since there are many different flavors of
@@ -13,10 +14,17 @@ class LinuxDistro(OperatingSystem):
         distname, version, _ = py_platform.linux_distribution(
             full_distribution_name=False)
 
+        distname = distname.lower()
+
         # Grabs major version from tuple on redhat; on other platforms
         # grab the first legal identifier in the version field.  On
         # debian you get things like 'wheezy/sid'; sid means unstable.
         # We just record 'wheezy' and don't get quite so detailed.
-        version = re.split(r'[^\w-]', version)[0]
+        version = re.split(r'[^\w-]', version)
+
+        if 'ubuntu' in distname:
+            version = '.'.join(version[0:2])
+        else:
+            version = version[0]
 
         super(LinuxDistro, self).__init__(distname, version)


### PR DESCRIPTION
This PR improves distribution detection in two ways:
1. Lowercase the distribution name for consistency. Currently, there is "fedora" and "Ubuntu".
2. Support Ubuntu's YY.MM version scheme. Version 14.04 is not equivalent to version 14.10.

Before:

```
$ spack arch
linux-Ubuntu14-x86_64
```

After:

```
$ spack arch
linux-ubuntu14.04-x86_64
```
