### PR TITLE
Fix alpha case of dependencies for some r-packages

### DIFF
--- a/var/spack/repos/builtin/packages/r-rjava/package.py
+++ b/var/spack/repos/builtin/packages/r-rjava/package.py
@@ -37,6 +37,8 @@ class RRjava(Package):
 
     extends('R')
 
+    depends_on('jdk')
+
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),
           self.stage.source_path)

--- a/var/spack/repos/builtin/packages/r-rmysql/package.py
+++ b/var/spack/repos/builtin/packages/r-rmysql/package.py
@@ -36,7 +36,7 @@ class RRmysql(Package):
 
     extends('R')
 
-    depends_on('r-DBI')
+    depends_on('r-dbi')
     depends_on('mariadb')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/r-rodbc/package.py
+++ b/var/spack/repos/builtin/packages/r-rodbc/package.py
@@ -36,7 +36,7 @@ class RRodbc(Package):
 
     extends('R')
 
-    depends_on('unixODBC')
+    depends_on('unixodbc')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-rpostgresql/package.py
+++ b/var/spack/repos/builtin/packages/r-rpostgresql/package.py
@@ -44,7 +44,7 @@ class RRpostgresql(Package):
 
     extends('R')
 
-    depends_on('r-DBI')
+    depends_on('r-dbi')
     depends_on('postgresql')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/r-rsqlite/package.py
+++ b/var/spack/repos/builtin/packages/r-rsqlite/package.py
@@ -38,7 +38,7 @@ class RRsqlite(Package):
 
     extends('R')
 
-    depends_on('r-DBI')
+    depends_on('r-dbi')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlconnect/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnect/package.py
@@ -33,12 +33,13 @@ class RXlconnect(Package):
     url      = "https://cran.r-project.org/src/contrib/XLConnect_0.2-11.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnect"
 
-    version('0.2-11', '9d1769a103cda05665df399cc335017d')
+    version('0.2-11', '9d1769a103cda05665df399cc335017d',
+            url='https://cran.r-project.org/src/contrib/Archive/XLConnect/XLConnect_0.2-11.tar.gz')
 
     extends('R')
 
-    depends_on('r-XLConnectJars')
-    depends_on('r-rJava')
+    depends_on('r-xlconnectjars')
+    depends_on('r-rjava')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
@@ -32,11 +32,12 @@ class RXlconnectjars(Package):
     url      = "https://cran.r-project.org/src/contrib/XLConnectJars_0.2-9.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnectJars"
 
-    version('0.2-9', 'e6d6b1acfede26acaa616ee421bd30fb')
+    version('0.2-9', 'e6d6b1acfede26acaa616ee421bd30fb',
+            url='https://cran.r-project.org/src/contrib/Archive/XLConnectJars/XLConnectJars_0.2-9.tar.gz')
 
     extends('R')
 
-    depends_on('r-rJava')
+    depends_on('r-rjava')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlsx/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsx/package.py
@@ -37,7 +37,7 @@ class RXlsx(Package):
 
     extends('R')
 
-    depends_on('r-rJava')
+    depends_on('r-rjava')
     depends_on('r-xlsxjars')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/r-xlsxjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsxjars/package.py
@@ -37,7 +37,7 @@ class RXlsxjars(Package):
 
     extends('R')
 
-    depends_on('r-rJava')
+    depends_on('r-rjava')
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),


### PR DESCRIPTION
A while ago I was asked to convert packages to all lowercase. That was
done but some dependencies did not get converted in the specification.
This commit fixes that as well as a couple of urls that need to be made
explicit and a missing dependency on jdk.