### PR TITLE
Fix graph command with ASCII output

### DIFF
--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -61,7 +61,6 @@ Note that ``graph_ascii`` assumes a single spec while ``graph_dot``
 can take a number of specs as input.
 
 """
-__all__ = ['topological_sort', 'graph_ascii', 'AsciiGraph', 'graph_dot']
 
 from heapq import *
 
@@ -70,6 +69,8 @@ from llnl.util.tty.color import *
 
 import spack
 from spack.spec import Spec
+
+__all__ = ['topological_sort', 'graph_ascii', 'AsciiGraph', 'graph_dot']
 
 
 def topological_sort(spec, **kwargs):
@@ -133,6 +134,7 @@ def find(seq, predicate):
 states = ('node', 'collapse', 'merge-right', 'expand-right', 'back-edge')
 NODE, COLLAPSE, MERGE_RIGHT, EXPAND_RIGHT, BACK_EDGE = states
 
+
 class AsciiGraph(object):
     def __init__(self):
         # These can be set after initialization or after a call to
@@ -154,17 +156,14 @@ class AsciiGraph(object):
         self._prev_state = None       # State of previous line
         self._prev_index = None       # Index of expansion point of prev line
 
-
     def _indent(self):
         self._out.write(self.indent * ' ')
-
 
     def _write_edge(self, string, index, sub=0):
         """Write a colored edge to the output stream."""
         name = self._frontier[index][sub]
         edge = "@%s{%s}" % (self._name_to_color[name], string)
         self._out.write(edge)
-
 
     def _connect_deps(self, i, deps, label=None):
         """Connect dependencies to existing edges in the frontier.
@@ -200,7 +199,8 @@ class AsciiGraph(object):
             collapse = True
             if self._prev_state == EXPAND_RIGHT:
                 # Special case where previous line expanded and i is off by 1.
-                self._back_edge_line([], j, i+1, True, label + "-1.5 " + str((i+1,j)))
+                self._back_edge_line([], j, i + 1, True,
+                                     label + "-1.5 " + str((i + 1, j)))
                 collapse = False
 
             else:
@@ -208,18 +208,19 @@ class AsciiGraph(object):
                 if self._prev_state == NODE and self._prev_index < i:
                     i += 1
 
-                if i-j > 1:
+                if i - j > 1:
                     # We need two lines to connect if distance > 1
-                    self._back_edge_line([], j,  i, True, label + "-1 " + str((i,j)))
+                    self._back_edge_line([], j,  i, True,
+                                         label + "-1 " + str((i, j)))
                     collapse = False
 
-            self._back_edge_line([j], -1, -1, collapse, label + "-2 " + str((i,j)))
+            self._back_edge_line([j], -1, -1, collapse,
+                                 label + "-2 " + str((i, j)))
             return True
 
         elif deps:
             self._frontier.insert(i, deps)
             return False
-
 
     def _set_state(self, state, index, label=None):
         if state not in states:
@@ -233,7 +234,6 @@ class AsciiGraph(object):
                 str(self._prev_state) if self._prev_state else ''))
             self._out.write("%-20s" % (str(label) if label else ''))
             self._out.write("%s" % self._frontier)
