### PR TITLE
Tell Mercurial where to find CA certs

### DIFF
--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -22,23 +22,48 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
+import llnl.util.tty as tty
+import os
 
 
 class Mercurial(Package):
     """Mercurial is a free, distributed source control management tool."""
+
     homepage = "https://www.mercurial-scm.org"
     url      = "https://www.mercurial-scm.org/release/mercurial-3.9.tar.gz"
 
-    version('3.9'  , 'e2b355da744e94747daae3a5339d28a0')
+    version('3.9.1', '3759dd10edb8c1a6dfb8ff0ce82658ce')
+    version('3.9',   'e2b355da744e94747daae3a5339d28a0')
     version('3.8.4', 'cec2c3db688cb87142809089c6ae13e9')
     version('3.8.3', '97aced7018614eeccc9621a3dea35fda')
     version('3.8.2', 'c38daa0cbe264fc621dc3bb05933b0b3')
     version('3.8.1', '172a8c588adca12308c2aca16608d7f4')
 
-    depends_on("python @2.6:2.7.999")
-    depends_on("py-docutils", type="build")
+    extends('python')
+    depends_on('python@2.6:2.8')
+    depends_on('py-docutils', type='build')
 
     def install(self, spec, prefix):
-        make('PREFIX=%s' % prefix, 'install')
+        make('install', 'PREFIX={0}'.format(prefix))
+
+        # Configuration of HTTPS certificate authorities
+        # https://www.mercurial-scm.org/wiki/CACertificates
+        hgrc_filename = join_path(prefix.etc, 'mercurial', 'hgrc')
+        mkdirp(os.path.dirname(hgrc_filename))
+
+        with open(hgrc_filename, 'w') as hgrc:
+            if os.path.exists('/etc/ssl/certs/ca-certificates.crt'):
+                # Debian/Ubuntu/Gentoo/Arch Linux
+                hgrc.write('[web]\ncacerts = /etc/ssl/certs/ca-certificates.crt')  # noqa
+            elif os.path.exists('/etc/pki/tls/certs/ca-bundle.crt'):
+                # Fedora/RHEL/CentOS
+                hgrc.write('[web]\ncacerts = /etc/pki/tls/certs/ca-bundle.crt')
+            elif os.path.exists('/etc/ssl/ca-bundle.pem'):
+                # openSUSE/SLE
+                hgrc.write('[web]\ncacerts = /etc/ssl/ca-bundle.pem')
+            else:
+                tty.warn('CA certificate not found. You may not be able to '
+                         'connect to an HTTPS server. If your CA certificate '
+                         'is in a non-standard location, you should add it to '
+                         '{0}'.format(hgrc_filename))


### PR DESCRIPTION
I had a user complaint that my Mercurial installation wasn't working for his HTTPS repository. It turns out that we didn't have a global hgrc set up to tell Mercurial where to find our CA certificates. Prior to Mercurial 3.9, this would produce a harmless warning message:
```
warning: bitbucket.org certificate with fingerprint 3f:d3:c5:17:23:3c:cd:f5:2d:17:76:06:93:7e:ee:97:42:21:14:aa not verified (check hostfingerprints or web.cacerts config setting) 
```
But as of Mercurial 3.9, this now produces an error message:
```
(an attempt was made to load CA certificates but none were loaded; see https://mercurial-scm.org/wiki/SecureConnections for how to configure Mercurial to avoid this error)
abort: error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590) 
```
This PR creates an `hgrc` file in the installation directory that points to the location of the CA certs.

Aside from this main goal, the PR also:

- Adds the latest version, 3.9.1
- Makes mercurial a Python extension
 - I don't expect anyone to activate it, but Mercurial technically builds a `site-packages` directory, so why not
