### PR TITLE
Run HDF 5 tests post-installation

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -143,8 +143,8 @@ class Hdf5(AutotoolsPackage):
 
         return ["--with-zlib=%s" % spec['zlib'].prefix] + extra_args
 
-    def check(self):
-        super(Hdf5, self).check()
+    @AutotoolsPackage.sanity_check('install')
+    def check_install(self):
         # Build and run a small program to test the installed HDF5 library
         spec = self.spec
         print("Checking HDF5 installation...")


### PR DESCRIPTION
Fixes a bug introduced in #1186. See #2250 for details. Closes #2250.