### PR TITLE
Updated version - r-lattice

### DIFF
--- a/var/spack/repos/builtin/packages/r-lattice/package.py
+++ b/var/spack/repos/builtin/packages/r-lattice/package.py
@@ -32,10 +32,10 @@ class RLattice(Package):
     handle most nonstandard requirements. See ?Lattice for an introduction."""
 
     homepage = "http://lattice.r-forge.r-project.org/"
-    url      = "https://cran.r-project.org/src/contrib/lattice_0.20-33.tar.gz"
+    url      = "https://cran.r-project.org/src/contrib/lattice_0.20-34.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/lattice"
 
-    version('0.20-33', 'd487c94db1bfe00a27270f4c71baf53e')
+    version('0.20-34', 'c2a648b22d4206ae7526fb70b8e90fed')
 
     extends('R')
 


### PR DESCRIPTION
New version of r-lattice.

I've realized some problems with r packages but I've been working for a while with an outdated Spack version so I'm not sure if it will be reproducible. 

The point is that when a r-package stays behind the current version hosted in the CRAN repository, like in this case, the fetch process fails. The Cran policy is to move the current version of a r-package to `https://cran.r-project.org/src/contrib` and the old ones remains in `https://cran.r-project.org/src/contrib/Archive/package_name/`. It seems that the list_url does not work properly in this case and it does not search the specified version in this last url, but I'm not pretty sure about that. 

Could anyone check it?

The error message I had was this:

```
==> Error: FetchError: All fetchers failed for r-lattice-0.20-33-y42n4xs7kb7wzvu47qmikcrwgrtiowte
     921      def do_fetch(self, mirror_only=False):
     922          """
     923          Creates a stage directory and downloads the tarball for this package.
     924          Working directory will be set to the stage directory.
     925          """
     926          if not self.spec.concrete:
     927              raise ValueError("Can only fetch concrete packages.")
     928  
     929          start_time = time.time()
     930          if spack.do_checksum and self.version not in self.versions:
     931              tty.warn("There is no checksum on file to fetch %s safely." %
     932                       self.spec.format('$_$@'))
     933  
     934              # Ask the user whether to skip the checksum if we're
     935              # interactive, but just fail if non-interactive.
     936              ck_msg = "Add a checksum or use --no-checksum to skip this check."
     937              ignore_checksum = False
     938              if sys.stdout.isatty():
     939                  ignore_checksum = tty.get_yes_or_no("  Fetch anyway?",
     940                                                      default=False)
     941                  if ignore_checksum:
     942                      tty.msg("Fetching with no checksum.", ck_msg)
     943  
     944              if not ignore_checksum:
     945                  raise FetchError("Will not fetch %s" %
     946                                   self.spec.format('$_$@'), ck_msg)
     947  
  >> 948          self.stage.fetch(mirror_only)
     949  
     950          self._fetch_time = time.time() - start_time
     951  
     952          if spack.do_checksum and self.version in self.versions:
     953              self.stage.check()
     954  
     955          self.stage.cache_local()
```