### PR TITLE
Add dependency type to r- packages

### DIFF
--- a/var/spack/repos/builtin/packages/r-devtools/package.py
+++ b/var/spack/repos/builtin/packages/r-devtools/package.py
@@ -36,14 +36,14 @@ class RDevtools(Package):
 
     extends('R')
 
-    depends_on('r-httr')
-    depends_on('r-memoise')
-    depends_on('r-whisker')
-    depends_on('r-digest')
-    depends_on('r-rstudioapi')
-    depends_on('r-jsonlite')
-    depends_on('r-git2r')
-    depends_on('r-withr')
+    depends_on('r-httr', type=nolink)
+    depends_on('r-memoise', type=nolink)
+    depends_on('r-whisker', type=nolink)
+    depends_on('r-digest', type=nolink)
+    depends_on('r-rstudioapi', type=nolink)
+    depends_on('r-jsonlite', type=nolink)
+    depends_on('r-git2r', type=nolink)
+    depends_on('r-withr', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-dplyr/package.py
+++ b/var/spack/repos/builtin/packages/r-dplyr/package.py
@@ -36,14 +36,15 @@ class RDplyr(Package):
     version('0.5.0', '1fcafcacca70806eea2e6d465cdb94ef')
 
     extends('R')
-    depends_on('r-assertthat')
-    depends_on('r-R6')
-    depends_on('r-rcpp')
-    depends_on('r-tibble')
-    depends_on('r-magrittr')
-    depends_on('r-lazyeval')
-    depends_on('r-dbi')
-    depends_on('r-bh')
+
+    depends_on('r-assertthat', type=nolink)
+    depends_on('r-R6', type=nolink)
+    depends_on('r-rcpp', type=nolink)
+    depends_on('r-tibble', type=nolink)
+    depends_on('r-magrittr', type=nolink)
+    depends_on('r-lazyeval', type=nolink)
+    depends_on('r-dbi', type=nolink)
+    depends_on('r-bh', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-ggplot2/package.py
+++ b/var/spack/repos/builtin/packages/r-ggplot2/package.py
@@ -42,12 +42,12 @@ class RGgplot2(Package):
 
     extends('R')
 
-    depends_on('r-digest')
-    depends_on('r-gtable')
-    depends_on('r-mass')
-    depends_on('r-plyr')
-    depends_on('r-reshape2')
-    depends_on('r-scales')
+    depends_on('r-digest', type=nolink)
+    depends_on('r-gtable', type=nolink)
+    depends_on('r-mass', type=nolink)
+    depends_on('r-plyr', type=nolink)
+    depends_on('r-reshape2', type=nolink)
+    depends_on('r-scales', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-ggvis/package.py
+++ b/var/spack/repos/builtin/packages/r-ggvis/package.py
@@ -38,13 +38,13 @@ class RGgvis(Package):
 
     extends('R')
 
-    depends_on('r-assertthat')
-    depends_on('r-jsonlite')
-    depends_on('r-shiny')
-    depends_on('r-magrittr')
-    depends_on('r-dplyr')
-    depends_on('r-lazyeval')
-    depends_on('r-htmltools')
+    depends_on('r-assertthat', type=nolink)
+    depends_on('r-jsonlite', type=nolink)
+    depends_on('r-shiny', type=nolink)
+    depends_on('r-magrittr', type=nolink)
+    depends_on('r-dplyr', type=nolink)
+    depends_on('r-lazyeval', type=nolink)
+    depends_on('r-htmltools', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-gridextra/package.py
+++ b/var/spack/repos/builtin/packages/r-gridextra/package.py
@@ -37,7 +37,7 @@ class RGridextra(Package):
 
     extends('R')
 
-    depends_on('r-gtable')
+    depends_on('r-gtable', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-htmltools/package.py
+++ b/var/spack/repos/builtin/packages/r-htmltools/package.py
@@ -36,8 +36,8 @@ class RHtmltools(Package):
 
     extends('R')
 
-    depends_on('r-digest')
-    depends_on('r-rcpp')
+    depends_on('r-digest', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-httpuv/package.py
+++ b/var/spack/repos/builtin/packages/r-httpuv/package.py
@@ -42,7 +42,7 @@ class RHttpuv(Package):
 
     extends('R')
 
-    depends_on('r-rcpp')
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-httr/package.py
+++ b/var/spack/repos/builtin/packages/r-httr/package.py
@@ -38,11 +38,11 @@ class RHttr(Package):
 
     extends('R')
 
-    depends_on('r-jsonlite')
-    depends_on('r-mime')
-    depends_on('r-curl')
-    depends_on('r-openssl')
-    depends_on('r-R6')
+    depends_on('r-jsonlite', type=nolink)
+    depends_on('r-mime', type=nolink)
+    depends_on('r-curl', type=nolink)
+    depends_on('r-openssl', type=nolink)
+    depends_on('r-R6', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-lubridate/package.py
+++ b/var/spack/repos/builtin/packages/r-lubridate/package.py
@@ -40,7 +40,8 @@ class RLubridate(Package):
     version('1.5.6', 'a5dc44817548ee219d26a10bae92e611')
 
     extends('R')
-    depends_on('r-stringr')
+
+    depends_on('r-stringr', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -39,7 +39,7 @@ class RMagic(Package):
 
     extends('R')
 
-    depends_on('r-abind')
+    depends_on('r-abind', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-matrix/package.py
+++ b/var/spack/repos/builtin/packages/r-matrix/package.py
@@ -37,7 +37,7 @@ class RMatrix(Package):
 
     extends('R')
 
-    depends_on('r-lattice')
+    depends_on('r-lattice', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-memoise/package.py
+++ b/var/spack/repos/builtin/packages/r-memoise/package.py
@@ -37,7 +37,7 @@ class RMemoise(Package):
 
     extends('R')
 
-    depends_on('r-digest')
+    depends_on('r-digest', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-munsell/package.py
+++ b/var/spack/repos/builtin/packages/r-munsell/package.py
@@ -40,7 +40,7 @@ class RMunsell(Package):
 
     extends('R')
 
-    depends_on('r-colorspace')
+    depends_on('r-colorspace', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-plyr/package.py
+++ b/var/spack/repos/builtin/packages/r-plyr/package.py
@@ -42,7 +42,7 @@ class RPlyr(Package):
 
     extends('R')
 
-    depends_on('r-rcpp')
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-rcppeigen/package.py
+++ b/var/spack/repos/builtin/packages/r-rcppeigen/package.py
@@ -48,8 +48,8 @@ class RRcppeigen(Package):
 
     extends('R')
 
-    depends_on('r-matrix')
-    depends_on('r-rcpp')
+    depends_on('r-matrix', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-reshape2/package.py
+++ b/var/spack/repos/builtin/packages/r-reshape2/package.py
@@ -37,9 +37,9 @@ class RReshape2(Package):
 
     extends('R')
 
-    depends_on('r-plyr')
-    depends_on('r-stringr')
-    depends_on('r-rcpp')
+    depends_on('r-plyr', type=nolink)
+    depends_on('r-stringr', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-rmysql/package.py
+++ b/var/spack/repos/builtin/packages/r-rmysql/package.py
@@ -36,7 +36,7 @@ class RRmysql(Package):
 
     extends('R')
 
-    depends_on('r-dbi')
+    depends_on('r-dbi', type=nolink)
     depends_on('mariadb')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/r-rpostgresql/package.py
+++ b/var/spack/repos/builtin/packages/r-rpostgresql/package.py
@@ -44,7 +44,7 @@ class RRpostgresql(Package):
 
     extends('R')
 
-    depends_on('r-dbi')
+    depends_on('r-dbi', type=nolink)
     depends_on('postgresql')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/r-rsqlite/package.py
+++ b/var/spack/repos/builtin/packages/r-rsqlite/package.py
@@ -38,7 +38,7 @@ class RRsqlite(Package):
 
     extends('R')
 
-    depends_on('r-dbi')
+    depends_on('r-dbi', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-rstan/package.py
+++ b/var/spack/repos/builtin/packages/r-rstan/package.py
@@ -44,13 +44,13 @@ class RRstan(Package):
 
     extends('R')
 
-    depends_on('r-ggplot2')
-    depends_on('r-stanheaders')
-    depends_on('r-inline')
-    depends_on('r-gridextra')
-    depends_on('r-rcpp')
-    depends_on('r-rcppeigen')
-    depends_on('r-bh')
+    depends_on('r-ggplot2', type=nolink)
+    depends_on('r-stanheaders', type=nolink)
+    depends_on('r-inline', type=nolink)
+    depends_on('r-gridextra', type=nolink)
+    depends_on('r-rcpp', type=nolink)
+    depends_on('r-rcppeigen', type=nolink)
+    depends_on('r-bh', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-scales/package.py
+++ b/var/spack/repos/builtin/packages/r-scales/package.py
@@ -37,12 +37,12 @@ class RScales(Package):
 
     extends('R')
 
-    depends_on('r-rcolorbrewer')
-    depends_on('r-dichromat')
-    depends_on('r-plyr')
-    depends_on('r-munsell')
-    depends_on('r-labeling')
-    depends_on('r-rcpp')
+    depends_on('r-rcolorbrewer', type=nolink)
+    depends_on('r-dichromat', type=nolink)
+    depends_on('r-plyr', type=nolink)
+    depends_on('r-munsell', type=nolink)
+    depends_on('r-labeling', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-shiny/package.py
+++ b/var/spack/repos/builtin/packages/r-shiny/package.py
@@ -39,13 +39,13 @@ class RShiny(Package):
 
     extends('R')
 
-    depends_on('r-httpuv')
-    depends_on('r-mime')
-    depends_on('r-jsonlite')
-    depends_on('r-xtable')
-    depends_on('r-digest')
-    depends_on('r-htmltools')
-    depends_on('r-R6')
+    depends_on('r-httpuv', type=nolink)
+    depends_on('r-mime', type=nolink)
+    depends_on('r-jsonlite', type=nolink)
+    depends_on('r-xtable', type=nolink)
+    depends_on('r-digest', type=nolink)
+    depends_on('r-htmltools', type=nolink)
+    depends_on('r-R6', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-stringr/package.py
+++ b/var/spack/repos/builtin/packages/r-stringr/package.py
@@ -40,8 +40,8 @@ class RStringr(Package):
 
     extends('R')
 
-    depends_on('r-stringi')
-    depends_on('r-magrittr')
+    depends_on('r-stringi', type=nolink)
+    depends_on('r-magrittr', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-tibble/package.py
+++ b/var/spack/repos/builtin/packages/r-tibble/package.py
@@ -37,9 +37,9 @@ class RTibble(Package):
 
     extends('R')
 
-    depends_on('r-assertthat')
-    depends_on('r-lazyeval')
-    depends_on('r-rcpp')
+    depends_on('r-assertthat', type=nolink)
+    depends_on('r-lazyeval', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-tidyr/package.py
+++ b/var/spack/repos/builtin/packages/r-tidyr/package.py
@@ -37,12 +37,12 @@ class RTidyr(Package):
     version('0.5.1', '3cadc869510c054ed93d374ab44120bd')
 
     extends('R')
-    depends_on('r-tibble')
-    depends_on('r-dplyr')
-    depends_on('r-stringi')
-    depends_on('r-lazyeval')
-    depends_on('r-magrittr')
-    depends_on('r-rcpp')
+    depends_on('r-tibble', type=nolink)
+    depends_on('r-dplyr', type=nolink)
+    depends_on('r-stringi', type=nolink)
+    depends_on('r-lazyeval', type=nolink)
+    depends_on('r-magrittr', type=nolink)
+    depends_on('r-rcpp', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlconnect/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnect/package.py
@@ -33,13 +33,13 @@ class RXlconnect(Package):
     url      = "https://cran.r-project.org/src/contrib/XLConnect_0.2-11.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnect"
 
-    version('0.2-11', '9d1769a103cda05665df399cc335017d',
-            url='https://cran.r-project.org/src/contrib/Archive/XLConnect/XLConnect_0.2-11.tar.gz')
+    version('0.2-12', '3340d05d259f0a41262eab4ed32617ad')
+    version('0.2-11', '9d1769a103cda05665df399cc335017d')
 
     extends('R')
 
-    depends_on('r-xlconnectjars')
-    depends_on('r-rjava')
+    depends_on('r-xlconnectjars', type=nolink)
+    depends_on('r-rjava', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
@@ -32,12 +32,12 @@ class RXlconnectjars(Package):
     url      = "https://cran.r-project.org/src/contrib/XLConnectJars_0.2-9.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnectJars"
 
-    version('0.2-9', 'e6d6b1acfede26acaa616ee421bd30fb',
-            url='https://cran.r-project.org/src/contrib/Archive/XLConnectJars/XLConnectJars_0.2-9.tar.gz')
+    version('0.2-12', '6984e5140cd1c887c017ef6f88cbba81')
+    version('0.2-9', 'e6d6b1acfede26acaa616ee421bd30fb')
 
     extends('R')
 
-    depends_on('r-rjava')
+    depends_on('r-rjava', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlsx/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsx/package.py
@@ -37,8 +37,8 @@ class RXlsx(Package):
 
     extends('R')
 
-    depends_on('r-rjava')
-    depends_on('r-xlsxjars')
+    depends_on('r-rjava', type=nolink)
+    depends_on('r-xlsxjars', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),

--- a/var/spack/repos/builtin/packages/r-xlsxjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsxjars/package.py
@@ -37,7 +37,7 @@ class RXlsxjars(Package):
 
     extends('R')
 
-    depends_on('r-rjava')
+    depends_on('r-rjava', type=nolink)
 
     def install(self, spec, prefix):
         R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),


### PR DESCRIPTION
This PR adds the `nolink` dependency type to r- package dependencies.
This is needed due to the new dependency types in Spack. A couple of
packages were updated with new versions as well.