### PR TITLE
libSplash: spack dependency bug fixed (other still persists)

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -45,8 +45,8 @@ class Libsplash(Package):
             description='Enable parallel I/O (one-file aggregation) support')
 
     depends_on('cmake', type='build')
-    depends_on('hdf5@1.8.6:')
-    depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5@1.8.6:', when='~mpi')
+    depends_on('hdf5@1.8.6:+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -37,6 +37,8 @@ class Libsplash(Package):
     homepage = "https://github.com/ComputationalRadiationPhysics/libSplash"
     url      = "https://github.com/ComputationalRadiationPhysics/libSplash/archive/v1.4.0.tar.gz"
 
+    version('develop', branch='dev',
+            git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('1.4.0', '2de37bcef6fafa1960391bf44b1b50e0')
     version('1.3.1', '524580ba088d97253d03b4611772f37c')
     version('1.2.4', '3fccb314293d22966beb7afd83b746d0')

--- a/var/spack/repos/builtin/packages/pngwriter/package.py
+++ b/var/spack/repos/builtin/packages/pngwriter/package.py
@@ -38,6 +38,8 @@ class Pngwriter(Package):
     homepage = "http://pngwriter.sourceforge.net/"
     url      = "https://github.com/pngwriter/pngwriter/archive/0.5.6.tar.gz"
 
+    version('develop', branch='dev',
+            git='https://github.com/pngwriter/pngwriter.git')
     version('0.5.6', 'c13bd1fdc0e331a246e6127b5f262136')
 
     depends_on('cmake', type='build')


### PR DESCRIPTION
the spack-internal dependency resolution bug mentioned in
      https://github.com/LLNL/spack/pull/1667#discussion_r76809742
    
seems to be fixed now, and is even causing a bug when not rewritten
      https://github.com/LLNL/spack/pull/1667#discussion_r77460027
    
This fixes it.
    
- use any version of hdf5 if no mpi is requested
- enforce "parallel" version of hdf5 if mpi is requested

Minor: Also adds missing `develop` versions to `libSplash` and `PNGwriter` in the second commit. (I know, I know...)

ccing @adamjstewart