### PR TITLE
Set Clang as the default compiler on macOS

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -15,9 +15,4 @@
 # -------------------------------------------------------------------------
 packages:
   all:
-    compiler: [gcc, intel, pgi, clang, xl, nag]
-    providers:
-      mpi: [openmpi, mpich]
-      blas: [openblas]
-      lapack: [openblas]
-      pil: [py-pillow]
+    compiler: [clang, gcc, intel]

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -26,7 +26,6 @@
 system and configuring Spack to use multiple compilers.
 """
 import imp
-import platform
 
 from llnl.util.lang import list_modules
 from llnl.util.filesystem import join_path

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -44,12 +44,6 @@ _path_instance_vars = ['cc', 'cxx', 'f77', 'fc']
 _other_instance_vars = ['modules', 'operating_system']
 _cache_config_file = []
 
-# TODO: customize order in config file
-if platform.system() == 'Darwin':
-    _default_order = ['clang', 'gcc', 'intel']
-else:
-    _default_order = ['gcc', 'intel', 'pgi', 'clang', 'xlc', 'nag']
-
 
 def _auto_compiler_spec(function):
     def converter(cspec_like, *args, **kwargs):
@@ -167,18 +161,6 @@ def all_compilers(scope=None, init_config=True):
     # Return compiler specs from the merged config.
     return [spack.spec.CompilerSpec(s['compiler']['spec'])
             for s in all_compilers_config(scope, init_config)]
-
-
-def default_compiler():
-    versions = []
-    for name in _default_order:
-        versions = find(name)
-        if versions:
-            break
-    else:
-        raise NoCompilersError()
-
-    return sorted(versions)[-1]
 
 
 def find_compilers(*paths):

--- a/lib/spack/spack/preferred_packages.py
+++ b/lib/spack/spack/preferred_packages.py
@@ -28,9 +28,6 @@ from spack.version import *
 
 
 class PreferredPackages(object):
-    # Arbitrary, but consistent
-    _default_order = {'compiler': ['gcc', 'intel', 'clang', 'pgi', 'xlc']}
-
     def __init__(self):
         self.preferred = spack.config.get_config('packages')
         self._spec_for_pkgname_cache = {}
@@ -128,9 +125,6 @@ class PreferredPackages(object):
         key = (pkgname, component, second_key)
         if key not in self._spec_for_pkgname_cache:
             pkglist = self._order_for_package(pkgname, component, second_key)
-            if not pkglist:
-                if component in self._default_order:
-                    pkglist = self._default_order[component]
             if component == 'compiler':
                 self._spec_for_pkgname_cache[key] = \
                     [spack.spec.CompilerSpec(s) for s in pkglist]


### PR DESCRIPTION
The default compiler on macOS is GCC, even though I thought it was supposed to be set to Clang. Apparently, there are two places where the default compiler is set, neither of which is in the regular Spack configuration file hierarchy. This PR is an attempt to resolve that.

I blindly deleted a few things, but I'm not sure what relies on them, so don't expect this to pass any tests. `spack spec` shows that it now defaults to Clang on macOS, so it is working to some extent.