### PR TITLE
Adding pic_flag property to compilers

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -78,6 +78,10 @@ class Clang(Compiler):
             else:
                 return "-std=c++11"
 
+    @property
+    def pic_flag(self):
+        return "-fPIC"
+
     @classmethod
     def default_version(cls, comp):
         """The '--version' option works for clang compilers.

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -74,6 +74,10 @@ class Gcc(Compiler):
         else:
             return "-std=c++14"
 
+    @property
+    def pic_flag(self):
+        return "-fPIC"
+
     @classmethod
     def fc_version(cls, fc):
         return get_compiler_version(

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -65,6 +65,10 @@ class Intel(Compiler):
         else:
             return "-std=c++11"
 
+    @property
+    def pic_flag(self):
+        return "-fPIC"
+
     @classmethod
     def default_version(cls, comp):
         """The '--version' option seems to be the most consistent one

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -56,6 +56,10 @@ class Nag(Compiler):
         # However, it can be mixed with a compiler that does support it
         return "-std=c++11"
 
+    @property
+    def pic_flag(self):
+        return "-PIC"
+
     # Unlike other compilers, the NAG compiler passes options to GCC, which
     # then passes them to the linker. Therefore, we need to doubly wrap the
     # options with '-Wl,-Wl,,'

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -55,6 +55,10 @@ class Pgi(Compiler):
     def cxx11_flag(self):
         return "-std=c++11"
 
+    @property
+    def pic_flag(self):
+        return "-fpic"
+
     @classmethod
     def default_version(cls, comp):
         """The '-V' option works for all the PGI compilers.

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -58,6 +58,10 @@ class Xl(Compiler):
         else:
             return "-qlanglvl=extended0x"
 
+    @property
+    def pic_flag(self):
+        return "-qpic"
+
     @classmethod
     def default_version(cls, comp):
         """The '-qversion' is the standard option fo XL compilers.


### PR DESCRIPTION
Different compilers have different flags for PIC (position-independent
code). This patch provides a common ground to accessing it inside specs.

See discussions in #508 and #2373. This patch does not address the issue
of mixed compilers as mentioned in #508.