### PR TITLE
mpich/package.py is missing 'import os'

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 
 
 class Mpich(Package):


### PR DESCRIPTION
+ Add missing 'import os'. Thanks to @pramodk for catching this.
+ Patches #1989.
