### PR TITLE
Fixes to Handling Multiple Architectures

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -471,6 +471,20 @@ def arch_from_dict(d):
         os_name = d['platform_os']
         target_name = d['target']
 
+        # NOTE: The way that the following code handles constructing
+        # new architectures is the root cause of a number of bugs
+        # that crop up when attempting to use a single Spack instance
+        # to handle installs on multiple architectures.
+        #
+        # The main problem is that Spack constructs a new architecture
+        # using the current host architecture as a base.  In order to
+        # accurately recreate architecture objects for other platforms,
+        # all of the information about the other platform should be
+        # given to this function and that platform should be used as
+        # the base instead.  Facilitating this change will require
+        # updating the Spack package YAML to accomodate all of the
+        # information about the host platform.
+
         if platform_name:
             arch.platform = _platform_from_dict(platform_name)
         else:

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -243,7 +243,7 @@ class OperatingSystem(object):
         self.version = version
 
     def __str__(self):
-        return self.name + self.version
+        return "%s%s" % (self.name, self.version)
 
     def __repr__(self):
         return self.__str__()
@@ -441,7 +441,7 @@ def verify_platform(platform_name):
 
     if platform_name not in platform_names:
         tty.die("%s is not a supported platform; supported platforms are %s" %
-            (platform_name, platform_names))
+                (platform_name, platform_names))
 
 
 def arch_for_spec(arch_spec):
@@ -450,7 +450,7 @@ def arch_for_spec(arch_spec):
     assert(arch_spec.concrete)
 
     arch_plat = get_platform(arch_spec.platform)
