### PR TITLE
Platform-specific config scopes

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -83,7 +83,6 @@ from llnl.util.filesystem import join_path
 import llnl.util.tty as tty
 
 import spack
-import spack.compilers
 from spack.util.naming import mod_to_class
 from spack.util.environment import get_path
 from spack.util.multiproc import parmap
@@ -276,6 +275,8 @@ class OperatingSystem(object):
         # Once the paths are cleaned up, do a search for each type of
         # compiler.  We can spawn a bunch of parallel searches to reduce
         # the overhead of spelunking all these directories.
+        # NOTE: we import spack.compilers here to avoid init order cycles
+        import spack.compilers
         types = spack.compilers.all_compiler_types()
         compiler_lists = parmap(lambda cmp_cls:
                                 self.find_compiler(cmp_cls, *filtered_path),

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -29,13 +29,8 @@ description = "Get and set configuration options."
 
 def setup_parser(subparser):
     # User can only choose one
-    scope_group = subparser.add_mutually_exclusive_group()
-    scope_group.add_argument(
-        '--user', action='store_const', const='user', dest='scope',
-        help="Use config file in user home directory (default).")
-    scope_group.add_argument(
-        '--site', action='store_const', const='site', dest='scope',
-        help="Use config file in spack prefix.")
+    subparser.add_argument('--scope', choices=spack.config.config_scopes,
+                           help="Configuration scope to read/modify.")
 
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='config_command')
 


### PR DESCRIPTION
Adds the ability to have platform-specific configuration scopes.  This allows Spack to know about things like default Blue Gene/Q compiler locations and default modules to load for Cray compilers out of the box.  In particular, this helps with #1980 - where we'd like to get @pramodk's settings into the mainline so that users don't have to do much of anything to configure Spack on BG/Q.

The platform config scopes go in subdirectories of a normal Spack config scopes.  The precedence looks like this:

1. `defaults`, in `etc/spack/defaults`: default configs that ship with Spack (e.g. `packages.yaml`)
1. `defaults/bgq`, in `etc/spack/defaults/bgq`: platform-specific overrides of defaults.
1. `site`, in `etc/spack`: spack-instance-specific settings.
1. `site/bgq`, in `etc/spack/bgq`: platform-specific overrides of site settings.
1. `user`, in `~/.spack`: user-specific settings.
1. `user/bgq`, in `~/.spack/bgq`: platform-specific overrides of user settings.

All of these are merged the same way the current `defaults`, `site`, and `user` scopes are merged.

@alalazo @adamjstewart @pramodk