### PR TITLE
Fix building latest version of flex

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -27,6 +27,7 @@ from spack import *
 
 class Autoconf(AutotoolsPackage):
     """Autoconf -- system configuration part of autotools"""
+
     homepage = 'https://www.gnu.org/software/autoconf/'
     url = 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz'
 
@@ -35,7 +36,8 @@ class Autoconf(AutotoolsPackage):
     version('2.59', 'd4d45eaa1769d45e59dcb131a4af17a0')
     version('2.13', '9de56d4a161a723228220b0f425dc711')
 
-    depends_on('m4', type='build')
+    depends_on('m4@1.4.6:',   type='build')
+    depends_on('perl@5.006:', type='build')
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -37,7 +37,6 @@ class Autoconf(AutotoolsPackage):
     version('2.13', '9de56d4a161a723228220b0f425dc711')
 
     depends_on('m4@1.4.6:',   type='build')
-    depends_on('perl@5.006:', type='build')
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -25,10 +25,9 @@
 from spack import *
 
 
-class Automake(Package):
-    """
-    Automake -- make file builder part of autotools
-    """
+class Automake(AutotoolsPackage):
+    """Automake -- make file builder part of autotools"""
+
     homepage = 'http://www.gnu.org/software/automake/'
     url      = 'http://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz'
 
@@ -36,7 +35,8 @@ class Automake(Package):
     version('1.14.1', 'd052a3e884631b9c7892f2efce542d75')
     version('1.11.6', '0286dc30295b62985ca51919202ecfcc')
 
-    depends_on('autoconf')
+    depends_on('autoconf', type='build')
+    depends_on('perl',     type='build')
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))
@@ -47,8 +47,3 @@ class Automake(Package):
         executables = ['aclocal', 'automake']
         for name in executables:
             setattr(module, name, self._make_executable(name))
-
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -36,7 +36,6 @@ class Automake(AutotoolsPackage):
     version('1.11.6', '0286dc30295b62985ca51919202ecfcc')
 
     depends_on('autoconf', type='build')
-    depends_on('perl',     type='build')
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -59,11 +59,10 @@ class Flex(AutotoolsPackage):
 
         return url
 
+    def autoreconf(self, spec, prefix):
+        pass
+
     @when('@:2.6.0')
     def autoreconf(self, spec, prefix):
         libtoolize('--install', '--force')
         autoreconf('--install', '--force')
-
-    @when('@2.6.1:')
-    def autoreconf(self, spec, prefix):
-        pass

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -29,25 +29,41 @@ class Flex(AutotoolsPackage):
     """Flex is a tool for generating scanners."""
 
     homepage = "https://github.com/westes/flex"
-    url = "https://github.com/westes/flex/archive/v2.6.2.tar.gz"
+    url = "https://github.com/westes/flex/releases/download/v2.6.2/flex-2.6.2.tar.gz"
 
-    version('2.6.2', 'acde3a89ef2b376aac94586fd5fda460')
-    version('2.6.1', 'c4f31e0e4bd1711b7c91f16ef526ad90')
+    version('2.6.2', 'cc6d76c333db7653d5caf423a3335239')
+    version('2.6.1', '05bcd8fb629e0ae130311e8a6106fa82')
     version('2.6.0', '760be2ee9433e822b6eb65318311c19d')
     version('2.5.39', '5865e76ac69c05699f476515592750d7')
-                
-    depends_on("bison", type='build')
-    depends_on("m4", type='build')
-    depends_on('autoconf', type='build')
-    depends_on('libtool', type='build')
-    
+
+    depends_on('bison',         type='build')
+    depends_on('gettext@0.19:', type='build')
+    depends_on('help2man',      type='build')
+
+    # Older tarballs don't come with a configure script
+    depends_on('m4',       type='build', when='@:2.6.0')
+    depends_on('autoconf', type='build', when='@:2.6.0')
+    depends_on('automake', type='build', when='@:2.6.0')
+    depends_on('libtool',  type='build', when='@:2.6.0')
+
     def url_for_version(self, version):
-        base_url = "https://github.com/westes/flex/archive"
-        if version >= Version("2.6.0"):
-            return "{0}/v{1}.tar.gz".format(base_url, version)
+        url = "https://github.com/westes/flex"
+        if version >= Version('2.6.1'):
+            url += "/releases/download/v{0}/flex-{0}.tar.gz".format(version)
+        elif version == Version('2.6.0'):
+            url += "/archive/v{0}.tar.gz".format(version)
+        elif version >= Version('2.5.37'):
+            url += "/archive/flex-{0}.tar.gz".format(version)
         else:
