### PR TITLE
Update references in debug command

### DIFF
--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -74,16 +74,16 @@ def create_db_tarball(args):
     tarball_name = "spack-db.%s.tar.gz" % _debug_tarball_suffix()
     tarball_path = os.path.abspath(tarball_name)
 
-    base = os.path.basename(spack.install_path)
+    base = os.path.basename(spack.store.root)
     transform_args = []
     if 'GNU' in tar('--version', output=str):
         transform_args = ['--transform', 's/^%s/%s/' % (base, tarball_name)]
     else:
         transform_args = ['-s', '/^%s/%s/' % (base, tarball_name)]
 
-    wd = os.path.dirname(spack.install_path)
+    wd = os.path.dirname(spack.store.root)
     with working_dir(wd):
-        files = [spack.installed_db._index_path]
+        files = [spack.store.db._index_path]
         files += glob('%s/*/*/*/.spack/spec.yaml' % base)
         files = [os.path.relpath(f) for f in files]
 


### PR DESCRIPTION
As mentioned in #2123 the following command broke recently:

```
spack debug create-db-tarball
```

This fixes references to the spack root