### PR TITLE
[Bug Fix] Issues with non-numeric versions, as well as preferred=True

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -170,9 +170,6 @@ class DefaultConcretizer(object):
         n = len(yaml_specs)
         yaml_index = {spec : n-index for index,spec in enumerate(yaml_specs)}
 
-        if True or 'develop' in yaml_index:
-            print('yaml_specs', yaml_specs)
-
         # List of versions we could consider, in sorted order
         unsorted_versions = [v for v in pkg.versions
              if any(v.satisfies(sv) for sv in spec.versions)]
@@ -183,9 +180,6 @@ class DefaultConcretizer(object):
             v.isnumeric(),        # Don't rely on Version.__lt__ to get this right
             v) for v in unsorted_versions]
         keys.sort(reverse=True)
-
-        if True or 'develop' in yaml_index:
-            print('keys', keys)
 
         # List of versions in complete sorted order
         valid_versions = [x[-1] for x in keys]

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -165,18 +165,22 @@ class DefaultConcretizer(object):
 
         # ---------- Produce prioritized list of versions
         # Get list of preferences from packages.yaml
-        preferred = spack.pkgsort  # == spack.preferred_packages.PreferredPackages()
-        yaml_specs = [x[0] for x in preferred._spec_for_pkgname(spec.name, 'version', None)]
+        preferred = spack.pkgsort
+        # NOTE: spack.pkgsort == spack.preferred_packages.PreferredPackages()
+
+        yaml_specs = [x[0] for x in \
+            preferred._spec_for_pkgname(spec.name, 'version', None)]
         n = len(yaml_specs)
-        yaml_index = dict([(spc, n-index) for index,spc in enumerate(yaml_specs)])
+        yaml_index = dict( \
+            [(spc, n - index) for index, spc in enumerate(yaml_specs)])
 
         # List of versions we could consider, in sorted order
