### PR TITLE
git: Don't link against -lrt on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import sys
 from spack import *
 
 
@@ -79,5 +80,8 @@ class Git(Package):
 
         which('autoreconf')('-i')
         configure(*configure_args)
+        if sys.platform == "darwin":
+            # Don't link with -lrt; the system has no (and needs no) librt
+            filter_file(r' -lrt$', '', 'Makefile')
         make()
         make("install")


### PR DESCRIPTION
There is no librt on Darwin, and it's not necessary either.