### PR TITLE
PNGwriter, libSplash: Add `master` version

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -37,6 +37,8 @@ class Libsplash(Package):
     homepage = "https://github.com/ComputationalRadiationPhysics/libSplash"
     url      = "https://github.com/ComputationalRadiationPhysics/libSplash/archive/v1.4.0.tar.gz"
 
+    version('dev', branch='dev',
+            git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('1.4.0', '2de37bcef6fafa1960391bf44b1b50e0')

--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -37,6 +37,8 @@ class Libsplash(Package):
     homepage = "https://github.com/ComputationalRadiationPhysics/libSplash"
     url      = "https://github.com/ComputationalRadiationPhysics/libSplash/archive/v1.4.0.tar.gz"
 
+    version('master', branch='master',
+            git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('1.4.0', '2de37bcef6fafa1960391bf44b1b50e0')
     version('1.3.1', '524580ba088d97253d03b4611772f37c')
     version('1.2.4', '3fccb314293d22966beb7afd83b746d0')

--- a/var/spack/repos/builtin/packages/pngwriter/package.py
+++ b/var/spack/repos/builtin/packages/pngwriter/package.py
@@ -38,6 +38,8 @@ class Pngwriter(Package):
     homepage = "http://pngwriter.sourceforge.net/"
     url      = "https://github.com/pngwriter/pngwriter/archive/0.5.6.tar.gz"
 
+    version('dev', branch='dev',
+            git='https://github.com/pngwriter/pngwriter.git')
     version('master', branch='master',
             git='https://github.com/pngwriter/pngwriter.git')
     version('0.5.6', 'c13bd1fdc0e331a246e6127b5f262136')

--- a/var/spack/repos/builtin/packages/pngwriter/package.py
+++ b/var/spack/repos/builtin/packages/pngwriter/package.py
@@ -38,6 +38,8 @@ class Pngwriter(Package):
     homepage = "http://pngwriter.sourceforge.net/"
     url      = "https://github.com/pngwriter/pngwriter/archive/0.5.6.tar.gz"
 
+    version('master', branch='master',
+            git='https://github.com/pngwriter/pngwriter.git')
     version('0.5.6', 'c13bd1fdc0e331a246e6127b5f262136')
 
     depends_on('cmake', type='build')


### PR DESCRIPTION
Adds `dev`~~`elop`~~ and `master` versions to`PNGwriter` and `libSplash` that build out of the corresponding development upstream branches from github.

~~Actually, adding a `lastes-stable` version that builds new (but not yet in spack sha-ed versions) would be also interesting. In most git repos that would be the HEAD of the [master](http://nvie.com/posts/a-successful-git-branching-model/) branch.~~