### PR TITLE
Cray: Fix a typo that could cause an infinite recursion when calling env/cc

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -98,7 +98,7 @@ class Cray(Platform):
         cray_wrapper_names = join_path(spack.build_env_path, 'cray')
         if os.path.isdir(cray_wrapper_names):
             env.prepend_path('PATH', cray_wrapper_names)
-            env.prepend_path('SPACK_ENV_PATHS', cray_wrapper_names)
+            env.prepend_path('SPACK_ENV_PATH', cray_wrapper_names)
 
     @classmethod
     def detect(self):


### PR DESCRIPTION
Fixes #1428.  See comments on this issue for more detail.