### PR TITLE
sbang filtering now works on non-writable files.

### DIFF
--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -26,6 +26,7 @@
 Test that Spack's shebang filtering works correctly.
 """
 import os
+import stat
 import unittest
 import tempfile
 import shutil
@@ -40,6 +41,7 @@ lua_line         = "#!/this/" + ('x' * 200) + "/is/lua\n"
 lua_line_patched = "--!/this/" + ('x' * 200) + "/is/lua\n"
 sbang_line       = '#!/bin/bash %s/bin/sbang\n' % spack.spack_root
 last_line        = "last!\n"
+
 
 class SbangTest(unittest.TestCase):
     def setUp(self):
@@ -74,10 +76,8 @@ class SbangTest(unittest.TestCase):
             f.write(long_line)
             f.write(last_line)
 
-
     def tearDown(self):
-         shutil.rmtree(self.tempdir, ignore_errors=True)
-
+        shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def test_shebang_handling(self):
         filter_shebangs_in_directory(self.tempdir)
@@ -104,3 +104,14 @@ class SbangTest(unittest.TestCase):
             self.assertEqual(f.readline(), sbang_line)
             self.assertEqual(f.readline(), long_line)
             self.assertEqual(f.readline(), last_line)
+
+    def test_shebang_handles_non_writable_files(self):
+        # make a file non-writable
+        st = os.stat(self.long_shebang)
+        not_writable_mode = st.st_mode & ~stat.S_IWRITE
+        os.chmod(self.long_shebang, not_writable_mode)
+
+        self.test_shebang_handling()
+
+        st = os.stat(self.long_shebang)
+        self.assertEqual(oct(not_writable_mode), oct(st.st_mode))


### PR DESCRIPTION
Fixes #1425 

- sbang now changes mode to writable and restores mode if a file is not
  writable.

@sknigh: does this work for you?