### PR TITLE
New command flag: spack install --dependencies-only

### DIFF
--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -101,7 +101,7 @@ def diy(self, args):
 
         package.do_install(
             keep_prefix=args.keep_prefix,
-            ignore_deps=args.ignore_deps,
+            install_deps=not args.ignore_deps,
             verbose=not args.quiet,
             keep_stage=True,   # don't remove source dir for DIY.
             dirty=args.dirty)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -39,7 +39,8 @@ def setup_parser(subparser):
         help="Do not try to install dependencies of requested packages.")
     subparser.add_argument(
         '-d', '--dependencies-only', action='store_true', dest='deps_only',
-        help='Install dependencies of this package, but not the package itself.')
+        help='Install dependencies of this package, ' +
+        'but not the package itself.')
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int,
         help="Explicitly set number of make jobs.  Default is #cpus.")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from __future__ import print_function
 import argparse
 
 import llnl.util.tty as tty
@@ -36,6 +37,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
         help="Do not try to install dependencies of requested packages.")
+    subparser.add_argument(
+        '-d', '--dependencies-only', action='store_true', dest='deps_only',
+        help='Install dependencies of this package, but not the package itself.')
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int,
         help="Explicitly set number of make jobs.  Default is #cpus.")
@@ -83,7 +87,8 @@ def install(parser, args):
             package.do_install(
                 keep_prefix=args.keep_prefix,
                 keep_stage=args.keep_stage,
-                ignore_deps=args.ignore_deps,
+                install_deps=not args.ignore_deps,
+                install_self=not args.deps_only,
                 make_jobs=args.jobs,
                 run_tests=args.run_tests,
                 verbose=args.verbose,

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -91,7 +91,8 @@ def setup(self, args):
 
         package.do_install(
             keep_prefix=True,  # Don't remove install directory
-            ignore_deps=args.ignore_deps,
+            install_deps=not args.ignore_deps,
+            install_self=True,
             verbose=args.verbose,
             keep_stage=True,   # don't remove source dir for SETUP.
             install_phases=set(['setup', 'provenance']),

--- a/lib/spack/spack/cmd/test_install.py
+++ b/lib/spack/spack/cmd/test_install.py
@@ -180,7 +180,8 @@ def install_single_spec(spec, number_of_jobs):
         start_time = time.time()
         package.do_install(keep_prefix=False,
                            keep_stage=True,
-                           ignore_deps=False,
+                           install_deps=True,
+                           install_self=True,
                            make_jobs=number_of_jobs,
                            verbose=True,
                            fake=False)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -878,7 +878,7 @@ class Package(object):
                    explicit=False,
                    dirty=False,
                    install_phases=install_phases):
-       """Called by commands to install a package and its dependencies.
+        """Called by commands to install a package and its dependencies.
 
         Package implementations should override install() to describe
         their build process.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -868,7 +868,8 @@ class Package(object):
     def do_install(self,
                    keep_prefix=False,
                    keep_stage=False,
-                   ignore_deps=False,
+                   install_deps=True,
+                   install_self=True,
                    skip_patch=False,
                    verbose=False,
                    make_jobs=None,
@@ -887,8 +888,10 @@ class Package(object):
         :param keep_stage: By default, stage is destroyed only if there are \
             no exceptions during build. Set to True to keep the stage
             even with exceptions.
-        :param ignore_deps: Don't install dependencies before installing this \
-                       package
+        :param install_deps: Install dependencies before installing this \
+            package
+        :param install_self: Install this package once dependencies have \
+            been installed.
         :param fake: Don't really build; install fake stub files instead.
         :param skip_patch: Skip patch stage of build if True.
         :param verbose: Display verbose build output (by default, suppresses \
@@ -922,6 +925,7 @@ class Package(object):
         tty.msg("Installing %s" % self.name)
 
         # First, install dependencies recursively.
+<<<<<<< ac3e21f8d4be5786761b5009690e09f6ec564c79
         if not ignore_deps:
             self.do_install_dependencies(keep_prefix=keep_prefix,
                                          keep_stage=keep_stage,
@@ -932,6 +936,24 @@ class Package(object):
                                          make_jobs=make_jobs,
                                          run_tests=run_tests,
                                          dirty=dirty)
+=======
+        if install_deps:
+            for dep in self.spec.dependencies():
+                dep.package.do_install(
+                    keep_prefix=keep_prefix,
+                    keep_stage=keep_stage,
+                    install_deps=install_deps,
+                    install_self=True,
+                    fake=fake,
+                    skip_patch=skip_patch,
+                    verbose=verbose,
+                    make_jobs=make_jobs,
+                    run_tests=run_tests)
+
+        # The rest of this function is to install ourself, once deps have been installed.
+        if not install_self:
+            return
+>>>>>>> 51f9a517d39c132e5771137c43599ba27603cd35
 
         # Set run_tests flag before starting build.
         self.run_tests = run_tests
@@ -939,6 +961,7 @@ class Package(object):
         # Set parallelism before starting build.
         self.make_jobs = make_jobs
 
+        # ------------------- BEGIN def build_process()
         # Then install the package itself.
         def build_process():
             """Forked for each build. Has its own process and python
@@ -1022,6 +1045,7 @@ class Package(object):
                     (_hms(self._fetch_time), _hms(build_time),
                      _hms(self._total_time)))
             print_pkg(self.prefix)
+        # ------------------- END def build_process()
 
         try:
             # Create the install prefix and fork the build process.
@@ -1078,11 +1102,6 @@ class Package(object):
         if not installed:
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)
-
-    def do_install_dependencies(self, **kwargs):
-        # Pass along paths of dependencies here
-        for dep in self.spec.dependencies():
-            dep.package.do_install(**kwargs)
 
     @property
     def build_log_path(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -259,7 +259,7 @@ class Package(object):
            parallel = False
            ...
 
-    This changes thd default behavior so that make is sequential.  If you still
+    This changes the default behavior so that make is sequential.  If you still
     want to build some parts in parallel, you can do this in your install
     function:
 
@@ -878,7 +878,7 @@ class Package(object):
                    explicit=False,
                    dirty=False,
                    install_phases=install_phases):
-        """Called by commands to install a package and its dependencies.
+       """Called by commands to install a package and its dependencies.
 
         Package implementations should override install() to describe
         their build process.
@@ -899,6 +899,7 @@ class Package(object):
         :param dirty: Don't clean the build environment before installing.
         :param make_jobs: Number of make jobs to use for install. Default is \
             ncpus
+        :param force: Install again, even if already installed.
         :param run_tests: Run tests within the package's install()
         """
         if not self.spec.concrete:
@@ -925,18 +926,6 @@ class Package(object):
         tty.msg("Installing %s" % self.name)
 
         # First, install dependencies recursively.
-<<<<<<< ac3e21f8d4be5786761b5009690e09f6ec564c79
-        if not ignore_deps:
-            self.do_install_dependencies(keep_prefix=keep_prefix,
-                                         keep_stage=keep_stage,
-                                         ignore_deps=ignore_deps,
-                                         fake=fake,
-                                         skip_patch=skip_patch,
-                                         verbose=verbose,
-                                         make_jobs=make_jobs,
-                                         run_tests=run_tests,
-                                         dirty=dirty)
-=======
         if install_deps:
             for dep in self.spec.dependencies():
                 dep.package.do_install(
@@ -948,12 +937,13 @@ class Package(object):
                     skip_patch=skip_patch,
                     verbose=verbose,
                     make_jobs=make_jobs,
-                    run_tests=run_tests)
+                    run_tests=run_tests,
+                    dirty=dirty)
 
-        # The rest of this function is to install ourself, once deps have been installed.
+        # The rest of this function is to install ourself,
+        # once deps have been installed.
         if not install_self:
             return
->>>>>>> 51f9a517d39c132e5771137c43599ba27603cd35
 
         # Set run_tests flag before starting build.
         self.run_tests = run_tests


### PR DESCRIPTION
This allows Spack to install just a package's dependencies, without installing the package itself.  Useful for non-standard packages, such as `modele`, which can't be installed with a simple `spack install`.
