### PR TITLE
Add py-setuptools dependencies to packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -43,6 +43,7 @@ class PyH5py(Package):
     # Build dependencies
     depends_on('py-cython@0.19:', type='build')
     depends_on('pkg-config', type='build')
+    depends_on('py-setuptools', type='build')
     depends_on('hdf5@1.8.4:')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -24,8 +24,10 @@
 ##############################################################################
 from spack import *
 
+
 class PyNetworkx(Package):
-    """NetworkX is a Python package for the creation, manipulation, and study of the structure, dynamics, and functions of complex networks."""
+    """NetworkX is a Python package for the creation, manipulation, and study
+    of the structure, dynamics, and functions of complex networks."""
     homepage = "http://networkx.github.io/"
     url      = "https://pypi.python.org/packages/source/n/networkx/networkx-1.11.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -34,6 +34,7 @@ class PyNetworkx(Package):
     extends('python')
 
     depends_on('py-decorator', type=nolink)
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-pytables/package.py
+++ b/var/spack/repos/builtin/packages/py-pytables/package.py
@@ -37,6 +37,7 @@ class PyPytables(Package):
     depends_on('py-numpy', type=nolink)
     depends_on('py-numexpr', type=nolink)
     depends_on('py-cython', type=nolink)
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         env["HDF5_DIR"] = spec['hdf5'].prefix

--- a/var/spack/repos/builtin/packages/py-pytables/package.py
+++ b/var/spack/repos/builtin/packages/py-pytables/package.py
@@ -23,10 +23,11 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import re
+
 
 class PyPytables(Package):
-    """PyTables is a package for managing hierarchical datasets and designed to efficiently and easily cope with extremely large amounts of data."""
+    """PyTables is a package for managing hierarchical datasets and designed to
+    efficiently and easily cope with extremely large amounts of data."""
     homepage = "http://www.pytables.org/"
     url      = "https://github.com/PyTables/PyTables/archive/v.3.2.2.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -42,6 +42,7 @@ class PyScikitImage(Package):
     depends_on('py-six', type=nolink)
     depends_on('py-scipy', type=nolink)
     depends_on('py-matplotlib', type=nolink)
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
Add py-setuptools as dependency
    
With the addition of dependency types and with `py-setuptools` set as
type='build' there are more packages that need to have `py-setuptools`
added as a dependency.

This PR adds that dependency for the following packages:
    - py-h5py
    - py-networkx
    - py-pytables
    - py-scikit-image