### PR TITLE
Set py-pillow to be the default pil provider

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -19,3 +19,4 @@ packages:
       mpi: [openmpi, mpich]
       blas: [openblas]
       lapack: [openblas]
+      pil: [py-pillow]


### PR DESCRIPTION
Both `py-pil` and `py-pillow` are providers for `pil`, but `py-pil` is currently chosen by default. This PR sets `py-pillow` as the default `pil` provider. The original Python Imaging Library (PIL) doesn't support Python 3. In fact, the latest release came out in 2009. In contrast, Pillow, the friendly PIL fork, is in active development and supports Python 2 and 3.