### PR TITLE
Packages: Add libwebsockets

### DIFF
--- a/var/spack/repos/builtin/packages/libwebsockets/package.py
+++ b/var/spack/repos/builtin/packages/libwebsockets/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libwebsockets(CMakePackage):
+    """C library for lightweight websocket clients and servers."""
+
+    homepage = "https://github.com/warmcat/libwebsockets"
+    url      = "https://github.com/warmcat/libwebsockets/archive/v2.1.0.tar.gz"
+
+    version('2.1.0', '4df3be57dee43aeebd54a3ed56568f50')
+    version('2.0.3', 'a025156d606d90579e65d53ccd062a94')
+    version('1.7.9', '7b3692ead5ae00fd0e1d56c080170f07')
+
+    depends_on('cmake', type='build')
+    depends_on('zlib')
+    depends_on('openssl')


### PR DESCRIPTION
This adds the built recipe for [libwebsockets](https://libwebsockets.org/lws-api-doc-master/html/index.html), a *C library for lightweight websocket clients and servers*.

### GitHub Repo

https://github.com/warmcat/libwebsockets

### Downstream Usage

In [ISAAC](https://github.com/ComputationalRadiationPhysics/isaac) which is an *in situ visualization library* based on [alpaka](https://github.com/ComputationalRadiationPhysics/alpaka) and/or CUDA which is used in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).