### PR TITLE
Updates to CGAL and ICU4C packages

### DIFF
--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -22,44 +22,57 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
 
 
 class Cgal(Package):
-    """CGAL is a software project that provides easy access to efficient and
-       reliable geometric algorithms in the form of a C++ library. CGAL
-       is used in various areas needing geometric computation, such as
-       geographic information systems, computer aided design, molecular
-       biology, medical imaging, computer graphics, and robotics.
-
+    """The Computational Geometry Algorithms Library (CGAL) is a C++ library
+    that aims to provide easy access to efficient and reliable algorithms in
+    computational geometry. CGAL is used in various areas needing geometric
+    computation, such as geographic information systems, computer aided design,
+    molecular biology, medical imaging, computer graphics, and robotics.
     """
     homepage = 'http://www.cgal.org/'
     url = 'https://github.com/CGAL/cgal/archive/releases/CGAL-4.7.tar.gz'
 
+    version('4.9', '7b628db3e5614347f776c046b7666089')
     version('4.7', '4826714810f3b4c65cac96b90fb03b67')
     version('4.6.3', 'e8ee2ecc8d2b09b94a121c09257b576d')
 
-    # Installation instructions :
-    # http://doc.cgal.org/latest/Manual/installation.html
     variant('shared', default=True,
             description='Enables the build of shared libraries')
     variant('debug', default=False,
             description='Builds a debug version of the libraries')
 
+    # Essential Third Party Libraries
     depends_on('boost')
-    depends_on('mpfr')
     depends_on('gmp')
+    depends_on('mpfr')
     depends_on('zlib')
+    # depends_on('opengl')
+    depends_on('qt@5:')
+
+    # Optional Third Party Libraries
+    # depends_on('leda')
+    # depends_on('mpfi')
+    # depends_on('rs')
+    # depends_on('rs3')
+    # depends_on('ntl')
+    # depends_on('eigen')
+    # depends_on('libqglviewer')
+    # depends_on('esbtl')
+    # depends_on('intel-tbb')
+
+    # Build dependencies
     depends_on('cmake', type='build')
 
-    # FIXME : Qt5 dependency missing (needs Qt5 and OpenGL)
-    # FIXME : Optional third party libraries missing
-
     def install(self, spec, prefix):
+        # Installation instructions:
+        # http://doc.cgal.org/latest/Manual/installation.html
 
         options = []
         options.extend(std_cmake_args)
+
         # CGAL supports only Release and Debug build type. Any other build type
         # will raise an error at configure time
         if '+debug' in spec:
@@ -72,9 +85,7 @@ class Cgal(Package):
         else:
             options.append('-DBUILD_SHARED_LIBS:BOOL=OFF')
 
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+        cmake('.', *options)
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -28,17 +28,22 @@ from spack import *
 class Icu4c(Package):
     """ICU is a mature, widely used set of C/C++ and Java libraries providing
        Unicode and Globalization support for software applications.
-
     """
-
     homepage = "http://site.icu-project.org/"
-    url      = "http://downloads.sourceforge.net/project/icu/ICU4C/54.1/icu4c-54_1-src.tgz"
+    url      = "http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz"
 
-    version('54_1', 'e844caed8f2ca24c088505b0d6271bc0')
+    version('57.1', '976734806026a4ef8bdd17937c8898b9')
+
+    def url_for_version(self, version):
+        base_url = "http://download.icu-project.org/files/icu4c"
+        return "{0}/{1}/icu4c-{2}-src.tgz".format(
+            base_url, version, version.underscored)
 
     def install(self, spec, prefix):
-        cd("source")
-        configure("--prefix=%s" % prefix)
+        cd('source')
+
+        configure('--prefix={0}'.format(prefix))
 
         make()
-        make("install")
+        make('check')
+        make('install')


### PR DESCRIPTION
Updates to CGAL:

- Add latest version
- Link to Qt
- Be more explicit about missing dependencies
- Simplify install instructions to be more in line with http://doc.cgal.org/latest/Manual/installation.html

Updates to ICU4C:

- Switch from sourceforge to ICU's own download page
 - Sourceforge link wasn't working for me
- Add latest version
- Switch version numbering scheme from underscores to dots
- Add `url_for_version` so that other versions can be downloaded
- Add `make check` to prevent unforeseen problems later on
