### PR TITLE
Adding latest version of fenics

### DIFF
--- a/var/spack/repos/builtin/packages/fenics/hdf5~cxx-detection.patch
+++ b/var/spack/repos/builtin/packages/fenics/hdf5~cxx-detection.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2016-08-16 02:30:13.466078087 +0200
++++ b/CMakeLists.txt	2016-08-16 02:30:36.879586772 +0200
+@@ -553,7 +553,7 @@
+     set(ENV{HDF5_ROOT} "$ENV{HDF5_DIR}")
+   endif()
+   set(HDF5_PREFER_PARALLEL TRUE)
+-  find_package(HDF5)
++  find_package(HDF5 COMPONENTS C)
+   set_package_properties(HDF5 PROPERTIES TYPE OPTIONAL
+     DESCRIPTION "Hierarchical Data Format 5 (HDF5)"
+     URL "https://www.hdfgroup.org/HDF5")

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -189,9 +189,6 @@ class Fenics(Package):
                 self.cmake_is_on('zlib')),
         ]
 
-        if '+hdf5' in spec and 'hdf5~cxx' in spec:
-            cmake_args.append('-DHDF5_hdf5_cpp_LIBRARY:PATH=""')
-
         cmake_args.extend(std_cmake_args)
 
         with working_dir('build', create=True):

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -62,7 +62,7 @@ class Fenics(Package):
     # variant('slepc4py',     default=True,  description='Uses SLEPc4py')
     # variant('pastix',       default=True,  description='Compile with Pastix')
 
-    patch('petsc-3.7.patch', when='^petsc@3.7:')
+    patch('petsc-3.7.patch', when='@1.6.1^petsc@3.7:')
     patch('petsc-version-detection.patch', when='@:1.6.1')
 
     extends('python')
@@ -91,6 +91,16 @@ class Fenics(Package):
     depends_on('swig@3.0.3:')
 
     releases = [
+        {
+            'version': '2016.1.0',
+            'md5': '92e8d00f6487a575987201f0b0d19173',
+            'resources': {
+                'ffc': '35457ae164e481ba5c9189ebae060a47',
+                'fiat': 'ac0c49942831ee434301228842bcc280',
+                'instant': '0e3dbb464c4d90d691f31f0fdd63d4f6',
+                'ufl': '37433336e5c9b58d1d5ab4acca9104a7',
+            }
+        },
         {
             'version': '1.6.0',
             'md5': '35cb4baf7ab4152a40fb7310b34d5800',
@@ -175,6 +185,9 @@ class Fenics(Package):
             '-DDOLFIN_ENABLE_ZLIB:BOOL={0}'.format(
                 self.cmake_is_on('zlib')),
         ]
+
+        if '+hdf5' in spec and 'hdf5~cxx' in spec:
+            cmake_args.append('-DHDF5_hdf5_cpp_LIBRARY:PATH=""')
 
         cmake_args.extend(std_cmake_args)
 

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -134,6 +134,15 @@ class Fenics(Package):
                      when='@{version}'.format(**release),
                      placement=name)
 
+    def patch(self):
+        pass
+
+    @when('+hdf5~cxx')
+    def patch(self):
+        filter_file(r'find_package(HDF5)',
+                    r'find_package(HDF5 COMPONENTS C)',
+                    'CMakeLists.txt')
+
     def cmake_is_on(self, option):
         return 'ON' if option in self.spec else 'OFF'
 

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -70,7 +70,7 @@ class Fenics(Package):
 
     depends_on('eigen@3.2.0:', type='build')
     depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono')
-    
+
     depends_on('mpi', when='+mpi')
     depends_on('hdf5', when='+hdf5')
     depends_on('parmetis@4.0.2:^metis+real64', when='+parmetis')
@@ -89,7 +89,7 @@ class Fenics(Package):
     depends_on('py-sympy', type=nolink)
     depends_on('swig@3.0.3:', type=nolink)
     depends_on('cmake@2.8.12:', type=nolink)
