### PR TITLE
Update Package : Qt (Add 'WebKit' Support)

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -6,7 +6,7 @@
 # Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
 # LLNL-CODE-647188
 #
-# For details, see https://github.com/llnl/spack  # NOQA: ignore=E501
+# For details, see https://github.com/llnl/spack
 # Please also see the LICENSE file for our notice and the LGPL.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -29,9 +29,9 @@ import sys
 
 class Qt(Package):
     """Qt is a comprehensive cross-platform C++ application framework."""
-    homepage = 'http://qt.io'  # NOQA: ignore=E501
-    url      = 'http://download.qt.io/archive/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.tar.gz'  # NOQA: ignore=E501
-    list_url = 'http://download.qt.io/archive/qt/'  # NOQA: ignore=E501
+    homepage = 'http://qt.io'
+    url      = 'http://download.qt.io/archive/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.tar.gz'
+    list_url = 'http://download.qt.io/archive/qt/'
     list_depth = 4
 
     version('5.7.0',  '9a46cce61fc64c20c3ac0a0e0fa41b42')
@@ -48,12 +48,13 @@ class Qt(Package):
     variant('krellpatch', default=False, description="Build with openspeedshop based patch.")
     variant('mesa',       default=False, description="Depend on mesa.")
     variant('gtk',        default=False, description="Build with gtkplus.")
+    variant('webkit',     default=False, description="Build the Webkit extension")
     variant('examples',   default=False, description="Build examples.")
     variant('dbus',       default=False, description="Build with D-Bus support.")
 
     patch('qt3krell.patch', when='@3.3.8b+krellpatch')
 
-    # https://github.com/xboxdrv/xboxdrv/issues/188  # NOQA: ignore=E501
+    # https://github.com/xboxdrv/xboxdrv/issues/188
     patch('btn_trigger_happy.patch', when='@5.7.0:')
 
     patch('qt4-corewlan-new-osx.patch', when='@4')
@@ -62,7 +63,7 @@ class Qt(Package):
 
     # Use system openssl for security.
     depends_on("openssl")
-
+    depends_on("glib")
     depends_on("gtkplus", when='+gtk')
     depends_on("libxml2")
     depends_on("zlib")
@@ -72,17 +73,23 @@ class Qt(Package):
     depends_on("libpng", when='@4:')
     depends_on("libmng")
     depends_on("jpeg")
-
-    # Webkit
-    # depends_on("gperf")
-    # depends_on("flex", type='build')
-    # depends_on("bison", type='build')
-    # depends_on("ruby", type='build')
     depends_on("icu4c")
 
     # OpenGL hardware acceleration
     depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb", when=sys.platform != 'darwin')
+
+    # Webkit
+    depends_on("flex", when='+webkit', type='build')
+    depends_on("bison", when='+webkit', type='build')
+    depends_on("gperf", when='+webkit')
+    depends_on("fontconfig", when='+webkit')
+
+    # Multimedia
+    # depends_on("gstreamer", when='+multimedia')
+    # depends_on("pulse", when='+multimedia')
+    # depends_on("flac", when='+multimedia')
+    # depends_on("ogg", when='+multimedia')
 
     def url_for_version(self, version):
         # URL keeps getting more complicated with every release
@@ -115,8 +122,8 @@ class Qt(Package):
 
         return url
 
-    def setup_environment(self, spack_env, env):
-        env.set('QTDIR', self.prefix)
+    def setup_environment(self, spack_env, run_env):
+        run_env.set('QTDIR', self.prefix)
 
     def setup_dependent_environment(self, spack_env, run_env, dspec):
         spack_env.set('QTDIR', self.prefix)
@@ -130,7 +137,7 @@ class Qt(Package):
                         'mkspecs/common/g++-base.conf')
 
             # Necessary to build with GCC 6 and other modern compilers
-            # http://stackoverflow.com/questions/10354371/  # NOQA: ignore=E501
+            # http://stackoverflow.com/questions/10354371/
             filter_file('(^QMAKE_CXXFLAGS .*)', r'\1 -std=gnu++98',
                         'mkspecs/common/gcc-base.conf')
 
