### PR TITLE
fix download url for paraver

### DIFF
--- a/var/spack/repos/builtin/packages/paraver/package.py
+++ b/var/spack/repos/builtin/packages/paraver/package.py
@@ -32,9 +32,9 @@ class Paraver(Package):
         is expressed on its input trace format.  Traces for parallel MPI,
         OpenMP and other programs can be genereated with Extrae."""
     homepage = "http://www.bsc.es/computer-sciences/performance-tools/paraver"
-    url      = "http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.5.3.tar.gz"
+    url      = "http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.6.2.tar.gz"
 
-    version('4.5.3', '625de9ec0d639acd18d1aaa644b38f72')
+    version('4.6.2', 'c54e124382b597574628b00e31649803')
 
     depends_on("boost")
     # depends_on("extrae")

--- a/var/spack/repos/builtin/packages/paraver/package.py
+++ b/var/spack/repos/builtin/packages/paraver/package.py
@@ -34,6 +34,8 @@ class Paraver(Package):
     homepage = "http://www.bsc.es/computer-sciences/performance-tools/paraver"
     url      = "http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.6.2.tar.gz"
 
+    # NOTE: Paraver provides only latest version for download.
+    #       Don't keep/add older versions.
     version('4.6.2', 'c54e124382b597574628b00e31649803')
 
     depends_on("boost")


### PR DESCRIPTION
Old package not available, need to update URL:

```bash
○ → spack install -v paraver
........
==> Trying to fetch from http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.5.3.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
==> Fetching from http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.5.3.tar.gz failed.
==> Error: All fetchers failed for paraver-4.5.3-aejyretokzxwzvplrzhllqoekkfxlrsz
==> Error: Installation process had nonzero exit code : 256
```
New version URL:
```bash
==> Trying to fetch from http://www.bsc.es/ssl/apps/performanceTools/files/paraver-sources-4.6.2.tar.gz
######################################################################## 100.0%
```