### PR TITLE
Does nothing if no prexisting config.guess is found.

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -80,6 +80,8 @@ class AutotoolsPackage(PackageBase):
                 return True
             except:
                 pass
+        else:
+            return True
 
         # Look for a spack-installed automake package
         if 'automake' in self.spec:

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -122,7 +122,7 @@ class AutotoolsPackage(PackageBase):
         """Perform any required patches."""
 
         if self.patch_config_guess and self.spec.satisfies(
-                'arch=linux-redhat7-ppc64le'):
+                'arch=linux-rhel7-ppc64le'):
             if not self.do_patch_config_guess():
                 raise RuntimeError('Failed to find suitable config.guess')
 


### PR DESCRIPTION
#2221 does not work on our PPC64LE system. This commit allows `do_patch_config_guess` to exit 'True' when no pre-existing `my_config_guess` is found and therefore no `config.guess` needs to be patched.
