### PR TITLE
Update module documentation

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -544,7 +544,7 @@ most likely via the ``+blas`` variant specification.
 
        modules:
          tcl:
-           naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${COMPILERVERSION}'
+           naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${COMPILERVER}'
            all:
              conflict: ['${PACKAGE}', 'intel/14.0.1']
 


### PR DESCRIPTION
The naming scheme variable COMPILERVERSION does not exist, correct name ist COMPILERVER.