### PR TITLE
Don't overwrite PYTHONPATH in docs Makefile

### DIFF
--- a/lib/spack/docs/Makefile
+++ b/lib/spack/docs/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
-export PYTHONPATH = ../../spack
+export PYTHONPATH := ../../spack:$(PYTHONPATH)
 APIDOC_FILES  = spack*.rst
 
 # Internal variables.


### PR DESCRIPTION
Prepend, don't overwrite. This should solve problems for people who depend on modules like Sphinx which may need to be accessed from the PYTHONPATH.

@glennpj Can you try this out and see if it fixes the problem you brought up in https://github.com/LLNL/spack/pull/1685#issuecomment-243922131?