### PR TITLE
PETSc: Explicitly point to cpp when configuring

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -90,6 +90,8 @@ class Petsc(Package):
     def mpi_dependent_options(self):
         if '~mpi' in self.spec:
             compiler_opts = [
+                '--with-cpp=cpp',
+                '--with-cxxcpp=cpp',
                 '--with-cc=%s' % os.environ['CC'],
                 '--with-cxx=%s' % (os.environ['CXX']
                                    if self.compiler.cxx is not None else '0'),
@@ -111,6 +113,8 @@ class Petsc(Package):
                 raise RuntimeError('\n'.join(errors))
         else:
             compiler_opts = [
+                '--with-cpp=cpp',
+                '--with-cxxcpp=cpp',
                 '--with-mpi=1',
                 '--with-mpi-dir=%s' % self.spec['mpi'].prefix,
             ]


### PR DESCRIPTION
I encountered an HPC system where PETSc's configure stage does not find a valid `cpp` (C preprocessor). Explicitly pointing to Spack's `cpp` wrapper resolves the problem.