### PR TITLE
Fix read locks on read-only file systems

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -70,7 +70,8 @@ class Lock(object):
         while (time.time() - start_time) < timeout:
             try:
                 if self._fd is None:
-                    self._fd = os.open(self._file_path, os.O_RDWR)
+                    mode = os.O_RDWR if op == fcntl.LOCK_EX else os.O_RDONLY
+                    self._fd = os.open(self._file_path, mode)
 
                 fcntl.lockf(self._fd, op | fcntl.LOCK_NB)
                 if op == fcntl.LOCK_EX:


### PR DESCRIPTION
This PR causes read locks to be opened with `O_RDONLY` since nothing is written to them anyway.

Rationale: We provide a global Spack installation for all users. The installation is hosted on an NFS file system that is mounted read-only on the compute nodes. This change allows users to load modules etc.