### PR TITLE
Close #1683 Apply ADIOS 1.10.0 Patch (HDF5 1.10+)

### DIFF
--- a/var/spack/repos/builtin/packages/adios/adios_1100.patch
+++ b/var/spack/repos/builtin/packages/adios/adios_1100.patch
@@ -1,0 +1,29 @@
+From 3b21a8a4150962c6938baeceacd04f619cea2fbc Mon Sep 17 00:00:00 2001
+From: Norbert Podhorszki <pnorbert@ornl.gov>
+Date: Thu, 1 Sep 2016 16:26:23 -0400
+Subject: [PATCH] ifdef around 'bool' type. hdf5 1.10 defines bool and breaks
+ compiling bp2h5.c
+
+---
+ utils/bp2h5/bp2h5.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/utils/bp2h5/bp2h5.c b/utils/bp2h5/bp2h5.c
+index 9c500c7..fa746bd 100644
+--- a/utils/bp2h5/bp2h5.c
++++ b/utils/bp2h5/bp2h5.c
+@@ -43,9 +43,11 @@
+ #include "dmalloc.h"
+ #endif
+ 
+-typedef int bool;
+-#define false 0
+-#define true  1
++#ifndef bool
++    typedef int bool;
++#   define false 0
++#   define true  1
++#endif
+ 
+ bool noindex = false;              // do no print array indices with data
+ bool printByteAsChar = false;      // print 8 bit integer arrays as string

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -36,6 +36,8 @@ class Adios(Package):
     homepage = "http://www.olcf.ornl.gov/center-projects/adios/"
     url      = "https://github.com/ornladios/ADIOS/archive/v1.10.0.tar.gz"
 
+    version('develop', git='https://github.com/ornladios/ADIOS.git',
+            branch='master')
     version('1.10.0', 'eff450a4c0130479417cfd63186957f3')
     version('1.9.0', '310ff02388bbaa2b1c1710ee970b5678')
 
@@ -51,13 +53,11 @@ class Adios(Package):
     # transforms
     variant('zlib', default=True, description='Enable szip transform support')
     variant('szip', default=False, description='Enable szip transform support')
-    # serial file converters
-    variant('hdf5', default=False, description='Enable bp2h5 converter')
-    variant('netcdf', default=False, description='Enable bp2ncd(3) converter')
+    # transports and serial file converters
+    variant('hdf5', default=False, description='Enable parallel HDF5 transport and serial bp2h5 converter')
 
     # Lots of setting up here for this package
     # module swap PrgEnv-intel PrgEnv-$COMP
-    # module load cray-netcdf/4.3.3.1
     # module load cray-hdf5/1.8.14
     # module load python/2.7.10
 
@@ -71,10 +71,8 @@ class Adios(Package):
     # optional transformations
     depends_on('zlib', when='+zlib')
     depends_on('szip', when='+szip')
-    # optional transports
-    # optional serial file converters
-    depends_on('hdf5@1.8:', when='+hdf5')
-    depends_on('netcdf@3', when='+netcdf')
+    # optional transports & file converters
+    depends_on('hdf5@1.8:+mpi', when='+hdf5')
 
     # Fix ADIOS <=1.10.0 compile error on HDF5 1.10+
     #   https://github.com/ornladios/ADIOS/commit/3b21a8a41509
@@ -122,9 +120,7 @@ class Adios(Package):
         if '+szip' in spec:
             extra_args.append('--with-szip=%s' % spec['szip'].prefix)
         if '+hdf5' in spec:
-            extra_args.append('--with-hdf5=%s' % spec['hdf5'].prefix)
-        if '+netcdf' in spec:
-            extra_args.append('--with-netcdf=%s' % spec['netcdf'].prefix)
+            extra_args.append('--with-phdf5=%s' % spec['hdf5'].prefix)
 
         sh = which('sh')
         sh('./autogen.sh')

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -48,10 +48,12 @@ class Adios(Package):
     variant('mpi', default=True, description='Enable MPI support')
     variant('infiniband', default=False, description='Enable infiniband support')
 
