### PR TITLE
Add all Sphinx dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-alabaster/package.py
+++ b/var/spack/repos/builtin/packages/py-alabaster/package.py
@@ -25,19 +25,19 @@
 from spack import *
 
 
-class PyDocutils(Package):
-    """Docutils is an open-source text processing system for processing
-    plaintext documentation into useful formats, such as HTML, LaTeX,
-    man-pages, open-document or XML. It includes reStructuredText, the
-    easy to read, easy to use, what-you-see-is-what-you-get plaintext
-    markup language."""
+class PyAlabaster(Package):
+    """Alabaster is a visually (c)lean, responsive, configurable theme
+    for the Sphinx documentation system."""
 
-    homepage = "http://docutils.sourceforge.net/"
-    url      = "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    homepage = "https://pypi.python.org/pypi/alabaster"
+    url      = "https://pypi.python.org/packages/source/a/alabaster/alabaster-0.7.9.tar.gz"
 
-    version('0.12', '4622263b62c5c771c03502afa3157768')
+    version('0.7.9', 'b29646a8bbe7aa52830375b7d17b5d7a',
+            url="https://pypi.python.org/packages/71/c3/70da7d8ac18a4f4c502887bd2549e05745fa403e2cd9d06a8a9910a762bc/alabaster-0.7.9.tar.gz")
 
     extends('python')
+
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-babel/package.py
+++ b/var/spack/repos/builtin/packages/py-babel/package.py
@@ -25,19 +25,21 @@
 from spack import *
 
 
-class PyDocutils(Package):
-    """Docutils is an open-source text processing system for processing
-    plaintext documentation into useful formats, such as HTML, LaTeX,
-    man-pages, open-document or XML. It includes reStructuredText, the
-    easy to read, easy to use, what-you-see-is-what-you-get plaintext
-    markup language."""
+class PyBabel(Package):
+    """Babel is an integrated collection of utilities that assist in
+    internationalizing and localizing Python applications, with an
+    emphasis on web-based applications."""
 
-    homepage = "http://docutils.sourceforge.net/"
-    url      = "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    homepage = "http://babel.pocoo.org/en/latest/"
+    url      = "https://pypi.python.org/packages/source/b/babel/babel-2.3.4.tar.gz"
 
