### PR TITLE
Package all of Xorg/X11/XCB

### DIFF
--- a/var/spack/repos/builtin/packages/applewmproto/package.py
+++ b/var/spack/repos/builtin/packages/applewmproto/package.py
@@ -25,17 +25,17 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Applewmproto(Package):
+    """Apple Rootless Window Management Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protcol that allows X window managers
+    to better interact with the Mac OS X Aqua user interface when
+    running X11 in a rootless mode."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/applewmproto"
+    url      = "https://www.x.org/archive/individual/proto/applewmproto-1.4.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.4.2', 'ecc8a4424a893ce120f5652dba62e9e6')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/applewmproto/package.py
+++ b/var/spack/repos/builtin/packages/applewmproto/package.py
@@ -37,6 +37,9 @@ class Applewmproto(Package):
 
     version('1.4.2', 'ecc8a4424a893ce120f5652dba62e9e6')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/appres/package.py
+++ b/var/spack/repos/builtin/packages/appres/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Appres(Package):
+    """The appres program prints the resources seen by an application (or
+    subhierarchy of an application) with the specified class and instance
+    names.  It can be used to determine which resources a particular
+    program will load."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/appres"
+    url      = "https://www.x.org/archive/individual/app/appres-1.0.4.tar.gz"
+
+    version('1.0.4', 'f82aabe6bbb8960781b63c6945bb361b')
+
+    depends_on('libx11')
+    depends_on('libxt')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/bdftopcf/package.py
+++ b/var/spack/repos/builtin/packages/bdftopcf/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Bdftopcf(Package):
+    """bdftopcf is a font compiler for the X server and font server.  Fonts
+    in Portable Compiled Format can be read by any architecture, although
+    the file is structured to allow one particular architecture to read
+    them directly without reformatting.  This allows fast reading on the
+    appropriate machine, but the files are still portable (but read more
+    slowly) on other machines."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/bdftopcf"
+    url      = "https://www.x.org/archive/individual/app/bdftopcf-1.0.5.tar.gz"
+
+    version('1.0.5', '456416d33e0d41a96b5a3725d99e1be3')
+
+    depends_on('libxfont')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/beforelight/package.py
+++ b/var/spack/repos/builtin/packages/beforelight/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Beforelight(Package):
+    """The beforelight program is a sample implementation of a screen saver
+    for X servers supporting the MIT-SCREEN-SAVER extension.   It is only
+    recommended for use as a code sample, as it does not include features
+    such as screen locking or configurability."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/beforelight"
+    url      = "https://www.x.org/archive/individual/app/beforelight-1.0.5.tar.gz"
+
+    version('1.0.5', 'f0433eb6df647f36bbb5b38fb2beb22a')
+
+    depends_on('libx11')
+    depends_on('libxscrnsaver')
+    depends_on('libxt')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/bigreqsproto/package.py
+++ b/var/spack/repos/builtin/packages/bigreqsproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Bigreqsproto(Package):
+    """Big Requests Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol to enable the use of requests
+    that exceed 262140 bytes in length."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/bigreqsproto"
+    url      = "https://www.x.org/archive/individual/proto/bigreqsproto-1.1.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.1.2', '9b83369ac7a5eb2bf54c8f34db043a0e')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/bigreqsproto/package.py
+++ b/var/spack/repos/builtin/packages/bigreqsproto/package.py
@@ -36,6 +36,9 @@ class Bigreqsproto(Package):
 
     version('1.1.2', '9b83369ac7a5eb2bf54c8f34db043a0e')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/bitmap/package.py
+++ b/var/spack/repos/builtin/packages/bitmap/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Bitmap(Package):
+    """bitmap, bmtoa, atobm - X bitmap (XBM) editor and converter utilities."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/bitmap"
+    url      = "https://www.x.org/archive/individual/app/bitmap-1.0.8.tar.gz"
+
+    version('1.0.8', '0ca600041bb0836ae7c9f5db5ce09091')
+
+    depends_on('libx11')
+    depends_on('libxmu')
+    depends_on('xbitmaps')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/bitmap/package.py
+++ b/var/spack/repos/builtin/packages/bitmap/package.py
@@ -35,11 +35,11 @@ class Bitmap(Package):
 
     depends_on('libx11')
     depends_on('libxmu')
-    depends_on('xbitmaps')
     depends_on('libxaw')
     depends_on('libxmu')
     depends_on('libxt')
 
