### PR TITLE
libSplash: Add Spack Package

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -46,8 +46,8 @@ class Libsplash(Package):
             description='Enable parallel I/O (one-file aggregation) support')
 
     depends_on('cmake', type='build')
-    depends_on('hdf5@1.8.6:', when='~mpi')
-    depends_on('hdf5@1.8.6:+mpi', when='+mpi')
+    depends_on('hdf5@1.8.6:')
+    depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libsplash(Package):
+    """
+    libSplash aims at developing a HDF5-based I/O library for HPC simulations.
+    It is created as an easy-to-use frontend for the standard HDF5 library
+    with support for MPI processes in a cluster environment. While the
+    standard HDF5 library provides detailed low-level control, libSplash
+    simplifies tasks commonly found in large-scale HPC simulations, such as
+    iterative computations and MPI distributed processes.
+    """
+
+    homepage = "https://github.com/ComputationalRadiationPhysics/libSplash"
+    url      = "https://github.com/ComputationalRadiationPhysics/libSplash/archive/v1.4.0.tar.gz"
+
+    version('1.4.0', '2de37bcef6fafa1960391bf44b1b50e0')
+    version('1.3.1', '524580ba088d97253d03b4611772f37c')
+    version('1.2.4', '3fccb314293d22966beb7afd83b746d0')
+
+    variant('mpi', default=True,
+            description='Enable parallel I/O (one-file aggregation) support')
+
+    depends_on('cmake', type='build')
+    depends_on('hdf5@1.8.6:', when='~mpi')
+    depends_on('hdf5@1.8.6:+mpi', when='+mpi')
+    depends_on('mpi', when='+mpi')
+
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            cmake('-DCMAKE_INSTALL_PREFIX=%s' % prefix,
+                  '..', *std_cmake_args)
+
+            make()
+            make('install')


### PR DESCRIPTION
Adds a package for [libSplash](https://github.com/ComputationalRadiationPhysics/libSplash), a high-level library around serial and parallel HDF5 for regular grids and particle data sets.

```
libSplash aims at developing a HDF5-based I/O library for HPC
simulations. It is created as an easy-to-use frontend for the
standard HDF5 library with support for MPI processes in a cluster
environment. While the standard HDF5 library provides detailed
low-level control, libSplash simplifies tasks commonly found in
large-scale HPC simulations, such as iterative computations
and MPI distributed processes.
```

libSplash is a dependency for [PIConGPU](http://picongpu.hzdr.de), an open-source, many-core, fully-relativistic particle-in-cell code and further software developed at [Helmholz-Zentrum Dresden - Rossendorf](https://www.hzdr.de).

libSplash builds in two versions, one without MPI writing domain-decomposed posix-style HDF5 files per process and one (default) with MPI and MPI-I/O ("parallel HDF5") support aggregating into a single file per MPI communicator.

libSplash is used in conjunction with [openPMD](http://openPMD.org), see also [github.com/openPMD/](https://github.com/openPMD/).

### Dependency Graph

```bash
$ spack graph libsplash+mpi
o  libsplash
|\
| |\
| o |  hdf5
|/| | 
| o |  zlib
|  /
o |  mpi
 /
o  cmake

$ spack graph --concretize libsplash+mpi
o  libsplash
|\
| |\
| | o  cmake
| | |\
| | o |  openssl
| o | |  hdf5
|/| | | 
| |/ /
| o |  zlib
|  /
o |  openmpi
| o  ncurses
| 
o  hwloc
o  libpciaccess
o  libtool
o  m4
o  libsigsegv

$ spack graph libsplash
o  libsplash
o  cmake

$ spack graph --concretize libsplash
o  libsplash
|\
| |\
| | o  cmake
| | |\
| | o |  openssl
| o | |  hdf5
|/| | | 
| |/ /
| o |  zlib
|  /
o |  openmpi
| o  ncurses
| 
o  hwloc
o  libpciaccess
o  libtool
o  m4
o  libsigsegv

$ spack graph libsplash~mpi
o  libsplash
|\
o |  hdf5
o |  zlib
 /
o  cmake

$ spack graph --concretize libsplash~mpi
o  libsplash
|\
| o  cmake
| |\
| o |  openssl
o | |  hdf5
|/ /
o |  zlib
 /
o  ncurses
```