### PR TITLE
boost: fix a bug which broke it on macOS with clang+gfortran

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import spack
 import sys
 import os
 
@@ -171,9 +170,8 @@ class Boost(Package):
                 # error: duplicate initialization of intel-linux with the following parameters:  # noqa
                 # error: version = <unspecified>
                 # error: previous initialization at ./user-config.jam:1
-                compiler_wrapper = join_path(spack.build_env_path, 'c++')
                 f.write("using {0} : : {1} ;\n".format(boostToolsetId,
-                                                       compiler_wrapper))
+                                                       spack_cxx))
 
             if '+mpi' in spec:
                 f.write('using mpi : %s ;\n' %
@@ -221,7 +219,6 @@ class Boost(Package):
             options.extend([
                 'toolset=%s' % self.determine_toolset(spec)
             ])
-
 
         return threadingOpts
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -165,9 +165,15 @@ class Boost(Package):
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in
             # compilers.yaml. Make sure this does not happen:
-            compiler_wrapper = join_path(spack.build_env_path, 'c++')
-            f.write("using {0} : : {1} ;\n".format(boostToolsetId,
-                                                   compiler_wrapper))
+            if not spec.satisfies('%intel'):
+                # using intel-linux : : spack_cxx in user-config.jam leads to
+                # error: at project-config.jam:12
+                # error: duplicate initialization of intel-linux with the following parameters:  # noqa
+                # error: version = <unspecified>
+                # error: previous initialization at ./user-config.jam:1
+                compiler_wrapper = join_path(spack.build_env_path, 'c++')
+                f.write("using {0} : : {1} ;\n".format(boostToolsetId,
+                                                       compiler_wrapper))
 
             if '+mpi' in spec:
                 f.write('using mpi : %s ;\n' %
@@ -207,9 +213,15 @@ class Boost(Package):
                                multithreaded} must be enabled""")
 
         options.extend([
-            'toolset=%s' % self.determine_toolset(spec),
             'link=%s' % ','.join(linkTypes),
-            '--layout=tagged'])
+            '--layout=tagged'
+        ])
+
+        if not spec.satisfies('%intel'):
+            options.extend([
+                'toolset=%s' % self.determine_toolset(spec)
+            ])
+
 
         return threadingOpts
 

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -104,6 +104,7 @@ class Dealii(Package):
     depends_on("oce",              when='+oce')
     depends_on("p4est",            when='+p4est+mpi')
     depends_on("petsc+mpi",        when='@8.4.2:+petsc+mpi')
+    depends_on('python',           when='@8.5.0:+python')
     depends_on("slepc",            when='@8.4.2:+slepc+petsc+mpi')
     depends_on("petsc@:3.6.4+mpi", when='@:8.4.1+petsc+mpi')
     depends_on("slepc@:3.6.3",     when='@:8.4.1+slepc+petsc+mpi')


### PR DESCRIPTION
fix a bug introduced in https://github.com/LLNL/spack/pull/1621 which made boost broken on macOS with clang+gfortran.

Prior to this PR boost used gcc
```
$ otool -L ~/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.61.0-q23jffr3h2hg5hmpfyv6ual75r7ucwqz/lib/libboost_python-mt.dylib
/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.61.0-q23jffr3h2hg5hmpfyv6ual75r7ucwqz/lib/libboost_python-mt.dylib:
    /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.61.0-q23jffr3h2hg5hmpfyv6ual75r7ucwqz/lib/libboost_python-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
    /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/gcc-6.2.0-thrupxvh7uemrmwdmo372dxk4vxgh2bt/lib64/libstdc++.6.dylib (compatibility version 7.0.0, current version 7.22.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
    /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/gcc-6.2.0-thrupxvh7uemrmwdmo372dxk4vxgh2bt/lib64/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)
```
even with
```
compilers:
- compiler:
    modules: []
    operating_system: sierra
    paths:
      cc: /usr/bin/clang
      cxx: /usr/bin/clang++
      f77: /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/gcc-6.2.0-thrupxvh7uemrmwdmo372dxk4vxgh2bt/bin/gfortran
      fc: /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/gcc-6.2.0-thrupxvh7uemrmwdmo372dxk4vxgh2bt/bin/gfortran
    spec: clang@8.0.0-apple
```
This PR fixes it back to 
```
$ otool -L ~/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.60.0-fqoy5kmitv5o2fomtopkmcn36upcpxdg/lib/libboost_python-mt.dylib
/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.60.0-fqoy5kmitv5o2fomtopkmcn36upcpxdg/lib/libboost_python-mt.dylib:
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/boost-1.60.0-fqoy5kmitv5o2fomtopkmcn36upcpxdg/lib/libboost_python-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```
and more importantly resolves cryptic linking errors like 
```
Undefined symbols for architecture x86_64:
  "boost::python::objects::function_object(boost::python::objects::py_function const&, std::__1::pair<boost::python::detail::keyword const*, boost::python::detail::keyword const*> const&)", referenced from:
      void boost::python::detail::def_init_aux<boost::python::class_<dealii::python::CellAccessorWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>, boost::python::default_call_policies, boost::mpl::vector3<dealii::python::TriangulationWrapper&, int const, int const>, boost::mpl::size<boost::mpl::vector3<dealii::python::TriangulationWrapper&, int const, int const> > >(boost::python::class_<dealii::python::CellAccessorWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>&, boost::mpl::vector3<dealii::python::TriangulationWrapper&, int const, int const> const&, boost::mpl::size<boost::mpl::vector3<dealii::python::TriangulationWrapper&, int const, int const> >, boost::python::default_call_policies const&, char const*, std::__1::pair<boost::python::detail::keyword const*, boost::python::detail::keyword const*> const&) in export_cell_accessor.cc.o
      void boost::python::class_<dealii::python::CellAccessorWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>::def_impl<dealii::python::CellAccessorWrapper, dealii::python::PointWrapper (dealii::python::CellAccessorWrapper::*)() const, boost::python::detail::def_helper<char [69], boost::python::detail::keywords<1ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> >(dealii::python::CellAccessorWrapper*, char const*, dealii::python::PointWrapper (dealii::python::CellAccessorWrapper::*)() const, boost::python::detail::def_helper<char [69], boost::python::detail::keywords<1ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> const&, ...) in export_cell_accessor.cc.o
      void boost::python::class_<dealii::python::CellAccessorWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>::def_impl<dealii::python::CellAccessorWrapper, void (dealii::python::CellAccessorWrapper::*)(int, dealii::python::PointWrapper&), boost::python::detail::def_helper<char [69], boost::python::detail::keywords<3ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> >(dealii::python::CellAccessorWrapper*, char const*, void (dealii::python::CellAccessorWrapper::*)(int, dealii::python::PointWrapper&), boost::python::detail::def_helper<char [69], boost::python::detail::keywords<3ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> const&, ...) in export_cell_accessor.cc.o
      void boost::python::class_<dealii::python::CellAccessorWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>::def_impl<dealii::python::CellAccessorWrapper, dealii::python::PointWrapper (dealii::python::CellAccessorWrapper::*)(int) const, boost::python::detail::def_helper<char [69], boost::python::detail::keywords<2ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> >(dealii::python::CellAccessorWrapper*, char const*, dealii::python::PointWrapper (dealii::python::CellAccessorWrapper::*)(int) const, boost::python::detail::def_helper<char [69], boost::python::detail::keywords<2ul>, boost::python::detail::not_specified, boost::python::detail::not_specified> const&, ...) in export_cell_accessor.cc.o
      void boost::python::detail::def_init_aux<boost::python::class_<dealii::python::PointWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>, boost::python::default_call_policies, boost::mpl::vector1<boost::python::list>, boost::mpl::size<boost::mpl::vector1<boost::python::list> > >(boost::python::class_<dealii::python::PointWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>&, boost::mpl::vector1<boost::python::list> const&, boost::mpl::size<boost::mpl::vector1<boost::python::list> >, boost::python::default_call_policies const&, char const*, std::__1::pair<boost::python::detail::keyword const*, boost::python::detail::keyword const*> const&) in export_point.cc.o
      void boost::python::detail::def_init_aux<boost::python::class_<dealii::python::TriangulationWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>, boost::python::default_call_policies, boost::mpl::vector1<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, boost::mpl::size<boost::mpl::vector1<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> > >(boost::python::class_<dealii::python::TriangulationWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>&, boost::mpl::vector1<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> const&, boost::mpl::size<boost::mpl::vector1<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> >, boost::python::default_call_policies const&, char const*, std::__1::pair<boost::python::detail::keyword const*, boost::python::detail::keyword const*> const&) in export_triangulation.cc.o
      void boost::python::detail::def_init_aux<boost::python::class_<dealii::python::TriangulationWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>, boost::python::default_call_policies, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, boost::mpl::size<boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> > >(boost::python::class_<dealii::python::TriangulationWrapper, boost::python::detail::not_specified, boost::python::detail::not_specified, boost::python::detail::not_specified>&, boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> const&, boost::mpl::size<boost::mpl::vector2<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> >, boost::python::default_call_policies const&, char const*, std::__1::pair<boost::python::detail::keyword const*, boost::python::detail::keyword const*> const&) in export_triangulation.cc.o
      ...
  "boost::python::objects::register_dynamic_id_aux(boost::python::type_info, std::__1::pair<void*, boost::python::type_info> (*)(void*))", referenced from:
      dealii::python::export_cell_accessor() in export_cell_accessor.cc.o
      dealii::python::export_point() in export_point.cc.o
      dealii::python::export_triangulation() in export_triangulation.cc.o
  "boost::archive::text_iarchive_impl<boost::archive::text_iarchive>::text_iarchive_impl(std::__1::basic_istream<char, std::__1::char_traits<char> >&, unsigned int)", referenced from:
      dealii::python::TriangulationWrapper::load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in triangulation_wrapper.cc.o
  "boost::archive::text_oarchive_impl<boost::archive::text_oarchive>::save(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      boost::archive::basic_text_oarchive<boost::archive::text_oarchive>::save_override(boost::archive::class_name_type const&) in triangulation_wrapper.cc.o
  "boost::archive::text_oarchive_impl<boost::archive::text_oarchive>::text_oarchive_impl(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, unsigned int)", referenced from:
      dealii::python::TriangulationWrapper::save(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const in triangulation_wrapper.cc.o
  "boost::archive::basic_text_iprimitive<std::__1::basic_istream<char, std::__1::char_traits<char> > >::~basic_text_iprimitive()", referenced from:
      dealii::python::TriangulationWrapper::load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in triangulation_wrapper.cc.o
      boost::archive::text_iarchive::~text_iarchive() in triangulation_wrapper.cc.o
      boost::archive::text_iarchive::~text_iarchive() in triangulation_wrapper.cc.o
  "boost::archive::basic_text_oprimitive<std::__1::basic_ostream<char, std::__1::char_traits<char> > >::~basic_text_oprimitive()", referenced from:
      dealii::python::TriangulationWrapper::save(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const in triangulation_wrapper.cc.o
      boost::archive::text_oarchive::~text_oarchive() in triangulation_wrapper.cc.o
      boost::archive::text_oarchive::~text_oarchive() in triangulation_wrapper.cc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
See https://github.com/dealii/dealii/issues/3057.

@KineticTheory please check if it still works with Intel compilers. Otherwise we need to find a way to keep both cases working.

TODO:

- [x] check that `spack install dealii@develop~oce` builds fine without those linking errors.