### PR TITLE
Fix archiving resources from SCM repos

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -44,7 +44,7 @@ from spack.version import *
 from spack.util.compression import allowed_archive
 
 
-def mirror_archive_filename(spec, fetcher):
+def mirror_archive_filename(spec, fetcher, resourceId=None):
     """Get the name of the spec's archive in the mirror."""
     if not spec.version.concrete:
         raise ValueError("mirror.path requires spec with concrete version.")
@@ -67,15 +67,18 @@ def mirror_archive_filename(spec, fetcher):
         # Otherwise we'll make a .tar.gz ourselves
         ext = 'tar.gz'
 
-    filename = "%s-%s" % (spec.package.name, spec.version)
-    if ext:
-        filename += ".%s" % ext
+    if resourceId:
+        filename = "%s-%s" % (resourceId, spec.version) + ".%s" % ext
+    else:
+        filename = "%s-%s" % (spec.package.name, spec.version) + ".%s" % ext
+
     return filename
 
 
-def mirror_archive_path(spec, fetcher):
+def mirror_archive_path(spec, fetcher, resourceId=None):
     """Get the relative path to the spec's archive within a mirror."""
-    return join_path(spec.name, mirror_archive_filename(spec, fetcher))
+    return join_path(
+        spec.name, mirror_archive_filename(spec, fetcher, resourceId))
 
 
 def get_matching_versions(specs, **kwargs):
@@ -204,8 +207,9 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
                     name = spec.format("$_$@")
                 else:
                     resource = stage.resource
-                    archive_path = join_path(
-                        subdir, suggest_archive_basename(resource))
+                    archive_path = os.path.abspath(join_path(
+                        mirror_root,
+                        mirror_archive_path(spec, fetcher, resource.name)))
                     name = "{resource} ({pkg}).".format(
                         resource=resource.name, pkg=spec.format("$_$@"))
                 subdir = os.path.dirname(archive_path)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -687,7 +687,8 @@ class PackageBase(object):
 
     def _make_resource_stage(self, root_stage, fetcher, resource):
         resource_stage_folder = self._resource_stage(resource)
-        resource_mirror = join_path(self.name, os.path.basename(fetcher.url))
+        resource_mirror = spack.mirror.mirror_archive_path(
+            self.spec, fetcher, resource.name)
         stage = ResourceStage(resource.fetcher,
                               root=root_stage,
                               resource=resource,
@@ -702,8 +703,12 @@ class PackageBase(object):
         # Construct a path where the stage should build..
         s = self.spec
         stage_name = "%s-%s-%s" % (s.name, s.version, s.dag_hash())
-        # Build the composite stage
-        stage = Stage(fetcher, mirror_path=mp, name=stage_name, path=self.path)
+
+        # Check list_url alternative archive URLs
+        dynamic_fetcher = fs.from_list_url(self)
+        alternate_fetchers = [dynamic_fetcher] if dynamic_fetcher else None
+        stage = Stage(fetcher, mirror_path=mp, name=stage_name, path=self.path,
+                      alternate_fetchers=alternate_fetchers)
         return stage
 
     def _make_stage(self):


### PR DESCRIPTION
This fixes #1520

Some packages which include resources fetched from source control
repositories terminated package installs because they failed to
archive; specifically, this affected all SCM resources which identify
a specific state of the repo - for example a revision in svn or a
tag/revision in git. This is because the resource stage creation
logic did not choose an appropriate archive name for these kinds of
resources.

This commit changes the archive filenames of URL-based resources; this
was not strictly necessary but has the added benefit that the URL
basename no longer needs to uniquely identify the resource - for
example if different versions of the same resource have the same name
but are stored in different directories.
