### PR TITLE
Move archive_version setting to if block

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -318,10 +318,11 @@ class Stage(object):
             fetchers.insert(0, spack.cache.fetcher(self.mirror_path, digest))
 
             # Look for the archive in list_url
-            archive_version = spack.url.parse_version(self.default_fetcher.url)
             package_name = os.path.dirname(self.mirror_path)
             pkg = spack.repo.get(package_name)
             if pkg.list_url is not None and pkg.url is not None:
+                archive_version = spack.url.parse_version(
+                    self.default_fetcher.url)
                 versions = pkg.fetch_remote_versions()
                 try:
                     url_from_list = versions[Version(archive_version)]


### PR DESCRIPTION
The archive_version variable should only get set if versions will be
checked and that is only if there is a list_url in the package file. For
VCS repos setting the variable triggers an error from web.py as it
parses the default_fetcher object.

This should fix #1422.