### PR TITLE
Use JSON for the database instead of YAML.

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -41,14 +41,6 @@ SPACK_PREFIX = os.path.dirname(os.path.dirname(SPACK_FILE))
 SPACK_LIB_PATH = os.path.join(SPACK_PREFIX, "lib", "spack")
 sys.path.insert(0, SPACK_LIB_PATH)
 
-# Try to use system YAML if it is available, as it might have libyaml
-# support (for faster loading via C).  Load it before anything in
-# lib/spack/external so it will take precedence over Spack's PyYAML.
-try:
-    import yaml
-except ImportError:
-    pass   # ignore and use slow yaml
-
 # Add external libs
 SPACK_EXTERNAL_LIBS = os.path.join(SPACK_LIB_PATH, "external")
 sys.path.insert(0, SPACK_EXTERNAL_LIBS)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -449,15 +449,24 @@ class Database(object):
     def _read(self):
         """Re-read Database from the data in the set location.
 
-        This does no locking.
+        This does no locking, with one exception: it will automatically
+        migrate an index.yaml to an index.json if possible. This requires
+        taking a write lock.
+
         """
         if os.path.isfile(self._index_path):
             # Read from JSON file if a JSON database exists
             self._read_from_file(self._index_path, format='json')
 
         elif os.path.isfile(self._old_yaml_index_path):
-            # Read chck for a YAML file if we can't find JSON.
-            self._read_from_file(self._old_yaml_index_path, format='yaml')
+            if os.access(self._db_dir, os.R_OK | os.W_OK):
+                # if we can write, then read AND write a JSON file.
+                self._read_from_file(self._old_yaml_index_path, format='yaml')
+                with WriteTransaction(self.lock, timeout=_db_lock_timeout):
+                    self._write(None, None, None)
+            else:
+                # Read chck for a YAML file if we can't find JSON.
+                self._read_from_file(self._old_yaml_index_path, format='yaml')
 
         else:
             # The file doesn't exist, try to traverse the directory.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -55,6 +55,7 @@ from spack.version import Version
 import spack.spec
 from spack.error import SpackError
 import spack.util.spack_yaml as syaml
+import spack.util.spack_json as sjson
 
 
 # DB goes in this directory underneath the root
@@ -134,10 +135,12 @@ class Database(object):
         under ``root/.spack-db``, which is created if it does not
         exist.  This is the ``db_dir``.
 
-        The Database will attempt to read an ``index.yaml`` file in
-        ``db_dir``.  If it does not find one, it will be created when
-        needed by scanning the entire Database root for ``spec.yaml``
-        files according to Spack's ``DirectoryLayout``.
+        The Database will attempt to read an ``index.json`` file in
+        ``db_dir``.  If it does not find one, it will fall back to read
+        an ``index.yaml`` if one is present.  If that does not exist, it
+        will create a database when needed by scanning the entire
+        Database root for ``spec.yaml`` files according to Spack's
+        ``DirectoryLayout``.
 
         Caller may optionally provide a custom ``db_dir`` parameter
         where data will be stored.  This is intended to be used for
@@ -154,7 +157,8 @@ class Database(object):
             self._db_dir = db_dir
 
         # Set up layout of database files within the db dir
-        self._index_path = join_path(self._db_dir, 'index.yaml')
+        self._old_yaml_index_path = join_path(self._db_dir, 'index.yaml')
+        self._index_path = join_path(self._db_dir, 'index.json')
         self._lock_path = join_path(self._db_dir, 'lock')
 
         # This is for other classes to use to lock prefix directories.
@@ -179,8 +183,8 @@ class Database(object):
         """Get a read lock context manager for use in a `with` block."""
         return ReadTransaction(self.lock, self._read, timeout=timeout)
 
