### PR TITLE
fix : stops infinite recursion for python 2.6

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -531,8 +531,9 @@ class Spec(object):
         """Delegate to self.package if the attribute is not in the spec"""
         # This line is to avoid infinite recursion in case package is
         # not present among self attributes
-        package = super(Spec, self).__getattribute__('package')
-        return getattr(package, item)
+        if item.endswith('libs'):
+            return getattr(self.package, item)
+        raise AttributeError()
 
     def get_dependency(self, name):
         dep = self._dependencies.get(name)


### PR DESCRIPTION
@adamjstewart @tgamblin with reference to the bug introduced in #1682 : this seems to work for me ~~, but I am still waiting for a build on python 2.6.6 that uses `spec['lapack'].lapack_libs` to finish.~~


