### PR TITLE
Made optional CGAL dependencies optional.

### DIFF
--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -44,8 +44,12 @@ class Cgal(Package):
     variant('debug', default=False,
             description='Builds a debug version of the libraries')
 
-    # See "7 CGAL Libraries" at:
+    # ---- See "7 CGAL Libraries" at:
     # http://doc.cgal.org/latest/Manual/installation.html
+
+    # The CORE library provides exact arithmetic for geometric computations.
+    # See: http://cs.nyu.edu/exact/core_pages/
+    #      http://cs.nyu.edu/exact/core_pages/svn-core.html
     variant('core', default=False,
             description='Build the CORE library for algebraic numbers')
     variant('imageio', default=False,

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -44,13 +44,29 @@ class Cgal(Package):
     variant('debug', default=False,
             description='Builds a debug version of the libraries')
 
+    # See "7 CGAL Libraries" at:
+    # http://doc.cgal.org/latest/Manual/installation.html
+    variant('core', default=False,
+            description='Build the CORE library for algebraic numbers')
+    variant('imageio', default=False,
+            description='Build utilities to read/write image files')
+    variant('demos', default=False,
+            description='Build CGAL demos')
+
+
     # Essential Third Party Libraries
-    depends_on('boost')
+    depends_on('boost+thread+system')
     depends_on('gmp')
     depends_on('mpfr')
+
+    # Required for CGAL_ImageIO
+    depends_on('opengl', when='+imageio')
     depends_on('zlib')
-    # depends_on('opengl')
-    depends_on('qt@5:')
+
+    # Optional to build CGAL_Qt5 (demos)
+    # depends_on('opengl', when='+demos')   # not yet in Spack
+    depends_on('qt@5:', when='+demos')
+
 
     # Optional Third Party Libraries
     # depends_on('leda')
@@ -70,20 +86,21 @@ class Cgal(Package):
         # Installation instructions:
         # http://doc.cgal.org/latest/Manual/installation.html
 
-        options = []
-        options.extend(std_cmake_args)
-
-        # CGAL supports only Release and Debug build type. Any other build type
-        # will raise an error at configure time
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
-
-        if '+shared' in spec:
-            options.append('-DBUILD_SHARED_LIBS:BOOL=ON')
-        else:
-            options.append('-DBUILD_SHARED_LIBS:BOOL=OFF')
+        options = std_cmake_args + [
+            # CGAL supports only Release and Debug build type. Any
+            # other build type will raise an error at configure time
+            '-DCMAKE_BUILD_TYPE:STRING=%s' %
+                ('Debug' if '+debug' in spec else 'Release'),
+            '-DBUILD_SHARED_LIBS:BOOL=%s' %
+                ('ON' if '+shared' in spec else 'OFF'),
+            '-DWITH_CGAL_Core:BOOL=%s' %
+                ('YES' if '+core' in spec else 'NO'),
+            '-DWITH_CGAL_ImageIO:BOOL=%s' %
+                ('YES' if '+imageio' in spec else 'NO'),
+            '-DWITH_CGAL_Qt5:BOOL=%s' %
+                ('YES' if '+demos' in spec else 'NO'),
+        ]
+        
 
         with working_dir('spack-build', create=True):
             cmake('..', *options)

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -64,7 +64,7 @@ class Cgal(Package):
     depends_on('mpfr')
 
     # Required for CGAL_ImageIO
-    depends_on('opengl', when='+imageio')
+    # depends_on('opengl', when='+imageio') # not yet in Spack
     depends_on('zlib')
 
     # Optional to build CGAL_Qt5 (demos)
@@ -94,17 +94,15 @@ class Cgal(Package):
             # CGAL supports only Release and Debug build type. Any
             # other build type will raise an error at configure time
             '-DCMAKE_BUILD_TYPE:STRING=%s' %
-                ('Debug' if '+debug' in spec else 'Release'),
+            ('Debug' if '+debug' in spec else 'Release'),
             '-DBUILD_SHARED_LIBS:BOOL=%s' %
-                ('ON' if '+shared' in spec else 'OFF'),
+            ('ON' if '+shared' in spec else 'OFF'),
             '-DWITH_CGAL_Core:BOOL=%s' %
-                ('YES' if '+core' in spec else 'NO'),
+            ('YES' if '+core' in spec else 'NO'),
             '-DWITH_CGAL_ImageIO:BOOL=%s' %
-                ('YES' if '+imageio' in spec else 'NO'),
+            ('YES' if '+imageio' in spec else 'NO'),
             '-DWITH_CGAL_Qt5:BOOL=%s' %
-                ('YES' if '+demos' in spec else 'NO'),
-        ]
-        
+            ('YES' if '+demos' in spec else 'NO')]
 
         with working_dir('spack-build', create=True):
             cmake('..', *options)

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -57,7 +57,6 @@ class Cgal(Package):
     variant('demos', default=False,
             description='Build CGAL demos')
 
-
     # Essential Third Party Libraries
     depends_on('boost+thread+system')
     depends_on('gmp')
@@ -70,7 +69,6 @@ class Cgal(Package):
     # Optional to build CGAL_Qt5 (demos)
     # depends_on('opengl', when='+demos')   # not yet in Spack
     depends_on('qt@5:', when='+demos')
-
 
     # Optional Third Party Libraries
     # depends_on('leda')


### PR DESCRIPTION
@adamjstewart 
This PR makes  optional dependencies optional.  It addresses concerns in #2005.  At this point, it has not yet been tested. 
