### PR TITLE
Add latest versions of Flux prerequisites

### DIFF
--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -29,13 +29,21 @@ class Libsodium(Package):
     """Sodium is a modern, easy-to-use software library for encryption,
     decryption, signatures, password hashing and more."""
     homepage = "https://download.libsodium.org/doc/"
-    url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.3.tar.gz"
+    url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.11.tar.gz"
 
+    version('1.0.11', 'b58928d035064b2a46fb564937b83540')
+    version('1.0.10', 'ea89dcbbda0b2b6ff6a1c476231870dd')
     version('1.0.3', 'b3bcc98e34d3250f55ae196822307fab')
     version('1.0.2', 'dc40eb23e293448c6fc908757738003f')
     version('1.0.1', '9a221b49fba7281ceaaf5e278d0f4430')
     version('1.0.0', '3093dabe4e038d09f0d150cef064b2f7')
     version('0.7.1', 'c224fe3923d1dcfe418c65c8a7246316')
+
+    def url_for_version(self, version):
+        url = 'https://download.libsodium.org/libsodium/releases/'
+        if version < Version('1.0.4'):
+            url += 'old/'
+        return url + 'libsodium-{0}.tar.gz'.format(version)
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -30,6 +30,7 @@ class Zeromq(Package):
     homepage = "http://zguide.zeromq.org/"
     url      = "http://download.zeromq.org/zeromq-4.1.2.tar.gz"
 
+    version('4.1.4', 'a611ecc93fffeb6d058c0e6edf4ad4fb')
     version('4.1.2', '159c0c56a895472f02668e692d122685')
     version('4.1.1', '0a4b44aa085644f25c177f79dc13f253')
     version('4.0.7', '9b46f7e7b0704b83638ef0d461fd59ab')
@@ -37,6 +38,7 @@ class Zeromq(Package):
     version('4.0.5', '73c39f5eb01b9d7eaf74a5d899f1d03d')
 
     depends_on("libsodium")
+    depends_on("libsodium@:1.0.3", when='@:4.1.2')
 
     def install(self, spec, prefix):
         configure("--with-libsodium", "--prefix=%s" % prefix)


### PR DESCRIPTION
The current develop branch of Flux requires an updated version of zeromq (which in turn requires a newer version of libsodium).  Also includes a fix for older version of libsodium since the URLs have changed.