### PR TITLE
More specific dependency versions, wrap make check

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -39,9 +39,9 @@ class Hdf(Package):
 
     variant('szip', default=False, description="Enable szip support")
 
-    depends_on('jpeg')
+    depends_on('jpeg@6b:')
     depends_on('szip', when='+szip')
-    depends_on('zlib')
+    depends_on('zlib@1.1.4:')
 
     depends_on('bison', type='build')
     depends_on('flex',  type='build')
@@ -49,9 +49,9 @@ class Hdf(Package):
     def install(self, spec, prefix):
         config_args = [
             'CFLAGS=-fPIC',
-            '--prefix=%s' % prefix,
-            '--with-jpeg=%s' % spec['jpeg'].prefix,
-            '--with-zlib=%s' % spec['zlib'].prefix,
+            '--prefix={0}'.format(prefix),
+            '--with-jpeg={0}'.format(spec['jpeg'].prefix),
+            '--with-zlib={0}'.format(spec['zlib'].prefix),
             '--disable-netcdf',  # must be disabled to build NetCDF with HDF4
             '--enable-fortran',
             '--disable-shared',  # fortran and shared libs are not compatible
@@ -59,12 +59,17 @@ class Hdf(Package):
             '--enable-production'
         ]
 
-        # SZip support
+        # Szip support
         if '+szip' in spec:
-            config_args.append('--with-szlib=%s' % spec['szip'].prefix)
+            config_args.append('--with-szlib={0}'.format(spec['szip'].prefix))
+        else:
+            config_args.append('--without-szlib')
 
         configure(*config_args)
 
         make()
-        make('check')
+
+        if self.run_tests:
+            make('check')
+
         make('install')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -60,7 +60,7 @@ class Hdf5(Package):
 
     depends_on("mpi", when='+mpi')
     depends_on("szip", when='+szip')
-    depends_on("zlib")
+    depends_on("zlib@1.1.2:")
 
     def validate(self, spec):
         """
@@ -146,6 +146,10 @@ class Hdf5(Package):
             "--with-zlib=%s" % spec['zlib'].prefix,
             *extra_args)
         make()
+
+        if self.run_tests:
+            make("check")
+
         make("install")
         self.check_install(spec)
 

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -46,10 +46,10 @@ class Netcdf(Package):
     depends_on("hdf", when='+hdf4')
 
     # Required for DAP support
-    depends_on("curl")
+    depends_on("curl@7.18.0:")
 
     # Required for NetCDF-4 support
-    depends_on("zlib")
+    depends_on("zlib@1.2.5:")
     depends_on('hdf5')
 
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
@@ -105,7 +105,7 @@ class Netcdf(Package):
             LDFLAGS.append("-L%s/lib"     % spec['hdf'].prefix)
             LIBS.append("-l%s"         % "jpeg")
 
-        if 'szip' in spec:
+        if '+szip' in spec:
             CPPFLAGS.append("-I%s/include" % spec['szip'].prefix)
             LDFLAGS.append("-L%s/lib"     % spec['szip'].prefix)
             LIBS.append("-l%s"         % "sz")
@@ -120,4 +120,8 @@ class Netcdf(Package):
 
         configure(*config_args)
         make()
+
+        if self.run_tests:
+            make("check")
+
         make("install")


### PR DESCRIPTION
This PR adds more specific version constraints on the dependencies of HDF4, HDF5, and NetCDF. It also wraps `make check` so that it only gets run if someone explicitly tells it to. `make check` failed for HDF4 for me on my laptop.