### PR TITLE
Bug: fix jdk package's use of distutils

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -25,7 +25,7 @@
 #
 # Author: Justin Too <too1@llnl.gov>
 #
-import distutils
+import distutils.dir_util
 
 import spack
 from spack import *


### PR DESCRIPTION
The jdk package recently started failing for me, with this message:

See issue #1364, @citibeth's fix works fine.

Closes #1364 