-
 
     def _back_edge_line(self, prev_ends, end, start, collapse, label=None):
         """Write part of a backwards edge in the graph.
@@ -288,26 +288,25 @@ class AsciiGraph(object):
         self._indent()
 
         for p in prev_ends:
-            advance(p,         lambda: [("| ", self._pos)] )
-            advance(p+1,       lambda: [("|/", self._pos)] )
+            advance(p,         lambda: [("| ", self._pos)])  # NOQA: ignore=E272
+            advance(p + 1,     lambda: [("|/", self._pos)])  # NOQA: ignore=E272
 
         if end >= 0:
-            advance(end + 1,   lambda: [("| ", self._pos)] )
-            advance(start - 1, lambda: [("|",  self._pos), ("_", end)] )
+            advance(end + 1,   lambda: [("| ", self._pos)])  # NOQA: ignore=E272
+            advance(start - 1, lambda: [("|",  self._pos), ("_", end)])  # NOQA: ignore=E272
         else:
-            advance(start - 1, lambda: [("| ", self._pos)] )
+            advance(start - 1, lambda: [("| ", self._pos)])  # NOQA: ignore=E272
 
         if start >= 0:
-            advance(start,     lambda: [("|",  self._pos), ("/", end)] )
+            advance(start,     lambda: [("|",  self._pos), ("/", end)])  # NOQA: ignore=E272
 
         if collapse:
-            advance(flen,      lambda: [(" /", self._pos)] )
+            advance(flen,      lambda: [(" /", self._pos)])  # NOQA: ignore=E272
         else:
-            advance(flen,      lambda: [("| ", self._pos)] )
+            advance(flen,      lambda: [("| ", self._pos)])  # NOQA: ignore=E272
 
         self._set_state(BACK_EDGE, end, label)
         self._out.write("\n")
-
 
     def _node_line(self, index, name):
         """Writes a line with a node at index."""
@@ -317,13 +316,12 @@ class AsciiGraph(object):
 
         self._out.write("%s " % self.node_character)
 
-        for c in range(index+1, len(self._frontier)):
+        for c in range(index + 1, len(self._frontier)):
             self._write_edge("| ", c)
 
         self._out.write(" %s" % name)
         self._set_state(NODE, index)
         self._out.write("\n")
-
 
     def _collapse_line(self, index):
         """Write a collapsing line after a node was added at index."""
@@ -336,20 +334,18 @@ class AsciiGraph(object):
         self._set_state(COLLAPSE, index)
         self._out.write("\n")
 
-
     def _merge_right_line(self, index):
         """Edge at index is same as edge to right.  Merge directly with '\'"""
         self._indent()
         for c in range(index):
             self._write_edge("| ", c)
         self._write_edge("|", index)
-        self._write_edge("\\", index+1)
-        for c in range(index+1, len(self._frontier)):
-            self._write_edge("| ", c )
+        self._write_edge("\\", index + 1)
+        for c in range(index + 1, len(self._frontier)):
+            self._write_edge("| ", c)
 
         self._set_state(MERGE_RIGHT, index)
         self._out.write("\n")
-
 
     def _expand_right_line(self, index):
         self._indent()
@@ -357,14 +353,13 @@ class AsciiGraph(object):
             self._write_edge("| ", c)
 
         self._write_edge("|", index)
-        self._write_edge("\\", index+1)
+        self._write_edge("\\", index + 1)
 
-        for c in range(index+2, len(self._frontier)):
+        for c in range(index + 2, len(self._frontier)):
             self._write_edge(" \\", c)
 
         self._set_state(EXPAND_RIGHT, index)
         self._out.write("\n")
