### PR TITLE
Workaround for illegal package merging in py-matplotlib/py-basemap

### DIFF
--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -52,13 +52,10 @@ class PyBasemap(Package):
         # legal Python for "Implicit Namespace Packages":
         #     https://www.python.org/dev/peps/pep-0420/
         #     https://github.com/Homebrew/homebrew-python/issues/112
-        # In practice, Python will wee only the basemap version of mpl_toolkits
+        # In practice, Python will see only the basemap version of mpl_toolkits
         path_m = find_package_dir(spec['py-matplotlib'].prefix, 'mpl_toolkits')
         path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
         link_dir(path_m, path_b)
-
-
-
 
 def find_package_dir(spack_package_root, name):
 
@@ -102,7 +99,7 @@ def link_dir(src_root, dest_root, link=os.symlink):
             continue
 
         # Make sure the destination directory exists
-        dest_path = os.path.join(dest_root, src_path[len(src_root)+1:])
+        dest_path = os.path.join(dest_root, src_path[len(src_root) + 1:])
         try:
             os.makedirs(dest_path)
         except:
@@ -113,5 +110,4 @@ def link_dir(src_root, dest_root, link=os.symlink):
             src = os.path.join(src_path, fname)
             dst = os.path.join(dest_path, fname)
             if not os.path.exists(dst):
-                #print('%s -->\n%s' % (src,dst))
                 link(src, dst)

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -57,6 +57,7 @@ class PyBasemap(Package):
         path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
         link_dir(path_m, path_b)
 
