### PR TITLE
Features/frontend default build

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -513,3 +513,8 @@ def sys_type():
     """
     arch = Arch(platform(), 'default_os', 'default_target')
     return str(arch)
+
+
+@memoized
+def frontend_sys_type():
+    return str(Arch(platform(), 'frontend', 'frontend'))

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -22,7 +22,7 @@ class Cnl(OperatingSystem):
         super(Cnl, self).__init__(name, version)
 
     def __str__(self):
-        return self.name
+        return self.name + self.version
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1090,7 +1090,7 @@ class Spec(object):
 
             successors = deps
             if direction == 'parents':
-                successors = self.dependents_dict()  # TODO: deptype?
+                successors = self.dependents_dict(deptype)
 
             visited.add(key)
             for name in sorted(successors):
@@ -1308,6 +1308,23 @@ class Spec(object):
         except Exception as e:
             raise sjson.SpackJSONError("error parsing JSON spec:", str(e))
 
+    def build_dep(self):
+        # If this spec is the root, it will automatically be included in
+        # traverse
+        return not (self.root in
+                    self.traverse(
+                        deptype=('link', 'run'), direction='parents'))
+
+    def link_root(self):
+        parents = list(self.traverse(deptype=('link',), direction='parents',
+                       order='pre'))
+        return parents[-1]
+
+    def disjoint_build_tree(self):
+        link_root = self.link_root()
+        build_subtree = list(link_root.traverse(direction='children'))
+        return all(x.build_dep() for x in build_subtree)
+
     def _concretize_helper(self, presets=None, visited=None):
         """Recursive helper function for concretize().
            This concretizes everything bottom-up.  As things are
@@ -1326,8 +1343,8 @@ class Spec(object):
 
         # Concretize deps first -- this is a bottom-up process.
         for name in sorted(self._dependencies.keys()):
-            changed |= self._dependencies[
-                name].spec._concretize_helper(presets, visited)
+            dep = self._dependencies[name]
+            changed |= dep.spec._concretize_helper(presets, visited)
 
         if self.name in presets:
             changed |= self.constrain(presets[self.name])

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -85,6 +85,36 @@ class ConcretizeTest(MockPackagesTest):
         self.check_concretize('mpich debug=2')
         self.check_concretize('mpich')
 
+    def test_concretize_with_build_dep(self):
+        # Set the target as the backend. Since the cmake build dependency is
+        # not explicitly configured to target the backend it should target
+        # the frontend (whatever compiler that is, it is different)
+        spec = self.check_concretize('cmake-client platform=test target=be')
+        client_compiler = spack.compilers.compiler_for_spec(
+            spec.compiler, spec.architecture)
+        cmake_spec = spec['cmake']
+        cmake_compiler = spack.compilers.compiler_for_spec(
+            cmake_spec.compiler, cmake_spec.architecture)
+        self.assertTrue(client_compiler.operating_system !=
+                        cmake_compiler.operating_system)
+
+    def test_concretize_link_dep_of_build_dep(self):
+        # The link dep of the build dep should use the same compiler as
+        # the build dep, and both should be different from the root
+        spec = self.check_concretize('dttop platform=test target=be')
+        dttop_compiler = spack.compilers.compiler_for_spec(
+            spec.compiler, spec.architecture)
+        dtlink2_spec = spec['dtlink2']
+        dtlink2_compiler = spack.compilers.compiler_for_spec(
+            dtlink2_spec.compiler, dtlink2_spec.architecture)
+        dtbuild1_spec = spec['dtbuild1']
+        dtbuild1_compiler = spack.compilers.compiler_for_spec(
+            dtbuild1_spec.compiler, dtbuild1_spec.architecture)
+        self.assertTrue(dttop_compiler.operating_system !=
+                        dtlink2_compiler.operating_system)
+        self.assertTrue(dtbuild1_compiler.operating_system ==
+                        dtlink2_compiler.operating_system)
+
     def test_conretize_compiler_flags(self):
         self.check_concretize('mpich cppflags="-O3"')
 


### PR DESCRIPTION
A few notes:

-whether a dependency is a build dep is determined by checking whether one can reach the root by traversing link deps
-link dependencies of build deps should be built with the frontend compiler
-if a parent links to a dependency of a build dep however, that may not always be the case (I think this is mostly handled)

Also this appears to significantly boost concretization time as-is.