### PR TITLE
Correct env vars for modulecmd; Fixes #1481

### DIFF
--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -1,5 +1,4 @@
 import re
-import os
 
 from spack.architecture import OperatingSystem
 from spack.util.executable import *
@@ -43,17 +42,10 @@ class Cnl(OperatingSystem):
             modulecmd = which('modulecmd')
             modulecmd.add_default_arg('python')
 
-            # Save the environment variable to restore later
-            old_modulepath = os.environ['MODULEPATH']
-            # if given any explicit paths, search them for module files too
-            if paths:
-                module_paths = ':' + ':'.join(p for p in paths)
-                os.environ['MODULEPATH'] = module_paths
-
             output = modulecmd(
                 'avail', cmp_cls.PrgEnv_compiler, output=str, error=str)
-            matches = re.findall(
-                r'(%s)/([\d\.]+[\d])' % cmp_cls.PrgEnv_compiler, output)
+            version_regex = r'(%s)/([\d\.]+[\d])' % cmp_cls.PrgEnv_compiler
+            matches = re.findall(version_regex, output)
             for name, version in matches:
                 v = version
                 comp = cmp_cls(
@@ -61,9 +53,5 @@ class Cnl(OperatingSystem):
                     ['cc', 'CC', 'ftn'], [cmp_cls.PrgEnv, name + '/' + v])
 
                 compilers.append(comp)
-
-            # Restore modulepath environment variable
-            if paths:
-                os.environ['MODULEPATH'] = old_modulepath
 
         return compilers

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -27,6 +27,7 @@ def _target_from_clean_env(name):
         # CAUTION - $USER is generally needed to initialize the environment.
         # There may be other variables needed for general success.
         output = env('USER=%s' % os.environ['USER'],
+                     'HOME=%s' % os.environ['HOME'],
                      '/bin/bash', '--noprofile', '--norc', '-c',
                      '. /etc/profile; module list -lt',
                      output=str, error=str)


### PR DESCRIPTION
Two things:
1. @mpbelhorn and I found that some Cray systems expect `$HOME` to be defined for a "clean" environment, otherwise modulecmd throws errors and Spack can't get a default module list.
2. More interestingly, the CNL operating system class has been looking for modulefiles in `$PATH` instead of `$MODULEPATH`. I think this may have been done for consistency with the compiler discovery patterns in other operating systems, but since there are no modulefiles in `$PATH` on any of the Cray systems that I can access, I think it may be more suitable to rely on `$MODULEPATH`.

To verify, run `./bin/spack compiler find` in develop with an empty compilers.yaml. You should see that it fails to find any compilers for the CNL operating system. Repeat with this branch, and your cup should runneth over with CNL compilers.

Tested successfully on Titan, Gaea C3, Cori, and BlueWaters.
