### PR TITLE
Allow newer versions of GCC to compile older versions of GCC

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/gcc-backport.patch
+++ b/var/spack/repos/builtin/packages/gcc/gcc-backport.patch
@@ -1,0 +1,138 @@
+2016-02-20  Bernd Edlinger  <bernd.edlinger@hotmail.de>
+
+	Backported from mainline
+	2016-02-19  Jakub Jelinek  <jakub@redhat.com>
+		    Bernd Edlinger  <bernd.edlinger@hotmail.de>
+
+	* Make-lang.in: Invoke gperf with -L C++.
+ 	* cfns.gperf: Remove prototypes for hash and libc_name_p
+ 	inlines.
+ 	* cfns.h: Regenerated.
+	* except.c (nothrow_libfn_p): Adjust.
+
+Index: gcc/cp/Make-lang.in
+===================================================================
+--- a/gcc/cp/Make-lang.in	(revision 233574)
++++ b/gcc/cp/Make-lang.in	(working copy)
+@@ -111,7 +111,7 @@ else
+ # deleting the $(srcdir)/cp/cfns.h file.
+ $(srcdir)/cp/cfns.h:
+ endif
+-	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L ANSI-C \
++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
+ 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
+ 
+ #
+Index: gcc/cp/cfns.gperf
+===================================================================
+--- a/gcc/cp/cfns.gperf	(revision 233574)
++++ b/gcc/cp/cfns.gperf	(working copy)
+@@ -1,3 +1,5 @@
++%language=C++
++%define class-name libc_name
+ %{
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -16,14 +18,6 @@ for more details.
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ %}
+ %%
+ # The standard C library functions, for feeding to gperf; the result is used
+Index: gcc/cp/cfns.h
+===================================================================
+--- a/gcc/cp/cfns.h	(revision 233574)
++++ b/gcc/cp/cfns.h	(working copy)
+@@ -1,5 +1,5 @@
+-/* ANSI-C code produced by gperf version 3.0.3 */
+-/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L ANSI-C cfns.gperf  */
++/* C++ code produced by gperf version 3.0.4 */
++/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L C++ --output-file cfns.h cfns.gperf  */
+ 
+ #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+@@ -28,7 +28,7 @@
+ #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+ #endif
+ 
+-#line 1 "cfns.gperf"
++#line 3 "cfns.gperf"
+ 
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -47,26 +47,19 @@ for more details.
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 
+-#ifdef __GNUC__
+-__inline
+-#else
+-#ifdef __cplusplus
+-inline
+-#endif
+-#endif
+-static unsigned int
+-hash (register const char *str, register unsigned int len)
++class libc_name
+ {
++private:
++  static inline unsigned int hash (const char *str, unsigned int len);
++public:
++  static const char *libc_name_p (const char *str, unsigned int len);
++};
++
++inline unsigned int
++libc_name::hash (register const char *str, register unsigned int len)
++{
+   static const unsigned short asso_values[] =
+     {
+       400, 400, 400, 400, 400, 400, 400, 400, 400, 400,
+@@ -122,14 +115,8 @@ along with GCC; see the file COPYING3.  If not see
+   return hval + asso_values[(unsigned char)str[len - 1]];
+ }
+ 
+-#ifdef __GNUC__
+-__inline
+-#ifdef __GNUC_STDC_INLINE__
+-__attribute__ ((__gnu_inline__))
+-#endif
+-#endif
+ const char *
+-libc_name_p (register const char *str, register unsigned int len)
++libc_name::libc_name_p (register const char *str, register unsigned int len)
+ {
+   enum
+     {
+Index: gcc/cp/except.c
+===================================================================
+--- a/gcc/cp/except.c	(revision 233574)
++++ b/gcc/cp/except.c	(working copy)
+@@ -1040,7 +1040,8 @@ nothrow_libfn_p (const_tree fn)
+      unless the system headers are playing rename tricks, and if
+      they are, we don't want to be confused by them.  */
+   id = DECL_NAME (fn);
+-  return !!libc_name_p (IDENTIFIER_POINTER (id), IDENTIFIER_LENGTH (id));
++  return !!libc_name::libc_name_p (IDENTIFIER_POINTER (id),
++				   IDENTIFIER_LENGTH (id));
+ }
+ 
+ /* Returns nonzero if an exception of type FROM will be caught by a

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -58,6 +58,7 @@ class Gcc(Package):
         provides('golang', when='@4.7.1:')
 
     patch('piclibs.patch', when='+piclibs')
+    patch('gcc-backport.patch', when='@5.3.0')
 
     def install(self, spec, prefix):
         # libjava/configure needs a minor fix to install into spack paths.

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -58,7 +58,7 @@ class Gcc(Package):
         provides('golang', when='@4.7.1:')
 
     patch('piclibs.patch', when='+piclibs')
-    patch('gcc-backport.patch', when='@5.3.0')
+    patch('gcc-backport.patch', when='@4.7:5.3')
 
     def install(self, spec, prefix):
         # libjava/configure needs a minor fix to install into spack paths.


### PR DESCRIPTION
Fixes #2044.

This PR adds the patch from the [bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69959) found by @svenevs in #2044. From what I understand, the problem is that GCC 6 defaults to `-std=gnu++14`, but older versions of GCC don't comply with this standard. An alternative solution would be to use `CXXFLAGS="-std=gnu++98"` when compiling older versions of GCC, but I opted for the patch because that's what GCC did upstream.

Why would you want to build GCC 5 if you already have a GCC 6 compiler? The main use case is on bleeding-edge OSes like Fedora, where you only have GCC 6.2.0, but software like CUDA only supports up to GCC 5.3.0.

Testing: I successfully installed GCC 5.3.0 with GCC 6.2.0 on macOS. I also made sure that the patch applied for all versions of GCC between 4.7 and 5.3. Pre-4.7, we would either have to use `CXXFLAGS="-std=gnu++98"` or come up with another patch.

@svenevs If you want to test this, it should now work on both Fedora and macOS for you.