### PR TITLE
Don't cache truncated dag hash for spec

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -974,10 +974,10 @@ class Spec(object):
             yaml_text = syaml.dump(
                 self.to_node_dict(), default_flow_style=True, width=maxint)
             sha = hashlib.sha1(yaml_text)
-            b32_hash = base64.b32encode(sha.digest()).lower()[:length]
+            b32_hash = base64.b32encode(sha.digest()).lower()
             if self.concrete:
                 self._hash = b32_hash
-            return b32_hash
+            return b32_hash[:length]
 
     def dag_hash_bit_prefix(self, bits):
         """Get the first <bits> bits of the DAG hash as an integer type."""


### PR DESCRIPTION
If Spec.dag_hash was called for the first time with a 'length'
specified, the cached hash was truncated. This ensures that the
full hash is cached.

This came up for me when working with modules. At some
point they happened to dispatch the first call to Spec.dag_hash
with the length set to 7.