-    if not (arch_plat.operating_system(arch_spec.platform_os) and \
+    if not (arch_plat.operating_system(arch_spec.platform_os) and
             arch_plat.target(arch_spec.target)):
         raise ValueError(
             "Can't recreate arch for spec %s on current arch %s; "

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -126,8 +126,7 @@ class Target(object):
 @key_ordering
 class Platform(object):
     """ Abstract class that each type of Platform will subclass.
-        Will return a instance of it once it
-        is returned
+        Will return a instance of it once it is returned.
     """
 
     priority        = None  # Subclass sets number. Controls detection order
@@ -139,6 +138,9 @@ class Platform(object):
     back_os         = None
     default_os      = None
 
+    reserved_targets = ['default_target', 'frontend', 'fe', 'backend', 'be']
+    reserved_oss = ['default_os', 'frontend', 'fe', 'backend', 'be']
+
     def __init__(self, name):
         self.targets = {}
         self.operating_sys = {}
@@ -149,7 +151,7 @@ class Platform(object):
         Raises an error if the platform specifies a name
         that is reserved by spack as an alias.
         """
-        if name in ['frontend', 'fe', 'backend', 'be', 'default_target']:
+        if name in Platform.reserved_targets:
             raise ValueError(
                 "%s is a spack reserved alias "
                 "and cannot be the name of a target" % name)
@@ -174,7 +176,7 @@ class Platform(object):
         """ Add the operating_system class object into the
             platform.operating_sys dictionary
         """
-        if name in ['frontend', 'fe', 'backend', 'be', 'default_os']:
+        if name in Platform.reserved_oss:
             raise ValueError(
                 "%s is a spack reserved alias "
                 "and cannot be the name of an OS" % name)
@@ -409,13 +411,17 @@ class Arch(object):
         return (platform, platform_os, target)
 
     def to_dict(self):
-        return syaml_dict((
-            ('platform',
-             str(self.platform) if self.platform else None),
-            ('platform_os',
-             str(self.platform_os) if self.platform_os else None),
-            ('target',
-             str(self.target) if self.target else None)))
+        str_or_none = lambda v: str(v) if v else None
+        d = syaml_dict([
+            ('platform', str_or_none(self.platform)),
+            ('platform_os', str_or_none(self.platform_os)),
+            ('target', str_or_none(self.target))])
+        return syaml_dict([('arch', d)])
+
+    @staticmethod
+    def from_dict(d):
+        spec = spack.spec.ArchSpec.from_dict(d)
+        return arch_for_spec(spec)
 
 
 def get_platform(platform_name):

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -76,6 +76,7 @@ attributes front_os and back_os. The operating system as described earlier,
 will be responsible for compiler detection.
 """
 import os
+import imp
 import inspect
 
 from llnl.util.lang import memoized, list_modules, key_ordering
@@ -447,6 +448,17 @@ def _platform_from_dict(platform_name):
     for p in platform_list:
         if platform_name.replace("_", "").lower() == p.__name__.lower():
             return p()
+
+
+def verify_platform(platform_name):
+    """ Determines whether or not the platform with the given name is supported
+        in Spack.  For more information, see the 'spack.platforms' submodule.
+    """
+    platform_name = platform_name.replace("_", "").lower()
+    platform_names = [p.__name__.lower() for p in all_platforms()]
+
+    if platform_name not in platform_names:
+        raise ValueError("%s is not a supported platform" % platform_name)
 
 
 def arch_from_dict(d):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -339,7 +339,7 @@ def set_build_environment_variables(pkg, env, dirty=False):
             if os.path.isdir(pcdir):
                 env.prepend_path('PKG_CONFIG_PATH', pcdir)
 
-    if pkg.spec.architecture.target.module_name:
+    if pkg.architecture.target.module_name:
         load_module(pkg.spec.architecture.target.module_name)
 
     return env
@@ -492,7 +492,7 @@ def setup_package(pkg, dirty=False):
 
     set_compiler_environment_variables(pkg, spack_env)
     set_build_environment_variables(pkg, spack_env, dirty)
-    pkg.spec.architecture.platform.setup_platform_environment(pkg, spack_env)
+    pkg.architecture.platform.setup_platform_environment(pkg, spack_env)
     load_external_modules(pkg)
     # traverse in postorder so package can use vars from its dependencies
     spec = pkg.spec

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -115,8 +115,8 @@ class Compiler(object):
     def __init__(self, cspec, operating_system,
                  paths, modules=[], alias=None, environment=None,
                  extra_rpaths=None, **kwargs):
-        self.operating_system = operating_system
         self.spec = cspec
+        self.operating_system = str(operating_system)
         self.modules = modules
         self.alias = alias
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -240,47 +240,6 @@ class DefaultConcretizer(object):
 
         return True   # Things changed
 
-    def _concretize_operating_system(self, spec):
-        if spec.architecture.platform_os is not None and isinstance(
-                spec.architecture.platform_os,
-                spack.architecture.OperatingSystem):
-            return False
-
-        if spec.root.architecture and spec.root.architecture.platform_os:
-            if isinstance(spec.root.architecture.platform_os,
-                          spack.architecture.OperatingSystem):
-                spec.architecture.platform_os = \
-                    spec.root.architecture.platform_os
-        else:
-            spec.architecture.platform_os = \
-                spec.architecture.platform.operating_system('default_os')
-        return True  # changed
-
-    def _concretize_target(self, spec):
-        if spec.architecture.target is not None and isinstance(
-                spec.architecture.target, spack.architecture.Target):
-            return False
-        if spec.root.architecture and spec.root.architecture.target:
-            if isinstance(spec.root.architecture.target,
-                          spack.architecture.Target):
-                spec.architecture.target = spec.root.architecture.target
-        else:
-            spec.architecture.target = spec.architecture.platform.target(
-                'default_target')
-        return True  # changed
-
-    def _concretize_platform(self, spec):
-        if spec.architecture.platform is not None and isinstance(
-                spec.architecture.platform, spack.architecture.Platform):
-            return False
-        if spec.root.architecture and spec.root.architecture.platform:
-            if isinstance(spec.root.architecture.platform,
-                          spack.architecture.Platform):
-                spec.architecture.platform = spec.root.architecture.platform
-        else:
-            spec.architecture.platform = spack.architecture.platform()
-        return True  # changed?
-
     def concretize_architecture(self, spec):
         """If the spec is empty provide the defaults of the platform. If the
         architecture is not a basestring, then check if either the platform,
@@ -302,12 +261,12 @@ class DefaultConcretizer(object):
 
         default_archs = [root_arch, sys_arch]
         while not spec.architecture.concrete and default_archs:
-            default_arch = default_archs.pop(0)
+            arch = default_archs.pop(0)
 
-            replacement_fields = [k for k, v in default_arch.to_cmp_dict()
+            replacement_fields = [k for k, v in arch.to_cmp_dict().iteritems()
                                   if v and not getattr(spec.architecture, k)]
             for field in replacement_fields:
-                setattr(spec.architecture, field, getattr(default_arch, field))
+                setattr(spec.architecture, field, getattr(arch, field))
                 spec_changed = True
 
         return spec_changed

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -352,13 +352,8 @@ class DefaultConcretizer(object):
         # Takes advantage of the proper logic already existing in
         # compiler_for_spec Should think whether this can be more
         # efficient
-        def _proper_compiler_style(cspec, arch):
-            platform = arch.platform
-            compilers = spack.compilers.compilers_for_spec(cspec,
-                                                           platform=platform)
-            return filter(lambda c: c.operating_system ==
-                          arch.platform_os, compilers)
-            # return compilers
+        def _proper_compiler_style(cspec, aspec):
+            return spack.compilers.compilers_for_spec(cspec, arch_spec=aspec)
 
         all_compilers = spack.compilers.all_compilers()
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -898,7 +898,14 @@ class PackageBase(object):
         return self.spec.prefix
 
     @property
-    # TODO: Change this to architecture
+    def architecture(self):
+        """Get the spack.architecture.Arch object that represents the
+        environment in which this package will be built."""
+        if not self.spec.concrete:
+            raise ValueError("Can only get the arch for concrete package.")
+        return spack.architecture.arch_for_spec(self.spec.architecture)
+
+    @property
     def compiler(self):
         """Get the spack.compiler.Compiler object used to build this package"""
         if not self.spec.concrete:

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -23,8 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack.architecture import Platform, Target
-from spack.operating_systems.linux_distro import LinuxDistro
-from spack.operating_systems.cnl import Cnl
+from spack.architecture import OperatingSystem as OS
 
 
 class Test(Platform):
@@ -33,18 +32,17 @@ class Test(Platform):
     back_end    = 'x86_64'
     default     = 'x86_64'
 
-    back_os = 'CNL10'
-    default_os = 'CNL10'
+    front_os = 'redhat6'
+    back_os = 'debian6'
+    default_os = 'debian6'
 
     def __init__(self):
         super(Test, self).__init__('test')
         self.add_target(self.default, Target(self.default))
         self.add_target(self.front_end, Target(self.front_end))
 
-        self.add_operating_system(self.default_os, Cnl())
-        linux_dist = LinuxDistro()
-        self.front_os = linux_dist.name
-        self.add_operating_system(self.front_os, linux_dist)
+        self.add_operating_system(self.default_os, OS('debian', 6))
+        self.add_operating_system(self.front_os, OS('redhat', 6))
 
     @classmethod
     def detect(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -310,10 +310,6 @@ class ArchSpec(object):
             refer to valid platforms.
         """
         value = str(value) if value is not None else None
-
-        if value is not None:
-            spack.architecture.verify_platform(value)
-
         self._platform = value
 
     @property
@@ -429,6 +425,8 @@ class ArchSpec(object):
 
     @staticmethod
     def from_dict(d):
+        if type(d['arch']) != type(d):
+            return ArchSpec('spackcompat', 'v08', d['arch'])
         d = d['arch']
         return ArchSpec(d['platform'], d['platform_os'], d['target'])
 
@@ -874,7 +872,7 @@ class Spec(object):
             new_vals = tuple(kwargs.get(arg, None) for arg in arch_attrs)
             self.architecture = ArchSpec(*new_vals)
         else:
-            new_attrvals = [(a, v) for a, v in kwargs.iteritems() 
+            new_attrvals = [(a, v) for a, v in kwargs.iteritems()
                             if a in arch_attrs]
             for new_attr, new_value in new_attrvals:
                 if getattr(self.architecture, new_attr):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -877,7 +877,12 @@ class Spec(object):
             new_attrvals = [(a, v) for a, v in kwargs.iteritems() 
                             if a in arch_attrs]
             for new_attr, new_value in new_attrvals:
-                setattr(self.architecture, new_attr, new_value)
+                if getattr(self.architecture, new_attr):
+                    raise DuplicateArchitectureError(
+                        "Spec for '%s' cannot have two '%s' specified "
+                        "for its architecture" % (self.name, new_attr))
+                else:
+                    setattr(self.architecture, new_attr, new_value)
 
     def _set_compiler(self, compiler):
         """Called by the parser to set the compiler."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -425,8 +425,21 @@ class ArchSpec(object):
 
     @staticmethod
     def from_dict(d):
-        if type(d['arch']) != type(d):
-            return ArchSpec('spackcompat', 'unknown', d['arch'])
+        """Import an ArchSpec from raw YAML/JSON data.
+
+        This routine implements a measure of compatibility with older
+        versions of Spack.  Spack releases before 0.10 used a single
+        string with no OS or platform identifiers.  We import old Spack
+        architectures with platform ``spack09``, OS ``unknown``, and the
+        old arch string as the target.
+
+        Specs from `0.10` or later have a more fleshed out architecture
+        descriptor with a platform, an OS, and a target.
+
+        """
+        if not isinstance(d['arch'], dict):
+            return ArchSpec('spack09', 'unknown', d['arch'])
+
         d = d['arch']
         return ArchSpec(d['platform'], d['platform_os'], d['target'])
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -426,7 +426,7 @@ class ArchSpec(object):
     @staticmethod
     def from_dict(d):
         if type(d['arch']) != type(d):
-            return ArchSpec('spackcompat', 'v08', d['arch'])
+            return ArchSpec('spackcompat', 'unknown', d['arch'])
         d = d['arch']
         return ArchSpec(d['platform'], d['platform_os'], d['target'])
 

--- a/lib/spack/spack/test/__init__.py
+++ b/lib/spack/spack/test/__init__.py
@@ -28,9 +28,11 @@ import os
 import llnl.util.tty as tty
 import nose
 import spack
+import spack.architecture
 from llnl.util.filesystem import join_path
 from llnl.util.tty.colify import colify
 from spack.test.tally_plugin import Tally
+from spack.platforms.test import Test as TestPlatform
 """Names of tests to be included in Spack's test suite"""
 
 # All the tests Spack knows about.
@@ -84,6 +86,13 @@ test_names = [
 ]
 
 
+def setup_tests():
+    """Prepare the environment for the Spack tests to be run."""
+    test_platform = TestPlatform()
+    spack.architecture.real_platform = spack.architecture.platform
+    spack.architecture.platform = lambda: test_platform
+
+
 def list_tests():
     """Return names of all tests that can be run for Spack."""
     return test_names
@@ -117,6 +126,8 @@ def run(names, outputDir, verbose=False):
         runOpts += ["--with-xunit",
                     "--xunit-file={0}".format(xmlOutputPath)]
     argv = [""] + runOpts + modules
+
+    setup_tests()
     nose.run(argv=argv, addplugins=[tally])
 
     succeeded = not tally.failCount and not tally.errorCount

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -54,10 +54,7 @@ class ArchitectureTest(MockPackagesTest):
         arch.platform_os = arch.platform.operating_system('default_os')
         arch.target = arch.platform.target('default_target')
 
-        d = arch.to_dict()
-
-        new_arch = spack.architecture.arch_from_dict(d)
-
+        new_arch = spack.architecture.Arch.from_dict(arch.to_dict())
         self.assertEqual(arch, new_arch)
 
         self.assertTrue(isinstance(arch, spack.architecture.Arch))
@@ -114,10 +111,12 @@ class ArchitectureTest(MockPackagesTest):
         """Test when user inputs just frontend that both the frontend target
             and frontend operating system match
         """
-        frontend_os = self.platform.operating_system("frontend")
-        frontend_target = self.platform.target("frontend")
+        frontend_os = str(self.platform.operating_system("frontend"))
+        frontend_target = str(self.platform.target("frontend"))
+
         frontend_spec = Spec("libelf os=frontend target=frontend")
         frontend_spec.concretize()
+
         self.assertEqual(frontend_os, frontend_spec.architecture.platform_os)
         self.assertEqual(frontend_target, frontend_spec.architecture.target)
 
@@ -125,19 +124,22 @@ class ArchitectureTest(MockPackagesTest):
         """Test when user inputs backend that both the backend target and
             backend operating system match
         """
-        backend_os = self.platform.operating_system("backend")
-        backend_target = self.platform.target("backend")
+        backend_os = str(self.platform.operating_system("backend"))
+        backend_target = str(self.platform.target("backend"))
+
         backend_spec = Spec("libelf os=backend target=backend")
         backend_spec.concretize()
+
         self.assertEqual(backend_os, backend_spec.architecture.platform_os)
         self.assertEqual(backend_target, backend_spec.architecture.target)
 
     def test_user_defaults(self):
-        default_os = self.platform.operating_system("default_os")
-        default_target = self.platform.target("default_target")
+        default_os = str(self.platform.operating_system("default_os"))
+        default_target = str(self.platform.target("default_target"))
 
         default_spec = Spec("libelf")  # default is no args
         default_spec.concretize()
+
         self.assertEqual(default_os, default_spec.architecture.platform_os)
         self.assertEqual(default_target, default_spec.architecture.target)
 
@@ -156,8 +158,9 @@ class ArchitectureTest(MockPackagesTest):
             spec = Spec("libelf os=%s target=%s" % (o, t))
             spec.concretize()
             results.append(spec.architecture.platform_os ==
-                           self.platform.operating_system(o))
-            results.append(spec.architecture.target == self.platform.target(t))
+                           str(self.platform.operating_system(o)))
+            results.append(spec.architecture.target ==
+                           str(self.platform.target(t)))
         res = all(results)
 
         self.assertTrue(res)

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -72,7 +72,7 @@ class ArchitectureTest(MockPackagesTest):
                                    spack.architecture.Target))
 
     def test_platform(self):
