### PR TITLE
Update documentation URL after switch to readthedocs

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -39,7 +39,7 @@ class Cuda(Package):
     Type, select runfile and click Download. Spack will search your
     current directory for this file. Alternatively, add this file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html.
 
     Note: This package does not currently install the drivers necessary
     to run CUDA. These will need to be installed manually. See:

--- a/var/spack/repos/builtin/packages/daal/package.py
+++ b/var/spack/repos/builtin/packages/daal/package.py
@@ -9,7 +9,7 @@ class Daal(IntelInstaller):
 
     Note: You will have to add the download file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html"""
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://software.intel.com/en-us/daal"
 

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -11,7 +11,7 @@ class IntelParallelStudio(IntelInstaller):
 
     Note: You will have to add the download file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html"""
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -77,7 +77,7 @@ class Intel(IntelInstaller):
 
     Note: You will have to add the download file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html"""
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 

--- a/var/spack/repos/builtin/packages/ipp/package.py
+++ b/var/spack/repos/builtin/packages/ipp/package.py
@@ -9,7 +9,7 @@ class Ipp(IntelInstaller):
 
     Note: You will have to add the download file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html"""
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://software.intel.com/en-us/intel-ipp"
 

--- a/var/spack/repos/builtin/packages/mkl/package.py
+++ b/var/spack/repos/builtin/packages/mkl/package.py
@@ -9,7 +9,7 @@ class Mkl(IntelInstaller):
 
     Note: You will have to add the download file to a
     mirror so that Spack can find it. For instructions on how to set up a
-    mirror, see http://software.llnl.gov/spack/mirrors.html.
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html.
 
     To set the threading layer at run time set MKL_THREADING_LAYER
     variable to one of the following values: INTEL (default), SEQUENTIAL, PGI.

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -36,7 +36,7 @@ class Pgi(Package):
     architecture) to the format: pgi-<version>.tar.gz. Spack will search your
     current directory for a file of this format. Alternatively, add this
     file to a mirror so that Spack can find it. For instructions on how to
-    set up a mirror, see http://software.llnl.gov/spack/mirrors.html"""
+    set up a mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "http://www.pgroup.com/"
     url = "file://%s/pgi-16.3.tar.gz" % os.getcwd()

--- a/var/spack/repos/builtin/packages/turbomole/package.py
+++ b/var/spack/repos/builtin/packages/turbomole/package.py
@@ -29,14 +29,14 @@ import subprocess
 
 class Turbomole(Package):
     """TURBOMOLE: Program Package for ab initio Electronic Structure
-       Calculations. NB: Requires a license to download."""
+    Calculations.
 
-    # NOTE: Turbomole requires purchase of a license to download. Go to the
-    # NOTE: Turbomole home page, http://www.turbomole-gmbh.com, for details.
-    # NOTE: Spack will search the current directory for this file. It is
-    # NOTE: probably best to add this file to a Spack mirror so that it can be
-    # NOTE: found from anywhere.  For information on setting up a Spack mirror
-    # NOTE: see http://software.llnl.gov/spack/mirrors.html
+    Note: Turbomole requires purchase of a license to download. Go to the
+    Turbomole home page, http://www.turbomole-gmbh.com, for details.
+    Spack will search the current directory for this file. It is
+    probably best to add this file to a Spack mirror so that it can be
+    found from anywhere.  For information on setting up a Spack mirror
+    see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "http://www.turbomole-gmbh.com/"
 


### PR DESCRIPTION
The old page returns a 404 error.

@tgamblin The GitHub description for Spack still points to the old documentation URL as well.