### PR TITLE
Allow shell support to work when set -u is set

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -58,7 +58,7 @@
 
 function spack {
     # Zsh does not do word splitting by default, this enables it for this function only
-    if [ -n "$ZSH_VERSION" ]; then
+    if [ -n "${ZSH_VERSION:-}" ]; then
         emulate -L sh
     fi
 


### PR DESCRIPTION
Fixes #2417.

@thiagotei Can you test this out? You may need to completely log out and log back in as it might not override the original function. As I mentioned in #2417, it isn't a great idea to set `set -u` in your `~/.bashrc`. Most developers won't have this variable set, so you will probably find other Bash scripts in Spack (and outside of Spack) that will break because of this. If you find anything else that doesn't work, can you let me know? The solution will likely be the same as this PR.