-
 
     def write(self, spec, **kwargs):
         """Write out an ascii graph of the provided spec.
@@ -399,7 +394,7 @@ class AsciiGraph(object):
         # Colors associated with each node in the DAG.
         # Edges are colored by the node they point to.
         self._name_to_color = dict((name, self.colors[i % len(self.colors)])
-                                  for i, name in enumerate(topo_order))
+                                   for i, name in enumerate(topo_order))
 
         # Frontier tracks open edges of the graph as it's written out.
         self._frontier = [[spec.name]]
@@ -408,7 +403,8 @@ class AsciiGraph(object):
             i = find(self._frontier, lambda f: len(f) > 1)
 
             if i >= 0:
-                # Expand frontier until there are enough columns for all children.
+                # Expand frontier until there are enough columns for all
+                # children.
 
                 # Figure out how many back connections there are and
                 # sort them so we do them in order
@@ -425,8 +421,9 @@ class AsciiGraph(object):
                     prev_ends = []
                     for j, (b, d) in enumerate(back):
                         self._frontier[i].remove(d)
-                        if i-b > 1:
-                            self._back_edge_line(prev_ends, b, i, False, 'left-1')
+                        if i - b > 1:
+                            self._back_edge_line(prev_ends, b, i, False,
+                                                 'left-1')
                             del prev_ends[:]
                         prev_ends.append(b)
 
@@ -440,12 +437,13 @@ class AsciiGraph(object):
                 elif len(self._frontier[i]) > 1:
                     # Expand forward after doing all back connections
 
-                    if (i+1 < len(self._frontier) and len(self._frontier[i+1]) == 1
-                        and self._frontier[i+1][0] in self._frontier[i]):
+                    if (i + 1 < len(self._frontier) and
+                       len(self._frontier[i + 1]) == 1 and
+                       self._frontier[i + 1][0] in self._frontier[i]):
                         # We need to connect to the element to the right.
                         # Keep lines straight by connecting directly and
                         # avoiding unnecessary expand/contract.
-                        name = self._frontier[i+1][0]
+                        name = self._frontier[i + 1][0]
                         self._frontier[i].remove(name)
                         self._merge_right_line(i)
 
@@ -459,9 +457,8 @@ class AsciiGraph(object):
                         self._frontier.pop(i)
                         self._connect_deps(i, deps, "post-expand")
 
-
                 # Handle any remaining back edges to the right
-                j = i+1
+                j = i + 1
                 while j < len(self._frontier):
                     deps = self._frontier.pop(j)
                     if not self._connect_deps(j, deps, "back-from-right"):
@@ -479,8 +476,9 @@ class AsciiGraph(object):
                 # Replace node with its dependencies
                 self._frontier.pop(i)
                 if node.dependencies():
-                    deps = sorted((d.name for d in node.dependencies()), reverse=True)
-                    self._connect_deps(i, deps, "new-deps") # anywhere.
+                    deps = sorted((d.name for d in node.dependencies()),
+                                  reverse=True)
+                    self._connect_deps(i, deps, "new-deps")  # anywhere.
 
                 elif self._frontier:
                     self._collapse_line(i)
@@ -500,7 +498,6 @@ def graph_ascii(spec, **kwargs):
     graph.node_character = node_character
 
     graph.write(spec, color=color, out=out)
-
 
 
 def graph_dot(*specs, **kwargs):

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -94,7 +94,7 @@ def topological_sort(spec, **kwargs):
     nodes = spec.index()
 
     topo_order = []
-    par = {name: parents(nodes[name]) for name in nodes.keys()}
+    par = dict((name, parents(nodes[name])) for name in nodes.keys())
     remaining = [name for name in nodes.keys() if not parents(nodes[name])]
     heapify(remaining)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -460,7 +460,7 @@ class DependencyMap(HashableMap):
 
     def __str__(self):
         return ''.join(
-            ["^" + str(self[name].spec) for name in sorted(self.keys())])
+            ["^" + self[name].format() for name in sorted(self.keys())])
 
 
 @key_ordering
@@ -861,7 +861,7 @@ class Spec(object):
             for name in sorted(successors):
                 child = successors[name]
                 children = child.spec.traverse_with_deptype(
-                    visited, d=d + 1, deptype=deptype_query,
+                    visited, d=d + 1, deptype=deptype,
                     deptype_query=deptype_query,
                     _self_deptype=child.deptypes, **kwargs)
                 for elt in children:

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -476,20 +476,20 @@ class SpecDagTest(MockPackagesTest):
         dag = Spec('dtuse')
         dag.normalize()
 
-        names = ['dtuse', 'dttop', 'dtlink1', 'dtlink3', 'dtlink4',
-                 'dtrun1', 'dtlink5', 'dtrun3']
+        names = ['dtuse', 'dttop', 'dtbuild1', 'dtbuild2', 'dtlink2',
+                 'dtlink1', 'dtlink3', 'dtlink4']
 
-        traversal = dag.traverse()
+        traversal = dag.traverse(deptype=('build', 'link'))
         self.assertEqual([x.name for x in traversal], names)
 
     def test_deptype_traversal_with_builddeps(self):
         dag = Spec('dttop')
         dag.normalize()
 
-        names = ['dttop', 'dtbuild1', 'dtlink2', 'dtrun2', 'dtlink1',
-                 'dtlink3', 'dtlink4', 'dtrun1', 'dtlink5', 'dtrun3']
+        names = ['dttop', 'dtbuild1', 'dtbuild2', 'dtlink2',
+                 'dtlink1', 'dtlink3', 'dtlink4']
 
-        traversal = dag.traverse()
+        traversal = dag.traverse(deptype=('build', 'link'))
         self.assertEqual([x.name for x in traversal], names)
 
     def test_deptype_traversal_full(self):
@@ -500,15 +500,14 @@ class SpecDagTest(MockPackagesTest):
                  'dtlink1', 'dtlink3', 'dtlink4', 'dtrun1', 'dtlink5',
                  'dtrun3', 'dtbuild3']
 
-        traversal = dag.traverse(deptype_query=spack.alldeps)
+        traversal = dag.traverse(deptype=spack.alldeps)
         self.assertEqual([x.name for x in traversal], names)
 
-    def test_deptype_traversal_pythonpath(self):
+    def test_deptype_traversal_run(self):
         dag = Spec('dttop')
         dag.normalize()
 
-        names = ['dttop', 'dtbuild1', 'dtrun2', 'dtlink1', 'dtrun1',
-                 'dtrun3']
+        names = ['dttop', 'dtrun1', 'dtrun3']
 
-        traversal = dag.traverse(deptype=spack.nolink, deptype_query='run')
+        traversal = dag.traverse(deptype='run')
         self.assertEqual([x.name for x in traversal], names)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -32,8 +32,6 @@ import spack
 import spack.architecture
 import spack.package
 
-from llnl.util.lang import list_modules
-
 from spack.spec import Spec
 from spack.test.mock_packages_test import *
 
@@ -51,21 +49,19 @@ class SpecDagTest(MockPackagesTest):
         self.assertRaises(spack.spec.UnsatisfiableVersionSpecError,
                           spec.normalize)
 
-
     def test_preorder_node_traversal(self):
         dag = Spec('mpileaks ^zmpi')
         dag.normalize()
 
         names = ['mpileaks', 'callpath', 'dyninst', 'libdwarf', 'libelf',
                  'zmpi', 'fake']
-        pairs = zip([0,1,2,3,4,2,3], names)
+        pairs = zip([0, 1, 2, 3, 4, 2, 3], names)
 
         traversal = dag.traverse()
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(depth=True)
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_preorder_edge_traversal(self):
         dag = Spec('mpileaks ^zmpi')
@@ -73,14 +69,13 @@ class SpecDagTest(MockPackagesTest):
 
         names = ['mpileaks', 'callpath', 'dyninst', 'libdwarf', 'libelf',
                  'libelf', 'zmpi', 'fake', 'zmpi']
-        pairs = zip([0,1,2,3,4,3,2,3,1], names)
+        pairs = zip([0, 1, 2, 3, 4, 3, 2, 3, 1], names)
 
         traversal = dag.traverse(cover='edges')
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(cover='edges', depth=True)
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_preorder_path_traversal(self):
         dag = Spec('mpileaks ^zmpi')
@@ -88,14 +83,13 @@ class SpecDagTest(MockPackagesTest):
 
         names = ['mpileaks', 'callpath', 'dyninst', 'libdwarf', 'libelf',
                  'libelf', 'zmpi', 'fake', 'zmpi', 'fake']
-        pairs = zip([0,1,2,3,4,3,2,3,1,2], names)
+        pairs = zip([0, 1, 2, 3, 4, 3, 2, 3, 1, 2], names)
 
         traversal = dag.traverse(cover='paths')
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(cover='paths', depth=True)
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_postorder_node_traversal(self):
         dag = Spec('mpileaks ^zmpi')
@@ -103,14 +97,13 @@ class SpecDagTest(MockPackagesTest):
 
         names = ['libelf', 'libdwarf', 'dyninst', 'fake', 'zmpi',
                  'callpath', 'mpileaks']
-        pairs = zip([4,3,2,3,2,1,0], names)
+        pairs = zip([4, 3, 2, 3, 2, 1, 0], names)
 
         traversal = dag.traverse(order='post')
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(depth=True, order='post')
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_postorder_edge_traversal(self):
         dag = Spec('mpileaks ^zmpi')
@@ -118,14 +111,13 @@ class SpecDagTest(MockPackagesTest):
 
         names = ['libelf', 'libdwarf', 'libelf', 'dyninst', 'fake', 'zmpi',
                  'callpath', 'zmpi', 'mpileaks']
-        pairs = zip([4,3,3,2,3,2,1,1,0], names)
+        pairs = zip([4, 3, 3, 2, 3, 2, 1, 1, 0], names)
 
         traversal = dag.traverse(cover='edges', order='post')
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(cover='edges', depth=True, order='post')
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_postorder_path_traversal(self):
         dag = Spec('mpileaks ^zmpi')
@@ -133,14 +125,13 @@ class SpecDagTest(MockPackagesTest):
 
         names = ['libelf', 'libdwarf', 'libelf', 'dyninst', 'fake', 'zmpi',
                  'callpath', 'fake', 'zmpi', 'mpileaks']
-        pairs = zip([4,3,3,2,3,2,1,2,1,0], names)
+        pairs = zip([4, 3, 3, 2, 3, 2, 1, 2, 1, 0], names)
 
         traversal = dag.traverse(cover='paths', order='post')
         self.assertEqual([x.name for x in traversal], names)
 
         traversal = dag.traverse(cover='paths', depth=True, order='post')
-        self.assertEqual([(x, y.name) for x,y in traversal], pairs)
-
+        self.assertEqual([(x, y.name) for x, y in traversal], pairs)
 
     def test_conflicting_spec_constraints(self):
         mpileaks = Spec('mpileaks ^mpich ^callpath ^dyninst ^libelf ^libdwarf')
@@ -153,8 +144,7 @@ class SpecDagTest(MockPackagesTest):
             spec._dependencies['mpich'].spec = Spec('mpich@2.0')
 
         self.assertRaises(spack.spec.InconsistentSpecError,
-                lambda: mpileaks.flat_dependencies(copy=False))
-
+                          lambda: mpileaks.flat_dependencies(copy=False))
 
     def test_normalize_twice(self):
         """Make sure normalize can be run twice on the same spec,
