### PR TITLE
Work around cmake problems in VTK

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/gcc.patch
+++ b/var/spack/repos/builtin/packages/vtk/gcc.patch
@@ -1,0 +1,21 @@
+--- old/CMake/vtkCompilerExtras.cmake
++++ new/CMake/vtkCompilerExtras.cmake
+@@ -26,6 +26,8 @@
+   execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+     OUTPUT_VARIABLE _gcc_version_info
+     ERROR_VARIABLE _gcc_version_info)
++
++  string (REPLACE ";" "" _gcc_version_info "${_gcc_version_info}")
+ 
+   string (REGEX MATCH "[345]\\.[0-9]\\.[0-9]"
+     _gcc_version "${_gcc_version_info}")
+--- old/CMake/GenerateExportHeader.cmake
++++ new/CMake/GenerateExportHeader.cmake
+@@ -166,6 +166,7 @@
+     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+       OUTPUT_VARIABLE _gcc_version_info
+       ERROR_VARIABLE _gcc_version_info)
++    string (REPLACE ";" "" _gcc_version_info "${_gcc_version_info}")
+     string(REGEX MATCH "[345]\\.[0-9]\\.[0-9]"
+       _gcc_version "${_gcc_version_info}")
+     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -40,6 +40,8 @@ class Vtk(Package):
 
     version('6.1.0', '25e4dfb3bad778722dcaec80cd5dab7d')
 
+    patch("gcc.patch")
+
     depends_on('cmake', type='build')
     depends_on("qt")
 


### PR DESCRIPTION
The cmake scripts can't handle the semicolons in gcc's version output. Filter them out before detecting the version.