+    depends_on('xbitmaps', type='build')
     depends_on('xproto@7.0.25:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/compiz/package.py
+++ b/var/spack/repos/builtin/packages/compiz/package.py
@@ -38,24 +38,26 @@ class Compiz(Package):
 
     version('0.7.8', 'e99977d9170a7bd5d571004eed038428')
 
-    # FIXME: add dependencies
-    # x11-xcb
-    # xcomposite
-    # xfixes
-    # xdamage
-    # xrandr
-    # xinerama
-    # ice
-    # sm
-    # libxml-2.0
-    # libxslt
+    depends_on('libxcb')
+    depends_on('libxcomposite')
+    depends_on('libxfixes')
+    depends_on('libxdamage')
+    depends_on('libxrandr')
+    depends_on('libxinerama')
+    depends_on('libice')
+    depends_on('libsm')
+    depends_on('libxml2')
+    depends_on('libxslt')
+
+    # TODO: add dependencies
     # libstartup-notification-1.0 >= 0.7
-    # xrender
-    # libpng
-    # glib-2.0
-    # gconf-2.0
+    depends_on('libxrender')
+    depends_on('libpng')
+    depends_on('glib')
+    depends_on('gconf')
 
     def install(self, spec, prefix):
-        # FIXME: Unknown build system
+        configure('--prefix={0}'.format(prefix))
+
         make()
         make('install')

--- a/var/spack/repos/builtin/packages/compiz/package.py
+++ b/var/spack/repos/builtin/packages/compiz/package.py
@@ -1,0 +1,61 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Compiz(Package):
+    """compiz - OpenGL window and compositing manager.
+
+    Compiz is an OpenGL compositing manager that use
+    GLX_EXT_texture_from_pixmap for binding redirected top-level
+    windows to texture objects. It has a flexible plug-in system
+    and it is designed to run well on most graphics hardware."""
+
+    homepage = "http://www.compiz.org/"
+    url      = "https://www.x.org/archive/individual/app/compiz-0.7.8.tar.gz"
+
+    version('0.7.8', 'e99977d9170a7bd5d571004eed038428')
+
+    # FIXME: add dependencies
+    # x11-xcb
+    # xcomposite
+    # xfixes
+    # xdamage
+    # xrandr
+    # xinerama
+    # ice
+    # sm
+    # libxml-2.0
+    # libxslt
+    # libstartup-notification-1.0 >= 0.7
+    # xrender
+    # libpng
+    # glib-2.0
+    # gconf-2.0
+
+    def install(self, spec, prefix):
+        # FIXME: Unknown build system
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/compositeproto/package.py
+++ b/var/spack/repos/builtin/packages/compositeproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Compositeproto(Package):
+    """Composite Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This package contains header files and documentation for the composite
+    extension.  Library and server implementations are separate."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/compositeproto"
+    url      = "https://www.x.org/archive/individual/proto/compositeproto-0.4.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('0.4.2', '2dea7c339432b3363faf2d29c208e7b5')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/compositeproto/package.py
+++ b/var/spack/repos/builtin/packages/compositeproto/package.py
@@ -36,6 +36,9 @@ class Compositeproto(Package):
 
     version('0.4.2', '2dea7c339432b3363faf2d29c208e7b5')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/constype/package.py
+++ b/var/spack/repos/builtin/packages/constype/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Constype(Package):
+    """constype prints on the standard output the Sun code for the type of
+    display that the specified device is.
+
+    It was originally written for SunOS, but has been ported to other
+    SPARC OS'es and to Solaris on both SPARC & x86."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/constype"
+    url      = "https://www.x.org/archive/individual/app/constype-1.0.4.tar.gz"
+
+    version('1.0.4', '2333b9ac9fd32e58b05afa651c4590a3')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/damageproto/package.py
+++ b/var/spack/repos/builtin/packages/damageproto/package.py
@@ -26,7 +26,10 @@ from spack import *
 
 
 class Damageproto(Package):
-    """Damage extension protocol specification and header files."""
+    """X Damage Extension.
+
+    This package contains header files and documentation for the X Damage
+    extension.  Library and server implementations are separate."""
 
     homepage = "https://cgit.freedesktop.org/xorg/proto/damageproto"
     url      = "https://www.x.org/releases/individual/proto/damageproto-1.2.1.tar.gz"

--- a/var/spack/repos/builtin/packages/damageproto/package.py
+++ b/var/spack/repos/builtin/packages/damageproto/package.py
@@ -25,22 +25,15 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class Damageproto(Package):
+    """Damage extension protocol specification and header files."""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/damageproto"
+    url      = "https://www.x.org/releases/individual/proto/damageproto-1.2.1.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('1.2.1', 'bf8c47b7f48625230cff155180f8ddce')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
-        make()
-        # make('check')  # fails tests
         make('install')

--- a/var/spack/repos/builtin/packages/damageproto/package.py
+++ b/var/spack/repos/builtin/packages/damageproto/package.py
@@ -36,6 +36,9 @@ class Damageproto(Package):
 
     version('1.2.1', 'bf8c47b7f48625230cff155180f8ddce')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/dmxproto/package.py
+++ b/var/spack/repos/builtin/packages/dmxproto/package.py
@@ -25,17 +25,17 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Dmxproto(Package):
+    """Distributed Multihead X (DMX) Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol for clients to access a front-end proxy
+    X server that controls multiple back-end X servers making up a large
+    display."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://dmx.sourceforge.net/"
+    url      = "https://www.x.org/archive/individual/proto/dmxproto-2.3.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.3.1', '7c52af95aac192e8de31bd9a588ce121')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/dmxproto/package.py
+++ b/var/spack/repos/builtin/packages/dmxproto/package.py
@@ -37,6 +37,9 @@ class Dmxproto(Package):
 
     version('2.3.1', '7c52af95aac192e8de31bd9a588ce121')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/dri2proto/package.py
+++ b/var/spack/repos/builtin/packages/dri2proto/package.py
@@ -37,6 +37,9 @@ class Dri2proto(Package):
 
     version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/dri2proto/package.py
+++ b/var/spack/repos/builtin/packages/dri2proto/package.py
@@ -26,14 +26,14 @@ from spack import *
 
 
 class Dri2proto(Package):
-    """DRI2 Protocol Headers."""
-    homepage = "http://http://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "http://xorg.freedesktop.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    """X11 Direct Rendering Infrastructure 2 Protocol Headers."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
+    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
 
     version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure('--prefix={0}'.format(prefix))
 
-        make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/dri3proto/package.py
+++ b/var/spack/repos/builtin/packages/dri3proto/package.py
@@ -26,7 +26,11 @@ from spack import *
 
 
 class Dri3proto(Package):
-    """X11 Direct Rendering Infrastructure 2 Protocol Headers."""
+    """Direct Rendering Infrastructure 3 Extension.
+
+    This extension defines a protocol to securely allow user applications to
+    access the video hardware without requiring data to be passed through the
+    X server."""
 
     homepage = "https://cgit.freedesktop.org/xorg/proto/dri3proto/"
     url      = "https://www.x.org/releases/individual/proto/dri3proto-1.0.tar.gz"

--- a/var/spack/repos/builtin/packages/dri3proto/package.py
+++ b/var/spack/repos/builtin/packages/dri3proto/package.py
@@ -25,22 +25,15 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class Dri3proto(Package):
+    """X11 Direct Rendering Infrastructure 2 Protocol Headers."""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/dri3proto/"
+    url      = "https://www.x.org/releases/individual/proto/dri3proto-1.0.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('1.0', '25e84a49a076862277ee12aebd49ff5f')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
-        make()
-        # make('check')  # fails tests
         make('install')

--- a/var/spack/repos/builtin/packages/dri3proto/package.py
+++ b/var/spack/repos/builtin/packages/dri3proto/package.py
@@ -37,6 +37,9 @@ class Dri3proto(Package):
 
     version('1.0', '25e84a49a076862277ee12aebd49ff5f')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/editres/package.py
+++ b/var/spack/repos/builtin/packages/editres/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Editres(Package):
+    """Dynamic resource editor for X Toolkit applications."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/editres"
+    url      = "https://www.x.org/archive/individual/app/editres-1.0.6.tar.gz"
+
+    version('1.0.6', '310c504347ca499874593ac96e935353')
+
+    depends_on('libxaw')
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxmu')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/encodings/package.py
+++ b/var/spack/repos/builtin/packages/encodings/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Encodings(Package):
+    """X.org encodings font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/encodings"
+    url      = "https://www.x.org/archive/individual/font/encodings-1.0.4.tar.gz"
+
+    version('1.0.4', '1a631784ce204d667abcc329b851670c')
+
+    depends_on('font-util', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/encodings/package.py
+++ b/var/spack/repos/builtin/packages/encodings/package.py
@@ -33,7 +33,8 @@ class Encodings(Package):
 
     version('1.0.4', '1a631784ce204d667abcc329b851670c')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('mkfontscale', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/evieext/package.py
+++ b/var/spack/repos/builtin/packages/evieext/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Evieext(Package):
+    """Extended Visual Information Extension (XEVIE).
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol for a client to determine information
+    about core X visuals beyond what the core protocol provides."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/evieproto"
+    url      = "https://www.x.org/archive/individual/proto/evieext-1.1.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.1.1', '018a7d24d0c7926d594246320bcb6a86')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/evieext/package.py
+++ b/var/spack/repos/builtin/packages/evieext/package.py
@@ -36,6 +36,9 @@ class Evieext(Package):
 
     version('1.1.1', '018a7d24d0c7926d594246320bcb6a86')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/builtin/packages/fixesproto/package.py
@@ -37,6 +37,9 @@ class Fixesproto(Package):
 
     version('5.0', '1b3115574cadd4cbea1f197faa7c1de4')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/builtin/packages/fixesproto/package.py
@@ -25,17 +25,17 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Fixesproto(Package):
+    """X Fixes Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    The extension makes changes to many areas of the protocol to resolve
+    issues raised by application interaction with core protocol mechanisms
+    that cannot be adequately worked around on the client side of the wire."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/fixesproto"
+    url      = "https://www.x.org/archive/individual/proto/fixesproto-5.0.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('5.0', '1b3115574cadd4cbea1f197faa7c1de4')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAdobe100dpi(Package):
+    """X.org adobe-100dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/adobe-100dpi"
+    url      = "https://www.x.org/archive/individual/font/font-adobe-100dpi-1.0.3.tar.gz"
+
+    version('1.0.3', 'ba61e7953f4f5cec5a8e69c262bbc7f9')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-100dpi/package.py
@@ -33,7 +33,8 @@ class FontAdobe100dpi(Package):
 
     version('1.0.3', 'ba61e7953f4f5cec5a8e69c262bbc7f9')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
@@ -33,7 +33,8 @@ class FontAdobe75dpi(Package):
 
     version('1.0.3', '7a414bb661949cec938938fd678cf649')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-75dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAdobe75dpi(Package):
+    """X.org adobe-75dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/adobe-75dpi"
+    url      = "https://www.x.org/archive/individual/font/font-adobe-75dpi-1.0.3.tar.gz"
+
+    version('1.0.3', '7a414bb661949cec938938fd678cf649')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAdobeUtopia100dpi(Package):
+    """X.org adobe-utopia-100dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/adobe-utopia-100dpi"
+    url      = "https://www.x.org/archive/individual/font/font-adobe-utopia-100dpi-1.0.4.tar.gz"
+
+    version('1.0.4', '128416eccd59b850f77a9b803681da3c')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-100dpi/package.py
@@ -33,7 +33,8 @@ class FontAdobeUtopia100dpi(Package):
 
     version('1.0.4', '128416eccd59b850f77a9b803681da3c')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAdobeUtopia75dpi(Package):
+    """X.org adobe-utopia-75dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/adobe-utopia-75dpi"
+    url      = "https://www.x.org/archive/individual/font/font-adobe-utopia-75dpi-1.0.4.tar.gz"
+
+    version('1.0.4', '74c73a5b73c6c3224b299f1fc033e508')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-75dpi/package.py
@@ -33,7 +33,8 @@ class FontAdobeUtopia75dpi(Package):
 
     version('1.0.4', '74c73a5b73c6c3224b299f1fc033e508')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-adobe-utopia-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-adobe-utopia-type1/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAdobeUtopiaType1(Package):
+    """X.org adobe-utopia-type1 font."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/font/adobe-utopia-type1"
+    url      = "https://www.x.org/archive/individual/font/font-adobe-utopia-type1-1.0.4.tar.gz"
+
+    version('1.0.4', 'b0676c3495acabad519ee98a94163904')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-alias/package.py
+++ b/var/spack/repos/builtin/packages/font-alias/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontAlias(Package):
+    """X.org alias font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/alias"
+    url      = "https://www.x.org/archive/individual/font/font-alias-1.0.3.tar.gz"
+
+    version('1.0.3', '535138efe0a95f5fe521be6a6b9c4888')
+
+    depends_on('font-util', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-alias/package.py
+++ b/var/spack/repos/builtin/packages/font-alias/package.py
@@ -33,7 +33,8 @@ class FontAlias(Package):
 
     version('1.0.3', '535138efe0a95f5fe521be6a6b9c4888')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
 

--- a/var/spack/repos/builtin/packages/font-arabic-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-arabic-misc/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontArabicMisc(Package):
+    """X.org arabic-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/arabic-misc"
+    url      = "https://www.x.org/archive/individual/font/font-arabic-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '918457df65ef93f09969c6ab01071789')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-arabic-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-arabic-misc/package.py
@@ -33,7 +33,8 @@ class FontArabicMisc(Package):
 
     version('1.0.3', '918457df65ef93f09969c6ab01071789')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBh100dpi(Package):
+    """X.org bh-100dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-100dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bh-100dpi-1.0.3.tar.gz"
+
+    version('1.0.3', '09e63a5608000531179e1ab068a35878')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-100dpi/package.py
@@ -33,7 +33,8 @@ class FontBh100dpi(Package):
 
     version('1.0.3', '09e63a5608000531179e1ab068a35878')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
@@ -33,7 +33,8 @@ class FontBh75dpi(Package):
 
     version('1.0.3', '88fec4ebc4a265684bff3abdd066f14f')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-75dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBh75dpi(Package):
+    """X.org bh-75dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-75dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bh-75dpi-1.0.3.tar.gz"
+
+    version('1.0.3', '88fec4ebc4a265684bff3abdd066f14f')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
@@ -33,7 +33,8 @@ class FontBhLucidatypewriter100dpi(Package):
 
     version('1.0.3', '5f716f54e497fb4ec1bb3a5d650ac6f7')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-100dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBhLucidatypewriter100dpi(Package):
+    """X.org bh-lucidatypewriter-100dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-lucidatypewriter-100dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bh-lucidatypewriter-100dpi-1.0.3.tar.gz"
+
+    version('1.0.3', '5f716f54e497fb4ec1bb3a5d650ac6f7')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
@@ -33,7 +33,8 @@ class FontBhLucidatypewriter75dpi(Package):
 
     version('1.0.3', 'cab8a44ae329aab7141c7adeef0daf5a')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-lucidatypewriter-75dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBhLucidatypewriter75dpi(Package):
+    """X.org bh-lucidatypewriter-75dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-lucidatypewriter-75dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bh-lucidatypewriter-75dpi-1.0.3.tar.gz"
+
+    version('1.0.3', 'cab8a44ae329aab7141c7adeef0daf5a')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bh-ttf/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-ttf/package.py
@@ -33,7 +33,8 @@ class FontBhTtf(Package):
 
     version('1.0.3', '4ce741ec4edaa11cd38988d355a7578b')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-ttf/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-ttf/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBhTtf(Package):
+    """X.org bh-ttf font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-ttf"
+    url      = "https://www.x.org/archive/individual/font/font-bh-ttf-1.0.3.tar.gz"
+
+    version('1.0.3', '4ce741ec4edaa11cd38988d355a7578b')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bh-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-type1/package.py
@@ -33,7 +33,8 @@ class FontBhType1(Package):
 
     version('1.0.3', '62d4e8f782a6a0658784072a5df5ac98')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-bh-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bh-type1/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBhType1(Package):
+    """X.org bh-type1 font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bh-type1"
+    url      = "https://www.x.org/archive/individual/font/font-bh-type1-1.0.3.tar.gz"
+
+    version('1.0.3', '62d4e8f782a6a0658784072a5df5ac98')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
@@ -33,7 +33,8 @@ class FontBitstream100dpi(Package):
 
     version('1.0.3', 'c27bf37e9b8039f93bd90b8131ed37ad')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-100dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBitstream100dpi(Package):
+    """X.org bitstream-100dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bitstream-100dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bitstream-100dpi-1.0.3.tar.gz"
+
+    version('1.0.3', 'c27bf37e9b8039f93bd90b8131ed37ad')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
@@ -33,7 +33,8 @@ class FontBitstream75dpi(Package):
 
     version('1.0.3', '4ff6c5d6aebe69371e27b09ad8313d25')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-75dpi/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBitstream75dpi(Package):
+    """X.org bitstream-75dpi font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bitstream-75dpi"
+    url      = "https://www.x.org/archive/individual/font/font-bitstream-75dpi-1.0.3.tar.gz"
+
+    version('1.0.3', '4ff6c5d6aebe69371e27b09ad8313d25')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
@@ -33,7 +33,8 @@ class FontBitstreamSpeedo(Package):
 
     version('1.0.2', 'f0a777b351cf5adefefcf4823e0c1c01')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class FontBitstreamSpeedo(Package):
-    """FIXME: Put a proper description of your package here."""
+    """X.org bitstream-speedo font."""
 
     homepage = "http://cgit.freedesktop.org/xorg/font/bitstream-speedo"
     url      = "https://www.x.org/archive/individual/font/font-bitstream-speedo-1.0.2.tar.gz"

--- a/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-speedo/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBitstreamSpeedo(Package):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bitstream-speedo"
+    url      = "https://www.x.org/archive/individual/font/font-bitstream-speedo-1.0.2.tar.gz"
+
+    version('1.0.2', 'f0a777b351cf5adefefcf4823e0c1c01')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontBitstreamType1(Package):
+    """X.org bitstream-type1 font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/bitstream-type1"
+    url      = "https://www.x.org/archive/individual/font/font-bitstream-type1-1.0.3.tar.gz"
+
+    version('1.0.3', 'ff91738c4d3646d7999e00aa9923f2a0')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-bitstream-type1/package.py
@@ -33,7 +33,8 @@ class FontBitstreamType1(Package):
 
     version('1.0.3', 'ff91738c4d3646d7999e00aa9923f2a0')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
@@ -33,7 +33,8 @@ class FontCronyxCyrillic(Package):
 
     version('1.0.3', '3119ba1bc7f775c162c96e17a912fe30')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-cronyx-cyrillic/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontCronyxCyrillic(Package):
+    """X.org cronyx-cyrillic font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/cronyx-cyrillic"
+    url      = "https://www.x.org/archive/individual/font/font-cronyx-cyrillic-1.0.3.tar.gz"
+
+    version('1.0.3', '3119ba1bc7f775c162c96e17a912fe30')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-cursor-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-cursor-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontCursorMisc(Package):
+    """X.org cursor-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/cursor-misc"
+    url      = "https://www.x.org/archive/individual/font/font-cursor-misc-1.0.3.tar.gz"
+
+    version('1.0.3', 'a0bf70c7e498f1cd8e3fdf6154f2bb00')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-cursor-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-cursor-misc/package.py
@@ -33,7 +33,8 @@ class FontCursorMisc(Package):
 
     version('1.0.3', 'a0bf70c7e498f1cd8e3fdf6154f2bb00')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
@@ -33,7 +33,8 @@ class FontDaewooMisc(Package):
 
     version('1.0.3', '71a7e2796f045c9d217a19c4e6c25bc1')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-daewoo-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontDaewooMisc(Package):
+    """X.org daewoo-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/daewoo-misc"
+    url      = "https://www.x.org/archive/individual/font/font-daewoo-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '71a7e2796f045c9d217a19c4e6c25bc1')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-dec-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-dec-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontDecMisc(Package):
+    """X.org dec-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/dec-misc"
+    url      = "https://www.x.org/archive/individual/font/font-dec-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '5a9242f6b60ecf2b8c5b158322ca2a40')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-dec-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-dec-misc/package.py
@@ -33,7 +33,8 @@ class FontDecMisc(Package):
 
     version('1.0.3', '5a9242f6b60ecf2b8c5b158322ca2a40')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-ibm-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-ibm-type1/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontIbmType1(Package):
+    """X.org ibm-type1 font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/ibm-type1"
+    url      = "https://www.x.org/archive/individual/font/font-ibm-type1-1.0.3.tar.gz"
+
+    version('1.0.3', '2806116e4adcb89d3d5ff5faf65e57c1')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-ibm-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-ibm-type1/package.py
@@ -33,7 +33,8 @@ class FontIbmType1(Package):
 
     version('1.0.3', '2806116e4adcb89d3d5ff5faf65e57c1')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-isas-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-isas-misc/package.py
@@ -33,7 +33,8 @@ class FontIsasMisc(Package):
 
     version('1.0.3', 'ecc3b6fbe8f5721ddf5c7fc66f73e76f')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-isas-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-isas-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontIsasMisc(Package):
+    """X.org isas-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/isas-misc"
+    url      = "https://www.x.org/archive/individual/font/font-isas-misc-1.0.3.tar.gz"
+
+    version('1.0.3', 'ecc3b6fbe8f5721ddf5c7fc66f73e76f')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-jis-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-jis-misc/package.py
@@ -33,7 +33,8 @@ class FontJisMisc(Package):
 
     version('1.0.3', 'c48ee5749ae25075d2c7a6111c195e7b')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-jis-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-jis-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontJisMisc(Package):
+    """X.org jis-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/jis-misc"
+    url      = "https://www.x.org/archive/individual/font/font-jis-misc-1.0.3.tar.gz"
+
+    version('1.0.3', 'c48ee5749ae25075d2c7a6111c195e7b')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-micro-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-micro-misc/package.py
@@ -33,7 +33,8 @@ class FontMicroMisc(Package):
 
     version('1.0.3', '4de3f0ce500aef85f198c52ace5e66ac')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-micro-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-micro-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMicroMisc(Package):
+    """X.org micro-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/micro-misc"
+    url      = "https://www.x.org/archive/individual/font/font-micro-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '4de3f0ce500aef85f198c52ace5e66ac')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMiscCyrillic(Package):
+    """X.org misc-cyrillic font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/misc-cyrillic"
+    url      = "https://www.x.org/archive/individual/font/font-misc-cyrillic-1.0.3.tar.gz"
+
+    version('1.0.3', 'e7b13da5325f62dd3f630beade6d2656')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-cyrillic/package.py
@@ -33,7 +33,8 @@ class FontMiscCyrillic(Package):
 
     version('1.0.3', 'e7b13da5325f62dd3f630beade6d2656')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMiscEthiopic(Package):
+    """X.org misc-ethiopic font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/misc-ethiopic"
+    url      = "https://www.x.org/archive/individual/font/font-misc-ethiopic-1.0.3.tar.gz"
+
+    version('1.0.3', '02ddea9338d9d36804ad38f3daadb55a')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-ethiopic/package.py
@@ -33,7 +33,8 @@ class FontMiscEthiopic(Package):
 
     version('1.0.3', '02ddea9338d9d36804ad38f3daadb55a')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-misc-meltho/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-meltho/package.py
@@ -33,7 +33,8 @@ class FontMiscMeltho(Package):
 
     version('1.0.3', '8380696483478449c39b04612f20eea8')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/font-misc-meltho/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-meltho/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMiscMeltho(Package):
+    """X.org misc-meltho font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/misc-meltho"
+    url      = "https://www.x.org/archive/individual/font/font-misc-meltho-1.0.3.tar.gz"
+
+    version('1.0.3', '8380696483478449c39b04612f20eea8')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-misc-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-misc/package.py
@@ -33,7 +33,8 @@ class FontMiscMisc(Package):
 
     version('1.1.2', '23a79b92275375315129b440206c85b9')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-misc-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-misc-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMiscMisc(Package):
+    """X.org misc-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/misc-misc"
+    url      = "https://www.x.org/archive/individual/font/font-misc-misc-1.1.2.tar.gz"
+
+    version('1.1.2', '23a79b92275375315129b440206c85b9')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-mutt-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-mutt-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontMuttMisc(Package):
+    """X.org mutt-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/mutt-misc"
+    url      = "https://www.x.org/archive/individual/font/font-mutt-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '6c2de53ba514f720e02af48eef28ff32')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-mutt-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-mutt-misc/package.py
@@ -33,7 +33,8 @@ class FontMuttMisc(Package):
 
     version('1.0.3', '6c2de53ba514f720e02af48eef28ff32')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
@@ -33,7 +33,8 @@ class FontSchumacherMisc(Package):
 
     version('1.1.2', '1f3386a0a690ba8117fc05b501f9f91b')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-schumacher-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontSchumacherMisc(Package):
+    """X.org schumacher-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/schumacher-misc"
+    url      = "https://www.x.org/archive/individual/font/font-schumacher-misc-1.1.2.tar.gz"
+
+    version('1.1.2', '1f3386a0a690ba8117fc05b501f9f91b')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
@@ -33,7 +33,8 @@ class FontScreenCyrillic(Package):
 
     version('1.0.4', '4cadaf2ba4c4d0f4cb9b4e7b8f0a3019')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-screen-cyrillic/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontScreenCyrillic(Package):
+    """X.org screen-cyrillic font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/screen-cyrillic"
+    url      = "https://www.x.org/archive/individual/font/font-screen-cyrillic-1.0.4.tar.gz"
+
+    version('1.0.4', '4cadaf2ba4c4d0f4cb9b4e7b8f0a3019')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-sony-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sony-misc/package.py
@@ -33,7 +33,8 @@ class FontSonyMisc(Package):
 
     version('1.0.3', '4026cb88e2253efc0b8376003780ccb6')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-sony-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sony-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontSonyMisc(Package):
+    """X.org sony-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/sony-misc"
+    url      = "https://www.x.org/archive/individual/font/font-sony-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '4026cb88e2253efc0b8376003780ccb6')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-sun-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sun-misc/package.py
@@ -33,7 +33,7 @@ class FontSunMisc(Package):
 
     version('1.0.3', '87ce97ce0582e76bc4064a4d4d10db09')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-sun-misc/package.py
+++ b/var/spack/repos/builtin/packages/font-sun-misc/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontSunMisc(Package):
+    """X.org sun-misc font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/sun-misc"
+    url      = "https://www.x.org/archive/individual/font/font-sun-misc-1.0.3.tar.gz"
+
+    version('1.0.3', '87ce97ce0582e76bc4064a4d4d10db09')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontUtil(Package):
+    """X.Org font package creation/installation utilities."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/util"
+    url      = "https://www.x.org/archive/individual/font/font-util-1.3.1.tar.gz"
+
+    version('1.3.1', 'd153a9af216e4498fa171faea2c82514')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
@@ -33,7 +33,8 @@ class FontWinitzkiCyrillic(Package):
 
     version('1.0.3', '777c667b080b33793528d5abf3247a48')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('bdftopcf', type='build')

--- a/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
+++ b/var/spack/repos/builtin/packages/font-winitzki-cyrillic/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontWinitzkiCyrillic(Package):
+    """X.org winitzki-cyrillic font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/winitzki-cyrillic"
+    url      = "https://www.x.org/archive/individual/font/font-winitzki-cyrillic-1.0.3.tar.gz"
+
+    version('1.0.3', '777c667b080b33793528d5abf3247a48')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FontXfree86Type1(Package):
+    """X.org xfree86-type1 font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/font/xfree86-type1"
+    url      = "https://www.x.org/archive/individual/font/font-xfree86-type1-1.0.4.tar.gz"
+
+    version('1.0.4', '89c33c5176cd580de6636ad50ce7777b')
+
+    depends_on('font-util', type='build')
+    depends_on('fontconfig', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('mkfontscale', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')
+
+        # `make install` copies the files to the font-util installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
+++ b/var/spack/repos/builtin/packages/font-xfree86-type1/package.py
@@ -33,7 +33,8 @@ class FontXfree86Type1(Package):
 
     version('1.0.4', '89c33c5176cd580de6636ad50ce7777b')
 
-    depends_on('font-util', type='build')
+    depends_on('font-util')
+
     depends_on('fontconfig', type='build')
     depends_on('mkfontdir', type='build')
     depends_on('mkfontscale', type='build')

--- a/var/spack/repos/builtin/packages/fontcacheproto/package.py
+++ b/var/spack/repos/builtin/packages/fontcacheproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Fontcacheproto(Package):
+    """X.org FontcacheProto protocol headers."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/fontcacheproto"
+    url      = "https://www.x.org/archive/individual/proto/fontcacheproto-0.1.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('0.1.3', '5a91ab914ffbfbc856e6fcde52e6f3e3')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/builtin/packages/fontsproto/package.py
@@ -33,6 +33,9 @@ class Fontsproto(Package):
 
     version('2.1.3', '0415f0360e33f3202af67c6c46782251')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/builtin/packages/fontsproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Fontsproto(Package):
+    """X Fonts Extension."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/fontsproto"
+    url      = "https://www.x.org/archive/individual/proto/fontsproto-2.1.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.1.3', '0415f0360e33f3202af67c6c46782251')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/fonttosfnt/package.py
+++ b/var/spack/repos/builtin/packages/fonttosfnt/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fonttosfnt(Package):
+    """Wrap a bitmap font in a sfnt (TrueType) wrapper."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/fonttosfnt"
+    url      = "https://www.x.org/archive/individual/app/fonttosfnt-1.0.4.tar.gz"
+
+    version('1.0.4', 'ba77fd047a9cca400f17db8c46b06ce8')
+
+    depends_on('freetype')
+    depends_on('libfontenc')
+
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/fslsfonts/package.py
+++ b/var/spack/repos/builtin/packages/fslsfonts/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fslsfonts(Package):
+    """fslsfonts produces a list of fonts served by an X font server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/fslsfonts"
+    url      = "https://www.x.org/archive/individual/app/fslsfonts-1.0.5.tar.gz"
+
+    version('1.0.5', 'ef781bd6a7b529d3ed7a256055715730')
+
+    depends_on('libfs')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/fstobdf/package.py
+++ b/var/spack/repos/builtin/packages/fstobdf/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fstobdf(Package):
+    """The fstobdf program reads a font from a font server and prints a BDF
+    file on the standard output that may be used to recreate the font.
+    This is useful in testing servers, debugging font metrics, and
+    reproducing lost BDF files."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/fstobdf"
+    url      = "https://www.x.org/archive/individual/app/fstobdf-1.0.6.tar.gz"
+
+    version('1.0.6', '6d3f24673fcb9ce266f49dc140bbf250')
+
+    depends_on('libx11')
+    depends_on('libfs')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/gccmakedep/package.py
+++ b/var/spack/repos/builtin/packages/gccmakedep/package.py
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Gccmakedep(Package):
+    """X.org gccmakedep utilities."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/util/gccmakedep/"
+    url      = "https://www.x.org/archive/individual/util/gccmakedep-1.0.3.tar.gz"
+
+    version('1.0.3', '127ddb6131eb4a56fdf6644a63ade788')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/gconf/package.py
+++ b/var/spack/repos/builtin/packages/gconf/package.py
@@ -26,26 +26,26 @@ from spack import *
 
 
 class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+    """GConf is a system for storing application preferences."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
+    homepage = "https://projects.gnome.org/gconf/"
     url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
 
     version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
 
     depends_on('glib@2.14.0:')
+    depends_on('libxml2')
+
+    # TODO: add missing dependencies
     # gio-2.0 >= 2.31.0
     # gthread-2.0
     # gmodule-2.0 >= 2.7.0
     # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    # dbus-1 >= 1.0.0
+    # dbus-glib-1 >= 0.74
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/gconf/package.py
+++ b/var/spack/repos/builtin/packages/gconf/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Gconf(Package):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "http://www.example.com"
+    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+
+    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')
+
+    def install(self, spec, prefix):
+        # FIXME: Modify the configure line to suit your build system here.
+        configure('--prefix={0}'.format(prefix))
+
+        # FIXME: Add logic to build and install here.
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/glproto/package.py
+++ b/var/spack/repos/builtin/packages/glproto/package.py
@@ -36,6 +36,9 @@ class Glproto(Package):
 
     version('1.4.17', 'd69554c1b51a83f2c6976a640819911b')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/glproto/package.py
+++ b/var/spack/repos/builtin/packages/glproto/package.py
@@ -26,7 +26,10 @@ from spack import *
 
 
 class Glproto(Package):
-    """X11 OpenGL extension wire protocol."""
+    """OpenGL Extension to the X Window System.
+
+    This extension defines a protocol for the client to send 3D rendering
+    commands to the X server."""
 
     homepage = "https://www.x.org/wiki/"
     url      = "https://www.x.org/archive/individual/proto/glproto-1.4.17.tar.gz"

--- a/var/spack/repos/builtin/packages/glproto/package.py
+++ b/var/spack/repos/builtin/packages/glproto/package.py
@@ -25,22 +25,15 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class Glproto(Package):
+    """X11 OpenGL extension wire protocol."""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "https://www.x.org/wiki/"
+    url      = "https://www.x.org/archive/individual/proto/glproto-1.4.17.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('1.4.17', 'd69554c1b51a83f2c6976a640819911b')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
-        make()
-        # make('check')  # fails tests
         make('install')

--- a/var/spack/repos/builtin/packages/grandr/package.py
+++ b/var/spack/repos/builtin/packages/grandr/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Grandr(Package):
+    """RandR user interface using GTK+ libraries."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/app/grandr"
+    url      = "https://www.x.org/archive/individual/app/grandr-0.1.tar.gz"
+
+    version('0.1', '707109a105f2ab1bb216e6e6a5a10ba4')
+
+    depends_on('gtkplus@2.0.0:')
+    depends_on('gconf')
+    depends_on('xrandr@1.2:')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/hsakmt/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt/package.py
@@ -25,19 +25,17 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Hsakmt(Package):
+    """hsakmt is a thunk library that provides a userspace interface to amdkfd
+    (AMD's HSA Linux kernel driver). It is the HSA equivalent of libdrm."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "https://cgit.freedesktop.org/amd/hsakmt/"
+    url      = "https://www.x.org/archive/individual/lib/hsakmt-1.0.0.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.0.0', '9beb20104e505300daf541266c4c3c3d')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/iceauth/package.py
+++ b/var/spack/repos/builtin/packages/iceauth/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Iceauth(Package):
+    """The iceauth program is used to edit and display the authorization
+    information used in connecting with ICE.   It operates very much
+    like the xauth program for X11 connection authentication records."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/iceauth"
+    url      = "https://www.x.org/archive/individual/app/iceauth-1.0.7.tar.gz"
+
+    version('1.0.7', '183e834ec8bd096ac084ad4acbc29f51')
+
+    depends_on('libice')
+
+    depends_on('xproto@7.0.22:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/ico/package.py
+++ b/var/spack/repos/builtin/packages/ico/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Ico(Package):
+    """ico is a simple animation program that may be used for testing various
+    X11 operations and extensions.  It displays a wire-frame rotating
+    polyhedron, with hidden lines removed, or a solid-fill polyhedron with
+    hidden faces removed."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/ico"
+    url      = "https://www.x.org/archive/individual/app/ico-1.0.4.tar.gz"
+
+    version('1.0.4', '8833b2da01a7f919b0db8e5a49184c0f')
+
+    depends_on('libx11@0.99.1:')
+
+    depends_on('xproto@7.0.22:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/imake/package.py
+++ b/var/spack/repos/builtin/packages/imake/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Imake(Package):
+    """The imake build system."""
+
+    homepage = "http://www.snake.net/software/imake-stuff/"
+    url      = "https://www.x.org/archive/individual/util/imake-1.0.7.tar.gz"
+
+    version('1.0.7', '186ca7b8ff0de8752f2a2d0426542363')
+
+    depends_on('xproto')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/imake/package.py
+++ b/var/spack/repos/builtin/packages/imake/package.py
@@ -33,8 +33,7 @@ class Imake(Package):
 
     version('1.0.7', '186ca7b8ff0de8752f2a2d0426542363')
 
-    depends_on('xproto')
-
+    depends_on('xproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/inputproto/package.py
+++ b/var/spack/repos/builtin/packages/inputproto/package.py
@@ -36,6 +36,9 @@ class Inputproto(Package):
 
     version('2.3.2', '6450bad6f8d5ebe354b01b734d1fd7ca')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/inputproto/package.py
+++ b/var/spack/repos/builtin/packages/inputproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Inputproto(Package):
+    """X Input Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol to provide additional input devices
+    management such as graphic tablets."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/inputproto"
+    url      = "https://www.x.org/archive/individual/proto/inputproto-2.3.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.3.2', '6450bad6f8d5ebe354b01b734d1fd7ca')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
+++ b/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
@@ -1,0 +1,67 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class IntelGpuTools(Package):
+    """Intel GPU Tools is a collection of tools for development and testing of
+    the Intel DRM driver. There are many macro-level test suites that get used
+    against the driver, including xtest, rendercheck, piglit, and oglconform,
+    but failures from those can be difficult to track down to kernel changes,
+    and many require complicated build procedures or specific testing
+    environments to get useful results. Therefore, Intel GPU Tools includes
+    low-level tools and tests specifically for development and testing of the
+    Intel DRM Driver."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/app/intel-gpu-tools/"
+    url      = "https://www.x.org/archive/individual/app/intel-gpu-tools-1.16.tar.gz"
+
+    version('1.16', '3996f10fc86a28ec59e1cf7b227dad78')
+
+    depends_on('libdrm@2.4.64:')
+    depends_on('libpciaccess@0.10:')
+    depends_on('cairo@1.12.0:')
+    depends_on('glib')
+
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
+    depends_on('python@3:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    # xrandr ?
+
+    # gtk-doc-tools
+    # libunwind-dev
+    # python-docutils
+    # x11proto-dri2-dev
+    # xutils-dev
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/kbproto/package.py
+++ b/var/spack/repos/builtin/packages/kbproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Kbproto(Package):
+    """X Keyboard Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protcol to provide a number of new capabilities
+    and controls for text keyboards."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/kbproto"
+    url      = "https://www.x.org/archive/individual/proto/kbproto-1.0.7.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.0.7', '19acc5f02ae80381e216f443134e0bbb')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/kbproto/package.py
+++ b/var/spack/repos/builtin/packages/kbproto/package.py
@@ -36,6 +36,9 @@ class Kbproto(Package):
 
     version('1.0.7', '19acc5f02ae80381e216f443134e0bbb')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/lbxproxy/package.py
+++ b/var/spack/repos/builtin/packages/lbxproxy/package.py
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Lbxproxy(Package):
+    """lbxproxy accepts client connections, multiplexes them over a single
+    connection to the X server, and performs various optimizations on the
+    X protocol to make it faster over low bandwidth and/or high latency
+    connections.
+
+    Note that the X server source from X.Org no longer supports the LBX
+    extension, so this program is only useful in connecting to older
+    X servers."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/lbxproxy"
+    url      = "https://www.x.org/archive/individual/app/lbxproxy-1.0.3.tar.gz"
+
+    version('1.0.3', '50a2a1ae15e8edf7582f76bcdf6b8197')
+
+    depends_on('libxext')
+    depends_on('liblbxutil')
+    depends_on('libx11')
+    depends_on('libice')
+
+    depends_on('xtrans', type='build')
+    depends_on('xproxymanagementprotocol', type='build')
+    depends_on('bigreqsproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/libapplewm/package.py
+++ b/var/spack/repos/builtin/packages/libapplewm/package.py
@@ -38,8 +38,10 @@ class Libapplewm(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('applewmproto@1.4:')
+    depends_on('xextproto', type='build')
+    depends_on('applewmproto@1.4:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libapplewm/package.py
+++ b/var/spack/repos/builtin/packages/libapplewm/package.py
@@ -25,19 +25,28 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libapplewm(Package):
+    """AppleWM is a simple library designed to interface with the Apple-WM
+    extension. This extension allows X window managers to better interact with
+    the Mac OS X Aqua user interface when running X11 in a rootless mode."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libAppleWM"
+    url      = "https://www.x.org/archive/individual/lib/libAppleWM-1.4.1.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.4.1', '52c587641eb57f00978d28d98d487af8')
+
+    depends_on('libx11')
+    depends_on('libxext')
+
+    depends_on('xextproto')
+    depends_on('applewmproto@1.4:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
+        # Crashes with this error message on Linux:
+        # HIServices/Processes.h: No such file or directory
+        # May only build properly on macOS?
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libdmx/package.py
+++ b/var/spack/repos/builtin/packages/libdmx/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libdmx(Package):
+    """libdmx - X Window System DMX (Distributed Multihead X) extension
+    library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libdmx"
+    url      = "https://www.x.org/archive/individual/lib/libdmx-1.1.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.1.3', 'eed755e7cdb161e05f70e955f2b0ef4d')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('dmxproto@2.2.99.1:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libdmx/package.py
+++ b/var/spack/repos/builtin/packages/libdmx/package.py
@@ -37,8 +37,10 @@ class Libdmx(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('dmxproto@2.2.99.1:')
+    depends_on('xextproto', type='build')
+    depends_on('dmxproto@2.2.99.1:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -30,16 +30,20 @@ class Libdrm(Package):
     rendering  manager, on  Linux,  BSD and  other  operating
     systems that support the  ioctl interface."""
 
-    homepage = "http://dri.freedesktop.org/libdrm/"  # no real website...
+    homepage = "http://dri.freedesktop.org/libdrm/"
     url      = "http://dri.freedesktop.org/libdrm/libdrm-2.4.59.tar.gz"
 
+    version('2.4.70', 'a8c275bce5f3d71a5ca25e8fb60df084')
     version('2.4.59', '105ac7af1afcd742d402ca7b4eb168b6')
     version('2.4.33', '86e4e3debe7087d5404461e0032231c8')
 
     depends_on('libpciaccess')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure('--prefix={0}'.format(prefix),
+                  '--enable-static',
+                  'LIBS=-lrt')  # This fixes a bug with `make check`
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -37,7 +37,8 @@ class Libdrm(Package):
     version('2.4.59', '105ac7af1afcd742d402ca7b4eb168b6')
     version('2.4.33', '86e4e3debe7087d5404461e0032231c8')
 
-    depends_on('libpciaccess')
+    depends_on('libpciaccess@0.10:')
+    depends_on('libpthread-stubs')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix),

--- a/var/spack/repos/builtin/packages/libfontenc/package.py
+++ b/var/spack/repos/builtin/packages/libfontenc/package.py
@@ -33,7 +33,11 @@ class Libfontenc(Package):
 
     version('1.1.3', '0ffa28542aa7d246299b1f7211cdb768')
 
-    depends_on('xproto')
+    depends_on('zlib')
+
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libfontenc/package.py
+++ b/var/spack/repos/builtin/packages/libfontenc/package.py
@@ -25,19 +25,18 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libfontenc(Package):
+    """libfontenc - font encoding library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libfontenc"
+    url      = "https://www.x.org/archive/individual/lib/libfontenc-1.1.3.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.3', '0ffa28542aa7d246299b1f7211cdb768')
+
+    depends_on('xproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libfs/package.py
+++ b/var/spack/repos/builtin/packages/libfs/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libfs(Package):
+    """libFS - X Font Service client library.
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    This library is used by clients of X Font Servers (xfs), such as
+    xfsinfo, fslsfonts, and the X servers themselves."""
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libFS"
+    url      = "https://www.x.org/archive/individual/lib/libFS-1.0.7.tar.gz"
+
+    version('1.0.7', 'd8c1246f5b3d0e7ccf2190d3bf2ecb73')
+
+    depends_on('xproto@7.0.17:')
+    depends_on('fontsproto')
+    depends_on('xtrans')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libfs/package.py
+++ b/var/spack/repos/builtin/packages/libfs/package.py
@@ -36,9 +36,11 @@ class Libfs(Package):
 
     version('1.0.7', 'd8c1246f5b3d0e7ccf2190d3bf2ecb73')
 
-    depends_on('xproto@7.0.17:')
-    depends_on('fontsproto')
-    depends_on('xtrans')
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('fontsproto', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -25,19 +25,19 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libice(Package):
+    """libICE - Inter-Client Exchange Library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libICE"
+    url      = "https://www.x.org/archive/individual/lib/libICE-1.0.9.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.0.9', '95812d61df8139c7cacc1325a26d5e37')
+
+    depends_on('xproto')
+    depends_on('xtrans')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -33,8 +33,10 @@ class Libice(Package):
 
     version('1.0.9', '95812d61df8139c7cacc1325a26d5e37')
 
-    depends_on('xproto')
-    depends_on('xtrans')
+    depends_on('xproto', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/liblbxutil/package.py
+++ b/var/spack/repos/builtin/packages/liblbxutil/package.py
@@ -33,8 +33,10 @@ class Liblbxutil(Package):
 
     version('1.1.0', '2735cd23625d4cc870ec4eb7ca272788')
 
-    depends_on('xextproto@7.0.99.1:')
-    depends_on('xproto')
+    depends_on('xextproto@7.0.99.1:', type='build')
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     # There is a bug in the library that causes the following messages:
     # undefined symbol: Xfree

--- a/var/spack/repos/builtin/packages/liblbxutil/package.py
+++ b/var/spack/repos/builtin/packages/liblbxutil/package.py
@@ -25,23 +25,25 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Liblbxutil(Package):
+    """liblbxutil - Low Bandwith X extension (LBX) utility routines."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/liblbxutil"
+    url      = "https://www.x.org/archive/individual/lib/liblbxutil-1.1.0.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.1.0', '2735cd23625d4cc870ec4eb7ca272788')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
-
+    depends_on('xextproto@7.0.99.1:')
     depends_on('xproto')
+
+    # There is a bug in the library that causes the following messages:
+    # undefined symbol: Xfree
+    # undefined symbol: Xalloc
+    # See https://bugs.freedesktop.org/show_bug.cgi?id=8421
+    # Adding a dependency on libxdmcp and adding LIBS=-lXdmcp did not fix it
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/liboldx/package.py
+++ b/var/spack/repos/builtin/packages/liboldx/package.py
@@ -35,6 +35,9 @@ class Liboldx(Package):
 
     depends_on('libx11')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/liboldx/package.py
+++ b/var/spack/repos/builtin/packages/liboldx/package.py
@@ -25,23 +25,18 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Liboldx(Package):
+    """X version 10 backwards compatibility."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/liboldX/"
+    url      = "https://www.x.org/archive/individual/lib/liboldX-1.0.1.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.1', 'ea7c4b6a19bf2d04100e2580abf83fae')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
-
-    depends_on('xproto')
+    depends_on('libx11')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -29,11 +29,13 @@ class Libpciaccess(Package):
     """Generic PCI access library."""
 
     homepage = "http://cgit.freedesktop.org/xorg/lib/libpciaccess/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libpciaccess-0.13.4.tar.bz2"
+    url      = "http://xorg.freedesktop.org/archive/individual/lib/libpciaccess-0.13.4.tar.gz"
 
-    version('0.13.4', 'ace78aec799b1cf6dfaea55d3879ed9f')
+    version('0.13.4', 'cc1fad87da60682af1d5fa43a5da45a4')
 
     depends_on('libtool', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         # libpciaccess does not support OS X
@@ -42,6 +44,7 @@ class Libpciaccess(Package):
             mkdir(prefix.lib)
             return
 
-        configure("--prefix=%s" % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libpthread-stubs/package.py
+++ b/var/spack/repos/builtin/packages/libpthread-stubs/package.py
@@ -27,13 +27,12 @@ from spack import *
 
 class LibpthreadStubs(Package):
     """The libpthread-stubs package provides weak aliases for pthread
-       functions not provided in libc or otherwise available by
-       default."""
+    functions not provided in libc or otherwise available by default."""
 
-    homepage = "http://xcb.freedesktop.org/"
-    url      = "http://xcb.freedesktop.org/dist/libpthread-stubs-0.1.tar.bz2"
+    homepage = "https://xcb.freedesktop.org/"
+    url      = "https://xcb.freedesktop.org/dist/libpthread-stubs-0.3.tar.gz"
 
-    version('0.3', 'e8fa31b42e13f87e8f5a7a2b731db7ee')
+    version('0.3', 'a09d928c4af54fe5436002345ef71138')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libpthread-stubs/package.py
+++ b/var/spack/repos/builtin/packages/libpthread-stubs/package.py
@@ -28,13 +28,14 @@ from spack import *
 class LibpthreadStubs(Package):
     """The libpthread-stubs package provides weak aliases for pthread
        functions not provided in libc or otherwise available by
-       default. """
+       default."""
+
     homepage = "http://xcb.freedesktop.org/"
     url      = "http://xcb.freedesktop.org/dist/libpthread-stubs-0.1.tar.bz2"
 
     version('0.3', 'e8fa31b42e13f87e8f5a7a2b731db7ee')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -25,19 +25,20 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libsm(Package):
+    """libSM - X Session Management Library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libSM"
+    url      = "https://www.x.org/archive/individual/lib/libSM-1.2.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.2.2', '18e5084ed9500b1b47719fd1758f0ec8')
+
+    depends_on('libice@1.0.5:')
+    depends_on('xproto')
+    depends_on('xtrans')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -34,8 +34,11 @@ class Libsm(Package):
     version('1.2.2', '18e5084ed9500b1b47719fd1758f0ec8')
 
     depends_on('libice@1.0.5:')
-    depends_on('xproto')
-    depends_on('xtrans')
+
+    depends_on('xproto', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libwindowswm/package.py
+++ b/var/spack/repos/builtin/packages/libwindowswm/package.py
@@ -25,19 +25,27 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libwindowswm(Package):
+    """WindowsWM - Cygwin/X rootless window management extension.
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    WindowsWM is a simple library designed to interface with the
+    Windows-WM extension.  This extension allows X window managers to
+    better interact with the Cygwin XWin server when running X11 in a
+    rootless mode."""
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libWindowsWM"
+    url      = "https://www.x.org/archive/individual/lib/libWindowsWM-1.0.1.tar.gz"
+
+    version('1.0.1', 'f260e124706ff6209c566689528667c6')
+
+    depends_on('libx11')
+    depends_on('libxext')
+
+    depends_on('xextproto')
+    depends_on('windowswmproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libwindowswm/package.py
+++ b/var/spack/repos/builtin/packages/libwindowswm/package.py
@@ -41,8 +41,10 @@ class Libwindowswm(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('windowswmproto')
+    depends_on('xextproto', type='build')
+    depends_on('windowswmproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -35,11 +35,13 @@ class Libx11(Package):
 
     depends_on('libxcb@1.1.92:')
 
-    depends_on('xproto@7.0.17:')
-    depends_on('xextproto')
-    depends_on('xtrans')
-    depends_on('kbproto')
-    depends_on('inputproto')
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('kbproto', type='build')
+    depends_on('inputproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -25,19 +25,25 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Libx11(Package):
+    """Core X11 protocol client library."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://www.x.org/"
+    url      = "https://www.x.org/archive//individual/lib/libX11-1.6.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    version('1.6.3', '7d16653fe7c36209799175bb3dc1ae46')
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    depends_on('libxau')
+    depends_on('libxcb@1.1.92:')
+    depends_on('xproto@7.0.17:')
+    depends_on('xextproto')
+    depends_on('xtrans')
+    depends_on('kbproto')
+    depends_on('inputproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
+        make()
+        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -26,15 +26,15 @@ from spack import *
 
 
 class Libx11(Package):
-    """Core X11 protocol client library."""
+    """libX11 - Core X11 protocol client library."""
 
     homepage = "https://www.x.org/"
-    url      = "https://www.x.org/archive//individual/lib/libX11-1.6.3.tar.gz"
+    url      = "https://www.x.org/archive/individual/lib/libX11-1.6.3.tar.gz"
 
     version('1.6.3', '7d16653fe7c36209799175bb3dc1ae46')
 
-    depends_on('libxau')
     depends_on('libxcb@1.1.92:')
+
     depends_on('xproto@7.0.17:')
     depends_on('xextproto')
     depends_on('xtrans')

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -27,16 +27,15 @@ from spack import *
 
 class Libxau(Package):
     """The libXau package contains a library implementing the X11
-       Authorization Protocol. This is useful for restricting client
-       access to the display."""
+    Authorization Protocol. This is useful for restricting client
+    access to the display."""
 
-    homepage = "http://xcb.freedesktop.org/"
-    url      = "http://ftp.x.org/pub/individual/lib/libXau-1.0.8.tar.bz2"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXau/"
+    url      = "https://www.x.org/archive/individual/lib/libXau-1.0.8.tar.gz"
 
-    version('1.0.8', '685f8abbffa6d145c0f930f00703b21b')
+    version('1.0.8', 'a85cd601d82bc79c0daa280917572e20')
 
     depends_on('xproto')
-    depends_on('pkg-config', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -35,7 +35,9 @@ class Libxau(Package):
 
     version('1.0.8', 'a85cd601d82bc79c0daa280917572e20')
 
-    depends_on('xproto')
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -29,6 +29,7 @@ class Libxau(Package):
     """The libXau package contains a library implementing the X11
        Authorization Protocol. This is useful for restricting client
        access to the display."""
+
     homepage = "http://xcb.freedesktop.org/"
     url      = "http://ftp.x.org/pub/individual/lib/libXau-1.0.8.tar.bz2"
 
@@ -38,7 +39,8 @@ class Libxau(Package):
     depends_on('pkg-config', type='build')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -25,19 +25,26 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxaw(Package):
+    """Xaw is the X Athena Widget Set.
+    Xaw is a widget set based on the X Toolkit Intrinsics (Xt) Library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXaw"
+    url      = "https://www.x.org/archive/individual/lib/libXaw-1.0.13.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.0.13', '6c522476024df5872cddc5f1562fb656')
+
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxt')
+    depends_on('libxmu')
+    depends_on('libxpm')
+
+    depends_on('xproto')
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -40,8 +40,10 @@ class Libxaw(Package):
     depends_on('libxmu')
     depends_on('libxpm')
 
-    depends_on('xproto')
-    depends_on('xextproto')
+    depends_on('xproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxaw3d(Package):
+    """Xaw3d is the X 3D Athena Widget Set.
+    Xaw3d is a widget set based on the X Toolkit Intrinsics (Xt) Library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXaw3d"
+    url      = "https://www.x.org/archive/individual/lib/libXaw3d-1.6.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.6.2', 'e51e00b734853e555ae9b367d213de45')
+
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxmu')
+    depends_on('libxext')
+    depends_on('libxpm')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -40,6 +40,9 @@ class Libxaw3d(Package):
     depends_on('libxext')
     depends_on('libxpm')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -34,14 +34,18 @@ class Libxcb(Package):
     homepage = "http://xcb.freedesktop.org/"
     url      = "http://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
 
+    version('1.12', '95eee7c28798e16ba5443f188b27a476')
     version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
     version('1.11.1', '118623c15a96b08622603a71d8789bf3')
 
-    depends_on("python", type='build')
-    depends_on("xcb-proto")
-    depends_on("pkg-config", type='build')
-    depends_on("libpthread-stubs")
+    depends_on('pkg-config@0.15.0:', type='build')
+    depends_on('python@2:2.8', type='build')
+    depends_on('gperf@3.0.1:')
+
+    # Xorg modules
     depends_on('libxau')
+    depends_on('xcb-proto')
+    depends_on('libpthread-stubs')
 
     def patch(self):
         filter_file(
@@ -50,9 +54,10 @@ class Libxcb(Package):
             'src/xcb.h')
 
     def install(self, spec, prefix):
-        env['PKG_CONFIG_PATH'] = env[
-            'PKG_CONFIG_PATH'] + ':/usr/lib64/pkgconfig'
-        configure("--prefix=%s" % prefix)
+        env['PKG_CONFIG_PATH'] += ':/usr/lib64/pkgconfig'
+
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -25,19 +25,22 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxcomposite(Package):
+    """libXcomposite - client library for the Composite extension to the
+    X11 protocol."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXcomposite"
+    url      = "https://www.x.org/archive/individual/lib/libXcomposite-0.4.4.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('0.4.4', 'af860b1554a423735d831e6f29ac1ef5')
+
+    depends_on('libx11')
+    depends_on('libxfixes')
+
+    depends_on('compositeproto@0.4:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -37,7 +37,9 @@ class Libxcomposite(Package):
     depends_on('libx11')
     depends_on('libxfixes')
 
-    depends_on('compositeproto@0.4:')
+    depends_on('compositeproto@0.4:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -37,7 +37,9 @@ class Libxcursor(Package):
     depends_on('libxfixes')
     depends_on('libx11')
 
-    depends_on('fixesproto')
+    depends_on('fixesproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -25,19 +25,22 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxcursor(Package):
+    """libXcursor - X Window System Cursor management library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXcursor"
+    url      = "https://www.x.org/archive/individual/lib/libXcursor-1.1.14.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.14', '39c8423de190d64f1c52fbc00022e52c')
+
+    depends_on('libxrender@0.8.2:')
+    depends_on('libxfixes')
+    depends_on('libx11')
+
+    depends_on('fixesproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -36,9 +36,11 @@ class Libxdamage(Package):
     depends_on('libxfixes')
     depends_on('libx11')
 
-    depends_on('damageproto@1.1:')
-    depends_on('fixesproto')
-    depends_on('xextproto')
+    depends_on('damageproto@1.1:', type='build')
+    depends_on('fixesproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxdamage(Package):
+    """This package contains the library for the X Damage extension."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXdamage"
+    url      = "https://www.x.org/archive/individual/lib/libXdamage-1.1.4.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.4', '95867778da012623815214769007c0d7')
+
+    depends_on('libxfixes')
+    depends_on('libx11')
+
+    depends_on('damageproto@1.1:')
+    depends_on('fixesproto')
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -25,19 +25,19 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxdmcp(Package):
+    """libXdmcp - X Display Manager Control Protocol library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXdmcp"
+    url      = "https://www.x.org/archive/individual/lib/libXdmcp-1.1.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.2', 'ab0d6a38f0344a05d698ec7d48cfa5a8')
+
+    depends_on('xproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -33,7 +33,9 @@ class Libxdmcp(Package):
 
     version('1.1.2', 'ab0d6a38f0344a05d698ec7d48cfa5a8')
 
-    depends_on('xproto')
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxevie/package.py
+++ b/var/spack/repos/builtin/packages/libxevie/package.py
@@ -36,9 +36,11 @@ class Libxevie(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xproto')
-    depends_on('xextproto')
-    depends_on('evieext')
+    depends_on('xproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('evieext', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxevie/package.py
+++ b/var/spack/repos/builtin/packages/libxevie/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxevie(Package):
+    """Xevie - X Event Interception Extension (XEvIE)."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXevie"
+    url      = "https://www.x.org/archive/individual/lib/libXevie-1.0.3.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.0.3', '100e6485cabfe6e788e09c110ca680d8')
+
+    depends_on('libx11')
+    depends_on('libxext')
+
+    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('evieext')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -35,8 +35,10 @@ class Libxext(Package):
 
     depends_on('libx11@1.6:')
 
-    depends_on('xproto@7.0.13:')
-    depends_on('xextproto@7.1.99:')
+    depends_on('xproto@7.0.13:', type='build')
+    depends_on('xextproto@7.1.99:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -25,19 +25,20 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Libxext(Package):
+    """library for common extensions to the X11 protocol."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://www.x.org/"
+    url      = "https://www.x.org/archive/individual/lib/libXext-1.3.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    version('1.3.3', '93f5ec084c998efbfb0befed22f9b57f')
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    depends_on('libx11')
+    depends_on('libxcb')
+    depends_on('libxau')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
+        make()
         make('install')

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -26,16 +26,17 @@ from spack import *
 
 
 class Libxext(Package):
-    """library for common extensions to the X11 protocol."""
+    """libXext - library for common extensions to the X11 protocol."""
 
-    homepage = "https://www.x.org/"
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXext"
     url      = "https://www.x.org/archive/individual/lib/libXext-1.3.3.tar.gz"
 
     version('1.3.3', '93f5ec084c998efbfb0befed22f9b57f')
 
-    depends_on('libx11')
-    depends_on('libxcb')
-    depends_on('libxau')
+    depends_on('libx11@1.6:')
+
+    depends_on('xproto@7.0.13:')
+    depends_on('xextproto@7.1.99:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxfixes(Package):
+    """This package contains header files and documentation for the XFIXES
+    extension.  Library and server implementations are separate."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfixes"
+    url      = "https://www.x.org/archive/individual/lib/libXfixes-5.0.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('5.0.2', '3636e59f8f5fa2e469d556d49f30e98d')
+
+    depends_on('libx11@1.6:')
+
+    depends_on('xproto')
+    depends_on('fixesproto@5.0:')
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -36,9 +36,11 @@ class Libxfixes(Package):
 
     depends_on('libx11@1.6:')
 
-    depends_on('xproto')
-    depends_on('fixesproto@5.0:')
-    depends_on('xextproto')
+    depends_on('xproto', type='build')
+    depends_on('fixesproto@5.0:', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxfont/package.py
+++ b/var/spack/repos/builtin/packages/libxfont/package.py
@@ -25,19 +25,28 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxfont(Package):
+    """libXfont provides the core of the legacy X11 font system, handling the
+    index files (fonts.dir, fonts.alias, fonts.scale), the various font file
+    formats, and rasterizing them.   It is used by the X servers, the
+    X Font Server (xfs), and some font utilities (bdftopcf for instance),
+    but should not be used by normal X11 clients.  X11 clients access fonts
+    via either the new API's in libXft, or the legacy API's in libX11."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfont"
+    url      = "https://www.x.org/archive/individual/lib/libXfont-1.5.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.5.2', 'e8c616db0e59df4614980915e79bb05e')
+
+    depends_on('xtrans')
+    depends_on('libfontenc')
+    depends_on('freetype')
+
+    depends_on('xproto')
+    depends_on('fontsproto@2.1.3:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxfont/package.py
+++ b/var/spack/repos/builtin/packages/libxfont/package.py
@@ -38,12 +38,14 @@ class Libxfont(Package):
 
     version('1.5.2', 'e8c616db0e59df4614980915e79bb05e')
 
-    depends_on('xtrans')
     depends_on('libfontenc')
     depends_on('freetype')
 
-    depends_on('xproto')
-    depends_on('fontsproto@2.1.3:')
+    depends_on('xtrans', type='build')
+    depends_on('xproto', type='build')
+    depends_on('fontsproto@2.1.3:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -25,19 +25,28 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxfont2(Package):
+    """libXfont provides the core of the legacy X11 font system, handling the
+    index files (fonts.dir, fonts.alias, fonts.scale), the various font file
+    formats, and rasterizing them.   It is used by the X servers, the
+    X Font Server (xfs), and some font utilities (bdftopcf for instance),
+    but should not be used by normal X11 clients.  X11 clients access fonts
+    via either the new API's in libXft, or the legacy API's in libX11."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfont"
+    url      = "https://www.x.org/archive/individual/lib/libXfont2-2.0.1.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('2.0.1', '6ae5ae1f9fb1213b04f14a802a1d721c')
+
+    depends_on('xtrans')
+    depends_on('libfontenc')
+    depends_on('freetype')
+
+    depends_on('xproto')
+    depends_on('fontsproto@2.1.3:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -38,12 +38,14 @@ class Libxfont2(Package):
 
     version('2.0.1', '6ae5ae1f9fb1213b04f14a802a1d721c')
 
-    depends_on('xtrans')
     depends_on('libfontenc')
     depends_on('freetype')
 
-    depends_on('xproto')
-    depends_on('fontsproto@2.1.3:')
+    depends_on('xtrans', type='build')
+    depends_on('xproto', type='build')
+    depends_on('fontsproto@2.1.3:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxfontcache/package.py
+++ b/var/spack/repos/builtin/packages/libxfontcache/package.py
@@ -36,8 +36,10 @@ class Libxfontcache(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('fontcacheproto')
+    depends_on('xextproto', type='build')
+    depends_on('fontcacheproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxfontcache/package.py
+++ b/var/spack/repos/builtin/packages/libxfontcache/package.py
@@ -25,23 +25,22 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxfontcache(Package):
+    """Xfontcache - X-TrueType font cache extension client library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfontcache"
+    url      = "https://www.x.org/archive/individual/lib/libXfontcache-1.0.5.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.5', '5030fc9c7f16dbb52f92a8ba2c574f5c')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('fontcacheproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -42,6 +42,9 @@ class Libxft(Package):
     depends_on('libx11')
     depends_on('libxrender@0.8.2:')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -25,23 +25,25 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxft(Package):
+    """X FreeType library.
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    Xft version 2.1 was the first stand alone release of Xft, a library that
+    connects X applications with the FreeType font rasterization library. Xft
+    uses fontconfig to locate fonts so it has no configuration files."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXft"
+    url      = "https://www.x.org/archive/individual/lib/libXft-2.3.2.tar.gz"
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    version('2.3.2', '3a2c1ce2641817dace55cd2bfe10b0f0')
 
-    depends_on('xproto')
+    depends_on('freetype@2.1.6:')
+    depends_on('fontconfig@2.5.92:')
+    depends_on('libx11')
+    depends_on('libxrender@0.8.2:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -25,23 +25,24 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxi(Package):
+    """libXi - library for the X Input Extension."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXi"
+    url      = "https://www.x.org/archive/individual/lib/libXi-1.7.6.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.7.6', 'f3828f9d7893068f6f6f10fe15b31afa')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext@1.0.99.1:')
+    depends_on('libxfixes@5:')
 
-    depends_on('xproto')
+    depends_on('xproto@7.0.13:')
+    depends_on('xextproto@7.0.3:')
+    depends_on('inputproto@2.2.99.1:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -37,9 +37,9 @@ class Libxi(Package):
     depends_on('libxext@1.0.99.1:')
     depends_on('libxfixes@5:')
 
-    depends_on('xproto@7.0.13:')
-    depends_on('xextproto@7.0.3:')
-    depends_on('inputproto@2.2.99.1:')
+    depends_on('xproto@7.0.13:', type='build')
+    depends_on('xextproto@7.0.3:', type='build')
+    depends_on('inputproto@2.2.99.1:', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -25,23 +25,22 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxinerama(Package):
+    """libXinerama - API for Xinerama extension to X11 Protocol."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXinerama"
+    url      = "https://www.x.org/archive/individual/lib/libXinerama-1.1.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.1.3', '7224a1baa9733a54053550a3fb4be118')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('xineramaproto@1.1.99.1:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -36,8 +36,10 @@ class Libxinerama(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('xineramaproto@1.1.99.1:')
+    depends_on('xextproto', type='build')
+    depends_on('xineramaproto@1.1.99.1:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxkbfile/package.py
+++ b/var/spack/repos/builtin/packages/libxkbfile/package.py
@@ -35,11 +35,12 @@ class Libxkbfile(Package):
 
     depends_on('libx11')
 
-    depends_on('kbproto')
+    depends_on('kbproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxkbfile/package.py
+++ b/var/spack/repos/builtin/packages/libxkbfile/package.py
@@ -25,19 +25,17 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxkbfile(Package):
+    """XKB file handling routines."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libxkbfile"
+    url      = "https://www.x.org/archive/individual/lib/libxkbfile-1.0.9.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.9', '5aab87eba67f37dd910a19be5c1129ee')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
 
-    depends_on('xproto')
+    depends_on('kbproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxkbui/package.py
+++ b/var/spack/repos/builtin/packages/libxkbui/package.py
@@ -25,23 +25,20 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxkbui(Package):
+    """X.org libxkbui library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libxkbui/"
+    url      = "https://www.x.org/archive/individual/lib/libxkbui-1.0.2.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.2', 'a6210171defde64d9e8bcf6a6f6074b0')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
-
-    depends_on('xproto')
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxkbfile')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxkbui/package.py
+++ b/var/spack/repos/builtin/packages/libxkbui/package.py
@@ -37,6 +37,9 @@ class Libxkbui(Package):
     depends_on('libxt')
     depends_on('libxkbfile')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -40,7 +40,9 @@ class Libxmu(Package):
     depends_on('libxext')
     depends_on('libx11')
 
-    depends_on('xextproto')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -25,19 +25,25 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxmu(Package):
+    """This library contains miscellaneous utilities and is not part of the
+    Xlib standard.  It contains routines which only use public interfaces so
+    that it may be layered on top of any proprietary implementation of Xlib
+    or Xt."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXmu"
+    url      = "https://www.x.org/archive/individual/lib/libXmu-1.1.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.2', 'd5be323b02e6851607205c8e941b4e61')
+
+    depends_on('libxt')
+    depends_on('libxext')
+    depends_on('libx11')
+
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -37,8 +37,10 @@ class Libxp(Package):
     depends_on('libxext')
     depends_on('libxau')
 
-    depends_on('xextproto')
-    depends_on('printproto')
+    depends_on('xextproto', type='build')
+    depends_on('printproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxp(Package):
+    """libXp - X Print Client Library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXp"
+    url      = "https://www.x.org/archive/individual/lib/libXp-1.0.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.3', '1157da663b28e110f440ce64cede6e18')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext')
+    depends_on('libxau')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('printproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -39,7 +39,9 @@ class Libxpm(Package):
 
     depends_on('libx11')
 
-    depends_on('xproto')
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -26,9 +26,9 @@ from spack import *
 
 
 class Libxpm(Package):
-    """Xpm file format library"""
+    """libXpm - X Pixmap (XPM) image file format library."""
 
-    homepage = "https://www.x.org/"
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXpm"
     url      = "https://www.x.org/archive//individual/lib/libXpm-3.5.11.tar.gz"
 
     version('3.5.11', '7c67c878ee048206b070bc0b24154f04')
@@ -37,8 +37,12 @@ class Libxpm(Package):
     version('3.5.8', '2d81d6633e67ac5562e2fbee126b2897')
     version('3.5.7', '7bbc8f112f7143ed6961a58ce4e14558')
 
+    depends_on('libx11')
+
+    depends_on('xproto')
+
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxpresent/package.py
+++ b/var/spack/repos/builtin/packages/libxpresent/package.py
@@ -36,9 +36,11 @@ class Libxpresent(Package):
 
     depends_on('libx11')
 
-    depends_on('xproto')
-    depends_on('presentproto@1.0:')
-    depends_on('xextproto')
+    depends_on('xproto', type='build')
+    depends_on('presentproto@1.0:', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxpresent/package.py
+++ b/var/spack/repos/builtin/packages/libxpresent/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxpresent(Package):
+    """This package contains header files and documentation for the Present
+    extension.  Library and server implementations are separate."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXpresent/"
+    url      = "https://www.x.org/archive/individual/lib/libXpresent-1.0.0.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.0', '2f543a595c3e6a519e2e38d079002958')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
 
     depends_on('xproto')
+    depends_on('presentproto@1.0:')
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxprintapputil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintapputil/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxprintapputil(Package):
+    """Xprint application utility routines."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXprintAppUtil/"
+    url      = "https://www.x.org/archive/individual/lib/libXprintAppUtil-1.0.1.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.1', '3adb71fa34a2d4e75d8b840310318f76')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxp')
+    depends_on('libxprintutil')
+    depends_on('libxau')
 
-    depends_on('xproto')
+    depends_on('printproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxprintapputil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintapputil/package.py
@@ -38,7 +38,9 @@ class Libxprintapputil(Package):
     depends_on('libxprintutil')
     depends_on('libxau')
 
-    depends_on('printproto')
+    depends_on('printproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxprintutil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintutil/package.py
@@ -38,7 +38,9 @@ class Libxprintutil(Package):
     depends_on('libxt')
     depends_on('libxau')
 
-    depends_on('printproto')
+    depends_on('printproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxprintutil/package.py
+++ b/var/spack/repos/builtin/packages/libxprintutil/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxprintutil(Package):
+    """Xprint application utility routines."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXprintUtil/"
+    url      = "https://www.x.org/archive/individual/lib/libXprintUtil-1.0.1.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.1', '2f02e812f3e419534ced6fcb5860825f')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxp')
+    depends_on('libxt')
+    depends_on('libxau')
 
-    depends_on('xproto')
+    depends_on('printproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -37,9 +37,11 @@ class Libxrandr(Package):
     depends_on('libxext')
     depends_on('libxrender')
 
-    depends_on('randrproto@1.5:')
-    depends_on('xextproto')
-    depends_on('renderproto')
+    depends_on('randrproto@1.5:', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('renderproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -25,23 +25,24 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxrandr(Package):
+    """libXrandr - X Resize, Rotate and Reflection extension library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXrandr"
+    url      = "https://www.x.org/archive/individual/lib/libXrandr-1.5.0.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.5.0', 'e2fafff575b94ba0b15983eb4df93656')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext')
+    depends_on('libxrender')
 
-    depends_on('xproto')
+    depends_on('randrproto@1.5:')
+    depends_on('xextproto')
+    depends_on('renderproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -35,7 +35,9 @@ class Libxrender(Package):
 
     depends_on('libx11@1.6:')
 
-    depends_on('renderproto@0.9:')
+    depends_on('renderproto@0.9:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -25,19 +25,20 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxrender(Package):
+    """libXrender - library for the Render Extension to the X11 protocol."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXrender"
+    url      = "https://www.x.org/archive/individual/lib/libXrender-0.9.9.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('0.9.9', '0c797c4f2a7b782896bc223e6dac4333')
+
+    depends_on('libx11@1.6:')
+
+    depends_on('renderproto@0.9:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -36,8 +36,10 @@ class Libxres(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('resourceproto@1.0:')
+    depends_on('xextproto', type='build')
+    depends_on('resourceproto@1.0:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -25,23 +25,22 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxres(Package):
+    """libXRes - X-Resource extension client library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXRes"
+    url      = "https://www.x.org/archive/individual/lib/libXres-1.0.7.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.7', '7fad9ab34201bb4adffcbf0cd7e87a89')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('resourceproto@1.0:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -36,8 +36,10 @@ class Libxscrnsaver(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('scrnsaverproto@1.2:')
+    depends_on('xextproto', type='build')
+    depends_on('scrnsaverproto@1.2:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -25,19 +25,22 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxscrnsaver(Package):
+    """XScreenSaver - X11 Screen Saver extension client library"""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXScrnSaver"
+    url      = "https://www.x.org/archive/individual/lib/libXScrnSaver-1.2.2.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.2.2', '79227e7d8c0dad27654c526de3d6fef3')
+
+    depends_on('libx11')
+    depends_on('libxext')
+
+    depends_on('xextproto')
+    depends_on('scrnsaverproto@1.2:')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -37,7 +37,9 @@ class Libxshmfence(Package):
 
     version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
 
-    depends_on('xproto')
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -29,13 +29,14 @@ class Libxshmfence(Package):
     """This is a tiny library that exposes a event API on top of Linux
     futexes."""
 
-    homepage = "http://keithp.com/blogs/dri3_extension/"  # not really...
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
     url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
 
     version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -37,8 +37,10 @@ class Libxt(Package):
     depends_on('libice')
     depends_on('libx11')
 
-    depends_on('xproto')
-    depends_on('kbproto')
+    depends_on('xproto', type='build')
+    depends_on('kbproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -25,19 +25,23 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxt(Package):
+    """libXt - X Toolkit Intrinsics library."""
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXt"
+    url      = "https://www.x.org/archive/individual/lib/libXt-1.1.5.tar.gz"
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    version('1.1.5', '77d317fbc508dd6adefb59d57a663032')
+
+    depends_on('libsm')
+    depends_on('libice')
+    depends_on('libx11')
+
+    depends_on('xproto')
+    depends_on('kbproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxtrap/package.py
+++ b/var/spack/repos/builtin/packages/libxtrap/package.py
@@ -46,8 +46,10 @@ class Libxtrap(Package):
     depends_on('libxt')
     depends_on('libxext')
 
-    depends_on('trapproto')
-    depends_on('xextproto')
+    depends_on('trapproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxtrap/package.py
+++ b/var/spack/repos/builtin/packages/libxtrap/package.py
@@ -25,19 +25,32 @@
 from spack import *
 
 
-class Ncview(Package):
-    """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+class Libxtrap(Package):
+    """libXTrap is the Xlib-based client API for the DEC-XTRAP extension.
 
-    version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
+    XTrap was a proposed standard extension for X11R5 which facilitated the
+    capturing of server protocol and synthesizing core input events.
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    Digital participated in the X Consortium's xtest working group which chose
+    to evolve XTrap functionality into the XTEST & RECORD extensions for X11R6.
+
+    As X11R6 was released in 1994, XTrap has now been deprecated for over
+    15 years, and uses of it should be quite rare."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXTrap"
+    url      = "https://www.x.org/archive/individual/lib/libXTrap-1.0.1.tar.gz"
+
+    version('1.0.1', 'fde266b82ee14da3e4f4f81c9584c1ea')
+
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxext')
+
+    depends_on('trapproto')
+    depends_on('xextproto')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -25,23 +25,33 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxtst(Package):
+    """libXtst provides the Xlib-based client API for the XTEST & RECORD
+    extensions.
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    The XTEST extension is a minimal set of client and server extensions
+    required to completely test the X11 server with no user intervention.
+    This extension is not intended to support general journaling and
+    playback of user actions.
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    The RECORD extension supports the recording and reporting of all
+    core X protocol and arbitrary X extension protocol."""
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXtst"
+    url      = "https://www.x.org/archive/individual/lib/libXtst-1.2.2.tar.gz"
 
-    depends_on('xproto')
+    version('1.2.2', 'efef3b1e44bd8074a601c0c5ce0788f4')
+
+    depends_on('libx11')
+    depends_on('libxext@1.0.99.4:')
+    depends_on('libxi')
+
+    depends_on('recordproto@1.13.99.1:')
+    depends_on('xextproto@7.0.99.3:')
+    depends_on('inputproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -46,9 +46,11 @@ class Libxtst(Package):
     depends_on('libxext@1.0.99.4:')
     depends_on('libxi')
 
-    depends_on('recordproto@1.13.99.1:')
-    depends_on('xextproto@7.0.99.3:')
-    depends_on('inputproto')
+    depends_on('recordproto@1.13.99.1:', type='build')
+    depends_on('xextproto@7.0.99.3:', type='build')
+    depends_on('inputproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxv(Package):
+    """libXv - library for the X Video (Xv) extension to the
+    X Window System."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXv"
+    url      = "https://www.x.org/archive/individual/lib/libXv-1.0.10.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.10', 'e7182673b4bbe3ca00ac932e22edc038')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('videoproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -37,8 +37,10 @@ class Libxv(Package):
     depends_on('libx11@1.6:')
     depends_on('libxext')
 
-    depends_on('xextproto')
-    depends_on('videoproto')
+    depends_on('xextproto', type='build')
+    depends_on('videoproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxvmc/package.py
+++ b/var/spack/repos/builtin/packages/libxvmc/package.py
@@ -37,8 +37,10 @@ class Libxvmc(Package):
     depends_on('libxext')
     depends_on('libxv')
 
-    depends_on('xextproto')
-    depends_on('videoproto')
+    depends_on('xextproto', type='build')
+    depends_on('videoproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxvmc/package.py
+++ b/var/spack/repos/builtin/packages/libxvmc/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxvmc(Package):
+    """X.org libXvMC library."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXvMC"
+    url      = "https://www.x.org/archive/individual/lib/libXvMC-1.0.9.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.9', 'a28c0780373537f4774565309b31a69e')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext')
+    depends_on('libxv')
 
-    depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('videoproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxxf86dga(Package):
+    """libXxf86dga - Client library for the XFree86-DGA extension."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86dga"
+    url      = "https://www.x.org/archive/individual/lib/libXxf86dga-1.1.4.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.1.4', '8ed1c8674e730e8d333dfe4b9f2097d9')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
     depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('xf86dgaproto@2.0.99.2:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -36,9 +36,11 @@ class Libxxf86dga(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xproto')
-    depends_on('xextproto')
-    depends_on('xf86dgaproto@2.0.99.2:')
+    depends_on('xproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('xf86dgaproto@2.0.99.2:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxxf86misc/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86misc/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxxf86misc(Package):
+    """libXxf86misc - Extension library for the XFree86-Misc X extension."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86misc"
+    url      = "https://www.x.org/archive/individual/lib/libXxf86misc-1.0.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.0.3', 'c8d8743e146bcd2aa9856117ac5ef6c0')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11')
+    depends_on('libxext')
 
     depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('xf86miscproto')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/libxxf86misc/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86misc/package.py
@@ -36,9 +36,11 @@ class Libxxf86misc(Package):
     depends_on('libx11')
     depends_on('libxext')
 
-    depends_on('xproto')
-    depends_on('xextproto')
-    depends_on('xf86miscproto')
+    depends_on('xproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('xf86miscproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -36,9 +36,11 @@ class Libxxf86vm(Package):
     depends_on('libx11@1.6:')
     depends_on('libxext')
 
-    depends_on('xproto')
-    depends_on('xextproto')
-    depends_on('xf86vidmodeproto@2.2.99.1:')
+    depends_on('xproto', type='build')
+    depends_on('xextproto', type='build')
+    depends_on('xf86vidmodeproto@2.2.99.1:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class Libxshmfence(Package):
-    """libxshmfence - Shared memory 'SyncFence' synchronization primitive.
+class Libxxf86vm(Package):
+    """libXxf86vm - Extension library for the XFree86-VidMode X extension."""
 
-    This library offers a CPU-based synchronization primitive compatible
-    with the X SyncFence objects that can be shared between processes
-    using file descriptor passing."""
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86vm"
+    url      = "https://www.x.org/archive/individual/lib/libXxf86vm-1.1.4.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
-    url      = "http://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.2.tar.gz"
+    version('1.1.4', '675bd0c521472628d5796602f625ef51')
 
-    version('1.2', 'f0b30c0fc568b22ec524859ee28556f1')
+    depends_on('libx11@1.6:')
+    depends_on('libxext')
 
     depends_on('xproto')
+    depends_on('xextproto')
+    depends_on('xf86vidmodeproto@2.2.99.1:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/listres/package.py
+++ b/var/spack/repos/builtin/packages/listres/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Listres(Package):
+    """The listres program generates a list of X resources for a widget
+    in an X client written using a toolkit based on libXt."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/listres"
+    url      = "https://www.x.org/archive/individual/app/listres-1.0.3.tar.gz"
+
+    version('1.0.3', '77cafc32e8e02cca2d4453e73e0c0e7d')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+    depends_on('libxmu')
+
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/lndir/package.py
+++ b/var/spack/repos/builtin/packages/lndir/package.py
@@ -34,8 +34,7 @@ class Lndir(Package):
 
     version('1.0.3', '7173b2e4832658d319c2980a7c834205')
 
-    depends_on('xproto@7.0.17:')
-
+    depends_on('xproto@7.0.17:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/lndir/package.py
+++ b/var/spack/repos/builtin/packages/lndir/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Lndir(Package):
+    """lndir - create a shadow directory of symbolic links to another
+    directory tree."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/util/lndir"
+    url      = "https://www.x.org/archive/individual/util/lndir-1.0.3.tar.gz"
+
+    version('1.0.3', '7173b2e4832658d319c2980a7c834205')
+
+    depends_on('xproto@7.0.17:')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/luit/package.py
+++ b/var/spack/repos/builtin/packages/luit/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Luit(Package):
+    """Luit is a filter that can be run between an arbitrary application and
+    a UTF-8 terminal emulator such as xterm.  It will convert application
+    output from the locale's encoding into UTF-8, and convert terminal
+    input from UTF-8 into the locale's encoding."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/luit"
+    url      = "https://www.x.org/archive/individual/app/luit-1.1.1.tar.gz"
+
+    version('1.1.1', '04128a52f68c05129f709196819ddad3')
+
+    depends_on('libfontenc')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix),
+                  # see http://www.linuxquestions.org/questions/linux-from-scratch-13/can't-compile-luit-xorg-applications-4175476308/  # noqa
+                  'CFLAGS=-U_XOPEN_SOURCE -D_XOPEN_SOURCE=600')
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/makedepend/package.py
+++ b/var/spack/repos/builtin/packages/makedepend/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Makedepend(Package):
+    """makedepend - create dependencies in makefiles."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/util/makedepend"
+    url      = "https://www.x.org/archive/individual/util/makedepend-1.0.5.tar.gz"
+
+    version('1.0.5', 'efb2d7c7e22840947863efaedc175747')
+
+    depends_on('xproto@7.0.17:')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/makedepend/package.py
+++ b/var/spack/repos/builtin/packages/makedepend/package.py
@@ -33,8 +33,7 @@ class Makedepend(Package):
 
     version('1.0.5', 'efb2d7c7e22840947863efaedc175747')
 
-    depends_on('xproto@7.0.17:')
-
+    depends_on('xproto@7.0.17:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -41,22 +41,20 @@ class Mesa(Package):
     depends_on('bison@2.4.1:', type='build')
 
     # For DRI and hardware acceleration
-    depends_on('dri2proto@2.6:')
+    depends_on('libpthread-stubs')
     depends_on('libdrm')
-    depends_on('xorg-server@1.5:')
+    depends_on('openssl')
+    depends_on('glproto@1.4.14:', type='build')
+    depends_on('dri2proto@2.6:', type='build')
+    depends_on('dri3proto@1.0:', type='build')
+    depends_on('presentproto@1.0:', type='build')
+    depends_on('libxcb@1.9.3:')
+    depends_on('libxshmfence@1.1:')
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxdamage')
+    depends_on('libxfixes')
 
-    # depends_on('libdrm@2.4.66:')
-    # depends_on('libxshmfence@1.1:')
-    # depends_on('libx11')
-    # depends_on('libxext')
-    # depends_on('libxdamage')
-    # depends_on('libxfixes')
-    # depends_on('libxcb@1.9.3:')
-
-    # depends_on('dri2proto@2.6:', type='build')
-    # depends_on('dri3proto@1.0:', type='build')
-    # depends_on('glproto@1.4.14:', type='build')
-    # depends_on('presentproto@1.0:', type='build')
 
 
     # pthread-stubs libglvnd >= 0.1.0 $dri_modules glproto >= $GLPROTO_REQUIRED
@@ -70,6 +68,8 @@ class Mesa(Package):
     # wayland-client >= $WAYLAND_REQUIRED wayland-server >= $WAYLAND_REQUIRED
     # xcb-xfixes libdrm_amdgpu >= $LIBDRM_AMDGPU_REQUIRED
     # libdrm_freedreno >= $LIBDRM_FREEDRENO_REQUIRED
+
+    depends_on('pkg-config@0.9.0:', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -51,10 +51,7 @@ class Mesa(Package):
     depends_on('libxext')
     depends_on('libxdamage')
     depends_on('libxfixes')
-    depends_on('libx11-xcb')
     depends_on('libxcb@1.9.3:')
-    depends_on('libxcb-glx@1.8.1:')
-    depends_on('libxcb-dri2@1.8:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -46,8 +46,15 @@ class Mesa(Package):
     depends_on('glproto@1.4.14:')
     depends_on('presentproto@1.0:')
     depends_on('libdrm@2.4.66:')
-    depends_on('libxcb@1.9.3:')
     depends_on('libxshmfence@1.1:')
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxdamage')
+    depends_on('libxfixes')
+    depends_on('libx11-xcb')
+    depends_on('libxcb@1.9.3:')
+    depends_on('libxcb-glx@1.8.1:')
+    depends_on('libxcb-dri2@1.8:')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -44,10 +44,6 @@ class Mesa(Package):
     depends_on('libpthread-stubs')
     depends_on('libdrm')
     depends_on('openssl')
-    depends_on('glproto@1.4.14:', type='build')
-    depends_on('dri2proto@2.6:', type='build')
-    depends_on('dri3proto@1.0:', type='build')
-    depends_on('presentproto@1.0:', type='build')
     depends_on('libxcb@1.9.3:')
     depends_on('libxshmfence@1.1:')
     depends_on('libx11')
@@ -55,25 +51,17 @@ class Mesa(Package):
     depends_on('libxdamage')
     depends_on('libxfixes')
 
-
-
-    # pthread-stubs libglvnd >= 0.1.0 $dri_modules glproto >= $GLPROTO_REQUIRED
-    # dri2proto >= $DRI2PROTO_REQUIRED dri3proto >= $DRI3PROTO_REQUIRED
-    # presentproto >= $PRESENTPROTO_REQUIRED $dri3_modules $dri_modules
-    # libdrm_intel >= $LIBDRM_INTEL_REQUIRED libdrm_nouveau >= $LIBDRM_NVVIEUX_REQUIRED
-    # libdrm_radeon >= $LIBDRM_RADEON_REQUIRED xcb-dri3 xcb-present xcb-sync
-    # xshmfence >= $XSHMFENCE_REQUIRED x11-xcb xcb xcb-dri2 >= $XCBDRI2_REQUIRED
-    # xvmc >= $XVMC_REQUIRED vdpau >= $VDPAU_REQUIRED
-    # libomxil-bellagio >= $LIBOMXIL_BELLAGIO_REQUIRED libva >= $LIBVA_REQUIRED
-    # wayland-client >= $WAYLAND_REQUIRED wayland-server >= $WAYLAND_REQUIRED
-    # xcb-xfixes libdrm_amdgpu >= $LIBDRM_AMDGPU_REQUIRED
-    # libdrm_freedreno >= $LIBDRM_FREEDRENO_REQUIRED
-
+    depends_on('glproto@1.4.14:', type='build')
+    depends_on('dri2proto@2.6:', type='build')
+    depends_on('dri3proto@1.0:', type='build')
+    depends_on('presentproto@1.0:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
+
+    # TODO: Add package for systemd, provides libudev
+    # Using the system package manager to install systemd didn't work for me
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -30,9 +30,9 @@ class Mesa(Package):
     specification - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/12.0.2/mesa-12.0.2.tar.gz"
+    url      = "ftp://ftp.freedesktop.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
 
-    version('12.0.2', 'e9e4b430288e343b5f5310eb559c9858')
+    version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
 
     # General dependencies
     depends_on('python@2.6.4:')
@@ -42,16 +42,34 @@ class Mesa(Package):
 
     # For DRI and hardware acceleration
     depends_on('dri2proto@2.6:')
-    depends_on('dri3proto@1.0:')
-    depends_on('glproto@1.4.14:')
-    depends_on('presentproto@1.0:')
-    depends_on('libdrm@2.4.66:')
-    depends_on('libxshmfence@1.1:')
-    depends_on('libx11')
-    depends_on('libxext')
-    depends_on('libxdamage')
-    depends_on('libxfixes')
-    depends_on('libxcb@1.9.3:')
+    depends_on('libdrm')
+    depends_on('xorg-server@1.5:')
+
+    # depends_on('libdrm@2.4.66:')
+    # depends_on('libxshmfence@1.1:')
+    # depends_on('libx11')
+    # depends_on('libxext')
+    # depends_on('libxdamage')
+    # depends_on('libxfixes')
+    # depends_on('libxcb@1.9.3:')
+
+    # depends_on('dri2proto@2.6:', type='build')
+    # depends_on('dri3proto@1.0:', type='build')
+    # depends_on('glproto@1.4.14:', type='build')
+    # depends_on('presentproto@1.0:', type='build')
+
+
+    # pthread-stubs libglvnd >= 0.1.0 $dri_modules glproto >= $GLPROTO_REQUIRED
+    # dri2proto >= $DRI2PROTO_REQUIRED dri3proto >= $DRI3PROTO_REQUIRED
+    # presentproto >= $PRESENTPROTO_REQUIRED $dri3_modules $dri_modules
+    # libdrm_intel >= $LIBDRM_INTEL_REQUIRED libdrm_nouveau >= $LIBDRM_NVVIEUX_REQUIRED
+    # libdrm_radeon >= $LIBDRM_RADEON_REQUIRED xcb-dri3 xcb-present xcb-sync
+    # xshmfence >= $XSHMFENCE_REQUIRED x11-xcb xcb xcb-dri2 >= $XCBDRI2_REQUIRED
+    # xvmc >= $XVMC_REQUIRED vdpau >= $VDPAU_REQUIRED
+    # libomxil-bellagio >= $LIBOMXIL_BELLAGIO_REQUIRED libva >= $LIBVA_REQUIRED
+    # wayland-client >= $WAYLAND_REQUIRED wayland-server >= $WAYLAND_REQUIRED
+    # xcb-xfixes libdrm_amdgpu >= $LIBDRM_AMDGPU_REQUIRED
+    # libdrm_freedreno >= $LIBDRM_FREEDRENO_REQUIRED
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -30,28 +30,28 @@ class Mesa(Package):
     specification - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/older-versions/8.x/8.0.5/MesaLib-8.0.5.tar.gz"
+    url      = "ftp://ftp.freedesktop.org/pub/mesa/12.0.2/mesa-12.0.2.tar.gz"
 
-    # version('10.4.4', '8d863a3c209bf5116b2babfccccc68ce')
-    version('8.0.5', 'cda5d101f43b8784fa60bdeaca4056f2')
+    version('12.0.2', 'e9e4b430288e343b5f5310eb559c9858')
 
-    # mesa 7.x, 8.x, 9.x
-    depends_on("libdrm@2.4.33")
-    depends_on("llvm@3.0")
-    depends_on("libxml2+python")
+    # General dependencies
+    depends_on('python@2.6.4:')
+    depends_on('py-mako@0.3.4:')
+    depends_on('flex@2.5.35:', type='build')
+    depends_on('bison@2.4.1:', type='build')
 
-    # patch("llvm-fixes.patch") # using newer llvm
-
-    # mesa 10.x
-    # depends_on("py-mako")
-    # depends_on("flex", type='build')
-    # depends_on("bison", type='build')
-    # depends_on("dri2proto")
-    # depends_on("libxcb")
-    # depends_on("libxshmfence")
+    # For DRI and hardware acceleration
+    depends_on('dri2proto@2.6:')
+    depends_on('dri3proto@1.0:')
+    depends_on('glproto@1.4.14:')
+    depends_on('presentproto@1.0:')
+    depends_on('libdrm@2.4.66:')
+    depends_on('libxcb@1.9.3:')
+    depends_on('libxshmfence@1.1:')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/mkfontdir/package.py
+++ b/var/spack/repos/builtin/packages/mkfontdir/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mkfontdir(Package):
+    """mkfontdir creates the fonts.dir files needed by the legacy X server
+    core font system.   The current implementation is a simple wrapper script
+    around the mkfontscale program, which must be built and installed first."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/mkfontdir"
+    url      = "https://www.x.org/archive/individual/app/mkfontdir-1.0.7.tar.gz"
+
+    version('1.0.7', '52a5bc129f3f3ac54e7115608cec3cdc')
+
+    depends_on('mkfontscale', type='run')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/mkfontscale/package.py
+++ b/var/spack/repos/builtin/packages/mkfontscale/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mkfontscale(Package):
+    """mkfontscale creates the fonts.scale and fonts.dir index files used by the
+    legacy X11 font system."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/mkfontscale"
+    url      = "https://www.x.org/archive/individual/app/mkfontscale-1.1.2.tar.gz"
+
+    version('1.1.2', 'fab4e1598b8948c124ec7a9f06d30e5b')
+
+    depends_on('libfontenc')
+    depends_on('freetype')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -32,12 +32,13 @@ class Ncview(Package):
 
     version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
 
-    depends_on("netcdf")
-    depends_on("udunits2")
-    depends_on("libpng")
-    depends_on("libxaw")
+    depends_on('netcdf')
+    depends_on('udunits2')
+    depends_on('libpng')
+    depends_on('libxaw')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
+        configure('--prefix={0}'.format(prefix))
+
         make()
-        make("install")
+        make('install')

--- a/var/spack/repos/builtin/packages/oclock/package.py
+++ b/var/spack/repos/builtin/packages/oclock/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Oclock(Package):
+    """oclock is a simple analog clock using the SHAPE extension to make
+    a round (possibly transparent) window."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/oclock"
+    url      = "https://www.x.org/archive/individual/app/oclock-1.0.3.tar.gz"
+
+    version('1.0.3', 'f25b05d987ef8ed6dd5a887c82eace62')
+
+    depends_on('libx11')
+    depends_on('libxmu')
+    depends_on('libxext')
+    depends_on('libxt')
+    depends_on('libxkbfile')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -28,15 +28,17 @@ import sys
 
 class Pixman(Package):
     """The Pixman package contains a library that provides low-level
-       pixel manipulation features such as image compositing and
-       trapezoid rasterization."""
+    pixel manipulation features such as image compositing and
+    trapezoid rasterization."""
+
     homepage = "http://www.pixman.org"
     url      = "http://cairographics.org/releases/pixman-0.32.6.tar.gz"
 
+    version('0.34.0', 'e80ebae4da01e77f68744319f01d52a3')
     version('0.32.6', '3a30859719a41bd0f5cccffbfefdd4c2')
 
-    depends_on("pkg-config", type="build")
-    depends_on("libpng")
+    depends_on('pkg-config', type='build')
+    depends_on('libpng')
 
     def install(self, spec, prefix):
         config_args = ["--prefix=" + prefix,
@@ -48,4 +50,5 @@ class Pixman(Package):
         configure(*config_args)
 
         make()
-        make("install")
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/presentproto/package.py
+++ b/var/spack/repos/builtin/packages/presentproto/package.py
@@ -25,22 +25,15 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class Presentproto(Package):
+    """Present protocol specification and Xlib/Xserver headers."""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/presentproto/"
+    url      = "https://www.x.org/archive/individual/proto/presentproto-1.0.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('1.0', '57eaf4bb58e86476ec89cfb42d675961')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
-        make()
-        # make('check')  # fails tests
         make('install')

--- a/var/spack/repos/builtin/packages/presentproto/package.py
+++ b/var/spack/repos/builtin/packages/presentproto/package.py
@@ -33,6 +33,9 @@ class Presentproto(Package):
 
     version('1.0', '57eaf4bb58e86476ec89cfb42d675961')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/printproto/package.py
+++ b/var/spack/repos/builtin/packages/printproto/package.py
@@ -34,6 +34,9 @@ class Printproto(Package):
 
     version('1.0.5', '5afeb3a7de8a14b417239a14ea724268')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/printproto/package.py
+++ b/var/spack/repos/builtin/packages/printproto/package.py
@@ -25,17 +25,14 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Printproto(Package):
+    """Xprint extension to the X11 protocol - a portable, network-transparent
+    printing system."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/printproto"
+    url      = "https://www.x.org/archive/individual/proto/printproto-1.0.5.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.0.5', '5afeb3a7de8a14b417239a14ea724268')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/proxymngr/package.py
+++ b/var/spack/repos/builtin/packages/proxymngr/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Proxymngr(Package):
+    """The proxy manager (proxymngr) is responsible for resolving requests from
+    xfindproxy (and other similar clients), starting new proxies when
+    appropriate, and keeping track of all of the available proxy services.
+    The proxy manager strives to reuse existing proxies whenever possible."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/proxymngr"
+    url      = "https://www.x.org/archive/individual/app/proxymngr-1.0.4.tar.gz"
+
+    version('1.0.4', 'a165cf704f6a413f0bacf65ea470331f')
+
+    depends_on('libice')
+    depends_on('libxt')
+    depends_on('lbxproxy')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('xproxymanagementprotocol', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/py-mako/package.py
+++ b/var/spack/repos/builtin/packages/py-mako/package.py
@@ -32,10 +32,15 @@ class PyMako(Package):
     homepage = "https://pypi.python.org/pypi/mako"
     url = "https://pypi.python.org/packages/source/M/Mako/Mako-1.0.1.tar.gz"
 
+    version('1.0.4', 'c5fc31a323dd4990683d2f2da02d4e20')
     version('1.0.1', '9f0aafd177b039ef67b90ea350497a54')
 
-    depends_on('py-setuptools', type='build')
     extends('python')
 
+    depends_on('py-setuptools', type='build')
+    # depends_on('py-mock',   type='test')  # TODO: Add test deptype
+    # depends_on('py-pytest', type='test')  # TODO: Add test deptype
+    depends_on('py-markupsafe@0.9.2:', type=nolink)
+
     def install(self, spec, prefix):
-        setup_py('install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-py/package.py
+++ b/var/spack/repos/builtin/packages/py-py/package.py
@@ -25,22 +25,17 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class PyPy(Package):
+    """library with cross-python path, ini-parsing, io, code, log facilities"""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "http://pylib.readthedocs.io/en/latest/"
+    url      = "https://pypi.python.org/packages/source/p/py/py-1.4.31.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('1.4.31', '5d2c63c56dc3f2115ec35c066ecd582b')
+
+    extends('python')
+
+    depends_on('py-setuptools', type='build')
 
     def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
-
-        make()
-        # make('check')  # fails tests
-        make('install')
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -25,22 +25,19 @@
 from spack import *
 
 
-class Gperf(Package):
-    """GNU gperf is a perfect hash function generator. For a given
-    list of strings, it produces a hash function and hash table, in
-    form of C or C++ code, for looking up a value depending on the
-    input string. The hash function is perfect, which means that the
-    hash table has no collisions, and the hash table lookup needs a
-    single string comparison only."""
+class PyPytest(Package):
+    """pytest: simple powerful testing with Python."""
 
-    homepage = "https://www.gnu.org/software/gperf/"
-    url      = "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz"
+    homepage = "http://doc.pytest.org/en/latest/"
+    url      = "https://pypi.python.org/packages/source/p/pytest/pytest-3.0.2.tar.gz"
 
-    version('3.0.4', 'c1f1db32fb6598d6a93e6e88796a8632')
+    version('3.0.2', '61dc36e65a6f6c11c53b1388e043a9f5',
+            url="https://pypi.python.org/packages/2b/05/e20806c99afaff43331f5fd8770bb346145303882f98ef3275fa1dd66f6d/pytest-3.0.2.tar.gz")
+
+    extends('python')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-py@1.4.29:', type=nolink)
 
     def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
-
-        make()
-        # make('check')  # fails tests
-        make('install')
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/randrproto/package.py
+++ b/var/spack/repos/builtin/packages/randrproto/package.py
@@ -37,8 +37,10 @@ class Randrproto(Package):
 
     version('1.5.0', '863d6ee3e0b2708f75d968470ed31eb9')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
-        make()
         make('install')

--- a/var/spack/repos/builtin/packages/randrproto/package.py
+++ b/var/spack/repos/builtin/packages/randrproto/package.py
@@ -25,19 +25,20 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Randrproto(Package):
+    """X Resize and Rotate Extension (RandR).
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol for clients to dynamically change X
+    screens, so as to resize, rotate and reflect the root window of a screen.
+    """
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/randrproto"
+    url      = "https://www.x.org/archive/individual/proto/randrproto-1.5.0.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.5.0', '863d6ee3e0b2708f75d968470ed31eb9')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
+        make()
         make('install')

--- a/var/spack/repos/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/builtin/packages/recordproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Recordproto(Package):
+    """X Record Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol for the recording and playback of user
+    actions in the X Window System."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/recordproto"
+    url      = "https://www.x.org/archive/individual/proto/recordproto-1.14.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.14.2', '868235e1e150e68916d5a316ebc4ccc4')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/builtin/packages/recordproto/package.py
@@ -36,6 +36,9 @@ class Recordproto(Package):
 
     version('1.14.2', '868235e1e150e68916d5a316ebc4ccc4')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/rendercheck/package.py
+++ b/var/spack/repos/builtin/packages/rendercheck/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Rendercheck(Package):
+    """rendercheck is a program to test a Render extension implementation
+    against separate calculations of expected output."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/rendercheck"
+    url      = "https://www.x.org/archive/individual/app/rendercheck-1.5.tar.gz"
+
+    version('1.5', '92ddef6d01f02529521af103f9b9bf60')
+
+    depends_on('libxrender')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/renderproto/package.py
+++ b/var/spack/repos/builtin/packages/renderproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Renderproto(Package):
+    """X Rendering Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines the protcol for a digital image composition as
+    the foundation of a new rendering model within the X Window System."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/renderproto"
+    url      = "https://www.x.org/archive/individual/proto/renderproto-0.11.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('0.11.1', '9b103359123e375bb7760f7dbae3dece')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/renderproto/package.py
+++ b/var/spack/repos/builtin/packages/renderproto/package.py
@@ -36,6 +36,9 @@ class Renderproto(Package):
 
     version('0.11.1', '9b103359123e375bb7760f7dbae3dece')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/resourceproto/package.py
+++ b/var/spack/repos/builtin/packages/resourceproto/package.py
@@ -36,6 +36,9 @@ class Resourceproto(Package):
 
     version('1.2.0', '33091d5358ec32dd7562a1aa225a70aa')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/resourceproto/package.py
+++ b/var/spack/repos/builtin/packages/resourceproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Resourceproto(Package):
+    """X Resource Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol that allows a client to query the  X  server
+    about its usage of various resources."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/resourceproto"
+    url      = "https://www.x.org/archive/individual/proto/resourceproto-1.2.0.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.2.0', '33091d5358ec32dd7562a1aa225a70aa')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/resourceproto/package.py
+++ b/var/spack/repos/builtin/packages/resourceproto/package.py
@@ -28,8 +28,8 @@ from spack import *
 class Resourceproto(Package):
     """X Resource Extension.
 
-    This extension defines a protocol that allows a client to query the  X  server
-    about its usage of various resources."""
+    This extension defines a protocol that allows a client to query the
+    X server about its usage of various resources."""
 
     homepage = "http://cgit.freedesktop.org/xorg/proto/resourceproto"
     url      = "https://www.x.org/archive/individual/proto/resourceproto-1.2.0.tar.gz"

--- a/var/spack/repos/builtin/packages/rgb/package.py
+++ b/var/spack/repos/builtin/packages/rgb/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Rgb(Package):
+    """X color name database.
+
+    This package includes both the list mapping X color names to RGB values
+    (rgb.txt) and, if configured to use a database for color lookup, the
+    rgb program to convert the text file into the binary database format.
+
+    The "others" subdirectory contains some alternate color databases."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/rgb"
+    url      = "https://www.x.org/archive/individual/app/rgb-1.0.6.tar.gz"
+
+    version('1.0.6', '9759d058108f39066bbdf1d5d6de048c')
+
+    depends_on('xorg-server')
+
+    depends_on('xproto', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/rstart/package.py
+++ b/var/spack/repos/builtin/packages/rstart/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Rstart(Package):
+    """This package includes both the client and server sides implementing
+    the protocol described in the "A Flexible Remote Execution Protocol
+    Based on rsh" paper found in the specs/ subdirectory.
+
+    This software has been deprecated in favor of the X11 forwarding
+    provided in common ssh implementations."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/rstart"
+    url      = "https://www.x.org/archive/individual/app/rstart-1.0.5.tar.gz"
+
+    version('1.0.5', '32db3625cb5e841e17d6bc696f21edfb')
+
+    depends_on('xproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/scripts/package.py
+++ b/var/spack/repos/builtin/packages/scripts/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Scripts(Package):
+    """Various X related scripts."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/scripts"
+    url      = "https://www.x.org/archive/individual/app/scripts-1.0.1.tar.gz"
+
+    version('1.0.1', '1e8294a126a2a7556b21025a8d933e8b')
+
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/scrnsaverproto/package.py
+++ b/var/spack/repos/builtin/packages/scrnsaverproto/package.py
@@ -36,6 +36,9 @@ class Scrnsaverproto(Package):
 
     version('1.2.2', '21704f1bad472d94abd22fea5704bb48')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/scrnsaverproto/package.py
+++ b/var/spack/repos/builtin/packages/scrnsaverproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Scrnsaverproto(Package):
+    """MIT Screen Saver Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol to control screensaver features
+    and also to query screensaver info on specific windows."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/scrnsaverproto"
+    url      = "https://www.x.org/archive/individual/proto/scrnsaverproto-1.2.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.2.2', '21704f1bad472d94abd22fea5704bb48')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/sessreg/package.py
+++ b/var/spack/repos/builtin/packages/sessreg/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Sessreg(Package):
+    """Sessreg is a simple program for managing utmp/wtmp entries for X
+    sessions. It was originally written for use with xdm, but may also be
+    used with other display managers such as gdm or kdm."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/sessreg"
+    url      = "https://www.x.org/archive/individual/app/sessreg-1.1.0.tar.gz"
+
+    version('1.1.0', '5d7eb499043c7fdd8d53c5ba43660312')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def patch(self):
+        kwargs = {'string': True}
+        filter_file('$(CPP) $(DEFS)', '$(CPP) -P $(DEFS)',
+                    'man/Makefile.in', **kwargs)
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/setxkbmap/package.py
+++ b/var/spack/repos/builtin/packages/setxkbmap/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Setxkbmap(Package):
+    """setxkbmap is an X11 client to change the keymaps in the X server for a
+    specified keyboard to use the layout determined by the options listed
+    on the command line."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/setxkbmap"
+    url      = "https://www.x.org/archive/individual/app/setxkbmap-1.3.1.tar.gz"
+
+    version('1.3.1', 'fdfc0fc643a50fb0b5fa7546e4d28868')
+
+    depends_on('libxkbfile')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/showfont/package.py
+++ b/var/spack/repos/builtin/packages/showfont/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Showfont(Package):
+    """showfont displays data about a font from an X font server.
+    The information shown includes font information, font properties,
+    character metrics, and character bitmaps."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/showfont"
+    url      = "https://www.x.org/archive/individual/app/showfont-1.0.5.tar.gz"
+
+    version('1.0.5', 'cea973363df01fb27a87e939600137fd')
+
+    depends_on('libfs')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/smproxy/package.py
+++ b/var/spack/repos/builtin/packages/smproxy/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Smproxy(Package):
+    """smproxy allows X applications that do not support X11R6 session
+    management to participate in an X11R6 session."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/smproxy"
+    url      = "https://www.x.org/archive/individual/app/smproxy-1.0.6.tar.gz"
+
+    version('1.0.6', '012c259f5a89e5c636037446d44eb354')
+
+    depends_on('libsm')
+    depends_on('libice')
+    depends_on('libxt')
+    depends_on('libxmu')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from distutils.dir_util import copy_tree
+
+
+class SublimeText(Package):
+    """Sublime Text is a sophisticated text editor for code, markup and
+    prose."""
+
+    homepage = "http://www.sublimetext.com/"
+    url      = "https://download.sublimetext.com/sublime_text_3_build_3126_x64.tar.bz2"
+
+    version('3126',  'acc34252b0ea7dff1f581c5db1564dcb')
+    version('2.0.2', '699cd26d7fe0bada29eb1b2cd7b50e4b')
+
+    # Sublime text comes as a pre-compiled binary.
+    # Since we can't link to Spack packages, we'll just have to
+    # add them as runtime dependencies.
+
+    # depends_on('libgobject', type='run')
+    depends_on('glib', type='run')
+    depends_on('libx11', type='run')
+    depends_on('pcre', type='run')
+    depends_on('libffi', type='run')
+    depends_on('libxcb', type='run')
+    depends_on('libxau', type='run')
+
+    def url_for_version(self, version):
+        if version.up_to(1) == '2':
+            return "https://download.sublimetext.com/Sublime%20Text%20{0}%20x64.tar.bz2".format(version)
+        else:
+            return "https://download.sublimetext.com/sublime_text_3_build_{0}_x64.tar.bz2".format(version)
+
+    def install(self, spec, prefix):
+        # Sublime text comes as a pre-compiled binary.
+        copy_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/taskd/package.py
+++ b/var/spack/repos/builtin/packages/taskd/package.py
@@ -27,7 +27,7 @@ from spack import *
 
 class Taskd(Package):
     """TaskWarrior task synchronization daemon"""
-    # FIXME: add a proper url for your package's homepage here.
+
     homepage = "http://www.taskwarrior.org"
     url      = "http://taskwarrior.org/download/taskd-1.1.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/transset/package.py
+++ b/var/spack/repos/builtin/packages/transset/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Transset(Package):
+    """transset is an utility for setting opacity property."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/transset"
+    url      = "https://www.x.org/archive/individual/app/transset-1.0.1.tar.gz"
+
+    version('1.0.1', '4bbee6f6ea6fbd403280b4bb311db6dc')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/trapproto/package.py
+++ b/var/spack/repos/builtin/packages/trapproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Trapproto(Package):
+    """X.org TrapProto protocol headers."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://cgit.freedesktop.org/xorg/proto/trapproto"
+    url      = "https://www.x.org/archive/individual/proto/trapproto-3.4.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('3.4.3', '1344759ae8d7d923e64f5eec078a679b')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/twm/package.py
+++ b/var/spack/repos/builtin/packages/twm/package.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Twm(Package):
+    """twm is a window manager for the X Window System.  It provides
+    titlebars, shaped windows, several forms of icon management,
+    user-defined macro functions, click-to-type and pointer-driven
+    keyboard focus, and user-specified key and pointer button bindings."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/twm"
+    url      = "https://www.x.org/archive/individual/app/twm-1.0.9.tar.gz"
+
+    version('1.0.9', 'e98fcb32f774ac1ff7bf82101b79f61e')
+
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxt')
+    depends_on('libxmu')
+    depends_on('libice')
+    depends_on('libsm')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -25,11 +25,13 @@
 from spack import *
 
 
-class XorgUtilMacros(Package):
-    """The m4 macros used by all of the Xorg packages."""
+class UtilMacros(Package):
+    """This is a set of autoconf macros used by the configure.ac scripts in
+    other Xorg modular packages, and is needed to generate new versions
+    of their configure scripts with autoconf."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/util/macros/"
-    url = "http://ftp.x.org/pub/individual/util/util-macros-1.19.0.tar.bz2"
+    homepage = "http://cgit.freedesktop.org/xorg/util/macros/"
+    url = "https://www.x.org/archive/individual/util/util-macros-1.19.0.tar.bz2"
 
     version('1.19.0', '1cf984125e75f8204938d998a8b6c1e1')
 

--- a/var/spack/repos/builtin/packages/videoproto/package.py
+++ b/var/spack/repos/builtin/packages/videoproto/package.py
@@ -36,6 +36,9 @@ class Videoproto(Package):
 
     version('2.3.3', 'd984100603ee2420072f27bb491f4b7d')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/videoproto/package.py
+++ b/var/spack/repos/builtin/packages/videoproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Videoproto(Package):
+    """X Video Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension provides a protocol for a video output mechanism,
+    mainly to rescale video playback in the video controller hardware."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/videoproto"
+    url      = "https://www.x.org/archive/individual/proto/videoproto-2.3.3.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.3.3', 'd984100603ee2420072f27bb491f4b7d')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/viewres/package.py
+++ b/var/spack/repos/builtin/packages/viewres/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Viewres(Package):
+    """viewres displays a tree showing the widget class hierarchy of the
+    Athena Widget Set (libXaw)."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/viewres"
+    url      = "https://www.x.org/archive/individual/app/viewres-1.0.4.tar.gz"
+
+    version('1.0.4', 'a3c7fe561945951f848e319680753760')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/windowswmproto/package.py
+++ b/var/spack/repos/builtin/packages/windowswmproto/package.py
@@ -25,17 +25,18 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Windowswmproto(Package):
+    """This module provides the definition of the WindowsWM extension to the
+    X11 protocol, used for coordination between an X11 server and the
+    Microsoft Windows native window manager.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    WindowsWM is only intended to be used on Cygwin when running a
+    rootless XWin server."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/windowswmproto"
+    url      = "https://www.x.org/archive/individual/proto/windowswmproto-1.0.4.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.0.4', '558db92a8e4e1b07e9c62eca3f04dd8d')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/x11perf/package.py
+++ b/var/spack/repos/builtin/packages/x11perf/package.py
@@ -25,27 +25,25 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class X11perf(Package):
+    """Simple X server performance benchmarker."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/x11perf"
+    url      = "https://www.x.org/archive/individual/app/x11perf-1.6.0.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.6.0', '8dcdb74db8c70dca4b4eab11dc33dd31')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libx11')
+    depends_on('libxmu')
+    depends_on('libxrender')
+    depends_on('libxft')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xauth/package.py
+++ b/var/spack/repos/builtin/packages/xauth/package.py
@@ -25,27 +25,27 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xauth(Package):
+    """The xauth program is used to edit and display the authorization
+    information used in connecting to the X server."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xauth"
+    url      = "https://www.x.org/archive/individual/app/xauth-1.0.9.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.9', 'def3b4588504ee3d8ec7be607826df02')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libx11')
+    depends_on('libxau')
+    depends_on('libxext')
+    depends_on('libxmu')
+
+    depends_on('xproto@7.0.17:')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
+        # make('check')  # TODO: add package for cmdtest build dependency
         make('install')

--- a/var/spack/repos/builtin/packages/xbacklight/package.py
+++ b/var/spack/repos/builtin/packages/xbacklight/package.py
@@ -25,27 +25,25 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xbacklight(Package):
+    """Xbacklight is used to adjust the backlight brightness where supported.
+    It uses the RandR extension to find all outputs on the X server
+    supporting backlight brightness control and changes them all in the
+    same way."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xbacklight"
+    url      = "https://www.x.org/archive/individual/app/xbacklight-1.2.1.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.2.1', 'e8e4c86b0f867e23aa3532618a697609')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxcb')
+    depends_on('xcb-util')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xbiff/package.py
+++ b/var/spack/repos/builtin/packages/xbiff/package.py
@@ -25,27 +25,27 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xbiff(Package):
+    """xbiff provides graphical notification of new e-mail.
+    It only handles mail stored in a filesystem accessible file,
+    not via IMAP, POP or other remote access protocols."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xbiff"
+    url      = "https://www.x.org/archive/individual/app/xbiff-1.0.3.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.3', '779c888cb45da82a612e7f47971df9ab')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxext')
+    depends_on('libx11')
+
+    depends_on('xbitmaps', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xbitmaps/package.py
+++ b/var/spack/repos/builtin/packages/xbitmaps/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xbitmaps(Package):
+    """The xbitmaps package contains bitmap images used by multiple
+    applications built in Xorg."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/data/bitmaps/"
+    url      = "https://www.x.org/archive/individual/data/xbitmaps-1.1.1.tar.gz"
+
+    version('1.1.1', '288bbe310db67280a9e2e5ebc5602595')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')

--- a/var/spack/repos/builtin/packages/xcalc/package.py
+++ b/var/spack/repos/builtin/packages/xcalc/package.py
@@ -25,27 +25,25 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xcalc(Package):
+    """xcalc is a scientific calculator X11 client that can emulate a TI-30
+    or an HP-10C."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xcalc"
+    url      = "https://www.x.org/archive/individual/app/xcalc-1.0.6.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.6', 'a192ebb5e5f33925c71713501173d8e0')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxaw')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcb-demo/package.py
+++ b/var/spack/repos/builtin/packages/xcb-demo/package.py
@@ -25,36 +25,26 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbDemo(Package):
+    """xcb-demo: A collection of demo programs that use the XCB library."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-demo-0.1.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.1', '803c5c91d54e734e6f6fa3f04f2463ff')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb')
+    depends_on('xcb-util')
+    depends_on('xcb-util-image')
+    depends_on('xcb-util-wm')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
+
+        # FIXME: crashes with the following error message
+        # X11/XCB/xcb.h: No such file or directory
 
         make()
         make('check')

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -31,10 +31,13 @@ class XcbProto(Package):
     homepage = "http://xcb.freedesktop.org/"
     url      = "http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz"
 
+    version('1.12', '5ee1ec124ea8d56bd9e83b8e9e0b84c4')
     version('1.11', 'c8c6cb72c84f58270f4db1f39607f66a')
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+    extends('python')
 
-        make()
-        make("install")
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        # make('check')  # fails xmllint validation
+        make('install')

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -26,7 +26,8 @@ from spack import *
 
 
 class XcbProto(Package):
-    """Protocol for libxcb"""
+    """xcb-proto provides the XML-XCB protocol descriptions that libxcb uses to
+    generate the majority of its code and API."""
 
     homepage = "http://xcb.freedesktop.org/"
     url      = "http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz"

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -25,37 +25,27 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilCursor(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.1.3', '4b0768fa497127131a47f07e5c8cf745')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
+    depends_on('xcb-util-renderutil')
+    depends_on('xcb-util-image')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcb-util-errors/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-errors/package.py
@@ -25,33 +25,23 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilErrors(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('1.0', 'dc4a6ce073a81a0b7e614a2988f275cc')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
 
     depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xcb-util-image/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-image/package.py
@@ -25,33 +25,24 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilImage(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.4.0', '32c9c2f72ebd58a2b2e210f27fee86f7')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
+    depends_on('xcb-util')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
+    depends_on('xproto@7.0.8:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -25,37 +25,26 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilKeysyms(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.4.0', '2decde7b02b4b3bde99a02c17b64d5dc')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
+    depends_on('xproto@7.0.8:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
@@ -25,37 +25,25 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilRenderutil(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.3.9', 'ac18c1b70ae69845e112f1d987926436')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -25,37 +25,25 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtilWm(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.4.1', '0831399918359bf82930124fa9fd6a9b')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcb-util/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util/package.py
@@ -25,37 +25,25 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class XcbUtil(Package):
+    """The XCB util modules provides a number of libraries which sit on top
+    of libxcb, the core X protocol library, and some of the extension
+    libraries. These experimental libraries provide convenience functions
+    and interfaces which make the raw X protocol more usable. Some of the
+    libraries also provide client-side code which is not strictly part of
+    the X protocol but which have traditionally been provided by Xlib."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('0.4.0', '157d82738aa89934b6adaf3ca508a0f5')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    depends_on('libxcb@1.4:')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
-
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xclipboard/package.py
+++ b/var/spack/repos/builtin/packages/xclipboard/package.py
@@ -25,27 +25,29 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xclipboard(Package):
+    """xclipboard is used to collect and display text selections that are
+    sent to the CLIPBOARD by other clients.  It is typically used to save
+    CLIPBOARD selections for later use.  It stores each CLIPBOARD
+    selection as a separate string, each of which can be selected."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xclipboard"
+    url      = "https://www.x.org/archive/individual/app/xclipboard-1.1.3.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.1.3', 'cee91df9df1b5d63034681546fd78c0b')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt@1.1:')
+    depends_on('libx11')
+    depends_on('libxkbfile')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xclock/package.py
+++ b/var/spack/repos/builtin/packages/xclock/package.py
@@ -25,27 +25,30 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xclock(Package):
+    """xclock is the classic X Window System clock utility.  It displays
+    the time in analog or digital form, continuously updated at a
+    frequency which may be specified by the user."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xclock"
+    url      = "https://www.x.org/archive/individual/app/xclock-1.0.7.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.7', 'bbade10e6234d8db276212014e8c77fa')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libx11')
+    depends_on('libxrender')
+    depends_on('libxft')
+    depends_on('libxkbfile')
+    depends_on('libxt')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcmiscproto/package.py
+++ b/var/spack/repos/builtin/packages/xcmiscproto/package.py
@@ -36,6 +36,9 @@ class Xcmiscproto(Package):
 
     version('1.2.2', 'ded6cd23fb2800df93ebf2b3f3b01119')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xcmiscproto/package.py
+++ b/var/spack/repos/builtin/packages/xcmiscproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xcmiscproto(Package):
+    """XC-MISC Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol that provides Xlib two ways to query
+    the server for available resource IDs."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xcmiscproto"
+    url      = "https://www.x.org/archive/individual/proto/xcmiscproto-1.2.2.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.2.2', 'ded6cd23fb2800df93ebf2b3f3b01119')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xcmsdb/package.py
+++ b/var/spack/repos/builtin/packages/xcmsdb/package.py
@@ -25,27 +25,24 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xcmsdb(Package):
+    """xcmsdb is used to load, query, or remove Device Color Characterization
+    data stored in properties on the root window of the screen as
+    specified in section 7, Device Color Characterization, of the
+    X11 Inter-Client Communication Conventions Manual (ICCCM)."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xcmsdb"
+    url      = "https://www.x.org/archive/individual/app/xcmsdb-1.0.5.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.5', 'e7b1699c831b44d7005bff45977ed56a')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcompmgr/package.py
+++ b/var/spack/repos/builtin/packages/xcompmgr/package.py
@@ -25,27 +25,27 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xcompmgr(Package):
+    """xcompmgr is a sample compositing manager for X servers supporting the
+    XFIXES, DAMAGE, RENDER, and COMPOSITE extensions.  It enables basic
+    eye-candy effects."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xcompmgr"
+    url      = "https://www.x.org/archive/individual/app/xcompmgr-1.1.7.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.1.7', '4992895c8934bbc99bb2447dfe5081f2')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxcomposite')
+    depends_on('libxfixes')
+    depends_on('libxdamage')
+    depends_on('libxrender')
+    depends_on('libxext')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xconsole/package.py
+++ b/var/spack/repos/builtin/packages/xconsole/package.py
@@ -25,27 +25,26 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xconsole(Package):
+    """xconsole displays in a X11 window the messages which are usually sent
+    to /dev/console."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xconsole"
+    url      = "https://www.x.org/archive/individual/app/xconsole-1.0.6.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.0.6', '46cb988e31a0cf9a02c2bbc4a82bd572')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt@1.0:')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xcursor-themes/package.py
+++ b/var/spack/repos/builtin/packages/xcursor-themes/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XcursorThemes(Package):
+    """This is a default set of cursor themes for use with libXcursor,
+    originally created for the XFree86 Project, and now shipped as part
+    of the X.Org software distribution."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/data/cursors"
+    url      = "https://www.x.org/archive/individual/data/xcursor-themes-1.0.4.tar.gz"
+
+    version('1.0.4', 'c82628f35e9950ba225050ad5803b92a')
+
+    depends_on('libxcursor')
+
+    depends_on('xcursorgen', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')
+
+        # `make install` copies the files to the libxcursor installation.
+        # Create a fake directory to convince Spack that we actually
+        # installed something.
+        mkdir(prefix.lib)

--- a/var/spack/repos/builtin/packages/xcursorgen/package.py
+++ b/var/spack/repos/builtin/packages/xcursorgen/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xcursorgen(Package):
+    """xcursorgen prepares X11 cursor sets for use with libXcursor."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xcursorgen"
+    url      = "https://www.x.org/archive/individual/app/xcursorgen-1.0.6.tar.gz"
+
+    version('1.0.6', '669df84fc30d89c12ce64b95aba26677')
+
+    depends_on('libx11')
+    depends_on('libxcursor')
+    depends_on('libpng@1.2.0:')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xdbedizzy/package.py
+++ b/var/spack/repos/builtin/packages/xdbedizzy/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xdbedizzy(Package):
+    """xdbedizzy is a demo of the X11 Double Buffer Extension (DBE)
+    creating a double buffered spinning scene."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xdbedizzy"
+    url      = "https://www.x.org/archive/individual/app/xdbedizzy-1.1.0.tar.gz"
+
+    version('1.1.0', '969be2f6bc62455431ab027f99720dc3')
+
+    depends_on('libx11')
+    depends_on('libxext')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xditview/package.py
+++ b/var/spack/repos/builtin/packages/xditview/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xditview(Package):
+    """xditview displays ditroff output on an X display."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xditview"
+    url      = "https://www.x.org/archive/individual/app/xditview-1.0.4.tar.gz"
+
+    version('1.0.4', '46dffbbc4de3039fdecabb73d10d6a4f')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xdm/package.py
+++ b/var/spack/repos/builtin/packages/xdm/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xdm(Package):
+    """X Display Manager / XDMCP server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xdm"
+    url      = "https://www.x.org/archive/individual/app/xdm-1.1.11.tar.gz"
+
+    version('1.1.11', 'aaf8c3d05d4a1e689d2d789c99a6023c')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+    depends_on('libxau')
+    depends_on('libxinerama')
+    depends_on('libxft')
+    depends_on('libxpm')
+    depends_on('libxaw')
+    depends_on('libxdmcp')
+    depends_on('libxt')
+    depends_on('libxext')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xdpyinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdpyinfo/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xdpyinfo(Package):
+    """xdpyinfo is a utility for displaying information about an X server.
+
+    It is used to examine the capabilities of a server, the predefined
+    values for various parameters used in communicating between clients
+    and the server, and the different types of screens, visuals, and X11
+    protocol extensions that are available."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xdpyinfo"
+    url      = "https://www.x.org/archive/individual/app/xdpyinfo-1.3.2.tar.gz"
+
+    version('1.3.2', 'dab410719d36c9df690cf3a8cd7d117e')
+
+    depends_on('libxext')
+    depends_on('libx11')
+    depends_on('libxtst')
+    depends_on('libxcb')
+
+    depends_on('xproto@7.0.22:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xdriinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdriinfo/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xdriinfo(Package):
+    """xdriinfo - query configuration information of X11 DRI drivers."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xdriinfo"
+    url      = "https://www.x.org/archive/individual/app/xdriinfo-1.0.5.tar.gz"
+
+    version('1.0.5', '34a4a9ae69c60f4c2566bf9ea4bcf311')
+
+    depends_on('libx11')
+    depends_on('expat')
+    depends_on('libxshmfence')
+    depends_on('libxext')
+    depends_on('libxdamage')
+    depends_on('libxfixes')
+    depends_on('pcre')
+
+    depends_on('glproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xedit/package.py
+++ b/var/spack/repos/builtin/packages/xedit/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xedit(Package):
+    """Xedit is a simple text editor for X."""
+
+    homepage = "https://cgit.freedesktop.org/xorg/app/xedit"
+    url      = "https://www.x.org/archive/individual/app/xedit-1.2.2.tar.gz"
+
+    version('1.2.2', '9fb9d6f63b574e5a4937384fbe6579c1')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt@1.0:')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xev/package.py
+++ b/var/spack/repos/builtin/packages/xev/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xev(Package):
+    """xev creates a window and then asks the X server to send it X11 events
+    whenever anything happens to the window (such as it being moved,
+    resized, typed in, clicked in, etc.).  You can also attach it to an
+    existing window.  It is useful for seeing what causes events to occur
+    and to display the information that they contain; it is essentially a
+    debugging and development tool, and should not be needed in normal
+    usage."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xev"
+    url      = "https://www.x.org/archive/individual/app/xev-1.2.2.tar.gz"
+
+    version('1.2.2', 'fdb374f77cdad8e104b989a0148c4c1f')
+
+    depends_on('libxrandr@1.2:')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xextproto/package.py
+++ b/var/spack/repos/builtin/packages/xextproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xextproto(Package):
+    """X Protocol Extensions."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xextproto"
+    url      = "https://www.x.org/archive/individual/proto/xextproto-7.3.0.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('7.3.0', '37b700baa8c8ea7964702d948dd13821')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xextproto/package.py
+++ b/var/spack/repos/builtin/packages/xextproto/package.py
@@ -33,6 +33,9 @@ class Xextproto(Package):
 
     version('7.3.0', '37b700baa8c8ea7964702d948dd13821')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xeyes/package.py
+++ b/var/spack/repos/builtin/packages/xeyes/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xeyes(Package):
+    """xeyes - a follow the mouse X demo, using the X SHAPE extension"""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xeyes"
+    url      = "https://www.x.org/archive/individual/app/xeyes-1.1.1.tar.gz"
+
+    version('1.1.1', '2c0522bce5c61bbe784d2b3491998d31')
+
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxext')
+    depends_on('libxmu')
+    depends_on('libxrender@0.4:')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xf86bigfontproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86bigfontproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86bigfontproto(Package):
+    """X.org XF86BigFontProto protocol headers."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86bigfontproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86bigfontproto-1.2.0.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.2.0', '91b0733ff4cbe55808d96073258aa3d1')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86dga/package.py
+++ b/var/spack/repos/builtin/packages/xf86dga/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xf86dga(Package):
+    """dga is a simple test client for the XFree86-DGA extension."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xf86dga"
+    url      = "https://www.x.org/archive/individual/app/xf86dga-1.0.3.tar.gz"
+
+    version('1.0.3', '3b87bb916c9df68cf5e4e969307b25b5')
+
+    depends_on('libx11')
+    depends_on('libxxf86dga@1.1:')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xf86dgaproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86dgaproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86dgaproto(Package):
+    """X.org XF86DGAProto protocol headers."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86dgaproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86dgaproto-2.1.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.1', '1fe79dc07857ad3e1fb8b8f2bdd70d1b')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86driproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86driproto/package.py
@@ -37,6 +37,9 @@ class Xf86driproto(Package):
 
     version('2.1.1', '3ba16a48d8d9f9f746f9bd281ba8fb3f')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xf86driproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86driproto/package.py
@@ -25,17 +25,17 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86driproto(Package):
+    """XFree86 Direct Rendering Infrastructure Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol to allow user applications to access
+    the video hardware without requiring data to be passed through the X
+    server."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86driproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86driproto-2.1.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.1.1', '3ba16a48d8d9f9f746f9bd281ba8fb3f')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86miscproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86miscproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86miscproto(Package):
+    """This package includes the protocol definitions of the "XFree86-Misc"
+    extension to the X11 protocol.  The "XFree86-Misc" extension is
+    supported by the XFree86 X server and versions of the Xorg X server
+    prior to Xorg 1.6."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86miscproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86miscproto-0.9.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('0.9.3', 'c6432f04f84929c94fa05b3a466c489d')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86rushproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86rushproto/package.py
@@ -25,17 +25,13 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86rushproto(Package):
+    """X.org XF86RushProto protocol headers."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86rushproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86rushproto-1.1.2.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.1.2', '6a6389473332ace01146cccfef228576')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xf86vidmodeproto(Package):
+    """XFree86 Video Mode Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This extension defines a protocol for dynamically configuring modelines
+    and gamma."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86vidmodeproto"
+    url      = "https://www.x.org/archive/individual/proto/xf86vidmodeproto-2.3.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('2.3.1', '99016d0fe355bae0bb23ce00fb4d4a2c')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
@@ -36,6 +36,9 @@ class Xf86vidmodeproto(Package):
 
     version('2.3.1', '99016d0fe355bae0bb23ce00fb4d4a2c')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfd(Package):
+    """xfd - display all the characters in a font using either the
+    X11 core protocol or libXft2."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfd"
+    url      = "https://www.x.org/archive/individual/app/xfd-1.1.2.tar.gz"
+
+    version('1.1.2', '12fe8f7c3e71352bf22124ad56d4ceaf')
+
+    depends_on('libxaw')
+    depends_on('fontconfig')
+    depends_on('libxft')
+    depends_on('libxrender')
+    depends_on('libxmu')
+    depends_on('libxt')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xfindproxy/package.py
+++ b/var/spack/repos/builtin/packages/xfindproxy/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfindproxy(Package):
+    """xfindproxy is used to locate available X11 proxy services.
+
+    It utilizes the Proxy Management Protocol to communicate with a proxy
+    manager.  The proxy manager keeps track of all available proxy
+    services, starts new proxies when necessary, and makes sure that
+    proxies are shared whenever possible."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfindproxy"
+    url      = "https://www.x.org/archive/individual/app/xfindproxy-1.0.4.tar.gz"
+
+    version('1.0.4', 'd0a7b53ae5827b342bccd3ebc7ec672f')
+
+    depends_on('libice')
+    depends_on('libxt')
+
+    depends_on('xproto', type='build')
+    depends_on('xproxymanagementprotocol', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xfontsel/package.py
+++ b/var/spack/repos/builtin/packages/xfontsel/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfontsel(Package):
+    """xfontsel application provides a simple way to display the X11 core
+    protocol fonts known to your X server, examine samples of each, and
+    retrieve the X Logical Font Description ("XLFD") full name for a font."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfontsel"
+    url      = "https://www.x.org/archive/individual/app/xfontsel-1.0.5.tar.gz"
+
+    version('1.0.5', '72a35e7fa786eb2b0194d75eeb4a02e3')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xfs/package.py
+++ b/var/spack/repos/builtin/packages/xfs/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfs(Package):
+    """X Font Server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfs"
+    url      = "https://www.x.org/archive/individual/app/xfs-1.1.4.tar.gz"
+
+    version('1.1.4', '0818a2e0317e0f0a1e8a15ca811827e2')
+
+    depends_on('libxfont@1.4.5:')
+    depends_on('font-util')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xfsinfo/package.py
+++ b/var/spack/repos/builtin/packages/xfsinfo/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfsinfo(Package):
+    """xfsinfo is a utility for displaying information about an X font
+    server.  It is used to examine the capabilities of a server, the
+    predefined values for various parameters used in communicating between
+    clients and the server, and the font catalogues and alternate servers
+    that are available."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfsinfo"
+    url      = "https://www.x.org/archive/individual/app/xfsinfo-1.0.5.tar.gz"
+
+    version('1.0.5', '36b64a3f37b87c759c5d17634e129fb9')
+
+    depends_on('libfs')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xfwp/package.py
+++ b/var/spack/repos/builtin/packages/xfwp/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xfwp(Package):
+    """xfwp proxies X11 protocol connections, such as through a firewall."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xfwp"
+    url      = "https://www.x.org/archive/individual/app/xfwp-1.0.3.tar.gz"
+
+    version('1.0.3', 'e23cc01894ae57e5959ca6a56d0f4f94')
+
+    depends_on('libice')
+
+    depends_on('xproto', type='build')
+    depends_on('xproxymanagementprotocol', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        # FIXME: fails with the error message:
+        # io.c:1039:7: error: implicit declaration of function 'swab'
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xgamma/package.py
+++ b/var/spack/repos/builtin/packages/xgamma/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xgamma(Package):
+    """xgamma allows X users to query and alter the gamma correction of a
+    monitor via the X video mode extension (XFree86-VidModeExtension)."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xgamma"
+    url      = "https://www.x.org/archive/individual/app/xgamma-1.0.6.tar.gz"
+
+    version('1.0.6', 'ac4f91bf1d9aa0433152ba6196288cc6')
+
+    depends_on('libx11')
+    depends_on('libxxf86vm')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xgc/package.py
+++ b/var/spack/repos/builtin/packages/xgc/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xgc(Package):
+    """xgc is an X11 graphics demo that shows various features of the X11
+    core protocol graphics primitives."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xgc"
+    url      = "https://www.x.org/archive/individual/app/xgc-1.0.5.tar.gz"
+
+    version('1.0.5', '605557a9c138f6dc848c87a21bc7c7fc')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xhost/package.py
+++ b/var/spack/repos/builtin/packages/xhost/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xhost(Package):
+    """xhost is used to manage the list of host names or user names
+    allowed to make connections to the X server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xhost"
+    url      = "https://www.x.org/archive/individual/app/xhost-1.0.7.tar.gz"
+
+    version('1.0.7', 'de34b4ba5194634dbeb29a1f008f495a')
+
+    depends_on('libx11')
+    depends_on('libxmu')
+    depends_on('libxau')
+
+    depends_on('xproto@7.0.22:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xineramaproto/package.py
+++ b/var/spack/repos/builtin/packages/xineramaproto/package.py
@@ -36,6 +36,9 @@ class Xineramaproto(Package):
 
     version('1.2.1', 'e0e148b11739e144a546b8a051b17dde')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xineramaproto/package.py
+++ b/var/spack/repos/builtin/packages/xineramaproto/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xineramaproto(Package):
+    """X Xinerama Extension.
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    This is an X extension that allows multiple physical screens controlled
+    by a single X server to appear as a single screen."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
+    homepage = "http://cgit.freedesktop.org/xorg/proto/xineramaproto"
+    url      = "https://www.x.org/archive/individual/proto/xineramaproto-1.2.1.tar.gz"
 
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.2.1', 'e0e148b11739e144a546b8a051b17dde')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xinit/package.py
+++ b/var/spack/repos/builtin/packages/xinit/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xinit(Package):
+    """The xinit program is used to start the X Window System server and a
+    first client program on systems that are not using a display manager
+    such as xdm."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xinit"
+    url      = "https://www.x.org/archive/individual/app/xinit-1.3.4.tar.gz"
+
+    version('1.3.4', '91c5697345016ec7841f5e5fccbe7a4c')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xinput/package.py
+++ b/var/spack/repos/builtin/packages/xinput/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xinput(Package):
+    """xinput is a utility to configure and test XInput devices."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xinput"
+    url      = "https://www.x.org/archive/individual/app/xinput-1.6.2.tar.gz"
+
+    version('1.6.2', '6684f6015298d22936438173be3b7ef5')
+
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxi@1.5.99.1:')
+    depends_on('libxrandr')
+    depends_on('libxinerama')
+
+    depends_on('inputproto@2.1.99.1:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkbcomp/package.py
+++ b/var/spack/repos/builtin/packages/xkbcomp/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkbcomp(Package):
+    """The X Keyboard (XKB) Extension essentially replaces the core protocol
+    definition of a keyboard. The extension makes it possible to specify
+    clearly and explicitly most aspects of keyboard behaviour on a per-key
+    basis, and to track more closely the logical and physical state of a
+    keyboard. It also includes a number of keyboard controls designed to
+    make keyboards more accessible to people with physical impairments."""
+
+    homepage = "https://www.x.org/wiki/XKB/"
+    url      = "https://www.x.org/archive/individual/app/xkbcomp-1.3.1.tar.gz"
+
+    version('1.3.1', '9e8ca110ed40d4703f8f73d99bc81576')
+
+    depends_on('libx11')
+    depends_on('libxkbfile')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('bison', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkbdata/package.py
+++ b/var/spack/repos/builtin/packages/xkbdata/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkbdata(Package):
+    """The XKB data files for the various keyboard models, layouts,
+    and locales."""
+
+    homepage = "https://www.x.org/wiki/XKB/"
+    url      = "https://www.x.org/archive/individual/data/xkbdata-1.0.1.tar.gz"
+
+    version('1.0.1', 'a7e0fbc9cc84c621243c777694388064')
+
+    depends_on('xkbcomp', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkbevd/package.py
+++ b/var/spack/repos/builtin/packages/xkbevd/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkbevd(Package):
+    """XKB event daemon demo."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xkbevd"
+    url      = "https://www.x.org/archive/individual/app/xkbevd-1.1.4.tar.gz"
+
+    version('1.1.4', '0e9e05761551b1e58bd541231f90ae87')
+
+    depends_on('libxkbfile')
+    depends_on('libx11')
+
+    depends_on('bison', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkbprint/package.py
+++ b/var/spack/repos/builtin/packages/xkbprint/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkbprint(Package):
+    """xkbprint generates a printable or encapsulated PostScript description
+    of an XKB keyboard description."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xkbprint"
+    url      = "https://www.x.org/archive/individual/app/xkbprint-1.0.4.tar.gz"
+
+    version('1.0.4', '4dd9d4fdbdc08f70dc402da149e4d5d8')
+
+    depends_on('libxkbfile')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkbutils/package.py
+++ b/var/spack/repos/builtin/packages/xkbutils/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkbutils(Package):
+    """xkbutils is a collection of small utilities utilizing the XKeyboard
+    (XKB) extension to the X11 protocol."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xkbutils"
+    url      = "https://www.x.org/archive/individual/app/xkbutils-1.0.4.tar.gz"
+
+    version('1.0.4', '6b898346b84e07c2f13b097193ca0413')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('inputproto', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XkeyboardConfig(Package):
+    """This project provides a consistent, well-structured, frequently
+    released, open source database of keyboard configuration data. The
+    project is targeted to XKB-based systems."""
+
+    homepage = "https://www.freedesktop.org/wiki/Software/XKeyboardConfig/"
+    url      = "https://www.x.org/archive/individual/data/xkeyboard-config/xkeyboard-config-2.18.tar.gz"
+
+    version('2.18', '96c43e04dbfbb1e6e6abd4678292062c')
+
+    depends_on('libx11@1.4.3:')
+
+    depends_on('libxslt', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('intltool@0.30:', type='build')
+    depends_on('xproto@7.0.20:', type='build')
+
+    # TODO: missing dependencies
+    # xgettext
+    # msgmerge
+    # msgfmt
+    # gmsgfmt
+    # perl@5.8.1:
+    # perl XML::Parser
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xkill/package.py
+++ b/var/spack/repos/builtin/packages/xkill/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xkill(Package):
+    """xkill is a utility for forcing the X server to close connections to
+    clients.  This program is very dangerous, but is useful for aborting
+    programs that have displayed undesired windows on a user's screen."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xkill"
+    url      = "https://www.x.org/archive/individual/app/xkill-1.0.4.tar.gz"
+
+    version('1.0.4', 'b04c15bfd0b619f1e4ff3e44607e738d')
+
+    depends_on('libx11')
+    depends_on('libxmu')
+
+    depends_on('xproto@7.0.22:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xload/package.py
+++ b/var/spack/repos/builtin/packages/xload/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xload(Package):
+    """xload displays a periodically updating histogram of the
+    system load average."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xload"
+    url      = "https://www.x.org/archive/individual/app/xload-1.1.2.tar.gz"
+
+    version('1.1.2', '0af9a68193849b16f8168f096682efb4')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xlogo/package.py
+++ b/var/spack/repos/builtin/packages/xlogo/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xlogo(Package):
+    """The xlogo program simply displays the X Window System logo."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xlogo"
+    url      = "https://www.x.org/archive/individual/app/xlogo-1.0.4.tar.gz"
+
+    version('1.0.4', '4c4f82c196a55a90800a77906f4353fb')
+
+    depends_on('libsm')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt@1.0:')
+    depends_on('libxext')
+    depends_on('libx11')
+    depends_on('libxft')
+    depends_on('libxrender')
+    depends_on('libxt')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xlsatoms/package.py
+++ b/var/spack/repos/builtin/packages/xlsatoms/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xlsatoms(Package):
+    """xlsatoms lists the interned atoms defined on an X11 server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xlsatoms"
+    url      = "https://www.x.org/archive/individual/app/xlsatoms-1.1.2.tar.gz"
+
+    version('1.1.2', '1f32e2b8c2135b5867291517848cb396')
+
+    depends_on('libxcb', when='@1.1:')
+    depends_on('libx11', when='@:1.0')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xlsclients/package.py
+++ b/var/spack/repos/builtin/packages/xlsclients/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xlsclients(Package):
+    """xlsclients is a utility for listing information about the client
+    applications running on a X11 server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xlsclients"
+    url      = "https://www.x.org/archive/individual/app/xlsclients-1.1.3.tar.gz"
+
+    version('1.1.3', '093c748d98b61dbddcaf3de1740fbd26')
+
+    depends_on('libxcb@1.6:', when='@1.1:')
+    depends_on('libx11', when='@:1.0')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xlsfonts/package.py
+++ b/var/spack/repos/builtin/packages/xlsfonts/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xlsfonts(Package):
+    """xlsfonts lists fonts available from an X server via the X11
+    core protocol."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xlsfonts"
+    url      = "https://www.x.org/archive/individual/app/xlsfonts-1.0.5.tar.gz"
+
+    version('1.0.5', '074cc44e5238c6a501523ef06caba517')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xmag/package.py
+++ b/var/spack/repos/builtin/packages/xmag/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmag(Package):
+    """xmag displays a magnified snapshot of a portion of an X11 screen."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xmag"
+    url      = "https://www.x.org/archive/individual/app/xmag-1.0.6.tar.gz"
+
+    version('1.0.6', '2827ae4b293535623b9f7b659c506dcd')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xman/package.py
+++ b/var/spack/repos/builtin/packages/xman/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xman(Package):
+    """xman is a graphical manual page browser using the Athena Widgets (Xaw)
+    toolkit."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xman"
+    url      = "https://www.x.org/archive/individual/app/xman-1.1.4.tar.gz"
+
+    version('1.1.4', 'f4238c79ee7227ea193898fc159f31e5')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xmessage/package.py
+++ b/var/spack/repos/builtin/packages/xmessage/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmessage(Package):
+    """xmessage displays a message or query in a window.  The user can click
+    on an "okay" button to dismiss it or can select one of several buttons
+    to answer a question.  xmessage can also exit after a specified time."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xmessage"
+    url      = "https://www.x.org/archive/individual/app/xmessage-1.0.4.tar.gz"
+
+    version('1.0.4', '69df5761fbec14c782948065a6f36028')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xmh/package.py
+++ b/var/spack/repos/builtin/packages/xmh/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmh(Package):
+    """The xmh program provides a graphical user interface to the
+    MH Message Handling System.  To actually do things with your
+    mail, it makes calls to the MH package."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xmh"
+    url      = "https://www.x.org/archive/individual/app/xmh-1.0.3.tar.gz"
+
+    version('1.0.3', '7547c5a5ab7309a1b10e8ecf48e60105')
+
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libxt')
+    depends_on('libx11')
+
+    depends_on('xbitmaps@1.1.0:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xmlto/package.py
+++ b/var/spack/repos/builtin/packages/xmlto/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmlto(Package):
+    """Utility xmlto is a simple shell script for converting XML files to various
+    formats. It serves as easy to use command line frontend to make fine output
+    without remembering many long options and searching for the syntax of the
+    backends."""
+
+    homepage = "http://cyberelk.net/tim/software/xmlto/"
+    url      = "https://fedorahosted.org/releases/x/m/xmlto/xmlto-0.0.28.tar.gz"
+
+    version('0.0.28', 'a1fefad9d83499a15576768f60f847c6')
+
+    # FIXME: missing a lot of dependencies
+    depends_on('libxslt')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/xmlto/package.py
+++ b/var/spack/repos/builtin/packages/xmlto/package.py
@@ -43,5 +43,4 @@ class Xmlto(Package):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xmodmap/package.py
+++ b/var/spack/repos/builtin/packages/xmodmap/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmodmap(Package):
+    """The xmodmap program is used to edit and display the keyboard modifier
+    map and keymap table that are used by client applications to convert
+    event keycodes into keysyms.  It is usually run from the user's
+    session startup script to configure the keyboard according to personal
+    tastes."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xmodmap"
+    url      = "https://www.x.org/archive/individual/app/xmodmap-1.0.9.tar.gz"
+
+    version('1.0.9', '771cf86bcdc3589e7add2e761f675099')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xmore/package.py
+++ b/var/spack/repos/builtin/packages/xmore/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xmore(Package):
+    """xmore - plain text display program for the X Window System."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xmore"
+    url      = "https://www.x.org/archive/individual/app/xmore-1.0.2.tar.gz"
+
+    version('1.0.2', '40b1850494f8af0939a1989c399efa11')
+
+    depends_on('libxaw')
+    depends_on('libxt')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-cf-files/package.py
+++ b/var/spack/repos/builtin/packages/xorg-cf-files/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XorgCfFiles(Package):
+    """The xorg-cf-files package contains the data files for the imake utility,
+    defining the known settings for a wide variety of platforms (many of which
+    have not been verified or tested in over a decade), and for many of the
+    libraries formerly delivered in the X.Org monolithic releases."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/util/cf"
+    url      = "https://www.x.org/archive/individual/util/xorg-cf-files-1.0.6.tar.gz"
+
+    version('1.0.6', 'c0ce98377c70d95fb48e1bd856109bf8')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XorgDocs(Package):
+    """This package provides miscellaneous documentation for the X Window
+    System that doesn't better fit into other packages.
+
+    The preferred documentation format for these documents is DocBook XML."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/doc/xorg-docs"
+    url      = "https://www.x.org/archive/individual/doc/xorg-docs-1.7.1.tar.gz"
+
+    version('1.7.1', 'ca689ccbf8ebc362afbe5cc5792a4abd')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+    depends_on('xorg-sgml-doctools@1.8:', type='build')
+    depends_on('xmlto', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-gtest/package.py
+++ b/var/spack/repos/builtin/packages/xorg-gtest/package.py
@@ -38,12 +38,14 @@ class XorgGtest(Package):
     depends_on('libxi')
     depends_on('xorg-server')
 
-    # TODO: needs testing once xorg-server is packaged
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    # TODO: may be missing evemu package?
     # TODO: what is the difference between xorg-gtest and googletest packages?
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xorg-gtest/package.py
+++ b/var/spack/repos/builtin/packages/xorg-gtest/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XorgGtest(Package):
+    """Provides a Google Test environment for starting and stopping
+    a X server for testing purposes."""
+
+    homepage = "https://people.freedesktop.org/~cndougla/xorg-gtest/"
+    url      = "https://www.x.org/archive/individual/test/xorg-gtest-0.7.1.tar.bz2"
+
+    version('0.7.1', '31beb4d7d2b4eba7f9265fa0cb4c6428')
+
+    depends_on('libx11')
+    depends_on('libxi')
+    depends_on('xorg-server')
+
+    # TODO: needs testing once xorg-server is packaged
+    # TODO: what is the difference between xorg-gtest and googletest packages?
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -39,22 +39,21 @@ class XorgServer(Package):
     depends_on('libxshmfence@1.1:')
     depends_on('libdrm@2.3.0:')
     depends_on('libx11')
-    #depends_on('gl@9.2.0:')
-
+    # depends_on('gl@9.2.0:')
 
     depends_on('dri2proto@2.8:', type='build')
     depends_on('dri3proto@1.0:', type='build')
     depends_on('glproto@1.4.17:', type='build')
 
-
-    #depends_on('flex', type='build')
-    #depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
 
     # $LIBSELINUX $REQUIRED_MODULES $REQUIRED_LIBS
-    # $LIBPCIACCESS $DGAPROTO $XORG_MODULES epoxy xdmcp xau xfixes x11-xcb xcb-aux
-    # xcb-image xcb-ewmh xcb-icccm $WINDOWSWMPROTO windowsdriproto khronos-opengl-registry
+    # $LIBPCIACCESS $DGAPROTO $XORG_MODULES epoxy xdmcp xau xfixes x11-xcb
+    # xcb-aux xcb-image xcb-ewmh xcb-icccm $WINDOWSWMPROTO windowsdriproto
+    # khronos-opengl-registry
     # $APPLEWMPROTO $LIBAPPLEWM xfixes $LIBDMX $LIBXEXT $LIBDMX xmu $LIBXEXT
     # $LIBDMX $LIBXI $LIBXEXT $LIBXTST $LIBXEXT xres $LIBXEXT $LIBXEXT
     # $XEPHYR_REQUIRED_LIBS
@@ -102,10 +101,7 @@ class XorgServer(Package):
     # LIBDBUS="dbus-1 >= 1.0"
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -50,6 +50,7 @@ class XorgServer(Package):
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
 
+    # TODO: add missing dependencies
     # $LIBSELINUX $REQUIRED_MODULES $REQUIRED_LIBS
     # $LIBPCIACCESS $DGAPROTO $XORG_MODULES epoxy xdmcp xau xfixes x11-xcb
     # xcb-aux xcb-image xcb-ewmh xcb-icccm $WINDOWSWMPROTO windowsdriproto

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -1,0 +1,111 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XorgServer(Package):
+    """X.Org Server is the free and open source implementation of the display
+    server for the X Window System stewarded by the X.Org Foundation."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/xserver"
+    url      = "https://www.x.org/archive/individual/xserver/xorg-server-1.18.99.901.tar.gz"
+
+    version('1.18.99.901', 'd0242b95991c221c4fcc0d283aba7a42')
+
+    depends_on('pixman@0.27.2:')
+    depends_on('font-util')
+    depends_on('libxshmfence@1.1:')
+    depends_on('libdrm@2.3.0:')
+    depends_on('libx11')
+    #depends_on('gl@9.2.0:')
+
+
+    depends_on('dri2proto@2.8:', type='build')
+    depends_on('dri3proto@1.0:', type='build')
+    depends_on('glproto@1.4.17:', type='build')
+
+
+    #depends_on('flex', type='build')
+    #depends_on('bison', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    # $LIBSELINUX $REQUIRED_MODULES $REQUIRED_LIBS
+    # $LIBPCIACCESS $DGAPROTO $XORG_MODULES epoxy xdmcp xau xfixes x11-xcb xcb-aux
+    # xcb-image xcb-ewmh xcb-icccm $WINDOWSWMPROTO windowsdriproto khronos-opengl-registry
+    # $APPLEWMPROTO $LIBAPPLEWM xfixes $LIBDMX $LIBXEXT $LIBDMX xmu $LIBXEXT
+    # $LIBDMX $LIBXI $LIBXEXT $LIBXTST $LIBXEXT xres $LIBXEXT $LIBXEXT
+    # $XEPHYR_REQUIRED_LIBS
+
+    # VIDEOPROTO="videoproto"
+    # COMPOSITEPROTO="compositeproto >= 0.4"
+    # RECORDPROTO="recordproto >= 1.13.99.1"
+    # SCRNSAVERPROTO="scrnsaverproto >= 1.1"
+    # RESOURCEPROTO="resourceproto >= 1.2.0"
+    # DRIPROTO="xf86driproto >= 2.1.0"
+    # XINERAMAPROTO="xineramaproto"
+    # BIGFONTPROTO="xf86bigfontproto >= 1.2.0"
+    # DGAPROTO="xf86dgaproto >= 2.0.99.1"
+    # DMXPROTO="dmxproto >= 2.2.99.1"
+    # VIDMODEPROTO="xf86vidmodeproto >= 2.2.99.1"
+    # WINDOWSWMPROTO="windowswmproto"
+    # APPLEWMPROTO="applewmproto >= 1.4"
+
+    # XPROTO="xproto >= 7.0.28"
+    # RANDRPROTO="randrproto >= 1.5.0"
+    # RENDERPROTO="renderproto >= 0.11"
+    # XEXTPROTO="xextproto >= 7.2.99.901"
+    # INPUTPROTO="inputproto >= 2.3"
+    # KBPROTO="kbproto >= 1.0.3"
+    # FONTSPROTO="fontsproto >= 2.1.3"
+    # FIXESPROTO="fixesproto >= 5.0"
+    # DAMAGEPROTO="damageproto >= 1.1"
+    # XCMISCPROTO="xcmiscproto >= 1.2.0"
+    # BIGREQSPROTO="bigreqsproto >= 1.1.0"
+    # XTRANS="xtrans >= 1.3.5"
+    # PRESENTPROTO="presentproto >= 1.0"
+
+    # LIBAPPLEWM="applewm >= 1.4"
+    # LIBDMX="dmx >= 1.0.99.1"
+    # LIBDRI="dri >= 7.8.0"
+    # LIBEGL="egl"
+    # LIBGBM="gbm >= 10.2.0"
+    # LIBXEXT="xext >= 1.0.99.4"
+    # LIBXFONT="xfont2 >= 2.0.0"
+    # LIBXI="xi >= 1.2.99.1"
+    # LIBXTST="xtst >= 1.0.99.2"
+    # LIBPCIACCESS="pciaccess >= 0.12.901"
+    # LIBUDEV="libudev >= 143"
+    # LIBSELINUX="libselinux >= 2.0.86"
+    # LIBDBUS="dbus-1 >= 1.0"
+
+    def install(self, spec, prefix):
+        # FIXME: Modify the configure line to suit your build system here.
+        configure('--prefix={0}'.format(prefix))
+
+        # FIXME: Add logic to build and install here.
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class XorgSgmlDoctools(Package):
+    """This package provides a common set of SGML entities and XML/CSS style
+    sheets used in building/formatting the documentation provided in other
+    X.Org packages."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/doc/xorg-sgml-doctools"
+    url      = "https://www.x.org/archive/individual/doc/xorg-sgml-doctools-1.11.tar.gz"
+
+    version('1.11', '51cf4c6b476e2b98a068fea6975b9b21')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xorg-util-macros/package.py
+++ b/var/spack/repos/builtin/packages/xorg-util-macros/package.py
@@ -34,6 +34,6 @@ class XorgUtilMacros(Package):
     version('1.19.0', '1cf984125e75f8204938d998a8b6c1e1')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')

--- a/var/spack/repos/builtin/packages/xphelloworld/package.py
+++ b/var/spack/repos/builtin/packages/xphelloworld/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xphelloworld(Package):
+    """Xprint sample applications."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xphelloworld"
+    url      = "https://www.x.org/archive/individual/app/xphelloworld-1.0.1.tar.gz"
+
+    version('1.0.1', 'b1851337a8e850d5c8e5a5ca5e3033da')
+
+    depends_on('libx11')
+    depends_on('libxaw')
+    depends_on('libxprintapputil')
+    depends_on('libxprintutil')
+    depends_on('libxp')
+    depends_on('libxt')
+
+    # FIXME: xphelloworld requires libxaw8, but libxaw only provides 6 and 7.
+    # It looks like xprint support was removed from libxaw at some point.
+    # But even the oldest version of libxaw doesn't build libxaw8.
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xplsprinters/package.py
+++ b/var/spack/repos/builtin/packages/xplsprinters/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xplsprinters(Package):
+    """List Xprint printers."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xplsprinters"
+    url      = "https://www.x.org/archive/individual/app/xplsprinters-1.0.1.tar.gz"
+
+    version('1.0.1', '8e5698b5a2a2a0fc78caeb23909dd284')
+
+    depends_on('libxp')
+    depends_on('libxprintutil')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xpr/package.py
+++ b/var/spack/repos/builtin/packages/xpr/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xpr(Package):
+    """xpr takes as input a window dump file produced by xwd
+    and formats it for output on various types of printers."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xpr"
+    url      = "https://www.x.org/archive/individual/app/xpr-1.0.4.tar.gz"
+
+    version('1.0.4', '6adfa60f458474c0c226454c233fc32f')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
+++ b/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xprehashprinterlist(Package):
+    """Rehash list of Xprint printers."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xprehashprinterlist"
+    url      = "https://www.x.org/archive/individual/app/xprehashprinterlist-1.0.1.tar.gz"
+
+    version('1.0.1', '395578955634e4b2daa5b78f6fa9222c')
+
+    depends_on('libxp')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xprop/package.py
+++ b/var/spack/repos/builtin/packages/xprop/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xprop(Package):
+    """xprop is a command line tool to display and/or set window and font
+    properties of an X server."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xprop"
+    url      = "https://www.x.org/archive/individual/app/xprop-1.2.2.tar.gz"
+
+    version('1.2.2', 'db03a6bcf7b0d0c2e691ea3083277cbc')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xproto/package.py
+++ b/var/spack/repos/builtin/packages/xproto/package.py
@@ -40,6 +40,9 @@ class Xproto(Package):
 
     version('7.0.29', '16a78dd2c5ad73011105c96235f6a0af')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xproto/package.py
+++ b/var/spack/repos/builtin/packages/xproto/package.py
@@ -29,14 +29,15 @@ class Xproto(Package):
     """The Xorg protocol headers provide the header files required to
        build the system, and to allow other applications to build against
        the installed X Window system."""
+
     homepage = "http://www.x.org/"
     url      = "https://www.x.org/archive//individual/proto/xproto-7.0.29.tar.gz"
 
     version('7.0.29', '16a78dd2c5ad73011105c96235f6a0af')
 
-    depends_on("xorg-util-macros")
+    depends_on('xorg-util-macros')
 
     def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")
+        configure('--prefix={0}'.format(prefix))
+
+        make('install')

--- a/var/spack/repos/builtin/packages/xproto/package.py
+++ b/var/spack/repos/builtin/packages/xproto/package.py
@@ -26,16 +26,19 @@ from spack import *
 
 
 class Xproto(Package):
-    """The Xorg protocol headers provide the header files required to
-       build the system, and to allow other applications to build against
-       the installed X Window system."""
+    """X Window System Core Protocol.
 
-    homepage = "http://www.x.org/"
-    url      = "https://www.x.org/archive//individual/proto/xproto-7.0.29.tar.gz"
+    This package provides the headers and specification documents defining
+    the X Window System Core Protocol, Version 11.
+
+    It also includes a number of headers that aren't purely protocol related,
+    but are depended upon by many other X Window System packages to provide
+    common definitions and porting layer."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/proto/x11proto"
+    url      = "https://www.x.org/archive/individual/proto/xproto-7.0.29.tar.gz"
 
     version('7.0.29', '16a78dd2c5ad73011105c96235f6a0af')
-
-    depends_on('xorg-util-macros')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xproxymanagementprotocol/package.py
+++ b/var/spack/repos/builtin/packages/xproxymanagementprotocol/package.py
@@ -25,17 +25,15 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xproxymanagementprotocol(Package):
+    """The Proxy Management Protocol is an ICE based protocol that provides a
+    way for application servers to easily locate proxy services available to
+    them."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "http://cgit.freedesktop.org/xorg/proto/pmproto"
+    url      = "https://www.x.org/archive/individual/proto/xproxymanagementprotocol-1.0.3.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.0.3', 'c4ab05a6174b4e9b6ae5b7cfbb6d718e')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xpyb/package.py
+++ b/var/spack/repos/builtin/packages/xpyb/package.py
@@ -25,37 +25,23 @@
 from spack import *
 
 
-class Libxcb(Package):
-    """The X protocol C-language Binding (XCB) is a replacement
-    for Xlib featuring a small footprint, latency hiding, direct
-    access to the protocol, improved threading support, and
-    extensibility."""
+class Xpyb(Package):
+    """xpyb provides a Python binding to the X Window System protocol
+    via libxcb."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.11.tar.gz"
+    url      = "https://xcb.freedesktop.org/dist/xpyb-1.3.1.tar.gz"
 
-    version('1.12', '95eee7c28798e16ba5443f188b27a476')
-    version('1.11', '1698dd837d7e6e94d029dbe8b3a82deb')
-    version('1.11.1', '118623c15a96b08622603a71d8789bf3')
+    version('1.3.1', '75d567e25517fb883a56f10b77fd2757')
 
-    depends_on('libpthread-stubs')
-    depends_on('libxau@0.99.2:')
-    depends_on('libxdmcp')
+    extends('python')
 
-    depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
-    depends_on('pkg-config@0.9.0:', type='build')
-    depends_on('util-macros', type='build')
+    depends_on('libxcb@1.5:')
 
-    def patch(self):
-        filter_file(
-            'typedef struct xcb_auth_info_t {',
-            'typedef struct {',
-            'src/xcb.h')
+    depends_on('xcb-proto@1.7.1:', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -25,27 +25,25 @@
 from spack import *
 
 
-class Gconf(Package):
-    """FIXME: Put a proper description of your package here."""
+class Xrandr(Package):
+    """xrandr - primitive command line interface to X11 Resize, Rotate, and
+    Reflect (RandR) extension."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "http://www.example.com"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    homepage = "http://cgit.freedesktop.org/xorg/app/xrandr"
+    url      = "https://www.x.org/archive/individual/app/xrandr-1.5.0.tar.gz"
 
-    version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
+    version('1.5.0', 'fe9cf76033fe5d973131eac67b6a3118')
 
-    depends_on('glib@2.14.0:')
-    # gio-2.0 >= 2.31.0
-    # gthread-2.0
-    # gmodule-2.0 >= 2.7.0
-    # gobject-2.0 >= 2.7.0
-    depends_on('libxml2')
+    depends_on('libxrandr@1.5:')
+    depends_on('libxrender')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
 
     def install(self, spec, prefix):
-        # FIXME: Modify the configure line to suit your build system here.
         configure('--prefix={0}'.format(prefix))
 
-        # FIXME: Add logic to build and install here.
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xrdb/package.py
+++ b/var/spack/repos/builtin/packages/xrdb/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xrdb(Package):
+    """xrdb - X server resource database utility."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xrdb"
+    url      = "https://www.x.org/archive/individual/app/xrdb-1.1.0.tar.gz"
+
+    version('1.1.0', 'd48983e561ef8b4b2e245feb584c11ce')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xrefresh/package.py
+++ b/var/spack/repos/builtin/packages/xrefresh/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xrefresh(Package):
+    """xrefresh - refresh all or part of an X screen."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xrefresh"
+    url      = "https://www.x.org/archive/individual/app/xrefresh-1.0.5.tar.gz"
+
+    version('1.0.5', 'e41c5148d894406484af59887257c465')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xrx/package.py
+++ b/var/spack/repos/builtin/packages/xrx/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xrx(Package):
+    """The remote execution (RX) service specifies a MIME format for invoking
+    applications remotely, for example via a World Wide Web browser.  This
+    RX format specifies a syntax for listing network services required by
+    the application, for example an X display server.  The requesting Web
+    browser must identify specific instances of the services in the request
+    to invoke the application."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xrx"
+    url      = "https://www.x.org/archive/individual/app/xrx-1.0.4.tar.gz"
+
+    version('1.0.4', 'dd4b8bf6eca5fc5be5df30c14050074c')
+
+    depends_on('libx11')
+    depends_on('libxt')
+    depends_on('libxext')
+    depends_on('libxau')
+    depends_on('libice')
+    depends_on('libxaw')
+
+    depends_on('xtrans', type='build')
+    depends_on('xproxymanagementprotocol', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xscope/package.py
+++ b/var/spack/repos/builtin/packages/xscope/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xscope(Package):
+    """XSCOPE -- a program to monitor X11/Client conversations."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xscope"
+    url      = "https://www.x.org/archive/individual/app/xscope-1.4.1.tar.gz"
+
+    version('1.4.1', 'c476fb73b354f4a5c388f3814052ce0d')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('xtrans', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xset/package.py
+++ b/var/spack/repos/builtin/packages/xset/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xset(Package):
+    """User preference utility for X."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xset"
+    url      = "https://www.x.org/archive/individual/app/xset-1.2.3.tar.gz"
+
+    version('1.2.3', '1a76965ed0e8cb51d3fa04d458cb3d8f')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xsetmode/package.py
+++ b/var/spack/repos/builtin/packages/xsetmode/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xsetmode(Package):
+    """Set the mode for an X Input device."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xsetmode"
+    url      = "https://www.x.org/archive/individual/app/xsetmode-1.0.0.tar.gz"
+
+    version('1.0.0', '0dc2a917138d0345c00e016ac720e085')
+
+    depends_on('libxi')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xsetpointer/package.py
+++ b/var/spack/repos/builtin/packages/xsetpointer/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xsetpointer(Package):
+    """Set an X Input device as the main pointer."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xsetpointer"
+    url      = "https://www.x.org/archive/individual/app/xsetpointer-1.0.1.tar.gz"
+
+    version('1.0.1', 'bb206b6875f2428c2281e1165b6c7f88')
+
+    depends_on('libxi')
+    depends_on('libx11')
+
+    depends_on('inputproto@1.4:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xsetroot/package.py
+++ b/var/spack/repos/builtin/packages/xsetroot/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xsetroot(Package):
+    """xsetroot - root window parameter setting utility for X."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xsetroot"
+    url      = "https://www.x.org/archive/individual/app/xsetroot-1.1.1.tar.gz"
+
+    version('1.1.1', '8c794914a2d0456317288c41451dbee3')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+    depends_on('libxcursor')
+
+    depends_on('xbitmaps', type='build')
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xsm/package.py
+++ b/var/spack/repos/builtin/packages/xsm/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xsm(Package):
+    """X Session Manager."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xsm"
+    url      = "https://www.x.org/archive/individual/app/xsm-1.0.3.tar.gz"
+
+    version('1.0.3', '60a2e5987d8e49a568599ba8fe59c8db')
+
+    depends_on('libx11')
+    depends_on('libxt@1.1.0:')
+    depends_on('libice')
+    depends_on('libsm')
+    depends_on('libxaw')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xstdcmap/package.py
+++ b/var/spack/repos/builtin/packages/xstdcmap/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xstdcmap(Package):
+    """The xstdcmap utility can be used to selectively define standard colormap
+    properties.  It is intended to be run from a user's X startup script to
+    create standard colormap definitions in order to facilitate sharing of
+    scarce colormap resources among clients using PseudoColor visuals."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xstdcmap"
+    url      = "https://www.x.org/archive/individual/app/xstdcmap-1.0.3.tar.gz"
+
+    version('1.0.3', '70c1fd18b79c3ea1dae136e2eabe1c82')
+
+    depends_on('libxmu')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -31,7 +31,7 @@ class Xtrans(Package):
     single place to add new transport types.  It is used by the X server,
     libX11, libICE, the X font server, and related components."""
 
-    homepage = "https://www.x.org/"
+    homepage = "http://cgit.freedesktop.org/xorg/lib/libxtrans"
     url      = "https://www.x.org/archive//individual/lib/xtrans-1.3.5.tar.gz"
 
     version('1.3.5', '6e4eac1b7c6591da0753052e1eccfb58')

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -36,6 +36,9 @@ class Xtrans(Package):
 
     version('1.3.5', '6e4eac1b7c6591da0753052e1eccfb58')
 
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Dri2proto(Package):
-    """Direct Rendering Infrastructure 2 Extension.
+class Xtrans(Package):
+    """xtrans is a library of code that is shared among various X packages to
+    handle network protocol transport in a modular fashion, allowing a
+    single place to add new transport types.  It is used by the X server,
+    libX11, libICE, the X font server, and related components."""
 
-    This extension defines a protocol to securely allow user applications to
-    access the video hardware without requiring data to be passed through the
-    X server."""
+    homepage = "https://www.x.org/"
+    url      = "https://www.x.org/archive//individual/lib/xtrans-1.3.5.tar.gz"
 
-    homepage = "https://cgit.freedesktop.org/xorg/proto/dri2proto/"
-    url      = "https://www.x.org/releases/individual/proto/dri2proto-2.8.tar.gz"
-
-    version('2.8', '19ea18f63d8ae8053c9fa84b60365b77')
+    version('1.3.5', '6e4eac1b7c6591da0753052e1eccfb58')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/xtrap/package.py
+++ b/var/spack/repos/builtin/packages/xtrap/package.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xtrap(Package):
+    """XTrap sample clients."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xtrap"
+    url      = "https://www.x.org/archive/individual/app/xtrap-1.0.2.tar.gz"
+
+    version('1.0.2', '601e4945535d2d25eb1bc640332e2363')
+
+    depends_on('libx11')
+    depends_on('libxtrap')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xts/package.py
+++ b/var/spack/repos/builtin/packages/xts/package.py
@@ -34,23 +34,27 @@ class Xts(Package):
 
     version('0.99.1', '1e5443fede389be606f3745a71483bac')
 
-    # Required libraries
     depends_on('libx11')
-    depends_on('libxau')
     depends_on('libxext')
     depends_on('libxi')
     depends_on('libxtst')
+    depends_on('libxau')
+    depends_on('libxt')
+    depends_on('libxmu')
+    depends_on('libxaw')
 
-    # Required utilities
-    depends_on('xdpyinfo', type='run')
-    depends_on('xset', type='run')
-    depends_on('perl', type='run')
-    depends_on('bdftopcf', type='run')
-    depends_on('mkfontdir', type='run')
+    depends_on('xtrans', type='build')
+    depends_on('bdftopcf', type='build')
+    depends_on('mkfontdir', type='build')
+    depends_on('perl', type='build')
+    depends_on('xset', type='build')
+    depends_on('xdpyinfo', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))
 
+        # FIXME: Crashes during compilation
+        # error: redeclaration of enumerator 'XawChainTop'
+
         make()
-        make('check')
         make('install')

--- a/var/spack/repos/builtin/packages/xts/package.py
+++ b/var/spack/repos/builtin/packages/xts/package.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xts(Package):
+    """This is a revamped version of X Test Suite (XTS) which removes some of
+    the ugliness of building and running the tests."""
+
+    homepage = "https://www.x.org/wiki/XorgTesting/"
+    url      = "https://www.x.org/archive/individual/test/xts-0.99.1.tar.gz"
+
+    version('0.99.1', '1e5443fede389be606f3745a71483bac')
+
+    # Required libraries
+    depends_on('libx11')
+    depends_on('libxau')
+    depends_on('libxext')
+    depends_on('libxi')
+    depends_on('libxtst')
+
+    # Required utilities
+    depends_on('xdpyinfo', type='run')
+    depends_on('xset', type='run')
+    depends_on('perl', type='run')
+    depends_on('bdftopcf', type='run')
+    depends_on('mkfontdir', type='run')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/xvidtune/package.py
+++ b/var/spack/repos/builtin/packages/xvidtune/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xvidtune(Package):
+    """xvidtune is a client interface to the X server video mode
+    extension (XFree86-VidModeExtension)."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xvidtune"
+    url      = "https://www.x.org/archive/individual/app/xvidtune-1.0.3.tar.gz"
+
+    version('1.0.3', 'e0c31d78741ae4aab2f4bfcc2abd4a3d')
+
+    depends_on('libxxf86vm')
+    depends_on('libxt')
+    depends_on('libxaw')
+    depends_on('libxmu')
+    depends_on('libx11')
+
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xvinfo/package.py
+++ b/var/spack/repos/builtin/packages/xvinfo/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xvinfo(Package):
+    """xvinfo prints out the capabilities of any video adaptors associated
+    with the display that are accessible through the X-Video extension."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xvinfo"
+    url      = "https://www.x.org/archive/individual/app/xvinfo-1.1.3.tar.gz"
+
+    version('1.1.3', '6890a19226c07344ae12e7a2ef12f2c6')
+
+    depends_on('libxv')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.25:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xwd/package.py
+++ b/var/spack/repos/builtin/packages/xwd/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xwd(Package):
+    """xwd - dump an image of an X window."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xwd"
+    url      = "https://www.x.org/archive/individual/app/xwd-1.0.6.tar.gz"
+
+    version('1.0.6', 'd6c132f5f00188ce2a1393f12bd34ad4')
+
+    depends_on('libx11')
+    depends_on('libxkbfile')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xwininfo/package.py
+++ b/var/spack/repos/builtin/packages/xwininfo/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xwininfo(Package):
+    """xwininfo prints information about windows on an X server. Various
+    information is displayed depending on which options are selected."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xwininfo"
+    url      = "https://www.x.org/archive/individual/app/xwininfo-1.1.3.tar.gz"
+
+    version('1.1.3', 'd26623fe240659a320367bc453f1d301')
+
+    depends_on('libxcb@1.6:')
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/xwud/package.py
+++ b/var/spack/repos/builtin/packages/xwud/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Xwud(Package):
+    """xwud allows X users to display in a window an image saved in a
+    specially formatted dump file, such as produced by xwd."""
+
+    homepage = "http://cgit.freedesktop.org/xorg/app/xwud"
+    url      = "https://www.x.org/archive/individual/app/xwud-1.0.4.tar.gz"
+
+    version('1.0.4', 'bb44485a37496f0121e5843bcf5bb01b')
+
+    depends_on('libx11')
+
+    depends_on('xproto@7.0.17:', type='build')
+    depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('util-macros', type='build')
+
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(prefix))
+
+        make()
+        make('install')


### PR DESCRIPTION
I'm trying to install a newer version of Mesa, but there's a lot of missing Xorg dependencies needed for DRI and hardware acceleration.

I decided to take a swing at packaging all of Xorg/X11/XCB, or at least the important parts. Everything can be found at https://www.x.org/archive/individual/. Here is my progress so far:

- [x] app - packaged, some are missing dependencies
- [x] data - Miscellaneous data, mostly for xcursor and xkeyboard
- [x] doc - documentation utilities
- [ ] driver - hardware-specific drivers
- [x] font - fonts and font-related utilities
- [x] lib - the actually important stuff
- [x] proto - protocol extensions/headers heavily used by Xorg libraries
- [x] test - packaged but not yet tested
- [x] util - m4 macros used by most Xorg packages
- [x] xcb - same as in https://xcb.freedesktop.org/dist/
- [x] xserver - packaged, missing dependencies