### PR TITLE
Olcf/unified cray platform

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -266,6 +266,19 @@ section_schemas = {
                                     ], },
                         },},},},},},
 
+    'targets': {
+        '$schema': 'http://json-schema.org/schema#',
+        'title': 'Spack target configuration file schema',
+        'type': 'object',
+        'additionalProperties': False,
+        'patternProperties': {
+            r'targets:?': {
+                'type': 'object',
+                'default': {},
+                'additionalProperties': False,
+                'patternProperties': {
+                    r'\w[\w-]*': { # target name
+                        'type': 'string' ,},},},},},
     'modules': {
         '$schema': 'http://json-schema.org/schema#',
         'title': 'Spack module file configuration file schema',

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -19,6 +19,8 @@ class Cnl(OperatingSystem):
         version = '10'
         super(Cnl, self).__init__(name, version)
 
+    def __str__(self):
+        return self.name
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -1,0 +1,87 @@
+import os
+import re
+import platform as py_platform
+#from subprocess import check_output
+import spack.config
+from spack.util.executable import which
+from spack.architecture import Platform, Target, NoPlatformError
+from spack.operating_systems.linux_distro import LinuxDistro
+from spack.operating_systems.cnl import Cnl
+
+
+# Craype- module prefixes that are not valid CPU targets.
+NON_TARGETS = ('hugepages', 'network', 'target', 'accel', 'xtpe')
+
+
+def _target_from_init(name):
+    matches = []
+    if name != 'front_end':
+        pattern = 'craype-(?!{0})(\S*)'.format('|'.join(NON_TARGETS))
+        with open('/etc/bash.bashrc.local', 'r') as conf:
+            for line in conf:
+                if re.search('^[^\#]*module[\s]*(?:add|load)', line):
+                     matches.extend(re.findall(pattern, line))
+    return matches[0] if matches else None
+
+
+class Cray(Platform):
+    priority = 10
+
+    def __init__(self):
+        ''' Create a Cray system platform.
+        
+        Target names should use craype target names but not include the
+        'craype-' prefix. Uses first viable target from:
+          self
+          envars [SPACK_FRONT_END, SPACK_BACK_END]
+          configuration file "targets.yaml" with keys 'front_end', 'back_end'
+          scanning /etc/bash/bashrc.local for back_end only
+        '''
+        super(Cray, self).__init__('cray')
+
+        # Get targets from config or make best guess from environment:
+        conf = spack.config.get_config('targets')
+        for name in ('front_end', 'back_end'):
+            _target = getattr(self, name, None)
+            if _target is None:
+                _target = os.environ.get('SPACK_' + name.upper())
+            if _target is None:
+                _target = conf.get(name)
+            if _target is None:
+                _target = _target_from_init(name)
+            setattr(self, name, _target)
+            
+            if _target is not None:
+                self.add_target(name, Target(_target, 'craype-' + _target))
+                self.add_target(_target, Target(_target, 'craype-' + _target))
+
+        if self.back_end is not None:
+            self.default = self.back_end
+            self.add_target('default', Target(self.default, 'craype-' + self.default))
+        else:
+            raise NoPlatformError()
+
+        front_distro = LinuxDistro()
+        back_distro = Cnl()
+
+        self.default_os = str(back_distro)
+        self.back_os = self.default_os
+        self.front_os = str(front_distro)
+
+        self.add_operating_system(self.back_os, back_distro)
+        self.add_operating_system(self.front_os, front_distro)
+
+    @classmethod
+    def setup_platform_environment(self, pkg, env):
+        """ Change the linker to default dynamic to be more
+            similar to linux/standard linker behavior
+        """
+        env.set('CRAYPE_LINK_TYPE', 'dynamic')
+        cray_wrapper_names = join_path(spack.build_env_path, 'cray')
+        if os.path.isdir(cray_wrapper_names):
+            env.prepend_path('PATH', cray_wrapper_names)
+            env.prepend_path('SPACK_ENV_PATHS', cray_wrapper_names)
+
+    @classmethod
+    def detect(self):
+        return os.environ.get('CRAYPE_VERSION') is not None

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,7 +27,7 @@ def _target_from_clean_env(name):
         # CAUTION - $USER is generally needed to initialize the environment.
         # There may be other variables needed for general success.
         output = env('USER=%s' % os.environ['USER'],
-                    '/bin/sh', '--noprofile', '-c',
+                    '/bin/bash', '--noprofile', '--norc', '-c',
                     '. /etc/profile; module list -lt',
                     output=str, error=str)
         default_modules = [i for i in output.splitlines()

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,9 +27,9 @@ def _target_from_clean_env(name):
         # CAUTION - $USER is generally needed to initialize the environment.
         # There may be other variables needed for general success.
         output = env('USER=%s' % os.environ['USER'],
-                    '/bin/bash', '--noprofile', '--norc', '-c',
-                    '. /etc/profile; module list -lt',
-                    output=str, error=str)
+                     '/bin/bash', '--noprofile', '--norc', '-c',
+                     '. /etc/profile; module list -lt',
+                     output=str, error=str)
         default_modules = [i for i in output.splitlines()
                            if len(i.split()) == 1]
         tty.debug("Found default modules:",

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,7 +27,8 @@ def _target_from_clean_env(name):
         # CAUTION - $USER is generally needed to initialize the environment.
         # There may be other variables needed for general success.
         output = env('USER=%s' % os.environ['USER'],
-                    '/bin/bash', '-l', '-c', 'module list -lt',
+                    '/bin/sh', '--noprofile', '-c',
+                    'source /etc/profile; module list -lt',
                     output=str, error=str)
         pattern = 'craype-(?!{0})(\S*)'.format('|'.join(NON_TARGETS))
         for line in output.splitlines():

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -28,7 +28,7 @@ def _target_from_clean_env(name):
         # There may be other variables needed for general success.
         output = env('USER=%s' % os.environ['USER'],
                     '/bin/sh', '--noprofile', '-c',
-                    'source /etc/profile; module list -lt',
+                    '. /etc/profile; module list -lt',
                     output=str, error=str)
         default_modules = [i for i in output.splitlines()
                            if len(i.split()) == 1]


### PR DESCRIPTION
This PR provides a platform to generically cover all Cray systems is introduced to avoid having
specific platforms for each of XK (XE, XT), XC, and future systems using CrayPE
and CNL.

The platform searches for 'front_end' and 'back_end' targets, in order, from:

  * Environment variables 'SPACK_FRONT_END' and 'SPACK_BACK_END'
  * A spack configuration file 'targets.yaml'
  * Parsing `/etc/bash.bashrc.local` for first loaded CrayPE CPU target.

If a back_end target is not found through one of these methods, an exception is
raised. Otherwise, the back_end is set as the default target. The shell init
script search is based on recommendations in Crayports case #144359.

Existence of a `targets.yaml` configuration file is optional and only eases identifying a cray front_end target.

No automagic way of determining front_end targets has been found (to date) so if
a front_end is not specified through configuration, it is ignored which should
leave a spack instance in a consistent state.