### PR TITLE
Fix bugs preventing readthedocs from rebuilding the documentation

### DIFF
--- a/lib/spack/docs/command_index.in
+++ b/lib/spack/docs/command_index.in
@@ -1,6 +1,6 @@
-=================
-Command index
-=================
+=============
+Command Index
+=============
 
 This is an alphabetical list of commands with links to the places they
 appear in the documentation.

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -67,13 +67,12 @@ os.environ['COLIFY_SIZE'] = '25x120'
 #
 # Generate package list using spack command
 #
-if not os.path.exists('package_list.rst'):
-    with open('package_list.rst', 'w') as plist_file:
-        subprocess.Popen(
-            [spack_root + '/bin/spack', 'package-list'], stdout=plist_file)
+with open('package_list.rst', 'w') as plist_file:
+    subprocess.Popen(
+        [spack_root + '/bin/spack', 'package-list'], stdout=plist_file)
 
 #
-# Find all the `spack-*` references and add them to a command index
+# Find all the `cmd-spack-*` references and add them to a command index
 #
 command_names = []
 for filename in glob('*rst'):
@@ -83,12 +82,11 @@ for filename in glob('*rst'):
             if match:
                 command_names.append(match.group(1).strip())
 
-if not os.path.exists('command_index.rst'):
-    shutil.copy('command_index.in', 'command_index.rst')
-    with open('command_index.rst', 'a') as index:
-        index.write('\n')
-        for cmd in sorted(command_names):
-            index.write('   * :ref:`%s`\n' % cmd)
+shutil.copy('command_index.in', 'command_index.rst')
+with open('command_index.rst', 'a') as index:
+    index.write('\n')
+    for cmd in sorted(command_names):
+        index.write('   * :ref:`%s`\n' % cmd)
 
 
 # Run sphinx-apidoc


### PR DESCRIPTION
This PR is designed to fix 2 bugs in our readthedocs documentation:

The [Package List](http://spack.readthedocs.io/en/latest/package_list.html) isn't being rebuilt anymore. Specifically, if you look at the package for [PGI](http://spack.readthedocs.io/en/latest/package_list.html#pgi), you'll notice that it doesn't reflect the changes that were made in #1901.

The [Command Index](http://spack.readthedocs.io/en/latest/command_index.html) isn't being rebuilt anymore. #1678 was supposed to fix the Command Index by removing things like `spack edit -force` and `spack mirror add` by making their tags more specific. The tags were changed in the rest of the documentation, but since `command_index.rst` isn't being refreshed, it didn't get the memo. Now all of the links are broken.

So what caused this problem? I noticed a bug where if you ran `make` twice in a row, it would cause warning messages with Sphinx (see #1741). @tgamblin attempted to resolve these warnings in #1902 by not rebuilding some of the cached files. Unfortunately, the if-statements he added to not rebuild `package_list.rst` and `command_index.rst` had some unintended consequences. According to the [readthedocs documentation](http://read-the-docs.readthedocs.io/en/latest/builds.html#understanding-what-s-going-on):

> The first step of the process is that we check out your code from the repository you have given us. If the code is already checked out, we update the copy to the branch that you have specified in your projects configuration.

So the problem is that readthedocs isn't starting from a fresh clone every time. Since it was reusing the old .rst files, `conf.py` told it not to rebuild them.

The solution was to remove the conditional if-statements added in #1902. Surprisingly, this doesn't seem to reintroduce the problem documented in #1741. Perhaps the other changes in #1902 were enough to prevent the problem on their own.