### PR TITLE
variant: added support for multi-valued variants

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -266,9 +266,27 @@ def key_ordering(cls):
 
 
 @key_ordering
-class HashableMap(dict):
+class HashableMap(collections.MutableMapping):
     """This is a hashable, comparable dictionary.  Hash is performed on
        a tuple of the values in the dictionary."""
+
+    def __init__(self):
+        self.dict = {}
+
+    def __getitem__(self, key):
+        return self.dict[key]
+
+    def __setitem__(self, key, value):
+        self.dict[key] = value
+
+    def __iter__(self):
+        return iter(self.dict)
+
+    def __len__(self):
+        return len(self.dict)
+
+    def __delitem__(self, key):
+        del self.dict[key]
 
     def _cmp_key(self):
         return tuple(sorted(self.values()))

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -22,22 +22,22 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import sys
-import os
-import textwrap
 import fcntl
-import termios
+import os
 import struct
+import sys
+import termios
+import textwrap
 import traceback
 from six import StringIO
 from six.moves import input
 
 from llnl.util.tty.color import *
 
-_debug   = False
+_debug = False
 _verbose = False
 _stacktrace = False
-indent  = "  "
+indent = "  "
 
 
 def is_verbose():
@@ -100,7 +100,7 @@ def msg(message, *args, **kwargs):
 def info(message, *args, **kwargs):
     format = kwargs.get('format', '*b')
     stream = kwargs.get('stream', sys.stdout)
-    wrap   = kwargs.get('wrap', False)
+    wrap = kwargs.get('wrap', False)
     break_long_words = kwargs.get('break_long_words', False)
     st_countback = kwargs.get('countback', 3)
 
@@ -218,7 +218,7 @@ def hline(label=None, **kwargs):
         char (str): Char to draw the line with.  Default '-'
         max_width (int): Maximum width of the line.  Default is 64 chars.
     """
-    char      = kwargs.pop('char', '-')
+    char = kwargs.pop('char', '-')
     max_width = kwargs.pop('max_width', 64)
     if kwargs:
         raise TypeError(

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -289,7 +289,7 @@ class AutotoolsPackage(PackageBase):
             self._if_make_target_execute('test')
             self._if_make_target_execute('check')
 
-    def _activate_or_not(self, active, inactive, name):
+    def _activate_or_not(self, active, inactive, name, active_parameters=None):
         spec = self.spec
         args = []
         # For each allowed value in the list of values
@@ -304,23 +304,36 @@ class AutotoolsPackage(PackageBase):
             if line_generator is None:
                 def _default_generator(is_activated):
                     if is_activated:
-                        return '--{0}-{1}'.format(active, value)
+                        line = '--{0}-{1}'.format(active, value)
+                        if active_parameters is not None and active_parameters(value):  # NOQA=ignore=E501
+                            line += '={0}'.format(active_parameters(value))
+                        print(line)
+                        return line
                     return '--{0}-{1}'.format(inactive, value)
                 line_generator = _default_generator
             args.append(line_generator(activated))
         return args
 
-    def with_or_without(self, name):
+    def with_or_without(self, name, active_parameters=None):
         """Inspects the multi-valued variant 'name' and returns the configure
         arguments that activate / deactivate the selected feature.
-        """
-        return self._activate_or_not('with', 'without', name)
 
-    def enable_or_disable(self, name):
+        :param str name: name of a valid multi-valued variant
+        :param callable active_parameters: if present accepts a single value
+            and returns the parameter to be used leading to an entry of the
+            type '--with-{name}={parameter}
+        """
+        return self._activate_or_not(
+            'with', 'without', name, active_parameters
+        )
+
+    def enable_or_disable(self, name, active_parameters=None):
         """Inspects the multi-valued variant 'name' and returns the configure
         arguments that activate / deactivate the selected feature.
         """
-        return self._activate_or_not('enable', 'disable', name)
+        return self._activate_or_not(
+            'enable', 'disable', name, active_parameters
+        )
 
     run_after('install')(PackageBase._run_default_install_time_test_callbacks)
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -307,7 +307,6 @@ class AutotoolsPackage(PackageBase):
                         line = '--{0}-{1}'.format(active, value)
                         if active_parameters is not None and active_parameters(value):  # NOQA=ignore=E501
                             line += '={0}'.format(active_parameters(value))
-                        print(line)
                         return line
                     return '--{0}-{1}'.format(inactive, value)
                 line_generator = _default_generator

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -77,6 +77,7 @@ def print_text_info(pkg):
 
         maxv = max(len(v) for v in sorted(pkg.variants))
         maxl = max(len(v.allowed_values) for _, v in pkg.variants.items())
+        maxl = max(maxl, 14)  # 14 is length of the column heading
         fmt = "%%-%ss%%-10s%%-%ss%%s" % (maxv + 4, maxl + 4)
 
         print("    " + fmt % ('Name',   'Default',   'Allowed values', 'Description'))

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -76,19 +76,22 @@ def print_text_info(pkg):
         pad = padder(pkg.variants, 4)
 
         maxv = max(len(v) for v in sorted(pkg.variants))
-        fmt = "%%-%ss%%-10s%%s" % (maxv + 4)
+        maxl = max(len(v.allowed_values) for _, v in pkg.variants.items())
+        fmt = "%%-%ss%%-10s%%-%ss%%s" % (maxv + 4, maxl + 4)
 
-        print("    " + fmt % ('Name',   'Default',   'Description'))
+        print("    " + fmt % ('Name',   'Default',   'Allowed values', 'Description'))
         print()
         for name in sorted(pkg.variants):
             v = pkg.variants[name]
-            default = 'on' if v.default else 'off'
+            default = 'on' if v.default is True else 'off'
+            if not isinstance(v.default, bool):
+                default = v.default
 
             lines = textwrap.wrap(v.description)
             lines[1:] = ["      " + (" " * maxv) + l for l in lines[1:]]
             desc = "\n".join(lines)
 
-            print("    " + fmt % (name, default, desc))
+            print("    " + fmt % (name, default, v.allowed_values, desc))
 
     print()
     print("Installation Phases:")

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -25,7 +25,7 @@
 from __future__ import print_function
 
 import textwrap
-
+import itertools
 from llnl.util.tty.colify import *
 import spack
 import spack.fetch_strategy as fs
@@ -49,6 +49,81 @@ def setup_parser(subparser):
         'name', metavar="PACKAGE", help="name of package to get info for")
 
 
+class VariantFormatter(object):
+    def __init__(self, variants, max_widths=(25, 20, 35)):
+        self.variants = variants
+        self.headers = ('Name [Default]', 'Allowed values', 'Description')
+        # Set max headers lengths
+        self.max_column_widths = max_widths
+
+        # Formats
+        fmt_name = '{0} [{1}]'
+
+        # Initialize column widths with the length of the
+        # corresponding headers, as they cannot be shorter
+        # than that
+        self.column_widths = [len(x) for x in self.headers]
+
+        # Update according to line lengths
+        for k, v in variants.items():
+            candidate_max_widths = (
+                len(fmt_name.format(k, self.default(v))),  # Name [Default]
+                len(v.allowed_values),  # Allowed values
+                len(v.description)  # Description
+            )
+
+            self.column_widths = (
+                max(self.column_widths[0], candidate_max_widths[0]),
+                max(self.column_widths[1], candidate_max_widths[1]),
+                max(self.column_widths[2], candidate_max_widths[2])
+            )
+
+        # Reduce to at most the maximum allowed
+        self.column_widths = (
+            min(self.column_widths[0], self.max_column_widths[0]),
+            min(self.column_widths[1], self.max_column_widths[1]),
+            min(self.column_widths[2], self.max_column_widths[2])
+        )
+
+        # Compute the format
+        self.fmt = "%%-%ss%%-%ss%%s" % (
+            self.column_widths[0] + 4,
+            self.column_widths[1] + 4
+        )
+
+    def default(self, v):
+        s = 'on' if v.default is True else 'off'
+        if not isinstance(v.default, bool):
+            s = v.default
+        return s
+
+    @property
+    def lines(self):
+        if not self.variants:
+            yield "    None"
+        else:
+            yield "    " + self.fmt % self.headers
+            yield '\n'
+            for k, v in sorted(self.variants.items()):
+                name = textwrap.wrap(
+                    '{0} [{1}]'.format(k, self.default(v)),
+                    width=self.column_widths[0]
+                )
+                allowed = textwrap.wrap(
+                    v.allowed_values,
+                    width=self.column_widths[1]
+                )
+                description = textwrap.wrap(
+                    v.description,
+                    width=self.column_widths[2]
+                )
+                for t in itertools.izip_longest(
+                        name, allowed, description, fillvalue=''
+                ):
+                    yield "    " + self.fmt % t
+                yield ''  # Trigger a new line
+
+
 def print_text_info(pkg):
     """Print out a plain text description of a package."""
     header = "{0}:   ".format(pkg.build_system_class)
@@ -70,29 +145,10 @@ def print_text_info(pkg):
 
     print()
     print("Variants:")
-    if not pkg.variants:
-        print("    None")
-    else:
-        pad = padder(pkg.variants, 4)
 
-        maxv = max(len(v) for v in sorted(pkg.variants))
-        maxl = max(len(v.allowed_values) for _, v in pkg.variants.items())
-        maxl = max(maxl, 14)  # 14 is length of the column heading
-        fmt = "%%-%ss%%-10s%%-%ss%%s" % (maxv + 4, maxl + 4)
-
-        print("    " + fmt % ('Name',   'Default',   'Allowed values', 'Description'))
-        print()
-        for name in sorted(pkg.variants):
-            v = pkg.variants[name]
-            default = 'on' if v.default is True else 'off'
-            if not isinstance(v.default, bool):
-                default = v.default
-
-            lines = textwrap.wrap(v.description)
-            lines[1:] = ["      " + (" " * maxv) + l for l in lines[1:]]
-            desc = "\n".join(lines)
-
-            print("    " + fmt % (name, default, v.allowed_values, desc))
+    formatter = VariantFormatter(pkg.variants)
+    for line in formatter.lines:
+        print(line)
 
     print()
     print("Installation Phases:")

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -69,7 +69,8 @@ def spec(parser, args):
     for spec in spack.cmd.parse_specs(args.specs):
         # With -y, just print YAML to output.
         if args.yaml:
-            spec.concretize()
+            if spec.name in spack.repo:
+                spec.concretize()
             print(spec.to_yaml())
             continue
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -251,6 +251,7 @@ class DefaultConcretizer(object):
             if name not in spec.variants:
                 changed = True
                 if name in preferred_variants:
