### PR TITLE
install: fixed choices for `--only` (removed the default)

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -47,7 +47,7 @@ def setup_parser(subparser):
         '--only',
         default='package,dependencies',
         dest='things_to_install',
-        choices=['package', 'dependencies', 'package,dependencies'],
+        choices=['package', 'dependencies'],
         help="""Select the mode of installation.
 The default is to install the package along with all its dependencies.
 Alternatively one can decide to install only the package or only


### PR DESCRIPTION
The value for the option is checked only if given, so we can set `package,dependencies` as a default and limit the choices to either `package` or `dependencies` if the option is given explicitly. The help will look like:
```console
$ spack install --help
usage: spack install [-h] [--only {package,dependencies}] [-j JOBS]
                     [--keep-prefix] [--keep-stage] [-n] [-v] [--fake]
                     [--clean | --dirty] [--run-tests] [--log-format {junit}]
                     [--log-file LOG_FILE]
                     ...

positional arguments:
  package               spec of the package to install

optional arguments:
  -h, --help            show this help message and exit
  --only {package,dependencies}
                        Select the mode of installation. The default is to
                        install the package along with all its dependencies.
                        Alternatively one can decide to install only the
                        package or only the dependencies.
  -j JOBS, --jobs JOBS  Explicitly set number of make jobs. Default is #cpus.
  --keep-prefix         Don't remove the install prefix if installation fails.
  --keep-stage          Don't remove the build stage if installation succeeds.
  -n, --no-checksum     Do not check packages against checksum
  -v, --verbose         Display verbose build output while installing.
  --fake                Fake install. Just remove prefix and create a fake
                        file.
  --clean               Clean environment before installing package.
  --dirty               Do NOT clean environment before installing.
  --run-tests           Run package level tests during installation.
  --log-format {junit}  Format to be used for log files.
  --log-file LOG_FILE   Filename for the log file. If not passed a default
                        will be used.
```
fixes #2303 