### PR TITLE
find, uninstall: improve messages in the case of empty DB

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -115,7 +115,7 @@ def find(parser, args):
     q_args = query_arguments(args)
     query_specs = args.specs(**q_args)
     # Exit early if no package matches the constraint
-    if not query_specs:
+    if not query_specs and args.constraint:
         msg = "No package matches the query: {0}".format(args.contraint)
         tty.msg(msg)
         return

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -101,7 +101,7 @@ def concretize_specs(specs, allow_multiple_matches=False, force=False):
             has_errors = True
 
         # No installed package matches the query
-        if len(matching) == 0:
+        if len(matching) == 0 and spec is not any:
             tty.error("%s does not match any installed packages." % spec)
             has_errors = True
 
@@ -195,6 +195,10 @@ def uninstall(parser, args):
         tty.die("uninstall requires at least one package argument.")
 
     uninstall_list = get_uninstall_list(args)
+
+    if not uninstall_list:
+        tty.msg("There are no package to uninstall.")
+        return
 
     if not args.yes_to_all:
         tty.msg("The following packages will be uninstalled : ")


### PR DESCRIPTION
This PR introduces minor changes to improve the messages prompted to users when the DB is empty.

Current messages:
```console
$ spack find
==> No package matches the query: []

$ spack uninstall -a
==> Error: <built-in function any> does not match any installed packages.
==> Error: You can either:
    a) Use a more specific spec, or
    b) use spack uninstall -a to uninstall ALL matching specs.
```
after the PR the two messages will be:
```console
$ spack find
==> 0 installed packages.

$ spack uninstall -a
==> There are no package to uninstall.
```