-    
+
     depends_on('py-setuptools', type='build')
     depends_on('py-sphinx@1.0.1:', when='+doc', type='build')
 

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -64,15 +64,13 @@ class Fenics(Package):
 
     patch('petsc-3.7.patch', when='@1.6.1^petsc@3.7:')
     patch('petsc-version-detection.patch', when='@:1.6.1')
+    patch('hdf5~cxx-detection.patch')
 
     extends('python')
 
-    depends_on('py-numpy')
-    depends_on('py-ply')
-    depends_on('py-six')
-    depends_on('py-sphinx@1.0.1:', when='+doc')
-    depends_on('eigen@3.2.0:')
-    depends_on('boost')
+    depends_on('eigen@3.2.0:', type='build')
+    depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono')
+    
     depends_on('mpi', when='+mpi')
     depends_on('hdf5', when='+hdf5')
     depends_on('parmetis@4.0.2:^metis+real64', when='+parmetis')
@@ -85,10 +83,15 @@ class Fenics(Package):
     depends_on('suite-sparse', when='+suite-sparse')
     depends_on('qt', when='+qt')
 
-    # This are the build dependencies
-    depends_on('py-setuptools')
-    depends_on('cmake@2.8.12:')
-    depends_on('swig@3.0.3:')
+    depends_on('py-ply', type=nolink)
+    depends_on('py-six', type=nolink)
+    depends_on('py-numpy', type=nolink)
+    depends_on('py-sympy', type=nolink)
+    depends_on('swig@3.0.3:', type=nolink)
+    depends_on('cmake@2.8.12:', type=nolink)
+    
+    depends_on('py-setuptools', type='build')
+    depends_on('py-sphinx@1.0.1:', when='+doc', type='build')
 
     releases = [
         {
@@ -133,15 +136,6 @@ class Fenics(Package):
                      destination='depends',
                      when='@{version}'.format(**release),
                      placement=name)
-
-    def patch(self):
-        pass
-
-    @when('+hdf5~cxx')
-    def patch(self):
-        filter_file(r'find_package(HDF5)',
-                    r'find_package(HDF5 COMPONENTS C)',
-                    'CMakeLists.txt')
 
     def cmake_is_on(self, option):
         return 'ON' if option in self.spec else 'OFF'

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -176,8 +176,8 @@ class Trilinos(Package):
             options.extend([
                 '-DTPL_ENABLE_HDF5:BOOL=ON',
                 '-DHDF5_INCLUDE_DIRS:PATH=%s' % spec['hdf5'].prefix.include,
-                '-DHDF5_LIBRARY_DIRS:PATH=%s' % spec['hdf5'].prefix.lib              
-                ])
+                '-DHDF5_LIBRARY_DIRS:PATH=%s' % spec['hdf5'].prefix.lib
+            ])
         else:
             options.extend(['-DTPL_ENABLE_HDF5:BOOL=OFF'])
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -172,6 +172,15 @@ class Trilinos(Package):
         else:
             options.extend(['-DTPL_ENABLE_Boost:BOOL=OFF'])
 
+        if '+hdf5' in spec:
+            options.extend([
+                '-DTPL_ENABLE_HDF5:BOOL=ON',
+                '-DHDF5_INCLUDE_DIRS:PATH=%s' % spec['hdf5'].prefix.include,
+                '-DHDF5_LIBRARY_DIRS:PATH=%s' % spec['hdf5'].prefix.lib              
+                ])
+        else:
+            options.extend(['-DTPL_ENABLE_HDF5:BOOL=OFF'])
+
         # Fortran lib
         libgfortran = os.path.dirname(os.popen(
             '%s --print-file-name libgfortran.a' %


### PR DESCRIPTION
This pr adds the version 2016.1.0 of fenics, add specifies the deptypes

I had a build that did not configure for trilinos so I also added explicitly the path to hdf5
And in fenics, cmake tries to find by default hdf5_cxx which is not used and might not be installed