### PR TITLE
Resolved issues of py-pillow, py-scipy and binutils dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -31,9 +31,8 @@ class Binutils(Package):
     homepage = "http://www.gnu.org/software/binutils/"
     url      = "https://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
 
-    # 2.26 is incompatible with py-pillow build for some reason.
     version('2.26', '64146a0faa3b411ba774f47d41de239f')
-    version('2.25', 'd9f3303f802a5b6b0bb73a335ab89d66', preferred=True)
+    version('2.25', 'd9f3303f802a5b6b0bb73a335ab89d66')
     version('2.24', 'e0f71a7b2ddab0f8612336ac81d9636b')
     version('2.23.2', '4f8fa651e35ef262edc01d60fb45702e')
     version('2.20.1', '2b9dc8f2b7dbd5ec5992c6e29de0b764')

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -66,8 +66,7 @@ class PyPillow(Package):
 
     # Required dependencies
     extends('python')
-    # Known not to work with 2.23, 2.25
-    depends_on('binutils@2.26:', type='build')
+    depends_on('binutils', type='build')
     depends_on('py-setuptools', type='build')
 
     # Recommended dependencies

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -32,8 +32,7 @@ class PyPillow(Package):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url = "https://pypi.python.org/packages/source" + \
-        "/P/Pillow/Pillow-3.0.0.tar.gz"
+    url = "https://pypi.python.org/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
 
     # TODO: This version should be deleted once the next release comes out.
     # TODO: It fixes a bug that prevented us from linking to Tk/Tcl.

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -32,7 +32,8 @@ class PyPillow(Package):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url      = "https://pypi.python.org/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
+    url = "https://pypi.python.org/packages/source" + \
+        "/P/Pillow/Pillow-3.0.0.tar.gz"
 
     # TODO: This version should be deleted once the next release comes out.
     # TODO: It fixes a bug that prevented us from linking to Tk/Tcl.
@@ -65,7 +66,8 @@ class PyPillow(Package):
 
     # Required dependencies
     extends('python')
-    depends_on('binutils', type='build')
+    # Known not to work with 2.23, 2.25
+    depends_on('binutils@2.26:', type='build')
     depends_on('py-setuptools', type='build')
 
     # Recommended dependencies

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyScipy(Package):
     """Scientific Library for Python."""
     homepage = "http://www.scipy.org/"
-    url      = "https://pypi.python.org/packages/source/s/scipy/scipy-0.15.0.tar.gz"
+    url = "https://pypi.python.org/packages/source/s/scipy/scipy-0.15.0.tar.gz"
 
     version('0.17.0', '5ff2971e1ce90e762c59d2cd84837224')
     version('0.15.1', 'be56cd8e60591d6332aac792a5880110')
@@ -36,6 +36,7 @@ class PyScipy(Package):
 
     extends('python')
     depends_on('py-nose', type='build')
+    depends_on('binutils@2.26:', type='build')
     depends_on('py-numpy+blas+lapack', type=nolink)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -36,6 +36,7 @@ class PyScipy(Package):
 
     extends('python')
     depends_on('py-nose', type='build')
+    # Known not to work with 2.23, 2.25
     depends_on('binutils@2.26:', type='build')
     depends_on('py-numpy+blas+lapack', type=nolink)
 


### PR DESCRIPTION
It turns out, everything works with binutils@2.26.  It is good that one version of binutils can work for everything... Spack is capable (in theory, not yet practice) of using different binutils for different packages.  But traditional systems (MacPorts, RPM, etc) are not really.  So it is comforting that we can use just one version of binutils for everything.

This PR resolves #1506
