### PR TITLE
New package - r-rmarkdown

### DIFF
--- a/var/spack/repos/builtin/packages/r-rmarkdown/package.py
+++ b/var/spack/repos/builtin/packages/r-rmarkdown/package.py
@@ -1,0 +1,50 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class RRmarkdown(Package):
+    """Convert R Markdown documents into a variety of formats."""
+
+    homepage = "http://rmarkdown.rstudio.com/"
+    url      = "https://cran.r-project.org/src/contrib/rmarkdown_1.0.tar.gz"
+    list_url = "https://cran.r-project.org/src/contrib/Archive/rmarkdown"
+
+    version('1.0', '264aa6a59e9680109e38df8270e14c58')
+
+    extends('R')
+
+    depends_on('r-knitr', type=nolink)
+    depends_on('r-yaml', type=nolink)
+    depends_on('r-htmltools', type=nolink)
+    depends_on('r-catools', type=nolink)
+    depends_on('r-evaluate', type=nolink)
+    depends_on('r-base64enc', type=nolink)
+    depends_on('r-jsonlite', type=nolink)
+
+    def install(self, spec, prefix):
+        R('CMD', 'INSTALL', '--library={0}'.format(self.module.r_lib_dir),
+          self.stage.source_path)


### PR DESCRIPTION
Convert R Markdown documents into a variety of formats. Please, note that this package and the existing `r-markdown` are different packages.