### PR TITLE
cmake: update the requirements for --no-system-jsoncpp option

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -89,7 +89,7 @@ class Cmake(Package):
         options = [
             '--prefix={0}'.format(prefix),
             '--parallel={0}'.format(make_jobs)]
-        if spec.satisfies("@3:"):
+        if spec.satisfies("@3.2:"):
             options.append(
                 # jsoncpp requires CMake to build
                 # use CMake-provided library to avoid circular dependency


### PR DESCRIPTION
The option only appeared in CMake 3.2 (specifically, in 3.2.0-rc2, see
https://cmake.org/pipermail/cmake-developers/2015-February/024552.html).