### PR TITLE
Qt library: added variant to enable/disable compilation of examples

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -47,6 +47,7 @@ class Qt(Package):
     variant('krellpatch', default=False, description="Build with openspeedshop based patch.")
     variant('mesa',       default=False, description="Depend on mesa.")
     variant('gtk',        default=False, description="Build with gtkplus.")
+    variant('examples',   default=False, description="Build examples.")
 
     patch('qt3krell.patch', when='@3.3.8b+krellpatch')
 
@@ -143,7 +144,7 @@ class Qt(Package):
 
     @property
     def common_config_args(self):
-        return [
+        common_arg_list = [
             '-prefix', self.prefix,
             '-v',
             '-opensource',
@@ -159,6 +160,11 @@ class Qt(Package):
             # NIS is deprecated in more recent glibc
             '-no-nis'
         ]
+
+        if '~examples' in self.spec:
+            common_arg_list.extend(['-nomake', 'examples'])
+
+        return common_arg_list
 
     # Don't disable all the database drivers, but should
     # really get them into spack at some point.


### PR DESCRIPTION
There are two reasons for this change:
1. Most likely it is not necessary to have the examples compiled in most of the cases, so it will reduce the time of the compilation process a little bit.
2. For me this is a workaround for this bug in the qt library: https://bugreports.qt.io/browse/QTBUG-53719