@@ -212,7 +219,7 @@ class Qt(Package):
     # Don't disable all the database drivers, but should
     # really get them into spack at some point.
 
-    @when('@3')  # NOQA: ignore=F811
+    @when('@3')
     def configure(self):
         # A user reported that this was necessary to link Qt3 on ubuntu
         os.environ['LD_LIBRARY_PATH'] = os.getcwd() + '/lib'
@@ -223,36 +230,40 @@ class Qt(Package):
                   '-release',
                   '-fast')
 
-    @when('@4')  # NOQA: ignore=F811
+    @when('@4')
     def configure(self):
         configure('-fast',
-                  '-no-webkit',
-                  '{0}-gtkstyle'.format('' if '+gtk' in self.spec else '-no'),
+                  '-{0}gtkstyle'.format('' if '+gtk' in self.spec else 'no-'),
+                  '-{0}webkit'.format('' if '+webkit' in self.spec else 'no-'),
                   '-arch', str(self.spec.architecture.target),
                   *self.common_config_args)
 
-    @when('@5.0:5.6')  # NOQA: ignore=F811
+    @when('@5.0:5.6')
     def configure(self):
+        webkit_args = [] if '+webkit' in self.spec else ['-skip', 'qtwebkit']
         configure('-no-eglfs',
                   '-no-directfb',
-                  '{0}-gtkstyle'.format('' if '+gtk' in self.spec else '-no'),
-                  '-skip', 'qtwebkit',
-                  *self.common_config_args)
+                  '-{0}gtkstyle'.format('' if '+gtk' in self.spec else 'no-'),
+                  *(webkit_args + self.common_config_args))
 
-    @when('@5.7:')  # NOQA: ignore=F811
+    @when('@5.7:')
     def configure(self):
-        args = self.common_config_args
+        config_args = self.common_config_args
 
         if not sys.platform == 'darwin':
-            args.extend([
+            config_args.extend([
                 '-qt-xcb',
+            ])
+
+        if '~webkit' in self.spec:
+            config_args.extend([
+                '-skip', 'webengine',
             ])
 
         configure('-no-eglfs',
                   '-no-directfb',
-                  '{0}-gtk'.format('' if '+gtk' in self.spec else '-no'),
-                  '-skip', 'webengine',
-                  *args)
+                  '-{0}gtk'.format('' if '+gtk' in self.spec else 'no-'),
+                  *config_args)
 
     def install(self, spec, prefix):
         self.configure()

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -128,6 +128,9 @@ class Qt(Package):
     def setup_dependent_environment(self, spack_env, run_env, dspec):
         spack_env.set('QTDIR', self.prefix)
 
+    def setup_dependent_package(self, module, ext_spec):
+        module.qmake = Executable(join_path(self.spec.prefix.bin, 'qmake'))
+
     def patch(self):
         if self.spec.satisfies('@4'):
             # Fix qmake compilers in the default mkspec


### PR DESCRIPTION
The changes in this pull request add the `+webkit` variant to the `qt` package, which is a boolean variant that determines whether or not `qt` builds with the optional [webkit module](http://doc.qt.io/qt-4.8/demos.html#webkit).  The majority of these changes were made in order to satisfy the new style guidelines; the only crucial changes are the added package dependencies (specifically, `flex`, `bison`, `icu4c`, `gperf`, and `fontconfig`).  I was able to build and link against installed variants `qt@4.8.6+webkit` and `qt@5.5.1+webkit` on RedHat6 when compiling with GCC 4.7.2, and I also verified that `qt@4.8.6~webkit` still builds properly.

Since I performed my tests on a machine that was previously configured to install `qt`, I suspect that I've missed a number of dependencies with these changes.  I tried using `ldd` on all of the output libraries/binaries to see what I missed and I've attached [a text list containing the relevant results](https://github.com/LLNL/spack/files/402729/qt-deps.txt).  If any of these dependencies seem like they shouldn't be handled by system libraries, please let me know and I'll add them as extra dependencies.