### PR TITLE
Bug Fix : Apply Compiler Flags Specified by Manual Compiler Configuration

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -218,12 +218,14 @@ If you want to see specifics on a particular compiler, you can run
 
    $ spack compiler info intel@15
    intel@15.0.0:
-           cc  = /usr/local/bin/icc-15.0.090
-           cxx = /usr/local/bin/icpc-15.0.090
-           f77 = /usr/local/bin/ifort-15.0.090
-           fc  = /usr/local/bin/ifort-15.0.090
-           modules  = []
-           operating system  = centos6
+     paths:
+       cc  = /usr/local/bin/icc-15.0.090
+       cxx = /usr/local/bin/icpc-15.0.090
+       f77 = /usr/local/bin/ifort-15.0.090
+       fc  = /usr/local/bin/ifort-15.0.090
+     modules = []
+     operating system = centos6
+   ...
 
 This shows which C, C++, and Fortran compilers were detected by Spack.
 Notice also that we didn't have to be too specific about the
@@ -253,39 +255,46 @@ Each compiler configuration in the file looks like this:
          fc: /usr/local/bin/ifort-15.0.024-beta
        spec: intel@15.0.0:
 
-For compilers, like ``clang``, that do not support Fortran, put
+For compilers that do not support Fortran (like ``clang``), put
 ``None`` for ``f77`` and ``fc``:
-
-.. code-block:: yaml
-
-       paths:
-         cc: /usr/bin/clang
-         cxx: /usr/bin/clang++
-         f77: None
-         fc: None
-       spec: clang@3.3svn:
-
-Once you save the file, the configured compilers will show up in the
-list displayed by ``spack compilers``.
-
-You can also add compiler flags to manually configured compilers. The
-valid flags are ``cflags``, ``cxxflags``, ``fflags``, ``cppflags``,
-``ldflags``, and ``ldlibs``. For example:
 
 .. code-block:: yaml
 
    compilers:
    - compiler:
        modules = []
-       operating_system: OS
+       operating_system: centos6
        paths:
-         cc: /usr/local/bin/icc-15.0.024-beta
-         cxx: /usr/local/bin/icpc-15.0.024-beta
-         f77: /usr/local/bin/ifort-15.0.024-beta
-         fc: /usr/local/bin/ifort-15.0.024-beta
+         cc: /usr/bin/clang
+         cxx: /usr/bin/clang++
+         f77: None
+         fc: None
+       spec: clang@3.3svn
+
+Once you save the file, the configured compilers will show up in the
+list displayed by ``spack compilers``.
+
+You can also add compiler flags to manually configured compilers. These
+flags should be specified in the ``flags`` section of the compiler
+specification. The valid flags are ``cflags``, ``cxxflags``, ``fflags``,
+``cppflags``, ``ldflags``, and ``ldlibs``. For example:
+
+.. code-block:: yaml
+
+   compilers:
+   - compiler:
+       modules = []
+       operating_system: centos6
+       paths:
+         cc: /usr/bin/gcc
+         cxx: /usr/bin/g++
+         f77: /usr/bin/gfortran
+         fc: /usr/bin/gfortran
        flags:
+         cflags: -O3 -fPIC
+         cxxflags: -O3 -fPIC
          cppflags: -O3 -fPIC
-       spec: intel@15.0.0:
+       spec: gcc@4.7.2
 
 These flags will be treated by spack as if they were entered from
 the command line each time this compiler is used. The compiler wrappers

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -246,7 +246,7 @@ Each compiler configuration in the file looks like this:
 
    compilers:
    - compiler:
-       modules = []
+       modules: []
        operating_system: centos6
        paths:
          cc: /usr/local/bin/icc-15.0.024-beta
@@ -262,7 +262,7 @@ For compilers that do not support Fortran (like ``clang``), put
 
    compilers:
    - compiler:
-       modules = []
+       modules: []
        operating_system: centos6
        paths:
          cc: /usr/bin/clang
@@ -283,7 +283,7 @@ specification. The valid flags are ``cflags``, ``cxxflags``, ``fflags``,
 
    compilers:
    - compiler:
-       modules = []
+       modules: []
        operating_system: centos6
        paths:
          cc: /usr/bin/gcc
@@ -536,7 +536,7 @@ configuration in ``compilers.yaml`` illustrates this technique:
 
    compilers:
    - compiler:
-       modules = [gcc-4.9.3, intel-15.0.24]
+       modules: [gcc-4.9.3, intel-15.0.24]
        operating_system: centos7
        paths:
          cc: /opt/intel-15.0.24/bin/icc-15.0.24-beta
@@ -577,7 +577,7 @@ flags to the ``icc`` command:
 
        compilers:
        - compiler:
-           modules = [intel-15.0.24]
+           modules: [intel-15.0.24]
            operating_system: centos7
            paths:
              cc: /opt/intel-15.0.24/bin/icc-15.0.24-beta

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -133,10 +133,13 @@ def compiler_info(args):
     else:
         for c in compilers:
             print str(c.spec) + ":"
