### PR TITLE
require fortran for MPI providers to avoid delayed compiler errors

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -82,6 +82,13 @@ class Mpich(Package):
         ]
 
     def install(self, spec, prefix):
+        # Until we can pass variants such as +fortran through virtual
+        # dependencies depends_on('mpi'), require Fortran compiler to
+        # avoid delayed build errors in dependents.
+        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+            raise InstallError('Mpich requires both C and Fortran ',
+                               'compilers!')
+
         config_args = [
             '--prefix={0}'.format(prefix),
             '--enable-shared',

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -232,6 +232,13 @@ class Mvapich2(Package):
         ]
 
     def install(self, spec, prefix):
+        # Until we can pass variants such as +fortran through virtual
+        # dependencies depends_on('mpi'), require Fortran compiler to
+        # avoid delayed build errors in dependents.
+        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+            raise InstallError('Mvapich2 requires both C and Fortran ',
+                               'compilers!')
+
         # we'll set different configure flags depending on our
         # environment
         configure_args = [

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -23,9 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
-
-import llnl.util.tty as tty
-
 from spack import *
 
 


### PR DESCRIPTION
As per discussion in https://github.com/LLNL/spack/issues/1859, require Fortran for now with `mpi` providers.

fixes https://github.com/LLNL/spack/issues/1859