### PR TITLE
Make libstdc++-detection work on Darwin

### DIFF
--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -54,10 +54,10 @@ class ABI(object):
         output = None
         if compiler.cxx:
             rungcc = Executable(compiler.cxx)
-            libname = "libstdc++.so"
+            libname = "libstdc++." + dso_suffix
         elif compiler.cc:
             rungcc = Executable(compiler.cc)
-            libname = "libgcc_s.so"
+            libname = "libgcc_s." + dso_suffix
         else:
             return None
         try:


### PR DESCRIPTION
Fixes #1777.