+                    # FIXME: check here
                     spec.variants[name] = preferred_variants.get(name)
                 else:
                     spec.variants[name] = VariantSpec(

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -41,7 +41,6 @@ from ordereddict_backport import OrderedDict
 from functools_backport import reverse_order
 
 import spack
-from spack.variant import VariantSpec
 import spack.spec
 import spack.compilers
 import spack.architecture
@@ -254,9 +253,8 @@ class DefaultConcretizer(object):
                     # FIXME: check here
                     spec.variants[name] = preferred_variants.get(name)
                 else:
-                    spec.variants[name] = VariantSpec(
-                        variant.name, variant.default
-                    )
+                    spec.variants[name] = variant.make_default()
+
         return changed
 
     def concretize_compiler(self, spec):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -250,7 +250,6 @@ class DefaultConcretizer(object):
             if name not in spec.variants:
                 changed = True
                 if name in preferred_variants:
-                    # FIXME: check here
                     spec.variants[name] = preferred_variants.get(name)
                 else:
                     spec.variants[name] = variant.make_default()

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -41,6 +41,7 @@ from ordereddict_backport import OrderedDict
 from functools_backport import reverse_order
 
 import spack
+from spack.variant import VariantSpec
 import spack.spec
 import spack.compilers
 import spack.architecture
@@ -245,14 +246,16 @@ class DefaultConcretizer(object):
         """
         changed = False
         preferred_variants = PackagePrefs.preferred_variants(spec.name)
-        for name, variant in spec.package_class.variants.items():
+        pkg_cls = spec.package_class
+        for name, variant in pkg_cls.variants.items():
             if name not in spec.variants:
                 changed = True
                 if name in preferred_variants:
                     spec.variants[name] = preferred_variants.get(name)
                 else:
-                    spec.variants[name] = spack.spec.VariantSpec(
-                        name, variant.default)
+                    spec.variants[name] = VariantSpec(
+                        variant.name, variant.default
+                    )
         return changed
 
     def concretize_compiler(self, spec):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -368,24 +368,31 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 
 
 @directive('variants')
-def variant(name, default=None, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
+def variant(
+        name,
+        default=None,
+        description='',
+        values=(True, False),
+        exclusive=True,
+        validator=None
+):
     """Define a variant for the package. Packager can specify a default
     value as well as a text description.
 
-    :param str name: name of the variant
-    :param default: default value for the variant, if not specified otherwise
-        the default will be False for a boolean variant and 'nothing' for a
-        multi-valued variant
-    :type default: bool or str
-    :param str description: description of the purpose of the variant
-    :param values: either a tuple of strings containing the allowed values,
-        or a callable accepting one value and returning True if it is valid
-    :type values: tuple or callable
-    :param bool exclusive: if True only one value per spec is allowed for
-        this variant
-    :param callable validator: optional group validator to enforce additional
-        logic. It receives a tuple of values and should raise an instance of
-        SpackError if the group doesn't meet the additional constraints
+    Args:
+        name (str): name of the variant
+        default (str or bool): default value for the variant, if not
+            specified otherwise the default will be False for a boolean
+            variant and 'nothing' for a multi-valued variant
+        description (str): description of the purpose of the variant
+        values (tuple or callable): either a tuple of strings containing the
+            allowed values, or a callable accepting one value and returning
+            True if it is valid
+        exclusive (bool): if True only one value per spec is allowed for
+            this variant
+        validator (callable): optional group validator to enforce additional
+            logic. It receives a tuple of values and should raise an instance
+            of SpackError if the group doesn't meet the additional constraints
     """
 
     if default is None:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -373,7 +373,7 @@ def variant(
         default=None,
         description='',
         values=(True, False),
-        exclusive=True,
+        multi=False,
         validator=None
 ):
     """Define a variant for the package. Packager can specify a default
@@ -388,7 +388,7 @@ def variant(
         values (tuple or callable): either a tuple of strings containing the
             allowed values, or a callable accepting one value and returning
             True if it is valid
-        exclusive (bool): if True only one value per spec is allowed for
+        multi (bool): if False only one value per spec is allowed for
             this variant
         validator (callable): optional group validator to enforce additional
             logic. It receives a tuple of values and should raise an instance
@@ -408,7 +408,7 @@ def variant(
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
         pkg.variants[name] = Variant(
-            name, default, description, values, exclusive, validator
+            name, default, description, values, multi, validator
         )
     return _execute
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -368,7 +368,7 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 
 
 @directive('variants')
-def variant(pkg, name, default=False, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
+def variant(name, default=False, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
     """Define a variant for the package. Packager can specify a default
     value as well as a text description.
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -368,9 +368,11 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 
 
 @directive('variants')
-def variant(name, default=False, description=""):
+def variant(name, default=False, description='', values=(True, False), exclusive=True):  # NOQA: ignore=E501
     """Define a variant for the package. Packager can specify a default
     value (on or off) as well as a text description."""
+
+    default = default
     description = str(description).strip()
 
     def _execute(pkg):
@@ -379,7 +381,7 @@ def variant(name, default=False, description=""):
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
-        pkg.variants[name] = Variant(default, description)
+            pkg.variants[name] = Variant(name, default, description, values, exclusive)
     return _execute
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -368,12 +368,14 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 
 
 @directive('variants')
-def variant(name, default=False, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
+def variant(name, default=None, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
     """Define a variant for the package. Packager can specify a default
     value as well as a text description.
 
     :param str name: name of the variant
     :param default: default value for the variant, if not specified otherwise
+        the default will be False for a boolean variant and 'nothing' for a
+        multi-valued variant
     :type default: bool or str
     :param str description: description of the purpose of the variant
     :param values: either a tuple of strings containing the allowed values,
@@ -385,6 +387,9 @@ def variant(name, default=False, description='', values=(True, False), exclusive
         logic. It receives a tuple of values and should raise an instance of
         SpackError if the group doesn't meet the additional constraints
     """
+
+    if default is None:
+        default = False if values == (True, False) else ''
 
     default = default
     description = str(description).strip()

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -370,7 +370,21 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 @directive('variants')
 def variant(pkg, name, default=False, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
     """Define a variant for the package. Packager can specify a default
-    value (on or off) as well as a text description."""
+    value as well as a text description.
+
+    :param str name: name of the variant
+    :param default: default value for the variant, if not specified otherwise
+    :type default: bool or str
+    :param str description: description of the purpose of the variant
+    :param values: either a tuple of strings containing the allowed values,
+        or a callable accepting one value and returning True if it is valid
+    :type values: tuple or callable
+    :param bool exclusive: if True only one value per spec is allowed for
+        this variant
+    :param callable validator: optional group validator to enforce additional
+        logic. It receives a tuple of values and should raise an instance of
+        SpackError if the group doesn't meet the additional constraints
+    """
 
     default = default
     description = str(description).strip()

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -368,7 +368,7 @@ def patch(url_or_filename, level=1, when=None, **kwargs):
 
 
 @directive('variants')
-def variant(name, default=False, description='', values=(True, False), exclusive=True):  # NOQA: ignore=E501
+def variant(pkg, name, default=False, description='', values=(True, False), exclusive=True, validator=None):  # NOQA: ignore=E501
     """Define a variant for the package. Packager can specify a default
     value (on or off) as well as a text description."""
 
@@ -381,7 +381,9 @@ def variant(name, default=False, description='', values=(True, False), exclusive
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
-            pkg.variants[name] = Variant(name, default, description, values, exclusive)
+        pkg.variants[name] = Variant(
+            name, default, description, values, exclusive, validator
+        )
     return _execute
 
 

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -100,3 +100,18 @@ class NoNetworkConnectionError(SpackError):
             "No network connection: " + str(message),
             "URL was: " + str(url))
         self.url = url
+
+
+class SpecError(SpackError):
+    """Superclass for all errors that occur while constructing specs."""
+
+
+class UnsatisfiableSpecError(SpecError):
+    """Raised when a spec conflicts with package constraints.
+       Provide the requirement that was violated when raising."""
+    def __init__(self, provided, required, constraint_type):
+        super(UnsatisfiableSpecError, self).__init__(
+            "%s does not satisfy %s" % (provided, required))
+        self.provided = provided
+        self.required = required
+        self.constraint_type = constraint_type

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2075,6 +2075,17 @@ class Spec(object):
 
         Returns True if the spec changed as a result, False if not.
         """
+        # If we are trying to constrain a concrete spec, either the spec
+        # already satisfies the constraint (and the method returns False)
+        # or it raises an exception
+        if self.concrete:
+            if self.satisfies(other):
+                return False
+            else:
+                raise UnsatisfiableSpecError(
+                    self, other, 'constrain a concrete spec'
+                )
+
         other = self._autospec(other)
 
         if not (self.name == other.name or

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1041,6 +1041,9 @@ class Spec(object):
             assert(self.compiler_flags is not None)
             self.compiler_flags[name] = value.split()
         else:
+            # All other flags represent variants. 'foo=true' and 'foo=false'
+            # map to '+foo' and '~foo' respectively. As such they need a
+            # BoolValuedVariant instance.
             if str(value).upper() == 'TRUE' or str(value).upper() == 'FALSE':
                 self.variants[name] = BoolValuedVariant(name, value)
             else:
@@ -2063,7 +2066,12 @@ class Spec(object):
                     raise UnknownVariantError(spec.name, not_existing)
 
                 for name, v in [(x, y) for (x, y) in spec.variants.items()]:
-                    # FIXME:
+                    # When parsing a spec every variant of the form
+                    # 'foo=value' will be interpreted by default as a
+                    # multi-valued variant. During validation of the
+                    # variants we use the information in the package
+                    # to turn any variant that needs it to a single-valued
+                    # variant.
                     pkg_variant = pkg_variants[name]
                     pkg_variant.validate_or_raise(v, pkg_cls)
                     spec.variants.substitute(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2058,6 +2058,7 @@ class Spec(object):
                     raise UnknownVariantError(spec.name, not_existing)
 
                 for name, v in [(x, y) for (x, y) in spec.variants.items()]:
+                    # FIXME:
                     pkg_variant = pkg_variants[name]
                     pkg_variant.validate_or_raise(v, pkg_cls)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2075,7 +2075,7 @@ class Spec(object):
                     pkg_variant = pkg_variants[name]
                     pkg_variant.validate_or_raise(v, pkg_cls)
                     spec.variants.substitute(
-                        name, pkg_variant.make_variant(v._original_value)
+                        pkg_variant.make_variant(v._original_value)
                     )
 
     def constrain(self, other, deps=True):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2031,13 +2031,12 @@ class Spec(object):
         return clone
 
     def validate_or_raise(self):
-        """This checks that names of packages and compilers in this spec are real.
-           If they're not, it will raise either UnknownPackageError or
-           UnsupportedCompilerError.
+        """Checks that names and values in this spec are real. If they're not,
+        it will raise an appropriate exception.
         """
         # FIXME: this function should be lazy, and collect all the errors
         # FIXME: before raising the exceptions, instead of being greedy and
-        # FIXME: collect one at a time
+        # FIXME: raise just the first one encountered
         for spec in self.traverse():
             # raise an UnknownPackageError if the spec's package isn't real.
             if (not spec.virtual) and spec.name:
@@ -2055,7 +2054,6 @@ class Spec(object):
                 pkg_variants = pkg_cls.variants
                 not_existing = set(spec.variants) - set(pkg_variants)
                 if not_existing:
-                    # FIXME: improve error message
                     raise UnknownVariantError(spec.name, not_existing)
 
                 for name, v in [(x, y) for (x, y) in spec.variants.items()]:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1411,8 +1411,9 @@ class Spec(object):
                 if name in _valid_compiler_flags:
                     spec.compiler_flags[name] = value
                 else:
-                    spec.variants[name] = VariantSpec(name, value)
-
+                    spec.variants[name] = VariantSpec.from_node_dict(
+                        name, value
+                    )
         elif 'variants' in node:
             for name, value in node['variants'].items():
                 spec.variants[name] = VariantSpec(name, value)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -121,16 +121,15 @@ from llnl.util.filesystem import find_headers, find_libraries, is_exe
 from llnl.util.lang import *
 from llnl.util.tty.color import *
 from spack.build_environment import get_path_from_module, load_module
+from spack.error import SpecError, UnsatisfiableSpecError
 from spack.provider_index import ProviderIndex
 from spack.util.crypto import prefix_bits
 from spack.util.executable import Executable
 from spack.util.prefix import Prefix
 from spack.util.spack_yaml import syaml_dict
 from spack.util.string import *
-from spack.version import *
-from spack.provider_index import ProviderIndex
 from spack.variant import *
-from spack.error import SpecError, UnsatisfiableSpecError
+from spack.version import *
 from yaml.error import MarkedYAMLError
 
 __all__ = [

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -24,6 +24,8 @@
 ##############################################################################
 
 import spack
+import pytest
+
 from spack.build_environment import get_std_cmake_args
 from spack.spec import Spec
 
@@ -40,3 +42,31 @@ def test_cmake_std_args(config, builtin_mock):
     s.concretize()
     pkg = spack.repo.get(s)
     assert get_std_cmake_args(pkg)
+
+
+@pytest.mark.usefixtures('config', 'builtin_mock')
+class TestAutotoolsPackage(object):
+
+    def test_with_or_without(self):
+        s = Spec('a')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        # Called without parameters
+        l = pkg.with_or_without('foo')
+        assert '--with-bar' in l
+        assert '--without-baz' in l
+        assert '--no-fee' in l
+
+        def activate(value):
+            return 'something'
+
+        l = pkg.with_or_without('foo', active_parameters=activate)
+        assert '--with-bar=something' in l
+        assert '--without-baz' in l
+        assert '--no-fee' in l
+
+        l = pkg.enable_or_disable('foo')
+        assert '--enable-bar' in l
+        assert '--disable-baz' in l
+        assert '--disable-fee' in l

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -75,7 +75,7 @@ def check_concretize(abstract_spec):
         # dag
         'callpath', 'mpileaks', 'libelf',
         # variant
-        'mpich+debug', 'mpich~debug', 'mpich debug=2', 'mpich',
+        'mpich+debug', 'mpich~debug', 'mpich debug=True', 'mpich',
         # compiler flags
         'mpich cppflags="-O3"',
         # with virtual

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -55,7 +55,7 @@ import spack.util.pattern
 @pytest.fixture(autouse=True)
 def no_stdin_duplication(monkeypatch):
     """Duplicating stdin (or any other stream) returns an empty
-    cStringIO object.
+    StringIO object.
     """
     monkeypatch.setattr(llnl.util.lang, 'duplicate_stream',
                         lambda x: StringIO())

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -265,6 +265,16 @@ class TestSpecSematics(object):
         check_satisfies('multivalue_variant foo="bar,baz"',
                         'foo="bar"')
 
+    def test_satisfies_single_valued_variant(self):
+        """Tests that the case reported in
+        https://github.com/LLNL/spack/pull/2386#issuecomment-282147639
+        is handled correctly.
+        """
+        a = Spec('a foobar=bar')
+        a.concretize()
+
+        assert a.satisfies('foobar=bar')
+
     def test_unsatisfiable_multi_value_variant(self):
 
         # Semantics for a multi-valued variant is different

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -244,31 +244,56 @@ class TestSpecSematics(object):
         check_satisfies('mpich foo=False', 'mpich~foo')
 
     def test_satisfies_multi_value_variant(self):
-        check_satisfies(
-            'multivalue_variant foo="bar,baz"',
-            'multivalue_variant foo="bar,baz"'
-        )
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'multivalue_variant foo="bar,baz"')
+
         # A more constrained spec satisfies a less constrained one
-        check_satisfies(
-            'multivalue_variant foo="bar,baz"',
-            'multivalue_variant foo="bar"'
-        )
-        check_satisfies(
-            'multivalue_variant foo="bar,baz"',
-            'multivalue_variant foo="baz"'
-        )
-        check_satisfies(
-            'multivalue_variant foo="bar,baz,barbaz"',
-            'multivalue_variant foo="bar,baz"'
-        )
-        check_satisfies(
-            'multivalue_variant foo="bar,baz"',
-            'foo="bar,baz"'
-        )
-        check_satisfies(
-            'multivalue_variant foo="bar,baz"',
-            'foo="bar"'
-        )
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'multivalue_variant foo="bar"')
+
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'multivalue_variant foo="baz"')
+
+        check_satisfies('multivalue_variant foo="bar,baz,barbaz"',
+                        'multivalue_variant foo="bar,baz"')
+
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'foo="bar,baz"')
+
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'foo="bar"')
+
+    def test_unsatisfiable_multi_value_variant(self):
+        # these should fail for concrete specs
+        check_unsatisfiable('multivalue_variant foo="bar"',
+                            'multivalue_variant foo="bar,baz"',
+                            concrete=True)
+
+        check_unsatisfiable('multivalue_variant foo="bar,baz"',
+                            'multivalue_variant foo="bar,baz,quux"',
+                            concrete=True)
+
+        # but succeed for abstract ones (b/c they COULD satisfy the
+        # constraint if constrained)
+        check_satisfiable('multivalue_variant foo="bar"',
+                          'multivalue_variant foo="bar,baz"')
+
+        check_satisfiable('multivalue_variant foo="bar,baz"',
+                          'multivalue_variant foo="bar,baz,quux"')
+
+    def test_unsatisfiable_variant_types(self):
+        # These should fail due to incompatible types
+        check_unsatisfiable('multivalue_variant +foo',
+                            'multivalue_variant foo="bar"')
+
+        check_unsatisfiable('multivalue_variant ~foo',
+                            'multivalue_variant foo="bar"')
+
+        check_unsatisfiable('multivalue_variant foo="bar"',
+                            'multivalue_variant +foo')
+
+        check_unsatisfiable('multivalue_variant foo="bar"',
+                            'multivalue_variant ~foo')
 
     def test_satisfies_unconstrained_variant(self):
         # only asked for mpich, no constraints.  Either will do.

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -26,7 +26,7 @@ import spack.architecture
 import pytest
 
 from spack.spec import *
-from spack.variant import InvalidVariantValueError
+from spack.variant import *
 
 
 def check_satisfies(spec, anon_spec, concrete=False):
@@ -306,6 +306,20 @@ class TestSpecSematics(object):
         # ...but will fail during concretization if there are
         # values in the variant that are not allowed
         with pytest.raises(InvalidVariantValueError):
+            a.concretize()
+
+        # This time we'll try to set a single-valued variant
+        a = Spec('multivalue_variant fee="bar"')
+        spec_str = 'multivalue_variant fee="baz"'
+        b = Spec(spec_str)
+        assert not a.satisfies(b)
+        assert not a.satisfies(spec_str)
+        # A variant cannot be parsed as single-valued until we try to
+        # concretize. This means that we can constrain the variant above
+        assert a.constrain(b)
+        # ...but will fail during concretization if there are
+        # multiple values set
+        with pytest.raises(MultipleValuesInExclusiveVariantError):
             a.concretize()
 
         # FIXME: remove after having checked the correctness of the semantics

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -243,6 +243,33 @@ class TestSpecSematics(object):
         check_satisfies('mpich~foo', 'mpich foo=FALSE')
         check_satisfies('mpich foo=False', 'mpich~foo')
 
+    def test_satisfies_multi_value_variant(self):
+        check_satisfies(
+            'multivalue_variant foo="bar,baz"',
+            'multivalue_variant foo="bar,baz"'
+        )
+        # A more constrained spec satisfies a less constrained one
+        check_satisfies(
+            'multivalue_variant foo="bar,baz"',
+            'multivalue_variant foo="bar"'
+        )
+        check_satisfies(
+            'multivalue_variant foo="bar,baz"',
+            'multivalue_variant foo="baz"'
+        )
+        check_satisfies(
+            'multivalue_variant foo="bar,baz,barbaz"',
+            'multivalue_variant foo="bar,baz"'
+        )
+        check_satisfies(
+            'multivalue_variant foo="bar,baz"',
+            'foo="bar,baz"'
+        )
+        check_satisfies(
+            'multivalue_variant foo="bar,baz"',
+            'foo="bar"'
+        )
+
     def test_satisfies_unconstrained_variant(self):
         # only asked for mpich, no constraints.  Either will do.
         check_satisfies('mpich+foo', 'mpich')
@@ -266,7 +293,7 @@ class TestSpecSematics(object):
         # No matchi in specs
         check_unsatisfiable('mpich~foo', 'mpich+foo')
         check_unsatisfiable('mpich+foo', 'mpich~foo')
-        check_unsatisfiable('mpich foo=1', 'mpich foo=2')
+        check_unsatisfiable('mpich foo=True', 'mpich foo=False')
 
     def test_satisfies_matching_compiler_flag(self):
         check_satisfies('mpich cppflags="-O3"', 'mpich cppflags="-O3"')
@@ -416,6 +443,19 @@ class TestSpecSematics(object):
             'libelf+debug~foo', 'libelf+debug', 'libelf+debug~foo'
         )
 
+    def test_constrain_multi_value_variant(self):
+        check_constrain(
+            'multivalue_variant foo="bar,baz"',
+            'multivalue_variant foo="bar"',
+            'multivalue_variant foo="baz"'
+        )
+
+        check_constrain(
+            'multivalue_variant foo="bar,baz,barbaz"',
+            'multivalue_variant foo="bar,barbaz"',
+            'multivalue_variant foo="baz"'
+        )
+
     def test_constrain_compiler_flags(self):
         check_constrain(
             'libelf cflags="-O3" cppflags="-Wall"',
@@ -455,7 +495,7 @@ class TestSpecSematics(object):
 
         check_invalid_constraint('libelf+debug', 'libelf~debug')
         check_invalid_constraint('libelf+debug~foo', 'libelf+debug+foo')
-        check_invalid_constraint('libelf debug=2', 'libelf debug=1')
+        check_invalid_constraint('libelf debug=True', 'libelf debug=False')
 
         check_invalid_constraint(
             'libelf cppflags="-O3"', 'libelf cppflags="-O2"')

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -246,8 +246,13 @@ class TestSpecSematics(object):
         check_satisfies('mpich foo=False', 'mpich~foo')
 
     def test_satisfies_multi_value_variant(self):
+        # Check quoting
         check_satisfies('multivalue_variant foo="bar,baz"',
                         'multivalue_variant foo="bar,baz"')
+        check_satisfies('multivalue_variant foo=bar,baz',
+                        'multivalue_variant foo=bar,baz')
+        check_satisfies('multivalue_variant foo="bar,baz"',
+                        'multivalue_variant foo=bar,baz')
 
         # A more constrained spec satisfies a less constrained one
         check_satisfies('multivalue_variant foo="bar,baz"',

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -73,7 +73,8 @@ def test_concrete_spec(config, builtin_mock):
     spec.concretize()
     check_yaml_round_trip(spec)
 
-def test_yaml_multivalue(self):
+
+def test_yaml_multivalue():
     spec = Spec('multivalue_variant foo="bar,baz"')
     spec.concretize()
     check_yaml_round_trip(spec)

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -73,6 +73,11 @@ def test_concrete_spec(config, builtin_mock):
     spec.concretize()
     check_yaml_round_trip(spec)
 
+def test_yaml_multivalue(self):
+    spec = Spec('multivalue_variant foo="bar,baz"')
+    spec.concretize()
+    check_yaml_round_trip(spec)
+
 
 def test_yaml_subdag(config, builtin_mock):
     spec = Spec('mpileaks^mpich+debug')

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -1,0 +1,162 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import unittest
+import numbers
+
+from spack.variant import *
+
+
+class VariantSpecTest(unittest.TestCase):
+
+    def test_value_property(self):
+        # Multiple values
+        a = VariantSpec('foo', 'bar,baz')
+        # Spaces are trimmed
+        b = VariantSpec('foo', 'bar, baz')
+        self.assertEqual(a.value, ('bar', 'baz'))
+        self.assertEqual(a, b)
+        self.assertTrue('bar' in a and 'baz' in a)
+        # Boolean - True
+        for x in (True, 'True', 'TRUE', 'TrUe'):
+            a.value = x
+            self.assertEqual(a.value, True)
+            self.assertTrue(True in a)
+        # Boolean - False
+        for x in (False, 'False', 'FALSE', 'FaLsE'):
+            a.value = x
+            self.assertEqual(a.value, False)
+            self.assertTrue(False in a)
+
+    def test_copy(self):
+        a = VariantSpec('foo', 'bar,baz')
+        b = a.copy()
+        self.assertTrue(a == b and a is not b)
+
+    def test_empty_string(self):
+        # Tests that an empty string will be
+        # transformed in a tuple containing
+        # an empty string
+        a = VariantSpec('foo', '')
+        self.assertEqual(a._value, ('',))
+
+    def test_repr_and_str(self):
+        a = VariantSpec('foo', 'bar,baz')
+        b = eval(repr(a))
+        self.assertEqual(a, b)
+        self.assertEqual(str(a), ' foo=bar,baz')
+        b = VariantSpec('foo', True)
+        self.assertEqual(str(b), '+foo')
+        b.value = False
+        self.assertEqual(str(b), '~foo')
+
+    def test_hash(self):
+        # Check that hashing does not depend on the order
+        # of the values given
+        a = VariantSpec('foo', 'bar,baz,bac')
+        b = VariantSpec('foo', 'bar,bac,baz')
+        c = VariantSpec('foo', 'baz,bac,bar')
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(hash(a), hash(c))
+
+
+class VariantTest(unittest.TestCase):
+
+    def test_validation(self):
+        a = Variant(
+            'foo',
+            default='',
+            description='',
+            values=('bar', 'baz', 'foobar'),
+            exclusive=True
+        )
+        # Valid vspec, shouldn't raise
+        vspec = VariantSpec('foo', 'bar')
+        a.validate_or_raise(vspec)
+        # Multiple values are not allowed
+        vspec.value = 'bar,baz'
+        self.assertRaises(
+            MultipleValuesInExclusiveVariantError,
+            a.validate_or_raise,
+            vspec
+        )
+        # Inconsistent vspec
+        vspec.name = 'FOO'
+        self.assertRaises(
+            InconsistentValidationError,
+            a.validate_or_raise,
+            vspec
+        )
+        # Valid multi-value vspec
+        a.exclusive = False
+        vspec.name = 'foo'
+        a.validate_or_raise(vspec)
+        # Add an invalid value
+        vspec.value = 'bar,baz,barbaz'
+        self.assertRaises(
+            InvalidVariantValueError,
+            a.validate_or_raise,
+            vspec
+        )
+
+    def test_callable_validator(self):
+
+        def validator(x):
+            return isinstance(int(x), numbers.Integral)
+
+        a = Variant(
+            'foo',
+            default=1024,
+            description='',
+            values=validator,
+            exclusive=True
+        )
+        vspec = VariantSpec('foo', a.default)
+        a.validate_or_raise(vspec)
+        vspec.value = 2056
+        a.validate_or_raise(vspec)
+
+
+class VariantMapTest(unittest.TestCase):
+
+    def test_invalid_values(self):
+        # Value with invalid type
+        a = VariantMap(None)
+        self.assertRaises(TypeError, a.__setitem__, 'foo', 2)
+        # Duplicate variant
+        a['foo'] = VariantSpec('foo', 'bar,baz')
+        self.assertRaises(
+            DuplicateVariantError,
+            a.__setitem__,
+            'foo',
+            VariantSpec('foo', 'bar')
+        )
+        # Non matching names between key and vspec.name
+        self.assertRaises(
+            KeyError,
+            a.__setitem__,
+            'bar',
+            VariantSpec('foo', 'bar')
+        )

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -509,7 +509,7 @@ class TestVariant(object):
             default='',
             description='',
             values=('bar', 'baz', 'foobar'),
-            exclusive=True
+            multi=False
         )
         # Valid vspec, shouldn't raise
         vspec = a.make_variant('bar')
@@ -525,7 +525,7 @@ class TestVariant(object):
             a.validate_or_raise(vspec)
 
         # Valid multi-value vspec
-        a.exclusive = False
+        a.multi = True
         vspec = a.make_variant('bar,baz')
         a.validate_or_raise(vspec)
         # Add an invalid value
@@ -546,7 +546,7 @@ class TestVariant(object):
             default=1024,
             description='',
             values=validator,
-            exclusive=True
+            multi=False
         )
         vspec = a.make_default()
         a.validate_or_raise(vspec)
@@ -562,7 +562,7 @@ class TestVariant(object):
             default='',
             description='',
             values=('bar', 'baz', 'foobar'),
-            exclusive=True
+            multi=False
         )
         assert a.allowed_values == 'bar, baz, foobar'
 

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -66,7 +66,7 @@ class VariantSpecTest(unittest.TestCase):
         a = VariantSpec('foo', 'bar,baz')
         b = eval(repr(a))
         self.assertEqual(a, b)
