### PR TITLE
Bugfix/update go packages

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -41,14 +41,17 @@ class GoBootstrap(Package):
 
     extendable = True
 
-    # NOTE: Go@1.4.2 is the only supported bootstrapping compiler because all
+    # NOTE: Go@1.4.x is the only supported bootstrapping compiler because all
     # later versions require a Go compiler to build.
-    # See: https://golang.org/doc/install/source
-    version('1.4.2', git='https://go.googlesource.com/go', tag='go1.4.2')
+    # See: https://golang.org/doc/install/source#go14 and
+    # https://github.com/golang/go/issues/17545 and
+    # https://github.com/golang/go/issues/16352
+    version('1.4-bootstrap-20161024', '76e42c8152e8560ded880a6d1d1f53cb',
+            url='https://storage.googleapis.com/golang/go1.4-bootstrap-20161024.tar.gz')
 
     variant('test', default=True, description='Build and run tests as part of the build.')
 
-    provides('golang@:1.4.2')
+    provides('golang@:1.4-bootstrap-20161024')
 
     depends_on('git', type='alldeps')
 
@@ -69,6 +72,7 @@ class GoBootstrap(Package):
         pass
 
     def install(self, spec, prefix):
+        env['CGO_ENABLED'] = '0'
         bash = which('bash')
         with working_dir('src'):
             bash('{0}.bash'.format('all' if '+test' in spec else 'make'))

--- a/var/spack/repos/builtin/packages/go/misc-cgo-testcshared.patch
+++ b/var/spack/repos/builtin/packages/go/misc-cgo-testcshared.patch
@@ -1,0 +1,11 @@
+--- misc/cgo/testcshared/test.bash.orig	2016-11-19 00:00:11.917000000 +0000
++++ misc/cgo/testcshared/test.bash	2016-11-19 00:00:22.081000000 +0000
+@@ -107,7 +107,7 @@
+ 
+ # test0: exported symbols in shared lib are accessible.
+ # TODO(iant): using _shared here shouldn't really be necessary.
+-$(go env CC) ${GOGCCFLAGS} -I ${installdir} -o testp main0.c libgo.$libext
++$(go env CC) ${GOGCCFLAGS} -I ${installdir} -o testp main0.c ./libgo.$libext
+ binpush testp
+ 
+ output=$(run LD_LIBRARY_PATH=. ./testp)

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -32,13 +32,12 @@ from spack import *
 class Go(Package):
     """The golang compiler and build environment"""
     homepage = "https://golang.org"
-    url = "https://go.googlesource.com/go"
+    url='https://storage.googleapis.com/golang/go1.7.3.src.tar.gz'
 
     extendable = True
 
-    version('1.6.2', git='https://go.googlesource.com/go', tag='go1.6.2')
-    version('1.5.4', git='https://go.googlesource.com/go', tag='go1.5.4')
-    version('1.4.2', git='https://go.googlesource.com/go', tag='go1.4.2')
+    version('1.7.3', '83d1b7bd4281479ab7d153e5152c9fc9')
+    version('1.6.2', 'd1b50fa98d9a71eeee829051411e6207')
 
     variant('test', default=True, description='Build and run tests as part of the build.')
 
@@ -48,6 +47,12 @@ class Go(Package):
     # TODO: Make non-c self-hosting compilers feasible without backflips
     # should be a dep on external go compiler
     depends_on('go-bootstrap', type='build')
+
+    # https://github.com/golang/go/issues/17545
+    patch('time_test.patch', when='@1.6.2:1.7.3')
+
+    # https://github.com/golang/go/issues/17986
+    patch('misc-cgo-testcshared.patch', level=0, when='@1.6.2:1.7.3')
 
     # NOTE: Older versions of Go attempt to download external files that have
     # since been moved while running the test suite.  This patch modifies the
@@ -64,6 +69,9 @@ class Go(Package):
     @when('@1.5.0:')
     def patch(self):
         pass
+
+    def url_for_version(self, version):
+        return "https://storage.googleapis.com/golang/go{0}.src.tar.gz".format(version)
 
     def install(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/go/time_test.patch
+++ b/var/spack/repos/builtin/packages/go/time_test.patch
@@ -1,0 +1,18 @@
+diff --git a/src/time/time_test.go b/src/time/time_test.go
+index 68236fd..2e47d08 100644
+--- a/src/time/time_test.go
++++ b/src/time/time_test.go
+@@ -943,8 +943,11 @@ func TestLoadFixed(t *testing.T) {
+ 	// but Go and most other systems use "east is positive".
+ 	// So GMT+1 corresponds to -3600 in the Go zone, not +3600.
+ 	name, offset := Now().In(loc).Zone()
+-	if name != "GMT+1" || offset != -1*60*60 {
+-		t.Errorf("Now().In(loc).Zone() = %q, %d, want %q, %d", name, offset, "GMT+1", -1*60*60)
++	// The zone abbreviation is "-01" since tzdata-2016g, and "GMT+1"
++	// on earlier versions; we accept both. (Issue #17276).
++	if !(name == "GMT+1" || name == "-01") || offset != -1*60*60 {
++		t.Errorf("Now().In(loc).Zone() = %q, %d, want %q or %q, %d",
++			name, offset, "GMT+1", "-01", -1*60*60)
+ 	}
+ }
+ 


### PR DESCRIPTION
Update the go-bootstrap package to use the recently instantiated 1.4-bootstrap-YYYYMMDD tarball and disable the unnecessary CGO bits so that it builds and tests cleanly.

Update the go package to:

- build from the source tarballs (with digests) rather than pulling from git;
- support 1.7.3 and 1.6.2, including patching around a couple of problems; and
- dropping support for 1.5.4 and 1.4.3 because they do not build cleanly.