### PR TITLE
Add latest versions, resolve variant resolution bug

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -38,6 +38,7 @@ class Gsl(Package):
     homepage = "http://www.gnu.org/software/gsl"
     url      = "http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-2.1.tar.gz"
 
+    version('2.2.1', '3d90650b7cfe0a6f4b29c2d7b0f86458')
     version('2.1', 'd8f70abafd3e9f0bae03c52d1f4e8de5')
     version('2.0', 'ae44cdfed78ece40e73411b63a78c375')
     version('1.16', 'e49a664db13d81c968415cd53f62bc8b')

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -34,6 +34,7 @@ class Hdf(Package):
     list_url = "https://www.hdfgroup.org/ftp/HDF/releases/"
     list_depth = 3
 
+    version('4.2.12', '79fd1454c899c05e34a3da0456ab0c1c')
     version('4.2.11', '063f9928f3a19cc21367b71c3b8bbf19')
 
     variant('szip', default=False, description="Enable szip support")

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -32,6 +32,7 @@ class Nco(Package):
     homepage = "https://sourceforge.net/projects/nco"
     url      = "https://github.com/nco/nco/archive/4.5.5.tar.gz"
 
+    version('4.6.1', 'ef43cc989229c2790a9094bd84728fd8')
     version('4.5.5', '9f1f1cb149ad6407c5a03c20122223ce')
 
     # See "Compilation Requirements" at:
@@ -39,18 +40,21 @@ class Nco(Package):
     variant('mpi', default=True)
 
     depends_on('netcdf')
-    depends_on('netcdf+mpi', when='+mpi')
-    depends_on('netcdf~mpi', when='~mpi')
-    depends_on('antlr@2.7.7+cxx')    # (required for ncap2)
-    depends_on('gsl')  # (desirable for ncap2)
-    depends_on('udunits2')       # (allows dimensional unit transformations)
-    # depends_on('opendap')      # (enables network transparency),
+    depends_on('antlr@2.7.7+cxx')  # required for ncap2
+    depends_on('gsl')              # desirable for ncap2
+    depends_on('udunits2')         # allows dimensional unit transformations
+    # depends_on('opendap')        # enables network transparency
 
     def install(self, spec, prefix):
+        # Workaround until variant forwarding works properly
+        if '+mpi' in spec and spec.satisfies('^netcdf~mpi'):
+            raise RuntimeError('Invalid spec. Package netcdf requires '
+                               'netcdf+mpi, but spec asked for netcdf~mpi.')
+
         opts = [
             '--prefix=%s' % prefix,
-            '--disable-openmp',    # TODO: Make this a variant
-            '--disable-dap',        # TODO: Make this a variant
+            '--disable-openmp',  # TODO: Make this a variant
+            '--disable-dap',     # TODO: Make this a variant
             '--disable-esmf']
         configure(*opts)
         make()


### PR DESCRIPTION
Adds the latest version of GSL, HDF, and NCO.

Resolves a variant resolution bug described in #1553. Without this bug fix, I ran into this problem:
```
$ spack graph nco
==> Error: Invalid spec: 'netcdf@4.4.1%gcc@6.1.1+hdf4~mpi arch=linux-fedora24-x86_64'. Package netcdf requires variant +mpi, but spec asked for ~mpi
```
This is because my `packages.yaml` says to build `netcdf~mpi`, but doesn't properly override `nco` which defaults to `+mpi`.