### PR TITLE
Make X11 font install dir the font search default

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -28,14 +28,20 @@ from spack import *
 class Fontconfig(AutotoolsPackage):
     """Fontconfig customizing font access"""
     homepage = "http://www.freedesktop.org/wiki/Software/fontconfig/"
-    url      = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
+    url = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
 
     version('2.11.1', 'e75e303b4f7756c2b16203a57ac87eba')
 
     depends_on('freetype')
     depends_on('libxml2')
     depends_on('pkg-config', type='build')
+    depends_on('font-util', type='build')
 
     def configure_args(self):
-        args = ["--enable-libxml2", "--disable-docs"]
+        args = ["--prefix=%s" % prefix,
+                "--enable-libxml2",
+                "--disable-docs",
+                "--with-default-fonts=%s" %
+                spec['font-util'].prefix + "/share/fonts",
+        ]
         return args

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Fontconfig(AutotoolsPackage):
     """Fontconfig is a library for configuring/customizing font access"""
     homepage = "http://www.freedesktop.org/wiki/Software/fontconfig/"
-    url = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
+    url      = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
 
     version('2.11.1', 'e75e303b4f7756c2b16203a57ac87eba')
 
@@ -42,6 +42,5 @@ class Fontconfig(AutotoolsPackage):
                 "--enable-libxml2",
                 "--disable-docs",
                 "--with-default-fonts=%s" %
-                spec['font-util'].prefix + "/share/fonts",
-        ]
+                spec['font-util'].prefix + "/share/fonts"]
         return args

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class Fontconfig(AutotoolsPackage):
-    """Fontconfig customizing font access"""
+    """Fontconfig is a library for configuring/customizing font access"""
     homepage = "http://www.freedesktop.org/wiki/Software/fontconfig/"
     url = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
 


### PR DESCRIPTION
We install the X11 fonts into `.../share/fonts` beneath the font-util
installation prefix, but that directory is not one of the places that
the font subsystem searches.

This commit makes the fontconfig package depend on the font-util
package, and then it makes

```python
spec['font-util'].prefix + "/share/fonts"
```

be the fontconfig default font location.

Before this change, plots drawn by R have bounding boxes where font
glyphs should be.  After this change fonts appear as expected.