### PR TITLE
Run make clean to prevent warning messages

### DIFF
--- a/share/spack/qa/run-doc-tests
+++ b/share/spack/qa/run-doc-tests
@@ -36,9 +36,6 @@ export PATH="$SPACK_ROOT/bin:$PATH"
 # Allows script to be run from anywhere
 cd "$DOC_DIR"
 
-# Cleanup temporary files upon exit or when script is killed
-trap 'make clean --silent' EXIT SIGINT SIGTERM
-
 # Treat warnings as fatal errors
 make clean --silent
 make SPHINXOPTS=-W

--- a/share/spack/qa/run-doc-tests
+++ b/share/spack/qa/run-doc-tests
@@ -9,7 +9,7 @@
 #     run-doc-tests
 #
 # Notes:
-#     Requires sphinx, git, mercurial, and subversion.
+#     Requires sphinx, graphviz, git, mercurial, and subversion.
 #
 
 QA_DIR="$(dirname "$0")"
@@ -40,5 +40,6 @@ cd "$DOC_DIR"
 trap 'make clean --silent' EXIT SIGINT SIGTERM
 
 # Treat warnings as fatal errors
+make clean --silent
 make SPHINXOPTS=-W
 


### PR DESCRIPTION
Take a look at #1741.

This PR doesn't solve the issue, but it does prevent users from running into problems when running `run-doc-tests` if their build directory isn't already clean.

By the way, I set up `run-doc-tests` to run `make clean` after it finishes. @citibeth pointed out that this makes it difficult to view the resulting HTML files. Should I remove this? The only problems this would cause would be wasted storage space (who cares) and it would cause problems if you try to go to the directory and run `make` without running `make clean` first. I don't think it would matter as far as Travis CI is concerned.