### PR TITLE
foam-extend: modification to accept flex version >= 2.6

### DIFF
--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -92,7 +92,7 @@ class FoamExtend(Package):
             filter_file(
                 r'-lMGridGen',
                 r'-lmgrid',
-                'src/fvAgglomerationMethods/MGridGenGamgAgglomeration/Make/options')  # noqa
+                'src/fvAgglomerationMethods/MGridGenGamgAgglomeration/Make/options')  # noqa: E501
 
         # Get the wmake arch and compiler
         (arch, foam_compiler) = self.set_arch()
@@ -215,17 +215,20 @@ class FoamExtend(Package):
                     for key, val in compiler_flags.iteritems():
                         fh.write('{0}{1} = {2}\n'.format(comp, key, val))
 
-        for _file in ['src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L',
-                      'src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L',
-                      'src/meshTools/triSurface/triSurface/interfaces/STL/readSTLASCII.L',
-                      'applications/utilities/preProcessing/fluentDataToFoam/fluentDataToFoam.L',
-                      'applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L',
-                      'applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L',
-                      'applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L',
-                      'applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L',
-                      'applications/utilities/mesh/conversion/fluent3DMeshToElmer/fluent3DMeshToElmer.L']:
+        _files_to_patch = [
+            'src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L',  # noqa: E501
+            'src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L',  # noqa: E501
+            'src/meshTools/triSurface/triSurface/interfaces/STL/readSTLASCII.L',  # noqa: E501
+            'applications/utilities/preProcessing/fluentDataToFoam/fluentDataToFoam.L',  # noqa: E501
+            'applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L',  # noqa: E501
+            'applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L',  # noqa: E501
+            'applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L',  # noqa: E501
+            'applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L',  # noqa: E501
+            'applications/utilities/mesh/conversion/fluent3DMeshToElmer/fluent3DMeshToElmer.L'  # noqa: E501
+        ]
+        for _file in _files_to_patch:
             filter_file(r'#if YY_FLEX_SUBMINOR_VERSION < 34',
-                        r'#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION < 34',
+                        r'#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION < 34',   # noqa: E501
                         _file)
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -39,7 +39,7 @@ class FoamExtend(Package):
 
     depends_on('mpi')
     depends_on('python')
-    depends_on('flex@:2.5.99')
+    depends_on('flex')
     depends_on('zlib')
     depends_on('cmake', type='build')
 
@@ -155,11 +155,11 @@ class FoamExtend(Package):
 
         if '+paraview' in self.spec:
             prefs_dict['PARAVIEW_SYSTEM'] = 1
-            prefs_dict['PARAVIEW_DIR'] = self.spec['paraview'].prefix,
-            prefs_dict['PARAVIEW_BIN_DIR'] = self.spec['paraview'].prefix.bin,
+            prefs_dict['PARAVIEW_DIR'] = self.spec['paraview'].prefix
+            prefs_dict['PARAVIEW_BIN_DIR'] = self.spec['paraview'].prefix.bin
             prefs_dict['QT_SYSTEM'] = 1
-            prefs_dict['QT_DIR'] = self.spec['qt'].prefix,
-            prefs_dict['QT_BIN_DIR'] = self.spec['qt'].prefix.bin,
+            prefs_dict['QT_DIR'] = self.spec['qt'].prefix
+            prefs_dict['QT_BIN_DIR'] = self.spec['qt'].prefix.bin
 
         # write the prefs files to define the configuration needed,
         # only the prefs.sh is used by this script but both are
@@ -215,6 +215,19 @@ class FoamExtend(Package):
                     for key, val in compiler_flags.iteritems():
                         fh.write('{0}{1} = {2}\n'.format(comp, key, val))
 
+        for _file in ['src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L',
+                      'src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L',
+                      'src/meshTools/triSurface/triSurface/interfaces/STL/readSTLASCII.L',
+                      'applications/utilities/preProcessing/fluentDataToFoam/fluentDataToFoam.L',
+                      'applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L',
+                      'applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L',
+                      'applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L',
+                      'applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L',
+                      'applications/utilities/mesh/conversion/fluent3DMeshToElmer/fluent3DMeshToElmer.L']:
+            filter_file(r'#if YY_FLEX_SUBMINOR_VERSION < 34',
+                        r'#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION < 34',
+                        _file)
+
     def setup_environment(self, spack_env, run_env):
         with working_dir(self.stage.path):
             spack_env.set('FOAM_INST_DIR', os.path.abspath('.'))
@@ -240,6 +253,7 @@ class FoamExtend(Package):
 
         if '+source' in spec:
             install_tree('src', join_path(install_path, 'src'))
+            install_tree('tutorials', join_path(install_path, 'tutorials'))
 
         install_tree('lib', join_path(install_path, 'lib'))
         install_tree('bin', join_path(install_path, 'bin'))


### PR DESCRIPTION
This is the changes I mentioned in #2401 to compile *foam* with flex version >=2.6.
I also corrected commas that where here for nothing and make the dependency with paraview fail.