### PR TITLE
r-curl update and changed remote archive

### DIFF
--- a/var/spack/repos/builtin/packages/r-curl/package.py
+++ b/var/spack/repos/builtin/packages/r-curl/package.py
@@ -38,8 +38,9 @@ class RCurl(Package):
 
     homepage = "https://github.com/jeroenooms/curl"
     url      = "https://cran.r-project.org/src/contrib/curl_0.9.7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RCurl"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/curl"
 
+    version('1.0', '93d34926d6071e1fba7e728b482f0dd9')
     version('0.9.7', 'a101f7de948cb828fef571c730f39217')
 
     extends('R')


### PR DESCRIPTION
This updates to the 1.0 version of r-curl. The remote archive directory
also changed so changed that here as well.