### PR TITLE
Add missing dependency for run-doc-tests

### DIFF
--- a/share/spack/qa/check_dependencies
+++ b/share/spack/qa/check_dependencies
@@ -27,6 +27,9 @@ for dep in "$@"; do
                 spack_package=py-flake8
                 pip_package=flake8
                 ;;
+            dot)
+                spack_package=graphviz
+                ;;
             git)
                 spack_package=git
                 ;;

--- a/share/spack/qa/run-doc-tests
+++ b/share/spack/qa/run-doc-tests
@@ -20,6 +20,7 @@ DOC_DIR="$SPACK_ROOT/lib/spack/docs"
 deps=(
     sphinx-apidoc
     sphinx-build
+    dot
     git
     hg
     svn


### PR DESCRIPTION
I just noticed this while trying to build the documentation on my laptop. Building the documentation requires the `dot` command, which comes from `graphviz`.
```
WARNING: dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting
```
I tried installing it with pip, but the pip version doesn't supply the dot command. `dnf install graphviz` worked for me. I assume Spack's graphviz package provides the same dot command.

Btw, is this something we should add to `.travis.yml`? It seems to be working atm...