### PR TITLE
GitLab: Tarball Version Test

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -154,6 +154,20 @@ class UrlParseTest(unittest.TestCase):
             'foo-bar', '1.21',
             'http://example.com/foo_bar-1.21.tar.gz')
 
+    def test_version_gitlab(self):
+        self.check(
+             'vtk', '7.0.0',
+             'https://gitlab.kitware.com/vtk/vtk/repository/'
+             'archive.tar.bz2?ref=v7.0.0')
+        self.check(
+             'icet', '1.2.3',
+             'https://gitlab.kitware.com/icet/icet/repository/'
+             'archive.tar.gz?ref=IceT-1.2.3')
+        self.check(
+             'foo', '42.1337',
+             'http://example.com/org/foo/repository/'
+             'archive.zip?ref=42.1337bar')
+
     def test_version_github(self):
         self.check(
             'yajl', '1.0.5',


### PR DESCRIPTION
Upload a test demonstrating #2290 

... and a proposed fix for it to support gitlab better.

Note: since gitlab is free software it is not bound to be installed on a common top level domain, so we should maybe avoid searching for a `gitlab` term in there (although, many people will *hopefully* have "gitlab" in either the subdomain or top level dir somewhere included...)