### PR TITLE
fix for  bluegene-q platform

### DIFF
--- a/lib/spack/spack/operating_systems/cnk.py
+++ b/lib/spack/spack/operating_systems/cnk.py
@@ -9,7 +9,7 @@ class Cnk(OperatingSystem):
     on that node."""
 
     def __init__(self):
-        name = 'CNK'
+        name = 'cnk'
         version = '1'
         super(Cnk, self).__init__(name, version)
 

--- a/lib/spack/spack/operating_systems/cnk.py
+++ b/lib/spack/spack/operating_systems/cnk.py
@@ -1,0 +1,17 @@
+from spack.architecture import OperatingSystem
+
+
+class Cnk(OperatingSystem):
+    """ Compute Node Kernel (CNK) is the node level operating system for
+    the IBM Blue Gene series of supercomputers. The compute nodes of the
+    Blue Gene family of supercomputers run CNK, a lightweight kernel that
+    runs on each node and supports one application running for one user
+    on that node."""
+
+    def __init__(self):
+        name = 'CNK'
+        version = '1'
+        super(Cnk, self).__init__(name, version)
+
+    def __str__(self):
+        return self.name

--- a/lib/spack/spack/platforms/bgq.py
+++ b/lib/spack/spack/platforms/bgq.py
@@ -7,8 +7,8 @@ from spack.operating_systems.cnk import Cnk
 class Bgq(Platform):
     priority    = 30
     front_end   = 'power7'
-    back_end    = 'powerpc'
-    default     = 'powerpc'
+    back_end    = 'ppc64'
+    default     = 'ppc64'
 
     def __init__(self):
         ''' IBM Blue Gene/Q system platform.'''

--- a/lib/spack/spack/platforms/bgq.py
+++ b/lib/spack/spack/platforms/bgq.py
@@ -1,5 +1,7 @@
 import os
 from spack.architecture import Platform, Target
+from spack.operating_systems.linux_distro import LinuxDistro
+from spack.operating_systems.cnk import Cnk
 
 
 class Bgq(Platform):
@@ -9,9 +11,22 @@ class Bgq(Platform):
     default     = 'powerpc'
 
     def __init__(self):
+        ''' IBM Blue Gene/Q system platform.'''
+
         super(Bgq, self).__init__('bgq')
+
         self.add_target(self.front_end, Target(self.front_end))
-        self.add_target(self.back_end, Target(self.back_end,))
+        self.add_target(self.back_end, Target(self.back_end))
+
+        front_distro = LinuxDistro()
+        back_distro = Cnk()
+
+        self.front_os = str(front_distro)
+        self.back_os = str(back_distro)
+        self.default_os = self.back_os
+
+        self.add_operating_system(str(front_distro), front_distro)
+        self.add_operating_system(str(back_distro), back_distro)
 
     @classmethod
     def detect(self):


### PR DESCRIPTION
this will fix #1784  and #1689!

Today I looked into how Cray CNL is implemented and made corresponding changes for bg-q. This is based on my "minimal" understanding of spack internals, so feel free to suggest changes / update the patch.

I built 7-8 packages for bg-q (front-end and back-end) without any issue. I followed below steps:
- After this patch you can find compilers. GNU compilers for back-end added manually. My compilers.yaml file looks like:

``` bash
compilers:
- compiler:
    modules: []
    operating_system: redhat6
    paths:
      cc: /usr/lib64/ccache/gcc
      cxx: /usr/lib64/ccache/g++
      f77: /usr/bin/gfortran
      fc: /usr/bin/gfortran
    spec: gcc@4.4.7
- compiler:
    modules: []
    operating_system: redhat6
    paths:
      cc: /opt/ibmcmp/vacpp/bg/12.1/bin/xlc_r
      cxx: /opt/ibmcmp/vacpp/bg/12.1/bin/xlc++
      f77: /opt/ibmcmp/xlf/bg/14.1/bin/xlf_r
      fc: /opt/ibmcmp/xlf/bg/14.1/bin/xlf2008
    spec: xl@12.1
- compiler:
    modules: []
    operating_system: CNK
    paths:
      cc: /usr/bin/bgxlc_r
      cxx: /usr/bin/bgxlc++
      f77: /usr/bin/bgxlf_r
      fc: /usr/bin/bgxlf2008
    spec: xl@12.1
- compiler:
    modules: []
    operating_system: CNK
    paths:
      cc: /bgsys/drivers/ppcfloor/gnu-linux/bin/powerpc64-bgq-linux-gcc
      cxx: /bgsys/drivers/ppcfloor/gnu-linux/bin/powerpc64-bgq-linux-g++
      f77: /bgsys/drivers/ppcfloor/gnu-linux/bin/powerpc64-bgq-linux-gfortran
      fc: /bgsys/drivers/ppcfloor/gnu-linux/bin/powerpc64-bgq-linux-gfortran
    spec: gcc@4.4.7
```

On BG-Q, MPI is located under:

``` bash
/bgsys/drivers/ppcfloor/comm/
```

I added entry into packages.yaml as:

``` bash
packages:
    mpich:
        paths:
            mpich@3.2%xl@12.1 arch=bgq-CNK-powerpc: /bgsys/drivers/ppcfloor/comm/xl
            mpich@3.2%gcc@4.4.7 arch=bgq-CNK-powerpc: /bgsys/drivers/ppcfloor/comm/gcc
        buildable: False
```

(initially I added dummy package for mpi env var setup, but it's not necessary)

To build a package for front-end:

``` bash
spack install package-xx os=redhat6
```

To build package for back-end:

``` bash
spack install package-xx  #OR spack install package-xx os=CNK
```
### Example

parmetis for CNK (by-default), cmake for front-end (i.e. redhat6) :

``` bash
$ spack spec parmetis ^mpich ^cmake os=redhat6
Input spec
------------------------------
  parmetis
      ^cmake arch=bgq-redhat6-None
      ^mpich

Normalized
------------------------------
  parmetis
      ^cmake@2.8: arch=bgq-redhat6-None
      ^metis@5:
      ^mpich

Concretized
------------------------------
  parmetis@4.0.3%xl@12.1~debug~gdb+shared arch=bgq-CNK-powerpc
      ^cmake@3.6.1%xl@12.1~doc+ncurses+openssl~ownlibs~qt arch=bgq-redhat6-powerpc
          ^bzip2@1.0.6%xl@12.1 arch=bgq-CNK-powerpc
          ^curl@7.50.3%xl@12.1 arch=bgq-CNK-powerpc
              ^openssl@1.0.2j%xl@12.1 arch=bgq-CNK-powerpc
                  ^zlib@1.2.8%xl@12.1 arch=bgq-CNK-powerpc
          ^expat@2.2.0%xl@12.1 arch=bgq-CNK-powerpc
          ^libarchive@3.2.1%xl@12.1 arch=bgq-CNK-powerpc
              ^libxml2@2.9.4%xl@12.1~python arch=bgq-CNK-powerpc
                  ^xz@5.2.2%xl@12.1 arch=bgq-CNK-powerpc
              ^lz4@131%xl@12.1 arch=bgq-CNK-powerpc
              ^lzma@4.32.7%xl@12.1 arch=bgq-CNK-powerpc
              ^lzo@2.09%xl@12.1 arch=bgq-CNK-powerpc
              ^nettle@3.2%xl@12.1 arch=bgq-CNK-powerpc
                  ^gmp@6.1.1%xl@12.1 arch=bgq-CNK-powerpc
                      ^m4@1.4.17%xl@12.1+sigsegv arch=bgq-CNK-powerpc
                          ^libsigsegv@2.10%xl@12.1 arch=bgq-CNK-powerpc
          ^ncurses@6.0%xl@12.1 arch=bgq-CNK-powerpc
      ^metis@5.1.0%xl@12.1~debug~gdb~idx64~real64+shared arch=bgq-CNK-powerpc
      ^mpich@3.2%xl@12.1+hydra+pmi~verbs arch=bgq-CNK-powerpc
```

@tgamblin :
- I didn't find CNK version in BG-Q RedBook, so added "version = '1'"
- In the parmetis example above, in concretized spec, metis and parmetis are configured for _CNK_ and CMake for _redhat6_. But why CMake dependencies for _CNK_?  how to force them for redhead6 as well? I have CMake as an external package in packages.yaml but wondering if there is way to force all dependencies of CMake to the same redhat6 (instead of specifying them all on command-line).
- If I just build CMake for front-end, I see correct spec:

``` bash
spack spec cmake os=redhat6
Input spec
------------------------------
  cmake arch=bgq-redhat6-None

Normalized
------------------------------
  cmake arch=bgq-redhat6-None

Concretized
------------------------------
  cmake@3.6.1%xl@12.1~doc+ncurses+openssl~ownlibs~qt arch=bgq-redhat6-powerpc
      ^bzip2@1.0.6%xl@12.1 arch=bgq-redhat6-powerpc
      ^curl@7.50.3%xl@12.1 arch=bgq-redhat6-powerpc
          ^openssl@1.0.2j%xl@12.1 arch=bgq-redhat6-powerpc
              ^zlib@1.2.8%xl@12.1 arch=bgq-redhat6-powerpc
      ^expat@2.2.0%xl@12.1 arch=bgq-redhat6-powerpc
      ^libarchive@3.2.1%xl@12.1 arch=bgq-redhat6-powerpc
          ^libxml2@2.9.4%xl@12.1~python arch=bgq-redhat6-powerpc
              ^xz@5.2.2%xl@12.1 arch=bgq-redhat6-powerpc
          ^lz4@131%xl@12.1 arch=bgq-redhat6-powerpc
          ^lzma@4.32.7%xl@12.1 arch=bgq-redhat6-powerpc
          ^lzo@2.09%xl@12.1 arch=bgq-redhat6-powerpc
          ^nettle@3.2%xl@12.1 arch=bgq-redhat6-powerpc
              ^gmp@6.1.1%xl@12.1 arch=bgq-redhat6-powerpc
                  ^m4@1.4.17%xl@12.1+sigsegv arch=bgq-redhat6-powerpc
                      ^libsigsegv@2.10%xl@12.1 arch=bgq-redhat6-powerpc
      ^ncurses@6.0%xl@12.1 arch=bgq-redhat6-powerpc
```
