### PR TITLE
Allow Spack to find old GCC compatibility fortran compilers

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -35,7 +35,7 @@ class Gcc(Compiler):
     cxx_names = ['g++']
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ['gfortran']
+    f77_names = ['gfortran', 'g77']
 
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['gfortran']


### PR DESCRIPTION
This change addresses @svenevs https://github.com/LLNL/spack/pull/2099#issuecomment-256158633

The old compatibility compilers for GCC are named:

- gcc34
- g++34
- g77

Adding the gcc/g++ suffixes was done in #2099. This PR adds the old g77 name. @svenevs Can you confirm that this takes care of everything?