@@ -166,14 +156,12 @@ class SpecDagTest(MockPackagesTest):
         spec.normalize()
         self.assertEqual(n1, spec)
 
-
     def test_normalize_a_lot(self):
         spec = Spec('mpileaks')
         spec.normalize()
         spec.normalize()
         spec.normalize()
         spec.normalize()
-
 
     def test_normalize_with_virtual_spec(self):
         dag = Spec('mpileaks',
@@ -189,13 +177,12 @@ class SpecDagTest(MockPackagesTest):
         # make sure nothing with the same name occurs twice
         counts = {}
         for spec in dag.traverse(key=id):
-            if not spec.name in counts:
+            if spec.name not in counts:
                 counts[spec.name] = 0
             counts[spec.name] += 1
 
         for name in counts:
             self.assertEqual(counts[name], 1, "Count for %s was not 1!" % name)
-
 
     def check_links(self, spec_to_check):
         for spec in spec_to_check.traverse():
@@ -203,66 +190,67 @@ class SpecDagTest(MockPackagesTest):
                 self.assertTrue(
                     spec.name in dependent.dependencies_dict(),
                     "%s not in dependencies of %s" %
-                        (spec.name, dependent.name))
+                    (spec.name, dependent.name))
 
             for dependency in spec.dependencies():
                 self.assertTrue(
                     spec.name in dependency.dependents_dict(),
                     "%s not in dependents of %s" %
-                        (spec.name, dependency.name))
-
+                    (spec.name, dependency.name))
 
     def test_dependents_and_dependencies_are_correct(self):
         spec = Spec('mpileaks',
-                   Spec('callpath',
-                        Spec('dyninst',
-                             Spec('libdwarf',
-                                  Spec('libelf')),
-                             Spec('libelf')),
-                        Spec('mpi')),
-                   Spec('mpi'))
+                    Spec('callpath',
+                         Spec('dyninst',
+                              Spec('libdwarf',
+                                   Spec('libelf')),
+                              Spec('libelf')),
+                         Spec('mpi')),
+                    Spec('mpi'))
 
         self.check_links(spec)
         spec.normalize()
         self.check_links(spec)
 
