### PR TITLE
Add latest version of libpng, ncview depends on libpng

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -30,6 +30,7 @@ class Libpng(Package):
     homepage = "http://www.libpng.org/pub/png/libpng.html"
     url      = "http://download.sourceforge.net/libpng/libpng-1.6.16.tar.gz"
 
+    version('1.6.24', '65213080dd30a9b16193d9b83adc1ee9')
     version('1.6.16', '1a4ad377919ab15b54f6cb6a3ae2622d')
     version('1.6.15', '829a256f3de9307731d4f52dc071916d')
     version('1.6.14', '2101b3de1d5f348925990f9aa8405660')
@@ -37,9 +38,10 @@ class Libpng(Package):
     version('1.4.19', '89bcbc4fc8b31f4a403906cf4f662330')
     version('1.2.56', '9508fc59d10a1ffadd9aae35116c19ee')
 
-    depends_on('zlib')
+    depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()
+        make("check")
         make("install")

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -34,6 +34,7 @@ class Ncview(Package):
 
     depends_on("netcdf")
     depends_on("udunits2")
+    depends_on("libpng")
 
     # OS Dependencies
     # Ubuntu: apt-get install libxaw7-dev


### PR DESCRIPTION
Not sure if libpng is required or optional, but ncview definitely links to it.