### PR TITLE
Bug Fix : Allow Packages to Have Variants w/ Non-Bool, Non-String Defaults

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -328,11 +328,10 @@ class VariantSpec(object):
         return VariantSpec(self.name, self.value)
 
     def __str__(self):
-        if self.value in [True, False]:
-            out = '+' if self.value else '~'
-            return out + self.name
+        if type(self.value) == bool:
+            return '{0}{1}'.format('+' if self.value else '~', self.name)
         else:
-            return ' ' + self.name + "=" + self.value
+            return ' {0}={1}'.format(self.name, self.value)
 
 
 class VariantMap(HashableMap):


### PR DESCRIPTION
The changes in this pull request fix a small bug that was preventing packages from having variants with default values that weren't boolean or string values.  The code previously prohibited these values because it required that all variant values support string addition (see [`lib/spack/spack/spec.py:330`](https://github.com/LLNL/spack/blob/2042e9a6d85d02adc9424ce6f973e17341ebb292/lib/spack/spack/spec.py#L330) for details).  This fix changes this requirement so that default values are required to be string convertible instead, which adds support for many more types (most notably, the integer and floating-point types).