### PR TITLE
py-rtree: Added package

### DIFF
--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -1,0 +1,14 @@
+from spack import *
+
+class Libspatialindex(Package):
+    homepage = "http://http://libspatialindex.github.io"
+    url      = "https://github.com/libspatialindex/libspatialindex/tarball/1.8.5"
+
+    version('1.8.5', 'a95d8159714dbda9a274792cd273d298')
+
+    depends_on("cmake")
+
+    def install(self, spec, prefix):
+        cmake('.', *std_cmake_args)
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -25,15 +25,10 @@
 from spack import *
 
 
-class Libspatialindex(Package):
+class Libspatialindex(CMakePackage):
     homepage = "http://http://libspatialindex.github.io"
     url      = "https://github.com/libspatialindex/libspatialindex/tarball/1.8.5"
 
     version('1.8.5', 'a95d8159714dbda9a274792cd273d298')
 
-    depends_on("cmake")
-
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-        make()
-        make("install")
+    depends_on("cmake", type='build')

--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -1,4 +1,29 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
+
 
 class Libspatialindex(Package):
     homepage = "http://http://libspatialindex.github.io"

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -1,0 +1,31 @@
+from spack import *
+import os
+
+class PyRtree(Package):
+    """Python interface to the RTREE.4 Library."""
+    homepage = "http://toblerity.org/rtree/"
+    url      = "https://github.com/Toblerity/rtree/tarball/0.8.2"
+
+
+    # Not an official release yet.  But changes in here are required to work with Spack
+    # (Spack installs libspatialindex installed in a non-standard location).
+    version('0.8.2.1', '394696ca849dd9f3a5ef24fb02a41ef4',
+        url='https://github.com/citibeth/rtree/tarball/3a87d86f66a3955676b2507d3bf424ade938a22b')
+
+    # Does not work with Spack
+    # version('0.8.2', '593c7ac6babc397b8ba58f1636c1e0a0')
+
+    # For testing/development purposes
+    # version('bakedenv', branch='160529-efischer/BakedInEnv', git='https://github.com/citibeth/rtree.git')
+
+    extends('python')
+
+    depends_on('libspatialindex')
+    depends_on('py-setuptools')
+
+    def install(self, spec, prefix):
+        lib = os.path.join(spec['libspatialindex'].prefix, 'lib')
+        os.environ['SPATIALINDEX_LIBRARY'] = os.path.join(lib, 'libspatialindex.%s' % dso_suffix)
+        os.environ['SPATIALINDEX_C_LIBRARY'] = os.path.join(lib, 'libspatialindex_c.%s' % dso_suffix)
+
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -46,7 +46,7 @@ class PyRtree(Package):
     extends('python')
 
     depends_on('py-setuptools', type='build')
-    depends_on('libspatialindex', type=nolink)
+    depends_on('libspatialindex')
 
     def install(self, spec, prefix):
         lib = os.path.join(spec['libspatialindex'].prefix, 'lib')

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -50,9 +50,9 @@ class PyRtree(Package):
 
     def install(self, spec, prefix):
         lib = os.path.join(spec['libspatialindex'].prefix, 'lib')
-        os.environ['SPATIALINDEX_LIBRARY'] =
+        os.environ['SPATIALINDEX_LIBRARY'] = \
             os.path.join(lib, 'libspatialindex.%s' % dso_suffix)
-        os.environ['SPATIALINDEX_C_LIBRARY'] =
+        os.environ['SPATIALINDEX_C_LIBRARY'] = \
             os.path.join(lib, 'libspatialindex_c.%s' % dso_suffix)
 
         setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -1,31 +1,58 @@
+##############################################################################
+# Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 import os
+
 
 class PyRtree(Package):
     """Python interface to the RTREE.4 Library."""
     homepage = "http://toblerity.org/rtree/"
     url      = "https://github.com/Toblerity/rtree/tarball/0.8.2"
 
-
-    # Not an official release yet.  But changes in here are required to work with Spack
-    # (Spack installs libspatialindex installed in a non-standard location).
+    # Not an official release yet.  But changes in here are required
+    # to work with Spack.  As it does with all packages, Spack
+    # installs libspatialindex in a non-system location.  Without the
+    # changes in this fork, py-rtree requires an environment variables
+    # to be set *at runtime*, in order to find libspatialindex.  That
+    # is not feasible within the Spack worldview.
     version('0.8.2.1', '394696ca849dd9f3a5ef24fb02a41ef4',
         url='https://github.com/citibeth/rtree/tarball/3a87d86f66a3955676b2507d3bf424ade938a22b')
 
     # Does not work with Spack
     # version('0.8.2', '593c7ac6babc397b8ba58f1636c1e0a0')
 
-    # For testing/development purposes
-    # version('bakedenv', branch='160529-efischer/BakedInEnv', git='https://github.com/citibeth/rtree.git')
-
     extends('python')
 
-    depends_on('libspatialindex')
-    depends_on('py-setuptools')
+    depends_on('py-setuptools', type='build')
+    depends_on('libspatialindex', type=nolink)
 
     def install(self, spec, prefix):
         lib = os.path.join(spec['libspatialindex'].prefix, 'lib')
-        os.environ['SPATIALINDEX_LIBRARY'] = os.path.join(lib, 'libspatialindex.%s' % dso_suffix)
-        os.environ['SPATIALINDEX_C_LIBRARY'] = os.path.join(lib, 'libspatialindex_c.%s' % dso_suffix)
+        os.environ['SPATIALINDEX_LIBRARY'] =
+            os.path.join(lib, 'libspatialindex.%s' % dso_suffix)
+        os.environ['SPATIALINDEX_C_LIBRARY'] =
+            os.path.join(lib, 'libspatialindex_c.%s' % dso_suffix)
 
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -37,6 +37,9 @@ class PyRtree(Package):
     # changes in this fork, py-rtree requires an environment variables
     # to be set *at runtime*, in order to find libspatialindex.  That
     # is not feasible within the Spack worldview.
+    version('0.8.2.2', 'b1fe96a73153db49ea6ce45a063d82cb',
+        url='https://github.com/citibeth/rtree/tarball/95a678cc7350857a1bb631bc41254efcd1fc0a0d')
+
     version('0.8.2.1', '394696ca849dd9f3a5ef24fb02a41ef4',
         url='https://github.com/citibeth/rtree/tarball/3a87d86f66a3955676b2507d3bf424ade938a22b')
 


### PR DESCRIPTION
- py-rtree = RTree (spatial indexing) data structure for Python
- libspatialindex = Underlying C library wrapped by py-rtree
