### PR TITLE
Various updates to scipy and numpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -32,9 +32,12 @@ class PyNumpy(Package):
     sophisticated (broadcasting) functions, tools for integrating C/C++ and
     Fortran code, and useful linear algebra, Fourier transform, and random
     number capabilities"""
+
     homepage = "http://www.numpy.org/"
     url      = "https://pypi.python.org/packages/source/n/numpy/numpy-1.9.1.tar.gz"
 
+    version('1.11.1', '2f44a895a8104ffac140c3a70edbd450',
+            url="https://pypi.python.org/packages/e0/4c/515d7c4ac424ff38cc919f7099bf293dd064ba9a600e1e3835b3edefdb18/numpy-1.11.1.tar.gz")
     version('1.11.0', 'bc56fb9fc2895aa4961802ffbdb31d0b')
     version('1.10.4', 'aed294de0aa1ac7bd3f9745f4f1968ad')
     version('1.9.2',  'a1ed53432dbcd256398898d35bc8e645')
@@ -44,6 +47,7 @@ class PyNumpy(Package):
     variant('lapack', default=True)
 
     extends('python')
+    depends_on('python@2.6:2.8,3.2:')
     depends_on('py-nose', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('blas',   when='+blas')
@@ -79,4 +83,4 @@ class PyNumpy(Package):
                 f.write('library_dirs=%s\n' % ':'.join(library_dirs))
                 f.write('rpath=%s\n' % ':'.join(library_dirs))
 
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -26,19 +26,25 @@ from spack import *
 
 
 class PyScipy(Package):
-    """Scientific Library for Python."""
+    """SciPy (pronounced "Sigh Pie") is a Scientific Library for Python.
+    It provides many user-friendly and efficient numerical routines such
+    as routines for numerical integration and optimization."""
+
     homepage = "http://www.scipy.org/"
     url = "https://pypi.python.org/packages/source/s/scipy/scipy-0.15.0.tar.gz"
 
+    version('0.18.1', '5fb5fb7ccb113ab3a039702b6c2f3327',
+            url="https://pypi.python.org/packages/22/41/b1538a75309ae4913cdbbdc8d1cc54cae6d37981d2759532c1aa37a41121/scipy-0.18.1.tar.gz")
     version('0.17.0', '5ff2971e1ce90e762c59d2cd84837224')
     version('0.15.1', 'be56cd8e60591d6332aac792a5880110')
     version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
 
     extends('python')
+    depends_on('python@2.6:2.8,3.2:')
     depends_on('py-nose', type='build')
     # Known not to work with 2.23, 2.25
     depends_on('binutils@2.26:', type='build')
-    depends_on('py-numpy+blas+lapack', type=nolink)
+    depends_on('py-numpy@1.7.1:+blas+lapack', type=nolink)
 
     def install(self, spec, prefix):
         if 'atlas' in spec:
@@ -50,4 +56,4 @@ class PyScipy(Package):
             env['BLAS'] = spec['blas'].blas_libs.joined()
             env['LAPACK'] = spec['lapack'].lapack_libs.joined()
 
-        python('setup.py', 'install', '--prefix=%s' % prefix)
+        setup_py('install', '--prefix={0}'.format(prefix))


### PR DESCRIPTION
The following updates have been made to py-scipy and py-numpy:

- Added the latest version
 - Old URL scheme no longer works for PyPi unfortunately
- Added more specific dependency constraints
- Switched to using `setup_py`
 - See #950 

Tested by installing the latest versions of py-scipy and py-numpy with Python 3.5.2.