### PR TITLE
Remove SPACK_DIRTY env var

### DIFF
--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -54,8 +54,7 @@ def setup_parser(subparser):
         help="specs to use for install.  Must contain package AND version.")
     subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
-        help="Install a package *without* cleaning the environment.  " +
-        "Or set SPACK_DIRTY environment variable")
+        help="Install a package *without* cleaning the environment.")
 
 
 def diy(self, args):
@@ -105,4 +104,4 @@ def diy(self, args):
             ignore_deps=args.ignore_deps,
             verbose=not args.quiet,
             keep_stage=True,   # don't remove source dir for DIY.
-            dirty=args.dirty or ('SPACK_DIRTY' in os.environ))
+            dirty=args.dirty)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -57,8 +57,7 @@ def setup_parser(subparser):
         help="Fake install. Just remove prefix and create a fake file.")
     subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
-        help="Install a package *without* cleaning the environment.  " +
-        "Or set SPACK_DIRTY environment variable")
+        help="Install a package *without* cleaning the environment")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to install")
@@ -90,5 +89,5 @@ def install(parser, args):
                 run_tests=args.run_tests,
                 verbose=args.verbose,
                 fake=args.fake,
-                dirty=args.dirty or ('SPACK_DIRTY' in os.environ),
+                dirty=args.dirty,
                 explicit=True)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -28,7 +28,6 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
-import os
 
 description = "Build and install packages"
 
@@ -57,7 +56,7 @@ def setup_parser(subparser):
         help="Fake install. Just remove prefix and create a fake file.")
     subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
-        help="Install a package *without* cleaning the environment")
+        help="Install a package *without* cleaning the environment.")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to install")

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -95,4 +95,4 @@ def setup(self, args):
             verbose=args.verbose,
             keep_stage=True,   # don't remove source dir for SETUP.
             install_phases=set(['setup', 'provenance']),
-            dirty=args.dirty or ('SPACK_DIRTY' in os.environ))
+            dirty=args.dirty)

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -48,8 +48,7 @@ def setup_parser(subparser):
         help="specs to use for install.  Must contain package AND version.")
     subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
-        help="Install a package *without* cleaning the environment.  " +
-        "Or set SPACK_DIRTY environment variable")
+        help="Install a package *without* cleaning the environment.")
 
 
 def setup(self, args):


### PR DESCRIPTION
@tgamblin 
The `SPACK_DIRTY` feature from #1625 was mistakenly merged (according to the conversation in #1625).  This PR reverses that, while keeping the `--dirty` propagation that was merged correctly.
