### PR TITLE
spack test : exits after ctrl+c fixes #2029

### DIFF
--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -107,25 +107,33 @@ def run(names, outputDir, verbose=False):
                 sys.exit(1)
 
     tally = Tally()
-    for test in names:
-        module = 'spack.test.' + test
-        print(module)
 
-        tty.msg("Running test: %s" % test)
+    modules = ['spack.test.' + test for test in names]
+    runOpts = ["--with-%s" % spack.test.tally_plugin.Tally.name]
 
-        runOpts = ["--with-%s" % spack.test.tally_plugin.Tally.name]
-
-        if outputDir:
-            xmlOutputFname = "unittests-{0}.xml".format(test)
-            xmlOutputPath = join_path(outputDir, xmlOutputFname)
-            runOpts += ["--with-xunit",
-                        "--xunit-file={0}".format(xmlOutputPath)]
-        argv = [""] + runOpts + [module]
-        nose.run(argv=argv, addplugins=[tally])
+    if outputDir:
+        xmlOutputFname = "unittests-{0}.xml".format(test)
+        xmlOutputPath = join_path(outputDir, xmlOutputFname)
+        runOpts += ["--with-xunit",
+                    "--xunit-file={0}".format(xmlOutputPath)]
+    argv = [""] + runOpts + modules
+    nose.run(argv=argv, addplugins=[tally])
 
     succeeded = not tally.failCount and not tally.errorCount
-    tty.msg("Tests Complete.", "%5d tests run" % tally.numberOfTestsRun,
-            "%5d failures" % tally.failCount, "%5d errors" % tally.errorCount)
+    tty.msg(
+        "Tests Complete.",
+        "%5d tests run" % tally.numberOfTestsRun,
+        "%5d failures" % tally.failCount,
+        "%5d errors" % tally.errorCount
+    )
+
+    if tally.fail_list:
+        items = [x for x in tally.fail_list]
+        tty.msg('List of failing tests:', *items)
+
+    if tally.error_list:
+        items = [x for x in tally.error_list]
+        tty.msg('List of tests with errors:', *items)
 
     if succeeded:
         tty.info("OK", format='g')

--- a/lib/spack/spack/test/tally_plugin.py
+++ b/lib/spack/spack/test/tally_plugin.py
@@ -35,6 +35,8 @@ class Tally(Plugin):
         self.successCount = 0
         self.failCount = 0
         self.errorCount = 0
+        self.error_list = []
+        self.fail_list = []
 
     @property
     def numberOfTestsRun(self):
@@ -52,9 +54,11 @@ class Tally(Plugin):
 
     def addError(self, test, err):
         self.errorCount += 1
+        self.error_list.append(test)
 
     def addFailure(self, test, err):
         self.failCount += 1
+        self.fail_list.append(test)
 
     def finalize(self, result):
         pass


### PR DESCRIPTION
Alternative to #2078 that runs all the tests at once. It also prints at the end of the tests the list of failing tests or of tests with errors.