### PR TITLE
TetGen: Fix Package Bugs and Add Variants

### DIFF
--- a/var/spack/repos/builtin/packages/tetgen/tetgen-1.5.0-free.patch
+++ b/var/spack/repos/builtin/packages/tetgen/tetgen-1.5.0-free.patch
@@ -1,0 +1,49 @@
+diff --git a/tetgen.h b/tetgen.h
+index 3196e03..2ff3138 100644
+--- a/tetgen.h
++++ b/tetgen.h
+@@ -2206,6 +2206,44 @@ public:
+     if (highordertable != NULL) {
+       delete [] highordertable;
+     }
++
++    bgm = NULL;
++
++    points = NULL;
++    dummypoint = NULL;
++
++    tetrahedrons = NULL;
++
++    subfaces = NULL;
++    subsegs = NULL;
++
++    tet2segpool = NULL;
++    tet2subpool = NULL;
++
++    flippool = NULL;
++    unflipqueue = NULL;
++
++    cavetetlist = NULL;
++    cavebdrylist = NULL;
++    caveoldtetlist = NULL;
++    cavetetvertlist = NULL;
++
++    caveshlist = NULL;
++    caveshbdlist = NULL;
++    cavesegshlist = NULL;
++    cavetetshlist = NULL;
++    cavetetseglist = NULL;
++    caveencshlist = NULL;
++    caveencseglist = NULL;
++
++    subsegstack = NULL;
++    subfacstack = NULL;
++    subvertstack = NULL;
++
++    idx2facetlist = NULL;
++    facetverticeslist = NULL;
++    segmentendpointslist = NULL;
++    highordertable = NULL;
+   }
+ 
+   ~tetgenmesh()


### PR DESCRIPTION
The changes in this pull request make the following changes to the `tetgen` package:

- Fix a bug that was causing memory error after internal failures in `tetgen@1.5.0` installs.
- Add the `+debug` variant, which allows `tetgen` to be configured to be built with or without debug information.
- Add the `+except` variant, which replaces the C asserts in `tetgen` with throw statements to facilitate better error handling when using `tetgen` as a library.

I've verified that the `tetgen@1.4.3/1.5.0+/~debug+/~except` variants of this package compile and install properly on RHEL6 when compiling with `gcc@4.7.2`.

Please let me know if there are any problems with these changes and I'll revise them as soon as I can!