### PR TITLE
spack graph improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/db
 /var/spack/stage
 /var/spack/cache
 /var/spack/repos/*/index.yaml

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -207,7 +207,7 @@ supply ``-p`` to Spack on the command line, before any subcommands.
 
 ``spack --profile`` output looks like this:
 
-.. command-output:: spack --profile graph dyninst
+.. command-output:: spack --profile graph --deptype=nobuild dyninst
    :ellipsis: 25
 
 The bottom of the output shows the top most time consuming functions,

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2888,9 +2888,22 @@ dependency graph.  For example:
 
 .. command-output:: spack graph mpileaks
 
-At the top is the root package in the DAG, with dependency edges
-emerging from it.  On a color terminal, the edges are colored by which
-dependency they lead to.
+At the top is the root package in the DAG, with dependency edges emerging
+from it.  On a color terminal, the edges are colored by which dependency
+they lead to.
+
+.. command-output:: spack graph --deptype=all mpileaks
+
+The ``deptype`` argument tells Spack what types of dependencies to graph.
+By default it includes link and run dependencies but not build
+dependencies.  Supplying ``--deptype=all`` will show the build
+dependencies as well.  This is equivalent to
+``--deptype=build,link,run``.  Options for ``deptype`` include:
+
+* Any combination of ``build``, ``link``, and ``run`` separated by
+  commas.
+* ``nobuild``, ``nolink``, ``norun`` to omit one type.
+* ``all`` or ``alldeps`` for all types of dependencies.
 
 You can also use ``spack graph`` to generate graphs in the widely used
 `Dot <http://www.graphviz.org/doc/info/lang.html>`_ format.  For

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -24,8 +24,11 @@
 ##############################################################################
 import argparse
 
+import llnl.util.tty as tty
+
 import spack
 import spack.cmd
+from spack.spec import *
 from spack.graph import *
 
 description = "Generate graphs of package dependency relationships."
@@ -43,8 +46,21 @@ def setup_parser(subparser):
         help="Generate graph in dot format and print to stdout.")
 
     subparser.add_argument(
-        '--concretize', action='store_true',
-        help="Concretize specs before graphing.")
+        '--normalize', action='store_true',
+        help="Skip concretization; only print normalized spec.")
+
+    subparser.add_argument(
+        '-s', '--static', action='store_true',
+        help="Use static information from packages, not dynamic spec info.")
+
+    subparser.add_argument(
+        '-i', '--installed', action='store_true',
+        help="Graph all installed specs in dot format (implies --dot).")
+
+    subparser.add_argument(
+        '-t', '--deptype', action='store',
+        help="Comma-separated list of deptypes to traverse. default=%s."
+        % ','.join(alldeps))
 
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER,
@@ -52,15 +68,29 @@ def setup_parser(subparser):
 
 
 def graph(parser, args):
-    specs = spack.cmd.parse_specs(
-        args.specs, normalize=True, concretize=args.concretize)
+    concretize = not args.normalize
+    if args.installed:
+        if args.specs:
+            tty.die("Can't specify specs with --installed")
+        args.dot = True
+        specs = spack.installed_db.query()
+
+    else:
+        specs = spack.cmd.parse_specs(
+            args.specs, normalize=True, concretize=concretize)
 
     if not specs:
         setup_parser.parser.print_help()
         return 1
 
+    deptype = alldeps
+    if args.deptype:
+        deptype = tuple(args.deptype.split(','))
+        validate_deptype(deptype)
+        deptype = canonical_deptype(deptype)
+
     if args.dot:  # Dot graph only if asked for.
-        graph_dot(*specs)
+        graph_dot(specs, static=args.static, deptype=deptype)
 
     elif specs:  # ascii is default: user doesn't need to provide it explicitly
         graph_ascii(specs[0], debug=spack.debug)

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -83,7 +83,7 @@ def graph(parser, args):
         setup_parser.parser.print_help()
         return 1
 
-    deptype = alldeps
+    deptype = nobuild
     if args.deptype:
         deptype = tuple(args.deptype.split(','))
         validate_deptype(deptype)
@@ -93,7 +93,7 @@ def graph(parser, args):
         graph_dot(specs, static=args.static, deptype=deptype)
 
     elif specs:  # ascii is default: user doesn't need to provide it explicitly
-        graph_ascii(specs[0], debug=spack.debug)
+        graph_ascii(specs[0], debug=spack.debug, deptype=deptype)
         for spec in specs[1:]:
             print  # extra line bt/w independent graphs
             graph_ascii(spec, debug=spack.debug)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -411,6 +411,20 @@ class Package(object):
         if self.is_extension:
             spack.repo.get(self.extendee_spec)._check_extendable()
 
+    def possible_dependencies(self, visited=None):
+        """Return set of possible transitive dependencies of this package."""
+        if visited is None:
+            visited = set()
+
+        visited.add(self.name)
+        for name in self.dependencies:
+            if name not in visited and not spack.spec.Spec(name).virtual:
+                pkg = spack.repo.get(name)
+                for name in pkg.possible_dependencies(visited):
+                    visited.add(name)
+
+        return visited
+
     @property
     def package_dir(self):
         """Return the directory where the package.py file lives."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1569,7 +1569,7 @@ class Spec(object):
         # actually deps of this package.  Raise an error.
         extra = set(spec_deps.keys()).difference(visited)
         if extra:
-            raise InvalidDependencyException(
+            raise InvalidDependencyError(
                 self.name + " does not depend on " + comma_or(extra))
 
         # Mark the spec as normal once done.
@@ -2667,17 +2667,11 @@ def parse_anonymous_spec(spec_like, pkg_name):
 
 
 class SpecError(spack.error.SpackError):
-
     """Superclass for all errors that occur while constructing specs."""
-
-    def __init__(self, message):
-        super(SpecError, self).__init__(message)
 
 
 class SpecParseError(SpecError):
-
     """Wrapper for ParseError for when we're parsing specs."""
-
     def __init__(self, parse_error):
         super(SpecParseError, self).__init__(parse_error.message)
         self.string = parse_error.string
@@ -2685,79 +2679,49 @@ class SpecParseError(SpecError):
 
 
 class DuplicateDependencyError(SpecError):
-
     """Raised when the same dependency occurs in a spec twice."""
-
-    def __init__(self, message):
-        super(DuplicateDependencyError, self).__init__(message)
 
 
 class DuplicateVariantError(SpecError):
-
     """Raised when the same variant occurs in a spec twice."""
-
-    def __init__(self, message):
-        super(DuplicateVariantError, self).__init__(message)
 
 
 class DuplicateCompilerSpecError(SpecError):
-
     """Raised when the same compiler occurs in a spec twice."""
-
-    def __init__(self, message):
-        super(DuplicateCompilerSpecError, self).__init__(message)
 
 
 class UnsupportedCompilerError(SpecError):
-
     """Raised when the user asks for a compiler spack doesn't know about."""
-
     def __init__(self, compiler_name):
         super(UnsupportedCompilerError, self).__init__(
             "The '%s' compiler is not yet supported." % compiler_name)
 
 
 class UnknownVariantError(SpecError):
-
     """Raised when the same variant occurs in a spec twice."""
-
     def __init__(self, pkg, variant):
         super(UnknownVariantError, self).__init__(
             "Package %s has no variant %s!" % (pkg, variant))
 
 
 class DuplicateArchitectureError(SpecError):
-
     """Raised when the same architecture occurs in a spec twice."""
-
-    def __init__(self, message):
-        super(DuplicateArchitectureError, self).__init__(message)
 
 
 class InconsistentSpecError(SpecError):
-
     """Raised when two nodes in the same spec DAG have inconsistent
        constraints."""
 
-    def __init__(self, message):
-        super(InconsistentSpecError, self).__init__(message)
 
-
-class InvalidDependencyException(SpecError):
-
+class InvalidDependencyError(SpecError):
     """Raised when a dependency in a spec is not actually a dependency
        of the package."""
 
-    def __init__(self, message):
-        super(InvalidDependencyException, self).__init__(message)
-
 
 class NoProviderError(SpecError):
-
     """Raised when there is no package that provides a particular
        virtual dependency.
     """
-
     def __init__(self, vpkg):
         super(NoProviderError, self).__init__(
             "No providers found for virtual package: '%s'" % vpkg)
@@ -2765,11 +2729,9 @@ class NoProviderError(SpecError):
 
 
 class MultipleProviderError(SpecError):
-
     """Raised when there is no package that provides a particular
        virtual dependency.
     """
-
     def __init__(self, vpkg, providers):
         """Takes the name of the vpkg"""
         super(MultipleProviderError, self).__init__(
@@ -2780,10 +2742,8 @@ class MultipleProviderError(SpecError):
 
 
 class UnsatisfiableSpecError(SpecError):
-
     """Raised when a spec conflicts with package constraints.
        Provide the requirement that was violated when raising."""
-
     def __init__(self, provided, required, constraint_type):
         super(UnsatisfiableSpecError, self).__init__(
             "%s does not satisfy %s" % (provided, required))
@@ -2793,89 +2753,72 @@ class UnsatisfiableSpecError(SpecError):
 
 
 class UnsatisfiableSpecNameError(UnsatisfiableSpecError):
-
     """Raised when two specs aren't even for the same package."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableSpecNameError, self).__init__(
             provided, required, "name")
 
 
 class UnsatisfiableVersionSpecError(UnsatisfiableSpecError):
-
     """Raised when a spec version conflicts with package constraints."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableVersionSpecError, self).__init__(
             provided, required, "version")
 
 
 class UnsatisfiableCompilerSpecError(UnsatisfiableSpecError):
-
     """Raised when a spec comiler conflicts with package constraints."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableCompilerSpecError, self).__init__(
             provided, required, "compiler")
 
 
 class UnsatisfiableVariantSpecError(UnsatisfiableSpecError):
-
     """Raised when a spec variant conflicts with package constraints."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableVariantSpecError, self).__init__(
             provided, required, "variant")
 
 
 class UnsatisfiableCompilerFlagSpecError(UnsatisfiableSpecError):
-
     """Raised when a spec variant conflicts with package constraints."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableCompilerFlagSpecError, self).__init__(
             provided, required, "compiler_flags")
 
 
 class UnsatisfiableArchitectureSpecError(UnsatisfiableSpecError):
-
     """Raised when a spec architecture conflicts with package constraints."""
-
     def __init__(self, provided, required):
         super(UnsatisfiableArchitectureSpecError, self).__init__(
             provided, required, "architecture")
 
 
 class UnsatisfiableProviderSpecError(UnsatisfiableSpecError):
-
     """Raised when a provider is supplied but constraints don't match
        a vpkg requirement"""
-
     def __init__(self, provided, required):
         super(UnsatisfiableProviderSpecError, self).__init__(
             provided, required, "provider")
+
 
 # TODO: get rid of this and be more specific about particular incompatible
 # dep constraints
 
 
 class UnsatisfiableDependencySpecError(UnsatisfiableSpecError):
-
     """Raised when some dependency of constrained specs are incompatible"""
-
     def __init__(self, provided, required):
         super(UnsatisfiableDependencySpecError, self).__init__(
             provided, required, "dependency")
 
 
 class SpackYAMLError(spack.error.SpackError):
-
     def __init__(self, msg, yaml_error):
         super(SpackYAMLError, self).__init__(msg, str(yaml_error))
 
 
 class AmbiguousHashError(SpecError):
-
     def __init__(self, msg, *specs):
         super(AmbiguousHashError, self).__init__(msg)
         for spec in specs:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -194,6 +194,7 @@ nobuild = ('link', 'run')
 norun   = ('link', 'build')
 special_types = {
     'alldeps': alldeps,
+    'all': alldeps,  # allow "all" as string but not symbol.
     'nolink': nolink,
     'nobuild': nobuild,
     'norun': norun,
@@ -1418,12 +1419,11 @@ class Spec(object):
             # parser doesn't allow it. Spack must be broken!
             raise InconsistentSpecError("Invalid Spec DAG: %s" % e.message)
 
-    def index(self):
+    def index(self, deptype=None):
         """Return DependencyMap that points to all the dependencies in this
            spec."""
         dm = DependencyMap()
-        # XXX(deptype): use a deptype kwarg.
-        for spec in self.traverse():
+        for spec in self.traverse(deptype=deptype):
             dm[spec.name] = spec
         return dm
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -241,15 +241,15 @@ class SpecDagTest(MockPackagesTest):
 
     def test_invalid_dep(self):
         spec = Spec('libelf ^mpich')
-        self.assertRaises(spack.spec.InvalidDependencyException,
+        self.assertRaises(spack.spec.InvalidDependencyError,
                           spec.normalize)
 
         spec = Spec('libelf ^libdwarf')
-        self.assertRaises(spack.spec.InvalidDependencyException,
+        self.assertRaises(spack.spec.InvalidDependencyError,
                           spec.normalize)
 
         spec = Spec('mpich ^dyninst ^libelf')
-        self.assertRaises(spack.spec.InvalidDependencyException,
+        self.assertRaises(spack.spec.InvalidDependencyError,
                           spec.normalize)
 
     def test_equal(self):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -24,34 +24,34 @@
 ##############################################################################
 import unittest
 
-import spack.spec
+import spack.spec as sp
 from spack.parse import Token
 from spack.spec import *
 
 # Sample output for a complex lexing.
-complex_lex = [Token(ID, 'mvapich_foo'),
-               Token(DEP),
-               Token(ID, '_openmpi'),
-               Token(AT),
-               Token(ID, '1.2'),
-               Token(COLON),
-               Token(ID, '1.4'),
-               Token(COMMA),
-               Token(ID, '1.6'),
-               Token(PCT),
-               Token(ID, 'intel'),
-               Token(AT),
-               Token(ID, '12.1'),
-               Token(COLON),
-               Token(ID, '12.6'),
-               Token(ON),
-               Token(ID, 'debug'),
-               Token(OFF),
-               Token(ID, 'qt_4'),
-               Token(DEP),
-               Token(ID, 'stackwalker'),
-               Token(AT),
-               Token(ID, '8.1_1e')]
+complex_lex = [Token(sp.ID, 'mvapich_foo'),
+               Token(sp.DEP),
+               Token(sp.ID, '_openmpi'),
+               Token(sp.AT),
+               Token(sp.ID, '1.2'),
+               Token(sp.COLON),
+               Token(sp.ID, '1.4'),
+               Token(sp.COMMA),
+               Token(sp.ID, '1.6'),
+               Token(sp.PCT),
+               Token(sp.ID, 'intel'),
+               Token(sp.AT),
+               Token(sp.ID, '12.1'),
+               Token(sp.COLON),
+               Token(sp.ID, '12.6'),
+               Token(sp.ON),
+               Token(sp.ID, 'debug'),
+               Token(sp.OFF),
+               Token(sp.ID, 'qt_4'),
+               Token(sp.DEP),
+               Token(sp.ID, 'stackwalker'),
+               Token(sp.AT),
+               Token(sp.ID, '8.1_1e')]
 
 
 class SpecSyntaxTest(unittest.TestCase):
@@ -74,16 +74,16 @@ class SpecSyntaxTest(unittest.TestCase):
         """
         if spec is None:
             spec = expected
-        output = spack.spec.parse(spec)
+        output = sp.parse(spec)
 
         parsed = (" ".join(str(spec) for spec in output))
         self.assertEqual(expected, parsed)
 
     def check_lex(self, tokens, spec):
         """Check that the provided spec parses to the provided token list."""
-        lex_output = SpecLexer().lex(spec)
+        lex_output = sp.SpecLexer().lex(spec)
         for tok, spec_tok in zip(tokens, lex_output):
-            if tok.type == ID:
+            if tok.type == sp.ID:
                 self.assertEqual(tok, spec_tok)
             else:
                 # Only check the type for non-identifiers.


### PR DESCRIPTION
Fixes #1098.

1. Distinguish between static (package) and dynamic (spec) graphs.
  - `spack graph`: dynamic graphs include information from particular specs (instances of
    packages) and can have multiple instances with hashes.
  - `spack graph --static`: static graphs ignore conditions and multiple instances (hashes) and
    plot raw dependencies among packages.


2. Allow graphing all packages in the install DB with `spack graph --installed`
  - useful for debugging.

3. Can now specify dependency type to traverse with `spack graph`, e.g.:
  - `spack graph --deptype build,link,run` (default)
  - `spack graph --deptype build,run` or `spack graph --deptype nolink`
  - etc.

4. `spack graph` now concretizes specs by default (this was confusing to people).
  - `spack graph --normalize` skips concretization for those who know what that means.

5. Fix bug in left-collapsing graph nodes.

6. update `graph_ascii` to handle deptypes, too.