### PR TITLE
MKL linux fixes

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -62,10 +62,10 @@ class Hypre(Package):
             '--prefix=%s' % prefix,
             '--with-lapack-libs=%s' % to_lib_name(
                 spec['lapack'].lapack_shared_lib),
-            '--with-lapack-lib-dirs=%s/lib' % spec['lapack'].prefix,
+            '--with-lapack-lib-dirs=%s' % spec['lapack'].prefix.lib,
             '--with-blas-libs=%s' % to_lib_name(
                 spec['blas'].blas_shared_lib),
-            '--with-blas-lib-dirs=%s/lib' % spec['blas'].prefix
+            '--with-blas-lib-dirs=%s' % spec['blas'].prefix.lib
         ]
 
         if '+shared' in self.spec:

--- a/var/spack/repos/builtin/packages/mkl/package.py
+++ b/var/spack/repos/builtin/packages/mkl/package.py
@@ -12,9 +12,9 @@ class Mkl(IntelInstaller):
     mirror, see http://software.llnl.gov/spack/mirrors.html.
 
     To set the threading layer at run time set MKL_THREADING_LAYER
-    variable to one of the following values: INTEL, SEQUENTIAL, PGI.
+    variable to one of the following values: INTEL (default), SEQUENTIAL, PGI.
     To set interface layer at run time, use set the MKL_INTERFACE_LAYER
-    variable to LP64 or ILP64.
+    variable to LP64 (default) or ILP64.
     """
 
     homepage = "https://software.intel.com/en-us/intel-mkl"
@@ -40,10 +40,10 @@ class Mkl(IntelInstaller):
 
         # Unfortunately MKL libs are natively distrubted in prefix/lib/intel64.
         # To make MKL play nice with Spack, symlink all files to prefix/lib:
-        mkl_lib_dir = os.path.join(prefix, "lib","intel64")
+        mkl_lib_dir = os.path.join(prefix, "lib", "intel64")
         for f in os.listdir(mkl_lib_dir):
-            os.symlink(os.path.join(mkl_lib_dir, f), os.path.join(self.prefix, "lib", f))
-
+            os.symlink(os.path.join(mkl_lib_dir, f),
+                       os.path.join(self.prefix, "lib", f))
 
     def setup_dependent_package(self, module, dspec):
         # For now use Single Dynamic Library:

--- a/var/spack/repos/builtin/packages/mkl/package.py
+++ b/var/spack/repos/builtin/packages/mkl/package.py
@@ -38,6 +38,13 @@ class Mkl(IntelInstaller):
         for f in os.listdir(mkl_dir):
             os.symlink(os.path.join(mkl_dir, f), os.path.join(self.prefix, f))
 
+        # Unfortunately MKL libs are natively distrubted in prefix/lib/intel64.
+        # To make MKL play nice with Spack, symlink all files to prefix/lib:
+        mkl_lib_dir = os.path.join(prefix, "lib","intel64")
+        for f in os.listdir(mkl_lib_dir):
+            os.symlink(os.path.join(mkl_lib_dir, f), os.path.join(self.prefix, "lib", f))
+
+
     def setup_dependent_package(self, module, dspec):
         # For now use Single Dynamic Library:
         # To set the threading layer at run time, use the
@@ -53,6 +60,7 @@ class Mkl(IntelInstaller):
         name = 'libmkl_rt.%s' % dso_suffix
         libdir = find_library_path(name, self.prefix.lib64, self.prefix.lib)
 
+        # Now set blas/lapack libs:
         self.spec.blas_shared_lib   = join_path(libdir, name)
         self.spec.lapack_shared_lib = self.spec.blas_shared_lib
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -143,10 +143,17 @@ class Trilinos(Package):
             '-DTrilinos_ENABLE_CXX11:BOOL=ON',
             '-DTPL_ENABLE_Netcdf:BOOL=ON',
             '-DTPL_ENABLE_HYPRE:BOOL=%s' % (
-                'ON' if '+hypre' in spec else 'OFF'),
-            '-DTPL_ENABLE_HDF5:BOOL=%s' % (
-                'ON' if '+hdf5' in spec else 'OFF'),
+                'ON' if '+hypre' in spec else 'OFF')
         ])
+
+        if '+hdf5' in spec:
+            options.extend([
+                '-DTPL_ENABLE_HDF5:BOOL=ON',
+                '-DHDF5_INCLUDE_DIRS:PATH=%s' % spec['hdf5'].prefix.include,
+                '-DHDF5_LIBRARY_DIRS:PATH=%s' % spec['hdf5'].prefix.lib
+            ])
+        else:
+            options.extend(['-DTPL_ENABLE_HDF5:BOOL=OFF'])
 
         if '+boost' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -138,7 +138,7 @@ class Trilinos(Package):
             '-DTPL_ENABLE_LAPACK=ON',
             '-DLAPACK_LIBRARY_NAMES=%s' % to_lib_name(
                 spec['lapack'].lapack_shared_lib),
-            '-DLAPACK_LIBRARY_DIRS=%s' % spec['lapack'].prefix,
+            '-DLAPACK_LIBRARY_DIRS=%s' % spec['lapack'].prefix.lib,
             '-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON',
             '-DTrilinos_ENABLE_CXX11:BOOL=ON',
             '-DTPL_ENABLE_Netcdf:BOOL=ON',


### PR DESCRIPTION
for now a workaround with MKL is to symlink all libs from `prefix.lib.intel64` to `prefix.lib`. Frankly, i have no idea why by default `prefix.lib` has the following folders:
```
ia32 # symlink to ./ia32_lin
ia32_lin
intel64 # symlink to ./intel64_lin
intel64_lin
intel64_lin_mic # similar to intel64_lin, but somehow fewer number of libs
```

p.s. this is WIP as I am running installation of `deal.II` with MKL and will add fixes if needed.

@lee218llnl ping.