### PR TITLE
Update and Clean Up the Visit and VTK Packages

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -77,11 +77,18 @@ class Vtk(Package):
                 # Enable Qt support here.
                 '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
                 '-DQT_QMAKE_EXECUTABLE:PATH={0}/qmake'.format(qt_bin),
-                # Ignore webkit because it's hard to build w/Qt
-                '-DVTK_Group_Qt:BOOL=OFF',
-                '-DModule_vtkGUISupportQt:BOOL=ON',
-                '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
+                '-DVTK_Group_Qt:BOOL=ON',
             ])
+
+            # NOTE: The following definitions are required in order to allow
+            # VTK to build with qt~webkit versions (see the documentation for
+            # more info: http://www.vtk.org/Wiki/VTK/Tutorials/QtSetup).
+            if '~webkit' in spec['qt']:
+                cmake_args.extend([
+                    '-DVTK_Group_Qt:BOOL=OFF',
+                    '-DModule_vtkGUISupportQt:BOOL=ON',
+                    '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
+                ])
 
             if spec.satisfies('@:6.1.0'):
                 cmake_args.append('-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY')

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 from spack import *
 
 
@@ -29,66 +30,63 @@ class Vtk(Package):
     """The Visualization Toolkit (VTK) is an open-source, freely
     available software system for 3D computer graphics, image
     processing and visualization. """
+
     homepage = "http://www.vtk.org"
-    url      = "http://www.vtk.org/files/release/6.1/VTK-6.1.0.tar.gz"
+    base_url = "http://www.vtk.org/files/release"
 
-    version("7.0.0", "5fe35312db5fb2341139b8e4955c367d",
-            url="http://www.vtk.org/files/release/7.0/VTK-7.0.0.tar.gz")
-
-    version("6.3.0", '0231ca4840408e9dd60af48b314c5b6d',
-            url="http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz")
-
+    version('7.0.0', '5fe35312db5fb2341139b8e4955c367d')
+    version('6.3.0', '0231ca4840408e9dd60af48b314c5b6d')
     version('6.1.0', '25e4dfb3bad778722dcaec80cd5dab7d')
 
-    patch("gcc.patch")
+    # VTK7 defaults to OpenGL2 rendering backend
+    variant('opengl2', default=True, description='Build with OpenGL2 instead of OpenGL as rendering backend')
+    variant('python', default=False, description='Build the python modules')
+
+    patch('gcc.patch')
+
+    depends_on('cmake', type='build')
+    depends_on('qt')
 
     extends('python', when='+python')
     depends_on('python', when='+python')
-    depends_on('cmake', type='build')
-    depends_on("qt")
 
-    # VTK7 defaults to OpenGL2 rendering backend
-    variant('opengl2', default=True,
-            description='Build with OpenGL instead of OpenGL2 backend')
-    variant('python', default=False,
-            description='Build the python modules')
+    def url_for_version(self, ver):
+        return '{0}/{1}/VTK-{2}.tar.gz'.format(Vtk.base_url, ver.up_to(2), ver)
 
     def install(self, spec, prefix):
         def feature_to_bool(feature, on='ON', off='OFF'):
-            if feature in spec:
-                return on
-            return off
+            return on if '+{0}'.format(feature) in spec else off
 
         with working_dir('spack-build', create=True):
-            cmake_args = [
-                "..",
-                "-DBUILD_SHARED_LIBS=ON",
-                "-DVTK_WRAP_PYTHON=" + ("ON" if "+python" in spec else "OFF"),
-                # Disable wrappers for other languages.
-                "-DVTK_WRAP_JAVA=OFF",
-                "-DVTK_WRAP_TCL=OFF"]
-            cmake_args.extend(std_cmake_args)
+            opengl_ver = 'OpenGL{0}'.format('2' if '+opengl2' in spec else '')
+            qt_ver = spec['qt'].version.up_to(1)
+            qt_bin = spec['qt'].prefix.bin
 
-            # Enable Qt support here.
+            cmake_args = std_cmake_args[:]
             cmake_args.extend([
-                "-DQT_QMAKE_EXECUTABLE:PATH=%s/qmake" % spec['qt'].prefix.bin,
-                "-DVTK_Group_Qt:BOOL=ON",
+                '-DBUILD_SHARED_LIBS=ON',
+                '-DVTK_RENDERING_BACKEND:STRING={0}'.format(opengl_ver),
+
+                # Enable/Disable wrappers for Python.
+                '-DVTK_WRAP_PYTHON={0}'.format(feature_to_bool('python')),
+
+                # Disable wrappers for other languages.
+                '-DVTK_WRAP_JAVA=OFF',
+                '-DVTK_WRAP_TCL=OFF',
+
+                # Enable Qt support here.
+                '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
+                '-DQT_QMAKE_EXECUTABLE:PATH={0}/qmake'.format(qt_bin),
                 # Ignore webkit because it's hard to build w/Qt
-                "-DVTK_Group_Qt=OFF",
-                "-DModule_vtkGUISupportQt:BOOL=ON",
-                "-DModule_vtkGUISupportQtOpenGL:BOOL=ON"
+                '-DVTK_Group_Qt:BOOL=OFF',
+                '-DModule_vtkGUISupportQt:BOOL=ON',
+                '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
             ])
 
-            if spec['qt'].satisfies('@5'):
-                cmake_args.append("-DVTK_QT_VERSION:STRING=5")
+            if spec.satisfies('@:6.1.0'):
+                cmake_args.append('-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY')
+                cmake_args.append('-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY')
 
-            if spec.satisfies("@6.1.0"):
-                cmake_args.append("-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY")
-                cmake_args.append("-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY")
-
-            cmake_args.append('-DVTK_RENDERING_BACKEND:STRING=%s' %
-                              feature_to_bool('+opengl2', 'OpenGL2', 'OpenGL'))
-
-            cmake(*cmake_args)
+            cmake('..', *cmake_args)
             make()
-            make("install")
+            make('install')


### PR DESCRIPTION
The changes in this pull request make the following improvements to the `visit` and `vtk` packages:

- Link `visit` explicitly with the Spack-installed `vtk` during installation.
- Add `qt+/~webkit` handling support to the `vtk` package.
- Add a general `url_for_version` method to the `vtk` package.
- Update all string replacement operations to use `format` instead of `%`.
- Remove a couple of weird line indentation issues introduced during the style update (see #1496).

I've verified that the `visit@2.10.3` and `vtk@6.1.0~opengl2 ^qt@4.8.6+/~webkit` variants of these packages compile and install properly on CHAOS when compiling with `gcc@4.7.2`.  Please let me know if there are any problems with these updates and I'll fix them as soon as I can!