### PR TITLE
Fix erroneously stripped trailing whitespace in patch

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/g_date_strftime.patch
+++ b/var/spack/repos/builtin/packages/pkg-config/g_date_strftime.patch
@@ -20,14 +20,15 @@ index 4aece02..92c34d2 100644
 +#pragma GCC diagnostic push
 +#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 +
- gsize
- g_date_strftime (gchar       *s,
-                  gsize        slen,
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
 @@ -2549,3 +2552,5 @@ g_date_strftime (gchar       *s,
    return retval;
  #endif
  }
 +
 +#pragma GCC diagnostic pop
---
+-- 
 2.7.1
+


### PR DESCRIPTION
My `.gitconfig` told git to check for trailing whitespace and silently strip it. Unfortunately, `patch` requires the lines to match _exactly_. Fixes #1461.