-
     def test_unsatisfiable_version(self):
         self.set_pkg_dep('mpileaks', 'mpich@1.0')
         spec = Spec('mpileaks ^mpich@2.0 ^callpath ^dyninst ^libelf ^libdwarf')
-        self.assertRaises(spack.spec.UnsatisfiableVersionSpecError, spec.normalize)
-
+        self.assertRaises(spack.spec.UnsatisfiableVersionSpecError,
+                          spec.normalize)
 
     def test_unsatisfiable_compiler(self):
         self.set_pkg_dep('mpileaks', 'mpich%gcc')
-        spec = Spec('mpileaks ^mpich%intel ^callpath ^dyninst ^libelf ^libdwarf')
-        self.assertRaises(spack.spec.UnsatisfiableCompilerSpecError, spec.normalize)
-
+        spec = Spec('mpileaks ^mpich%intel ^callpath ^dyninst ^libelf'
+                    ' ^libdwarf')
+        self.assertRaises(spack.spec.UnsatisfiableCompilerSpecError,
+                          spec.normalize)
 
     def test_unsatisfiable_compiler_version(self):
         self.set_pkg_dep('mpileaks', 'mpich%gcc@4.6')
-        spec = Spec('mpileaks ^mpich%gcc@4.5 ^callpath ^dyninst ^libelf ^libdwarf')
-        self.assertRaises(spack.spec.UnsatisfiableCompilerSpecError, spec.normalize)
-
+        spec = Spec('mpileaks ^mpich%gcc@4.5 ^callpath ^dyninst ^libelf'
+                    ' ^libdwarf')
+        self.assertRaises(spack.spec.UnsatisfiableCompilerSpecError,
+                          spec.normalize)
 
     def test_unsatisfiable_architecture(self):
