### PR TITLE
fix mpich installation when fortran compiler is not installed/enabled

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -116,8 +116,12 @@ class Mpich(Package):
         kwargs = {'ignore_absent': True, 'backup': False, 'string': True}
         filter_file(env['CC'], self.compiler.cc,  mpicc,  **kwargs)
         filter_file(env['CXX'], self.compiler.cxx, mpicxx, **kwargs)
-        filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
-        filter_file(env['FC'], self.compiler.fc,  mpif90, **kwargs)
+
+        if self.compiler.f77:
+            filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
+
+        if self.compiler.fc:
+            filter_file(env['FC'], self.compiler.fc,  mpif90, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)


### PR DESCRIPTION
While trying mpich installation on Ubuntu machine without gfortran compiler, I see following:

`spack install -v mpich@3.2 %gcc@4.8`

Spack filter_compilers routine end up with error:

```
Traceback (most recent call last):
  File "/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/lib/spack/spack/build_environment.py", line 512, in fork
    function()
  File "/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/lib/spack/spack/package.py", line 958, in build_process
    self.install(self.spec, self.prefix)
  File "/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/var/spack/repos/builtin/packages/mpich/package.py", line 98, in install
    self.filter_compilers()
  File "/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/var/spack/repos/builtin/packages/mpich/package.py", line 119, in filter_compilers
    filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
  File "/usr/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'F77'
==> Error: Installation process had nonzero exit code : 256
```

MPICH configure line from spack was:

```
=== configuring in test/mpi (/tmp/kumbhar/spack-stage/spack-stage-I4R1pS/mpich-3.2/test/mpi)
configure: running /bin/bash ./configure --disable-option-checking '--prefix=/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/opt/spack/linux-Ubuntu14-x86_64/gcc-4.8/mpich-3.2-qzrmue4o7ddvaghl3kszkj74w6t2xhmm'  '--with-pmi=yes' '--with-pm=hydra' '--enable-shared' '--without-ibverbs' '--disable-f77' '--disable-fc' '--disable-fortran' 'CC=/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/lib/spack/env/gcc/gcc' 'CXX=/home/kumbhar/workarena/softwares/sources/spack-llnl/spack/lib/spack/env/gcc/g++' --cache-file=/dev/null --srcdir=.
```

filter_compilers should filter fortran wrappers if fortran was enabled.

Let me know if there is better way to handle this.
