### PR TITLE
py-pil: Protect against building with Python3.

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -19,3 +19,4 @@ packages:
       mpi: [openmpi, mpich]
       blas: [openblas]
       lapack: [openblas]
+      pil: [py-pillow]

--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -39,7 +39,8 @@ class PyPil(Package):
 
     # py-pil currently only works with Python2.
     # If you are using Python 3, try using py-pillow instead.
-    extends('python@1.5.2:2.8')
+    extends('python')
+    depends_on('python@1.5.2:2.8')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -38,11 +38,7 @@ class PyPil(Package):
     provides('pil')
 
     # py-pil currently only works with Python2.
-    # If you are using Python3, add to your packages.yaml:
-    # packages:
-    #     all:
-    #         providers:
-    #             pil: [py-pillow]
+    # If you are using Python 3, try using py-pillow instead.
     extends('python@1.5.2:2.8')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -37,7 +37,13 @@ class PyPil(Package):
 
     provides('pil')
 
-    extends('python')
+    # py-pil currently only works with Python2.
+    # If you are using Python3, add to your packages.yaml:
+    # packages:
+    #     all:
+    #         providers:
+    #             pil: [py-pillow]
+    extends('python@:2.8')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -43,7 +43,7 @@ class PyPil(Package):
     #     all:
     #         providers:
     #             pil: [py-pillow]
-    extends('python@:2.8')
+    extends('python@1.5.2:2.8')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
`py-pil` does not currently build with Python3.  This PR encodes that fact into the `py-pil` package, turning a build error into a an error during the `spack spec` phase.

`py-pil` and `py-pillow` both implement the `pil` virtual package.  If one is using Python3 (for example, one specified `python@3:` in `packages.yaml`), then Spack should figure out that `py-pil` is not going to work and use `py-pillow` instead.  It does not do that.  Instead, it gives an error message during `spack spec`.  I consider this a bug, but not high priority:
```
$ spack spec py-basemap
==> Error: Invalid spec: 'python@3.5.2%gcc@5.3.0~tk~ucs4 arch=linux-SuSE11-x86_64'. Package python requires version :2.8, but spec asked for 3.5.2
```

Stepping back... why do we include `py-pil` in the Spack repo anyway?  `py-pillow` seems to be more current, and I can't see any reason to prever `py-pil` over it.  Can we at least set `py-pillow` to be the default `pil` provider?
