### PR TITLE
Update emacs: current release, use our x11 bits

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -45,7 +45,7 @@ class Emacs(Package):
     depends_on('giflib', when='+X')
     depends_on('libx11', when='+X')
     depends_on('libxaw', when='+X toolkit=athena')
-    depends_on('gtkplus', when='+X toolkit=gtk')
+    depends_on('gtkplus+X', when='+X toolkit=gtk')
 
     def install(self, spec, prefix):
         args = []

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -35,32 +35,30 @@ class Emacs(Package):
     version('25.1', '95c12e6a9afdf0dcbdd7d2efa26ca42c')
     version('24.5', 'd74b597503a68105e61b5b9f6d065b44')
 
-    variant('X', default=True, description="Enable a X toolkit (GTK+)")
-    variant('gtkplus', default=False,
-            description="Enable a GTK+ as X toolkit (ignored if ~X)")
+    variant('X', default=True, description="Enable an X toolkit")
+    variant('toolkit', default='gtk', 
+        description="Select an X toolkit (gtk, athena)")
 
     depends_on('ncurses')
     depends_on('libtiff', when='+X')
     depends_on('libpng', when='+X')
     depends_on('libxpm', when='+X')
     depends_on('giflib', when='+X')
-    depends_on('gtkplus', when='+X+gtkplus')
+    depends_on('libx11', when='+X')
+    depends_on('libxaw', when='+X toolkit=athena')
+    depends_on('glib', when='+X toolkit=gtk')
+    depends_on('gtkplus', when='+X toolkit=gtk')
 
     def install(self, spec, prefix):
         args = []
         if '+X' in spec:
-            if '+gtkplus' in spec:
-                toolkit = 'gtk{0}'.format(spec['gtkplus'].version.up_to(1))
-            else:
-                toolkit = 'no'
+            # TODO: should check that toolkit is valid (gtk, athena)
             args = [
                 '--with-x',
-                '--with-x-toolkit={0}'.format(toolkit)
+                '--with-x-toolkit={0}'.format(spec.variants['toolkit'].value)
             ]
         else:
             args = ['--without-x']
-            if '+gtkplus' in spec:
-                tty.warn('The variant +gtkplus is ignored if ~X is selected.')
 
         configure('--prefix={0}'.format(prefix), *args)
 

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import llnl.util.tty as tty
 
 
 class Emacs(Package):
@@ -36,8 +35,8 @@ class Emacs(Package):
     version('24.5', 'd74b597503a68105e61b5b9f6d065b44')
 
     variant('X', default=True, description="Enable an X toolkit")
-    variant('toolkit', default='gtk', 
-        description="Select an X toolkit (gtk, athena)")
+    variant('toolkit', default='gtk',
+            description="Select an X toolkit (gtk, athena)")
 
     depends_on('ncurses')
     depends_on('libtiff', when='+X')

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -34,7 +34,7 @@ class Emacs(Package):
     version('25.1', '95c12e6a9afdf0dcbdd7d2efa26ca42c')
     version('24.5', 'd74b597503a68105e61b5b9f6d065b44')
 
-    variant('X', default=True, description="Enable an X toolkit")
+    variant('X', default=False, description="Enable an X toolkit")
     variant('toolkit', default='gtk',
             description="Select an X toolkit (gtk, athena)")
 
@@ -45,16 +45,18 @@ class Emacs(Package):
     depends_on('giflib', when='+X')
     depends_on('libx11', when='+X')
     depends_on('libxaw', when='+X toolkit=athena')
-    depends_on('glib', when='+X toolkit=gtk')
     depends_on('gtkplus', when='+X toolkit=gtk')
 
     def install(self, spec, prefix):
         args = []
+        toolkit = spec.variants['toolkit'].value
         if '+X' in spec:
-            # TODO: should check that toolkit is valid (gtk, athena)
+            if toolkit not in ('gtk', 'athena'):
+                raise InstallError("toolkit must be one of (gtk, athena), not %s" %
+                                   toolkit)
             args = [
                 '--with-x',
-                '--with-x-toolkit={0}'.format(spec.variants['toolkit'].value)
+                '--with-x-toolkit={0}'.format(toolkit)
             ]
         else:
             args = ['--without-x']

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -52,7 +52,7 @@ class Emacs(Package):
         toolkit = spec.variants['toolkit'].value
         if '+X' in spec:
             if toolkit not in ('gtk', 'athena'):
-                raise InstallError("toolkit must be one of (gtk, athena), not %s" %
+                raise InstallError("toolkit must be in (gtk, athena), not %s" %
                                    toolkit)
             args = [
                 '--with-x',

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -36,6 +36,8 @@ class GdkPixbuf(Package):
 
     version('2.31.2', '6be6bbc4f356d4b79ab4226860ab8523')
 
+    depends_on("pkg-config", type="build")
+    depends_on("gettext")
     depends_on("glib")
     depends_on("jpeg")
     depends_on("libpng")

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -34,11 +34,14 @@ class Gtkplus(Package):
         '2.24.25', '612350704dd3aacb95355a4981930c6f',
         url="http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.25.tar.xz")
 
+    variant('X', default=True, description="Enable an X toolkit")
+
     depends_on("atk")
     depends_on("gdk-pixbuf")
     depends_on("glib")
     depends_on("pango")
-    depends_on("glib")
+    depends_on("pango~X", when='~X')
+    depends_on("pango+X", when='+X')
 
     def patch(self):
         # remove disable deprecated flag.

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -36,7 +36,7 @@ class Gtkplus(Package):
 
     depends_on("atk")
     depends_on("gdk-pixbuf")
-    depends_on("glib", type='build')
+    depends_on("glib")
     depends_on("pango")
     depends_on("glib")
 

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -36,6 +36,7 @@ class Gtkplus(Package):
 
     depends_on("atk")
     depends_on("gdk-pixbuf")
+    depends_on("glib", type='build')
     depends_on("pango")
     depends_on("glib")
 

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -38,7 +38,7 @@ class Pango(Package):
     version('1.36.8', '217a9a753006275215fa9fa127760ece')
     version('1.40.1', '6fc88c6529890d6c8e03074d57a3eceb')
 
-    variant('X', default=True, description="Enable an X toolkit")
+    variant('X', default=False, description="Enable an X toolkit")
 
     depends_on("pkg-config", type="build")
     depends_on("harfbuzz")

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -38,9 +38,13 @@ class Pango(Package):
     version('1.36.8', '217a9a753006275215fa9fa127760ece')
     version('1.40.1', '6fc88c6529890d6c8e03074d57a3eceb')
 
+    variant('X', default=True, description="Enable an X toolkit")
+
     depends_on("pkg-config", type="build")
     depends_on("harfbuzz")
     depends_on("cairo")
+    depends_on("cairo~X", when='~X')
+    depends_on("cairo+X", when='+X')
     depends_on("glib")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Add checksum for 25.1 release.

Rework the X support:
- use Spack's X11 bits
- add ability to specify an X toolkit (gtk or athena, default is gtk).
- change toolkit names to align with Emacs' configure usage.
