### PR TITLE
Add package for htop

### DIFF
--- a/var/spack/repos/builtin/packages/htop/package.py
+++ b/var/spack/repos/builtin/packages/htop/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Htop(Package):
+    """htop is an interactive text-mode process viewer for Unix systems."""
+
+    homepage = "https://github.com/hishamhm/htop"
+    url      = "https://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz"
+
+    version('2.0.2', '7d354d904bad591a931ad57e99fea84a')
+
+    depends_on('ncurses')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+        make()
+        make('install')


### PR DESCRIPTION
Add package for htop, an interactive text-mode process viewer for
Unix systems.  Think top, with pretty colors and dyanmic bar graphs.

More info [here](https://github.com/hishamhm/htop).