### PR TITLE
On Cray machines, use the Cray compile wrappers instead of MPI wrappers.

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -62,10 +62,18 @@ class Mpich(Package):
         spack_env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dep_spec):
-        self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
-        self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
-        self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
-        self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        # Is this a Cray machine? (TODO: We need a better test than this.)
+        if os.environ.get('CRAYPE_VERSION'):
+            self.spec.mpicc = spack_cc
+            self.spec.mpicxx = spack_cxx
+            self.spec.mpifc = spack_fc
+            self.spec.mpif77 = spack_f77
+        else:
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+
         self.spec.mpicxx_shared_libs = [
             join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))


### PR DESCRIPTION
+ Cray compile wrappers are MPI wrappers.
+ Packages that need to be compiled with MPI compile wrappers normally use `mpicc`, `mpic++` and `mpif90` provided by the MPI vendor. However, when using _cray-mpich_ as the MPI vendor, the compile wrappers `CC`, `cc` and `ftn` must be used.
+ In this scenario, the _mpich_ package is hijacked by specifying _cray-mpich_ as an external package under the `mpich:` section of `packages.yaml`. For example:
```
  packages:
    mpich:
      modules:
        mpich@7.4.2%intel@16.0.3 arch=cray-CNL-haswell: cray-mpich/7.4.2
      buildable: False
    all:
      providers:
        mpi: [mpich]
```
+ This change allows packages like _parmetis_ to be built using the Cray compile wrappers. For example: `spack install parmetis%intel@16.0.3 ^mpich@7.4.2 os=CNL`
+ This commit relies on the existence of the environment variable `CRAYPE_VERSION` to determine if the current machine is running a Cray environment. This check is insufficient, but I'm not sure how to improve this logic.
+ Fixes #1827