### PR TITLE
Further restrict versions of GCC patched

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -58,7 +58,7 @@ class Gcc(Package):
         provides('golang', when='@4.7.1:')
 
     patch('piclibs.patch', when='+piclibs')
-    patch('gcc-backport.patch', when='@4.7:5.3')
+    patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
 
     def install(self, spec, prefix):
         # libjava/configure needs a minor fix to install into spack paths.


### PR DESCRIPTION
Fixes #2258 

I didn't test this patch on every version of GCC because it takes forever to download each one and I'm on WiFi at the moment. It looks like they backported this patch into some branches of GCC. I wish Spack would just ignore the patch if it doesn't work or has already been applied.

If anyone wants to test out this patch on more versions, be my guest. I'll update the ranges accordingly.