### PR TITLE
[WIP] Various updates to GCC package

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -33,8 +33,8 @@ class Gcc(AutotoolsPackage):
        Objective-C, Fortran, and Java."""
 
     homepage = "https://gcc.gnu.org/"
-    url = "http://ftp.gnu.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2"
-    list_url = 'http://ftp.gnu.org/gnu/gcc/'
+    url      = "http://ftp.gnu.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2"
+    list_url = "http://ftp.gnu.org/gnu/gcc/"
     list_depth = 2
 
     version('6.2.0', '9768625159663b300ae4de2f4745fcc4')
@@ -97,7 +97,6 @@ class Gcc(AutotoolsPackage):
            not (spec.satisfies('@:4.9.3') and 'ppc64le' in spec.architecture):
             enabled_languages.add('go')
 
-
         # Generic options to compile GCC
         args = [
             '--libdir={0}/lib64'.format(self.prefix),
@@ -133,24 +132,24 @@ class Gcc(AutotoolsPackage):
     @property
     def spec_dir(self):
         # e.g. lib64/gcc/x86_64-unknown-linux-gnu/4.9.2
-        spec_dir = glob.glob("%s/lib64/gcc/*/*" % self.prefix)
+        spec_dir = glob.glob('{0}/lib64/gcc/*/*'.format(self.prefix))
         return spec_dir[0] if spec_dir else None
 
     def write_rpath_specs(self):
         """Generate a spec file so the linker adds a rpath to the libs
            the compiler used to build the executable."""
         if not self.spec_dir:
-            tty.warn("Could not install specs for %s." %
-                     self.spec.format('$_$@'))
+            tty.warn('Could not install specs for {0}.'.format(
+                     self.spec.format('$_$@')))
             return
 
         gcc = Executable(join_path(self.prefix.bin, 'gcc'))
-        lines = gcc('-dumpspecs', output=str).strip().split("\n")
+        lines = gcc('-dumpspecs', output=str).strip().split('\n')
         specs_file = join_path(self.spec_dir, 'specs')
-        with open(specs_file, 'w') as out
+        with open(specs_file, 'w') as out:
             for line in lines:
-                out.write(line + "\n")
-                if line.startswith("*link:"):
-                    out.write("-rpath %s/lib:%s/lib64 \\\n" %
-                              (self.prefix, self.prefix))
+                out.write(line + '\n')
+                if line.startswith('*link:'):
+                    out.write(r'-rpath {0}/lib:{0}/lib64 \n'.format(
+                        self.prefix))
         set_install_permissions(specs_file)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -53,10 +53,6 @@ class Gcc(Package):
     patch('gcc-backport.patch', when='@4.7:5.3')
 
     def install(self, spec, prefix):
-        # libjava/configure needs a minor fix to install into spack paths.
-        filter_file(r"'@.*@'", "'@[[:alnum:]]*@'", 'libjava/configure',
-                    string=True)
-
         enabled_languages = set(('c', 'c++', 'fortran', 'java', 'objc'))
 
         if spec.satisfies("@4.7.1:") and sys.platform != 'darwin' and \

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -31,12 +31,6 @@ class Gcc(Package):
     version('4.6.4', 'b407a3d1480c11667f293bfb1f17d1a4')
     version('4.5.4', '27e459c2566b8209ab064570e1b378f7')
 
-    variant('binutils',
-            default=sys.platform != 'darwin',
-            description="Build via binutils")
-    variant('gold',
-            default=sys.platform != 'darwin',
-            description="Build the gold linker plugin for ld-based LTO")
     variant('piclibs',
             default=False,
             description="Build PIC versions of libgfortran.a and libstdc++.a")
@@ -45,8 +39,6 @@ class Gcc(Package):
     depends_on("gmp")
     depends_on("mpc", when='@4.5:')
     depends_on("isl", when='@5.0:')
-    depends_on("binutils~libiberty", when='+binutils ~gold')
-    depends_on("binutils~libiberty+gold", when='+binutils +gold')
 
     # TODO: integrate these libraries.
     # depends_on("ppl")
@@ -91,19 +83,7 @@ class Gcc(Package):
                    "--with-mpc=%s" % spec['mpc'].prefix, "--with-mpfr=%s" %
                    spec['mpfr'].prefix, "--with-gmp=%s" % spec['gmp'].prefix,
                    "--enable-lto", "--with-quad"]
-        # Binutils
-        if spec.satisfies('+binutils'):
-            static_bootstrap_flags = "-static-libstdc++ -static-libgcc"
-            binutils_options = [
-                "--with-sysroot=/", "--with-stage1-ldflags=%s %s" %
-                (self.rpath_args, static_bootstrap_flags),
-                "--with-boot-ldflags=%s %s" %
-                (self.rpath_args, static_bootstrap_flags), "--with-gnu-ld",
-                "--with-ld=%s/bin/ld" % spec['binutils'].prefix,
-                "--with-gnu-as",
-                "--with-as=%s/bin/as" % spec['binutils'].prefix
-            ]
-            options.extend(binutils_options)
+
         # Isl
         if 'isl' in spec:
             isl_options = ["--with-isl=%s" % spec['isl'].prefix]

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -58,7 +58,7 @@ class Gcc(AutotoolsPackage):
 
     depends_on('gmp@4.3.2:')
     depends_on('mpfr@2.4.2:')
-    depends_on('mpc@0.8.1', when='@4.5:')
+    depends_on('mpc@0.8.1:', when='@4.5:')
     depends_on('isl@0.14:0.16', when='@5.0:')
 
     # TODO: Integrate these libraries. They are needed for GCC 4.7 and earlier.


### PR DESCRIPTION
The main goal of this PR is to remove the `binutils` dependency from the GCC package. Every time I've ever built `gcc+binutils` (the default on Linux) it has crashed. Other users have reported the same thing.

From what I understand, binutils was added as a dependency because someone tried building GCC on a system with an ancient version of binutils. This problem is already documented in Spack's [Getting Started](http://spack.readthedocs.io/en/latest/getting_started.html#binutils) section. According to the documentation, `binutils` shouldn't be added as a dependency, mainly because every package containing C/C++/Fortran code _technically_ depends on `binutils`, but we don't want to add it to every package. Instead, users who run into this problem should build a newer version of binutils and add it to their environment manually. It's more of a Spack dependency than a GCC dependency.

Aside from binutils, this PR also updates GCC to use the new `AutotoolsPackage` base class and removes old hacks that are no longer needed. I marked this WIP because it should probably be tested on a few different OSes (mainly macOS) before it is merged.