### PR TITLE
Packages: Add Jansson

### DIFF
--- a/var/spack/repos/builtin/packages/jansson/package.py
+++ b/var/spack/repos/builtin/packages/jansson/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Jansson(CMakePackage):
+    """Jansson is a C library for encoding, decoding and manipulating JSON
+       data."""
+
+    homepage = "http://www.digip.org/jansson/"
+    url      = "https://github.com/akheron/jansson/archive/v2.9.tar.gz"
+
+    version('2.9', 'd2db25c437b359fc5a065ed938962237')
+
+    depends_on('cmake', type='build')


### PR DESCRIPTION
This adds the built recipe for [Jansson](http://www.digip.org/jansson/), *a C library for encoding, decoding and manipulating JSON data.*

### GitHub Repo

https://github.com/akheron/jansson

### Downstream Usage

In [ISAAC](https://github.com/ComputationalRadiationPhysics/isaac) which is an *in situ visualization library* based on [alpaka](https://github.com/ComputationalRadiationPhysics/alpaka) and/or CUDA which is used in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).