### PR TITLE
Update Package: Metis

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -176,8 +176,8 @@ class Metis(Package):
 
     @when('@5:')
     def install(self, spec, prefix):
-        build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path
+        build_directory = join_path(source_directory, 'build')
 
         options = std_cmake_args[:]
         options.append('-DGKLIB_PATH:PATH=%s/GKlib' % source_directory)

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -191,6 +191,11 @@ class Metis(Package):
             make()
             make('install')
 
+            # FIXME: On some systems, the installed binaries for METIS cannot
+            # be executed without first being read.
+            ls = which('ls')
+            ls('-all', prefix.bin)
+
             # now run some tests:
             for f in ['4elt', 'copter2', 'mdual']:
                 graph = join_path(source_directory, 'graphs', '%s.graph' % f)

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -60,12 +60,10 @@ class Parmetis(Package):
         return '%s/%sparmetis-%s.tar.gz' % (Parmetis.base_url, verdir, version)
 
     def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
-
-        build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path
+        build_directory = join_path(source_directory, 'build')
 
+        options = std_cmake_args[:]
         options.extend([
             '-DGKLIB_PATH:PATH=%s/GKlib' % spec['metis'].prefix.include,
             '-DMETIS_PATH:PATH=%s' % spec['metis'].prefix,

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -38,11 +38,9 @@ class Parmetis(Package):
     version('4.0.3', 'f69c479586bf6bb7aff6a9bc0c739628')
     version('4.0.2', '0912a953da5bb9b5e5e10542298ffdce')
 
-    variant('shared', default=True,
-            description='Enables the build of shared libraries')
-    variant('debug', default=False,
-            description='Builds the library in debug mode')
-    variant('gdb', default=False, description='Enables gdb support')
+    variant('shared', default=True, description='Enables the build of shared libraries.')
+    variant('debug', default=False, description='Builds the library in debug mode.')
+    variant('gdb', default=False, description='Enables gdb support.')
 
     depends_on('cmake@2.8:', type='build')
     depends_on('mpi')
@@ -50,9 +48,9 @@ class Parmetis(Package):
 
     patch('enable_external_metis.patch')
     # bug fixes from PETSc developers
-    # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/
+    # https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/  # NOQA: E501
     patch('pkg-parmetis-1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b.patch')
-    # https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/
+    # https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/  # NOQA: E501
     patch('pkg-parmetis-82409d68aa1d6cbc70740d0f35024aae17f7d5cb.patch')
 
     def url_for_version(self, version):


### PR DESCRIPTION
The changes in this pull request make the following improvements to the `metis` package:

1. Fix a bug that was causing the tests for `metis@5:` installs to fail on some systems .
2. Update the patching strategies for the `metis` and `parmetis` packages so that they can take advantage of Spack's patch skipping capabilities (previously these packages would fail when re-patching due to  build environment complications).
3. Clean up line break and style problems introduced during the automated Spack SQA update.

I'm not really satisfied with the solution I implemented for change 1, but it should be sufficient for the time being.  If anyone can think of a cleaner implementation, please let me know and I'll put it into this PR.  Also, please let me know if there are any other changes that I should update!