### PR TITLE
Add missing build dependencies to hdf package

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -38,13 +38,12 @@ class Hdf(Package):
 
     variant('szip', default=False, description="Enable szip support")
 
-    depends_on("jpeg")
-    depends_on("szip", when='+szip')
-    depends_on("zlib")
+    depends_on('jpeg')
+    depends_on('szip', when='+szip')
+    depends_on('zlib')
 
-    def url_for_version(self, version):
-        return "https://www.hdfgroup.org/ftp/HDF/releases/HDF" + str(
-            version) + "/src/hdf-" + str(version) + ".tar.gz"
+    depends_on('bison', type='build')
+    depends_on('flex',  type='build')
 
     def install(self, spec, prefix):
         config_args = [
@@ -66,4 +65,5 @@ class Hdf(Package):
         configure(*config_args)
 
         make()
-        make("install")
+        make('check')
+        make('install')


### PR DESCRIPTION
I didn't realize hdf depended on bison and flex until I tried building it on a machine without them. It crashed during configure, but it's happy now.

While I was at it, I noticed hdf actually has an pretty intensive test suite. It only took 30 seconds to run, but it seems to check a lot of things, so I think it's good to include.

Also, Spack has finally gotten smart enough where the url_for_version function is no longer necessary, so I removed it.