-        unsorted_versions = [v for v in pkg.versions
-             if any(v.satisfies(sv) for sv in spec.versions)]
+        unsorted_versions = [v for v in pkg.versions \
+            if any(v.satisfies(sv) for sv in spec.versions)]
 
         keys = [(
             # Respect order listed in packages.yaml
-            yaml_index.get(v,-1),
+            yaml_index.get(v, -1),
             # The preferred=True flag (packages or packages.yaml or both?)
             pkg.versions.get(Version(v)).get('preferred', False),
             # @develop special case
@@ -190,7 +194,6 @@ class DefaultConcretizer(object):
         # List of versions in complete sorted order
         valid_versions = [x[-1] for x in keys]
         # --------------------------
-
 
         if valid_versions:
             spec.versions = ver([valid_versions[0]])
@@ -272,7 +275,7 @@ class DefaultConcretizer(object):
             spec.architecture = spack.architecture.Arch()
             return True
 
-            # Concretize the operating_system and target based of the spec
+        # Concretize the operating_system and target based of the spec
         ret = any((self._concretize_platform(spec),
                    self._concretize_operating_system(spec),
                    self._concretize_target(spec)))

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -168,7 +168,7 @@ class DefaultConcretizer(object):
         preferred = spack.pkgsort  # == spack.preferred_packages.PreferredPackages()
         yaml_specs = [x[0] for x in preferred._spec_for_pkgname(spec.name, 'version', None)]
         n = len(yaml_specs)
-        yaml_index = {spec : n-index for index,spec in enumerate(yaml_specs)}
+        yaml_index = dict([(spc, n-index) for index,spc in enumerate(yaml_specs)])
 
         # List of versions we could consider, in sorted order
         unsorted_versions = [v for v in pkg.versions

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -33,6 +33,7 @@ or user preferences.
 TODO: make this customizable and allow users to configure
       concretization  policies.
 """
+from __future__ import print_function
 import spack
 import spack.spec
 import spack.compilers
@@ -169,6 +170,9 @@ class DefaultConcretizer(object):
         n = len(yaml_specs)
         yaml_index = {spec : n-index for index,spec in enumerate(yaml_specs)}
 
+        if True or 'develop' in yaml_index:
+            print('yaml_specs', yaml_specs)
+
         # List of versions we could consider, in sorted order
         unsorted_versions = [v for v in pkg.versions
              if any(v.satisfies(sv) for sv in spec.versions)]
@@ -176,21 +180,20 @@ class DefaultConcretizer(object):
         keys = [(
             yaml_index.get(v,-1),
             pkg.versions.get(Version(v)).get('preferred', False),
+            v.isnumeric(),        # Don't rely on Version.__lt__ to get this right
             v) for v in unsorted_versions]
         keys.sort(reverse=True)
 
+        if True or 'develop' in yaml_index:
+            print('keys', keys)
+
         # List of versions in complete sorted order
-        valid_versions = [x[2] for x in keys]
+        valid_versions = [x[-1] for x in keys]
         # --------------------------
 
 
         if valid_versions:
-            # Disregard @develop and take the next valid version
-            if ver(valid_versions[0]) == ver('develop') and \
-                    len(valid_versions) > 1:
-                spec.versions = ver([valid_versions[1]])
-            else:
-                spec.versions = ver([valid_versions[0]])
+            spec.versions = ver([valid_versions[0]])
         else:
             # We don't know of any SAFE versions that match the given
             # spec.  Grab the spec's versions and grab the highest

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -168,14 +168,16 @@ class DefaultConcretizer(object):
         preferred = spack.pkgsort
         # NOTE: spack.pkgsort == spack.preferred_packages.PreferredPackages()
 
-        yaml_specs = [x[0] for x in \
+        yaml_specs = [
+            x[0] for x in
             preferred._spec_for_pkgname(spec.name, 'version', None)]
         n = len(yaml_specs)
-        yaml_index = dict( \
+        yaml_index = dict(
             [(spc, n - index) for index, spc in enumerate(yaml_specs)])
 
         # List of versions we could consider, in sorted order
-        unsorted_versions = [v for v in pkg.versions \
+        unsorted_versions = [
+            v for v in pkg.versions
             if any(v.satisfies(sv) for sv in spec.versions)]
 
         keys = [(

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -175,9 +175,15 @@ class DefaultConcretizer(object):
              if any(v.satisfies(sv) for sv in spec.versions)]
 
         keys = [(
+            # Respect order listed in packages.yaml
             yaml_index.get(v,-1),
+            # The preferred=True flag (packages or packages.yaml or both?)
             pkg.versions.get(Version(v)).get('preferred', False),
-            v.isnumeric(),        # Don't rely on Version.__lt__ to get this right
+            # @develop special case
+            v.isdevelop(),
+            # Numeric versions more preferred than non-numeric
+            v.isnumeric(),
+            # Compare the version itself
             v) for v in unsorted_versions]
         keys.sort(reverse=True)
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -428,3 +428,6 @@ class VersionsTest(unittest.TestCase):
         self.assertEqual(str(b), '1_2-3')
         # Raise TypeError on tuples
         self.assertRaises(TypeError, b.__getitem__, 1, 2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -269,7 +269,6 @@ class Version(object):
         # with more segments is bigger.
         return len(self.version) < len(other.version)
 
-
     @coerced
     def __lt__(self, other):
         """Version comparison is designed for consistency with the way RPM
@@ -293,8 +292,7 @@ class Version(object):
         # Now we know !sdev
         odev = other.isdevelop()
         if odev:
-            return True    #  src < dst
-
+            return True    # src < dst
 
         # now we know neither self nor other isdevelop().
 
@@ -307,14 +305,12 @@ class Version(object):
                 # Numeric > Non-numeric (always)
                 return False
         else:
-            if other.isnumeric(): # self = non-numeric, other = numeric
+            if other.isnumeric():  # self = non-numeric, other = numeric
                 # non-numeric < numeric (always)
                 return True
             else:  # Both non-numeric
                 # Maybe consider other ways to compare here...
                 return self.string < other.string
-
-
 
     @coerced
     def __eq__(self, other):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -248,7 +248,7 @@ class Version(object):
     def concrete(self):
         return self
 
-    def _numeric_lt(self0, other):
+    def _numeric_lt(self, other):
         """Compares two versions, knowing they're both numeric"""
         # Standard comparison of two numeric versions
         for a, b in zip(self.version, other.version):
@@ -286,12 +286,15 @@ class Version(object):
             return False
 
         # First priority: anything < develop
-        skey = self.isdevelop()
-        okey = other.isdevelop()
-        if (skey < okey):
-            return True
-        if (okey <= skey):
-            return False
+        sdev = self.isdevelop()
+        if sdev:
+            return False    # source = develop, it can't be < anything
+
+        # Now we know !sdev
+        odev = other.isdevelop()
+        if odev:
+            return True    #  src < dst
+
 
         # now we know neither self nor other isdevelop().
 

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -172,7 +172,7 @@ class Version(object):
             system
             myfavoritebranch
         """
-        return isinstance(self.version[0], int)
+        return isinstance(self.version[0], numbers.Integral)
 
     def isdevelop(self):
         """Triggers on the special case of the `@develop` version."""

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -250,24 +250,24 @@ class Version(object):
 
     def _numeric_lt(self0, other):
         """Compares two versions, knowing they're both numeric"""
-                # Standard comparison of two numeric versions
-                for a, b in zip(self.version, other.version):
-                    if a == b:
-                        continue
-                    else:
-                        # Numbers are always "newer" than letters.
-                        # This is for consistency with RPM.  See patch
-                        # #60884 (and details) from bugzilla #50977 in
-                        # the RPM project at rpm.org.  Or look at
-                        # rpmvercmp.c if you want to see how this is
-                        # implemented there.
-                        if type(a) != type(b):
-                            return type(b) == int
-                        else:
-                            return a < b
-                # If the common prefix is equal, the one
-                # with more segments is bigger.
-                return len(self.version) < len(other.version)
+        # Standard comparison of two numeric versions
+        for a, b in zip(self.version, other.version):
+            if a == b:
+                continue
+            else:
+                # Numbers are always "newer" than letters.
+                # This is for consistency with RPM.  See patch
+                # #60884 (and details) from bugzilla #50977 in
+                # the RPM project at rpm.org.  Or look at
+                # rpmvercmp.c if you want to see how this is
+                # implemented there.
+                if type(a) != type(b):
+                    return type(b) == int
+                else:
+                    return a < b
+        # If the common prefix is equal, the one
+        # with more segments is bigger.
+        return len(self.version) < len(other.version)
 
 
     @coerced


### PR DESCRIPTION
Fix bug in handling of precedence of preferred=True vs. versions given in packages.yaml (#1556)

BTW... the code to compare versions is convoluted, inefficient and bug-prone.  A re-think might be in order, along the lines of this PR.  Rather than making a "grand compare" function, we might be better off keeping comparisons to simple things (like versions), and then writing code like the code here to produce prioritized lists when needed.
