### PR TITLE
Restore default RPATH settings & allow packages to limit to immediate deps.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -383,8 +383,11 @@ def set_module_variables_for_package(pkg, module):
 
 
 def get_rpath_deps(pkg):
-    """We only need to RPATH immediate dependencies."""
-    return pkg.spec.dependencies(deptype='link')
+    """Return immediate or transitive RPATHs depending on the package."""
+    if pkg.transitive_rpaths:
+        return [d for d in pkg.spec.traverse(root=False, deptype=('link'))]
+    else:
+        return pkg.spec.dependencies(deptype='link')
 
 
 def get_rpaths(pkg):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -310,17 +310,26 @@ class Package(object):
     #
     """By default we build in parallel.  Subclasses can override this."""
     parallel = True
+
     """# jobs to use for parallel make. If set, overrides default of ncpus."""
     make_jobs = None
+
     """By default do not run tests within package's install()"""
     run_tests = False
+
     """Most packages are NOT extendable. Set to True if you want extensions."""
     extendable = False
+
+    """When True, add RPATHs for the entire DAG. When False, add RPATHs only
+       for immediate dependencies."""
+    transitive_rpaths = True
+
     """List of prefix-relative file paths (or a single path). If these do
        not exist after install, or if they exist but are not files,
        sanity checks fail.
     """
     sanity_check_is_file = []
+
     """List of prefix-relative directory paths (or a single path). If
        these do not exist after install, or if they exist but are not
        directories, sanity checks will fail.

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -32,6 +32,10 @@ class Dealii(Package):
     homepage = "https://www.dealii.org"
     url      = "https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.tar.gz"
 
+    # Don't add RPATHs to this package for the full build DAG.
+    # only add for immediate deps.
+    transitive_rpaths = False
+
     version('8.4.2', '84c6bd3f250d3e0681b645d24cb987a7')
     version('8.4.1', 'efbaf16f9ad59cfccad62302f36c3c1d')
     version('8.4.0', 'ac5dbf676096ff61e092ce98c80c2b00')


### PR DESCRIPTION
@davydden @adamjstewart 

Package authors can now set `transitive_rpaths` in their packages.

- Default is once again to use transitive `RPATH`s for the whole DAG.
   - Some packages (netcdf) NEED RPATHs for transitive deps.

- Packages can override with `transitive_rpaths=False` in `package.py`
  - Without this, some packages (dealii) will exceed OS limits when the DAG is too large