### PR TITLE
Add detection for redhat enterprise server to distro.py

### DIFF
--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -60,7 +60,8 @@ NORMALIZED_OS_ID = {}
 #: * Value: Normalized value.
 NORMALIZED_LSB_ID = {
     'enterpriseenterprise': 'oracle',  # Oracle Enterprise Linux
-    'redhatenterpriseworkstation': 'rhel',  # RHEL 6.7
+    'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
+    'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
 }
 
 #: Translation table for normalizing the distro ID derived from the file name


### PR DESCRIPTION
Fixes issue raised in #1629 -- RHEL is now detected properly on servers, too.

- Will also submit this to upstream `distro`.