### PR TITLE
Better spack spec

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -89,3 +89,11 @@ _arguments['clean'] = Args(
 _arguments['dirty'] = Args(
     '--dirty', action='store_true', dest='dirty',
     help='Do NOT clean environment before installing.')
+
+_arguments['long'] = Args(
+    '-l', '--long', action='store_true',
+    help='Show dependency hashes as well as versions.')
+
+_arguments['very_long'] = Args(
+    '-L', '--very-long', action='store_true',
+    help='Show full dependency hashes as well as versions.')

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -52,14 +52,8 @@ def setup_parser(subparser):
         const='deps',
         help='Show full dependency DAG of installed packages')
 
-    subparser.add_argument('-l', '--long',
-                           action='store_true',
-                           dest='long',
-                           help='Show dependency hashes as well as versions.')
-    subparser.add_argument('-L', '--very-long',
-                           action='store_true',
-                           dest='very_long',
-                           help='Show dependency hashes as well as versions.')
+    arguments.add_common_arguments(subparser, ['long', 'very_long'])
+
     subparser.add_argument('-f', '--show-flags',
                            action='store_true',
                            dest='show_flags',

--- a/lib/spack/spack/test/spack_yaml.py
+++ b/lib/spack/spack/test/spack_yaml.py
@@ -90,3 +90,19 @@ class SpackYamlTest(unittest.TestCase):
         check(self.data['config_file']['some_list'][2],   8,  8)
         check(self.data['config_file']['another_list'],  10, 10)
         check(self.data['config_file']['some_key'],      11, 11)
+
+    def test_yaml_aliases(self):
+        aliased_list_1 = ['foo']
+        aliased_list_2 = []
+        dict_with_aliases = {
+            'a': aliased_list_1,
+            'b': aliased_list_1,
+            'c': aliased_list_1,
+            'd': aliased_list_2,
+            'e': aliased_list_2,
+            'f': aliased_list_2,
+        }
+        string = syaml.dump(dict_with_aliases)
+
+        # ensure no YAML aliases appear in syaml dumps.
+        self.assertFalse('*id' in string)

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -202,6 +202,11 @@ class OrderedLineDumper(Dumper):
                 node.flow_style = best_style
         return node
 
+    def ignore_aliases(self, _data):
+        """Make the dumper NEVER print YAML aliases."""
+        return True
+
+
 # Make our special objects look like normal YAML ones.
 OrderedLineDumper.add_representer(syaml_dict, OrderedLineDumper.represent_dict)
 OrderedLineDumper.add_representer(syaml_list, OrderedLineDumper.represent_list)


### PR DESCRIPTION
Fixes #2229.  Resolves #2224.

**Bugfix**
- [x] Gets rid of YAML aliases in `spec.yaml`

@citibeth @alalazo @adamjstewart can you verify?

`spack spec`:
- [x] `-I` option to show whether packages are installed, missing, or not yet installed.
- [x] `--cover` option to control tree traversal depth
- [x] `-l` and `-L` options to show short and long hashes like `spack find`
- [x] `--yaml` option to just print out the concrete `spec.yaml`

Here's the new `spack spec` output:
```console
$ spack spec -h
usage: spack spec [-h] [-l] [-L] [-y] [-c {nodes,edges,paths}] [-I] ...

positional arguments:
  specs                 specs of packages

optional arguments:
  -h, --help            show this help message and exit
  -l, --long            Show dependency hashes as well as versions.
  -L, --very-long       Show full dependency hashes as well as versions.
  -y, --yaml            Print concrete spec as YAML.
  -c {nodes,edges,paths}, --cover {nodes,edges,paths}
                        How extensively to traverse the DAG. (default: nodes).
  -I, --install-status  Show if deps are installed [+] or missing [-] from DB.
```

```console
$ spack spec -Il nettle
Input spec
--------------------------------
     tvbiazl  nettle

Normalized
--------------------------------
     h3wm75e  nettle
     pvwnyri      ^gmp
     zwmnoet          ^m4

Concretized
--------------------------------
     kdctsd6  nettle@3.2%gcc@5.3.0 arch=darwin-elcapitan-x86_64
[+]  hqdjcbh      ^gmp@6.1.1%gcc@5.3.0 arch=darwin-elcapitan-x86_64
[+]  ygxpr52          ^m4@1.4.17%gcc@5.3.0+sigsegv arch=darwin-elcapitan-x86_64
[+]  rapr3qu              ^libsigsegv@2.10%gcc@5.3.0 arch=darwin-elcapitan-x86_64
```