### PR TITLE
Bugfix in concretize_compiler

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -386,9 +386,12 @@ class DefaultConcretizer(object):
 
         # copy concrete version into other_compiler
         try:
-            spec.compiler = next(c for c in matches if _proper_compiler_style(c, spec.architecture)).copy()
+            spec.compiler = next(
+                c for c in matches
+                if _proper_compiler_style(c, spec.architecture)).copy()
         except StopIteration:
-            raise UnavailableCompilerVersionError(spec.compiler, arch.platform_os)
+            raise UnavailableCompilerVersionError(spec.compiler,
+                                                  arch.platform_os)
         assert(spec.compiler.concrete)
         return True  # things changed.
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -388,7 +388,7 @@ class DefaultConcretizer(object):
         index = 0
         while not _proper_compiler_style(matches[index], spec.architecture):
             index += 1
-            if index == len(matches) - 1:
+            if index == len(matches):
                 arch = spec.architecture
                 raise UnavailableCompilerVersionError(spec.compiler,
                                                       arch.platform_os)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -385,14 +385,10 @@ class DefaultConcretizer(object):
                                                   arch.platform_os)
 
         # copy concrete version into other_compiler
-        index = 0
-        while not _proper_compiler_style(matches[index], spec.architecture):
-            index += 1
-            if index == len(matches):
-                arch = spec.architecture
-                raise UnavailableCompilerVersionError(spec.compiler,
-                                                      arch.platform_os)
-        spec.compiler = matches[index].copy()
+        try:
+            spec.compiler = next(c for c in matches if _proper_compiler_style(c, spec.architecture)).copy()
+        except StopIteration:
+            raise UnavailableCompilerVersionError(spec.compiler, arch.platform_os)
         assert(spec.compiler.concrete)
         return True  # things changed.
 


### PR DESCRIPTION
The loop at `lib/spack/spack/concretize.py:389` was not checking all of the elements in the list.