### PR TITLE
fix tau installation issue 

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -150,4 +150,4 @@ class Tau(Package):
     def setup_environment(self, spack_env, run_env):
         pattern = join_path(self.prefix.lib, 'Makefile.*')
         files = glob.glob(pattern)
-        run_env.set('TAU_MAKEFILE', files[0])
+        run_env.set('TAU_MAKEFILE', files[0] if files else '')

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -150,4 +150,11 @@ class Tau(Package):
     def setup_environment(self, spack_env, run_env):
         pattern = join_path(self.prefix.lib, 'Makefile.*')
         files = glob.glob(pattern)
-        run_env.set('TAU_MAKEFILE', files[0] if files else '')
+
+        # This function is called both at install time to set up
+        # the build environment and after install to generate the associated
+        # module file. In the former case there is no `self.prefix.lib`
+        # directory to inspect. The conditional below will set `TAU_MAKEFILE`
+        # in the latter case.
+        if files:
+            run_env.set('TAU_MAKEFILE', files[0])


### PR DESCRIPTION
I introduced `bug` in #2210 due to confusion of `setup_environment()`. See discussion in #2016.
`setup_environment()` is called before `install` phase which causes : 

```
==> Error: IndexError: list index out of range
/Users/kumbhar/spack/var/spack/repos/builtin/packages/tau/package.py:154, in setup_environment:
     150      def setup_environment(self, spack_env, run_env):
     151          pattern = join_path(self.prefix.lib, 'Makefile.*')
     152          files = glob.glob(pattern)
  >> 153         run_env.set('TAU_MAKEFILE', files[0])
```