### PR TITLE
some fixes to blas/lapack usage in packages

### DIFF
--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -88,8 +88,8 @@ class ArpackNg(Package):
         options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
 
         # Make sure we use Spack's blas/lapack:
-        lapack_libs = spec['lapack'].lapack_libs.joined()
-        blas_libs = spec['blas'].blas_libs.joined()
+        lapack_libs = spec['lapack'].lapack_libs.joined(';')
+        blas_libs = spec['blas'].blas_libs.joined(';')
 
         options.extend([
             '-DLAPACK_FOUND=true',

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -142,7 +142,7 @@ class Atlas(Package):
                                  'test_cblas_dgemm.output')
 
         include_flags = ["-I%s" % self.spec.prefix.include]
-        link_flags = self.lapack_libs.ld_flags
+        link_flags = self.lapack_libs.ld_flags.split()
 
         output = compile_c_and_execute(source_file, include_flags, link_flags)
         compare_output_file(output, blessed_file)

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -85,7 +85,7 @@ class Cantera(Package):
 
         # BLAS/LAPACK support
         if '+lapack' in spec:
-            lapack_blas = spec['lapack'].lapack_libs+spec['blas'].blas_libs
+            lapack_blas = spec['lapack'].lapack_libs + spec['blas'].blas_libs
             options.extend([
                 'blas_lapack_libs={0}'.format(','.join(lapack_blas.names)),
                 'blas_lapack_dir={0}'.format(spec['lapack'].prefix.lib)

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -85,8 +85,9 @@ class Cantera(Package):
 
         # BLAS/LAPACK support
         if '+lapack' in spec:
+            lapack_blas = spec['lapack'].lapack_libs+spec['blas'].blas_libs
             options.extend([
-                'blas_lapack_libs=lapack,blas',
+                'blas_lapack_libs={0}'.format(','.join(lapack_blas.names)),
                 'blas_lapack_dir={0}'.format(spec['lapack'].prefix.lib)
             ])
 

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -64,7 +64,10 @@ class IntelParallelStudio(IntelInstaller):
         shared = True if '+shared' in self.spec else False
         suffix = dso_suffix if '+shared' in self.spec else 'a'
         mkl_integer = ['libmkl_intel_ilp64'] if '+ilp64' in self.spec else ['libmkl_intel_lp64']  # NOQA: ignore=E501
-        mkl_threading = ['libmkl_intel_thread'] if '+openmp' in self.spec else ['libmkl_sequential']  # NOQA: ignore=E501
+        mkl_threading = ['libmkl_sequential']
+        if '+openmp' in self.spec:
+            mkl_threading = ['libmkl_intel_thread', 'libiomp5'] if '%intel' in self.spec else ['libmkl_gnu_thread']  # NOQA: ignore=E501
+        # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
             root=join_path(self.prefix.lib, 'intel64'),

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -53,9 +53,8 @@ class Ipopt(Package):
         mumps_flags = "-ldmumps -lmumps_common -lpord -lmpiseq"
         mumps_libcmd = "-L%s " % mumps_dir.lib + mumps_flags
 
-        # By convention, spack links blas & lapack libs to libblas & liblapack
-        blas_lib = "-L%s" % blas_dir.lib + " -lblas"
-        lapack_lib = "-L%s" % lapack_dir.lib + " -llapack"
+        blas_lib = spec['blas'].blas_libs.ld_flags
+        lapack_lib = spec['lapack'].lapack_libs.ld_flags
 
         configure_args = [
             "--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -89,7 +89,7 @@ class Mfem(Package):
         options = ['PREFIX=%s' % prefix]
 
         if '+lapack' in spec:
-            lapack_lib = (spec['lapack'].lapack_libs+spec['blas'].blas_libs).ld_flags
+            lapack_lib = (spec['lapack'].lapack_libs + spec['blas'].blas_libs).ld_flags  # NOQA: ignore=E501
             options.extend([
                 'MFEM_USE_LAPACK=YES',
                 'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -89,8 +89,7 @@ class Mfem(Package):
         options = ['PREFIX=%s' % prefix]
 
         if '+lapack' in spec:
-            lapack_lib = '-L{0} -llapack -L{1} -lblas'.format(
-                spec['lapack'].prefix.lib, spec['blas'].prefix.lib)
+            lapack_lib = (spec['lapack'].lapack_libs+spec['blas'].blas_libs).ld_flags
             options.extend([
                 'MFEM_USE_LAPACK=YES',
                 'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,

--- a/var/spack/repos/builtin/packages/mkl/package.py
+++ b/var/spack/repos/builtin/packages/mkl/package.py
@@ -39,8 +39,9 @@ class Mkl(IntelInstaller):
         suffix = dso_suffix if '+shared' in self.spec else 'a'
         mkl_integer = ['libmkl_intel_ilp64'] if '+ilp64' in self.spec else ['libmkl_intel_lp64']  # NOQA: ignore=E501
         mkl_threading = ['libmkl_sequential']
-        if '+openmp' in spec:
-            mkl_threading = ['libmkl_intel_thread'] if '%intel' in self.spec else ['libmkl_gnu_thread']  # NOQA: ignore=E501
+        if '+openmp' in self.spec:
+            mkl_threading = ['libmkl_intel_thread', 'libiomp5'] if '%intel' in self.spec else ['libmkl_gnu_thread']  # NOQA: ignore=E501
+        # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
             root=join_path(self.prefix.lib, 'intel64'),

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -91,12 +91,9 @@ class NetlibLapack(Package):
             cmake_args.extend(['-DCBLAS=ON'])  # always build CBLAS
 
         if '+external-blas' in spec:
-            # TODO : mechanism to specify the library should be more general,
-            # TODO : but this allows to have an hook to an external blas
             cmake_args.extend([
                 '-DUSE_OPTIMIZED_BLAS:BOOL=ON',
-                '-DBLAS_LIBRARIES:PATH=%s' % join_path(
-                    spec['blas'].prefix.lib, 'libblas.a')
+                '-DBLAS_LIBRARIES:PATH=%s' % spec['blas'].blas_libs.joined(';')
             ])
 
         cmake_args.extend(std_cmake_args)

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -79,8 +79,8 @@ class NetlibScalapack(Package):
         options.extend([
             '-DLAPACK_FOUND=true',
             '-DLAPACK_INCLUDE_DIRS=%s' % spec['lapack'].prefix.include,
-            '-DLAPACK_LIBRARIES=%s' % (lapack.joined()),
-            '-DBLAS_LIBRARIES=%s' % (blas.joined())
+            '-DLAPACK_LIBRARIES=%s' % (lapack.joined(';')),
+            '-DBLAS_LIBRARIES=%s' % (blas.joined(';'))
         ])
 
         if '+fpic' in spec:

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -111,24 +111,6 @@ class Openblas(Package):
         # no quotes around prefix (spack doesn't use a shell)
         make('install', "PREFIX=%s" % prefix, *make_defs)
 
-        # TODO : the links below are mainly there because client
-        # TODO : packages are wrongly written. Check if they can be removed
-
-        # Blas virtual package should provide blas.a and libblas.a
-        with working_dir(prefix.lib):
-            symlink('libopenblas.a', 'blas.a')
-            symlink('libopenblas.a', 'libblas.a')
-            if '+shared' in spec:
-                symlink('libopenblas.%s' % dso_suffix,
-                        'libblas.%s' % dso_suffix)
-
-        # Lapack virtual package should provide liblapack.a
-        with working_dir(prefix.lib):
-            symlink('libopenblas.a', 'liblapack.a')
-            if '+shared' in spec:
-                symlink('libopenblas.%s' % dso_suffix,
-                        'liblapack.%s' % dso_suffix)
-
         # Openblas may pass its own test but still fail to compile Lapack
         # symbols. To make sure we get working Blas and Lapack, do a small
         # test.
@@ -141,10 +123,8 @@ class Openblas(Package):
                                  'test_cblas_dgemm.output')
 
         include_flags = ["-I%s" % join_path(spec.prefix, "include")]
-        link_flags = ["-L%s" % join_path(spec.prefix, "lib"),
-                      "-llapack",
-                      "-lblas",
-                      "-lpthread"]
+        link_flags = self.lapack_libs.ld_flags.split()
+        link_flags.extend(["-lpthread"])
         if '+openmp' in spec:
             link_flags.extend([self.compiler.openmp_flag])
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -131,11 +131,11 @@ class Petsc(Package):
             '--with-shared-libraries=%s' % ('1' if '+shared' in spec else '0'),
             '--with-debugging=%s' % ('1' if '+debug' in spec else '0')
         ])
-        # Make sure we use exactly the same Blas/Lapack libraries (threaded/non-threaded etc)
+        # Make sure we use exactly the same Blas/Lapack libraries
         # across the DAG. To that end list them explicitly
         lapack_blas = spec['lapack'].lapack_libs + spec['blas'].blas_libs
         options.extend([
-          '--with-blas-lapack-lib=%s' % lapack_blas.joined()
+            '--with-blas-lapack-lib=%s' % lapack_blas.joined()
         ])
 
         # Activates library support if needed

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -129,9 +129,15 @@ class Petsc(Package):
             '--with-scalar-type=%s' % (
                 'complex' if '+complex' in spec else 'real'),
             '--with-shared-libraries=%s' % ('1' if '+shared' in spec else '0'),
-            '--with-debugging=%s' % ('1' if '+debug' in spec else '0'),
-            '--with-blas-lapack-dir=%s' % spec['lapack'].prefix
+            '--with-debugging=%s' % ('1' if '+debug' in spec else '0')
         ])
+        # Make sure we use exactly the same Blas/Lapack libraries (threaded/non-threaded etc)
+        # across the DAG. To that end list them explicitly
+        lapack_blas = spec['lapack'].lapack_libs + spec['blas'].blas_libs
+        options.extend([
+          '--with-blas-lapack-lib=%s' % lapack_blas.joined()
+        ])
+
         # Activates library support if needed
         for library in ('metis', 'boost', 'hdf5', 'hypre', 'parmetis',
                         'mumps', 'scalapack'):

--- a/var/spack/repos/builtin/packages/superlu-mt/package.py
+++ b/var/spack/repos/builtin/packages/superlu-mt/package.py
@@ -86,7 +86,7 @@ class SuperluMt(Package):
         if '+blas' in spec:
             config.extend([
                 'BLASDEF    = -DUSE_VENDOR_BLAS',
-                'BLASLIB    = -L{0} -lblas'.format(spec['blas'].prefix.lib)
+                'BLASLIB    = {0}'.format(spec['blas'].blas_libs.ld_flags)
             ])
         else:
             config.append('BLASLIB    = ../lib/libblas$(PLAT).a')


### PR DESCRIPTION
some updates to blas/lapack usage inside packages to incorporate https://github.com/LLNL/spack/pull/1682 and also fix a few issues.

builds on `Ubuntu@16.04`+`gcc@5.4.0`:
- [x] `dealii@develop ^atlas`
- [x] `dealii@develop ^openblas`
- [x] `dealii@develop ^mkl`
- [x] `cantera ^openblas`
- [x] `ipopt ^openblas`
- [x] `Mfem+lapack ^openblas`
- [x] `SuperluMt ^openblas`
- [ ] `netliblapack+external-blas ^openblas`

p.s. i uninstall system's `blas`/`lapack` to make sure they are not picked up somewhere and lead to a false positive build.
