### PR TITLE
Correct Charm++ install procedure

### DIFF
--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 
+import os
 import platform
 import shutil
 import sys
@@ -169,4 +170,19 @@ class Charm(Package):
         # this wouldn't be difficult.
         build = Executable(join_path(".", "build"))
         build(target, version, *options)
+
+        # Charm++'s install script does not copy files, it only creates
+        # symbolic links. Fix this.
+        for dirpath, dirnames, filenames in os.walk(prefix):
+            for filename in filenames:
+                filepath = join_path(dirpath, filename)
+                if os.path.islink(filepath):
+                    tmppath = filepath + ".tmp"
+                    # Skip dangling symbolic links
+                    try:
+                        shutil.copy2(filepath, tmppath)
+                        os.remove(filepath)
+                        os.rename(tmppath, filepath)
+                    except:
+                        pass
         shutil.rmtree(join_path(prefix, "tmp"))


### PR DESCRIPTION
Charm++ only creates symbolic links instead of copying files. Correct this.