### PR TITLE
CDash cleanups

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -26,6 +26,7 @@ import argparse
 import codecs
 import functools
 import os
+import platform
 import time
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
@@ -106,9 +107,10 @@ class TestResult(object):
 
 
 class TestSuite(object):
-    def __init__(self):
+    def __init__(self, spec):
         self.root = ET.Element('testsuite')
         self.tests = []
+        self.spec = spec
 
     def append(self, item):
         if not isinstance(item, TestCase):
@@ -128,6 +130,8 @@ class TestSuite(object):
         )
         self.root.set('failures', str(number_of_failures))
         self.root.set('tests', str(len(self.tests)))
+        self.root.set('name', str(self.spec))
+        self.root.set('hostname', platform.node())
 
         for item in self.tests:
             self.root.append(item.element)
@@ -322,7 +326,7 @@ def install(parser, args, **kwargs):
         if not log_filename:
             log_filename = default_log_file(spec)
         # Create the test suite in which to log results
-        test_suite = TestSuite()
+        test_suite = TestSuite(spec)
         # Decorate PackageBase.do_install to get installation status
         PackageBase.do_install = junit_output(
             spec, test_suite

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -130,7 +130,7 @@ class TestSuite(object):
         )
         self.root.set('failures', str(number_of_failures))
         self.root.set('tests', str(len(self.tests)))
-        self.root.set('name', str(self.spec))
+        self.root.set('name', self.spec.short_spec)
         self.root.set('hostname', platform.node())
 
         for item in self.tests:
@@ -247,7 +247,7 @@ def junit_output(spec, test_suite):
                 test_case.set_duration(duration)
                 text = fetch_text(self.build_log_path)
                 test_case.set_result(
-                    TestResult.ERRORED,
+                    TestResult.FAILED,
                     message='Unable to fetch package',
                     text=text
                 )
@@ -257,7 +257,7 @@ def junit_output(spec, test_suite):
                 test_case.set_duration(duration)
                 text = fetch_text(self.build_log_path)
                 test_case.set_result(
-                    TestResult.ERRORED,
+                    TestResult.FAILED,
                     message='Unexpected exception thrown during install',
                     text=text
                 )
@@ -267,7 +267,7 @@ def junit_output(spec, test_suite):
                 test_case.set_duration(duration)
                 text = fetch_text(self.build_log_path)
                 test_case.set_result(
-                    TestResult.ERRORED,
+                    TestResult.FAILED,
                     message='Unknown error',
                     text=text
                 )

--- a/var/spack/repos/builtin/packages/jemalloc/package.py
+++ b/var/spack/repos/builtin/packages/jemalloc/package.py
@@ -31,6 +31,7 @@ class Jemalloc(Package):
     homepage = "http://www.canonware.com/jemalloc/"
     url      = "https://github.com/jemalloc/jemalloc/releases/download/4.0.4/jemalloc-4.0.4.tar.bz2"
 
+    version('4.3.1', 'f204c0ea1aef92fbb339dc640de338a6')
     version('4.2.1', '094b0a7b8c77c464d0dc8f0643fd3901')
     version('4.2.0', 'e6b5d5a1ea93a04207528d274efdd144')
     version('4.1.0', 'c4e53c947905a533d5899e5cc3da1f94')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -37,6 +37,7 @@ class Petsc(Package):
     homepage = "http://www.mcs.anl.gov/petsc/index.html"
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.5.3.tar.gz"
 
+    version('develop', git='https://bitbucket.org/petsc/petsc.git', tag='master')
     version('3.7.4', 'aaf94fa54ef83022c14091f10866eedf')
     version('3.7.2', '50da49867ce7a49e7a0c1b37f4ec7b34')
     version('3.6.4', '7632da2375a3df35b8891c9526dbdde7')
@@ -67,6 +68,9 @@ class Petsc(Package):
             description='Activates support for SuperluDist (only parallel)')
 
     # Virtual dependencies
+    # Git repository needs sowing to build Fortran interface
+    depends_on('sowing', when='@develop')
+    
     depends_on('blas')
     depends_on('lapack')
     depends_on('mpi', when='+mpi')
@@ -127,6 +131,7 @@ class Petsc(Package):
     def install(self, spec, prefix):
         options = ['--with-ssl=0',
                    '--download-c2html=0',
+                   '--download-sowing=0',		   
                    '--download-hwloc=0']
         options.extend(self.mpi_dependent_options())
         options.extend([

--- a/var/spack/repos/builtin/packages/sowing/package.py
+++ b/var/spack/repos/builtin/packages/sowing/package.py
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Sowing(Package):
+    """Sowing generates Fortran interfaces and documentation for PETSc
+       and MPICH.
+    """
+
+    homepage = "http://www.mcs.anl.gov/petsc/index.html"
+    url = "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/sowing-1.1.23-p1.tar.gz"
+
+    version('1.1.23-p1', '65aaf3ae2a4c0f30d532fec291702e16')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+        make('ALL', parallel=False)
+        make("install")


### PR DESCRIPTION
use short spec for cdash
cdash does not handle 'errored' properly, thus using failed instead