### PR TITLE
For OpenMPI v 2+, add a configure option to provide C++ bindings.

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -37,7 +37,7 @@ class Moab(Package):
     homepage = "https://bitbucket.org/fathomteam/moab"
     url      = "http://ftp.mcs.anl.gov/pub/fathom/moab-4.6.3.tar.gz"
 
-    version('4.9.1', 'bcb8bee3e58c076c7f31884db119088e')
+    version('4.9.1', '19cc2189fa266181ad9109b18d0b2ab8')
     version('4.9.0', '40695d0a159040683cfa05586ad4a7c2')
     version('4.8.2', '1dddd10f162fce3cfffaedc48f6f467d')
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -165,6 +165,10 @@ class Openmpi(Package):
                        "--enable-shared",
                        "--enable-static"]
 
+        # for Open-MPI 2.0:, C++ bindings are disabled by default.
+        if self.spec.satisfies('@2.0:'):
+            config_args.extend(['--enable-mpi-cxx'])
+
         if getattr(self, 'config_extra', None) is not None:
             config_args.extend(self.config_extra)
 


### PR DESCRIPTION
+ Starting with version 2.0, OpenMPI no longer provides C++ bindings by default (libmpi_cxx.so). Add a configure option to instruct the build to also build and install libmpi_cxx.so.
+ This MPI feature is needed by at least one spack package (moab).
+ Fix a bad hash value for moab-4.9.1.