### PR TITLE
spack bootstrap: fix missing include

### DIFF
--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -28,7 +28,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import join_path, mkdirp
 
 import spack
-from spack.util.executable import which
+from spack.util.executable import ProcessError, which
 
 _SPACK_UPSTREAM = 'https://github.com/llnl/spack'
 


### PR DESCRIPTION
fix a missing include in booststrap.
found on debian 8 with python 2.7

without the fix I got the following error running `spack bootstrap $MYDIR`:
```
Traceback (most recent call last):
  File "/home/axel/proggen_partiell/spack/bin/spack", line 184, in <module>
    main()
  File "/home/axel/proggen_partiell/spack/bin/spack", line 161, in main
    return_val = command(parser, args)
  File "/home/axel/proggen_partiell/spack/lib/spack/spack/cmd/bootstrap.py", line 72, in bootstrap
    origin_url, branch = get_origin_info(args.remote)
  File "/home/axel/proggen_partiell/spack/lib/spack/spack/cmd/bootstrap.py", line 64, in get_origin_info
    except ProcessError:
NameError: global name 'ProcessError' is not defined
```