-        output_platform_class = spack.architecture.platform()
+        output_platform_class = spack.architecture.real_platform()
         if os.path.exists('/opt/cray/craype'):
             my_platform_class = Cray()
         elif os.path.exists('/bgsys'):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -250,7 +250,7 @@ class ConcretizeTest(MockPackagesTest):
     def test_external_package_module(self):
         # No tcl modules on darwin/linux machines
         # TODO: improved way to check for this.
-        platform = spack.architecture.platform().name
+        platform = spack.architecture.real_platform().name
         if (platform == 'darwin' or platform == 'linux'):
             return
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -133,14 +133,49 @@ class SpecSematicsTest(MockPackagesTest):
 
     def test_satisfies_architecture(self):
         self.check_satisfies(
+            'foo platform=test',
+            'platform=test')
+        self.check_satisfies(
+            'foo platform=test',
+            'platform=test target=frontend')
+        self.check_satisfies(
+            'foo platform=test',
+            'platform=test os=frontend target=frontend')
+        self.check_satisfies(
+            'foo platform=test os=frontend target=frontend',
+            'platform=test')
+        self.check_unsatisfiable(
+            'foo platform=test',
+            'platform=linux os=frontend target=frontend')
+
+        self.check_satisfies(
+            'foo arch=test-None-None',
+            'platform=test')
+        self.check_satisfies(
+            'foo arch=test-None-frontend',
+            'platform=test target=frontend')
+        self.check_satisfies(
+            'foo arch=test-frontend-frontend',
+            'platform=test os=frontend target=frontend')
+        self.check_satisfies(
+            'foo arch=test-frontend-frontend',
+            'platform=test')
+        self.check_unsatisfiable(
+            'foo arch=test-frontend-frontend',
+            'platform=test os=frontend target=backend')
+
+        self.check_satisfies(
             'foo platform=test target=frontend os=frontend',
             'platform=test target=frontend os=frontend')
         self.check_satisfies(
             'foo platform=test target=backend os=backend',
-            'platform=test target=backend', 'platform=test os=backend')
+            'platform=test target=backend os=backend')
         self.check_satisfies(
             'foo platform=test target=default_target os=default_os',
-            'platform=test target=default_target os=default_os')
+            'platform=test os=default_os')
+        self.check_unsatisfiable(
+            'foo platform=test target=default_target os=default_os',
+            'platform=linux target=default_target os=default_os')
 
     def test_satisfies_dependencies(self):
         self.check_satisfies('mpileaks^mpich', '^mpich')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -146,7 +146,7 @@ class SpecSematicsTest(MockPackagesTest):
             'platform=test')
         self.check_unsatisfiable(
             'foo platform=test',
-            'platform=linux os=frontend target=frontend')
+            'platform=linux os=redhat6 target=x86_32')
 
         self.check_satisfies(
             'foo arch=test-None-None',
@@ -174,8 +174,8 @@ class SpecSematicsTest(MockPackagesTest):
             'foo platform=test target=default_target os=default_os',
             'platform=test os=default_os')
         self.check_unsatisfiable(
-            'foo platform=test target=default_target os=default_os',
-            'platform=linux target=default_target os=default_os')
+            'foo platform=test target=x86_32 os=redhat6',
+            'platform=linux target=x86_32 os=redhat6')
 
     def test_satisfies_dependencies(self):
         self.check_satisfies('mpileaks^mpich', '^mpich')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -136,6 +136,9 @@ class SpecSematicsTest(MockPackagesTest):
             'foo platform=test',
             'platform=test')
         self.check_satisfies(
+            'foo platform=linux',
+            'platform=linux')
+        self.check_satisfies(
             'foo platform=test',
             'platform=test target=frontend')
         self.check_satisfies(
@@ -144,9 +147,16 @@ class SpecSematicsTest(MockPackagesTest):
         self.check_satisfies(
             'foo platform=test os=frontend target=frontend',
             'platform=test')
+
         self.check_unsatisfiable(
-            'foo platform=test',
-            'platform=linux os=redhat6 target=x86_32')
+            'foo platform=linux',
+            'platform=test os=redhat6 target=x86_32')
+        self.check_unsatisfiable(
+            'foo os=redhat6',
+            'platform=test os=debian6 target=x86_64')
+        self.check_unsatisfiable(
+            'foo target=x86_64',
+            'platform=test os=redhat6 target=x86_32')
 
         self.check_satisfies(
             'foo arch=test-None-None',

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -120,6 +120,10 @@ class SpecSyntaxTest(unittest.TestCase):
             'mvapich_foo'
             '^_openmpi@1.2:1.4,1.6%intel@12.1 cppflags="-O3"+debug~qt_4'
             '^stackwalker@8.1_1e')
