### PR TITLE
fontconfig: add --disable-docs to configure

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -36,7 +36,9 @@ class Fontconfig(Package):
     depends_on('libxml2')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix, "--enable-libxml2")
+        configure("--prefix=%s" % prefix,
+                  "--enable-libxml2",
+                  "--disable-docs")
 
         make()
         make("install")


### PR DESCRIPTION
Building the documentation for fontconfig requires docbook. 

Adding the spack package `docbook-xml` as a build dependency does not fix the problem. 

Simplest solution: don't build the documentation!