### PR TITLE
Improve diagnostics to ease debugging

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -128,6 +128,8 @@ parser.add_argument('-p', '--profile', action='store_true',
                     help="Profile execution using cProfile.")
 parser.add_argument('-v', '--verbose', action='store_true',
                     help="Print additional output during builds")
+parser.add_argument('-s', '--stacktrace', action='store_true',
+                    help="Add stacktrace information to all printed statements")
 parser.add_argument('-V', '--version', action='version',
                     version="%s" % spack.spack_version)
 
@@ -155,6 +157,7 @@ def main():
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)
+    tty.set_stacktrace(args.stacktrace)
     spack.debug = args.debug
 
     if spack.debug:

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -67,12 +67,12 @@ def set_stacktrace(flag):
 
 
 def process_stacktrace(countback):
-    """Returns a string with the file and line of the stackframe 'countback' frames from the bottom of the stack"""
+    """Gives file and line frame 'countback' frames from the bottom"""
     st = traceback.extract_stack()
-    #First entry should be bin/spack. Use this to get spack 'root'.
-    #bin/spack is 9 characters, the length of the 'root' is then len-9.
-    root_len = len(st[0][0])-9
-    st_idx = len(st)-countback-1
+    # First entry should be bin/spack. Use this to get spack 'root'.
+    # bin/spack is 9 characters, the length of the 'root' is then len-9.
+    root_len = len(st[0][0]) - 9
+    st_idx = len(st) - countback - 1
     st_text = "%s:%i " % (st[st_idx][0][root_len:], st[st_idx][1])
     return st_text
 
@@ -96,7 +96,8 @@ def info(message, *args, **kwargs):
     st_text = ""
     if _stacktrace:
         st_text = process_stacktrace(st_countback)
-    cprint("@%s{%s==>} %s" % (format, st_text, cescape(str(message))), stream=stream)
+    cprint("@%s{%s==>} %s" % (format, st_text, cescape(str(message))),
+           stream=stream)
     for arg in args:
         if wrap:
             lines = textwrap.wrap(

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -69,9 +69,13 @@ def set_stacktrace(flag):
 def process_stacktrace(countback):
     """Gives file and line frame 'countback' frames from the bottom"""
     st = traceback.extract_stack()
-    # First entry should be bin/spack. Use this to get spack 'root'.
-    # bin/spack is 9 characters, the length of the 'root' is then len-9.
-    root_len = len(st[0][0]) - 9
+    # All entries will be spack files based on how this function is called.
+    # We use commonprefix to find what the spack 'root' directory is.
+    file_list = []
+    for frame in st:
+        file_list.append(frame[0])
+    root_dir = os.path.commonprefix(file_list)
+    root_len = len(root_dir)
     st_idx = len(st) - countback - 1
     st_text = "%s:%i " % (st[st_idx][0][root_len:], st[st_idx][1])
     return st_text

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -69,11 +69,13 @@ def set_stacktrace(flag):
 def process_stacktrace(countback):
     """Gives file and line frame 'countback' frames from the bottom"""
     st = traceback.extract_stack()
-    # All entries will be spack files based on how this function is called.
-    # We use commonprefix to find what the spack 'root' directory is.
+    # Not all entries may be spack files, we have to remove those that aren't.
     file_list = []
     for frame in st:
-        file_list.append(frame[0])
+        # Check that the file is a spack file
+        if frame[0].find("/spack") >= 0:
+            file_list.append(frame[0])
+    # We use commonprefix to find what the spack 'root' directory is.
     root_dir = os.path.commonprefix(file_list)
     root_len = len(root_dir)
     st_idx = len(st) - countback - 1


### PR DESCRIPTION
The option -s now causes file and line number information to be printed
along with any invocation of msg, info, etc...

This will greatly ease debugging.