### PR TITLE
Add latest version of Armadillo

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -33,6 +33,7 @@ class Armadillo(Package):
     homepage = "http://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-7.200.1.tar.xz"
 
+    version('7.500.0', '7d316fdf3c3c7ea92b64704180ae315d')
     version('7.200.2', 'b21585372d67a8876117fd515d8cf0a2')
     version('7.200.1', 'ed86d6df0058979e107502e1fe3e469e')
 


### PR DESCRIPTION
I'm having a bit of trouble linking to the Armadillo libraries. When I try compiling something with Armadillo, I'm seeing the following error message:
```
$ g++  -I/soft/spack-0.9.1/opt/spack/linux-centos6-x86_64/gcc-6.1.0/armadillo-7.500.0-inxgdirrm2cqscwwgqagoztainepayo7/include transport_linear_chain.cpp   -o transport_linear_chain
In file included from /soft/spack-0.9.1/opt/spack/linux-centos6-x86_64/gcc-6.1.0/armadillo-7.500.0-inxgdirrm2cqscwwgqagoztainepayo7/include/armadillo:83,
                 from transport_linear_chain.cpp:11:
/soft/spack-0.9.1/opt/spack/linux-centos6-x86_64/gcc-6.1.0/armadillo-7.500.0-inxgdirrm2cqscwwgqagoztainepayo7/include/armadillo_bits/include_superlu.hpp:91:53: error: /blues/gpfs/home/software/spack-0.9.1/opt/spack/1-centos6-x86_64/gcc-6.1.0/superlu-5.2.1-7y4mnsbozswcsktwfvvdreocwobyroy4/include/supermatrix.h: No such file or directory
```
The main thing to note here is that Armadillo thinks `supermatrix.h` is in `opt/spack/1-centos6-x86_64` when it is really in `opt/spack/linux-centos6-x86_64`. Has anyone ever seen something like this before? I contacted a developer, so hopefully they'll have an answer for me. But I assume it's not an RPATH problem on our end.