### PR TITLE
patchelf: Add version

### DIFF
--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -30,6 +30,7 @@ class Patchelf(Package):
        ELF executables."""
 
     homepage = "https://nixos.org/patchelf.html"
+    url = "http://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.gz"
 
     list_url = "http://nixos.org/releases/patchelf/"
     list_depth = 2

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -31,9 +31,6 @@ class Patchelf(Package):
 
     homepage = "https://nixos.org/patchelf.html"
 
-    def url_for_version(self, version):
-        return "http://nixos.org/releases/patchelf/patchelf-%s/patchelf-%s.tar.gz" % (version, version)
-
     list_url = "http://nixos.org/releases/patchelf/"
     list_depth = 2
 

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -30,10 +30,14 @@ class Patchelf(Package):
        ELF executables."""
 
     homepage = "https://nixos.org/patchelf.html"
-    url      = "http://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.gz"
+    def url_for_version(self, version):
+        return "http://nixos.org/releases/patchelf/" \
+            + "patchelf-%s/patchelf-%s.tar.gz" % (version, version)
+
     list_url = "http://nixos.org/releases/patchelf/"
     list_depth = 2
 
+    version('0.9', '3c265508526760f233620f35d79c79fc')
     version('0.8', '407b229e6a681ffb0e2cdd5915cb2d01')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -30,9 +30,9 @@ class Patchelf(Package):
        ELF executables."""
 
     homepage = "https://nixos.org/patchelf.html"
+
     def url_for_version(self, version):
-        return "http://nixos.org/releases/patchelf/" \
-            + "patchelf-%s/patchelf-%s.tar.gz" % (version, version)
+        return "http://nixos.org/releases/patchelf/patchelf-%s/patchelf-%s.tar.gz" % (version, version)
 
     list_url = "http://nixos.org/releases/patchelf/"
     list_depth = 2


### PR DESCRIPTION
Added a new version; required more sophisticated `url_for_version()`.  Should be ready to merge.