### PR TITLE
Suggest setuptools when creating Python package

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -120,7 +120,8 @@ dependencies_dict = {
     extends('python')
 
     # FIXME: Add additional dependencies if required.
-    # depends_on('py-foo', type=nolink)""",
+    # depends_on('py-setuptools', type='build')
+    # depends_on('py-foo',        type=nolink)""",
 
     'R': """\
     extends('R')


### PR DESCRIPTION
`py-setuptools` is a required build dependency for about half of the Python packages in Spack. Since it is so common, we should suggest it in newly created Python packages. This prevents people from forgetting it, and saves them time when adding it. It also reinforces the idea that we should remember to specify dependency types and not just blindly assign `nolink`.