### PR TITLE
Update gcc package with info about gcc-5.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -15,6 +15,7 @@ class Gcc(Package):
     list_depth = 2
 
     version('6.1.0', '8fb6cb98b8459f5863328380fbf06bd1')
+    version('5.4.0', '4c626ac2a83ef30dfb9260e6f59c2b30')
     version('5.3.0', 'c9616fd448f980259c31de613e575719')
     version('5.2.0', 'a51bcfeb3da7dd4c623e27207ed43467')
     version('4.9.3', '6f831b4d251872736e8e9cc09746f327')


### PR DESCRIPTION
Add version and hash for gcc-5.4.0.  Builds sucessfully as `spack build gcc-5.4.0` on a CentOS 7 system on Digital Ocean.