-        platform = spack.architecture.platform()
-
         self.set_pkg_dep('mpileaks', 'mpich platform=test target=be')
-        spec = Spec('mpileaks ^mpich platform=test target=fe ^callpath ^dyninst ^libelf ^libdwarf')
-        self.assertRaises(spack.spec.UnsatisfiableArchitectureSpecError, spec.normalize)
-
+        spec = Spec('mpileaks ^mpich platform=test target=fe ^callpath'
+                    ' ^dyninst ^libelf ^libdwarf')
+        self.assertRaises(spack.spec.UnsatisfiableArchitectureSpecError,
+                          spec.normalize)
 
     def test_invalid_dep(self):
         spec = Spec('libelf ^mpich')
-        self.assertRaises(spack.spec.InvalidDependencyException, spec.normalize)
+        self.assertRaises(spack.spec.InvalidDependencyException,
+                          spec.normalize)
 
         spec = Spec('libelf ^libdwarf')
-        self.assertRaises(spack.spec.InvalidDependencyException, spec.normalize)
+        self.assertRaises(spack.spec.InvalidDependencyException,
+                          spec.normalize)
 
         spec = Spec('mpich ^dyninst ^libelf')
-        self.assertRaises(spack.spec.InvalidDependencyException, spec.normalize)
-
+        self.assertRaises(spack.spec.InvalidDependencyException,
+                          spec.normalize)
 
     def test_equal(self):
         # Different spec structures to test for equality
@@ -301,10 +289,10 @@ class SpecDagTest(MockPackagesTest):
         self.assertFalse(flip_flat.eq_dag(flip_dag))
         self.assertFalse(dag.eq_dag(flip_dag))
 
-
     def test_normalize_mpileaks(self):
         # Spec parsed in from a string
-        spec = Spec('mpileaks ^mpich ^callpath ^dyninst ^libelf@1.8.11 ^libdwarf')
+        spec = Spec('mpileaks ^mpich ^callpath ^dyninst ^libelf@1.8.11'
+                    ' ^libdwarf')
 
         # What that spec should look like after parsing
         expected_flat = Spec(
@@ -367,7 +355,6 @@ class SpecDagTest(MockPackagesTest):
         self.assertEqual(spec, non_unique_nodes)
         self.assertFalse(spec.eq_dag(non_unique_nodes))
 
-
     def test_normalize_with_virtual_package(self):
         spec = Spec('mpileaks ^mpi ^libelf@1.8.11 ^libdwarf')
         spec.normalize()
@@ -383,7 +370,6 @@ class SpecDagTest(MockPackagesTest):
 
         self.assertEqual(str(spec), str(expected_normalized))
 
-
     def test_contains(self):
         spec = Spec('mpileaks ^mpi ^libelf@1.8.11 ^libdwarf')
         self.assertTrue(Spec('mpi') in spec)
@@ -393,7 +379,6 @@ class SpecDagTest(MockPackagesTest):
         self.assertTrue(Spec('libdwarf') in spec)
         self.assertFalse(Spec('libgoblin') in spec)
         self.assertTrue(Spec('mpileaks') in spec)
-
 
     def test_copy_simple(self):
         orig = Spec('mpileaks')
@@ -411,7 +396,6 @@ class SpecDagTest(MockPackagesTest):
         copy_ids = set(id(s) for s in copy.traverse())
         self.assertFalse(orig_ids.intersection(copy_ids))
 
-
     def test_copy_normalized(self):
         orig = Spec('mpileaks')
         orig.normalize()
@@ -428,7 +412,6 @@ class SpecDagTest(MockPackagesTest):
         orig_ids = set(id(s) for s in orig.traverse())
         copy_ids = set(id(s) for s in copy.traverse())
         self.assertFalse(orig_ids.intersection(copy_ids))
-
 
     def test_copy_concretized(self):
         orig = Spec('mpileaks')


### PR DESCRIPTION
Currently, calling the `graph` command with ASCII output fails:
```
$ spack graph netcdf
Traceback (most recent call last):
  ...
  File "spack/lib/spack/spack/graph.py", line 105, in topological_sort
    for dep in children(node).values():
AttributeError: 'list' object has no attribute 'values'
```

This PR fixes the ASCII output and also corrects two typos found in the `Spec` and `DependencyMap` classes.