### PR TITLE
Various improvements to run-flake8

### DIFF
--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -2,11 +2,6 @@
 #
 # This script runs source code style checks on Spack.
 #
-# It should be executed from the top-level directory of the repo,
-# e.g.:
-#
-#    share/spack/qa/run-flake8
-#
 # To run it, you'll need to have the Python flake8 installed locally.
 #
 PYTHONPATH=./lib/spack:$PYTHONPATH
@@ -16,6 +11,9 @@ if [[ ! $flake8 ]]; then
     echo "ERROR: flake8 is required to run this script."
     exit 1
 fi
+
+# Move to Spack root; allows script to be run from anywhere
+cd "$(dirname "$0")/../../.."
 
 # Add changed files that have been committed since branching off of develop
 changed=($(git diff --name-only --find-renames develop... -- '*.py'))

--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -25,6 +25,18 @@ changed+=($(git diff --name-only --find-renames -- '*.py'))
 # Ensure that each file in the array is unique
 changed=($(printf '%s\n' "${changed[@]}" | sort -u))
 
+function cleanup {
+    # Restore original package files after modifying them.
+    for file in "${changed[@]}"; do
+        if [[ -e "${file}.sbak~" ]]; then
+            mv "${file}.sbak~" "${file}"
+        fi
+    done
+}
+
+# Cleanup temporary files upon exit or when script is killed
+trap cleanup EXIT SIGINT SIGTERM
+
 # Add approved style exemptions to the changed packages.
 for file in "${changed[@]}"; do
     # Make a backup to restore later
@@ -52,7 +64,6 @@ for file in "${changed[@]}"; do
     perl -i -pe 's/^(.*(https?|file)\:.*)$/\1  # NOQA: ignore=E501/' $file
 done
 
-return_code=0
 if [[ "${changed[@]}" ]]; then
     echo =======================================================
     echo  flake8: running flake8 code checks on spack.
@@ -64,17 +75,10 @@ if [[ "${changed[@]}" ]]; then
         echo "Flake8 checks were clean."
     else
         echo "Flake8 found errors."
-        return_code=1
+        exit 1
     fi
 else
     echo No core framework files modified.
 fi
 
-# Restore original package files after modifying them.
-for file in "${changed[@]}"; do
-    if [[ -e "${file}.sbak~" ]]; then
-        mv "${file}.sbak~" "${file}"
-    fi
-done
-
-exit $return_code
+exit 0

--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -17,11 +17,18 @@ if [[ ! $flake8 ]]; then
     exit 1
 fi
 
-# Check if changed files are flake8 conformant [framework]
-changed=$(git diff --name-only --find-renames develop... | grep '.py$')
+# Add changed files that have been committed since branching off of develop
+changed=($(git diff --name-only --find-renames develop... -- '*.py'))
+# Add changed files that have been staged but not yet committed
+changed+=($(git diff --name-only --find-renames --cached -- '*.py'))
+# Add changed files that are unstaged
+changed+=($(git diff --name-only --find-renames -- '*.py'))
+
+# Ensure that each file in the array is unique
+changed=($(printf '%s\n' "${changed[@]}" | sort -u))
 
 # Add approved style exemptions to the changed packages.
-for file in $changed; do
+for file in "${changed[@]}"; do
     # Make a backup to restore later
     cp "$file" "$file.sbak~"
 
@@ -48,14 +55,14 @@ for file in $changed; do
 done
 
 return_code=0
-if [[ $changed ]]; then
+if [[ "${changed[@]}" ]]; then
     echo =======================================================
     echo  flake8: running flake8 code checks on spack.
     echo
     echo  Modified files:
-    echo  $changed | perl -pe 's/^/  /;s/ +/\n  /g'
+    echo  "${changed[@]}" | perl -pe 's/^/  /;s/ +/\n  /g'
     echo =======================================================
-    if flake8 --format pylint $changed; then
+    if flake8 --format pylint "${changed[@]}"; then
         echo "Flake8 checks were clean."
     else
         echo "Flake8 found errors."
@@ -66,7 +73,7 @@ else
 fi
 
 # Restore original package files after modifying them.
-for file in $changed; do
+for file in "${changed[@]}"; do
     if [[ -e "${file}.sbak~" ]]; then
         mv "${file}.sbak~" "${file}"
     fi


### PR DESCRIPTION
This PR makes the following modifications to run-flake8:

- Run flake8 checks on changed files that haven't been committed yet
- Allow `run-flake8` to be run from any directory, not just `$SPACK_ROOT`
- Always clean up temporary package.py files, even if the user hits <kbd>Ctrl</kbd>-<kbd>C</kbd>