### PR TITLE
Tells boost explictly about python libraries and headers

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -165,11 +165,7 @@ class Boost(Package):
 
         pylib = 'libpython%s.%s*' % spec['python'].version.version[:2]
         all_libs = join_path(spec['python'].prefix.lib, pylib)
-        if sys.platform == 'darwin':
-            libs = [u for u in all_libs if splitext(u)[1] == '.dylib']
-        else:
-            libs = [u for u in all_libs if splitext(u)[1] == '.so']
-
+        libs = [u for u in all_libs if splitext(u)[1] == dso_suffix]
         if len(libs) == 0:
             libs = [u for u in all_libs if splitext(u)[1] == '.a']
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import sys
 import os
+from glob import glob
 
 
 class Boost(Package):
@@ -156,7 +157,6 @@ class Boost(Package):
         return 'gcc'
 
     def bjam_python_line(self, spec):
-        from glob import glob
         from os.path import dirname, splitext
         pydir = 'python%s.%s*' % spec['python'].version.version[:2]
         incs = join_path(spec['python'].prefix.include, pydir, "pyconfig.h")

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -164,14 +164,14 @@ class Boost(Package):
         incs = " ".join([dirname(u) for u in incs])
 
         pylib = 'libpython%s.%s*' % spec['python'].version.version[:2]
-        alllibs = join_path(spec['python'].prefix.lib, pylib)
+        all_libs = join_path(spec['python'].prefix.lib, pylib)
         if sys.platform == 'darwin':
-            libs = [u for u in alllibs if splitext(u)[1] == '.dylib']
+            libs = [u for u in all_libs if splitext(u)[1] == '.dylib']
         else:
-            libs = [u for u in alllibs if splitext(u)[1] == '.so']
+            libs = [u for u in all_libs if splitext(u)[1] == '.so']
 
         if len(libs) == 0:
-            libs = [u for u in alllibs if splitext(u)[1] == '.a']
+            libs = [u for u in all_libs if splitext(u)[1] == '.a']
 
         libs = " ".join(libs)
         return 'using python : %s : %s : %s : %s ;\n' % (

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -171,7 +171,7 @@ class Boost(Package):
 
         libs = " ".join(libs)
         return 'using python : %s : %s : %s : %s ;\n' % (
-            spec['python'].version,
+            spec['python'].version.up_to(2),
             join_path(spec['python'].prefix.bin, 'python'),
             incs, libs
         )


### PR DESCRIPTION
Ideally, bjam would determine the libraries and headers from the executable. But it doesn't. This rigs a best guess for python libraries and headers.