### PR TITLE
Add package for ack

### DIFF
--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -43,9 +43,6 @@ class Ack(Package):
     # should:
     # depends_on('perl')
 
-    def unpack(self):
-        pass
-
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         ack = 'ack-{0}-single-file'.format(self.version)

--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -37,12 +37,15 @@ class Ack(Package):
 
     version('2.14', 'e74150a1609d28a70b450ef9cc2ed56b', expand=False)
 
-    # trust that there's a system perl for now, but perhaps someday we
-    # should:
-    # depends_on('perl')
+    depends_on('perl')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         ack = 'ack-{0}-single-file'.format(self.version)
+
+        # rewrite the script's #! line to call the perl dependency
+        shbang = '#!' + join_path(spec['perl'].prefix.bin, 'perl')
+        filter_file(r'^#!/usr/bin/env perl', shbang, ack)
+
         install(ack, join_path(prefix.bin, "ack"))
         set_executable(join_path(prefix.bin, "ack"))

--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -48,10 +48,6 @@ class Ack(Package):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        # find the file named like ack-2.14-single-file in a version
-        # independent manner (there should be only one )and install it
-        # as `ack`.
-        for f in os.listdir('.'):
-            if re.match('ack-\d*\.\d*-single-file', f):
-                install(f, join_path(prefix.bin, "ack"))
-                set_executable(join_path(prefix.bin, "ack"))
+        ack = 'ack-{0}-single-file'.format(self.version)
+        install(ack, join_path(prefix.bin, "ack"))
+        set_executable(join_path(prefix.bin, "ack"))

--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import re
+
+
+class Ack(Package):
+    """ack 2.14 is a tool like grep, optimized for programmers.
+
+       Designed for programmers with large heterogeneous trees of
+       source code, ack is written purely in portable Perl 5 and takes
+       advantage of the power of Perl's regular expressions."""
+
+    homepage = "http://beyondgrep.com/"
+    url      = "http://beyondgrep.com/ack-2.14-single-file"
+
+    version('2.14', 'e74150a1609d28a70b450ef9cc2ed56b', expand=False)
+
+    # trust that there's a system perl for now, but perhaps someday we
+    # should:
+    # depends_on('perl')
+
+    def unpack(self):
+        pass
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        # find the file named like ack-2.14-single-file in a version
+        # independent manner (there should be only one )and install it
+        # as `ack`.
+        for f in os.listdir('.'):
+            if re.match('ack-\d*\.\d*-single-file', f):
+                install(f, join_path(prefix.bin, "ack"))
+                set_executable(join_path(prefix.bin, "ack"))

--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
-import re
 
 
 class Ack(Package):


### PR DESCRIPTION
Add a package for [ack](http://beyondgrep.com/install/).  Simply install
the fatpacked script.

It uses '#!/usr/bin/env perl' and it very much not choosy about what
perl it needs.  For now just trust that there's one available, perhaps
someday we can/should uncomment the depends_on('perl').

Follows the methodolgy I used in nextflow.  Has the same
uninstall/install problem that nextflow has, there is an issue in
progress for that: https://github.com/LLNL/spack/issues/1308.

Tested on CentOS7.