### PR TITLE
Update mvapich2 to 2.2

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -28,14 +28,12 @@ from spack import *
 class Mvapich2(Package):
     """MVAPICH2 is an MPI implementation for Infiniband networks."""
     homepage = "http://mvapich.cse.ohio-state.edu/"
-    url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.2rc2.tar.gz"
+    url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.2.tar.gz"
 
-    version('2.2rc2', 'f9082ffc3b853ad1b908cf7f169aa878')
-    version('2.2b',   '5651e8b7a72d7c77ca68da48f3a5d108')
-    version('2.2a',   'b8ceb4fc5f5a97add9b3ff1b9cbe39d2')
-    version('2.1',    '0095ceecb19bbb7fb262131cb9c2cdd6')
-    version('2.0',    '9fbb68a4111a8b6338e476dc657388b4')
-    version('1.9',    '5dc58ed08fd3142c260b70fe297e127c')
+    version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e')
+    version('2.1', '0095ceecb19bbb7fb262131cb9c2cdd6')
+    version('2.0', '9fbb68a4111a8b6338e476dc657388b4')
+    version('1.9', '5dc58ed08fd3142c260b70fe297e127c')
 
     patch('ad_lustre_rwcontig_open_source.patch', when='@1.9')
 
@@ -95,6 +93,7 @@ class Mvapich2(Package):
     ##########
 
     # FIXME : CUDA support is missing
+    depends_on('bison')
     depends_on('libpciaccess')
 
     def url_for_version(self, version):


### PR DESCRIPTION
This PR updates mvapich2 to version 2.2. I also removed 2.2{rc2,b,a} because they caused 2.2rc2 to get picked over 2.2.

I am not sure whether the bison dependency is new with 2.2 but I just tried to build it with +nemesis and this required yacc.