### PR TITLE
Add --force flag, re-installs even if package was already installed.

### DIFF
--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -53,6 +53,9 @@ def setup_parser(subparser):
         'spec', nargs=argparse.REMAINDER,
         help="specs to use for install.  Must contain package AND version.")
     subparser.add_argument(
+        '--force', '-f', action='store_true', dest='force',
+        help='Install again even if package is already installed.')
+    subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
         help="Install a package *without* cleaning the environment.")
 
@@ -104,4 +107,5 @@ def diy(self, args):
             install_deps=not args.ignore_deps,
             verbose=not args.quiet,
             keep_stage=True,   # don't remove source dir for DIY.
+            force=args.force,
             dirty=args.dirty)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -29,7 +29,6 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
-import os
 
 description = "Build and install packages"
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -29,6 +29,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.cmd
+import os
 
 description = "Build and install packages"
 
@@ -59,6 +60,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--fake', action='store_true', dest='fake',
         help="Fake install. Just remove prefix and create a fake file.")
+    subparser.add_argument(
+        '--force', '-f', action='store_true', dest='force',
+        help='Install again even if package is already installed.')
     subparser.add_argument(
         '--dirty', action='store_true', dest='dirty',
         help="Install a package *without* cleaning the environment.")
@@ -95,4 +99,5 @@ def install(parser, args):
                 verbose=args.verbose,
                 fake=args.fake,
                 dirty=args.dirty,
+                force=args.force,
                 explicit=True)

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -96,4 +96,5 @@ def setup(self, args):
             verbose=args.verbose,
             keep_stage=True,   # don't remove source dir for SETUP.
             install_phases=set(['setup', 'provenance']),
+            force=True,
             dirty=args.dirty)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -953,7 +953,8 @@ class Package(object):
                     dirty=dirty,
                     force=False)
 
-        # The rest of this function is to install ourself, once deps have been installed.
+        # The rest of this function is to install ourself,
+        # once deps have been installed.
         if not install_self:
             return
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -39,6 +39,7 @@ import re
 import textwrap
 import time
 import string
+import shutil
 
 import llnl.util.tty as tty
 import spack
@@ -882,6 +883,7 @@ class Package(object):
                    fake=False,
                    explicit=False,
                    dirty=False,
+                   force=False,
                    install_phases=install_phases):
         """Called by commands to install a package and its dependencies.
 
@@ -921,12 +923,17 @@ class Package(object):
         layout = spack.install_layout
         if 'install' in install_phases and layout.check_installed(self.spec):
             tty.msg("%s is already installed in %s" % (self.name, self.prefix))
-            rec = spack.installed_db.get_record(self.spec)
-            if (not rec.explicit) and explicit:
-                with spack.installed_db.write_transaction():
-                    rec = spack.installed_db.get_record(self.spec)
-                    rec.explicit = True
-            return
+
+            if force:    # Delete if installed
+                tty.msg('Deleting it...')
+                shutil.rmtree(layout.path_for_spec(self.spec))
+            else:
+                rec = spack.installed_db.get_record(self.spec)
+                if (not rec.explicit) and explicit:
+                    with spack.installed_db.write_transaction():
+                        rec = spack.installed_db.get_record(self.spec)
+                        rec.explicit = True
+                return
 
         tty.msg("Installing %s" % self.name)
 
@@ -943,10 +950,10 @@ class Package(object):
                     verbose=verbose,
                     make_jobs=make_jobs,
                     run_tests=run_tests,
-                    dirty=dirty)
+                    dirty=dirty,
+                    force=False)
 
-        # The rest of this function is to install ourself,
-        # once deps have been installed.
+        # The rest of this function is to install ourself, once deps have been installed.
         if not install_self:
             return
 


### PR DESCRIPTION
This `--force` flag is useful when using `spack setup`, where "installs" are all fake anyway.  Don't want to have to do a `spack uninstall` every time we just want to generate a new `spconfig.py` file.
