### PR TITLE
Build Cube package with Qt (+gui variant)

### DIFF
--- a/var/spack/repos/builtin/packages/cube/package.py
+++ b/var/spack/repos/builtin/packages/cube/package.py
@@ -45,14 +45,19 @@ class Cube(Package):
     version('4.2.3', '8f95b9531f5a8f8134f279c2767c9b20',
             url="http://apps.fz-juelich.de/scalasca/releases/cube/4.2/dist/cube-4.2.3.tar.gz")
 
-    # TODO : add variant that builds GUI on top of Qt
+    variant('gui', default=False, description='Build CUBE GUI')
 
     depends_on('zlib')
+    depends_on('qt@4.6:', when='+gui')
 
     def install(self, spec, prefix):
         configure_args = ["--prefix=%s" % prefix,
-                          "--without-paraver",
-                          "--without-gui"]
+                          "--without-paraver"]
+
+        # TODO : need to handle cross compiling build
+        if '+gui' not in spec:
+            configure_args.append('--without-gui')
+
         configure(*configure_args)
-        make(parallel=False)
+        make()
         make("install", parallel=False)


### PR DESCRIPTION
On non cross-compiling platform, this will allow to build cube GUI.

(need to handle cross compiling platform build with "--with-frontend-compiler-suite". I will test/update that separately)