### PR TITLE
Import dso_suffix from spack.build_environment in abi.py

### DIFF
--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -26,6 +26,7 @@
 import os
 import spack
 import spack.spec
+from spack.build_environment import dso_suffix
 from spack.spec import CompilerSpec
 from spack.util.executable import Executable, ProcessError
 from llnl.util.lang import memoized


### PR DESCRIPTION
Fixes #1845

This issue happens because dso_suffix is used but not imported in abi.py.