### PR TITLE
Update package to use MPI compile wrappers as specified in MPI package.

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -121,16 +121,14 @@ class Hdf5(Package):
             # this is not actually a problem.
             extra_args.extend([
                 "--enable-parallel",
-                "CC=%s" % join_path(spec['mpi'].prefix.bin, "mpicc"),
+                "CC=%s" % spec['mpi'].mpicc
             ])
 
             if '+cxx' in spec:
-                extra_args.append("CXX=%s" % join_path(spec['mpi'].prefix.bin,
-                                                       "mpic++"))
+                extra_args.append("CXX=%s" % spec['mpi'].mpicxx)
 
             if '+fortran' in spec:
-                extra_args.append("FC=%s" % join_path(spec['mpi'].prefix.bin,
-                                                      "mpifort"))
+                extra_args.append("FC=%s" % spec['mpi'].mpifc)
 
         if '+szip' in spec:
             extra_args.append("--with-szlib=%s" % spec['szip'].prefix)
@@ -173,7 +171,7 @@ HDF5 version {version} {version}
             with open("check.c", 'w') as f:
                 f.write(source)
             if '+mpi' in spec:
-                cc = which(join_path(spec['mpi'].prefix.bin, "mpicc"))
+                cc = which('%s' % spec['mpi'].mpicc)
             else:
                 cc = which('cc')
             # TODO: Automate these path and library settings


### PR DESCRIPTION
+ Previously, these strings were hard coded to 'mpicc', 'mpic++', and 'mpifort'. This change is particularly useful if you want to compile with a Cray mpi-compile wrapper like 'cc' or 'ftn'
+ This is PR related to a comment found in #1827.