### PR TITLE
Do not check directory layout for external packages

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -468,7 +468,7 @@ class Database(object):
         if key not in self._data:
             installed = False
             path = None
-            if directory_layout:
+            if not spec.external and directory_layout:
                 path = directory_layout.path_for_spec(spec)
                 try:
                     directory_layout.check_installed(spec)


### PR DESCRIPTION
External packages do not have an spec.yaml file so don't check for it.
Without this change any time a package depends on an external package
when the new package is installed you will get the error

Install prefix exists but contains no spec.yaml

This problem has also haunted me since I started using Spack since PETSc
depends on Python and I used an external python but fortunately it
was relatively easy to debug once I could reproduce it at will.

Funded-by: IDEAS
Project: IDEAS/xSDK
Time: 1 hour