### PR TITLE
Fix list_url for fish shell

### DIFF
--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -32,8 +32,7 @@ class Fish(Package):
 
     homepage = "http://fishshell.com/"
     url      = "http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz"
-    list_url = "http://fishshell.com/files/"
-    list_depth = 2
+    list_url = "http://fishshell.com/"
 
     version('2.2.0', 'a76339fd14ce2ec229283c53e805faac48c3e99d9e3ede9d82c0554acfc7b77a')
 


### PR DESCRIPTION
Fixes #103.

Well, technically I didn't fix it. Someone else must have fixed it in another PR. This PR just reverts the `list_url` back to it's previous value so that it works again.

### Before
```
$ spack versions fish
==> Safe versions (already checksummed):
  2.2.0
==> Remote versions (not yet checksummed):
  Found no versions for fish
$ spack checksum fish
==> Error: Could not fetch any versions for fish
```

### After
```
$ spack versions fish
==> Safe versions (already checksummed):
  2.2.0
==> Remote versions (not yet checksummed):
  2.3.1  2.3.0  2.1.2  2.1.1  2.1.0  2.0.0
$ spack checksum fish
==> Found 7 versions of fish
  2.3.1     http://fishshell.com/files/2.3.1/fish-2.3.1.tar.gz
  2.3.0     http://fishshell.com/files/2.3.0/fish-2.3.0.tar.gz
  2.2.0     http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz
  2.1.2     http://fishshell.com/files/2.1.2/fish-2.1.2.tar.gz
  2.1.1     http://fishshell.com/files/2.1.1/fish-2.1.1.tar.gz
  2.1.0     http://fishshell.com/files/2.1.0/fish-2.1.0.tar.gz
  2.0.0     http://fishshell.com/files/2.0.0/fish-2.0.0.tar.gz

How many would you like to checksum? (default is 5, q to abort) 
==> Downloading...
==> Trying to fetch from http://fishshell.com/files/2.3.1/fish-2.3.1.tar.gz
######################################################################## 100.0%
==> Trying to fetch from http://fishshell.com/files/2.3.0/fish-2.3.0.tar.gz
######################################################################## 100.0%
==> Trying to fetch from http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz
######################################################################## 100.0%
==> Trying to fetch from http://fishshell.com/files/2.1.2/fish-2.1.2.tar.gz
######################################################################## 100.0%
==> Trying to fetch from http://fishshell.com/files/2.1.1/fish-2.1.1.tar.gz
######################################################################## 100.0%
==> Checksummed new versions of fish:
    version('2.3.1', '2d13852a5c8e9e5bca00502b93e046a4')
    version('2.3.0', '86c51dadf9c9cae223f4096190e78443')
    version('2.2.0', 'f6c3d940148593ff6648adb07986cbcb')
    version('2.1.2', '9cc73b46040174a1643d59d49ad28a48')
    version('2.1.1', '0251e6e5f25d1f326e071425ea1dee22')
```