-    version('0.12', '4622263b62c5c771c03502afa3157768')
+    version('2.3.4', 'afa20bc55b0e991833030129ad498f35',
+            url="https://pypi.python.org/packages/6e/96/ba2a2462ed25ca0e651fb7b66e7080f5315f91425a07ea5b34d7c870c114/Babel-2.3.4.tar.gz")
 
     extends('python')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-pytz',       type=nolink)
 
     def install(self, spec, prefix):
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-babel/package.py
+++ b/var/spack/repos/builtin/packages/py-babel/package.py
@@ -31,7 +31,7 @@ class PyBabel(Package):
     emphasis on web-based applications."""
 
     homepage = "http://babel.pocoo.org/en/latest/"
-    url      = "https://pypi.python.org/packages/source/b/babel/babel-2.3.4.tar.gz"
+    url      = "https://pypi.python.org/packages/source/B/Babel/Babel-2.3.4.tar.gz"
 
     version('2.3.4', 'afa20bc55b0e991833030129ad498f35',
             url="https://pypi.python.org/packages/6e/96/ba2a2462ed25ca0e651fb7b66e7080f5315f91425a07ea5b34d7c870c114/Babel-2.3.4.tar.gz")

--- a/var/spack/repos/builtin/packages/py-imagesize/package.py
+++ b/var/spack/repos/builtin/packages/py-imagesize/package.py
@@ -25,19 +25,19 @@
 from spack import *
 
 
-class PyDocutils(Package):
-    """Docutils is an open-source text processing system for processing
-    plaintext documentation into useful formats, such as HTML, LaTeX,
-    man-pages, open-document or XML. It includes reStructuredText, the
-    easy to read, easy to use, what-you-see-is-what-you-get plaintext
-    markup language."""
+class PyImagesize(Package):
+    """Parses image file headers and returns image size. Supports PNG, JPEG,
+    JPEG2000, and GIF image file formats."""
 
-    homepage = "http://docutils.sourceforge.net/"
-    url      = "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    homepage = "https://pypi.python.org/pypi/imagesize"
+    url      = "https://pypi.python.org/packages/source/i/imagesize/imagesize-0.7.1.tar.gz"
 
-    version('0.12', '4622263b62c5c771c03502afa3157768')
+    version('0.7.1', '976148283286a6ba5f69b0f81aef8052',
+            url="https://pypi.python.org/packages/53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826/imagesize-0.7.1.tar.gz")
 
     extends('python')
+
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-jinja2/package.py
+++ b/var/spack/repos/builtin/packages/py-jinja2/package.py
@@ -22,29 +22,28 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import depends_on, extends, version, nolink
-from spack import Package
+from spack import *
 
 
 class PyJinja2(Package):
-    """
-    Jinja2 is a template engine written in pure Python. It provides
+    """Jinja2 is a template engine written in pure Python. It provides
     a Django inspired non-XML syntax but supports inline expressions
-    and an optional sandboxed environment.
-    """
+    and an optional sandboxed environment."""
 
     homepage = "http://jinja.pocoo.org/"
-    url      = "https://github.com/pallets/jinja/archive/2.8.tar.gz"
+    url      = "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz"
 
-    version('2.8', '4114200650d7630594e3bc70af23f59e')
-    version('2.7.3', '55b87bdc8e585b8b5b86734eefce2621')
-    version('2.7.2', '8e8f226809ae6363009b9296e30adf30')
-    version('2.7.1', '69b6675553c81b1087f95cae7f2179bb')
-    version('2.7', 'ec70433f325051dcedacbb2465028a35')
+    version('2.8',   'edb51693fe22c53cee5403775c71a99e')
+    version('2.7.3', 'b9dffd2f3b43d673802fe857c8445b1a')
+    version('2.7.2', 'df1581455564e97010e38bc792012aa5')
+    version('2.7.1', '282aed153e69f970d6e76f78ed9d027a')
+    version('2.7',   'c2fb12cbbb523c57d3d15bfe4dc0e8fe')
 
-    extends("python")
-    depends_on("py-setuptools", type='build')
-    depends_on("py-markupsafe", type=nolink)
+    extends('python')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-markupsafe', type=nolink)
+    depends_on('py-babel@0.8:', type=nolink)  # optional, required for i18n
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -22,29 +22,27 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import depends_on, extends, version
-from spack import Package
+from spack import *
 
 
 class PyMarkupsafe(Package):
-    """
-    MarkupSafe is a library for Python that implements a unicode
-    string that is aware of HTML escaping rules and can be used
-    to implement automatic string escaping. It is used by Jinja 2,
-    the Mako templating engine, the Pylons web framework and many more.
-    """
+    """MarkupSafe is a library for Python that implements a unicode
+    string that is aware of HTML escaping rules and can be used to
+    implement automatic string escaping. It is used by Jinja 2, the
+    Mako templating engine, the Pylons web framework and many more."""
 
     homepage = "http://www.pocoo.org/projects/markupsafe/"
-    url      = "https://github.com/pallets/markupsafe/archive/0.23.tar.gz"
+    url      = "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
 
-    version('0.23', '1a0dadc95169832367c9dcf142155cde')
-    version('0.22', '7a2ac7427b58def567628d06dc328396')
-    version('0.21', 'aebcd93ee05269773c8b80bb6c86fc2f')
-    version('0.20', '0c1fef97c8fd6a986d708f08d7f84a02')
-    version('0.19', '64b05361adb92c11839fc470e308c593')
+    version('0.23', 'f5ab3deee4c37cd6a922fb81e730da6e')
+    version('0.22', 'cb3ec29fd5361add24cfd0c6e2953b3e')
+    version('0.21', 'fde838d9337fa51744283f46a1db2e74')
+    version('0.20', '7da066d9cb191a70aa85d0a3d43565d1')
+    version('0.19', 'ccb3f746c807c5500850987006854a6d')
 
-    extends("python")
-    depends_on("py-setuptools", type='build')
+    extends('python')
+
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -27,14 +27,17 @@ from spack import *
 
 class PyPygments(Package):
     """Pygments is a syntax highlighting package written in Python."""
+
     homepage = "https://pypi.python.org/pypi/pygments"
     url      = "https://pypi.python.org/packages/source/P/Pygments/Pygments-2.0.1.tar.gz"
 
+    version('2.1.3', 'ed3fba2467c8afcda4d317e4ef2c6150')
     version('2.0.1', 'e0daf4c14a4fe5b630da765904de4d6c')
     version('2.0.2', '238587a1370d62405edabd0794b3ec4a')
 
     extends('python')
+
     depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -27,14 +27,19 @@ from spack import *
 
 class PyPytz(Package):
     """World timezone definitions, modern and historical."""
+
     homepage = "https://pypi.python.org/pypi/pytz"
     url      = "https://pypi.python.org/packages/source/p/pytz/pytz-2014.10.tar.gz"
 
+    version('2016.6.1', 'b6c28a3b968bc1d8badfb61b93874e03',
+            url="https://pypi.python.org/packages/5d/8e/6635d8f3f9f48c03bb925fab543383089858271f9cfd1216b83247e8df94/pytz-2016.6.1.tar.gz")
     version('2014.10', 'eb1cb941a20c5b751352c52486aa1dd7')
     version('2015.4', '417a47b1c432d90333e42084a605d3d8')
     version('2016.3', 'abae92c3301b27bd8a9f56b14f52cb29')
 
     extends('python')
 
+    depends_on('py-setuptools', type='build')
+
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -32,6 +32,8 @@ class PySetuptools(Package):
     homepage = "https://pypi.python.org/pypi/setuptools"
     url      = "https://pypi.python.org/packages/source/s/setuptools/setuptools-11.3.tar.gz"
 
+    version('25.2.0', 'a0dbb65889c46214c691f6c516cf959c',
+            url="https://pypi.python.org/packages/9f/32/81c324675725d78e7f6da777483a3453611a427db0145dfb878940469692/setuptools-25.2.0.tar.gz")
     version('20.7.0', '5d12b39bf3e75e80fdce54e44b255615')
     version('20.6.7', '45d6110f3ec14924e44c33411db64fe6')
     version('20.5', 'fadc1e1123ddbe31006e5e43e927362b')
@@ -43,4 +45,4 @@ class PySetuptools(Package):
     extends('python')
 
     def install(self, spec, prefix):
-        setup_py('install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -27,14 +27,16 @@ from spack import *
 
 class PySix(Package):
     """Python 2 and 3 compatibility utilities."""
+
     homepage = "https://pypi.python.org/pypi/six"
     url      = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
 
-    version('1.9.0', '476881ef4012262dfc8adc645ee786c4')
     version('1.10.0', '34eed507548117b2ab523ab14b2f8b55')
+    version('1.9.0',  '476881ef4012262dfc8adc645ee786c4')
 
     extends('python')
+
     depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
+++ b/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
@@ -25,17 +25,14 @@
 from spack import *
 
 
-class PyDocutils(Package):
-    """Docutils is an open-source text processing system for processing
-    plaintext documentation into useful formats, such as HTML, LaTeX,
-    man-pages, open-document or XML. It includes reStructuredText, the
-    easy to read, easy to use, what-you-see-is-what-you-get plaintext
-    markup language."""
+class PySnowballstemmer(Package):
+    """This package provides 16 stemmer algorithms (15 + Poerter
+    English stemmer) generated from Snowball algorithms."""
 
-    homepage = "http://docutils.sourceforge.net/"
-    url      = "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    homepage = "https://pypi.python.org/pypi/snowballstemmer"
+    url      = "https://pypi.python.org/packages/source/s/snowballstemmer/snowballstemmer-1.2.1.tar.gz"
 
-    version('0.12', '4622263b62c5c771c03502afa3157768')
+    version('1.2.1', '643b019667a708a922172e33a99bf2fa')
 
     extends('python')
 

--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -25,19 +25,18 @@
 from spack import *
 
 
-class PyDocutils(Package):
-    """Docutils is an open-source text processing system for processing
-    plaintext documentation into useful formats, such as HTML, LaTeX,
-    man-pages, open-document or XML. It includes reStructuredText, the
-    easy to read, easy to use, what-you-see-is-what-you-get plaintext
-    markup language."""
+class PySphinxRtdTheme(Package):
+    """ReadTheDocs.org theme for Sphinx."""
 
-    homepage = "http://docutils.sourceforge.net/"
-    url      = "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    homepage = "https://pypi.python.org/pypi/sphinx_rtd_theme"
+    url      = "https://pypi.python.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.10a0.tar.gz"
 
-    version('0.12', '4622263b62c5c771c03502afa3157768')
+    version('0.1.10a0', '83bd95cae55aa8b773a8cc3a41094282',
+            url="https://pypi.python.org/packages/da/6b/1b75f13d8aa3333f19c6cdf1f0bc9f52ea739cae464fbee050307c121857/sphinx_rtd_theme-0.1.10a0.tar.gz")
 
     extends('python')
+
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -34,7 +34,7 @@ class PySphinx(Package):
             url='https://pypi.python.org/packages/8b/78/eeea2b837f911cdc301f5f05163f9729a2381cadd03ccf35b25afe816c90/Sphinx-1.4.5.tar.gz')
     version('1.3.1', '8786a194acf9673464c5455b11fd4332')
 
-    extends('python')
+    extends('python', ignore='bin/(pybabel|pygmentize)')
 
     depends_on('py-setuptools',              type='build')
     depends_on('py-six@1.4:',                type=nolink)

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -30,9 +30,22 @@ class PySphinx(Package):
     homepage = "http://sphinx-doc.org"
     url      = "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.3.1.tar.gz"
 
+    version('1.4.5', '5c2cd2dac45dfa6123d067e32a89e89a',
+            url='https://pypi.python.org/packages/8b/78/eeea2b837f911cdc301f5f05163f9729a2381cadd03ccf35b25afe816c90/Sphinx-1.4.5.tar.gz')
     version('1.3.1', '8786a194acf9673464c5455b11fd4332')
 
     extends('python')
 
+    depends_on('py-setuptools',              type='build')
+    depends_on('py-six@1.4:',                type=nolink)
+    depends_on('py-jinja2@2.3:',             type=nolink)
+    depends_on('py-pygments@2.0:',           type=nolink)
+    depends_on('py-docutils@0.11:',          type=nolink)
+    depends_on('py-snowballstemmer@1.1:',    type=nolink)
+    depends_on('py-babel@1.3:',              type=nolink)  # not 2.0
+    depends_on('py-alabaster@0.7:',          type=nolink)
+    depends_on('py-imagesize', when='@1.4:', type=nolink)
+    depends_on('py-sphinx-rtd-theme@0.1:',   type=nolink)  # optional as of 1.4
+
     def install(self, spec, prefix):
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -36,7 +36,10 @@ class PySphinx(Package):
 
     extends('python', ignore='bin/(pybabel|pygmentize)')
 
-    depends_on('py-setuptools',              type='build')
+    # Most Python packages only require py-setuptools as a build dependency.
+    # However, py-sphinx requires py-setuptools during runtime as well.
+    depends_on('py-setuptools',              type=nolink)
+
     depends_on('py-six@1.4:',                type=nolink)
     depends_on('py-jinja2@2.3:',             type=nolink)
     depends_on('py-pygments@2.0:',           type=nolink)


### PR DESCRIPTION
Sphinx was missing all of its dependencies. No one noticed because setuptools automatically pulls them down from PyPi if it can't find them, but that won't work on machines without internet access.

All of the dependency information comes from the `setup.py` files in each tarball.

I updated all of the packages to the latest version available on PyPi. Note that several of these latest versions don't work with the traditional URL scheme:
```
https://pypi.python.org/packages/source/<first_letter_of_package/<package>/<package>-<version>.tar.gz
```
If anyone can figure out why these versions don't work, please let me know. For now, I hardcoded the hash-specific URLs. @lee218llnl?