### PR TITLE
Stop python from linking with system ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/python/ncurses.patch
+++ b/var/spack/repos/builtin/packages/python/ncurses.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2016-08-30 15:39:59.334926574 -0500
++++ b/setup.py	2016-08-30 15:46:57.227946339 -0500
+@@ -745,8 +745,6 @@
+         # use the same library for the readline and curses modules.
+         if 'curses' in readline_termcap_library:
+             curses_library = readline_termcap_library
+-        elif self.compiler.find_library_file(lib_dirs, 'ncursesw'):
+-            curses_library = 'ncursesw'
+         elif self.compiler.find_library_file(lib_dirs, 'ncurses'):
+             curses_library = 'ncurses'
+         elif self.compiler.find_library_file(lib_dirs, 'curses'):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -74,6 +74,8 @@ class Python(Package):
     depends_on("tk",  when="+tk")
     depends_on("tcl", when="+tk")
 
+    patch('ncurses.patch')
+
     @when('@2.7,3.4:')
     def patch(self):
         # NOTE: Python's default installation procedure makes it possible for a


### PR DESCRIPTION
Python will look to link with libncursesw in preference to libncurses. Since
ncurses in spack is built without suffixes there is no libncursesw and
python will link to the system libncursesw for _curses.so and
_curses_panel.so, as well as libpanelw for _curses_panel.so.

This PR introduces a patch that simple removes the check for ncursesw in
setup.py and therefore sets `curses_library` to `ncurses`.

An alternative solution would be to have the ncurses package build the suffixed versions as well as the non-suffixed versions.