### PR TITLE
New URL scheme for newer (and older) versions of PDT

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
 
 
@@ -36,14 +35,15 @@ class Pdt(Package):
 
     """
     homepage = "https://www.cs.uoregon.edu/research/pdt/home.php"
+    url      = "http://www.cs.uoregon.edu/research/paracomp/pdtoolkit/Download/pdt-3.22.1.tar.gz"
 
-    version('3.21', '3092ca0d8833b69992c17e63ae66c263')
-    version('3.19', '5c5e1e6607086aa13bf4b1b9befc5864')
-
-    def url_for_version(self, version):
-        return 'https://www.cs.uoregon.edu/research/tau/pdt_releases/pdtoolkit-%s.tar.gz' % (version)
+    version('3.22.1', 'be6fac0b1edb3e3287b0cb78741a24b6')
+    version('3.22',   'e6c7879fc49ac5ff67a76ce31ef9e251')
+    version('3.21',   '8df94298b71703decf680709a4ddf68f')
+    version('3.19',   'ba5591994998771fdab216699e362228')
+    version('3.18.1', '05281b5c82a4754df936df99ad7eec0f')
 
     def install(self, spec, prefix):
         configure('-prefix=%s' % prefix)
         make()
-        make("install")
+        make('install')


### PR DESCRIPTION
I had to explicitly tell flake8 to ignore the long url on line 38, is that the right thing to do?