### PR TITLE
Allow spack create to handle packages with period in name

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -434,7 +434,6 @@ def create(parser, args):
     # Figure out a name and repo for the package.
     name, version = guess_name_and_version(url, args)
     spec = Spec(name)
-    name = spec.name.lower()  # factors out namespace, if any
     repo = find_repository(spec, args)
 
     tty.msg("This looks like a URL for %s version %s" % (name, version))

--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -59,10 +59,10 @@ class UrlParseTest(unittest.TestCase):
 
     def test_version_sourceforge_download(self):
         self.check(
-            'foo_bar', '1.21',
+            'foo-bar', '1.21',
             'http://sourceforge.net/foo_bar-1.21.tar.gz/download')
         self.check(
-            'foo_bar', '1.21',
+            'foo-bar', '1.21',
             'http://sf.net/foo_bar-1.21.tar.gz/download')
 
     def test_no_version(self):
@@ -71,7 +71,7 @@ class UrlParseTest(unittest.TestCase):
 
     def test_version_all_dots(self):
         self.check(
-            'foo.bar.la', '1.14', 'http://example.com/foo.bar.la.1.14.zip')
+            'foo-bar-la', '1.14', 'http://example.com/foo.bar.la.1.14.zip')
 
     def test_version_underscore_separator(self):
         self.check(
@@ -136,12 +136,12 @@ class UrlParseTest(unittest.TestCase):
 
     def test_version_single_digit(self):
         self.check(
-            'foo_bar', '45',
+            'foo-bar', '45',
             'http://example.com/foo_bar.45.tar.gz')
 
     def test_noseparator_single_digit(self):
         self.check(
-            'foo_bar', '45',
+            'foo-bar', '45',
             'http://example.com/foo_bar45.tar.gz')
 
     def test_version_developer_that_hates_us_format(self):
@@ -151,7 +151,7 @@ class UrlParseTest(unittest.TestCase):
 
     def test_version_regular(self):
         self.check(
-            'foo_bar', '1.21',
+            'foo-bar', '1.21',
             'http://example.com/foo_bar-1.21.tar.gz')
 
     def test_version_github(self):
@@ -216,7 +216,7 @@ class UrlParseTest(unittest.TestCase):
 
     def test_imagemagick_style(self):
         self.check(
-            'ImageMagick', '6.7.5-7',
+            'imagemagick', '6.7.5-7',
 
             'http://downloads.sf.net/project/machomebrew/mirror/ImageMagick-6.7.5-7.tar.bz2')
 
@@ -247,7 +247,7 @@ class UrlParseTest(unittest.TestCase):
 
     def test_xaw3d_version(self):
         self.check(
-            'Xaw3d', '1.5E',
+            'xaw3d', '1.5E',
             'ftp://ftp.visi.com/users/hawkeyd/X/Xaw3d-1.5E.tar.gz')
 
     def test_fann_version(self):
@@ -324,5 +324,5 @@ class UrlParseTest(unittest.TestCase):
 
     def test_github_raw_url(self):
         self.check(
-            'PowerParser', '2.0.7',
+            'powerparser', '2.0.7',
             'https://github.com/losalamos/CLAMR/blob/packages/PowerParser_v2.0.7.tgz?raw=true')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -305,6 +305,10 @@ def parse_name_offset(path, v=None):
             if match_string is stem:
                 start += offset
 
+            # package names should be lowercase and separated by dashes.
+            name = name.lower()
+            name = re.sub('[_.]', '-', name)
+
             return name, start, len(name)
 
     raise UndetectableNameError(path)


### PR DESCRIPTION
Fixes #2346.

Some package URLs include a period in their name, such as:
```
https://pypi.io/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.5.0.1.tar.gz
```
When running `spack create`, this was being interpreted as a package name of `ssl_match_hostname` and a NAMESPACE of `backports`. This PR replaces periods and underscores with dashes, so as to match the rest of Spack. I've never used Spack's NAMESPACE support, so can someone who does test this PR for me?

If anyone wants me to, I can rename packages like `the_silver_searcher` and `SAMRAI` to be lowercase and separated by dashes. And then we can get into the debate over `R` vs. `r` :smile: 