### PR TITLE
Update several R packages (r-shiny prereqs)

### DIFF
--- a/var/spack/repos/builtin/packages/r-jsonlite/package.py
+++ b/var/spack/repos/builtin/packages/r-jsonlite/package.py
@@ -42,6 +42,7 @@ class RJsonlite(Package):
     list_url = "https://cran.r-project.org/src/contrib/Archive/jsonlite"
 
     version('1.0', 'c8524e086de22ab39b8ac8000220cc87')
+    version('0.9.21', '4fc382747f88a79ff0718a0d06bed45d')
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-jsonlite/package.py
+++ b/var/spack/repos/builtin/packages/r-jsonlite/package.py
@@ -38,10 +38,10 @@ class RJsonlite(Package):
     use with dynamic data in systems and applications."""
 
     homepage = "https://github.com/jeroenooms/jsonlite"
-    url      = "https://cran.r-project.org/src/contrib/jsonlite_0.9.21.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/jsonlite_1.0.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/jsonlite"
 
-    version('0.9.21', '4fc382747f88a79ff0718a0d06bed45d')
+    version('1.0', 'c8524e086de22ab39b8ac8000220cc87')
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-mime/package.py
+++ b/var/spack/repos/builtin/packages/r-mime/package.py
@@ -34,6 +34,7 @@ class RMime(Package):
     list_url = "https://cran.r-project.org/src/contrib/Archive/mime"
 
     version('0.5', '87e00b6d57b581465c19ae869a723c4d')
+    version('0.4', '789cb33e41db2206c6fc7c3e9fbc2c02')
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-mime/package.py
+++ b/var/spack/repos/builtin/packages/r-mime/package.py
@@ -30,10 +30,10 @@ class RMime(Package):
     from /etc/mime.types in UNIX-type systems."""
 
     homepage = "https://github.com/yihui/mime"
-    url      = "https://cran.r-project.org/src/contrib/mime_0.4.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/mime_0.5.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/mime"
 
-    version('0.4', '789cb33e41db2206c6fc7c3e9fbc2c02')
+    version('0.5', '87e00b6d57b581465c19ae869a723c4d')
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-rcpp/package.py
+++ b/var/spack/repos/builtin/packages/r-rcpp/package.py
@@ -41,6 +41,7 @@ class RRcpp(Package):
     list_url = "https://cran.r-project.org/src/contrib/Archive/Rcpp"
 
     version('0.12.6', 'db4280fb0a79cd19be73a662c33b0a8b')
+    version('0.12.5', 'f03ec05b4e391cc46e7ce330e82ff5e2')
 
     extends('R')
 

--- a/var/spack/repos/builtin/packages/r-rcpp/package.py
+++ b/var/spack/repos/builtin/packages/r-rcpp/package.py
@@ -37,10 +37,10 @@ class RRcpp(Package):
     last two."""
 
     homepage = "http://dirk.eddelbuettel.com/code/rcpp.html"
-    url      = "https://cran.r-project.org/src/contrib/Rcpp_0.12.5.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/Rcpp_0.12.6.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/Rcpp"
 
-    version('0.12.5', 'f03ec05b4e391cc46e7ce330e82ff5e2')
+    version('0.12.6', 'db4280fb0a79cd19be73a662c33b0a8b')
 
     extends('R')
 


### PR DESCRIPTION
    r-jsonlite 0.0.21 -> 1.0
    r-mime     0.4    -> 0.5
    rcpp       0.12.5 -> 0.12.6

CRAN is funny.  The older versions of these packages are still available
in package specific directories but the current version is not there, so
I don't see any way to make the older versions work as well.