### PR TITLE
MVAPICH2 depends on libpciaccess

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -76,6 +76,7 @@ class Mvapich2(Package):
     ##########
 
     # FIXME : CUDA support is missing
+    depends_on('libpciaccess')
 
     def url_for_version(self, version):
         base_url = "http://mvapich.cse.ohio-state.edu/download"


### PR DESCRIPTION
Before this change, MVAPICH2 would link to the system libpciaccess:
```
$ ldd mvapich2-2.2b-5wegbfinckfpgzpho7en62finq2g7qu7/lib/libmpi.so
...
    libpciaccess.so.0 => /usr/lib64/libpciaccess.so.0 (0x00002ac2e9c59000)
...
```
After this change, MVAPICH2 now correctly links to Spack's libpciaccess:
```
$ ldd mvapich2-2.2b-safxp72yay4mzoahpdpt77sygczxvcmc/lib/libmpi.so
...
    libpciaccess.so.0 => /blues/gpfs/home/software/spack/opt/spack/linux-centos6-x86_64/intel-16.0.3/libpciaccess-0.13.4-u4kiiivsqq5st2tdlchz562mv7nietlj/lib/libpciaccess.so.0 (0x00002b6c04b5b000)
...
```
The need for this change is that I built mvapich2 on CentOS 6, which has `/usr/lib64/libpciaccess.so.0`, but it doesn't run on CentOS 5, which doesn't have libpciaccess.so.0 in that directory.