### PR TITLE
do not ignore nosetests script in py-nose

### DIFF
--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -36,7 +36,7 @@ class PyNose(Package):
     version('1.3.6', '0ca546d81ca8309080fc80cb389e7a16')
     version('1.3.7', '4d3ad0ff07b61373d2cefc89c5d0b20b')
 
-    extends('python', ignore=r'bin/nosetests.*$')
+    extends('python')
     depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
The py-nose package should not ignore the nosetests scripts. It appears that py-matplotlib is the only other package that tries to generate/activate this script and that package already ignores the nosetests scripts.