-    def _write_to_yaml(self, stream):
-        """Write out the databsae to a YAML file.
+    def _write_to_file(self, stream):
+        """Write out the databsae to a JSON file.
 
         This function does not do any locking or transactions.
         """
@@ -201,12 +205,12 @@ class Database(object):
         }
 
         try:
-            return syaml.dump(
-                database, stream=stream, default_flow_style=False)
+            sjson.dump(database, stream)
         except YAMLError as e:
-            raise SpackYAMLError("error writing YAML database:", str(e))
+            raise syaml.SpackYAMLError(
+                "error writing YAML database:", str(e))
 
-    def _read_spec_from_yaml(self, hash_key, installs):
+    def _read_spec_from_dict(self, hash_key, installs):
         """Recursively construct a spec from a hash in a YAML database.
 
         Does not do any locking.
@@ -241,24 +245,32 @@ class Database(object):
                 child = data[dhash].spec
                 spec._add_dependency(child, dtypes)
 
-    def _read_from_yaml(self, stream):
+    def _read_from_file(self, stream, format='json'):
         """
-        Fill database from YAML, do not maintain old data
+        Fill database from file, do not maintain old data
         Translate the spec portions from node-dict form to spec form
 
         Does not do any locking.
         """
+        if format.lower() == 'json':
+            load = sjson.load
+        elif format.lower() == 'yaml':
+            load = syaml.load
+        else:
+            raise ValueError("Invalid database format: %s" % format)
+
         try:
             if isinstance(stream, basestring):
                 with open(stream, 'r') as f:
-                    yfile = syaml.load(f)
+                    fdata = load(f)
             else:
-                yfile = syaml.load(stream)
-
+                fdata = load(stream)
         except MarkedYAMLError as e:
-            raise SpackYAMLError("error parsing YAML database:", str(e))
+            raise syaml.SpackYAMLError("error parsing YAML database:", str(e))
+        except Exception as e:
+            raise CorruptDatabaseError("error parsing database:", str(e))
 
-        if yfile is None:
+        if fdata is None:
             return
 
         def check(cond, msg):
@@ -266,10 +278,10 @@ class Database(object):
                 raise CorruptDatabaseError(
                     "Spack database is corrupt: %s" % msg, self._index_path)
 
-        check('database' in yfile, "No 'database' attribute in YAML.")
+        check('database' in fdata, "No 'database' attribute in YAML.")
 
         # High-level file checks
-        db = yfile['database']
+        db = fdata['database']
         check('installs' in db, "No 'installs' in YAML DB.")
         check('version' in db, "No 'version' in YAML DB.")
 
@@ -303,7 +315,7 @@ class Database(object):
         for hash_key, rec in installs.items():
             try:
                 # This constructs a spec DAG from the list of all installs
-                spec = self._read_spec_from_yaml(hash_key, installs)
+                spec = self._read_spec_from_dict(hash_key, installs)
 
                 # Insert the brand new spec in the database.  Each
                 # spec has its own copies of its dependency specs.
@@ -342,7 +354,7 @@ class Database(object):
         def _read_suppress_error():
             try:
                 if os.path.isfile(self._index_path):
-                    self._read_from_yaml(self._index_path)
+                    self._read_from_file(self._index_path)
             except CorruptDatabaseError as e:
                 self._error = e
                 self._data = {}
@@ -426,7 +438,7 @@ class Database(object):
         # Write a temporary database file them move it into place
         try:
             with open(temp_file, 'w') as f:
-                self._write_to_yaml(f)
+                self._write_to_file(f)
             os.rename(temp_file, self._index_path)
         except:
             # Clean up temp file if something goes wrong.
