### PR TITLE
Remove url_for_version as it breaks spack info

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -48,12 +48,6 @@ class Openssl(Package):
     depends_on("zlib")
     parallel = False
 
-    def url_for_version(self, version):
-        if '@system' in self.spec:
-            return '@system (reserved version for system openssl)'
-        else:
-            return super(Openssl, self).url_for_version(self.version)
-
     def handle_fetch_error(self, error):
         tty.warn("Fetching OpenSSL failed. This may indicate that OpenSSL has "
                  "been updated, and the version in your instance of Spack is "


### PR DESCRIPTION
Is this `@system` version even necessary? As far as I know, system installations are handled through packages.yaml. Leaving it in caused this problem:
```
$ spack info openssl
Package:    openssl
Homepage:   http://www.openssl.org

Safe versions:  
Traceback (most recent call last):
  File "/soft/spack-0.9.1/bin/spack", line 184, in <module>
    main()
  File "/soft/spack-0.9.1/bin/spack", line 161, in main
    return_val = command(parser, args)
  File "/blues/gpfs/home/software/spack-0.9.1/lib/spack/spack/cmd/info.py", line 114, in info
    print_text_info(pkg)
  File "/blues/gpfs/home/software/spack-0.9.1/lib/spack/spack/cmd/info.py", line 62, in print_text_info
    f = fs.for_package_version(pkg, v)
  File "/blues/gpfs/home/software/spack-0.9.1/lib/spack/spack/fetch_strategy.py", line 831, in for_package_version
    attrs['url'] = pkg.url_for_version(version)
  File "/blues/gpfs/home/software/spack-0.9.1/var/spack/repos/builtin/packages/openssl/package.py", line 55, in url_for_version
    return super(Openssl, self).url_for_version(self.version)
  File "/blues/gpfs/home/software/spack-0.9.1/lib/spack/spack/package.py", line 430, in version
    raise ValueError("Can only get of package with concrete version.")
ValueError: Can only get of package with concrete version.
```