+    # transforms
     variant('zlib', default=True, description='Enable szip transform support')
     variant('szip', default=False, description='Enable szip transform support')
-    variant('hdf5', default=False, description='Enable HDF5 transport support')
-    variant('netcdf', default=False, description='Enable NetCDF transport support')
+    # serial file converters
+    variant('hdf5', default=False, description='Enable bp2h5 converter')
+    variant('netcdf', default=False, description='Enable bp2ncd(3) converter')
 
     # Lots of setting up here for this package
     # module swap PrgEnv-intel PrgEnv-$COMP
@@ -70,8 +72,14 @@ class Adios(Package):
     depends_on('zlib', when='+zlib')
     depends_on('szip', when='+szip')
     # optional transports
-    depends_on('hdf5', when='+hdf5')
-    depends_on('netcdf', when='+netcdf')
+    # optional serial file converters
+    depends_on('hdf5@1.8:', when='+hdf5')
+    depends_on('netcdf@3', when='+netcdf')
+
+    # Fix ADIOS <=1.10.0 compile error on HDF5 1.10+
+    #   https://github.com/ornladios/ADIOS/commit/3b21a8a41509
+    #   https://github.com/LLNL/spack/issues/1683
+    patch('adios_1100.patch', when='@:1.10.0^hdf5@1.10:')
 
     def validate(self, spec):
         """


### PR DESCRIPTION
Close #1683: Apply the patch https://github.com/ornladios/ADIOS/commit/3b21a8a41509 for all released ADIOS version up to the latest 1.10.0 which will break when used with HDF5 1.10+.

The bug is already fixed upstream in ADIOS.

### Other Changes

- fix doc strings: `--with-hdf5` (and --`with-netcdf`) are not transports but serial file converters
- remove `bp2ncd` tool: depends on netcdf 3 and is not essential
- hdf5:
  - since `spec['hdf5+mpi'].prefix` does not exist, we only add one `+hdf5` variant,  its building
     - the *parallel* transport `--with-phdf5`
     - the *serial* converter `--with-hdf5`, but also build by `--with-phdf5`
     - building the serial converter alone is intentionally not possible this way and reduces confusion
- add: `develop` version as described `spack_workflows.rst` (the ADIOS development branch is `master`)

see: [official manual, section 2.3](http://users.nccs.gov/%7Epnorbert/ADIOS-UsersManual-1.10.0.pdf)

### Tests
- [x] old fail
```bash
# unpatched version
$ spack install adios +hdf5 # implies currently hdf5 1.10.0-patch1
==> No patches needed for adios
==> Building adios
==> Error: Command exited with status 2:
'make' '-j4'
[...]
  >> 132          make()
[...]
```

- [x] new: only apply patch when necessary
```bash
# old HDF5 version, latest (1.10.0) ADIOS version
$ spack install adios +hdf5 ^hdf5@1.8.16
[...]
==> Created stage in [...]/var/spack/stage/hdf5-1.8.16-[...]
==> No patches needed for hdf5
==> Building hdf5
==> Successfully installed hdf5
[...]
No patches needed for adios
==> Building adios
==> Warning: Patched overlong shebang in [...]opt/spack/linux-debian8-x86_64/gcc-4.9.2/adios-1.10.0-[...]/bin/gpp.py
==> Successfully installed adios
```

- [x] new: apply patch to fix
```bash
# latest versions
$ spack install adios +hdf5 # implies currently hdf5 1.10.0-patch1
[...]
==> Created stage in [...]var/spack/stage/hdf5-1.10.0-patch1-[...]
==> No patches needed for hdf5
==> Building hdf5
==> Successfully installed hdf5
[...]
==> Created stage in [...]/var/spack/stage/adios-1.10.0-[...]
==> Applied patch adios_1100.patch
==> Building adios
==> Warning: Patched overlong shebang in [...]opt/spack/linux-debian8-x86_64/gcc-4.9.2/adios-1.10.0-x6woxnqfn2gzu6smq5xgxtqrglpquowd/bin/gpp.py
==> Successfully installed adios
```