### PR TITLE
Added customization for make targets in 'build' and 'install' phases for AutotoolsPackage

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -45,12 +45,18 @@ class AutotoolsPackage(PackageBase):
 
     They all have sensible defaults and for many packages the only thing
     necessary will be to override `configure_args`
+
+    Additionally, you may specify make targets for build and install
+    phases by overriding `build_targets` and `install_targets`
     """
     phases = ['autoreconf', 'configure', 'build', 'install']
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'AutotoolsPackage'
     patch_config_guess = True
+
+    build_targets = []
+    install_targets = ['install']
 
     def do_patch_config_guess(self):
         """Some packages ship with an older config.guess and need to have
@@ -151,25 +157,13 @@ class AutotoolsPackage(PackageBase):
         options = ['--prefix={0}'.format(prefix)] + self.configure_args()
         inspect.getmodule(self).configure(*options)
 
-    def build_targets(self):
-        """Method to be overridden. Should return an iterable containing
-        all the build targets that must be passed to `make`
-        """
-        return []
-
-    def install_targets(self):
-        """Method to be overridden. Should return an iterable containing
-        all the install targets that must be passed to `make`
-        """
-        return ['install']
-
     def build(self, spec, prefix):
         """Make the build targets"""
-        inspect.getmodule(self).make(*self.build_targets())
+        inspect.getmodule(self).make(*self.build_targets)
 
     def install(self, spec, prefix):
         """Make the install targets"""
-        inspect.getmodule(self).make(*self.install_targets())
+        inspect.getmodule(self).make(*self.install_targets)
 
     @PackageBase.sanity_check('build')
     @PackageBase.on_package_attributes(run_tests=True)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1061,26 +1061,27 @@ class PackageBase(object):
         mkdirp(self.prefix.lib)
         mkdirp(self.prefix.man1)
 
-    def _if_make_target_execute(self, target):
+    def _make_target_exists(self, target):
         try:
             # Check if we have a makefile
             file = [x for x in ('Makefile', 'makefile') if os.path.exists(x)]
             file = file.pop()
         except IndexError:
             tty.msg('No Makefile found in the build directory')
-            return
+            return False
 
         # Check if 'target' is in the makefile
         regex = re.compile('^' + target + ':')
         with open(file, 'r') as f:
             matches = [line for line in f.readlines() if regex.match(line)]
 
-        if not matches:
-            tty.msg('Target \'' + target + ':\' not found in Makefile')
-            return
+        return bool(matches) # False if empty
 
-        # Execute target
-        inspect.getmodule(self).make(target)
+    def _if_make_target_execute(self, target):
+        if _make_target_exists(target):
+            inspect.getmodule(self).make(target)
+        else:
+            tty.msg('Target \'' + target + ':\' not found in Makefile')
 
     def _get_needed_resources(self):
         resources = []

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1075,7 +1075,7 @@ class PackageBase(object):
         with open(file, 'r') as f:
             matches = [line for line in f.readlines() if regex.match(line)]
 
-        return bool(matches) # False if empty
+        return bool(matches)  # False if empty
 
     def _if_make_target_execute(self, target):
         if _make_target_exists(target):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1061,27 +1061,26 @@ class PackageBase(object):
         mkdirp(self.prefix.lib)
         mkdirp(self.prefix.man1)
 
-    def _make_target_exists(self, target):
+    def _if_make_target_execute(self, target):
         try:
             # Check if we have a makefile
             file = [x for x in ('Makefile', 'makefile') if os.path.exists(x)]
             file = file.pop()
         except IndexError:
             tty.msg('No Makefile found in the build directory')
-            return False
+            return
 
         # Check if 'target' is in the makefile
         regex = re.compile('^' + target + ':')
         with open(file, 'r') as f:
             matches = [line for line in f.readlines() if regex.match(line)]
 
-        return bool(matches)  # False if empty
-
-    def _if_make_target_execute(self, target):
-        if _make_target_exists(target):
-            inspect.getmodule(self).make(target)
-        else:
+        if not matches:
             tty.msg('Target \'' + target + ':\' not found in Makefile')
+            return
+
+        # Execute target
+        inspect.getmodule(self).make(target)
 
     def _get_needed_resources(self):
         resources = []

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -32,8 +32,9 @@ class Blitz(AutotoolsPackage):
 
     version('1.0.0', '9f040b9827fe22228a892603671a77af')
 
-    def make_targets_build(self):
+    def build_targets(self):
         return ['lib']
 
-    def make_targets_test(self):
-        return ['check-testsuite', 'check-examples']
+    def check(self):
+        make('check-testsuite')
+        make('check-examples')

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -31,3 +31,9 @@ class Blitz(AutotoolsPackage):
     url = "https://github.com/blitzpp/blitz/tarball/1.0.0"
 
     version('1.0.0', '9f040b9827fe22228a892603671a77af')
+
+    def make_targets_build(self):
+        return ['lib']
+
+    def make_targets_test(self):
+        return ['check-testsuite', 'check-examples']

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -32,8 +32,7 @@ class Blitz(AutotoolsPackage):
 
     version('1.0.0', '9f040b9827fe22228a892603671a77af')
 
-    def build_targets(self):
-        return ['lib']
+    build_targets = ['lib']
 
     def check(self):
         make('check-testsuite')


### PR DESCRIPTION
Note: for some reason `make('target1', 'target2')` fails, so I had to run a separate `make` for each target.