@@ -440,8 +452,12 @@ class Database(object):
         This does no locking.
         """
         if os.path.isfile(self._index_path):
-            # Read from YAML file if a database exists
-            self._read_from_yaml(self._index_path)
+            # Read from JSON file if a JSON database exists
+            self._read_from_file(self._index_path, format='json')
+
+        elif os.path.isfile(self._old_yaml_index_path):
+            # Read chck for a YAML file if we can't find JSON.
+            self._read_from_file(self._old_yaml_index_path, format='yaml')
 
         else:
             # The file doesn't exist, try to traverse the directory.

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -75,7 +75,7 @@ class DatabaseTest(MockDatabase):
 
     def test_005_db_exists(self):
         """Make sure db cache file exists after creating."""
-        index_file = join_path(self.install_path, '.spack-db', 'index.yaml')
+        index_file = join_path(self.install_path, '.spack-db', 'index.json')
         lock_file = join_path(self.install_path, '.spack-db', 'lock')
 
         self.assertTrue(os.path.exists(index_file))

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -496,34 +496,6 @@ class SpecDagTest(MockPackagesTest):
         traversal = dag.traverse(deptype='run')
         self.assertEqual([x.name for x in traversal], names)
 
-    def test_using_ordered_dict(self):
-        """ Checks that dicts are ordered
-
-            Necessary to make sure that dag_hash is stable across python
-            versions and processes.
-        """
-        def descend_and_check(iterable, level=0):
-            from spack.util.spack_yaml import syaml_dict
-            from collections import Iterable, Mapping
-            if isinstance(iterable, Mapping):
-                self.assertTrue(isinstance(iterable, syaml_dict))
-                return descend_and_check(iterable.values(), level=level + 1)
-            max_level = level
-            for value in iterable:
-                if isinstance(value, Iterable) and not isinstance(value, str):
-                    nlevel = descend_and_check(value, level=level + 1)
-                    if nlevel > max_level:
-                        max_level = nlevel
-            return max_level
-
-        specs = ['mpileaks ^zmpi', 'dttop', 'dtuse']
-        for spec in specs:
-            dag = Spec(spec)
-            dag.normalize()
-            level = descend_and_check(dag.to_node_dict())
-            # level just makes sure we are doing something here
-            self.assertTrue(level >= 5)
-
     def test_hash_bits(self):
         """Ensure getting first n bits of a base32-encoded DAG hash works."""
 

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -27,6 +27,10 @@
 YAML format preserves DAG informatoin in the spec.
 
 """
+import spack.util.spack_yaml as syaml
+import spack.util.spack_json as sjson
+from spack.util.spack_yaml import syaml_dict
+
 from spack.spec import Spec
 from spack.test.mock_packages_test import *
 
@@ -64,3 +68,123 @@ class SpecYamlTest(MockPackagesTest):
 
         for dep in ('callpath', 'mpich', 'dyninst', 'libdwarf', 'libelf'):
             self.assertTrue(spec[dep].eq_dag(yaml_spec[dep]))
