### PR TITLE
Use PyYAML in Travis to increase build speeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
     packages:
       - graphviz
       - libyaml
+      - yaml-cpp-dev
 
 # Install various dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - pip install flake8
   - pip install sphinx
   - pip install mercurial
+  - pip install pyyaml
 
 before_script:
   # Need this for the git tests to succeed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
   apt:
     packages:
       - graphviz
-      - libyaml
+      - libyaml-dev
       - yaml-cpp-dev
 
 # Install various dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
   apt:
     packages:
       - graphviz
+      - libyaml
 
 # Install various dependencies
 install:


### PR DESCRIPTION
This is a follow-up to the discussion in #2010. @alalazo suggested using PyYAML/cYAML in the Travis environment if there's a chance it will speed up CI tests.

I'm not sure exactly which combination of `pip install pyyaml` and/or `apt-get install libyaml-dev` will get us what we want, so I'll add them one at a time and record the speeds we get.