### PR TITLE
Simplify the CMake build to make it more robust.

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -42,11 +42,11 @@ class Cmake(Package):
     version('3.0.2',    'db4c687a31444a929d2fdc36c4dfb95f')
     version('2.8.10.2', '097278785da7182ec0aea8769d06860c')
 
-    variant('ownlibs', default=False, description='Use CMake-provided third-party libraries')
+    variant('ownlibs', default=True, description='Use CMake-provided third-party libraries')
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
-    variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
+    variant('ncurses', default=False,  description='Enables the build of the ncurses gui')
 
     depends_on('curl',           when='~ownlibs')
     depends_on('expat',          when='~ownlibs')

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -46,7 +46,7 @@ class Cmake(Package):
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
-    variant('ncurses', default=False,  description='Enables the build of the ncurses gui')
+    variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
     depends_on('curl',           when='~ownlibs')
     depends_on('expat',          when='~ownlibs')


### PR DESCRIPTION
The idea is to detangle circular dependencies involving CMake, so that CMake can install in as trouble-free a way as possible.  CMake authors already anticipated this issue, so they included all their dependencies in the source tarball.  Although Spack builds usually prefer to use its own stuff for dependencies, CMake is an exception to that rule, due to the circular dependency issue.  It will have zero effect because, unlike many packages, CMake is only ever used as a build dependency; nothing ever links to it.  Until we have proper handling of build dependencies in concretization, removing dpendencies from CMake will also avoid other unnecessary concretization conflicts.

This PR make the following changes:

1. Set `+ownlibs` by default.
2. Don't build the `ncurses` interface by default.  I did not even know this existed; and certainly Spack will never use it.

This package needs further review:

1. I'm not convinced that `ownlibs` is sucessful at turning everything on or off.  See the result of `bootstrap --help` down below...

2. Remind me why CMake needs OpenSSL?  Especially CMake from within Spack?  I believe that CMake increasingly has auto-fetch / auto-build features that Spack has no use for.  I've left `openssl` on for now, but we should consider turning it off too by default.

If users want a tricked-out CMake, they should built it explicitly.  The default CMake build should produce something that works for building Spack packages.

```
$ ./bootstrap --help

Usage: ./bootstrap [<options>...] [-- <cmake-options>...]
Options: [defaults in brackets after descriptions]
Configuration:
  --help                  print this message
  --version               only print version information
  --verbose               display more information
  --parallel=n            bootstrap cmake in parallel, where n is
                          number of nodes [1]
  --enable-ccache         Enable ccache when building cmake
  --init=FILE             load FILE as script to populate cache
  --system-libs           use all system-installed third-party libraries
                          (for use only by package maintainers)
  --no-system-libs        use all cmake-provided third-party libraries
                          (default)
  --system-curl           use system-installed curl library
  --no-system-curl        use cmake-provided curl library (default)
  --system-expat          use system-installed expat library
  --no-system-expat       use cmake-provided expat library (default)
  --system-jsoncpp        use system-installed jsoncpp library
  --no-system-jsoncpp     use cmake-provided jsoncpp library (default)
  --system-zlib           use system-installed zlib library
  --no-system-zlib        use cmake-provided zlib library (default)
  --system-bzip2          use system-installed bzip2 library
  --no-system-bzip2       use cmake-provided bzip2 library (default)
  --system-liblzma        use system-installed liblzma library
  --no-system-liblzma     use cmake-provided liblzma library (default)
  --system-libarchive     use system-installed libarchive library
  --no-system-libarchive  use cmake-provided libarchive library (default)

  --qt-gui                build the Qt-based GUI (requires Qt >= 4.2)
  --no-qt-gui             do not build the Qt-based GUI (default)
  --qt-qmake=<qmake>      use <qmake> as the qmake executable to find Qt

  --server                enable the server mode (default if supported)
  --no-server             disable the server mode

  --sphinx-man            build man pages with Sphinx
  --sphinx-html           build html help with Sphinx
  --sphinx-qthelp         build qch help with Sphinx
  --sphinx-build=<sb>     use <sb> as the sphinx-build executable
  --sphinx-flags=<flags>  pass <flags> to sphinx-build executable

Directory and file names:
  --prefix=PREFIX         install files in tree rooted at PREFIX
                          [/usr/local]
  --bindir=DIR            install binaries in PREFIX/DIR
                          [bin]
  --datadir=DIR           install data files in PREFIX/DIR
                          [share/cmake-3.7]
  --docdir=DIR            install documentation files in PREFIX/DIR
                          [doc/cmake-3.7]
  --mandir=DIR            install man pages files in PREFIX/DIR/manN
                          [man]
  --xdgdatadir=DIR        install XDG specific files in PREFIX/DIR
                          [share]
```