+
+    def test_using_ordered_dict(self):
+        """ Checks that dicts are ordered
+
+            Necessary to make sure that dag_hash is stable across python
+            versions and processes.
+        """
+        def descend_and_check(iterable, level=0):
+            from spack.util.spack_yaml import syaml_dict
+            from collections import Iterable, Mapping
+            if isinstance(iterable, Mapping):
+                self.assertTrue(isinstance(iterable, syaml_dict))
+                return descend_and_check(iterable.values(), level=level + 1)
+            max_level = level
+            for value in iterable:
+                if isinstance(value, Iterable) and not isinstance(value, str):
+                    nlevel = descend_and_check(value, level=level + 1)
+                    if nlevel > max_level:
+                        max_level = nlevel
+            return max_level
+
+        specs = ['mpileaks ^zmpi', 'dttop', 'dtuse']
+        for spec in specs:
+            dag = Spec(spec)
+            dag.normalize()
+            level = descend_and_check(dag.to_node_dict())
+            # level just makes sure we are doing something here
+            self.assertTrue(level >= 5)
+
+    def test_ordered_read_not_required_for_consistent_dag_hash(self):
+        """Make sure ordered serialization isn't required to preserve hashes.
+
+        For consistent hashes, we require that YAML and json documents
+        have their keys serialized in a deterministic order. However, we
+        don't want to require them to be serialized in order. This
+        ensures that is not reauired.
+
+        """
+        specs = ['mpileaks ^zmpi', 'dttop', 'dtuse']
+        for spec in specs:
+            spec = Spec(spec)
+            spec.concretize()
+
+            #
+            # Dict & corresponding YAML & JSON from the original spec.
+            #
+            spec_dict = spec.to_dict()
+            spec_yaml = spec.to_yaml()
+            spec_json = spec.to_json()
+
+            #
+            # Make a spec with reversed OrderedDicts for every
+            # OrderedDict in the original.
+            #
+            reversed_spec_dict = reverse_all_dicts(spec.to_dict())
+
+            #
+            # Dump to YAML and JSON
+            #
+            yaml_string = syaml.dump(spec_dict, default_flow_style=False)
+            reversed_yaml_string = syaml.dump(reversed_spec_dict,
+                                              default_flow_style=False)
+            json_string = sjson.dump(spec_dict)
+            reversed_json_string = sjson.dump(reversed_spec_dict)
+
+            #
+            # Do many consistency checks
+            #
+
+            # spec yaml is ordered like the spec dict
+            self.assertEqual(yaml_string, spec_yaml)
+            self.assertEqual(json_string, spec_json)
+
+            # reversed string is different from the original, so it
+            # *would* generate a different hash
+            self.assertNotEqual(yaml_string, reversed_yaml_string)
+            self.assertNotEqual(json_string, reversed_json_string)
+
+            # build specs from the "wrongly" ordered data
+            round_trip_yaml_spec = Spec.from_yaml(yaml_string)
+            round_trip_json_spec = Spec.from_json(json_string)
+            round_trip_reversed_yaml_spec = Spec.from_yaml(
+                reversed_yaml_string)
+            round_trip_reversed_json_spec = Spec.from_yaml(
+                reversed_json_string)
+
+            # TODO: remove this when build deps are in provenance.
+            spec = spec.copy(deps=('link', 'run'))
+
+            # specs are equal to the original
+            self.assertEqual(spec, round_trip_yaml_spec)
+            self.assertEqual(spec, round_trip_json_spec)
+            self.assertEqual(spec, round_trip_reversed_yaml_spec)
+            self.assertEqual(spec, round_trip_reversed_json_spec)
+            self.assertEqual(round_trip_yaml_spec,
+                             round_trip_reversed_yaml_spec)
+            self.assertEqual(round_trip_json_spec,
+                             round_trip_reversed_json_spec)
+
+            # dag_hashes are equal
+            self.assertEqual(
+                spec.dag_hash(), round_trip_yaml_spec.dag_hash())
+            self.assertEqual(
+                spec.dag_hash(), round_trip_json_spec.dag_hash())
+            self.assertEqual(
+                spec.dag_hash(), round_trip_reversed_yaml_spec.dag_hash())
+            self.assertEqual(
+                spec.dag_hash(), round_trip_reversed_json_spec.dag_hash())
+
+
+def reverse_all_dicts(data):
+    """Descend into data and reverse all the dictionaries"""
+    if isinstance(data, dict):
+        return syaml_dict(reversed(
+            [(reverse_all_dicts(k), reverse_all_dicts(v))
+             for k, v in data.items()]))
+    elif isinstance(data, (list, tuple)):
+        return type(data)(reverse_all_dicts(elt) for elt in data)
+    else:
+        return data

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""Simple wrapper around JSON to guarantee consistent use of load/dump. """
+import json
+import spack.error
+
+__all__ = ['load', 'dump', 'SpackJSONError']
+
+_json_dump_args = {
+    'indent': True,
+    'separators': (',', ': ')
+}
+
+
+def load(stream):
+    """Spack JSON needs to be ordered to support specs."""
+    if isinstance(stream, basestring):
+        return json.loads(stream)
+    else:
+        return json.load(stream)
+
+
+def dump(data, stream=None):
+    """Dump JSON with a reasonable amount of indentation and separation."""
+    if stream is None:
+        return json.dumps(data, **_json_dump_args)
+    else:
+        return json.dump(data, stream, **_json_dump_args)
+
+
+class SpackJSONError(spack.error.SpackError):
+    """Raised when there are issues with JSON parsing."""
+    def __init__(self, msg, yaml_error):
+        super(SpackJSONError, self).__init__(msg, str(yaml_error))

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -32,23 +32,21 @@
 
 """
 import yaml
