### PR TITLE
module : token expansion in environment

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -37,6 +37,9 @@ class NameModifier(object):
         self.args = {'name': name}
         self.args.update(kwargs)
 
+    def update_args(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.args.update(kwargs)
 
 class NameValueModifier(object):
 
@@ -44,7 +47,11 @@ class NameValueModifier(object):
         self.name = name
         self.value = value
         self.separator = kwargs.get('separator', ':')
-        self.args = {'name': name, 'value': value, 'delim': self.separator}
+        self.args = {'name': name, 'value': value, 'separator': self.separator}
+        self.args.update(kwargs)
+
+    def update_args(self, **kwargs):
+        self.__dict__.update(kwargs)
         self.args.update(kwargs)
 
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -41,6 +41,7 @@ class NameModifier(object):
         self.__dict__.update(kwargs)
         self.args.update(kwargs)
 
+
 class NameValueModifier(object):
 
     def __init__(self, name, value, **kwargs):

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -287,7 +287,7 @@ class EnvModule(object):
     def upper_tokens(self):
         """Tokens that can be substituted in environment variable names"""
         upper_tokens = {
-            'name': self.spec.name.upper()
+            'name': self.spec.name.replace('-', '_').upper()
         }
         return upper_tokens
 

--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -89,7 +89,10 @@ configuration_alter_environment = {
     'enable': ['tcl'],
     'tcl': {
         'all': {
-            'filter': {'environment_blacklist': ['CMAKE_PREFIX_PATH']}
+            'filter': {'environment_blacklist': ['CMAKE_PREFIX_PATH']},
+            'environment': {
+                'set': {'{name}_ROOT': '{prefix}'}
+            }
         },
         'platform=test target=x86_64': {
             'environment': {
@@ -248,6 +251,7 @@ class TclTests(MockPackagesTest):
         self.assertEqual(
             len([x for x in content if 'setenv FOO "foo"' in x]), 1)
         self.assertEqual(len([x for x in content if 'unsetenv BAR' in x]), 1)
+        self.assertEqual(len([x for x in content if 'setenv MPILEAKS_ROOT' in x]), 1)
 
         spec = spack.spec.Spec('libdwarf %clang platform=test target=x86_32')
         content = self.get_modulefile_content(spec)
@@ -262,6 +266,7 @@ class TclTests(MockPackagesTest):
             len([x for x in content if 'is-loaded foo/bar' in x]), 1)
         self.assertEqual(
             len([x for x in content if 'module load foo/bar' in x]), 1)
+        self.assertEqual(len([x for x in content if 'setenv LIBDWARF_ROOT' in x]), 1)
 
     def test_blacklist(self):
         spack.modules.CONFIGURATION = configuration_blacklist

--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -251,7 +251,8 @@ class TclTests(MockPackagesTest):
         self.assertEqual(
             len([x for x in content if 'setenv FOO "foo"' in x]), 1)
         self.assertEqual(len([x for x in content if 'unsetenv BAR' in x]), 1)
-        self.assertEqual(len([x for x in content if 'setenv MPILEAKS_ROOT' in x]), 1)
+        self.assertEqual(
+            len([x for x in content if 'setenv MPILEAKS_ROOT' in x]), 1)
 
         spec = spack.spec.Spec('libdwarf %clang platform=test target=x86_32')
         content = self.get_modulefile_content(spec)
@@ -266,7 +267,8 @@ class TclTests(MockPackagesTest):
             len([x for x in content if 'is-loaded foo/bar' in x]), 1)
         self.assertEqual(
             len([x for x in content if 'module load foo/bar' in x]), 1)
-        self.assertEqual(len([x for x in content if 'setenv LIBDWARF_ROOT' in x]), 1)
+        self.assertEqual(
+            len([x for x in content if 'setenv LIBDWARF_ROOT' in x]), 1)
 
     def test_blacklist(self):
         spack.modules.CONFIGURATION = configuration_blacklist


### PR DESCRIPTION
##### Modifications:
- [x] fixes #1109 

##### Examples
A `modules.yaml` like : 
```yaml
enable:
  - tcl
tcl: 
  all:
    environment:
    set: 
      '{name}_ROOT': '{prefix}'
```
will produce a module file with e.g. an `HDF5_ROOT` variable set to the prefix of any `hdf5` installation done.

@trws In the end I maintained `separator`, as using `delim` would have required changing a lot of packages.