### PR TITLE
Use cYAML if it is available

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -40,6 +40,16 @@ SPACK_PREFIX = os.path.dirname(os.path.dirname(SPACK_FILE))
 # Allow spack libs to be imported in our scripts
 SPACK_LIB_PATH = os.path.join(SPACK_PREFIX, "lib", "spack")
 sys.path.insert(0, SPACK_LIB_PATH)
+
+# Try to use system YAML if it is available, as it might have libyaml
+# support (for faster loading via C).  Load it before anything in
+# lib/spack/external so it will take precedence over Spack's PyYAML.
+try:
+    import yaml
+except ImportError:
+    pass   # ignore and use slow yaml
+
+# Add external libs
 SPACK_EXTERNAL_LIBS = os.path.join(SPACK_LIB_PATH, "external")
 sys.path.insert(0, SPACK_EXTERNAL_LIBS)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -98,7 +98,7 @@ expansion when it is the first character in an id typed on the command line.
 import base64
 import hashlib
 import imp
-import sys
+import ctypes
 from StringIO import StringIO
 from operator import attrgetter
 
@@ -202,6 +202,9 @@ special_types = {
 }
 
 legal_deps = tuple(special_types) + alldeps
+
+"""Max integer helps avoid passing too large a value to cyaml."""
+maxint = 2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
 
 
 def validate_deptype(deptype):
@@ -969,7 +972,7 @@ class Spec(object):
             return self._hash[:length]
         else:
             yaml_text = syaml.dump(
-                self.to_node_dict(), default_flow_style=True, width=sys.maxint)
+                self.to_node_dict(), default_flow_style=True, width=maxint)
             sha = hashlib.sha1(yaml_text)
             b32_hash = base64.b32encode(sha.digest()).lower()[:length]
             if self.concrete:

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -32,6 +32,10 @@
 
 """
 import yaml
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError as e:
+    from yaml import Loader, Dumper
 from yaml.nodes import *
 from yaml.constructor import ConstructorError
 from ordereddict_backport import OrderedDict
@@ -64,7 +68,7 @@ def mark(obj, node):
     obj._end_mark = node.end_mark
 
 
-class OrderedLineLoader(yaml.Loader):
+class OrderedLineLoader(Loader):
     """YAML loader that preserves order and line numbers.
 
        Mappings read in by this loader behave like an ordered dict.
@@ -156,7 +160,7 @@ OrderedLineLoader.add_constructor(
     u'tag:yaml.org,2002:str', OrderedLineLoader.construct_yaml_str)
 
 
-class OrderedLineDumper(yaml.Dumper):
+class OrderedLineDumper(Dumper):
     """Dumper that preserves ordering and formats ``syaml_*`` objects.
 
       This dumper preserves insertion ordering ``syaml_dict`` objects


### PR DESCRIPTION
I threw this together working on #1562, and thought I'd just get it merged.

Spack ships with its own `PyYAML` module in `lib/spack/external/yaml`, but it doesn't use the C `libyaml` because we don't want to require compiling anything -- Spack _must_ run out of the box.  

cYAML is pretty fast, though, and with things like #1015 and #1535 the main bottleneck to operations like `spack find` is YAML parsing.  

This patch makes Spack use an already-installed PyYAML and the `CParser` and `CLoader` from `libyaml` if they're available.  It makes a `spack find` on @adamjstewart's 400+ installed packages from #1562 run **3x faster** (1s vs 3s) on my laptop.

@alalazo @davydden @adamjstewart @citibeth 