### PR TITLE
Update some Python version constraints in dependency statements

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -70,7 +70,7 @@ class Julia(Package):
     depends_on("curl")
     depends_on("git")           # I think Julia @0.5: doesn't use git any more
     depends_on("openssl")
-    depends_on("python @2.7:2.999")
+    depends_on("python @2.7.0:2.999")
 
     # Run-time dependencies:
     # depends_on("arpack")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -73,7 +73,7 @@ class Llvm(Package):
     depends_on('cmake@2.8.12.2:', type='build')
 
     # Universal dependency
-    depends_on('python@2.7:2.8')  # Seems not to support python 3.X.Y
+    depends_on('python@2.7.0:2.999')  # Seems not to support python 3.X.Y
 
     # lldb dependencies
     depends_on('ncurses', when='+lldb')

--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -37,7 +37,7 @@ class Mercurial(Package):
     version('3.8.2', 'c38daa0cbe264fc621dc3bb05933b0b3')
     version('3.8.1', '172a8c588adca12308c2aca16608d7f4')
 
-    depends_on("python @2.6:2.7.999")
+    depends_on("python @2.6.0:2.999")
     depends_on("py-docutils", type="build")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -41,7 +41,7 @@ class Nwchem(Package):
     depends_on('mpi')
     depends_on('scalapack')
 
-    depends_on('python@2.7:2.8', type=nolink)
+    depends_on('python@2.7.0:2.999', type=nolink)
 
     # patches for 6.6-27746:
     # TODO: add support for achived patches, i.e.

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -43,7 +43,7 @@ class Paraview(Package):
     variant('qt', default=False, description='Enable Qt support')
     variant('opengl2', default=False, description='Enable OpenGL2 backend')
 
-    depends_on('python@2:2.7', when='+python')
+    depends_on('python@2.0.0:2.999', when='+python')
     depends_on('py-numpy', when='+python', type='run')
     depends_on('py-matplotlib', when='+python', type='run')
     depends_on('tcl', when='+tcl')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -69,7 +69,7 @@ class Petsc(Package):
     depends_on('mpi', when='+mpi')
 
     # Build dependencies
-    depends_on('python @2.6:2.7')
+    depends_on('python @2.6.0:2.999')
 
     # Other dependencies
     depends_on('boost', when='+boost')

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -26,7 +26,7 @@ class Rust(Package):
     depends_on("curl")
     depends_on("git")
     depends_on("cmake")
-    depends_on("python@:2.8")
+    depends_on("python@2.0.0:2.999")
 
     # Cargo
     depends_on("openssl")

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -33,7 +33,7 @@ class UtilLinux(Package):
 
     version('2.25', 'f6d7fc6952ec69c4dc62c8d7c59c1d57')
 
-    depends_on("python@2.7:")
+    depends_on("python@2.7.0:")
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix,


### PR DESCRIPTION
(Not sure whether this is all correct; please comment and discuss.)

Update some Python version constraints to clarify intent (don't mention a non-existing Python 2.8).
Also, always use three-part version numbers, so that Spack is not tempted to choose non-existing Python versions.