### PR TITLE
fix blas-lapack in scipy and numpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -78,7 +78,8 @@ class PyNumpy(Package):
                 f.write('[DEFAULT]\n')
                 f.write('libraries=%s\n'    % ','.join(lapackblas.names))
                 f.write('library_dirs=%s\n' % ':'.join(lapackblas.directories))
-                if not platform.system() == "Darwin":
+                if not ((platform.system() == "Darwin") and
+                        (platform.mac_ver()[0] == '10.12')):
                     f.write('rpath=%s\n' % ':'.join(lapackblas.directories))
 
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -66,6 +66,7 @@ class PyNumpy(Package):
             'numpy/core/include')
 
     def install(self, spec, prefix):
+        # for build notes see http://www.scipy.org/scipylib/building/linux.html
         lapackblas = LibraryList('')
         if '+lapack' in spec:
             lapackblas += spec['lapack'].lapack_libs

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -78,6 +78,7 @@ class PyNumpy(Package):
                 f.write('[DEFAULT]\n')
                 f.write('libraries=%s\n'    % ','.join(lapackblas.names))
                 f.write('library_dirs=%s\n' % ':'.join(lapackblas.directories))
-                f.write('rpath=%s\n' % ':'.join(lapackblas.directories))
+                if not platform.system() == "Darwin":
+                    f.write('rpath=%s\n' % ':'.join(lapackblas.directories))
 
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -66,21 +66,18 @@ class PyNumpy(Package):
             'numpy/core/include')
 
     def install(self, spec, prefix):
-        libraries    = []
-        library_dirs = []
+        lapackblas = LibraryList('')
+        if '+lapack' in spec:
+            lapackblas += spec['lapack'].lapack_libs
 
         if '+blas' in spec:
-            libraries.append('blas')
-            library_dirs.append(spec['blas'].prefix.lib)
-        if '+lapack' in spec:
-            libraries.append('lapack')
-            library_dirs.append(spec['lapack'].prefix.lib)
+            lapackblas += spec['blas'].blas_libs
 
         if '+blas' in spec or '+lapack' in spec:
             with open('site.cfg', 'w') as f:
                 f.write('[DEFAULT]\n')
-                f.write('libraries=%s\n'    % ','.join(libraries))
-                f.write('library_dirs=%s\n' % ':'.join(library_dirs))
-                f.write('rpath=%s\n' % ':'.join(library_dirs))
+                f.write('libraries=%s\n'    % ','.join(lapackblas.names))
+                f.write('library_dirs=%s\n' % ':'.join(lapackblas.directories))
+                f.write('rpath=%s\n' % ':'.join(lapackblas.directories))
 
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -45,15 +45,11 @@ class PyScipy(Package):
     # Known not to work with 2.23, 2.25
     depends_on('binutils@2.26:', type='build')
     depends_on('py-numpy@1.7.1:+blas+lapack', type=nolink)
+    depends_on('blas')
+    depends_on('lapack')
 
     def install(self, spec, prefix):
-        if 'atlas' in spec:
-            # libatlas.so actually isn't always installed, but this
-            # seems to make the build autodetect things correctly.
-            env['ATLAS'] = join_path(
-                spec['atlas'].prefix.lib, 'libatlas.' + dso_suffix)
-        else:
-            env['BLAS'] = spec['blas'].blas_libs.joined()
-            env['LAPACK'] = spec['lapack'].lapack_libs.joined()
+        env['BLAS'] = spec['blas'].blas_libs.joined()
+        env['LAPACK'] = spec['lapack'].lapack_libs.joined()
 
         setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -49,7 +49,6 @@ class PyScipy(Package):
     depends_on('lapack')
 
     def install(self, spec, prefix):
-        env['BLAS'] = spec['blas'].blas_libs.joined()
-        env['LAPACK'] = spec['lapack'].lapack_libs.joined()
-
+        # NOTE: scipy picks up Blas/Lapack from numpy, see
+        # http://www.scipy.org/scipylib/building/linux.html#step-4-build-numpy-1-5-0
         setup_py('install', '--prefix={0}'.format(prefix))


### PR DESCRIPTION
 macOS Sierra: 

- [x] `spack install py-scipy ^openblas`

p.s. can't test with `atlas` as it is broken on Sierra.

Ubuntu 16.04+gcc@5.4.0 with uninstalled system blas/lapack:

- [x] `spack install py-scipy ^openblas`
- [x] `spack install py-scipy ^atlas`