### PR TITLE
Build py-numpy with MKL

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -86,7 +86,7 @@ class IntelParallelStudio(IntelInstaller):
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(self.prefix.lib, 'intel64'),
+            root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
             shared=shared
         )
         system_libs = [

--- a/var/spack/repos/builtin/packages/mkl/package.py
+++ b/var/spack/repos/builtin/packages/mkl/package.py
@@ -71,4 +71,17 @@ class Mkl(IntelInstaller):
         spack_env.set('MKLROOT', self.prefix)
 
     def setup_environment(self, spack_env, env):
+        # Remove paths that were guessed but are incorrect for this package.
+        env.remove_path('LIBRARY_PATH',
+                        join_path(self.prefix, 'lib'))
+        env.remove_path('LD_LIBRARY_PATH',
+                        join_path(self.prefix, 'lib'))
+        env.prepend_path('LD_LIBRARY_PATH',
+                         join_path(self.prefix, 'lib', 'intel64'))
+        env.prepend_path('LIBRARY_PATH',
+                         join_path(self.prefix, 'lib', 'intel64'))
+        env.prepend_path('LD_LIBRARY_PATH',
+                         join_path(self.prefix, 'lib', 'intel64'))
+        env.prepend_path('LIBRARY_PATH',
+                         join_path(self.prefix, 'lib', 'intel64'))
         env.set('MKLROOT', self.prefix)


### PR DESCRIPTION
This PR gets a GCC built python to use MKL for blas/lapack. This is not perfect and I
have put comments for TODO items.

The changes to intel-parallel-studio are to get the correct library path for blas. I was
using that to attempt to use it but there were a couple of other issues. The changes to
the mkl package are to get the proper paths in the environment module, similar to what
was done previously for the intel-parallel-studio package.

For py-numpy itself, the section title for the defaults changed from DEFAULTS to ALL with
numpy-1.10 so that is configured accordingly. Also, for MKL to be used there must be a
section called, '[mkl]'. Finally, the mkl_rt library is needed, especially when built
with GCC. As such, that library is made explicit in the [mkl] section of the config file.