### PR TITLE
Updated py-netcdf: added dependency on py-setuptools.

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf/package.py
@@ -35,6 +35,7 @@ class PyNetcdf(Package):
     extends('python')
     depends_on('py-numpy', type=nolink)
     depends_on('py-cython', type=nolink)
+    depends_on('py-setuptools', type=nolink)
     depends_on('netcdf')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
We need py-setuptools to be activated to use py-netcdf. Otherwise we get the following error when importing from the netCDF4 module:
`ImportError: No module named pkg_resources`