### PR TITLE
hdf5: fix for lib64 installation

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -175,7 +175,9 @@ HDF5 version {version} {version}
             # TODO: Automate these path and library settings
             cc('-c', "-I%s" % join_path(spec.prefix, "include"), "check.c")
             cc('-o', "check", "check.o",
-               "-L%s" % join_path(spec.prefix, "lib"), "-lhdf5",
+               "-L%s" % join_path(spec.prefix, "lib"),
+               "-L%s" % join_path(spec.prefix, "lib64"),
+               "-lhdf5",
                "-lz")
             try:
                 check = Executable('./check')


### PR DESCRIPTION
on OpenSuse13 `hdf5` installs into `prefix/lib64`. 

The proper fix to that problem is https://github.com/LLNL/spack/pull/1875 by @alalazo .