### PR TITLE
Force the recipe for Lua to use the spack compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -62,16 +62,18 @@ class Lua(Package):
         else:
             target = 'linux'
         make('INSTALL_TOP=%s' % prefix,
-             'MYLDFLAGS=-L%s -L%s ' % (
+             'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
+             'CC=%s' % spack_cc,
              target)
         make('INSTALL_TOP=%s' % prefix,
-             'MYLDFLAGS=-L%s -L%s ' % (
+             'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
+             'CC=%s' % spack_cc,
              'install')
 
         with working_dir(os.path.join('luarocks', 'luarocks')):

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -66,14 +66,14 @@ class Lua(Package):
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
-             'CC=%s' % spack_cc,
+             'CC=%s -std=gnu99' % spack_cc,
              target)
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
              'MYLIBS=-lncurses',
-             'CC=%s' % spack_cc,
+             'CC=%s -std=gnu99' % spack_cc,
              'install')
 
         with working_dir(os.path.join('luarocks', 'luarocks')):


### PR DESCRIPTION
I'm not sure how the old recipe worked for anyone. The Lua Makefiles set `CC=gcc` and, at least for my spack environment, the first `gcc` found in the `PATH` is `$SPACK_ROOT/lib/spack/env/gcc`, which is a directory. This caused the build to fail. It should be noted that this change drops the `-std=gnu99`, but this option doesn't appear to be required for a successful build.