### PR TITLE
On uninstall, change shortcut flag for --dependents to -R, as per Spa…

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -61,7 +61,7 @@ def setup_parser(subparser):
              "is both useful and dangerous, like rm -r")
 
     subparser.add_argument(
-        '-d', '--dependents', action='store_true', dest='dependents',
+        '-R', '--dependents', action='store_true', dest='dependents',
         help='also uninstall any packages that depend on the ones given '
              'via command line')
 


### PR DESCRIPTION
The convention we last discussed is:

  -r = Recurse through dependencies
  -R = Recurse THE OTHER WAY through dependents

Unless we want to agree on a different convention...
