### PR TITLE
pkg-config variant to use internal glib

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -42,7 +42,7 @@ class Glib(Package):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
-    depends_on('pkg-config', type='build')
+    depends_on('pkg-config+internal_glib', type='build')
     depends_on('libffi')
     depends_on('zlib')
     depends_on('gettext')

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -30,23 +30,27 @@ class PkgConfig(Package):
     and libraries"""
 
     homepage = "http://www.freedesktop.org/wiki/Software/pkg-config/"
-    url      = "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
+    url = "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
 
     version('0.29.1', 'f739a28cae4e0ca291f82d1d41ef107d')
     version('0.28',   'aa3c86e67551adc3ac865160e34a2a0d')
 
     parallel = False
+    variant('internal_glib', default=True,
+            description='Builds with internal glib')
 
     # The following patch is needed for gcc-6.1
     patch('g_date_strftime.patch')
 
     def install(self, spec, prefix):
-        configure("--prefix={0}".format(prefix),
-                  "--enable-shared",
-                  # There's a bootstrapping problem here;
-                  # glib uses pkg-config as well, so break
-                  # the cycle by using the internal glib.
-                  "--with-internal-glib")
+        args = ["--prefix={0}".format(prefix),
+                "--enable-shared"]
+        if "+internal_glib" in spec:
+            # There's a bootstrapping problem here;
+            # glib uses pkg-config as well, so break
+            # the cycle by using the internal glib.
+            args.append("--with-internal-glib")
+        configure(*args)
 
         make()
         make("install")


### PR DESCRIPTION
Pkg-config depends on glib which depends on pkg-config. As a result, pkg-config used to build glib internally. However, this fails on Mac. Building pkg-config with an internal glib is now a variant, turned on by default, and required to build glib.

To enable pkg-config with the system glib, users can add  to their `package.yaml`

```YAML
packages:
    pkgconfig:
        variants: -internal_glib
```