### PR TITLE
Move tutorial slides to external link and stop using git LFS

### DIFF
--- a/lib/spack/docs/tutorial/.gitattributes
+++ b/lib/spack/docs/tutorial/.gitattributes
@@ -1,1 +1,0 @@
-Spack-SC16-Tutorial.pdf filter=lfs diff=lfs merge=lfs -text

--- a/lib/spack/docs/tutorial_sc16.rst
+++ b/lib/spack/docs/tutorial_sc16.rst
@@ -15,12 +15,12 @@ the live demo scripts to see how Spack is used in practice.
 .. rubric:: Slides
 
 .. figure:: tutorial/sc16-tutorial-slide-preview.png
-   :target: _downloads/Spack-SC16-Tutorial.pdf
+   :target: http://software.llnl.gov/spack/files/Spack-SC16-Tutorial.pdf
    :height: 72px
    :align: left
    :alt: Slide Preview
 
-:download:`Download Slides <tutorial/Spack-SC16-Tutorial.pdf>`.
+`Download Slides <software.llnl.gov/spack/files/Spack-SC16-Tutorial.pdf>`_.
 
 **Full citation:** Todd Gamblin, Massimiliano Culpo, Gregory Becker, Matt
 Legendre, Greg Lee, Elizabeth Fischer, and Benedikt Hegner.


### PR DESCRIPTION
Fixes #2336.

@davydden: can you clone this branch successfully without git LFS errors?

- Seems like older git versions won't be able to clone an LFS repo.
- Reverting to an external link for the slides to avoid storing an 8MB
  file in the repo and to avoid using git LFS.