### PR TITLE
Update broken extrae package

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -53,8 +53,8 @@ class Extrae(Package):
        programming models either alone or in conjunction with MPI :
        OpenMP, CUDA, OpenCL, pthread, OmpSs"""
     homepage = "http://www.bsc.es/computer-sciences/extrae"
-    url      = "http://www.bsc.es/ssl/apps/performanceTools/files/extrae-3.0.1.tar.bz2"
-    version('3.0.1', 'a6a8ca96cd877723cd8cc5df6bdb922b')
+    url      = "http://www.bsc.es/ssl/apps/performanceTools/files/extrae-3.3.0.tar.bz2"
+    version('3.3.0', 'f46e3f1a6086b5b3ac41c9585b42952d')
 
     depends_on("mpi")
     depends_on("dyninst")
@@ -62,6 +62,9 @@ class Extrae(Package):
     depends_on("boost")
     depends_on("libdwarf")
     depends_on("papi")
+    depends_on("libelf")
+    depends_on("libxml2")
+    depends_on("binutils+libiberty")
 
     def install(self, spec, prefix):
         if 'openmpi' in spec:
@@ -80,6 +83,9 @@ class Extrae(Package):
                   "--with-papi=%s" % spec['papi'].prefix,
                   "--with-dyninst-headers=%s" % spec[
                       'dyninst'].prefix.include,
+                  "--with-elf=%s" % spec['libelf'].prefix,
+                  "--with-xml-prefix=%s" % spec['libxml2'].prefix,
+                  "--with-binutils=%s" % spec['binutils'].prefix,
                   "--with-dyninst-libs=%s" % spec['dyninst'].prefix.lib)
 
         make()


### PR DESCRIPTION
Hello All,

Extrae source tarballs are "removed" once they release new version. I have asked developers if they have separate repo for old tarballs.

I am updating current version.

Also, I saw following error while installing on my linux box:

```
checking for DWARF includes directory... /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/libdwarf-20160507-rtclsbfbxynxfkiaelrf4d2zgdikm2kv/include
checking for DWARF libraries directory... /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/libdwarf-20160507-rtclsbfbxynxfkiaelrf4d2zgdikm2kv/lib
checking for boost... found in /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/boost-1.51.0-5kmaqk4xfi5su6gbdrasmrslfubmm6j2
configure: error: Cannot add DynInst support without libelf. Check for --with-elf option
==> Error: Command exited with status 1:
'./configure' '--prefix=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/extrae-3.3.0-gvsu6rdacr3s7szwb4slxxpfop3og5rq' '--with-mpi=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/mpich-3.2-6kexagz7qofuapm2x76h7bl2lvokdgi3' '--with-unwind=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/libunwind-1.1-fzon6r23jq5qfobkmc3samwbt6ml6vzv' '--with-dyninst=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/dyninst-9.1.0-qn6yvzk3eny6h23lrsfnuhcuoeibfmfa' '--with-boost=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/boost-1.51.0-5kmaqk4xfi5su6gbdrasmrslfubmm6j2' '--with-dwarf=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/libdwarf-20160507-rtclsbfbxynxfkiaelrf4d2zgdikm2kv' '--with-papi=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/papi-5.4.3-x5d2rw42zk3k7dko3zodsxvrh7g4as6k' '--with-dyninst-headers=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/dyninst-9.1.0-qn6yvzk3eny6h23lrsfnuhcuoeibfmfa/include' '--with-dyninst-libs=/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/opt/spack/linux-redhat6-x86_64/gcc-5.4.0/dyninst-9.1.0-qn6yvzk3eny6h23lrsfnuhcuoeibfmfa/lib'
```

We usually provide xml config file for profiling and hence building with libxml2 by default.