-            print "\tcc  = %s" % c.cc
-            print "\tcxx = %s" % c.cxx
-            print "\tf77 = %s" % c.f77
-            print "\tfc  = %s" % c.fc
+            print "\tpaths:"
+            for cpath in ['cc', 'cxx', 'f77', 'fc']:
+                print "\t\t%s = %s" % (cpath, getattr(c, cpath, None))
+            if c.flags:
+                print "\tflags:"
+                for flag, flag_value in c.flags.iteritems():
+                    print "\t\t%s = %s" % (flag, flag_value)
             print "\tmodules  = %s" % c.modules
             print "\toperating system  = %s" % c.operating_system
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -65,6 +65,7 @@ def _to_dict(compiler):
     d['spec'] = str(compiler.spec)
     d['paths'] = dict((attr, getattr(compiler, attr, None))
                       for attr in _path_instance_vars)
+    d['flags'] = dict((fname, fvals) for fname, fvals in compiler.flags)
     d['operating_system'] = str(compiler.operating_system)
     d['modules'] = compiler.modules if compiler.modules else []
 
@@ -221,7 +222,7 @@ def compilers_for_spec(compiler_spec, scope=None, **kwargs):
     """This gets all compilers that satisfy the supplied CompilerSpec.
        Returns an empty list if none are found.
     """
-    platform = kwargs.get("platform", None)
+    platform = kwargs.get('platform', None)
     config = all_compilers_config(scope)
 
     def get_compilers(cspec):
@@ -241,7 +242,7 @@ def compilers_for_spec(compiler_spec, scope=None, **kwargs):
             compiler_paths = []
             for c in _path_instance_vars:
                 compiler_path = items['paths'][c]
-                if compiler_path != "None":
+                if compiler_path != 'None':
                     compiler_paths.append(compiler_path)
                 else:
                     compiler_paths.append(None)
@@ -250,21 +251,17 @@ def compilers_for_spec(compiler_spec, scope=None, **kwargs):
             if mods == 'None':
                 mods = []
 
+            os = None
             if 'operating_system' in items:
                 os = spack.architecture._operating_system_from_dict(
                     items['operating_system'], platform)
-            else:
-                os = None
 
-            alias = items['alias'] if 'alias' in items else None
+            alias = items.get('alias', None)
 
-            flags = {}
-            for f in spack.spec.FlagMap.valid_compiler_flags():
-                if f in items:
-                    flags[f] = items[f]
+            compiler_flags = items.get('flags', {})
 
             compilers.append(
-                cls(cspec, os, compiler_paths, mods, alias, **flags))
+                cls(cspec, os, compiler_paths, mods, alias, **compiler_flags))
 
         return compilers
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -213,7 +213,7 @@ def supported(compiler_spec):
 @_auto_compiler_spec
 def find(compiler_spec, scope=None):
     """Return specs of available compilers that match the supplied
-       compiler spec.  Return an list if nothing found."""
+       compiler spec.  Return an empty list if nothing found."""
     return [c for c in all_compilers(scope) if c.satisfies(compiler_spec)]
 
 

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -52,7 +52,11 @@ schema = {
                                 'f77': {'anyOf': [{'type': 'string'},
                                                   {'type': 'null'}]},
                                 'fc':  {'anyOf': [{'type': 'string'},
-                                                  {'type': 'null'}]},
+                                                  {'type': 'null'}]}}},
+                        'flags': {
+                            'type': 'object',
+                            'additionalProperties': False,
+                            'properties': {
                                 'cflags': {'anyOf': [{'type': 'string'},
                                                      {'type': 'null'}]},
                                 'cxxflags': {'anyOf': [{'type': 'string'},

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -51,7 +51,7 @@ test_command = [
     'arg5', 'arg6']
 
 
-class CompilerTest(unittest.TestCase):
+class CompilerWrapperTest(unittest.TestCase):
 
     def setUp(self):
         self.cc = Executable(join_path(spack.build_env_path, "cc"))

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -136,6 +136,31 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+- compiler:
+    spec: gcc@4.7.2
+    operating_system: redhat6
+    paths:
+      cc: /path/to/gcc472
+      cxx: /path/to/g++472
+      f77: /path/to/gfortran472
+      fc: /path/to/gfortran472
+    flags:
+      cflags: -O0
+      cxxflags: -O0
+      fflags: -O0
+    modules: 'None'
+- compiler:
+    spec: clang@3.5
+    operating_system: redhat6
+    paths:
+      cc: /path/to/clang35
+      cxx: /path/to/clang++35
+      f77: None
+      fc: None
+    flags:
+      cflags: -O3
+      cxxflags: -O3
+    modules: 'None'
 """.format(linux_os_name, linux_os_version)
 
 mock_packages_config = """\


### PR DESCRIPTION
The changes in this pull request fix a bug that was preventing compiler flags that were specified for a compiler in the `compilers.yaml` configuration file from being applied when that compiler was used to build packages.  Additionally, this pull request changes the structure of the `compilers.yaml` file to make a compiler's flag specifiers separate from its path specifiers (see [the new compiler schema](https://github.com/xjrc/spack/blob/bugfix/cflags-config/lib/spack/spack/schema/compilers.py) for details), which makes detecting and applying flag specifiers much simpler.  This pull request also includes updated documentation for the new `compilers.yaml` structure and tests to verify that this new structure has been properly integrated.

If there are any issues with these changes, please let me know and I'll revise them as soon as I can!