### PR TITLE
Fix cdd package definition, dotted is a property

### DIFF
--- a/var/spack/repos/builtin/packages/cdd/package.py
+++ b/var/spack/repos/builtin/packages/cdd/package.py
@@ -37,7 +37,7 @@ class Cdd(Package):
 
     def url_for_version(self, version):
         return ("ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/cdd-%s.tar.gz" %
-                str(version.dotted()).replace('.', ''))
+                str(version.dotted).replace('.', ''))
 
     version('0.61a', '22c24a7a9349dd7ec0e24531925a02d9')
 


### PR DESCRIPTION
Things that accessed the cdd package, such as `spack info cdd run
tripped over a buglet in the *cdd* package, causing them to exit with
something like this:

```
Caused by:
TypeError: 'str' object is not callable
  File "/rss/spack/lib/spack/spack/repository.py", line 584, in get
    self._instances[key] = package_class(copy)
  File "/rss/spack/lib/spack/spack/package.py", line 398, in __init__
    f = fs.for_package_version(self, self.version)
  File "/rss/spack/lib/spack/spack/fetch_strategy.py", line 852, in for_package_version
    attrs['url'] = pkg.url_for_version(version)
  File "/rss/spack/var/spack/repos/builtin/packages/cdd/package.py", line 40, in url_for_version
    str(version.dotted()).replace('.', ''))
```

@tgamblin pointed out that `dotted` is a property, not a function call
and that the parentheses are therefor inappropriate.

This deletes the parentheses.  `spack info cdd` now works for me.

closes #2047 