### PR TITLE
Use boost system layout by default

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -110,12 +110,14 @@ class Boost(Package):
             description="Additionally build shared libraries")
     variant('multithreaded', default=True,
             description="Build multi-threaded versions of libraries")
-    variant('singlethreaded', default=True,
+    variant('singlethreaded', default=False,
             description="Build single-threaded versions of libraries")
     variant('icu', default=False,
             description="Build with Unicode and ICU suport")
     variant('graph', default=False,
             description="Build the Boost Graph library")
+    variant('taggedlayout', default=False,
+            description="Augment library names with build options")
 
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')
@@ -208,12 +210,20 @@ class Boost(Package):
         if '+singlethreaded' in spec:
             threadingOpts.append('single')
         if not threadingOpts:
-            raise RuntimeError("""At least one of {singlethreaded,
-                               multithreaded} must be enabled""")
+            raise RuntimeError("At least one of {singlethreaded, " +
+                               "multithreaded} must be enabled")
+
+        if '+taggedlayout' in spec:
+            layout = 'tagged'
+        else:
+            if len(threadingOpts) > 1:
+                raise RuntimeError("Cannot build both single and " +
+                                   "multi-threaded targets with system layout")
+            layout = 'system'
 
         options.extend([
             'link=%s' % ','.join(linkTypes),
-            '--layout=tagged'
+            '--layout=%s' % layout
         ])
 
         if not spec.satisfies('%intel'):
@@ -222,6 +232,12 @@ class Boost(Package):
             ])
 
         return threadingOpts
+
+    def add_buildopt_symlinks(self, prefix):
+        with working_dir(prefix.lib):
+            for lib in os.listdir(os.curdir):
+                prefix, remainder = lib.split('.', 1)
+                symlink(lib, '%s-mt.%s' % (prefix, remainder))
 
     def install(self, spec, prefix):
         # On Darwin, Boost expects the Darwin libtool. However, one of the
@@ -285,6 +301,9 @@ class Boost(Package):
         # Boost.MPI if the threading options are not separated.
         for threadingOpt in threadingOpts:
             b2('install', 'threading=%s' % threadingOpt, *b2_options)
+
+        if '+multithreaded' in spec and '~taggedlayout' in spec:
+            self.add_buildopt_symlinks(prefix)
 
         # The shared libraries are not installed correctly
         # on Darwin; correct this

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -297,6 +297,8 @@ class Boost(Package):
 
         threadingOpts = self.determine_b2_options(spec, b2_options)
 
+        b2('--clean')
+
         # In theory it could be done on one call but it fails on
         # Boost.MPI if the threading options are not separated.
         for threadingOpt in threadingOpts:

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -41,8 +41,8 @@ class Boost(Package):
     list_url = "http://sourceforge.net/projects/boost/files/boost/"
     list_depth = 2
 
-    version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')  # TODO: fix build
-    version('1.61.0', '6095876341956f65f9d35939ccea1a9f', preferred=True)
+    version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')
+    version('1.61.0', '6095876341956f65f9d35939ccea1a9f')
     version('1.60.0', '65a840e1a0b13a558ff19eeb2c4f0cbe')
     version('1.59.0', '6aa9a5c6a4ca1016edd0ed1178e3cb87')
     version('1.58.0', 'b8839650e61e9c1c0a89f371dd475546')

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -96,8 +96,7 @@ class Cantera(Package):
             options.extend([
                 'build_thread_safe=yes',
                 'boost_inc_dir={0}'.format(spec['boost'].prefix.include),
-                'boost_lib_dir={0}'.format(spec['boost'].prefix.lib),
-                'boost_thread_lib=boost_thread-mt,boost_system-mt'
+                'boost_lib_dir={0}'.format(spec['boost'].prefix.lib)
             ])
         else:
             options.append('build_thread_safe=no')


### PR DESCRIPTION
This includes:

* use system layout by default
* prevent building multi- and single-threaded libs when using system layout
* build multi-threaded libs by default
* add in symlinks which emulate tagged layout when multithreaded libs are built with system layout (for packages like valgrind which expect the -mt suffix)

This addresses #710 (reasoning here also suggests that multi-threaded libs will nearly always be suitable as a drop-in replacement for single-threaded libs) and #1820.