### PR TITLE
Don't spider remote list_urls before making stage.

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -703,12 +703,7 @@ class PackageBase(object):
         # Construct a path where the stage should build..
         s = self.spec
         stage_name = "%s-%s-%s" % (s.name, s.version, s.dag_hash())
-
-        # Check list_url alternative archive URLs
-        dynamic_fetcher = fs.from_list_url(self)
-        alternate_fetchers = [dynamic_fetcher] if dynamic_fetcher else None
-        stage = Stage(fetcher, mirror_path=mp, name=stage_name, path=self.path,
-                      alternate_fetchers=alternate_fetchers)
+        stage = Stage(fetcher, mirror_path=mp, name=stage_name, path=self.path)
         return stage
 
     def _make_stage(self):


### PR DESCRIPTION
Fixes #2251 (tests back to normal runtime)

- Spack was automatically spidering remote URLs before creating a stage.
- This might be useful but we don't want to do it unconditionally, as it slows down package creation and isn't usually necessary.  Also, we especially don't want to bother with it if the user asked to fetch from mirrors first.

@alalazo @scheibelp 