### PR TITLE
Make libiconv work with C11

### DIFF
--- a/var/spack/repos/builtin/packages/libiconv/gets.patch
+++ b/var/spack/repos/builtin/packages/libiconv/gets.patch
@@ -1,0 +1,13 @@
+--- a/srclib/stdio.in.h
++++ b/srclib/stdio.in.h
+@@ -692,10 +692,6 @@
+ #  undef gets
+ # endif
+ _GL_CXXALIASWARN (gets);
+-/* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
+-_GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+ #endif
+ 
+ 

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -34,6 +34,10 @@ class Libiconv(Package):
 
     version('1.14', 'e34509b1623cec449dfeb73d7ce9c6c6')
 
+    # We cannot set up a warning for gets(), since gets() is not part
+    # of C11 any more and thus might not exist.
+    patch("gets.patch")
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix),
                   '--enable-extra-encodings')


### PR DESCRIPTION
C11 does not provide gets() any more, so we cannot reference it