### PR TITLE
Fix NetCDF/HDF5 dependency resolution problems

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -52,7 +52,7 @@ class Hdf5(Package):
     variant('cxx', default=True, description='Enable C++ support')
     variant('fortran', default=True, description='Enable Fortran support')
 
-    variant('mpi', default=False, description='Enable MPI support')
+    variant('mpi', default=True, description='Enable MPI support')
     variant('szip', default=False, description='Enable szip support')
     variant('threadsafe', default=False,
             description='Enable thread-safe capabilities')

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -50,10 +50,15 @@ class Netcdf(Package):
 
     # Required for NetCDF-4 support
     depends_on("zlib")
-    depends_on('hdf5@:1.8+mpi', when='@:4.4.0+mpi')
-    depends_on('hdf5+mpi', when='@4.4.1:+mpi')
-    depends_on('hdf5@:1.8~mpi', when='@:4.4.0~mpi')
-    depends_on('hdf5~mpi', when='@4.4.1:~mpi')
+    depends_on('hdf5')
+
+    # Variant forwarding
+    depends_on('hdf5+mpi',  when='+mpi')
+    depends_on('hdf5~mpi',  when='~mpi')
+
+    # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
+    # https://github.com/Unidata/netcdf-c/issues/250
+    depends_on('hdf5@:1.8', when='@:4.4.0')
 
     def install(self, spec, prefix):
         # Environment variables

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -52,15 +52,16 @@ class Netcdf(Package):
     depends_on("zlib")
     depends_on('hdf5')
 
-    # Variant forwarding
-    depends_on('hdf5+mpi',  when='+mpi')
-    depends_on('hdf5~mpi',  when='~mpi')
-
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250
     depends_on('hdf5@:1.8', when='@:4.4.0')
 
     def install(self, spec, prefix):
+        # Workaround until variant forwarding works properly
+        if '+mpi' in spec and spec.satisfies('^hdf5~mpi'):
+            raise RuntimeError('Invalid spec. Package netcdf requires '
+                               'hdf5+mpi, but spec asked for hdf5~mpi.')
+
         # Environment variables
         CPPFLAGS = []
         LDFLAGS  = []


### PR DESCRIPTION
Fixes #1552. This was causing errors like:
```
$ spack spec netcdf ^hdf5@1.8.16
Input spec
------------------------------
  netcdf
      ^hdf5

Normalized
------------------------------
==> Error: netcdf does not depend on hdf5
```
and
```
$ spack spec netcdf+mpi ^mvapich2
Input spec
------------------------------
  netcdf+mpi
      ^mvapich2

Normalized
------------------------------
==> Error: netcdf does not depend on mvapich2
```
Here's my understanding of the problem. @tgamblin can correct me if I'm wrong. During normalization, variants are ignored unless explicitly stated. So `netcdf+mpi ^hdf5` and `netcdf~mpi ^hdf5` work but `netcdf ^hdf5` doesn't. Also, versions are ignored during normalization unless explicitly stated. So `netcdf@4.4.1+mpi ^mvapich2` and `netcdf@4.4.0+mpi ^mvapich2` work but `netcdf+mpi ^mvapich2` doesn't. This solution spreads all of the constraints out so that they do not interfere. Obviously dependency resolution is a little bit broken if mpi defaults to true but netcdf doesn't depend on mpi, but that's another issue that's been well documented.