### PR TITLE
Feature/add package for fastqc

### DIFF
--- a/var/spack/repos/builtin/packages/fastqc/fastqc.patch
+++ b/var/spack/repos/builtin/packages/fastqc/fastqc.patch
@@ -1,0 +1,30 @@
+--- fastqc.orig	2015-11-20 09:25:00.000000000 +0000
++++ fastqc	2016-10-24 19:06:16.734000000 +0000
+@@ -38,12 +38,21 @@
+ 	$delimiter = ';';
+ }
+ 
+-if ($ENV{CLASSPATH}) {
+-	$ENV{CLASSPATH} .= "$delimiter$RealBin$delimiter$RealBin/sam-1.103.jar$delimiter$RealBin/jbzip2-0.9.jar$delimiter$RealBin/cisd-jhdf5.jar";
+-}
+-else {
+-	$ENV{CLASSPATH} = "$RealBin$delimiter$RealBin/sam-1.103.jar$delimiter$RealBin/jbzip2-0.9.jar$delimiter$RealBin/cisd-jhdf5.jar";
+-}
++# The lib dir is $RealBin/../lib
++# start with list of jars we need and prefix them with the lib dir
++# then stick CLASSPATH onto the front (empty or otherwise...)
++# then filter out anything that's empty (perhaps CLASSPATH...)
++# then join all the remainings bits with the delimiter.
++use File::Basename;
++use File::Spec::Functions;
++my $_lib = catfile(dirname($RealBin), 'lib');
++$ENV{CLASSPATH} =
++    join($delimiter,
++         grep {$_}
++             ($ENV{CLASSPATH},
++              $_lib,
++              map {"$_lib/$_"}
++                  qw(sam-1.103.jar jbzip2-0.9.jar cisd-jhdf5.jar)));
+ 
+ my @java_args;
+ my @files;

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -25,7 +25,6 @@
 from spack import *
 from distutils.dir_util import copy_tree
 
-# FIXME: make sure set_executable fix goes in first.
 class Fastqc(Package):
     """A quality control tool for high throughput sequence data."""
 
@@ -40,8 +39,9 @@ class Fastqc(Package):
     def install(self, spec, prefix):
         # ick...
         copy_tree('.', self.prefix)
-        # this assumes "set_executable" == "chmod +x..."
-        set_executable(join_path(prefix, 'fastqc'))
+        # ick, set_executable just makes it u+x, what about the others?
+        chmod = which('chmod')
+        chmod('+x', join_path(prefix, 'fastqc'))
 
     def setup_environment(self, spack_env, env):
         """Add <prefix> to the path; the package has a script at the

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -31,7 +31,7 @@ class Fastqc(Package):
     """A quality control tool for high throughput sequence data."""
 
     homepage = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
-    url      = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip"
+    url = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip"
 
     version('0.11.5', '3524f101c0ab0bae77c7595983170a76')
 
@@ -44,7 +44,7 @@ class Fastqc(Package):
         mkpath(self.prefix.bin)
         mkpath(self.prefix.lib)
         copy_file('fastqc', self.prefix.bin)
-        for j in ['cisd-jhdf5.jar', 'jbzip2-0.9.jar','sam-1.103.jar']:
+        for j in ['cisd-jhdf5.jar', 'jbzip2-0.9.jar', 'sam-1.103.jar']:
             copy_file(j, self.prefix.lib)
         for d in ['Configuration', 'net', 'org', 'Templates', 'uk']:
             copy_tree(d, join_path(self.prefix.lib, d))

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -23,7 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
+from distutils.dir_util import copy_tree, mkpath
+from distutils.file_util import copy_file
 
 
 class Fastqc(Package):
@@ -37,16 +38,21 @@ class Fastqc(Package):
     depends_on('jdk')
     depends_on('perl')          # for fastqc "script", any perl will do
 
+    patch('fastqc.patch', level=0)
+
     def install(self, spec, prefix):
-        # ick...
-        copy_tree('.', self.prefix)
-        # ick, set_executable just makes it u+x, what about the others?
+        mkpath(self.prefix.bin)
+        mkpath(self.prefix.lib)
+        copy_file('fastqc', self.prefix.bin)
+        for j in ['cisd-jhdf5.jar', 'jbzip2-0.9.jar','sam-1.103.jar']:
+            copy_file(j, self.prefix.lib)
+        for d in ['Configuration', 'net', 'org', 'Templates', 'uk']:
+            copy_tree(d, join_path(self.prefix.lib, d))
         chmod = which('chmod')
-        chmod('+x', join_path(prefix, 'fastqc'))
+        chmod('+x', join_path(self.prefix.bin, 'fastqc'))
 
     def setup_environment(self, spack_env, env):
         """Add <prefix> to the path; the package has a script at the
-           top level."""
-
-        env.prepend_path('PATH', self.prefix)
+           top level.
+        """
         env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from distutils.dir_util import copy_tree
+
+# FIXME: make sure set_executable fix goes in first.
+class Fastqc(Package):
+    """A quality control tool for high throughput sequence data."""
+
+    homepage = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+    url      = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip"
+
+    version('0.11.5', '3524f101c0ab0bae77c7595983170a76')
+
+    depends_on('jdk')
+    depends_on('perl')          # for fastqc "script", any perl will do
+
+    def install(self, spec, prefix):
+        # ick...
+        copy_tree('.', self.prefix)
+        # this assumes "set_executable" == "chmod +x..."
+        set_executable(join_path(prefix, 'fastqc'))
+
+    def setup_environment(self, spack_env, env):
+        """Add <prefix> to the path; the package has a script at the
+           top level."""
+
+        env.prepend_path('PATH', self.prefix)
+        env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -51,8 +51,10 @@ class Fastqc(Package):
         chmod = which('chmod')
         chmod('+x', join_path(self.prefix.bin, 'fastqc'))
 
+    # In theory the 'run' dependency on 'jdk' above should take
+    # care of this for me. In practice, it does not.
     def setup_environment(self, spack_env, env):
         """Add <prefix> to the path; the package has a script at the
            top level.
         """
-        # env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))
+        env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -25,6 +25,7 @@
 from spack import *
 from distutils.dir_util import copy_tree
 
+
 class Fastqc(Package):
     """A quality control tool for high throughput sequence data."""
 

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -35,7 +35,7 @@ class Fastqc(Package):
 
     version('0.11.5', '3524f101c0ab0bae77c7595983170a76')
 
-    depends_on('jdk')
+    depends_on('jdk', type='run')
     depends_on('perl')          # for fastqc "script", any perl will do
 
     patch('fastqc.patch', level=0)
@@ -55,4 +55,4 @@ class Fastqc(Package):
         """Add <prefix> to the path; the package has a script at the
            top level.
         """
-        env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))
+        #env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -55,4 +55,4 @@ class Fastqc(Package):
         """Add <prefix> to the path; the package has a script at the
            top level.
         """
-        #env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))
+        # env.prepend_path('PATH', join_path(self.spec['jdk'].prefix, 'bin'))


### PR DESCRIPTION
This adds a package for fastqc.

~~FEEDBACK REQUEST: I need some way to make the fastqc file executable.  `set_executable` only sets the user executable bit, which isnt' what I need in my environment.  This package uses _chmod_ (stolen from the cuda package).  What's the right way.  See also #1483~~

I think that this is ready to go.  I've changed it to install things into neater bin and lib subdirs and am going with the chmod() for now.
