### PR TITLE
Update R&friends to use our X11 libs

### DIFF
--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -50,6 +50,8 @@ class R(Package):
 
     variant('external-lapack', default=False,
             description='Links to externally installed BLAS/LAPACK')
+    variant('X', default=True,
+            description='Enable X11 support (call configure --with-x)')
 
     # Virtual dependencies
     depends_on('blas', when='+external-lapack')
@@ -65,12 +67,16 @@ class R(Package):
     depends_on('libtiff')
     depends_on('jpeg')
     depends_on('cairo')
+    depends_on('cairo+X', when='+X')
+    depends_on('cairo~X', when='~X')
     depends_on('pango')
     depends_on('freetype')
     depends_on('tcl')
     depends_on('tk')
-    depends_on('libx11')
-    depends_on('libxt')
+    depends_on('tk+X', when='+X')
+    depends_on('tk~X', when='~X')
+    depends_on('libx11', when='+X')
+    depends_on('libxt', when='+X')
     depends_on('curl')
     depends_on('pcre')
     depends_on('jdk')

--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -69,6 +69,8 @@ class R(Package):
     depends_on('freetype')
     depends_on('tcl')
     depends_on('tk')
+    depends_on('libx11')
+    depends_on('libxt')
     depends_on('curl')
     depends_on('pcre')
     depends_on('jdk')

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -33,6 +33,10 @@ class Cairo(AutotoolsPackage):
 
     version('1.14.0', 'fc3a5edeba703f906f2241b394f0cced')
 
+    depends_on('libx11')
+    depends_on('libxext')
+    depends_on('libxrender')
+    depends_on('libxcb')
     depends_on("libpng")
     depends_on("glib")
     depends_on("pixman")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -33,10 +33,12 @@ class Cairo(AutotoolsPackage):
 
     version('1.14.0', 'fc3a5edeba703f906f2241b394f0cced')
 
-    depends_on('libx11')
-    depends_on('libxext')
-    depends_on('libxrender')
-    depends_on('libxcb')
+    variant('X', default=True, description="Build with X11 support")
+
+    depends_on('libx11', when='+X')
+    depends_on('libxext', when='+X')
+    depends_on('libxrender', when='+X')
+    depends_on('libxcb', when='+X')
     depends_on("libpng")
     depends_on("glib")
     depends_on("pixman")

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -38,6 +38,7 @@ class Tk(Package):
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
 
     depends_on("tcl")
+    depends_on("libx11")
 
     def url_for_version(self, version):
         base_url = "http://prdownloads.sourceforge.net/tcl"

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -37,8 +37,10 @@ class Tk(Package):
     version('8.6.5', '11dbbd425c3e0201f20d6a51482ce6c4')
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
 
+    variant('X', default=True, description='Enable X11 support')
+
     depends_on("tcl")
-    depends_on("libx11")
+    depends_on("libx11", when='+X')
 
     def url_for_version(self, version):
         base_url = "http://prdownloads.sourceforge.net/tcl"


### PR DESCRIPTION
Add `depends_on()`'s for R, Cairo, and Tk so that they use the Spack X
bits.
