### PR TITLE
add config option for delimiter

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -526,6 +526,7 @@ class Dotkit(EnvModule):
                  % spack.user_config_path)
         return ''
 
+
 class SafeFormat(object):
     def __init__(self, **kw):
         self.__dict = kw
@@ -536,13 +537,11 @@ class SafeFormat(object):
 string.Formatter().vformat('{what} {man}', [], SafeFormat(man=2))
 
 
-
-
 class TclModule(EnvModule):
     name = 'tcl'
     path = join_path(spack.share_path, "modules")
 
-    default_delim_format=  '--delim "{delim}"'
+    default_delim_format = '--delim "{delim}"'
     try:
         delim_format = CONFIGURATION[name]['delim_format']
     except KeyError:
@@ -550,11 +549,14 @@ class TclModule(EnvModule):
 
     environment_modifications_formats = {
         PrependPath: string.Formatter().vformat(
-          'prepend-path {delim_format} {name} \"{value}\"\n',[],SafeFormat(delim_format=delim_format)),
+            'prepend-path {delim_format} {name} \"{value}\"\n',
+            [], SafeFormat(delim_format=delim_format)),
         AppendPath:  string.Formatter().vformat(
-          'append-path  {delim_format} {name} \"{value}\"\n',[],SafeFormat(delim_format=delim_format)),
-        RemovePath:  string.Formatter().vformat( 
-          'remove-path  {delim_format} {name} \"{value}\"\n',[],SafeFormat(delim_format=delim_format)),
+            'append-path  {delim_format} {name} \"{value}\"\n',
+            [], SafeFormat(delim_format=delim_format)),
+        RemovePath:  string.Formatter().vformat(
+            'remove-path  {delim_format} {name} \"{value}\"\n',
+            [], SafeFormat(delim_format=delim_format)),
         SetEnv: 'setenv {name} \"{value}\"\n',
         UnsetEnv: 'unsetenv {name}\n'
     }

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -112,6 +112,9 @@ schema = {
                         '$ref': '#/definitions/array_of_strings'},
                     'naming_scheme': {
                         'type': 'string'  # Can we be more specific here?
+                    },
+                    'delim_format': {
+                        'type': 'string'  # Can we be more specific here?
                     }
                 }},
                 {'patternProperties': {


### PR DESCRIPTION
This fixes issue #1003 that happen on old module systems that do not support --delim

This fix should leave things as they are, it just honor a line in module.yaml file like:
    delim_format: ' '

For example I use the following to produce spack module files that are usable on our clusters:

**etc/spack/module.yaml**

```yaml
modules:
  tcl:
    naming_scheme: '{name}/{version}-{compiler.name}-{compiler.version}'
    delim_format: ' '
    all:

      autoload: 'direct'
```