### PR TITLE
Fix spack checksum output indentation

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -113,6 +113,6 @@ def checksum(parser, args):
         tty.die("Could not fetch any versions for %s" % pkg.name)
 
     version_lines = [
-        "    version('%s', '%s')" % (v, h) for v, h in version_hashes
+        "  version('%s', '%s')" % (v, h) for v, h in version_hashes
     ]
     tty.msg("Checksummed new versions of %s:" % pkg.name, *version_lines)


### PR DESCRIPTION
Minor annoyance. When you run `spack checksum` on a package, it outputs the versions with 6 spaces of indentation:
```
==> Checksummed new versions of cgal:
      version('4.9', '7b628db3e5614347f776c046b7666089')
```
With this PR, it now outputs the versions with 4 spaces of indentation:
```
==> Checksummed new versions of cgal:
    version('4.9', '7b628db3e5614347f776c046b7666089')
```
This allows you to copy-n-paste into a package.py without having to change the indentation afterwards.