### PR TITLE
Fix copy bug with multiple users sharing same tarball cache

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -306,7 +306,7 @@ class URLFetchStrategy(FetchStrategy):
         if not self.archive_file:
             raise NoArchiveFileError("Cannot call archive() before fetching.")
 
-        shutil.copy(self.archive_file, destination)
+        shutil.copyfile(self.archive_file, destination)
 
     @_needs_stage
     def check(self):


### PR DESCRIPTION
When re-using previously downloaded tarballs, spack copies from
`var/spack/stage/PACKAGE-VERSION-HASH/downloaded_file` to
`var/spack/cache/PACKAGE/downloaded_file`. This fails if the source is owned by
a different user (`shutil.copy` tries to retain all meta data including file
ownership). Change to a non-meta-data copy function (`shutil.copyfile`).