+
 def find_package_dir(spack_package_root, name):
 
     """Finds directory with a specific name, somewhere inside a Spack

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -46,16 +46,20 @@ class PyBasemap(Package):
         env['GEOS_DIR'] = spec['geos'].prefix
         setup_py('install', '--prefix=%s' % prefix)
 
-        # Use symlinks to join the two mpl_toolkits/ directories into
-        # one, inside of basemap.  This is because Basemap tries to
-        # "add to" an existing package in Matplotlib, which is only
-        # legal Python for "Implicit Namespace Packages":
-        #     https://www.python.org/dev/peps/pep-0420/
-        #     https://github.com/Homebrew/homebrew-python/issues/112
-        # In practice, Python will see only the basemap version of mpl_toolkits
-        path_m = find_package_dir(spec['py-matplotlib'].prefix, 'mpl_toolkits')
-        path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
-        link_dir(path_m, path_b)
+        # We are not sure if this fix is needed before Python 3.5.2.
+        # If it is needed, this test should be changed.
+        # See: https://github.com/LLNL/spack/pull/1964
+        if spec.version >= Version('3.5.2'):
+            # Use symlinks to join the two mpl_toolkits/ directories into
+            # one, inside of basemap.  This is because Basemap tries to
+            # "add to" an existing package in Matplotlib, which is only
+            # legal Python for "Implicit Namespace Packages":
+            #     https://www.python.org/dev/peps/pep-0420/
+            #     https://github.com/Homebrew/homebrew-python/issues/112
+            # In practice, Python will see only the basemap version of mpl_toolkits
+            path_m = find_package_dir(spec['py-matplotlib'].prefix, 'mpl_toolkits')
+            path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
+            link_dir(path_m, path_b)
 
 
 def find_package_dir(spack_package_root, name):

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -49,7 +49,7 @@ class PyBasemap(Package):
         # We are not sure if this fix is needed before Python 3.5.2.
         # If it is needed, this test should be changed.
         # See: https://github.com/LLNL/spack/pull/1964
-        if spec.version >= Version('3.5.2'):
+        if spec['python'].version >= Version('3.5.2'):
             # Use symlinks to join the two mpl_toolkits/ directories into
             # one, inside of basemap.  This is because Basemap tries to
             # "add to" an existing package in Matplotlib, which is only

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -56,8 +56,10 @@ class PyBasemap(Package):
             # legal Python for "Implicit Namespace Packages":
             #     https://www.python.org/dev/peps/pep-0420/
             #     https://github.com/Homebrew/homebrew-python/issues/112
-            # In practice, Python will see only the basemap version of mpl_toolkits
-            path_m = find_package_dir(spec['py-matplotlib'].prefix, 'mpl_toolkits')
+            # In practice, Python will see only the basemap version of
+            # mpl_toolkits
+            path_m = find_package_dir(
+                spec['py-matplotlib'].prefix, 'mpl_toolkits')
             path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
             link_dir(path_m, path_b)
 

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 
 
 class PyBasemap(Package):
@@ -37,10 +38,80 @@ class PyBasemap(Package):
     extends('python')
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=nolink)
-    depends_on('py-matplotlib+gui', type=nolink)
+    depends_on('py-matplotlib', type=nolink)
     depends_on('pil', type=nolink)
     depends_on("geos")
 
     def install(self, spec, prefix):
         env['GEOS_DIR'] = spec['geos'].prefix
         setup_py('install', '--prefix=%s' % prefix)
+
+        # Use symlinks to join the two mpl_toolkits/ directories into
+        # one, inside of basemap.  This is because Basemap tries to
+        # "add to" an existing package in Matplotlib, which is only
+        # legal Python for "Implicit Namespace Packages":
+        #     https://www.python.org/dev/peps/pep-0420/
+        #     https://github.com/Homebrew/homebrew-python/issues/112
+        # In practice, Python will wee only the basemap version of mpl_toolkits
+        path_m = find_package_dir(spec['py-matplotlib'].prefix, 'mpl_toolkits')
+        path_b = find_package_dir(spec.prefix, 'mpl_toolkits')
+        link_dir(path_m, path_b)
+
+
+
+
+def find_package_dir(spack_package_root, name):
+
+    """Finds directory with a specific name, somewhere inside a Spack
+    package.
+
+    spack_package_root:
+        Root directory to start searching
+    oldname:
+        Original name of package (not fully qualified, just the leaf)
+    newname:
+        What to rename it to
+
+    """
+    for root, dirs, files in os.walk(spack_package_root):
+        path = os.path.join(root, name)
+
+        # Make sure it's a directory
+        if not os.path.isdir(path):
+            continue
+
+        # Make sure it's really a package
+        if not os.path.exists(os.path.join(path, '__init__.py')):
+            continue
+
+        return path
+
+    return None
+
+
+def link_dir(src_root, dest_root, link=os.symlink):
+    """Link all files in src_root into directory dest_root"""
+
+    for src_path, dirnames, filenames in os.walk(src_root):
+        if not filenames:
+            continue        # avoid explicitly making empty dirs
+
+        # Avoid internal Python stuff
+        src_leaf = os.path.split(src_path)[1]
+        if src_leaf.startswith('__'):
+            continue
+
+        # Make sure the destination directory exists
+        dest_path = os.path.join(dest_root, src_path[len(src_root)+1:])
+        try:
+            os.makedirs(dest_path)
+        except:
+            pass
+
+        # Link all files from src to dest directory
+        for fname in filenames:
+            src = os.path.join(src_path, fname)
+            dst = os.path.join(dest_path, fname)
+            if not os.path.exists(dst):
+                #print('%s -->\n%s' % (src,dst))
+                link(src, dst)


### PR DESCRIPTION
This PR addresses #1948 

Matplotlib defines a Python package called `mpl_tools`.  They put some Python code in that package, so it does not qualify as a Python *Implicit Namespace Package* ( https://www.python.org/dev/peps/pep-0420/ ).

Basemap also defines `mpl_tools`, implicitly as an *extension* of Matplotlib's `mpl_tools`.  The Python package `mpl_tools` can now be found *twice* on `$PYTHONPATH`: once in the `py-mathplotlib` Spack package, and once in the `py-basemap` Spack package.  This is not legal Python, except for the special case of an implicit namespace package (which does not apply here).

Maybe some Python interpreter in the past implicitly "merged" the two `mpl_tools` directories together, and it is clear that the authors of Matplotlib/Basemap added Jujitsu in those directories to try to make it happen that way (see the `__init__.py` files).  HOWEVER... it does not currently work with MY versions of Matplotlib (1.5.1), Basemap (1.0.7) and Python (3.5.2) on Spack.  On MY system, Python sees only the `basemap` version of `mpl_tools`.  It then throws an exception when Basemap tries to import things that are in the `matplotlib` version of `mpl_tools`.

The right way to solve this problem is to re-work Basemap and Matplotlib so they don't step on each others' toes that way.  It's not clear how this would be done, since this bad design decision is now baked into the library APIs.  This problem has been an issue for years without getting fixed; see for example (From 2014):   https://github.com/Homebrew/homebrew-python/issues/112

This PR solves the problem by symlinking all of the `mpl_tools` directory from `matplotlib` into `basemap`.  It's an un-holy mess, and wouldn't scale if there were additional packages that also implicitly "merge" into `mpl_tools` (there are none that I know of).  But it solves the problem at hand, it doesn't break the Spack paridigm, and is better than any other solution I could think of; for example, to create a Spack package that installs Matplotlib and Basemap simultaneously into one Spack prefix.
