### PR TITLE
Update gmp: fixed an issue with intel compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -40,8 +40,14 @@ class Gmp(Package):
     depends_on('m4', type='build')
 
     def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix),
-                  '--enable-cxx')
+        config_args = ['--prefix=' + prefix,
+                       '--enable-cxx']
+
+        # We need this flag if we want all the following checks to pass.
+        if spec.compiler.name == 'intel':
+            config_args.append('CXXFLAGS=-no-ftz')
+
+        configure(*config_args)
 
         make()
         make('check')


### PR DESCRIPTION
One of the checks failed when the package was built with intel compiler.

Fixed it according to this recommendation: https://gmplib.org/list-archives/gmp-bugs/2014-September/003525.html