### PR TITLE
New texlive release, updating the digest to match

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -32,6 +32,8 @@ class Texlive(Package):
 
     homepage = "http://www.tug.org/texlive"
 
+    # pull from specific site because the texlive mirrors to not all
+    # update in synchrony.
     version('live', '6d171d370f3a2f2b936b9b0c87e8d0fe',
             url="http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz")
 

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -32,8 +32,8 @@ class Texlive(Package):
 
     homepage = "http://www.tug.org/texlive"
 
-    version('live', '8402774984c67fed4a18b7f6491243a6',
-            url="http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz")
+    version('live', '6d171d370f3a2f2b936b9b0c87e8d0fe',
+            url="http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz")
 
     # There does not seem to be a complete list of schemes.
     # Examples include:

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -32,7 +32,7 @@ class Texlive(Package):
 
     homepage = "http://www.tug.org/texlive"
 
-    # pull from specific site because the texlive mirrors to not all
+    # pull from specific site because the texlive mirrors do not all
     # update in synchrony.
     version('live', '6d171d370f3a2f2b936b9b0c87e8d0fe',
             url="http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz")


### PR DESCRIPTION
November 1 seems to have brought a new texlive release, updating the digest to match.

Also switching the url from their automagic mirror to an explicit
site to avoid inconsistencies during their updates.

It seems like only yesterday (#2073) that I updated this....