### PR TITLE
py-numpy: rework blas/lapack 

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -75,15 +75,56 @@ class PyNumpy(PythonPackage):
             lapackblas += spec['blas'].blas_libs
 
         if '+blas' in spec or '+lapack' in spec:
+            # note that one should not use [blas_opt] and [lapack_opt], see
+            # https://github.com/numpy/numpy/commit/ffd4332262ee0295cb942c94ed124f043d801eb6
             with open('site.cfg', 'w') as f:
+                # Unfortunately, numpy prefers to provide each BLAS/LAPACK
+                # differently.
+                names  = ','.join(lapackblas.names)
+                dirs   = ':'.join(lapackblas.directories)
+                # First, workout the defaults.
                 # The section title for the defaults changed in @1.10, see
                 # https://github.com/numpy/numpy/blob/master/site.cfg.example
                 if spec.satisfies('@:1.9.2'):
                     f.write('[DEFAULT]\n')
                 else:
                     f.write('[ALL]\n')
-                f.write('libraries=%s\n'    % ','.join(lapackblas.names))
-                f.write('library_dirs=%s\n' % ':'.join(lapackblas.directories))
+                if not ('^openblas' in spec or
+                        '^mkl' in spec or
+                        '^atlas' in spec):
+                    f.write('libraries=%s\n'    % names)
+                    f.write('library_dirs=%s\n' % dirs)
+
                 if not ((platform.system() == "Darwin") and
                         (platform.mac_ver()[0] == '10.12')):
                     f.write('rpath=%s\n' % ':'.join(lapackblas.directories))
+
+                # Now special treatment for some (!) BLAS/LAPACK. Note that
+                # in this case library_dirs can not be specified within [ALL].
+                if '^openblas' in spec:
+                    f.write('[openblas]\n')
+                    f.write('libraries=%s\n'    % names)
+                    f.write('library_dirs=%s\n' % dirs)
+                elif '^mkl' in spec:
+                    # numpy does not expect system libraries needed for MKL
+                    # here.
+                    # names = [x for x in names if x.startswith('mkl')]
+                    # FIXME: as of @1.11.2, numpy does not work with separately
+                    # specified threading and interface layers. A workaround is
+                    # a terribly bad idea to use mkl_rt. In this case Spack
+                    # won't no longer be able to guarantee that one and the
+                    # same variant of Blas/Lapack (32/64bit, threaded/serial)
+                    # is used within the DAG. This may lead to a lot of
+                    # hard-to-debug segmentation faults on user's side. Users
+                    # may also break working installation by (unconciously)
+                    # setting environment variable to switch between different
+                    # interface and threading layers dynamically. From this
+                    # perspective it is no different from throwing away RPATH's
+                    # and using LD_LIBRARY_PATH throughout Spack.
+                    f.write('[mkl]\n')
+                    f.write('mkl_libs=%s\n'     % 'mkl_rt')
+                    f.write('library_dirs=%s\n' % dirs)
+                elif '^atlas' in spec:
+                    f.write('[atlas]\n')
+                    f.write('atlas_libs=%s\n'   % names)
+                    f.write('library_dirs=%s\n' % dirs)

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -76,7 +76,12 @@ class PyNumpy(PythonPackage):
 
         if '+blas' in spec or '+lapack' in spec:
             with open('site.cfg', 'w') as f:
