### PR TITLE
Symengine and associated packages

### DIFF
--- a/var/spack/repos/builtin/packages/flint/package.py
+++ b/var/spack/repos/builtin/packages/flint/package.py
@@ -1,0 +1,66 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Flint(Package):
+    """FLINT (Fast Library for Number Theory)."""
+
+    homepage = "http://www.flintlib.org"
+    url      = "http://mirrors.mit.edu/sage/spkg/upstream/flint/flint-2.5.2.tar.gz"
+
+    version('2.5.2', 'cda885309362150196aed66a5e0f0383')
+    version('2.4.5', '6504b9deabeafb9313e57153a1730b33')
+    version('develop', git='https://github.com/wbhart/flint2.git')
+
+    # Overlap in functionality between gmp and mpir
+    # All other dependencies must also be built with
+    # one or the other
+    # variant('mpir', default=False,
+    #         description='Compile with the MPIR library')
+
+    # Build dependencies
+    depends_on('autoconf', type='build')
+
+    # Other dependencies
+    depends_on('gmp')   # mpir is a drop-in replacement for this
+    depends_on('mpfr')  # Could also be built against mpir
+
+    def install(self, spec, prefix):
+        options = []
+        options = ["--prefix=%s" % prefix,
+                   "--with-gmp=%s" % spec['gmp'].prefix,
+                   "--with-mpfr=%s" % spec['mpfr'].prefix]
+
+        # if '+mpir' in spec:
+        #     options.extend([
+        #         "--with-mpir=%s" % spec['mpir'].prefix
+        #     ])
+
+        configure(*options)
+        make()
+        if self.run_tests:
+            make("check")
+        make("install")

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -35,12 +35,12 @@ class Mpc(Package):
     version('1.0.3', 'd6a1d5f8ddea3abd2cc3e98f58352d26')
     version('1.0.2', '68fadff3358fb3e7976c7a398a0af4c3')
 
-    depends_on("gmp")
-    depends_on("mpfr")
+    depends_on('gmp')   # mpir is a drop-in replacement for this
+    depends_on('mpfr')  # Could also be built against mpir
 
     def url_for_version(self, version):
         if version < Version("1.0.1"):
-            return "http://www.multiprecision.org/mpc/download/mpc-%s.tar.gz" % version
+            return "http://www.multiprecision.org/mpc/download/mpc-%s.tar.gz" % version  # NOQA
         else:
             return "ftp://ftp.gnu.org/gnu/mpc/mpc-%s.tar.gz" % version
 

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -35,7 +35,7 @@ class Mpfr(Package):
     version('3.1.3', '5fdfa3cfa5c86514ee4a241a1affa138')
     version('3.1.2', 'ee2c3ac63bf0c2359bf08fc3ee094c19')
 
-    depends_on('gmp')
+    depends_on('gmp')  # mpir is a drop-in replacement for this
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/mpir/package.py
+++ b/var/spack/repos/builtin/packages/mpir/package.py
@@ -1,0 +1,62 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mpir(Package):
+    """Multiple Precision Integers and Rationals."""
+
+    homepage = "https://github.com/wbhart/mpir"
+    url      = "https://github.com/wbhart/mpir/archive/mpir-2.7.0.tar.gz"
+
+    version('2.7.0', '985b5d57bd0e74c74125ee885b9c8f71')
+    version('2.6.0', 'ec17d6a7e026114ceb734b2466aa0a91')
+    version('develop', git='https://github.com/wbhart/mpir.git')
+
+    # This setting allows mpir to act as a drop-in replacement for gmp
+    variant('gmp_compat',        default=False,
+            description='Compile with GMP library compatibility')
+
+    # Build dependencies
+    depends_on('autoconf', type='build')
+
+    # Other dependencies
+    depends_on('yasm')
+
+    def install(self, spec, prefix):
+        # We definitely don't want to have MPIR build its
+        # own version of YASM. This tries to install it
+        # to a system directory.
+        options = ['--prefix={0}'.format(prefix),
+                   '--with-system-yasm']
+
+        if '+gmp_compat' in spec:
+            options.extend(['--enable-gmpcompat'])
+
+        configure(*options)
+        make()
+        if self.run_tests:
+            make('check')
+        make('install')

--- a/var/spack/repos/builtin/packages/piranha/package.py
+++ b/var/spack/repos/builtin/packages/piranha/package.py
@@ -1,0 +1,73 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Piranha(Package):
+    """Piranha is a computer-algebra library for the symbolic manipulation of
+    sparse multivariate polynomials and other closely-related symbolic objects
+    (such as Poisson series)."""
+
+    homepage = "https://bluescarni.github.io/piranha/sphinx/"
+    url      = "https://github.com/bluescarni/piranha/archive/v0.5.tar.gz"
+
+    version('0.5', '99546bae2be115737b6316751eb0b84d')
+    version('develop', git='https://github.com/bluescarni/piranha.git')
+
+    variant('python',   default=True,
+            description='Build the Python bindings')
+
+    # Build dependencies
+    depends_on('cmake@3.0:',  type='build')
+    extends('python',         when='+pyranha')
+    depends_on('python@2.6:', type='build', when='+pyranha')
+
+    # Other dependencies
+    depends_on('boost+iostreams+regex+serialization',
+               when='~python')
+    depends_on('boost+iostreams+regex+serialization+python',
+               when='+python')
+    depends_on('bzip2')
+    depends_on('gmp')   # mpir is a drop-in replacement for this
+    depends_on('mpfr')  # Could also be built against mpir
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        # Python bindings
+        options.extend([
+            '-DBUILD_PYRANHA=%s' % (
+                'ON' if '+python' in spec else 'OFF'),
+            '-DBUILD_TESTS:BOOL=ON',
+        ])
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *options)
+
+            make()
+            make('install')
+            if self.run_tests:
+                make('test')

