### PR TITLE
spack setup: Remove support for deprecated env var.

### DIFF
--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -111,7 +111,6 @@ env = dict(os.environ)
                     fout.write('    %s\n' % part)
                 fout.write('"""))\n')
 
-        fout.write("env['CMAKE_TRANSITIVE_INCLUDE_PATH'] = env['SPACK_TRANSITIVE_INCLUDE_PATH']   # Deprecated\n")  # NOQA: ignore=E501
         fout.write('\ncmd = cmdlist("""\n')
         fout.write('%s\n' % cmd[0])
         for arg in cmd[1:]:


### PR DESCRIPTION
Remove support for deprecated package.  See also #2085 and #2086