### PR TITLE
Charm++: Ignore compiler warnings while configuring

### DIFF
--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -47,6 +47,8 @@ class Charm(Package):
     # Support OpenMPI; see
     # <https://charm.cs.illinois.edu/redmine/issues/1206>
     patch("mpi.patch")
+    # Ignore compiler warnings while configuring
+    patch("strictpass.patch")
 
     # Communication mechanisms (choose exactly one)
     # TODO: Support Blue Gene/Q PAMI, Cray GNI, Cray shmem, CUDA

--- a/var/spack/repos/builtin/packages/charm/strictpass.patch
+++ b/var/spack/repos/builtin/packages/charm/strictpass.patch
@@ -1,0 +1,16 @@
+--- old/src/scripts/configure
++++ new/src/scripts/configure
+@@ -2146,13 +2146,6 @@
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail
+-        if test $pass -eq 1
+-	then
+- 	  if cat out | grep -i "warn" > /dev/null 2>&1
+-	  then
+-	    strictpass="0" && strictfail="1"
+-          fi
+-        fi
+ 	cat out >> $charmout
+ 	/bin/rm -f out
+ }


### PR DESCRIPTION
New compiler versions can output warnings that Charm++ didn't foresee, and aborting configuring Charm++ in this case makes Charm++ unusable on those systems, for no good reason.