### PR TITLE
Fix sbang for perl

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -111,8 +111,12 @@ while read line && ((lines < 2)) ; do
 done < "$script"
 
 # Invoke any interpreter found, or raise an error if none was found.
-if [ -n "$interpreter" ]; then
-    exec $interpreter "$@"
+if [[ -n "$interpreter" ]]; then
+    if [[ "${interpreter##*/}" = "perl" ]]; then
+        exec $interpreter -x "$@"
+    else
+        exec $interpreter "$@"
+    fi
 else
     echo "error: sbang found no interpreter in $script"
     exit 1

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -81,8 +81,10 @@ def filter_shebang(path):
     tty.warn("Patched overlong shebang in %s" % path)
 
 
-def filter_shebangs_in_directory(directory):
-    for file in os.listdir(directory):
+def filter_shebangs_in_directory(directory, filenames=None):
+    if filenames is None:
+        filenames = os.listdir(directory)
+    for file in filenames:
         path = os.path.join(directory, file)
 
         # only handle files
@@ -104,6 +106,6 @@ def post_install(pkg):
     """This hook edits scripts so that they call /bin/bash
        $spack_prefix/bin/sbang instead of something longer than the
        shebang limit."""
-    if not os.path.isdir(pkg.prefix.bin):
-        return
-    filter_shebangs_in_directory(pkg.prefix.bin)
+
+    for directory, _, filenames in os.walk(pkg.prefix):
+        filter_shebangs_in_directory(directory, filenames)


### PR DESCRIPTION
We encountered issues with spack's `git` installation when installing into deep directory hierarchies.
(Example: `spack install git && spack load git && git add -p` fails with `bad interpreter` error)

Two issues were found:
- git helpers (located under `libexec/git-core/*`) were not sbang-adjusted but only `bin/*`
- the perl interpreter needs an additional flag (`-x`, cf. perlrun docs)