### PR TITLE
intel-parallel-studio: fix location of MKL libs

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -86,7 +86,7 @@ class IntelParallelStudio(IntelInstaller):
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(self.prefix.lib, 'intel64'),
+            root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
             shared=shared
         )
         system_libs = [


### PR DESCRIPTION
a part of https://github.com/LLNL/spack/pull/2361/

p.s. i don't have intel-parallel-studio, somebody who has it please double check.

@glennpj ping.