### PR TITLE
boost: set 1.61 as preferred until 1.62 is fixed

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -41,8 +41,8 @@ class Boost(Package):
     list_url = "http://sourceforge.net/projects/boost/files/boost/"
     list_depth = 2
 
-    version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')
-    version('1.61.0', '6095876341956f65f9d35939ccea1a9f')
+    version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')  # TODO: fix build
+    version('1.61.0', '6095876341956f65f9d35939ccea1a9f', preferred=True)
     version('1.60.0', '65a840e1a0b13a558ff19eeb2c4f0cbe')
     version('1.59.0', '6aa9a5c6a4ca1016edd0ed1178e3cb87')
     version('1.58.0', 'b8839650e61e9c1c0a89f371dd475546')


### PR DESCRIPTION
a temporary workaround for https://github.com/LLNL/spack/issues/1903