### PR TITLE
hdf5-blosc: Remove commit id from version specification

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -51,7 +51,6 @@ class Hdf5Blosc(Package):
     homepage = "https://github.com/Blosc/hdf5-blosc"
     url      = "https://github.com/Blosc/hdf5-blosc/archive/master.zip"
 
-    # version('master', '02c04acbf4bec66ec8a35bf157d1c9de')
     version('master', branch='master')
 
     depends_on("c-blosc")

--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -51,7 +51,8 @@ class Hdf5Blosc(Package):
     homepage = "https://github.com/Blosc/hdf5-blosc"
     url      = "https://github.com/Blosc/hdf5-blosc/archive/master.zip"
 
-    version('master', '02c04acbf4bec66ec8a35bf157d1c9de')
+    # version('master', '02c04acbf4bec66ec8a35bf157d1c9de')
+    version('master', branch='master')
 
     depends_on("c-blosc")
     depends_on("hdf5")


### PR DESCRIPTION
The respective commit seems to have vanished.
Now using the master branch without specifying a particular commit.