### PR TITLE
Documentation: Fix accidental quotation. version() takes expand as a …

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -434,7 +434,7 @@ executables and other custom archive types), you can add
 .. code-block:: python
 
    version('8.2.1', '4136d7b4c04df68b686570afa26988ac',
-           url='http://example.com/foo-8.2.1-special-version.tar.gz', 'expand=False')
+           url='http://example.com/foo-8.2.1-special-version.tar.gz', expand=False)
 
 When ``expand`` is set to ``False``, Spack sets the current working
 directory to the directory containing the downloaded archive before it


### PR DESCRIPTION
…keyword.

The evidence I found that the documentation was wrong was in the [cuda package](https://github.com/LLNL/spack/blob/f59653ac2c9b20ec5954d90fda019c7652644ac9/var/spack/repos/builtin/packages/cuda/package.py#L53) and the [nextflow package](https://github.com/LLNL/spack/blob/48997cffa1360d70af0639e48ca6066a9111e442/var/spack/repos/builtin/packages/nextflow/package.py#L35) where they both use `expand` as a keyword and not a string.

Please let me know if this PR requires additional work.