### PR TITLE
get extension map from spack.store.layout

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -346,7 +346,7 @@ sys.__egginsert = p + len(new)
 
         super(Python, self).activate(ext_pkg, **args)
 
-        exts = spack.install_layout.extension_map(self.spec)
+        exts = spack.store.layout.extension_map(self.spec)
         exts[ext_pkg.name] = ext_pkg.spec
         self.write_easy_install_pth(exts)
 
@@ -354,7 +354,7 @@ sys.__egginsert = p + len(new)
         args.update(ignore=self.python_ignore(ext_pkg, args))
         super(Python, self).deactivate(ext_pkg, **args)
 
-        exts = spack.install_layout.extension_map(self.spec)
+        exts = spack.store.layout.extension_map(self.spec)
         # Make deactivate idempotent
         if ext_pkg.name in exts:
             del exts[ext_pkg.name]


### PR DESCRIPTION
@tgamblin `spack activate py-*` was failing because it looks like the extension_map moved. Let me know if I followed it correctly. This appears to work to me.