### PR TITLE
Use python platform.system for system ID

### DIFF
--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -22,6 +22,4 @@ class Darwin(Platform):
 
     @classmethod
     def detect(self):
-        platform = subprocess.Popen(['uname', '-a'], stdout=subprocess.PIPE)
-        platform, _ = platform.communicate()
-        return 'darwin' in platform.strip().lower()
+        return 'darwin' in platform.system().lower()

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -1,4 +1,3 @@
-import subprocess
 import platform
 from spack.architecture import Platform, Target
 from spack.operating_systems.mac_os import MacOs

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -1,4 +1,5 @@
 import subprocess
+import platform
 from spack.architecture import Platform, Target
 from spack.operating_systems.mac_os import MacOs
 

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -27,6 +27,4 @@ class Linux(Platform):
 
     @classmethod
     def detect(self):
-        platform = subprocess.Popen(['uname', '-a'], stdout=subprocess.PIPE)
-        platform, _ = platform.communicate()
-        return 'linux' in platform.strip().lower()
+        return 'linux' in platform.system().lower()

--- a/lib/spack/spack/platforms/linux.py
+++ b/lib/spack/spack/platforms/linux.py
@@ -1,4 +1,3 @@
-import subprocess
 import platform
 from spack.architecture import Platform, Target
 from spack.operating_systems.linux_distro import LinuxDistro


### PR DESCRIPTION
Uses python platform to identify the system. Fixes issue #1489. 