### PR TITLE
Add package for maven

### DIFF
--- a/var/spack/repos/builtin/packages/maven/package.py
+++ b/var/spack/repos/builtin/packages/maven/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from distutils.dir_util import copy_tree
+
+
+class Maven(Package):
+    """Apache Maven is a software project management and comprehension tool."""
+
+    homepage = "https://maven.apache.org/index.html"
+    url = "http://www.gtlib.gatech.edu/pub/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+
+    version('3.3.9', '516923b3955b6035ba6b0a5b031fbd8b')
+
+    depends_on('jdk')
+
+    def install(self, spec, prefix):
+        # install pre-built distribution
+        copy_tree('.', prefix)


### PR DESCRIPTION
Add a package that installed the pre-built maven distribution.

I've given up, for now, on building maven from source.  That processed
stumbled on two points before I gave up:

1. It downloaded several hundred .{pop,jar} files and I despaired of
   figuring out some way of mirroring and checksumming them; and

2. It exploded complaining about too many unacceptable license files,
   which seems odd in its own source tree.

Perhaps someone with more Java fu that I admit to can figure it out.
In the meantime, this is useful.