### PR TITLE
hdf5-blosc: Correct download url

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -49,9 +49,10 @@ def _install_shlib(name, src, dst):
 class Hdf5Blosc(Package):
     """Blosc filter for HDF5"""
     homepage = "https://github.com/Blosc/hdf5-blosc"
-    url      = "https://github.com/Blosc/hdf5-blosc/archive/master.zip"
+    url      = "https://github.com/Blosc/hdf5-blosc"
 
-    version('master', branch='master')
+    version('master', git='https://github.com/Blosc/hdf5-blosc',
+            branch='master')
 
     depends_on("c-blosc")
     depends_on("hdf5")


### PR DESCRIPTION
The current package is broken; my previous patch was incorrect. (I was fooled by Spack's download cache that already contained the package, so the incorrect url wasn't detected.)

This one works. Tested via `spack fetch` after `spack purge -d`.