-            return "{0}/flex-{1}.tar.gz".format(base_url, version)
-        
+            url += "/archive/flex-{0}.tar.gz".format(version.dashed)
+
+        return url
+
+    @when('@:2.6.0')
     def autoreconf(self, spec, prefix):
-        autogen = Executable('./autogen.sh')
-        autogen()
+        libtoolize('--install', '--force')
+        autoreconf('--install', '--force')
+
+    @when('@2.6.1:')
+    def autoreconf(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -23,37 +23,16 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import sys
 
 
-class M4(AutotoolsPackage):
-    """GNU M4 is an implementation of the traditional Unix macro processor."""
+class Help2man(AutotoolsPackage):
+    """help2man produces simple manual pages from the '--help' and '--version'
+    output of other commands."""
 
-    homepage = "https://www.gnu.org/software/m4/m4.html"
-    url      = "ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz"
+    homepage = "https://www.gnu.org/software/help2man/"
+    url      = "http://gnu.askapache.com/help2man/help2man-1.47.4.tar.xz"
 
-    version('1.4.17', 'a5e9954b1dae036762f7b13673a2cf76')
+    version('1.47.4', '544aca496a7d89de3e5d99e56a2f03d3')
 
-    patch('pgi.patch', when='@1.4.17')
-
-    variant('sigsegv', default=True,
-            description="Build the libsigsegv dependency")
-
-    depends_on('libsigsegv', when='+sigsegv')
-
-    def configure_args(self):
-        spec = self.spec
-        args = ['--enable-c++']
-
-        if '+sigsegv' in spec:
-            args.append('--with-libsigsegv-prefix={0}'.format(
-                spec['libsigsegv'].prefix))
-        else:
-            args.append('--without-libsigsegv-prefix')
-
-        # http://lists.gnu.org/archive/html/bug-m4/2016-09/msg00002.html
-        if (sys.platform == 'darwin') and (spec.satisfies('%gcc')) and \
-           (spec.architecture.platform_os.version == '10.12'):
-            args.append('ac_cv_type_struct_sched_param=yes')
-
-        return args
+    depends_on('perl',    type='build')
+    depends_on('gettext', type='build')

--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -34,5 +34,4 @@ class Help2man(AutotoolsPackage):
 
     version('1.47.4', '544aca496a7d89de3e5d99e56a2f03d3')
 
-    depends_on('perl',    type='build')
     depends_on('gettext', type='build')

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -25,8 +25,9 @@
 from spack import *
 
 
-class Libsigsegv(Package):
+class Libsigsegv(AutotoolsPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
+
     homepage = "https://www.gnu.org/software/libsigsegv/"
     url      = "ftp://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz"
 
@@ -34,9 +35,5 @@ class Libsigsegv(Package):
 
     version('2.10', '7f96fb1f65b3b8cbc1582fb7be774f0f')
 
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix,
-                  '--enable-shared')
-
-        make()
-        make("install")
+    def configure_args(self):
+        return ['--enable-shared']

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -25,17 +25,16 @@
 from spack import *
 
 
-class Libtool(Package):
-    """
-    libtool -- library building part of autotools
-    """
+class Libtool(AutotoolsPackage):
+    """libtool -- library building part of autotools."""
+
     homepage = 'https://www.gnu.org/software/libtool/'
     url = 'http://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz'
 
     version('2.4.6', 'addf44b646ddb4e3919805aa88fa7c5e')
     version('2.4.2', 'd2f3b7d4627e69e13514a40e72a24d50')
 
-    depends_on('m4', type='build')
+    depends_on('m4@1.4.6:', type='build')
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))
@@ -46,8 +45,3 @@ class Libtool(Package):
         executables = ['libtoolize', 'libtool']
         for name in executables:
             setattr(module, name, self._make_executable(name))
-
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")


### PR DESCRIPTION
Fixes #2398. Also adds missing build dependencies for Autotools builds. The only problem is that I am unable to install `flex@2.5.39`, which is needed by FOAM-extend. For some reason it crashes because it can't find flex, but flex can't depend on itself, right?