### PR TITLE
fix sqlite download url

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -34,7 +34,7 @@ class Sqlite(Package):
     homepage = "www.sqlite.org"
 
     version('3.8.5', '0544ef6d7afd8ca797935ccc2685a9ed',
-            url='http://www.sqlite.org/2014/sqlite-autoconf-3080500.tar.gz')
+            url='https://www.sqlite.org/2014/sqlite-autoconf-3080500.tar.gz')
 
     def get_arch(self):
         arch = architecture.Arch()


### PR DESCRIPTION
I saw OpenSpeedShop package installation failure due to sqlite:
```bash
./bin/spack install sqlite==> Installing sqlite
==> Trying to fetch from 
.........................
==> Trying to fetch from http://www.sqlite.org/2014/sqlite-autoconf-3080500.tar.gz

curl: (7) Failed to connect to www.sqlite.org port 80: Connection refused
==> Fetching from http://www.sqlite.org/2014/sqlite-autoconf-3080500.tar.gz failed.
==> Error: All fetchers failed for sqlite-3.8.5-ixppdoeiuvssathzv7iwep65cwgkydes
==> Error: Installation process had nonzero exit code : 256
```
With https:
```bash
./bin/spack install sqlite
==> Installing sqlite
==> Trying to fetch from 
...........
==> Trying to fetch from https://www.sqlite.org/2014/sqlite-autoconf-3080500.tar
######################################################################## 100.0%
```