### PR TITLE
No need to patch Lmod after 6.4.4

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -38,6 +38,7 @@ class Lmod(Package):
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'  # NOQA: ignore=E501
     url = 'https://github.com/TACC/Lmod/archive/6.4.1.tar.gz'
 
+    version('6.4.5', '14f6c58dbc0a5a75574d795eac2c1e3c')
     version('6.4.1', '7978ba777c8aa41a4d8c05fec5f780f4')
     version('6.3.7', '0fa4d5a24c41cae03776f781aa2dedc1')
     version('6.0.1', '91abf52fe5033bd419ffe2842ebe7af9')
@@ -55,15 +56,16 @@ class Lmod(Package):
         spack_env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
 
-    patch('fix_tclsh_paths.patch')
+    patch('fix_tclsh_paths.patch', when='@:6.4.3')
 
     def patch(self):
         """The tcl scripts should use the tclsh that was discovered
            by the configure script.  Touch up their #! lines so that the
            sed in the Makefile's install step has something to work on.
            Requires the change in the associated patch file.fg"""
-        for tclscript in glob('src/*.tcl'):
-            filter_file(r'^#!.*tclsh', '#!@path_to_tclsh@', tclscript)
+        if self.spec.version <= Version('6.4.3'):
+            for tclscript in glob('src/*.tcl'):
+                filter_file(r'^#!.*tclsh', '#!@path_to_tclsh@', tclscript)
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)


### PR DESCRIPTION
The Lmod author changed the src so that it uses the tclsh (and shared libraries) discovered at configure time.  He did it differently that I did in this patch, but he changes solve our problem too, so...