-        self.assertEqual(str(a), ' foo=bar,baz')
+        self.assertEqual(str(a), 'foo=bar,baz')
         b = VariantSpec('foo', True)
         self.assertEqual(str(b), '+foo')
         b.value = False

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -60,7 +60,7 @@ class VariantSpecTest(unittest.TestCase):
         # transformed in a tuple containing
         # an empty string
         a = VariantSpec('foo', '')
-        self.assertEqual(a._value, ('',))
+        self.assertEqual(a._value, tuple())
 
     def test_repr_and_str(self):
         a = VariantSpec('foo', 'bar,baz')

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -124,7 +124,10 @@ class VariantTest(unittest.TestCase):
     def test_callable_validator(self):
 
         def validator(x):
-            return isinstance(int(x), numbers.Integral)
+            try:
+                return isinstance(int(x), numbers.Integral)
+            except ValueError:
+                return False
 
         a = Variant(
             'foo',
@@ -137,6 +140,18 @@ class VariantTest(unittest.TestCase):
         a.validate_or_raise(vspec)
         vspec.value = 2056
         a.validate_or_raise(vspec)
+        vspec.value = 'foo'
+        self.assertRaises(InvalidVariantValueError, a.validate_or_raise, vspec)
+
+    def test_representation(self):
+        a = Variant(
+            'foo',
+            default='',
+            description='',
+            values=('bar', 'baz', 'foobar'),
+            exclusive=True
+        )
+        self.assertEqual(a.allowed_values, 'bar, baz, foobar')
 
 
 class VariantMapTest(unittest.TestCase):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -26,11 +26,12 @@
 variants both in packages and in specs.
 """
 
-from six import StringIO
-import csv
 import inspect
+import re
+
 import llnl.util.lang as lang
 import spack.error as error
+from six import StringIO
 
 
 class Variant(object):
@@ -64,7 +65,7 @@ class Variant(object):
         self.default = default
         self.description = str(description)
 
-        if inspect.isroutine(values):
+        if callable(values):
             # If 'values' is a callable, assume it is a single value
             # validator and reset the values to be explicit during debug
             self.single_value_validator = values
@@ -194,11 +195,7 @@ class MultiValuedVariant(object):
         # Store a tuple of CSV string representations
         # Tuple is necessary here instead of list because the
         # values need to be hashed
-        f = StringIO(str(value))
-        try:
-            t = next(csv.reader(f, skipinitialspace=True))
-        except StopIteration:
-            t = []
+        t = re.split(r'\s*,\s*', str(value))
 
         # With multi-value variants it is necessary
         # to remove duplicates and give an order
@@ -256,10 +253,7 @@ class MultiValuedVariant(object):
             return False
 
         # If names are different then they are not compatible
-        if other.name != self.name:
-            return False
-
-        return True
+        return other.name == self.name
 
     def constrain(self, other):
         """Modify self to match all the constraints for other if both

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -22,17 +22,368 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-"""Variant is a class describing flags on builds, or "variants".
-
-Could be generalized later to describe aribitrary parameters, but
-currently variants are just flags.
-
+"""The variant module contains data structures that are needed to manage
+variants both in packages and in specs.
 """
+
+import cStringIO
+import csv
+import inspect
+import llnl.util.lang as lang
+import spack.error as error
 
 
 class Variant(object):
-    """Represents a variant on a build.  Can be either on or off."""
+    """Represents a variant in a package, as declared in the
+    variant directive.
+    """
 
-    def __init__(self, default, description):
-        self.default     = default
+    def __init__(self, name, default, description, values=(True, False), exclusive=True):  # NOQA: ignore=E501
+        """Initialize a package variant.
+
+        :param str name: name of the variant
+        :param str default: default value for the variant in case
+        nothing has been specified
+        :param str description: purpose of the variant
+        :param sequence values: sequence of allowed values or a callable
+        accepting a single value as argument and returning True if the
+        value is good, False otherwise
+        :param bool exclusive: whether multiple CSV are allowed
+        """
+        self.name = name
+        self.default = default
         self.description = str(description)
+
+        if inspect.isroutine(values):
+            # If 'values' is a callable, assume it is a custom validator
+            # and reset the values to be explicit during debug
+            self.validator = values
+            self.values = None
+        else:
+            # Otherwise assume values is the set of allowed explicit values
+            self.values = tuple(values)
+            allowed = self.values + (self.default,)
+            self.validator = lambda x: x in allowed
+
+        self.exclusive = exclusive
+
+    def validate_or_raise(self, vspec, pkg=None):
+        """Validate a variant spec against this package variant. Raises an
+        exception if any error is found.
+
+        :param VariantSpec vspec: instance to be validated
+        :param Package pkg: the package that required the validation,
+        if available
+
+        :raises InconsistentValidationError: if vspec.name doesn't
+        match self.name
+        :raises MultipleValuesInExclusiveVariantError: if vspec has
+        multiple values but self.exclusive ==True
+        :raises InvalidVariantValueError: if vspec.value contains
+        invalid values
+        """
+        # Check the name of the variant
+        if self.name != vspec.name:
+            raise InconsistentValidationError(vspec, self)
+        # Check the values of the variant spec
+        value = vspec.value
+        if isinstance(vspec.value, bool):
+            value = (vspec.value,)
+        # If the value is exclusive there must be at most one
+        if self.exclusive and len(value) != 1:
+            raise MultipleValuesInExclusiveVariantError(vspec, pkg)
+        # Check and record the values that are not allowed
+        not_allowed_values = [x for x in value if not self.validator(x)]
+        if not_allowed_values:
+            raise InvalidVariantValueError(self, not_allowed_values, pkg)
+
+
+@lang.key_ordering
+class VariantSpec(object):
+    """Variants are named, build-time options for a package. Names depend
+    on the particular package being built, and each named variant can have
+    different (and possibly multiple) values.
+    """
+
+    def __init__(self, name, value):
+        self.name = name
+        # Stores the original value passed to initialize this instance
+        self._original_value = value
+        # Stores 'value' after a bit of massaging
+        # done by the property setter
+        self._value = None
+        # Invokes property setter
+        self.value = value
+
+    @property
+    def value(self):
+        """Returns either a boolean or a tuple of strings
+
+        :return: either a boolean or a tuple of strings
+        :rtype: bool or tuple
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        # Store the original value
+        self._original_value = value
+        # If value is a string representation of a boolean, turn
+        # it to a boolean
+        if str(value).upper() == 'TRUE':
+            self._value = True
+        elif str(value).upper() == 'FALSE':
+            self._value = False
+        # Otherwise store a tuple of CSV string representations
+        # Tuple is necessary here instead of list because the
+        # values need to be hashed
+        else:
+            f = cStringIO.StringIO(str(value))
+            try:
+                t = next(csv.reader(f, skipinitialspace=True))
+            except StopIteration:
+                t = ['']
+            # With multi-value variants it is necessary
+            # to remove duplicates and give an order
+            # to a set
+            self._value = tuple(sorted(set(t)))
+
+    def _cmp_key(self):
+        return self.name, self.value
+
+    def copy(self):
+        """Returns an instance of VariantSpec equivalent to self
+
+        :return: a copy of self
+        :rtype: VariantSpec
+
+        >>> a = VariantSpec('foo', True)
+        >>> b = a.copy()
+        >>> assert a == b
+        >>> assert a is not b
+        """
+        return VariantSpec(self.name, self._original_value)
+
+    def satisfies(self, other):
+        """Returns true if the other.value is a strict subset of self.
+        Does not try to validate.
+
+        :param VariantSpec other: constraint to be met for the method to
+        return True
+        :return: True or False
+        :rtype: bool
+        """
+        single_value_satisfies = self.value == other.value
+        multi_value_satisfies = False
+        if isinstance(self.value, tuple):
+            not_satisfied = set(other.value) - set(self.value)
+            multi_value_satisfies = len(not_satisfied) == 0
+        return single_value_satisfies or multi_value_satisfies
+
+    def compatible(self, other):
+        """Returns True if self and other are compatible, False otherwise.
+        As there is no semantic check, two VariantSpec are compatible if
+        either they contain the same value or they are both multi-valued.
+
+        :param VariantSpec other: instance against which we test compatibility
+        :return: True or False
+        :rtype: bool
+        """
+        single_value_compatible = self.value == other.value
+        multi_value_compatible = True
+        for x in (self.value, other.value):
+            multi_value_compatible &= isinstance(x, tuple)
+        return single_value_compatible or multi_value_compatible
+
+    def constrain(self, other):
+        """Modify self to match all the constraints for other if both
+        instances are multi-valued. Returns True if self changed,
+        False otherwise.
+
+        :param VariantSpec other: instance against which we constrain self
+        :return: True or False
+        :rtype: bool
+        """
+        changed = False
+        if isinstance(self.value, tuple) and isinstance(other.value, tuple):
+            old_value = self.value
+            self.value = ','.join(self.value + other.value)
+            return old_value != self.value
+        return changed
+
+    def yaml_entry(self):
+        """Returns a key, value tuple suitable to be an entry in a yaml dict
+
+        :return: (name, value_representation)
+        :rtype: tuple
+        """
+        v = self.value
+        if isinstance(self.value, tuple):
+            v = ','.join(self.value)
+        return self.name, v
+
+    def __contains__(self, item):
+        if isinstance(self._value, bool):
+            return item is self._value
+        return item in self._value
+
+    def __repr__(self):
+        cls = type(self)
+        return '{0.__name__}({1}, {2})'.format(
+            cls, repr(self.name), repr(self._original_value)
+        )
+
+    def __str__(self):
+        if isinstance(self.value, bool):
+            return '{0}{1}'.format('+' if self.value else '~', self.name)
+        else:
+            return ' {0}={1} '.format(
+                self.name, ','.join(str(x) for x in self.value))
+
+
+class VariantMap(lang.HashableMap):
+    """Map containing VariantSpec instances. New values can be added only
+    if the key is not already present.
+    """
+
+    def __init__(self, spec):
+        super(VariantMap, self).__init__()
+        self.spec = spec
+
+    def __setitem__(self, name, vspec):
+        # Raise a TypeError if vspec is not of the right type
+        if not isinstance(vspec, VariantSpec):
+            msg = 'VariantMap accepts only values of type VariantSpec'
+            raise TypeError(msg)
+        # Raise an error if the variant was already in this map
+        if name in self.dict:
+            msg = 'Cannot specify variant "{0}" twice'.format(name)
+            raise DuplicateVariantError(msg)
+        # Raise an error if name and vspec.name don't match
+        if name != vspec.name:
+            msg = 'Inconsistent key "{0}", must be "{1}" to match VariantSpec'
+            raise KeyError(msg.format(name, vspec.name))
+        # Set the item
+        super(VariantMap, self).__setitem__(name, vspec)
+
+    def satisfies(self, other, strict=False):
+        """Returns True if this VariantMap is more constrained than other,
+        False otherwise.
+
+        :param VariantMap other: VariantMap to satisfy
+        :param bool strict: if True return False if a key is in other and
+        not in self, otherwise discard that key and proceed with evaluation
+
+        :return: True or False
+        :rtype: bool
+        """
+        to_be_checked = [k for k in other]
+        if not (strict or self.spec._concrete):
+            to_be_checked = filter(lambda x: x in self, to_be_checked)
+
+        return all(
+            k in self and self[k].satisfies(other[k]) for k in to_be_checked
+        )
+
+    def constrain(self, other):
+        """Add all variants in other that aren't in self to self. Also
+        constrain all multi-valued variants that are already present.
+        Return True if self changed, False otherwise
+
+        :param VariantMap other: instance against which we constrain self
+        :return: True or False
+        :rtype: bool
+        :raises UnsatisfiableVariantSpecError: if a constraint is incompatible
+        with self
+        """
+        if other.spec._concrete:
+            for k in self:
+                if k not in other:
+                    raise UnsatisfiableVariantSpecError(self[k], '<absent>')
+
+        changed = False
+        for k in other:
+            if k in self:
+                # If they are not compatible raise an error
+                if not self[k].compatible(other[k]):
+                    raise UnsatisfiableVariantSpecError(self[k], other[k])
+                # If they are compatible merge them
+                changed = self[k].constrain(other[k])
+            else:
+                # If it is not present copy it straight away
+                self[k] = other[k].copy()
+                changed = True
+
+        return changed
+
+    @property
+    def concrete(self):
+        return self.spec._concrete or all(
+            v in self for v in self.spec.package_class.variants)
+
+    def copy(self):
+        """Return an instance of VariantMap equivalent to self
+
+        :return: a copy of self
+        :rtype: VariantMap
+        """
+        clone = VariantMap(self.spec)
+        for name, variant in self.items():
+            clone[name] = variant.copy()
+        return clone
+
+    def __str__(self):
+        sorted_keys = sorted(self.keys())
+        pad = ' ' if len(self) > 0 else ''
+        return "%s%s%s" % (
+            pad, ' '.join(str(self[key]) for key in sorted_keys), pad)
+
+
+class DuplicateVariantError(error.SpecError):
+    """Raised when the same variant occurs in a spec twice."""
+
+
+class UnknownVariantError(error.SpecError):
+    """Raised when an unknown variant occurs in a spec."""
+    def __init__(self, pkg, variant):
+        super(UnknownVariantError, self).__init__(
+            'Package {0} has no variant {1}!'.format(pkg, variant)
+        )
+
+
+class InconsistentValidationError(error.SpecError):
+    def __init__(self, vspec, variant):
+        msg = 'trying to validate variant "{0.name}" with the validator of "{1.name}"'  # NOQA: ignore=E501
+        super(InconsistentValidationError, self).__init__(
+            msg.format(vspec, variant)
+        )
+
+
+class MultipleValuesInExclusiveVariantError(error.SpecError):
+    def __init__(self, variant, pkg):
+        msg = 'multiple values are not allowed for variant "{0.name}"{1}'
+        pkg_info = ''
+        if pkg is not None:
+            pkg_info = ' in package "{0}"'.format(pkg.name)
+        super(MultipleValuesInExclusiveVariantError, self).__init__(
+            msg.format(variant, pkg_info)
+        )
+
+
+class InvalidVariantValueError(error.SpecError):
+    """Raised when a valid variant has at least an invalid value."""
+    def __init__(self, variant, invalid_values, pkg):
+        msg = 'invalid values for variant "{0.name}"{2}: {1}\n'
+        pkg_info = ''
+        if pkg is not None:
+            pkg_info = ' in package "{0}"'.format(pkg.name)
+        super(InvalidVariantValueError, self).__init__(
+            msg.format(variant, invalid_values, pkg_info)
+        )
+
+
+class UnsatisfiableVariantSpecError(error.UnsatisfiableSpecError):
+    """Raised when a spec variant conflicts with package constraints."""
+    def __init__(self, provided, required):
+        super(UnsatisfiableVariantSpecError, self).__init__(
+            provided, required, "variant")

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -97,6 +97,13 @@ class Variant(object):
         if not_allowed_values:
             raise InvalidVariantValueError(self, not_allowed_values, pkg)
 
+    @property
+    def allowed_values(self):
+        v = ''
+        if self.values is not None:
+            v = tuple(str(x) for x in self.values)
+        return ', '.join(v)
+
 
 @lang.key_ordering
 class VariantSpec(object):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -419,9 +419,6 @@ class VariantMap(lang.HashableMap):
         """Returns True if this VariantMap is more constrained than other,
         False otherwise.
 
-        TODO: how does this deal with exclusive-valued variants?  These
-        TODO: should be evaluated differently from multi-valued variants.
-
         :param VariantMap other: VariantMap to satisfy
         :param bool strict: if True return False if a key is in other and
             not in self, otherwise discard that key and proceed with evaluation
@@ -441,9 +438,6 @@ class VariantMap(lang.HashableMap):
         """Add all variants in other that aren't in self to self. Also
         constrain all multi-valued variants that are already present.
         Return True if self changed, False otherwise
-
-        TODO: how does this deal with exclusive-valued variants?  These
-        TODO: should be evaluated differently from multi-valued variants.
 
         :param VariantMap other: instance against which we constrain self
         :return: True or False

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -43,11 +43,11 @@ class Variant(object):
 
         :param str name: name of the variant
         :param str default: default value for the variant in case
-        nothing has been specified
+            nothing has been specified
         :param str description: purpose of the variant
         :param sequence values: sequence of allowed values or a callable
-        accepting a single value as argument and returning True if the
-        value is good, False otherwise
+            accepting a single value as argument and returning True if the
+            value is good, False otherwise
         :param bool exclusive: whether multiple CSV are allowed
         """
         self.name = name
@@ -73,14 +73,14 @@ class Variant(object):
 
         :param VariantSpec vspec: instance to be validated
         :param Package pkg: the package that required the validation,
-        if available
+            if available
 
         :raises InconsistentValidationError: if vspec.name doesn't
-        match self.name
+            match self.name
         :raises MultipleValuesInExclusiveVariantError: if vspec has
-        multiple values but self.exclusive ==True
+            multiple values but self.exclusive ==True
         :raises InvalidVariantValueError: if vspec.value contains
-        invalid values
+            invalid values
         """
         # Check the name of the variant
         if self.name != vspec.name:
@@ -169,7 +169,7 @@ class VariantSpec(object):
         Does not try to validate.
 
         :param VariantSpec other: constraint to be met for the method to
-        return True
+            return True
         :return: True or False
         :rtype: bool
         """
@@ -272,7 +272,7 @@ class VariantMap(lang.HashableMap):
 
         :param VariantMap other: VariantMap to satisfy
         :param bool strict: if True return False if a key is in other and
-        not in self, otherwise discard that key and proceed with evaluation
+            not in self, otherwise discard that key and proceed with evaluation
 
         :return: True or False
         :rtype: bool
@@ -293,8 +293,6 @@ class VariantMap(lang.HashableMap):
         :param VariantMap other: instance against which we constrain self
         :return: True or False
         :rtype: bool
-        :raises UnsatisfiableVariantSpecError: if a constraint is incompatible
-        with self
         """
         if other.spec._concrete:
             for k in self:
@@ -345,6 +343,7 @@ class DuplicateVariantError(error.SpecError):
 
 class UnknownVariantError(error.SpecError):
     """Raised when an unknown variant occurs in a spec."""
+
     def __init__(self, pkg, variant):
         super(UnknownVariantError, self).__init__(
             'Package {0} has no variant {1}!'.format(pkg, variant)
@@ -352,6 +351,7 @@ class UnknownVariantError(error.SpecError):
 
 
 class InconsistentValidationError(error.SpecError):
+
     def __init__(self, vspec, variant):
         msg = 'trying to validate variant "{0.name}" with the validator of "{1.name}"'  # NOQA: ignore=E501
         super(InconsistentValidationError, self).__init__(
@@ -360,6 +360,7 @@ class InconsistentValidationError(error.SpecError):
 
 
 class MultipleValuesInExclusiveVariantError(error.SpecError):
+
     def __init__(self, variant, pkg):
         msg = 'multiple values are not allowed for variant "{0.name}"{1}'
         pkg_info = ''
@@ -372,6 +373,7 @@ class MultipleValuesInExclusiveVariantError(error.SpecError):
 
 class InvalidVariantValueError(error.SpecError):
     """Raised when a valid variant has at least an invalid value."""
+
     def __init__(self, variant, invalid_values, pkg):
         msg = 'invalid values for variant "{0.name}"{2}: {1}\n'
         pkg_info = ''
@@ -384,6 +386,7 @@ class InvalidVariantValueError(error.SpecError):
 
 class UnsatisfiableVariantSpecError(error.UnsatisfiableSpecError):
     """Raised when a spec variant conflicts with package constraints."""
+
     def __init__(self, provided, required):
         super(UnsatisfiableVariantSpecError, self).__init__(
             provided, required, "variant")

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -460,7 +460,7 @@ class VariantMap(lang.HashableMap):
                 if not self[k].compatible(other[k]):
                     raise UnsatisfiableVariantSpecError(self[k], other[k])
                 # If they are compatible merge them
-                changed = self[k].constrain(other[k])
+                changed |= self[k].constrain(other[k])
             else:
                 # If it is not present copy it straight away
                 self[k] = other[k].copy()

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -225,7 +225,7 @@ class MultiValuedVariant(object):
         """Returns true if other.name == self.name and other.value is
         a strict subset of self. Does not try to validate.
 
-        :param variant other: constraint to be met for the method to
+        :param other: constraint to be met for the method to
             return True
         :return: True or False
         :rtype: bool
@@ -247,7 +247,7 @@ class MultiValuedVariant(object):
         As there is no semantic check, two VariantSpec are compatible if
         either they contain the same value or they are both multi-valued.
 
-        :param VariantSpec other: instance against which we test compatibility
+        :param other: instance against which we test compatibility
         :return: True or False
         :rtype: bool
         """
@@ -266,7 +266,7 @@ class MultiValuedVariant(object):
         instances are multi-valued. Returns True if self changed,
         False otherwise.
 
-        :param VariantSpec other: instance against which we constrain self
+        :param other: instance against which we constrain self
         :return: True or False
         :rtype: bool
         """
@@ -278,7 +278,7 @@ class MultiValuedVariant(object):
         if self.name != other.name:
             raise ValueError('variants must have the same name')
         old_value = self.value
-        self.value = ','.join(self.value + other.value)
+        self.value = ','.join(sorted(set(self.value + other.value)))
         return old_value != self.value
 
     def yaml_entry(self):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -121,10 +121,15 @@ class Variant(object):
         :return: representation of the allowed values
         :rtype: str
         """
-        v = ''
+        # Join an explicit set of allowed values
         if self.values is not None:
             v = tuple(str(x) for x in self.values)
-        return ', '.join(v)
+            return ', '.join(v)
+        # In case we were given a single-value validator
+        # print the docstring
+        docstring = inspect.getdoc(self.single_value_validator)
+        v = docstring if docstring else ''
+        return v
 
 
 @lang.key_ordering

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -45,7 +45,7 @@ class Variant(object):
             default,
             description,
             values=(True, False),
-            exclusive=True,
+            multi=False,
             validator=None
     ):
         """Initialize a package variant.
@@ -57,7 +57,7 @@ class Variant(object):
         :param sequence values: sequence of allowed values or a callable
             accepting a single value as argument and returning True if the
             value is good, False otherwise
-        :param bool exclusive: whether multiple CSV are allowed
+        :param bool multi: whether multiple CSV are allowed
         :param callable validator: optional callable used to enforce
             additional logic on the set of values being validated
         """
@@ -76,7 +76,7 @@ class Variant(object):
             allowed = self.values + (self.default,)
             self.single_value_validator = lambda x: x in allowed
 
-        self.exclusive = exclusive
+        self.multi = multi
         self.group_validator = validator
 
     def validate_or_raise(self, vspec, pkg=None):
@@ -104,7 +104,7 @@ class Variant(object):
             value = (vspec.value,)
 
         # If the value is exclusive there must be at most one
-        if self.exclusive and len(value) != 1:
+        if not self.multi and len(value) != 1:
             raise MultipleValuesInExclusiveVariantError(vspec, pkg)
 
         # Check and record the values that are not allowed
@@ -144,7 +144,7 @@ class Variant(object):
 
     @property
     def variant_cls(self):
-        if self.exclusive is False:
+        if self.multi:
             return MultiValuedVariant
         elif self.values == (True, False):
             return BoolValuedVariant

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -277,7 +277,7 @@ class VariantSpec(object):
         if isinstance(self.value, bool):
             return '{0}{1}'.format('+' if self.value else '~', self.name)
         else:
-            return ' {0}={1} '.format(
+            return '{0}={1}'.format(
                 self.name, ','.join(str(x) for x in self.value))
 
 
@@ -377,10 +377,30 @@ class VariantMap(lang.HashableMap):
         return clone
 
     def __str__(self):
+        # print keys in order
         sorted_keys = sorted(self.keys())
-        pad = ' ' if len(self) > 0 else ''
-        return "%s%s%s" % (
-            pad, ' '.join(str(self[key]) for key in sorted_keys), pad)
+
+        # add spaces before and after key/value variants.
+        string = cStringIO.StringIO()
+
+        kv = False
+        for key in sorted_keys:
+            vspec = self[key]
+
+            if not isinstance(vspec.value, bool):
+                # add space before all kv pairs.
+                string.write(' ')
+                kv = True
+            else:
+                # not a kv pair this time
+                if kv:
+                    # if it was LAST time, then pad after.
+                    string.write(' ')
+                kv = False
+
+            string.write(str(vspec))
+
+        return string.getvalue()
 
 
 class DuplicateVariantError(error.SpecError):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -407,13 +407,13 @@ class VariantMap(lang.HashableMap):
         # Set the item
         super(VariantMap, self).__setitem__(name, vspec)
 
-    def substitute(self, name, vspec):
-        if name not in self:
+    def substitute(self, vspec):
+        if vspec.name not in self:
             msg = 'cannot substitute a key that does not exist [{0}]'
-            raise KeyError(msg.format(name))
+            raise KeyError(msg.format(vspec.name))
 
         # Set the item
-        super(VariantMap, self).__setitem__(name, vspec)
+        super(VariantMap, self).__setitem__(vspec.name, vspec)
 
     def satisfies(self, other, strict=False):
         """Returns True if this VariantMap is more constrained than other,
@@ -428,7 +428,12 @@ class VariantMap(lang.HashableMap):
 
         """
         to_be_checked = [k for k in other]
-        if not (strict or self.spec._concrete):
+
+        strict_or_concrete = strict
+        if self.spec is not None:
+            strict_or_concrete |= self.spec._concrete
+
+        if not strict_or_concrete:
             to_be_checked = filter(lambda x: x in self, to_be_checked)
 
         return all(k in self and self[k].satisfies(other[k])
@@ -443,7 +448,7 @@ class VariantMap(lang.HashableMap):
         :return: True or False
         :rtype: bool
         """
-        if other.spec._concrete:
+        if other.spec is not None and other.spec._concrete:
             for k in self:
                 if k not in other:
                     raise UnsatisfiableVariantSpecError(self[k], '<absent>')

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -139,6 +139,12 @@ class VariantSpec(object):
     different (and possibly multiple) values.
     """
 
+    @staticmethod
+    def from_node_dict(name, value):
+        if isinstance(value, list):
+            value = ','.join(value)
+        return VariantSpec(name, value)
+
     def __init__(self, name, value):
         self.name = name
         # Stores the original value passed to initialize this instance
@@ -176,7 +182,7 @@ class VariantSpec(object):
             try:
                 t = next(csv.reader(f, skipinitialspace=True))
             except StopIteration:
-                t = ['']
+                t = []
             # With multi-value variants it is necessary
             # to remove duplicates and give an order
             # to a set
@@ -253,7 +259,7 @@ class VariantSpec(object):
         """
         v = self.value
         if isinstance(self.value, tuple):
-            v = ','.join(self.value)
+            v = list(self.value)
         return self.name, v
 
     def __contains__(self, item):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -26,7 +26,7 @@
 variants both in packages and in specs.
 """
 
-import cStringIO
+from six import StringIO
 import csv
 import inspect
 import llnl.util.lang as lang
@@ -194,7 +194,7 @@ class MultiValuedVariant(object):
         # Store a tuple of CSV string representations
         # Tuple is necessary here instead of list because the
         # values need to be hashed
-        f = cStringIO.StringIO(str(value))
+        f = StringIO(str(value))
         try:
             t = next(csv.reader(f, skipinitialspace=True))
         except StopIteration:
@@ -495,7 +495,7 @@ class VariantMap(lang.HashableMap):
         sorted_keys = sorted(self.keys())
 
         # add spaces before and after key/value variants.
-        string = cStringIO.StringIO()
+        string = StringIO()
 
         kv = False
         for key in sorted_keys:

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -25,13 +25,35 @@
 from spack import *
 
 
-class A(Package):
+class A(AutotoolsPackage):
     """Simple package with no dependencies"""
 
     homepage = "http://www.example.com"
     url      = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
+
+    variant(
+        'foo',
+        values=('bar', 'baz', 'fee'),
+        default='bar',
+        description='',
+        exclusive=False
+    )
+
+    def with_or_without_fee(self, activated):
+        if not activated:
+            return '--no-fee'
+        return '--fee-all-the-time'
+
+    def autoreconf(self, spec, prefix):
+        pass
+
+    def configure(self, spec, prefix):
+        pass
+
+    def build(self, spec, prefix):
+        pass
 
     def install(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -41,6 +41,14 @@ class A(AutotoolsPackage):
         exclusive=False
     )
 
+    variant(
+        'foobar',
+        values=('bar', 'baz', 'fee'),
+        default='bar',
+        description='',
+        exclusive=True
+    )
+
     def with_or_without_fee(self, activated):
         if not activated:
             return '--no-fee'

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -38,7 +38,7 @@ class A(AutotoolsPackage):
         values=('bar', 'baz', 'fee'),
         default='bar',
         description='',
-        exclusive=False
+        multi=True
     )
 
     variant(
@@ -46,7 +46,7 @@ class A(AutotoolsPackage):
         values=('bar', 'baz', 'fee'),
         default='bar',
         description='',
-        exclusive=True
+        multi=False
     )
 
     def with_or_without_fee(self, activated):

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -37,7 +37,6 @@ class MultivalueVariant(Package):
     variant('debug', default=False, description='Debug variant')
     variant(
         'foo',
-        default='',
         description='Muti-value non-exclusive variant',
         values=('bar', 'baz', 'barbaz'),
         exclusive=False

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -39,7 +39,7 @@ class MultivalueVariant(Package):
         'foo',
         description='Multi-valued variant',
         values=('bar', 'baz', 'barbaz'),
-        exclusive=False
+        multi=True
     )
 
     variant(
@@ -47,7 +47,7 @@ class MultivalueVariant(Package):
         description='Single-valued variant',
         default='bar',
         values=('bar', 'baz', 'barbaz'),
-        exclusive=True
+        multi=False
     )
 
     depends_on('mpi')

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -37,9 +37,17 @@ class MultivalueVariant(Package):
     variant('debug', default=False, description='Debug variant')
     variant(
         'foo',
-        description='Muti-value non-exclusive variant',
+        description='Multi-valued variant',
         values=('bar', 'baz', 'barbaz'),
         exclusive=False
+    )
+
+    variant(
+        'fee',
+        description='Single-valued variant',
+        default='bar',
+        values=('bar', 'baz', 'barbaz'),
+        exclusive=True
     )
 
     depends_on('mpi')

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class MultivalueVariant(Package):
+    homepage = "http://www.llnl.gov"
+    url = "http://www.llnl.gov/mpileaks-1.0.tar.gz"
+
+    version(1.0, 'foobarbaz')
+    version(2.1, 'foobarbaz')
+    version(2.2, 'foobarbaz')
+    version(2.3, 'foobarbaz')
+
+    variant('debug', default=False, description='Debug variant')
+    variant(
+        'foo',
+        default='',
+        description='Muti-value non-exclusive variant',
+        values=('bar', 'baz', 'barbaz'),
+        exclusive=False
+    )
+
+    depends_on('mpi')
+    depends_on('callpath')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -25,9 +25,10 @@
 from spack import *
 
 
-class Cdo(Package):
+class Cdo(AutotoolsPackage):
     """CDO is a collection of command line Operators to manipulate and analyse
-    Climate and NWP model Data. """
+    Climate and NWP model Data.
+    """
 
     homepage = "https://code.zmaw.de/projects/cdo"
     url      = "https://code.zmaw.de/attachments/download/12760/cdo-1.7.2.tar.gz"
@@ -38,84 +39,32 @@ class Cdo(Package):
     version('1.6.9', 'bf0997bf20e812f35e10188a930e24e2',
             url='https://code.zmaw.de/attachments/download/10198/cdo-1.6.9.tar.gz')
 
-    variant('szip', default=True, description='Enable szip compression for GRIB1')
-    variant('hdf5', default=False, description='Enable HDF5 support')
-    variant('netcdf', default=True, description='Enable NetCDF support')
-    variant('udunits2', default=True, description='Enable UDUNITS2 support')
-    variant('grib', default=True, description='Enable GRIB_API support')
-    variant('libxml2', default=True, description='Enable libxml2 support')
-    variant('proj', default=True, description='Enable PROJ library for cartographic projections')
-    variant('curl', default=True, description='Enable curl support')
-    variant('fftw', default=True, description='Enable support for fftw3')
-    variant('magics', default=True, description='Enable Magics library support')
+    variant(
+        'enable',
+        default='',
+        description='Enable support for various tools',
+        values=('szip', 'hdf5', 'netcdf', 'udunits2', 'grib', 'libxml2', 'proj', 'curl', 'fftw', 'magics'),  # NOQA: ignore=E501
+        exclusive=False
+    )
 
-    depends_on('szip', when='+szip')
-    depends_on('netcdf', when='+netcdf')
-    depends_on('hdf5+threadsafe', when='+hdf5')
-    depends_on('udunits2', when='+udunits2')
-    depends_on('grib-api', when='+grib')
-    depends_on('libxml2', when='+libxml2')
-    depends_on('proj', when='+proj')
-    depends_on('curl', when='+curl')
-    depends_on('fftw', when='+fftw')
-    depends_on('magics', when='+magics')
+    depends_on('szip', when='enable=szip')
+    depends_on('netcdf', when='enable=netcdf')
+    depends_on('hdf5+threadsafe', when='enable=hdf5')
+    depends_on('udunits2', when='enable=udunits2')
+    depends_on('grib-api', when='enable=grib')
+    depends_on('libxml2', when='enable=libxml2')
+    depends_on('proj', when='enable=proj')
+    depends_on('curl', when='enable=curl')
+    depends_on('fftw', when='enable=fftw')
+    depends_on('magics', when='enable=magics')
 
-    def install(self, spec, prefix):
-        config_args = ["--prefix=" + prefix,
-                       "--enable-shared",
-                       "--enable-static"]
-
-        if '+szip' in spec:
-            config_args.append('--with-szlib=' + spec['szip'].prefix)
-        else:
-            config_args.append('--without-szlib')
-
-        if '+hdf5' in spec:
-            config_args.append('--with-hdf5=' + spec['hdf5'].prefix)
-        else:
-            config_args.append('--without-hdf5')
-
-        if '+netcdf' in spec:
-            config_args.append('--with-netcdf=' + spec['netcdf'].prefix)
-        else:
-            config_args.append('--without-netcdf')
-
-        if '+udunits2' in spec:
-            config_args.append('--with-udunits2=' + spec['udunits2'].prefix)
-        else:
-            config_args.append('--without-udunits2')
-
-        if '+grib' in spec:
-            config_args.append('--with-grib_api=' + spec['grib-api'].prefix)
-        else:
-            config_args.append('--without-grib_api')
-
-        if '+libxml2' in spec:
-            config_args.append('--with-libxml2=' + spec['libxml2'].prefix)
-        else:
-            config_args.append('--without-libxml2')
-
-        if '+proj' in spec:
-            config_args.append('--with-proj=' + spec['proj'].prefix)
-        else:
-            config_args.append('--without-proj')
-
-        if '+curl' in spec:
-            config_args.append('--with-curl=' + spec['curl'].prefix)
-        else:
-            config_args.append('--without-curl')
-
-        if '+fftw' in spec:
-            config_args.append('--with-fftw3')
-        else:
-            config_args.append('--without-fftw3')
-
-        if '+magics' in spec:
-            config_args.append('--with-magics=' + spec['magics'].prefix)
-        else:
-            config_args.append('--without-magics')
-
-        configure(*config_args)
-
-        make()
-        make('install')
+    def configure_args(self):
+        spec = self.spec
+        config_args = [
+            '--enable-shared',
+            '--enable-static'
+        ]
+        config_args.extend(
+            self.with_or_without('enable', lambda x: spec[x].prefix)
+        )
+        return config_args

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Cdo(AutotoolsPackage):
+class Cdo(Package):
     """CDO is a collection of command line Operators to manipulate and analyse
     Climate and NWP model Data.
     """
@@ -39,32 +39,84 @@ class Cdo(AutotoolsPackage):
     version('1.6.9', 'bf0997bf20e812f35e10188a930e24e2',
             url='https://code.zmaw.de/attachments/download/10198/cdo-1.6.9.tar.gz')
 
-    variant(
-        'enable',
-        default='',
-        description='Enable support for various tools',
-        values=('szip', 'hdf5', 'netcdf', 'udunits2', 'grib', 'libxml2', 'proj', 'curl', 'fftw', 'magics'),  # NOQA: ignore=E501
-        exclusive=False
-    )
+    variant('szip', default=True, description='Enable szip compression for GRIB1')
+    variant('hdf5', default=False, description='Enable HDF5 support')
+    variant('netcdf', default=True, description='Enable NetCDF support')
+    variant('udunits2', default=True, description='Enable UDUNITS2 support')
+    variant('grib', default=True, description='Enable GRIB_API support')
+    variant('libxml2', default=True, description='Enable libxml2 support')
+    variant('proj', default=True, description='Enable PROJ library for cartographic projections')
+    variant('curl', default=True, description='Enable curl support')
+    variant('fftw', default=True, description='Enable support for fftw3')
+    variant('magics', default=True, description='Enable Magics library support')
 
-    depends_on('szip', when='enable=szip')
-    depends_on('netcdf', when='enable=netcdf')
-    depends_on('hdf5+threadsafe', when='enable=hdf5')
-    depends_on('udunits2', when='enable=udunits2')
-    depends_on('grib-api', when='enable=grib')
-    depends_on('libxml2', when='enable=libxml2')
-    depends_on('proj', when='enable=proj')
-    depends_on('curl', when='enable=curl')
-    depends_on('fftw', when='enable=fftw')
-    depends_on('magics', when='enable=magics')
+    depends_on('szip', when='+szip')
+    depends_on('netcdf', when='+netcdf')
+    depends_on('hdf5+threadsafe', when='+hdf5')
+    depends_on('udunits2', when='+udunits2')
+    depends_on('grib-api', when='+grib')
+    depends_on('libxml2', when='+libxml2')
+    depends_on('proj', when='+proj')
+    depends_on('curl', when='+curl')
+    depends_on('fftw', when='+fftw')
+    depends_on('magics', when='+magics')
 
-    def configure_args(self):
-        spec = self.spec
-        config_args = [
-            '--enable-shared',
-            '--enable-static'
-        ]
-        config_args.extend(
-            self.with_or_without('enable', lambda x: spec[x].prefix)
-        )
-        return config_args
+    def install(self, spec, prefix):
+        config_args = ["--prefix=" + prefix,
+                       "--enable-shared",
+                       "--enable-static"]
+
+        if '+szip' in spec:
+            config_args.append('--with-szlib=' + spec['szip'].prefix)
+        else:
+            config_args.append('--without-szlib')
+
+        if '+hdf5' in spec:
+            config_args.append('--with-hdf5=' + spec['hdf5'].prefix)
+        else:
+            config_args.append('--without-hdf5')
+
+        if '+netcdf' in spec:
+            config_args.append('--with-netcdf=' + spec['netcdf'].prefix)
+        else:
+            config_args.append('--without-netcdf')
+
+        if '+udunits2' in spec:
+            config_args.append('--with-udunits2=' + spec['udunits2'].prefix)
+        else:
+            config_args.append('--without-udunits2')
+
+        if '+grib' in spec:
+            config_args.append('--with-grib_api=' + spec['grib-api'].prefix)
+        else:
+            config_args.append('--without-grib_api')
+
+        if '+libxml2' in spec:
+            config_args.append('--with-libxml2=' + spec['libxml2'].prefix)
+        else:
+            config_args.append('--without-libxml2')
+
+        if '+proj' in spec:
+            config_args.append('--with-proj=' + spec['proj'].prefix)
+        else:
+            config_args.append('--without-proj')
+
+        if '+curl' in spec:
+            config_args.append('--with-curl=' + spec['curl'].prefix)
+        else:
+            config_args.append('--without-curl')
+
+        if '+fftw' in spec:
+            config_args.append('--with-fftw3')
+        else:
+            config_args.append('--without-fftw3')
+
+        if '+magics' in spec:
+            config_args.append('--with-magics=' + spec['magics'].prefix)
+        else:
+            config_args.append('--without-magics')
+
+        configure(*config_args)
+
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -73,9 +73,13 @@ class Mvapich2(AutotoolsPackage):
     )
 
     # 32 is needed when job size exceeds 32768 cores
-    variant('ch3_rank_bits', default=32,
-            description='Number of bits allocated to the rank field (16 or 32)'
-            )
+    variant(
+        'ch3_rank_bits',
+        default='32',
+        values=('16', '32'),
+        exclusive=True,
+        description='Number of bits allocated to the rank field (16 or 32)'
+    )
 
     variant(
         'process_managers',

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -68,7 +68,7 @@ class Mvapich2(AutotoolsPackage):
         'threads',
         default='multiple',
         values=('single', 'funneled', 'serialized', 'multiple'),
-        exclusive=True,
+        multi=False,
         description='Control the level of thread support'
     )
 
@@ -77,7 +77,7 @@ class Mvapich2(AutotoolsPackage):
         'ch3_rank_bits',
         default='32',
         values=('16', '32'),
-        exclusive=True,
+        multi=False,
         description='Number of bits allocated to the rank field (16 or 32)'
     )
 
@@ -85,7 +85,7 @@ class Mvapich2(AutotoolsPackage):
         'process_managers',
         description='List of the process managers to activate',
         values=('slurm', 'hydra', 'gforker', 'remshell'),
-        exclusive=False,
+        multi=True,
         validator=_process_manager_validator
     )
 

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -64,8 +64,13 @@ class Mvapich2(AutotoolsPackage):
     #   serialized  - User serializes calls to MPI (MPI_THREAD_SERIALIZED)
     #   multiple    - Fully multi-threaded (MPI_THREAD_MULTIPLE)
     #   runtime     - Alias to "multiple"
-    variant('threads', default='multiple',
-            description='Control the level of thread support')
+    variant(
+        'threads',
+        default='multiple',
+        values=('single', 'funneled', 'serialized', 'multiple'),
+        exclusive=True,
+        description='Control the level of thread support'
+    )
 
     # 32 is needed when job size exceeds 32768 cores
     variant('ch3_rank_bits', default=32,
@@ -83,6 +88,7 @@ class Mvapich2(AutotoolsPackage):
     variant(
         'fabrics',
         description='The fabric enabled for this build',
+        default='psm',
         values=(
             'psm', 'sock', 'nemesisib', 'nemesis', 'mrail', 'nemesisibtcp'
         )

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -169,7 +169,7 @@ class Mvapich2(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-    @AutotoolsPackage.precondition('configure')
+    @run_before('configure')
     def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to
@@ -206,7 +206,7 @@ class Mvapich2(AutotoolsPackage):
         args.extend(self.network_options)
         return args
 
-    @AutotoolsPackage.sanity_check('install')
+    @run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -74,7 +74,6 @@ class Mvapich2(AutotoolsPackage):
 
     variant(
         'process_managers',
-        default='',
         description='List of the process managers to activate',
         values=('slurm', 'hydra', 'gforker', 'remshell'),
         exclusive=False,
@@ -83,7 +82,6 @@ class Mvapich2(AutotoolsPackage):
 
     variant(
         'fabrics',
-        default='',
         description='The fabric enabled for this build',
         values=(
             'psm', 'sock', 'nemesisib', 'nemesis', 'mrail', 'nemesisibtcp'

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -26,7 +26,7 @@ from spack import *
 import sys
 
 
-class Mvapich2(Package):
+class Mvapich2(AutotoolsPackage):
     """MVAPICH2 is an MPI implementation for Infiniband networks."""
     homepage = "http://mvapich.cse.ohio-state.edu/"
     url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.2.tar.gz"
@@ -63,54 +63,22 @@ class Mvapich2(Package):
             description='Number of bits allocated to the rank field (16 or 32)'
             )
 
-    ##########
-    # TODO : Process managers should be grouped into the same variant,
-    # as soon as variant capabilities will be extended See
-    # https://groups.google.com/forum/#!topic/spack/F8-f8B4_0so
-    SLURM = 'slurm'
-    HYDRA = 'hydra'
-    GFORKER = 'gforker'
-    REMSHELL = 'remshell'
-    SLURM_INCOMPATIBLE_PMS = (HYDRA, GFORKER, REMSHELL)
-    variant(SLURM, default=False,
-            description='Set slurm as the only process manager')
-    variant(HYDRA, default=False,
-            description='Set hydra as one of the process managers')
-    variant(GFORKER, default=False,
-            description='Set gforker as one of the process managers')
-    variant(REMSHELL, default=False,
-            description='Set remshell as one of the process managers')
-    ##########
+    variant(
+        'process_managers',
+        default='',
+        description='List of the process managers to activate',
+        values=('slurm', 'hydra', 'gforker', 'remshell'),
+        exclusive=False
+    )
+    SLURM_INCOMPATIBLE_PMS = ('hydra', 'gforker', 'remshell')
 
-    ##########
-    # TODO : Network types should be grouped into the same variant, as
-    # soon as variant capabilities will be extended
-    PSM = 'psm'
-    SOCK = 'sock'
-    NEMESISIBTCP = 'nemesisibtcp'
-    NEMESISIB = 'nemesisib'
-    NEMESIS = 'nemesis'
-    MRAIL = 'mrail'
-    SUPPORTED_NETWORKS = (PSM, SOCK, NEMESIS, NEMESISIB, NEMESISIBTCP)
     variant(
-        PSM, default=False,
-        description='Configure for QLogic PSM-CH3')
-    variant(
-        SOCK, default=False,
-        description='Configure for TCP/IP-CH3')
-    variant(
-        NEMESISIBTCP, default=False,
-        description='Configure for both OFA-IB-Nemesis and TCP/IP-Nemesis')
-    variant(
-        NEMESISIB, default=False,
-        description='Configure for OFA-IB-Nemesis')
-    variant(
-        NEMESIS, default=False,
-        description='Configure for TCP/IP-Nemesis')
-    variant(
-        MRAIL, default=False,
-        description='Configure for OFA-IB-CH3')
-    ##########
+        'fabrics',
+        default='',
+        description='The fabric enabled for this build',
+        values=('psm', 'sock', 'nemesisib', 'nemesis', 'mrail', 'nemesisibtcp'),  # NOQA: ignore=E501
+        exclusive=True
+    )
 
     # FIXME : CUDA support is missing
     depends_on('bison')
@@ -123,110 +91,60 @@ class Mvapich2(Package):
         else:
             return "%s/mvapich/mv2/mvapich2-%s.tar.gz"  % (base_url, version)
 
-    @staticmethod
-    def enabled(x):
-        """Given a variant name returns the string that means the variant is
-        enabled
+    @property
+    def process_manager_options(self):
+        spec = self.spec
+        has_slurm = False
 
-        :param x: variant name
-        :return:
-        """
-        return '+' + x
+        # Slurm incompatible variants
+        slurm_incompatible_pms = []
+        for x in Mvapich2.SLURM_INCOMPATIBLE_PMS:
+            if 'process_managers={0}'.format(x) in spec:
+                slurm_incompatible_pms.append(x)
+        opts = ['--with-pm=%s' % ':'.join(slurm_incompatible_pms)]
 
-    def set_build_type(self, spec, configure_args):
-        """Appends to configure_args the flags that depends only on the build
-        type (i.e. release or debug)
-
-        :param spec: spec
-        :param configure_args: list of current configure arguments
-        """
-        if '+debug' in spec:
-            build_type_options = [
-                "--disable-fast",
-                "--enable-error-checking=runtime",
-                "--enable-error-messages=all",
-                # Permits debugging with TotalView
-                "--enable-g=dbg", "--enable-debuginfo"
-            ]
-        else:
-            build_type_options = ["--enable-fast=all"]
-
-        configure_args.extend(build_type_options)
-
-    def set_process_manager(self, spec, configure_args):
-        """Appends to configure_args the flags that will enable the
-        appropriate process managers
-
-        :param spec: spec
-        :param configure_args: list of current configure arguments
-        """
-        # Check that slurm variant is not activated together with
-        # other pm variants
-        has_slurm_incompatible_variants = \
-            any(self.enabled(x) in spec
-                for x in Mvapich2.SLURM_INCOMPATIBLE_PMS)
-
-        if self.enabled(Mvapich2.SLURM) in spec and \
-           has_slurm_incompatible_variants:
-            raise RuntimeError(" %s : 'slurm' cannot be activated \
-            together with other process managers" % self.name)
-
-        process_manager_options = []
         # See: http://slurm.schedmd.com/mpi_guide.html#mvapich2
-        if self.enabled(Mvapich2.SLURM) in spec:
+        if 'process_managers=slurm' in spec:
+            has_slurm = True
             if self.version > Version('2.0'):
-                process_manager_options = [
-                    "--with-pmi=pmi2",
-                    "--with-pm=slurm"
+                opts = [
+                    '--with-pmi=pmi2',
+                    '--with-pm=slurm'
                 ]
             else:
-                process_manager_options = [
-                    "--with-pmi=slurm",
-                    "--with-pm=no"
+                opts = [
+                    '--with-pmi=slurm',
+                    '--with-pm=no'
                 ]
+        # Check for incompatibilities
+        if has_slurm and slurm_incompatible_pms:
+            raise RuntimeError(
+                'slurm cannot be activated along with other process managers'
+            )
 
-        elif has_slurm_incompatible_variants:
-            pms = []
-            # The variant name is equal to the process manager name in
-            # the configuration options
-            for x in Mvapich2.SLURM_INCOMPATIBLE_PMS:
-                if self.enabled(x) in spec:
-                    pms.append(x)
-            process_manager_options = [
-                "--with-pm=%s" % ':'.join(pms)
-            ]
-        configure_args.extend(process_manager_options)
+        return opts
 
-    def set_network_type(self, spec, configure_args):
-        # Check that at most one variant has been activated
-        count = 0
-        for x in Mvapich2.SUPPORTED_NETWORKS:
-            if self.enabled(x) in spec:
-                count += 1
-        if count > 1:
-            raise RuntimeError('network variants are mutually exclusive \
-            (only one can be selected at a time)')
-
-        network_options = []
+    @property
+    def network_options(self):
+        opts = []
         # From here on I can suppose that only one variant has been selected
-        if self.enabled(Mvapich2.PSM) in spec:
-            network_options = ["--with-device=ch3:psm"]
-        elif self.enabled(Mvapich2.SOCK) in spec:
-            network_options = ["--with-device=ch3:sock"]
-        elif self.enabled(Mvapich2.NEMESISIBTCP) in spec:
-            network_options = ["--with-device=ch3:nemesis:ib,tcp"]
-        elif self.enabled(Mvapich2.NEMESISIB) in spec:
-            network_options = ["--with-device=ch3:nemesis:ib"]
-        elif self.enabled(Mvapich2.NEMESIS) in spec:
-            network_options = ["--with-device=ch3:nemesis"]
-        elif self.enabled(Mvapich2.MRAIL) in spec:
-            network_options = ["--with-device=ch3:mrail", "--with-rdma=gen2"]
-
-        configure_args.extend(network_options)
+        if 'fabrics=psm' in self.spec:
+            opts = ["--with-device=ch3:psm"]
+        elif 'fabrics=sock' in self.spec:
+            opts = ["--with-device=ch3:sock"]
+        elif 'fabrics=nemesisibtcp' in self.spec:
+            opts = ["--with-device=ch3:nemesis:ib,tcp"]
+        elif 'fabrics=nemesisib' in self.spec:
+            opts = ["--with-device=ch3:nemesis:ib"]
+        elif 'fabrics=nemesis' in self.spec:
+            opts = ["--with-device=ch3:nemesis"]
+        elif 'fabrics=mrail' in self.spec:
+            opts = ["--with-device=ch3:mrail", "--with-rdma=gen2"]
+        return opts
 
     def setup_environment(self, spack_env, run_env):
-        if self.enabled(Mvapich2.SLURM) in self.spec and \
-           self.version > Version('2.0'):
+        spec = self.spec
+        if 'process_managers=slurm' in spec and spec.satisfies('@2.0:'):
             run_env.set('SLURM_MPI_TYPE', 'pmi2')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
@@ -251,48 +169,44 @@ class Mvapich2(Package):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-    def install(self, spec, prefix):
+    @AutotoolsPackage.precondition('configure')
+    def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to
         # avoid delayed build errors in dependents.
         if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            raise InstallError('Mvapich2 requires both C and Fortran ',
-                               'compilers!')
+            raise InstallError(
+                'Mvapich2 requires both C and Fortran compilers!'
+            )
 
-        # we'll set different configure flags depending on our
-        # environment
-        configure_args = [
-            "--prefix=%s" % prefix,
-            "--enable-shared",
-            "--enable-romio",
-            "--disable-silent-rules",
+    def configure_args(self):
+        args = [
+            '--enable-shared',
+            '--enable-romio',
+            '-disable-silent-rules',
+            '--enable-fortran=all',
             "--enable-threads={0}".format(spec.variants['threads'].value),
             "--with-ch3-rank-bits={0}".format(
                 spec.variants['ch3_rank_bits'].value),
         ]
 
-        if self.compiler.f77 and self.compiler.fc:
-            configure_args.append("--enable-fortran=all")
-        elif self.compiler.f77:
-            configure_args.append("--enable-fortran=f77")
-        elif self.compiler.fc:
-            configure_args.append("--enable-fortran=fc")
+        if '+debug' in self.spec:
+            args.extend([
+                '--disable-fast',
+                '--enable-error-checking=runtime',
+                '--enable-error-messages=all',
+                # Permits debugging with TotalView
+                '--enable-g=dbg',
+                '--enable-debuginfo'
+            ])
         else:
-            configure_args.append("--enable-fortran=none")
+            args.append('--enable-fast=all')
 
-        # Set the type of the build (debug, release)
-        self.set_build_type(spec, configure_args)
-        # Set the process manager
-        self.set_process_manager(spec, configure_args)
-        # Determine network type by variant
-        self.set_network_type(spec, configure_args)
+        args.extend(self.process_manager_options)
+        args.extend(self.network_options)
+        return args
 
-        configure(*configure_args)
-        make()
-        make("install")
-
-        self.filter_compilers()
-
+    @AutotoolsPackage.sanity_check('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.
@@ -302,7 +216,7 @@ class Mvapich2(Package):
            be bound to whatever compiler they were built with.
         """
         bin = self.prefix.bin
-        mpicc  = join_path(bin, 'mpicc')
+        mpicc = join_path(bin, 'mpicc')
         mpicxx = join_path(bin, 'mpicxx')
         mpif77 = join_path(bin, 'mpif77')
         mpif90 = join_path(bin, 'mpif90')

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -24,6 +24,15 @@
 ##############################################################################
 from spack import *
 
+import numbers
+
+
+def is_integral(x):
+    try:
+        return isinstance(int(x), numbers.Integral)
+    except ValueError:
+        return False
+
 
 class Netcdf(AutotoolsPackage):
     """NetCDF is a set of software libraries and self-describing,
@@ -52,10 +61,18 @@ class Netcdf(AutotoolsPackage):
     # These variants control the number of dimensions (i.e. coordinates and
     # attributes) and variables (e.g. time, entity ID, number of coordinates)
     # that can be used in any particular NetCDF file.
-    variant('maxdims', default=1024,
-            description='Defines the maximum dimensions of NetCDF files.')
-    variant('maxvars', default=8192,
-            description='Defines the maximum variables of NetCDF files.')
+    variant(
+        'maxdims',
+        default=1024,
+        description='Defines the maximum dimensions of NetCDF files.',
+        values=is_integral
+    )
+    variant(
+        'maxvars',
+        default=8192,
+        description='Defines the maximum variables of NetCDF files.',
+        values=is_integral
+    )
 
     depends_on("m4", type='build')
     depends_on("hdf", when='+hdf4')

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -28,8 +28,9 @@ import numbers
 
 
 def is_integral(x):
+    """Any integer value"""
     try:
-        return isinstance(int(x), numbers.Integral)
+        return isinstance(int(x), numbers.Integral) and not isinstance(x, bool)
     except ValueError:
         return False
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -22,13 +22,15 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
 import os
+
+from spack import *
 
 
 def _verbs_dir():
     """Try to find the directory where the OpenFabrics verbs package is
-    installed. Return None if not found."""
+    installed. Return None if not found.
+    """
     try:
         # Try to locate Verbs by looking for a utility in the path
         ibv_devices = which("ibv_devices")
@@ -43,7 +45,7 @@ def _verbs_dir():
         if path == "/":
             path = "/usr"
         return path
-    except:
+    except TypeError:
         return None
 
 
@@ -82,22 +84,21 @@ class Openmpi(AutotoolsPackage):
     patch('configure.patch', when="@1.10.0:1.10.1")
     patch('fix_multidef_pmi_class.patch', when="@2.0.0:2.0.1")
 
-    # Fabrics
-    variant('psm', default=False, description='Build support for the PSM library')
-    variant('psm2', default=False,
-            description='Build support for the Intel PSM2 library')
-    variant('pmi', default=False,
-            description='Build support for PMI-based launchers')
-    variant('verbs', default=_verbs_dir() is not None,
-            description='Build support for OpenFabrics verbs')
-    variant('mxm', default=False, description='Build Mellanox Messaging support')
+    variant(
+        'fabrics',
+        default='' if _verbs_dir() is None else 'verbs',
+        description='List of fabrics that are enabled',
+        values=('psm', 'psm2', 'pmi', 'verbs', 'mxm'),
+        exclusive=False
+    )
 
-    # Schedulers
-    # TODO: support for alps and loadleveler is missing
-    variant('tm', default=False,
-            description='Build TM (Torque, PBSPro, and compatible) support')
-    variant('slurm', default=False,
-            description='Build SLURM scheduler component')
+    variant(
+        'schedulers',
+        default='',
+        description='List of schedulers for which support is enabled',
+        values=('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler'),
+        exclusive=False
+    )
 
     # Additional support options
     variant('java', default=False, description='Build Java support')
@@ -114,7 +115,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc')
     depends_on('hwloc +cuda', when='+cuda')
     depends_on('jdk', when='+java')
-    depends_on('sqlite', when='+sqlite3')
+    depends_on('sqlite', when='+sqlite3@:1.11')
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (
@@ -153,15 +154,22 @@ class Openmpi(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-    @property
-    def verbs(self):
+    def with_or_without_verbs(self, activated):
         # Up through version 1.6, this option was previously named
         # --with-openib
-        if self.spec.satisfies('@:1.6'):
-            return 'openib'
+        opt = 'openib'
         # In version 1.7, it was renamed to be --with-verbs
-        elif self.spec.satisfies('@1.7:'):
-            return 'verbs'
+        if self.spec.satisfies('@1.7:'):
+            opt = 'verbs'
+        # If the option has not been activated return
+        # --without-openib or --without-verbs
+        if not activated:
+            return '--without-{0}'.format(opt)
+        line = '--with-{0}'.format(opt)
+        path = _verbs_dir()
+        if (path is not None) and (path not in ('/usr', '/usr/local')):
+            line += '={0}'.format(path)
+        return line
 
     @run_before('autoreconf')
     def die_without_fortran(self):
@@ -175,48 +183,17 @@ class Openmpi(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-
         config_args = [
             '--enable-shared',
-            '--enable-static',
-            '--enable-mpi-cxx',
-            # Schedulers
-            '--with-tm' if '+tm' in spec else '--without-tm',
-            '--with-slurm' if '+slurm' in spec else '--without-slurm',
-            # Fabrics
-            '--with-psm' if '+psm' in spec else '--without-psm',
+            '--enable-static'
         ]
+        if self.spec.satisfies('@2.0:'):
+            # for Open-MPI 2.0:, C++ bindings are disabled by default.
+            config_args.extend(['--enable-mpi-cxx'])
 
-        # Intel PSM2 support
-        if spec.satisfies('@1.10:'):
-            if '+psm2' in spec:
-                config_args.append('--with-psm2')
-            else:
-                config_args.append('--without-psm2')
-
-        # PMI support
-        if spec.satisfies('@1.5.5:'):
-            if '+pmi' in spec:
-                config_args.append('--with-pmi')
-            else:
-                config_args.append('--without-pmi')
-
-        # Mellanox Messaging support
-        if spec.satisfies('@1.5.4:'):
-            if '+mxm' in spec:
-                config_args.append('--with-mxm')
-            else:
-                config_args.append('--without-mxm')
-
-        # OpenFabrics verbs support
-        if '+verbs' in spec:
-            path = _verbs_dir()
-            if path is not None and path not in ('/usr', '/usr/local'):
-                config_args.append('--with-{0}={1}'.format(self.verbs, path))
-            else:
-                config_args.append('--with-{0}'.format(self.verbs))
-        else:
-            config_args.append('--without-{0}'.format(self.verbs))
+        # Fabrics and schedulers
+        config_args.extend(self.with_or_without('fabrics'))
+        config_args.extend(self.with_or_without('schedulers'))
 
         # Hwloc support
         if spec.satisfies('@1.5.2:'):
@@ -270,11 +247,11 @@ class Openmpi(AutotoolsPackage):
     @run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
-           compilers that Spack built the package with.
+        compilers that Spack built the package with.
 
-           If this isn't done, they'll have CC, CXX and FC set
-           to Spack's generic cc, c++ and f90.  We want them to
-           be bound to whatever compiler they were built with.
+        If this isn't done, they'll have CC, CXX and FC set
+        to Spack's generic cc, c++ and f90.  We want them to
+        be bound to whatever compiler they were built with.
         """
         kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
         wrapper_basepath = join_path(self.prefix, 'share', 'openmpi')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -87,7 +87,7 @@ class Openmpi(AutotoolsPackage):
 
     variant(
         'fabrics',
-        default='' if _verbs_dir() is None else 'verbs',
+        default=None if _verbs_dir() is None else 'verbs',
         description='List of fabrics that are enabled',
         values=('psm', 'psm2', 'pmi', 'verbs', 'mxm'),
         exclusive=False
@@ -95,7 +95,6 @@ class Openmpi(AutotoolsPackage):
 
     variant(
         'schedulers',
-        default='',
         description='List of schedulers for which support is enabled',
         values=('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler'),
         exclusive=False

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 import os
 
 from spack import *

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -90,14 +90,14 @@ class Openmpi(AutotoolsPackage):
         default=None if _verbs_dir() is None else 'verbs',
         description='List of fabrics that are enabled',
         values=('psm', 'psm2', 'pmi', 'verbs', 'mxm'),
-        exclusive=False
+        multi=True
     )
 
     variant(
         'schedulers',
         description='List of schedulers for which support is enabled',
         values=('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler'),
-        exclusive=False
+        multi=True
     )
 
     # Additional support options


### PR DESCRIPTION
Resolves #1341

##### TLDR
This PR adds support for multi-valued variants. An example from the `openmpi` module is:
```python
variant(
    'schedulers',
    default='',
    description='List of schedulers for which support is enabled',
    values=('alps', 'lsf', 'tm', 'slurm', 'sge', 'loadleveler'),
    exclusive=False
)
```
Here `values` is the list of allowed values and `exclusive=False` means that more than one value can be selected simultaneously. One can thus say from the command line:
```console
spack install openmpi schedulers=lsf,loadleveler
```
The appropriate configure options will be activated by the line:
```python
config_args.extend(self.with_or_without('schedulers'))
```
in the `Openmpi.configure_args` method. The method `Autotools.with_or_without` is automatically transforming all the values activated in the variant into `--with-{value}`, and all the missing ones into `--without-{value}`.

The PR also refactors variant dependent code moving it in the `spack.variant` module and adds unit tests for the classes in `variant.py`.

##### Variant directive
This PR changes the variant directive in the following, **backward-compatible** way:
```python
def variant(pkg, name, default=False, description='', values=(True, False), exclusive=True, validator=None):
    ....
```
The semantics for the new arguments is:

1. `values`: either a tuple of allowed values, or a callable used as a single value validator (see `netcdf` for an example)
2. `exclusive`: if True only one value per spec is allowed for this variant
3. `validator`: optional callable used to enforce group logic during the semantic validation

The last argument (`validator`) won't be needed most of the time, but in complex cases like `mvapich2` it provides a convenient hook to enforce additional validation logic (in that particular case one can select either `slurm` alone as the scheduler or any other combination of all the non-slurm schedulers).

##### Miscellaneous notes
1. as far as I can see the hash for the packages I used to test this PR didn't change, but as I touched things that go into `_cmp_key` I put the `hash-change` tag to stay on the safe side
2. I changed the base class of `HashableMap`, see below
3. the `Variant` class (attached to packages) will act as a validator for the `VariantSpec` class (attached to specs). I considered a couple of different designs for this (like `Variant` being a factory for `VariantSpec` instances) and the one implemented here seems the cleanest to me.

##### Modifications
- [x] added support for multi-valued variants
- [x] refactored code related to variants into variant.py
- [x] added new generic features to AutotoolsPackage that leverage multi-valued variants
- [x] modified `openmpi`, `netcdf`, `mvapich2` and `cdo` to use new features
- [x] added unit tests for the new semantics (more to come)
- [ ] reference documentation