### PR TITLE
Fix MPICH without Fortran

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -116,8 +116,10 @@ class Mpich(Package):
         kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
         filter_file(env['CC'], self.compiler.cc,  mpicc,  **kwargs)
         filter_file(env['CXX'], self.compiler.cxx, mpicxx, **kwargs)
-        filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
-        filter_file(env['FC'], self.compiler.fc,  mpif90, **kwargs)
+        if 'F77' in env:
+            filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
+        if 'FC' in env:
+            filter_file(env['FC'], self.compiler.fc,  mpif90, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)


### PR DESCRIPTION
Currently, installing MPICH fails with a `KeyError` if no Fortran compiler is available. This patch fixes it.

I am actually not sure whether it really makes a lot of sense to support this configuration, though. Many packages fail if no Fortran compiler or Fortran MPI wrapper is found (for example, PAPI).
