### PR TITLE
[Prototype] Allow incompatible specs if they are 'build' dependencies

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1466,7 +1466,8 @@ class Spec(object):
             changed = True
         # Constrain package information with spec info
         try:
-            changed |= spec_deps[dep.name].spec.constrain(dep, deptypes=deptypes)
+            changed |= spec_deps[dep.name].spec.constrain(
+                dep, deptypes=deptypes)
 
         except UnsatisfiableSpecError as e:
             e.message = "Invalid spec: '%s'. "
@@ -1481,7 +1482,7 @@ class Spec(object):
             self._add_dependency(dependency.spec, dependency.deptypes)
 
         changed |= dependency.spec._normalize_helper(
-            visited, spec_deps, provider_index, level=level+1)
+            visited, spec_deps, provider_index, level=level + 1)
         return changed
 
     def _normalize_helper(self, visited, spec_deps, provider_index, level=0):
@@ -1509,9 +1510,10 @@ class Spec(object):
                 deptypes = pkg._deptypes[dep_name]
                 # If pkg_dep is a dependency, merge it.
                 if pkg_dep:
-                    if True:#level==0 or 'link' in deptypes or 'run' in deptypes:
+                    if level == 0 or 'link' in deptypes or 'run' in deptypes:
                         changed |= self._merge_dependency(
-                            pkg_dep, deptypes, visited, spec_deps, provider_index, level=level)
+                            pkg_dep, deptypes, visited, spec_deps,
+                            provider_index, level=level)
             any_change |= changed
 
         return any_change
@@ -1557,7 +1559,9 @@ class Spec(object):
         # traverse the package DAG and fill out dependencies according
         # to package files & their 'when' specs
         visited = set()
-        any_change = self._normalize_helper(visited, spec_deps, provider_index, level=0)
+        any_change = self._normalize_helper(
+            visited, spec_deps,
+            provider_index, level=0)
 
         # If there are deps specified but not visited, they're not
         # actually deps of this package.  Raise an error.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -95,6 +95,7 @@ thing.  Spack uses ~variant in directory names and in the canonical form of
 specs to avoid ambiguity.  Both are provided because ~ can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
+from __future__ import print_function
 import base64
 import hashlib
 import imp
@@ -1419,7 +1420,7 @@ class Spec(object):
                 raise UnsatisfiableProviderSpecError(required[0], vdep)
 
     def _merge_dependency(self, dep, deptypes, visited, spec_deps,
-                          provider_index):
+                          provider_index, level=0):
         """Merge the dependency into this spec.
 
         This is the core of normalize().  There are some basic steps:
@@ -1465,7 +1466,7 @@ class Spec(object):
             changed = True
         # Constrain package information with spec info
         try:
-            changed |= spec_deps[dep.name].spec.constrain(dep)
+            changed |= spec_deps[dep.name].spec.constrain(dep, deptypes=deptypes)
 
         except UnsatisfiableSpecError as e:
             e.message = "Invalid spec: '%s'. "
@@ -1480,10 +1481,10 @@ class Spec(object):
             self._add_dependency(dependency.spec, dependency.deptypes)
 
         changed |= dependency.spec._normalize_helper(
-            visited, spec_deps, provider_index)
+            visited, spec_deps, provider_index, level=level+1)
         return changed
 
-    def _normalize_helper(self, visited, spec_deps, provider_index):
+    def _normalize_helper(self, visited, spec_deps, provider_index, level=0):
         """Recursive helper function for _normalize."""
         if self.name in visited:
             return False
@@ -1508,8 +1509,9 @@ class Spec(object):
                 deptypes = pkg._deptypes[dep_name]
                 # If pkg_dep is a dependency, merge it.
                 if pkg_dep:
-                    changed |= self._merge_dependency(
-                        pkg_dep, deptypes, visited, spec_deps, provider_index)
+                    if True:#level==0 or 'link' in deptypes or 'run' in deptypes:
+                        changed |= self._merge_dependency(
+                            pkg_dep, deptypes, visited, spec_deps, provider_index, level=level)
             any_change |= changed
 
         return any_change
@@ -1555,7 +1557,7 @@ class Spec(object):
         # traverse the package DAG and fill out dependencies according
         # to package files & their 'when' specs
         visited = set()
-        any_change = self._normalize_helper(visited, spec_deps, provider_index)
+        any_change = self._normalize_helper(visited, spec_deps, provider_index, level=0)
 
         # If there are deps specified but not visited, they're not
         # actually deps of this package.  Raise an error.
@@ -1596,7 +1598,7 @@ class Spec(object):
                 if vname not in spec.package_class.variants:
                     raise UnknownVariantError(spec.name, vname)
 
-    def constrain(self, other, deps=True):
+    def constrain(self, other, deps=True, deptypes=None):
         """Merge the constraints of other with self.
 
         Returns True if the spec changed as a result, False if not.


### PR DESCRIPTION
Fixes #1768 

@tgamblin 
This PR is EXPERIMENTAL.  Review from a core Spack developer would be appreaciated.  Until then, I will run with it and see if it does anything bad.  My guess is at the very least, it changes all the hash codes.