+        self.check_parse(
+            "mvapich_foo"
+            "^_openmpi@1.2:1.4,1.6%intel@12.1 debug=2~qt_4"
+            "^stackwalker@8.1_1e arch=test-redhat6-x86_32")
 
     def test_canonicalize(self):
         self.check_parse(
@@ -143,6 +147,22 @@ class SpecSyntaxTest(unittest.TestCase):
         self.check_parse(
             "x^y@1,2:3,4%intel@1,2,3,4+a~b+c~d+e~f",
             "x ^y~f+e~d+c~b+a@4,2:3,1%intel@4,3,2,1")
+
+        self.check_parse(
+            "x arch=test-redhat6-None"
+            "^y arch=test-None-x86_64"
+            "^z arch=linux-None-None",
+
+            "x os=fe"
+            "^y target=be"
+            "^z platform=linux")
+
+        self.check_parse(
+            "x arch=test-debian6-x86_64"
+            "^y arch=test-debian6-x86_64",
+
+            "x os=default_os target=default_target"
+            "^y os=default_os target=default_target")
 
         self.check_parse("x^y", "x@: ^y@:")
 
@@ -182,7 +202,7 @@ class SpecSyntaxTest(unittest.TestCase):
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x ^y%gcc%intel")
 
-    def test_duplicate_arch(self):
+    def test_duplicate_architecture(self):
         self.assertRaises(
             DuplicateArchitectureError, self.check_parse,
             "x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
@@ -200,6 +220,35 @@ class SpecSyntaxTest(unittest.TestCase):
         self.assertRaises(
             DuplicateArchitectureError, self.check_parse,
             "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
+
+    def test_duplicate_architecture_component(self):
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x os=fe os=fe")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x os=fe os=be")
+
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x target=fe target=fe")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x target=fe target=be")
+
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x platform=test platform=test")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x platform=test platform=test")
+
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x os=fe platform=test target=fe os=fe")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x target=be platform=test os=be os=fe")
 
     # ========================================================================
     # Lex checks

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -183,18 +183,23 @@ class SpecSyntaxTest(unittest.TestCase):
                           self.check_parse, "x ^y%gcc%intel")
 
     def test_duplicate_arch(self):
