### PR TITLE
Fix doc for install_tree (cut/paste error)

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -189,7 +189,7 @@ def install(src, dest):
 
 
 def install_tree(src, dest, **kwargs):
-    """Manually install a file to a particular location."""
+    """Manually install a directory tree to a particular location."""
     tty.debug("Installing %s to %s" % (src, dest))
     shutil.copytree(src, dest, **kwargs)
 


### PR DESCRIPTION
It looks like the docs for copy_tree were cut/paste from copy and still referred to installing a "file".

This fixes that.