--- a/var/spack/repos/builtin/packages/py-symengine/package.py
+++ b/var/spack/repos/builtin/packages/py-symengine/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PySymengine(Package):
+    """Python wrappers for SymEngine, a symbolic manipulation library."""
+
+    homepage = "https://github.com/symengine/symengine.py"
+    url = "https://github.com/symengine/symengine.py/archive/v0.2.0.tar.gz"
+
+    version('0.2.0', 'e1d114fa12be4c8c7e9f24007e07718c')
+    version('develop', git='https://github.com/symengine/symengine.py.git')
+
+    # Build dependencies
+    extends('python')
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-setuptools',     type='build')
+    depends_on('py-cython@0.19.1:')
+    depends_on('cmake@2.8.7:',      type='build')
+    depends_on('symengine@0.2.0:')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s --symengine-dir=%s' %
+               (prefix, spec['symengine'].prefix))

--- a/var/spack/repos/builtin/packages/symengine/package.py
+++ b/var/spack/repos/builtin/packages/symengine/package.py
@@ -1,0 +1,113 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Symengine(Package):
+    """SymEngine is a fast symbolic manipulation library, written in C++."""
+
+    homepage = "https://github.com/symengine/symengine"
+    url      = "https://github.com/symengine/symengine/archive/v0.2.0.tar.gz"
+
+    version('0.2.0', '45401561add36a13c1f0b0c5f8d7422d')
+    version('0.1.0', '41ad7daed61fc5a77c285eb6c7303425')
+    version('develop', git='https://github.com/symengine/symengine.git')
+
+    variant('flint',        default=True,
+            description='Compile with Flint integer library')
+    variant('mpc',          default=True,
+            description='Compile with MPC library')
+    variant('mpfr',         default=True,
+            description='Compile with MPFR library')
+    variant('piranha',      default=False,
+            description='Compile with Piranha integer library')
+    variant('thread_safe',  default=True,
+            description='Enable thread safety option')
+    variant('openmp',       default=False,
+            description='Enable OpenMP support')
+    variant('shared',       default=True,
+            description='Enables the build of shared libraries')
+
+    # Build dependencies
+    depends_on('cmake',    type='build')
+
+    # Other dependencies
+    depends_on('gmp')  # mpir is a drop-in replacement for this
+    depends_on('mpc',      when='+mpc')  # Could also be built against mpir
+    depends_on('mpfr',     when='+mpfr')  # Could also be built against mpir
+    depends_on('flint',    when='+flint')  # Could also be built against mpir
+    depends_on('piranha',  when='+piranha~flint')  # Could also be built against mpir  # NOQA
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        # CMAKE_BUILD_TYPE should be Debug | Release
+        for word in options[:]:
+            if word.startswith('-DCMAKE_BUILD_TYPE'):
+                options.remove(word)
+
+        # See https://github.com/symengine/symengine/blob/master/README.md
+        # for build options
+        options.extend([
+            '-DCMAKE_BUILD_TYPE=Release',
+            '-DWITH_SYMENGINE_RCP:BOOL=ON',
+            '-DWITH_SYMENGINE_THREAD_SAFE:BOOL=%s' % (
+                'ON' if ('+thread_safe' or '+openmp') in spec else 'OFF'),
+            '-DBUILD_TESTS:BOOL=ON',
+            '-DBUILD_BENCHMARKS:BOOL=ON',
+            '-DWITH_MPC:BOOL=%s' % (
+                'ON' if '+mpc' in spec else 'OFF'),
+            '-DWITH_MPFR:BOOL=%s' % (
+                'ON' if '+mpfr' in spec else 'OFF'),
+            '-DINTEGER_CLASS:STRING=gmp',
+            '-DWITH_OPENMP:BOOL=%s' % (
+                'ON' if '+openmp' in spec else 'OFF'),
+            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
+                'ON' if '+shared' in spec else 'OFF'),
+        ])
+
+        if '+flint' in spec:
+            options.extend([
+                '-DWITH_FLINT:BOOL=ON',
+                '-DINTEGER_CLASS:STRING=flint'
+            ])
+        elif '+piranha' in spec:
+            options.extend([
+                '-DWITH_PIRANHA:BOOL=ON',
+                '-DINTEGER_CLASS:STRING=piranha'
+            ])
+        else:
+            options.extend([
+                '-DINTEGER_CLASS:STRING=gmp'
+            ])
+
+        with working_dir('spack-build', create=True):
+            cmake('..', *options)
+
+            make()
+            make('install')
+            if self.run_tests:
+                ctest()


### PR DESCRIPTION
Added symengine and piranha packages.

Some outstanding issues to be addressed:
- [x] symengine/symengine#1083
- [x] symengine/symengine#1085
- [x] bluescarni/piranha#79
- [x] bluescarni/piranha#80
- [x] symengine/symengine.py#102
- [x]  wbhart/flint2#293 - fixed by #1972