-                f.write('[DEFAULT]\n')
+                # The section title for the defaults changed in @1.10, see
+                # https://github.com/numpy/numpy/blob/master/site.cfg.example
+                if spec.satisfies('@:1.9.2'):
+                    f.write('[DEFAULT]\n')
+                else:
+                    f.write('[ALL]\n')
                 f.write('libraries=%s\n'    % ','.join(lapackblas.names))
                 f.write('library_dirs=%s\n' % ':'.join(lapackblas.directories))
                 if not ((platform.system() == "Darwin") and


### PR DESCRIPTION
another part of https://github.com/LLNL/spack/pull/2361 plus a lots of extras.


tested `py-numpy@1.11.2` by calling 
```
spack activate py-numpy; spack load python;
``` 
followed by (see https://github.com/Homebrew/homebrew-python/blob/master/numpy.rb#L123-L126)
```
python -c 'import numpy as np; t = np.ones((3,3),int); assert t.sum() == 9; assert np.dot(t,t).sum() == 27; np.show_config()'
```
on...

**macOS Sierra + clang**:
- [x] `spack install py-numpy+blas+lapack ^openblas`
```
lapack_opt_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openblas-0.2.19-7qdxwznmqzlbqtusssagtxkypivod6ct/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
blas_opt_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openblas-0.2.19-7qdxwznmqzlbqtusssagtxkypivod6ct/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
openblas_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openblas-0.2.19-7qdxwznmqzlbqtusssagtxkypivod6ct/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
openblas_lapack_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openblas-0.2.19-7qdxwznmqzlbqtusssagtxkypivod6ct/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
blas_mkl_info:
  NOT AVAILABLE
```

**Ubuntu 16.04 + GCC5.4**:
- [x] `spack install py-numpy+blas+lapack ^openblas`
```
lapack_opt_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/openblas-0.2.19-ehpxgz2j74uc7pbca5lnufmna4is3oqs/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
blas_opt_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/openblas-0.2.19-ehpxgz2j74uc7pbca5lnufmna4is3oqs/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
openblas_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/openblas-0.2.19-ehpxgz2j74uc7pbca5lnufmna4is3oqs/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
openblas_lapack_info:
    libraries = ['openblas', 'openblas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/openblas-0.2.19-ehpxgz2j74uc7pbca5lnufmna4is3oqs/lib']
    define_macros = [('HAVE_CBLAS', None)]
    language = c
blas_mkl_info:
  NOT AVAILABLE
```
- [x] `spack install py-numpy+blas+lapack ^atlas` (**mix threaded and non-threaded libs due to upstream**)
```
atlas_3_10_blas_threads_info:
    libraries = ['satlas', 'tatlas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/atlas-3.10.2-5jtibobvt7nlwd3zyviionsn7v4z2npd/lib']
    define_macros = [('HAVE_CBLAS', None), ('ATLAS_INFO', '"\\"3.10.2\\""')]
    language = c
lapack_opt_info:
    libraries = ['tatlas', 'satlas', 'tatlas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/atlas-3.10.2-5jtibobvt7nlwd3zyviionsn7v4z2npd/lib']
    define_macros = [('ATLAS_INFO', '"\\"3.10.2\\""')]
    language = f77
blas_opt_info:
    libraries = ['satlas', 'tatlas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/atlas-3.10.2-5jtibobvt7nlwd3zyviionsn7v4z2npd/lib']
    define_macros = [('HAVE_CBLAS', None), ('ATLAS_INFO', '"\\"3.10.2\\""')]
    language = c
openblas_info:
  NOT AVAILABLE
openblas_lapack_info:
  NOT AVAILABLE
atlas_3_10_threads_info:
    libraries = ['tatlas', 'satlas', 'tatlas']
    library_dirs = ['/home/davydden/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.0/atlas-3.10.2-5jtibobvt7nlwd3zyviionsn7v4z2npd/lib']
    define_macros = [('ATLAS_INFO', '"\\"3.10.2\\""')]
    language = f77
lapack_mkl_info:
  NOT AVAILABLE
blas_mkl_info:
  NOT AVAILABLE
```
- [x] `spack install py-numpy+blas+lapack ^mkl` (**not working due to upstream**)
```
lapack_info:
  NOT AVAILABLE
lapack_opt_info:
  NOT AVAILABLE
openblas_lapack_info:
  NOT AVAILABLE
blas_info:
  NOT AVAILABLE
atlas_3_10_blas_threads_info:
  NOT AVAILABLE
atlas_threads_info:
  NOT AVAILABLE
blas_src_info:
  NOT AVAILABLE
atlas_3_10_threads_info:
  NOT AVAILABLE
atlas_blas_info:
  NOT AVAILABLE
atlas_3_10_blas_info:
  NOT AVAILABLE
lapack_src_info:
  NOT AVAILABLE
atlas_blas_threads_info:
  NOT AVAILABLE
openblas_info:
  NOT AVAILABLE
blas_mkl_info:
  NOT AVAILABLE
blas_opt_info:
  NOT AVAILABLE
atlas_info:
  NOT AVAILABLE
atlas_3_10_info:
  NOT AVAILABLE
lapack_mkl_info:
  NOT AVAILABLE
```

@glennpj ping.