### PR TITLE
doxygen: Disable unnecessary graphviz dependency by default.

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -39,7 +39,7 @@ class Doxygen(Package):
     version('1.8.10', '79767ccd986f12a0f949015efb5f058f')
 
     # graphviz appears to be a run-time optional dependency
-    variant('graphviz', default=True,
+    variant('graphviz', default=False,
             description='Build with dot command support from Graphviz.')
 
     depends_on("cmake@2.8.12:", type='build')


### PR DESCRIPTION
Most users just want to see HTML docs, Graphviz is not needed.  And it pulls in a whole SLEW of dependencies, some of which could break.  (`libxcb`, for example, has a Python2 build dependency, which currently breaks Python3 builds).