-try:
-    from yaml import CLoader as Loader, CDumper as Dumper
-except ImportError as e:
-    from yaml import Loader, Dumper
+from yaml import Loader, Dumper
 from yaml.nodes import *
 from yaml.constructor import ConstructorError
 from ordereddict_backport import OrderedDict
 
+import spack.error
+
 # Only export load and dump
-__all__ = ['load', 'dump']
+__all__ = ['load', 'dump', 'SpackYAMLError']
 
 # Make new classes so we can add custom attributes.
 # Also, use OrderedDict instead of just dict.
 
 
 class syaml_dict(OrderedDict):
-
     def __repr__(self):
         mappings = ('%r: %r' % (k, v) for k, v in self.items())
         return '{%s}' % ', '.join(mappings)
@@ -223,3 +221,9 @@ def load(*args, **kwargs):
 def dump(*args, **kwargs):
     kwargs['Dumper'] = OrderedLineDumper
     return yaml.dump(*args, **kwargs)
+
+
+class SpackYAMLError(spack.error.SpackError):
+    """Raised when there are issues with YAML parsing."""
+    def __init__(self, msg, yaml_error):
+        super(SpackYAMLError, self).__init__(msg, str(yaml_error))

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -151,6 +151,7 @@ class OrderedLineLoader(Loader):
         mark(mapping, node)
         return mapping
 
+
 # register above new constructors
 OrderedLineLoader.add_constructor(
     u'tag:yaml.org,2002:map', OrderedLineLoader.construct_yaml_map)


### PR DESCRIPTION
Fixes #2027.

Ok, so #2010 was a nice speed boost but it doesn't work for everyone and only takes advantage of C YAML if you've got it installed.  Also, it seems to cause issues on BG/Q (see @pramodk's #2027).  So for reliability it seems like we *don't* really want to fall back on CYAML.  

However, YAML is just a more human-readable JSON, and JSON is built into Python.  They have the same object model (we even already use `jsonschema` to validate YAML config files).

So I tried it out and compared JSON and YAML speeds for reading the Spack DB (the is the main bottleneck for `spack find`).  Here is what I got:

- JSON is much faster than YAML 
  - **~180x** faster than Python YAML (on my mac)
  - **~25x** faster than C YAML on my mac.
- Don't need human readability for the package database.
- JSON requires no major changes to the code -- same object model as YAML.

So it seems like using JSON for the database and other index files is the way to go.  JSON is built into Python, unlike C YAML, so doesn't add a dependency, and it's faster than the C libyaml.

If you wan to try this out, [here is a gist](https://gist.github.com/tgamblin/93ba38c3dbe099e7c979e71d75b49f11) -- set `test_file` to the path to `opt/spack/.spack-db/index.yaml` (or wherever your install root is now that #2152 is in) and it'll print out the speedup of reading your install database with JSON and YAML using `timeit`. I didn't compare with pickle, but [people say JSON is faster than that](https://konstantin.blog/2010/pickle-vs-json-which-is-faster/), too.

You can also just try this PR out by merging it, then typing `spack reindex`, and it'll build you a `json` database.  `spack find` should run faster after that.  As written the PR will read an old `index.yaml` if it is present, but it will not write it again (once an index.json database is written it won't go back to YAML).

@pramodk @adamjstewart @alalazo @davydden @eschnett @lee218llnl: let me know how this does with your installations if you get a chance.  I'd be curious to now how fast `spack find` is with and without it.

Comments welcome.