### PR TITLE
Add proper distribution detection for Arch and Amazon Linux

### DIFF
--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -13,8 +13,8 @@ class LinuxDistro(OperatingSystem):
 
     def __init__(self):
         distname, version, _ = py_platform.linux_distribution(
-            # Add support for Arch Linux
-            supported_dists=py_platform._supported_dists + ('arch',),
+            # Add support for Arch and Amazon Linux
+            supported_dists=py_platform._supported_dists + ('arch', 'system'),
             full_distribution_name=False)
 
         # Grabs major version from tuple on redhat; on other platforms

--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -13,6 +13,8 @@ class LinuxDistro(OperatingSystem):
 
     def __init__(self):
         distname, version, _ = py_platform.linux_distribution(
+            # Add support for Arch Linux
+            supported_dists=py_platform._supported_dists + ('arch',),
             full_distribution_name=False)
 
         # Grabs major version from tuple on redhat; on other platforms


### PR DESCRIPTION
Fixes #2155, fixes #2156

Python 2 doesn't properly detect Arch Linux. This has been fixed in Python 3.3+, but was never backported to Python 2. This PR hopefully fixes that. See the following posts for details:

@krafczyk Can you test this out?
