### PR TITLE
Add binutils dependencies for packages that really do not like old/bu…

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -38,6 +38,7 @@ class PyCython(Package):
     version('0.21.2', 'd21adb870c75680dc857cd05d41046a4')
 
     extends('python')
+    depends_on('binutils', type='build')
 
     def install(self, spec, prefix):
         python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf/package.py
@@ -33,6 +33,8 @@ class PyNetcdf(Package):
     version('1.2.3.1', '4fc4320d4f2a77b894ebf8da1c9895af')
 
     extends('python')
+    depends_on('binutils', type='build')
+
     depends_on('py-numpy', type=nolink)
     depends_on('py-cython', type=nolink)
     depends_on('netcdf')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -42,9 +42,9 @@ class PyScipy(Package):
     extends('python')
     depends_on('python@2.6:2.8,3.2:')
     depends_on('py-nose', type='build')
-    # Known not to work with 2.23, 2.25
     depends_on('binutils@2.26:', type='build')
     depends_on('py-numpy@1.7.1:+blas+lapack', type=nolink)
+
 
     def install(self, spec, prefix):
         if 'atlas' in spec:

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -45,7 +45,6 @@ class PyScipy(Package):
     depends_on('binutils@2.26:', type='build')
     depends_on('py-numpy@1.7.1:+blas+lapack', type=nolink)
 
-
     def install(self, spec, prefix):
         if 'atlas' in spec:
             # libatlas.so actually isn't always installed, but this


### PR DESCRIPTION
A few packages seem to NOT like binutils with version <2.26.  This helps such packages build on older systems.  Users of newer systems should probably put binutils in their `packages.yaml` file (or we should do it by default)...
