### PR TITLE
atlas: fix lapack stage path

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -71,7 +71,10 @@ class Atlas(Package):
         # TODO: using, say, MSRs.  Or move this to a variant.
 
     def install(self, spec, prefix):
-
+        # reference to other package managers
+        # https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild/easyblocks/a/atlas.py
+        # https://github.com/macports/macports-ports/blob/master/math/atlas/Portfile
+        # https://github.com/Homebrew/homebrew-science/pull/3571
         options = []
         if '+shared' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -92,10 +92,8 @@ class Atlas(Package):
 
         # Lapack resource to provide full lapack build. Note that
         # ATLAS only provides a few LAPACK routines natively.
-        lapack_stage = self.stage[1]
-        lapack_tarfile = os.path.basename(lapack_stage.fetcher.url)
-        lapack_tarfile_path = join_path(lapack_stage.path, lapack_tarfile)
-        options.append('--with-netlib-lapack-tarfile=%s' % lapack_tarfile_path)
+        options.append('--with-netlib-lapack-tarfile=%s' %
+                       self.stage[1].archive_file)
 
         with working_dir('spack-build', create=True):
             configure = Executable('../configure')


### PR DESCRIPTION
partly fixes issues discussed in  #2366

p.s. there are other problems with Atlas both on macOS Sierra and on RHEL. On Sierra the build output makes zero sense to me, so i just accept it being broken.

**update:**

tested on Ubuntu16+5.4.0, compiles ok.