### PR TITLE
Update Package: Git-LFS

### DIFF
--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -40,7 +40,7 @@ class GitLfs(Package):
 
     # TODO: Implement this by following the instructions at this location:
     # https://github.com/github/git-lfs/blob/master/CONTRIBUTING.md#building
-    # variant('test', default=True, description='Build and run tests as part of the build.')
+    # variant('test', default=True, description='Build and run tests as part of the build.')  # NOQA: E501
 
     depends_on('go@1.5:', type='build')
     depends_on('git@1.8.2:', type='run')

--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -30,9 +30,7 @@ class GitLfs(Package):
        association with a Git repository.  Instead of storing the large files
        within the Git repository as blobs, Git LFS stores special "pointer
        files" in the repository, while storing the actual file contents on a
-       Git LFS server.  The contents of the large file are downloaded
-       automatically when needed, for example when a Git branch containing
-       the large file is checked out."""
+       Git LFS server."""
 
     homepage = "https://git-lfs.github.com"
     git_url  = "https://github.com/github/git-lfs.git"
@@ -40,12 +38,16 @@ class GitLfs(Package):
     version('1.4.1', git=git_url, tag='v1.4.1')
     version('1.3.1', git=git_url, tag='v1.3.1')
 
+    # TODO: Implement this by following the instructions at this location:
+    # https://github.com/github/git-lfs/blob/master/CONTRIBUTING.md#building
+    # variant('test', default=True, description='Build and run tests as part of the build.')
+
     depends_on('go@1.5:', type='build')
     depends_on('git@1.8.2:', type='run')
 
     def install(self, spec, prefix):
-        bootstrap = Executable(join_path('script', 'bootstrap'))
-        bootstrap()
+        bootstrap_script = Executable(join_path('script', 'bootstrap'))
+        bootstrap_script()
 
         mkdirp(prefix.bin)
         install(join_path('bin', 'git-lfs'), prefix.bin)

--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -26,17 +26,26 @@ from spack import *
 
 
 class GitLfs(Package):
-    """Tool for managing large files with Git."""
+    """Git LFS is a system for managing and versioning large files in
+       association with a Git repository.  Instead of storing the large files
+       within the Git repository as blobs, Git LFS stores special "pointer
+       files" in the repository, while storing the actual file contents on a
+       Git LFS server.  The contents of the large file are downloaded
+       automatically when needed, for example when a Git branch containing
+       the large file is checked out."""
 
     homepage = "https://git-lfs.github.com"
-    url      = "https://github.com/github/git-lfs/archive/v1.4.1.tar.gz"
+    git_url  = "https://github.com/github/git-lfs.git"
 
-    version('1.4.1', 'c62a314d96d3a30af4d98fa3305ad317')
+    version('1.4.1', git=git_url, tag='v1.4.1')
+    version('1.3.1', git=git_url, tag='v1.3.1')
 
     depends_on('go@1.5:', type='build')
     depends_on('git@1.8.2:', type='run')
 
     def install(self, spec, prefix):
-        bootstrap = Executable('./scripts/bootstrap')
+        bootstrap = Executable(join_path('script', 'bootstrap'))
         bootstrap()
-        install('bin/git-lfs', prefix.bin)
+
+        mkdirp(prefix.bin)
+        install(join_path('bin', 'git-lfs'), prefix.bin)

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -1,3 +1,27 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 import os
 import shutil
 import glob
@@ -17,25 +41,37 @@ class GoBootstrap(Package):
 
     extendable = True
 
-    # temporary fix until tags are pulled correctly
+    # NOTE: Go@1.4.2 is the only supported bootstrapping compiler because all
+    # later versions require a Go compiler to build.
+    # See: https://golang.org/doc/install/source
     version('1.4.2', git='https://go.googlesource.com/go', tag='go1.4.2')
 
-    variant('test',
-            default=True,
-            description="Run tests as part of build, a good idea but quite"
-            " time consuming")
+    variant('test', default=True, description='Build and run tests as part of the build.')
 
     provides('golang@:1.4.2')
 
-    depends_on('git')
+    depends_on('git', type='alldeps')
+
+    # NOTE: Older versions of Go attempt to download external files that have
+    # since been moved while running the test suite.  This patch modifies the
+    # test files so that these tests don't cause false failures.
+    # See: https://github.com/golang/go/issues/15694
+    @when('@:1.4.3')
+    def patch(self):
+        test_suite_file = FileFilter(join_path('src', 'run.bash'))
+        test_suite_file.filter(
+            r'^(.*)(\$GOROOT/src/cmd/api/run.go)(.*)$',
+            r'# \1\2\3',
+        )
+
+    @when('@1.5.0:')
+    def patch(self):
+        pass
 
     def install(self, spec, prefix):
         bash = which('bash')
         with working_dir('src'):
-            if '+test' in spec:
-                bash('all.bash')
-            else:
-                bash('make.bash')
+            bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
 
         try:
             os.makedirs(prefix)

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -1,3 +1,27 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 import os
 import shutil
 import glob
@@ -12,28 +36,39 @@ class Go(Package):
 
     extendable = True
 
-    version('1.5.4', git='https://go.googlesource.com/go', tag='go1.5.4')
     version('1.6.2', git='https://go.googlesource.com/go', tag='go1.6.2')
+    version('1.5.4', git='https://go.googlesource.com/go', tag='go1.5.4')
+    version('1.4.2', git='https://go.googlesource.com/go', tag='go1.4.2')
 
-    variant('test',
-            default=True,
-            description="Run tests as part of build, a good idea but quite"
-            " time consuming")
+    variant('test', default=True, description='Build and run tests as part of the build.')
 
     provides('golang')
 
-    # to-do, make non-c self-hosting compilers feasible without backflips
+    depends_on('git', type='alldeps')
+    # TODO: Make non-c self-hosting compilers feasible without backflips
     # should be a dep on external go compiler
     depends_on('go-bootstrap', type='build')
-    depends_on('git', type='alldeps')
+
+    # NOTE: Older versions of Go attempt to download external files that have
+    # since been moved while running the test suite.  This patch modifies the
+    # test files so that these tests don't cause false failures.
+    # See: https://github.com/golang/go/issues/15694
+    @when('@:1.4.3')
+    def patch(self):
+        test_suite_file = FileFilter(join_path('src', 'run.bash'))
+        test_suite_file.filter(
+            r'^(.*)(\$GOROOT/src/cmd/api/run.go)(.*)$',
+            r'# \1\2\3',
+        )
+
+    @when('@1.5.0:')
+    def patch(self):
+        pass
 
     def install(self, spec, prefix):
         bash = which('bash')
         with working_dir('src'):
-            if '+test' in spec:
-                bash('all.bash')
-            else:
-                bash('make.bash')
+            bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
 
         try:
             os.makedirs(prefix)


### PR DESCRIPTION
The changes in this pull request make the following improvements to the `git-lfs` package and its dependencies:

- Fix a bug that was preventing the `git-lfs` binary from being installed in the correct directory.
- Fix a bug that was causing the `(go|go-bootstrap)@1.4.2+test` package variants to fail erroneously after recent updates to the `go` test resource location.
- Add support for version 1.3.1 of the `git-lfs` package.

Please let me know if there are any problems with these updates and I'll fix them as soon as I can!