### PR TITLE
Make VisIt build again

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -31,13 +31,15 @@ class Visit(Package):
     homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
     url = "http://portal.nersc.gov/project/visit/releases/2.10.1/visit2.10.1.tar.gz"
 
-    version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
+    version('2.10.3', 'a1082a6f6dab3e2dcb58993603456c2b')
     version('2.10.2', '253de0837a9d69fb689befc98ea4d068')
+    version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
 
     depends_on("vtk@6.1.0~opengl2")
     depends_on("qt@4.8.6")
     depends_on("python")
     depends_on("silo+shared")
+    depends_on("hdf5~mpi")
 
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
@@ -46,6 +48,7 @@ class Visit(Package):
             feature_args.extend([
                 "-DVTK_MAJOR_VERSION=6",
                 "-DVTK_MINOR_VERSION=1",
+                "-DVISIT_USE_GLEW=OFF",
                 "-DVISIT_LOC_QMAKE_EXE:FILEPATH=%s/qmake-qt4" % spec[
                     'qt'].prefix.bin,
                 "-DPYTHON_EXECUTABLE:FILEPATH=%s/python" % spec[


### PR DESCRIPTION
- add new version 2.10.3
- explicitly require hdf5 variant ~mpi, since we don't know how to build with mpicc
- explicitly disable glew since it may not be installed