### PR TITLE
Add depends_on('perl'), depends_on('pcre') to git package

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -55,6 +55,7 @@ class Git(Package):
     depends_on("zlib")
     depends_on("pcre")
     depends_on("perl")
+    depends_on("zlib")
 
     def install(self, spec, prefix):
         configure_args = [

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -53,10 +53,8 @@ class Git(Package):
     depends_on("expat")
     depends_on("gettext")
     depends_on("zlib")
-
-    # Use system perl for now.
+    depends_on("pcre")
     depends_on("perl")
-    # depends_on("pcre")
 
     def install(self, spec, prefix):
         configure_args = [

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -55,7 +55,6 @@ class Git(Package):
     depends_on("zlib")
     depends_on("pcre")
     depends_on("perl")
-    depends_on("zlib")
 
     def install(self, spec, prefix):
         configure_args = [
@@ -63,6 +62,7 @@ class Git(Package):
             "--with-libpcre=%s" % spec['pcre'].prefix,
             "--with-openssl=%s" % spec['openssl'].prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
+            "--with-curl=%s" % spec['curl'].prefix,
             "--with-expat=%s" % spec['expat'].prefix,
             "--with-perl=%s" % join_path(spec['perl'].prefix.bin, 'perl'),
         ]

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -55,7 +55,7 @@ class Git(Package):
     depends_on("zlib")
 
     # Use system perl for now.
-    # depends_on("perl")
+    depends_on("perl")
     # depends_on("pcre")
 
     def install(self, spec, prefix):
@@ -64,8 +64,8 @@ class Git(Package):
             "--without-pcre",
             "--with-openssl=%s" % spec['openssl'].prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
-            "--with-curl=%s" % spec['curl'].prefix,
-            "--with-expat=%s" % spec['expat'].prefix
+            "--with-expat=%s" % spec['expat'].prefix,
+            "--with-perl=%s" % join_path(spec['perl'].prefix.bin, 'perl'),
         ]
 
         which('autoreconf')('-i')

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -57,6 +57,7 @@ class Git(Package):
     depends_on("perl")
 
     def install(self, spec, prefix):
+        env['LDFLAGS'] = "-L%s" % spec['gettext'].prefix.lib + " -lintl"
         configure_args = [
             "--prefix=%s" % prefix,
             "--with-libpcre=%s" % spec['pcre'].prefix,

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -59,7 +59,7 @@ class Git(Package):
     def install(self, spec, prefix):
         configure_args = [
             "--prefix=%s" % prefix,
-            "--without-pcre",
+            "--with-libpcre=%s" % spec['pcre'].prefix,
             "--with-openssl=%s" % spec['openssl'].prefix,
             "--with-zlib=%s" % spec['zlib'].prefix,
             "--with-expat=%s" % spec['expat'].prefix,


### PR DESCRIPTION
This commit changes the git package to depend_on('perl').  The system perl is not always sufficient to install git (e.g. a CentOS7 system with the development tools group installed has perl but not the ExtUtils::MakeMaker package that git needs) and one can't always update the system's perl.

This PR depends_on PR #1339, which adds a perl package to spack.