### PR TITLE
Set TAU_MAKEFILE env variable

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -148,7 +148,6 @@ class Tau(Package):
                     os.symlink(join_path(subdir, d), dest)
 
     def setup_environment(self, spack_env, run_env):
-        pattern = '%s/Makefile.*' % self.prefix.lib
+        pattern = join_path(self.prefix.lib, 'Makefile.*')
         files = glob.glob(pattern)
-        makefile = files[0] if files else ''
-        run_env.set('TAU_MAKEFILE', makefile)
+        run_env.set('TAU_MAKEFILE', files[0])

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -24,7 +24,7 @@
 ##############################################################################
 from spack import *
 import os
-import os.path
+import glob
 from llnl.util.filesystem import join_path
 
 
@@ -146,3 +146,9 @@ class Tau(Package):
                 dest = join_path(self.prefix, d)
                 if os.path.isdir(src) and not os.path.exists(dest):
                     os.symlink(join_path(subdir, d), dest)
+
+    def setup_environment(self, spack_env, run_env):
+        pattern = '%s/Makefile.*' % self.prefix.lib
+        files = glob.glob(pattern)
+        makefile = files[0] if files else ''
+        run_env.set('TAU_MAKEFILE', makefile)


### PR DESCRIPTION
User always need to set `TAU_MAKEFILE ` env variable. As we are installing
only `single variant`, we can/should set  it in `setup_environment`.