-        self.assertRaises(DuplicateArchitectureError,
-                          self.check_parse, "x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
 
-        self.assertRaises(DuplicateArchitectureError,
-                          self.check_parse, "x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
-        self.assertRaises(DuplicateArchitectureError,
-                          self.check_parse, "x arch=linux-rhel7-ppc64le arch=linux-rhel7-x86_64")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "x arch=linux-rhel7-ppc64le arch=linux-rhel7-x86_64")
 
-        self.assertRaises(DuplicateArchitectureError,
-                          self.check_parse, "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
-        self.assertRaises(DuplicateArchitectureError,
-                          self.check_parse, "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
+        self.assertRaises(
+            DuplicateArchitectureError, self.check_parse,
+            "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
 
     # ========================================================================
     # Lex checks

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -169,16 +169,32 @@ class SpecSyntaxTest(unittest.TestCase):
     def test_duplicate_compiler(self):
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x%intel%intel")
+
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x%intel%gcc")
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x%gcc%intel")
+
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x ^y%intel%intel")
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x ^y%intel%gcc")
         self.assertRaises(DuplicateCompilerSpecError,
                           self.check_parse, "x ^y%gcc%intel")
+
+    def test_duplicate_arch(self):
+        self.assertRaises(DuplicateArchitectureError,
+                          self.check_parse, "x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
+
+        self.assertRaises(DuplicateArchitectureError,
+                          self.check_parse, "x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
+        self.assertRaises(DuplicateArchitectureError,
+                          self.check_parse, "x arch=linux-rhel7-ppc64le arch=linux-rhel7-x86_64")
+
+        self.assertRaises(DuplicateArchitectureError,
+                          self.check_parse, "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64")
+        self.assertRaises(DuplicateArchitectureError,
+                          self.check_parse, "y ^x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le")
 
     # ========================================================================
     # Lex checks


### PR DESCRIPTION
Fixes #2249.  Fixes #1815.

The changes in this pull request will fix the issues described in issue #2249 and generally improve architecture handling in Spack.  These changes include the following updates:

- [x] Implement the `spack.spec.ArchSpec` type to represent abstract architecture requirements (e.g. like `spack.spec.CompilerSpec` does for compilers).
- [x] Replace the architecture information being used in the `spack.spec.Spec` type with `spack.spec.ArchSpec` to facilitate better ambiguous architecture handling.
- [x] Add unit tests to verify that the functionality specific to `spack.spec.ArchSpec` works properly.