### PR TITLE
Update libtiff: updated homepage and fetch urls.

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -27,8 +27,8 @@ from spack import *
 
 class Libtiff(Package):
     """libtiff graphics format library"""
-    homepage = "http://www.remotesensing.org/libtiff/"
-    url      = "http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz"
+    homepage = "http://www.simplesystems.org/libtiff/"
+    url      = "ftp://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz"
 
     version('4.0.3', '051c1068e6a0627f461948c365290410')
 

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -30,6 +30,7 @@ class Libtiff(Package):
     homepage = "http://www.simplesystems.org/libtiff/"
     url      = "ftp://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz"
 
+    version('4.0.6', 'd1d2e940dea0b5ad435f21f03d96dd72')
     version('4.0.3', '051c1068e6a0627f461948c365290410')
 
     depends_on('jpeg')


### PR DESCRIPTION
It looks like the homepage of the project has changed. The new homepage says that the source code should be fetched via ftp (the current http link does not work).