### PR TITLE
Revert change that broke py-scipy

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -111,6 +111,25 @@ class Openblas(Package):
         # no quotes around prefix (spack doesn't use a shell)
         make('install', "PREFIX=%s" % prefix, *make_defs)
 
+        # TODO: the links below are mainly there because client
+        # TODO: packages are wrongly written. Check if they can be removed
+		# NOTE: py-scipy requires these symlinks.  Please do not remove them
+		#       without checking that py-scipy can build without.
+        # Blas virtual package should provide blas.a and libblas.a
+        with working_dir(prefix.lib):
+            symlink('libopenblas.a', 'blas.a')
+            symlink('libopenblas.a', 'libblas.a')
+            if '+shared' in spec:
+                symlink('libopenblas.%s' % dso_suffix,
+                        'libblas.%s' % dso_suffix)
+
+        # Lapack virtual package should provide liblapack.a
+        with working_dir(prefix.lib):
+            symlink('libopenblas.a', 'liblapack.a')
+            if '+shared' in spec:
+                symlink('libopenblas.%s' % dso_suffix,
+                        'liblapack.%s' % dso_suffix)
+
         # Openblas may pass its own test but still fail to compile Lapack
         # symbols. To make sure we get working Blas and Lapack, do a small
         # test.

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -40,6 +40,8 @@ class PyScipy(Package):
     version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
 
     extends('python')
+    depends_on('blas')
+    depends_on('lapack')
     depends_on('python@2.6:2.8,3.2:')
     depends_on('py-nose', type='build')
     # Known not to work with 2.23, 2.25


### PR DESCRIPTION
@davydden  A recent change broke py-scipy:
https://github.com/LLNL/spack/commit/1e10309ff707a29fe91993d9a9b408182ffa77f1

This PR reverts (part of) that change by re-instating the symlinks to `libblas.so` and `liblapack.so`.

In hind sight... it looks like @davydden grepped for ``depends_on('blas')`` and ``depends_on('lapack')`` in making that change... and made sure that all those places worked.  ``py-scipy`` did not contain those ``depends_on()`` declarations, so no surprise it was missed (dependency is implict through ``py-numpy``).

This seemed wrong, and is likely why it was missed by @davydden.  I added ``depends_on('blas')`` and ``depends_on('lapack')``, although that change in and of itself does not fix the build (env['BLAS'], etc. were previously being set properly even without the ``depends_on()`` statments).

It's curious that ``py-numpy`` builds just fine but ``py-scipy`` seems to need the symlinks to ``libblas.so`` and ``liblapack.so``.  :shrug:

