### PR TITLE
Bug concretize external virtuals

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -95,7 +95,11 @@ class DefaultConcretizer(object):
                                      not b.external and b.external_module):
                 # We're choosing between different providers, so
                 # maintain order from provider sort
-                return candidates.index(a) - candidates.index(b)
+                index_of_a = next(i for i in range(0, len(candidates)) \
+                                  if a.satisfies(candidates[i]))
+                index_of_b = next(i for i in range(0, len(candidates)) \
+                                  if b.satisfies(candidates[i]))
+                return index_of_a - index_of_b
 
             result = cmp_specs(a, b)
             if result != 0:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -95,9 +95,9 @@ class DefaultConcretizer(object):
                                      not b.external and b.external_module):
                 # We're choosing between different providers, so
                 # maintain order from provider sort
-                index_of_a = next(i for i in range(0, len(candidates)) \
+                index_of_a = next(i for i in range(0, len(candidates))
                                   if a.satisfies(candidates[i]))
-                index_of_b = next(i for i in range(0, len(candidates)) \
+                index_of_b = next(i for i in range(0, len(candidates))
                                   if b.satisfies(candidates[i]))
                 return index_of_a - index_of_b
 

--- a/var/spack/repos/builtin.mock/packages/othervirtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/othervirtual/package.py
@@ -25,16 +25,13 @@
 from spack import *
 
 
-class Externalvirtual(Package):
+class Othervirtual(Package):
     homepage = "http://somewhere.com"
     url      = "http://somewhere.com/stuff-1.0.tar.gz"
 
-    version('1.0', '1234567890abcdef1234567890abcdef')
-    version('2.0', '234567890abcdef1234567890abcdef1')
-    version('2.1', '34567890abcdef1234567890abcdef12')
-    version('2.2', '4567890abcdef1234567890abcdef123')
+    version('1.0', '67890abcdef1234567890abcdef12345')
 
-    provides('stuff', when='@1.0:')
+    provides('stuff')
 
     def install(self, spec, prefix):
         pass


### PR DESCRIPTION
Fixes a concretization error and extends tests to cover this case in the future.

Specifically, concretization was failing if:
  - there were two or more providers of a spec
  - one of the providers was external
  - one of the providers had a version range in the when clause of its provides

The above conditions would lead to the concretizer comparing two specs that it expected to be names with versions, but instead were names with version ranges.  It was not equiped to handle this.