### PR TITLE
Spec.format updates to full-string property specification

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2311,7 +2311,7 @@ class Spec(object):
                 elif named_str == 'COMPILERNAME':
                     if self.compiler:
                         write(fmt % self.compiler.name, '%')
-                elif named_str == 'COMPILERVER':
+                elif named_str in ['COMPILERVER', 'COMPILERVERSION']:
                     if self.compiler:
                         write(fmt % self.compiler.versions, '%')
                 elif named_str == 'COMPILERFLAGS':

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2209,6 +2209,9 @@ class Spec(object):
                              ${SPACK_PREFIX}/opt
             ${PREFIX}        The package prefix
 
+        Note these are case-insensitive: for example you can specify either
+        ``${PACKAGE}`` or ``${package}``.
+
         Optionally you can provide a width, e.g. ``$20_`` for a 20-wide name.
         Like printf, you can provide '-' for left justification, e.g.
         ``$-20_`` for a left-justified name.
@@ -2299,6 +2302,7 @@ class Spec(object):
                                          "'%s'" % format_string)
                     named_str += c
                     continue
+                named_str = named_str.upper()
                 if named_str == 'PACKAGE':
                     name = self.name if self.name else ''
                     write(fmt % self.name, '@')


### PR DESCRIPTION
Address request in #2240 to support "COMPILERVERSION" in Spec.format

(as mentioned in #2240, the issue was already resolved by an existing PR, this just addresses a side request)

Originally only "COMPILERVER" was supported; this was the only truncated reference.

This supports both "COMPILERVER" and "COMPILERVERSION"