### PR TITLE
[Workaround] Set namespace='builtin' for Packges in packages.yaml

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -478,6 +478,7 @@ def spec_externals(spec):
             continue
 
         external_spec = spack.spec.Spec(external_spec, external=path)
+        external_spec.namespace = 'builtin'
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 
@@ -489,6 +490,7 @@ def spec_externals(spec):
 
         external_spec = spack.spec.Spec(
             external_spec, external=path, external_module=module)
+        external_spec.namespace = 'builtin'
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 


### PR DESCRIPTION
Previously, namespace was set to None.  This prevented proper comparison between Specs, causing the user's directives in `packages.yaml` to be ignored at times.

This PR needs a bit more thinking.  We should probably allow the user to specify a namespace in `packages.yaml`, rather than always hardcoding to 'builtin'.  However, in existing practice, 'builtin' is the only Spack repo that people seem to use.

This addresses #1622 
