### PR TITLE
Fixes bug closing Executable file io-streams

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -185,11 +185,11 @@ class Executable(object):
 
         finally:
             if close_ostream:
-                output.close()
+                ostream.close()
             if close_estream:
-                error.close()
+                estream.close()
             if close_istream:
-                input.close()
+                istream.close()
 
     def __eq__(self, other):
         return self.exe == other.exe


### PR DESCRIPTION
Input/output/error streams not directed to None or 'str' were not being closed
because `close()` method was called on the argument value (a string type)
instead of the open file descriptor object.