### PR TITLE
Use example deptypes in newly created packages

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -96,8 +96,7 @@ class ${class_name}(Package):
 
 ${versions}
 
-    # FIXME: Add additional dependencies if required.
-    ${dependencies}
+${dependencies}
 
     def install(self, spec, prefix):
 ${install}
@@ -105,13 +104,39 @@ ${install}
 
 # Build dependencies and extensions
 dependencies_dict = {
-    'autotools': "# depends_on('foo')",
-    'cmake':     "depends_on('cmake')",
-    'scons':     "depends_on('scons')",
-    'python':    "extends('python')",
-    'R':         "extends('R')",
-    'octave':    "extends('octave')",
-    'unknown':   "# depends_on('foo')"
+    'autotools': """\
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')""",
+
+    'cmake': """\
+    # FIXME: Add additional dependencies if required.
+    depends_on('cmake', type='build')""",
+
+    'scons': """\
+    # FIXME: Add additional dependencies if required.
+    depends_on('scons', type='build')""",
+
+    'python': """\
+    extends('python')
+
+    # FIXME: Add additional dependencies if required.
+    # depends_on('py-foo', type=nolink)""",
+
+    'R': """\
+    extends('R')
+
+    # FIXME: Add additional dependencies if required.
+    # depends_on('r-foo', type=nolink)""",
+
+    'octave': """\
+    extends('octave')
+
+    # FIXME: Add additional dependencies if required.
+    # depends_on('octave-foo', type=nolink)""",
+
+    'unknown': """\
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')"""
 }
 
 # Default installation instructions


### PR DESCRIPTION
Resolves #1337. Deptypes are still new and easy to forget when writing Python/R packages which require them. This PR adds example dependencies so that it is easier to follow the syntax. @glennpj @mathstuf @becker33 

I also noticed that my #1171 accidentally overwrote my changes in #1260, so I added back the cmake and scons build dependency types. @davydden @becker33 