### PR TITLE
Add single letter arg flags for spack graph

### DIFF
--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -39,14 +39,14 @@ def setup_parser(subparser):
 
     method = subparser.add_mutually_exclusive_group()
     method.add_argument(
-        '--ascii', action='store_true',
+        '-a', '--ascii', action='store_true',
         help="Draw graph as ascii to stdout (default).")
     method.add_argument(
-        '--dot', action='store_true',
+        '-d', '--dot', action='store_true',
         help="Generate graph in dot format and print to stdout.")
 
     subparser.add_argument(
-        '--normalize', action='store_true',
+        '-n', '--normalize', action='store_true',
         help="Skip concretization; only print normalized spec.")
 
     subparser.add_argument(


### PR DESCRIPTION
Before:
```
$ spack help graph
...
optional arguments:
  -h, --help            show this help message and exit
  --ascii               Draw graph as ascii to stdout (default).
  --dot                 Generate graph in dot format and print to stdout.
  --normalize           Skip concretization; only print normalized spec.
  -s, --static          Use static information from packages, not dynamic spec
                        info.
  -i, --installed       Graph all installed specs in dot format (implies
                        --dot).
  -t DEPTYPE, --deptype DEPTYPE
                        Comma-separated list of deptypes to traverse.
                        default=build,link,run.
```
After:
```
$ spack help graph
...
optional arguments:
  -h, --help            show this help message and exit
  -a, --ascii           Draw graph as ascii to stdout (default).
  -d, --dot             Generate graph in dot format and print to stdout.
  -n, --normalize       Skip concretization; only print normalized spec.
  -s, --static          Use static information from packages, not dynamic spec
                        info.
  -i, --installed       Graph all installed specs in dot format (implies
                        --dot).
  -t DEPTYPE, --deptype DEPTYPE
                        Comma-separated list of deptypes to traverse.
                        default=build,link,run.
```