### PR TITLE
Make CMake-based builds more verbose by default.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -408,7 +408,8 @@ def get_rpaths(pkg):
 def get_std_cmake_args(cmake_pkg):
     # standard CMake arguments
     ret = ['-DCMAKE_INSTALL_PREFIX=%s' % cmake_pkg.prefix,
-           '-DCMAKE_BUILD_TYPE=RelWithDebInfo']
+           '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+           '-DCMAKE_VERBOSE_MAKEFILE=ON']
     if platform.mac_ver()[0]:
         ret.append('-DCMAKE_FIND_FRAMEWORK=LAST')
 


### PR DESCRIPTION
+ Modify `std_cmake_args` so that cmake-based builds are more verbose.  The actual compile commands will now show up in `spack-build.out`.
+ Fixes #1986 