### PR TITLE
Wgrib Package for Wrangling GRIB files

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib/package.py
+++ b/var/spack/repos/builtin/packages/wgrib/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Wgrib(Package):
+    """WGRIB is a program to manipulate, inventory and decode GRIB files"""
+
+    homepage = "http://www.cpc.ncep.noaa.gov/products/wesley/wgrib.html"
+    url      = "http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz"
+
+    version('2.0.5', '84029e969b5b37e1ba791d0572895133')
+
+    parallel = False
+
+    def url_for_version(self, version):
+        """ This is just a link to the latest. Actual urls confuse spack
+            such that it is unable to detect the compression type """
+        return "http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz"
+
+    def install(self, spec, prefix):
+        gmake("FC=fcc CC=cc")
+
+        install_tree('bin', prefix.bin)
+        install_tree('lib', prefix.lib)
+        install_tree('include', prefix.include)
+        install_tree('man/man1', prefix.share_man1)
+
+        install('wgrib2/wgrib2', prefix.bin)


### PR DESCRIPTION
I believe this is ready to merged, but I would also like to solicit advice on good packaging practice:
1. This package seems to choke on parallel make, so I have set `gmake.jobs = 1` on line 44. Is that the best thing to do, or do we have an existing convention for asserting serial make on a per-package level?
2. The url I use in `url_for_version` is just a link to the latest version, so it will break as soon as the maintainers put out another release. However, the urls they use seem to confuse Spack about what kind of compression/archiver is used: `http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v2.0.5`. Is there a way I can clarify to spack that `*.tgz.v1.2.3` should be treated like `*.tar.gz`? Could I make a custom subclass of URLFetchStrategy and use it in this one package?
3. In their wisdom, the maintainers do not offer an `install` target for make, so I've got to copy stuff in place by hand (see lines 48-54). Have I done this in a clear-enough way, or have we got an established convention for this? Best example I could find is [the lmdb package](https://github.com/LLNL/spack/blob/f59653ac2c9b20ec5954d90fda019c7652644ac9/var/spack/repos/builtin/packages/lmdb/package.py).

Also, @citibeth or other climate folks that may be familiar with this package: Is it called "wgrib" or should it properly be called "wgrib2"? The docs seem to use both, but the build produces an executable called `wgrib2`.

Thank you for your feedback!
