### PR TITLE
Updated nettle to have m4 as an immediate dependency

### DIFF
--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -36,7 +36,7 @@ class Nettle(Package):
     version('2.7', '2caa1bd667c35db71becb93c5d89737f')
 
     depends_on('gmp')
-    depends_on('m4')
+    depends_on('m4', type='build')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -36,6 +36,7 @@ class Nettle(Package):
     version('2.7', '2caa1bd667c35db71becb93c5d89737f')
 
     depends_on('gmp')
+    depends_on('m4')
 
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix))


### PR DESCRIPTION
`spack install nettle` fails in current develop branch
[nettle_log.txt](https://github.com/LLNL/spack/files/514508/nettle_log.txt)
