### PR TITLE
libSplash: Add 1.5.0 Release

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -41,6 +41,7 @@ class Libsplash(Package):
             git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
+    version('1.5.0', 'c1efec4c20334242c8a3b6bfdc0207e3')
     version('1.4.0', '2de37bcef6fafa1960391bf44b1b50e0')
     version('1.3.1', '524580ba088d97253d03b4611772f37c')
     version('1.2.4', '3fccb314293d22966beb7afd83b746d0')


### PR DESCRIPTION
Add the latest release of libSplash, version 1.5.0.