### PR TITLE
Update go to 1.7.4 and 1.6.4 to fix security issues

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -28,16 +28,32 @@ import glob
 import llnl.util.tty as tty
 from spack import *
 
+#
+# - vanilla CentOS 7, and possibly other systems, fail a test:
+#   TestCloneNEWUSERAndRemapRootDisableSetgroups
+#
+#   The Fix, discussed here: https://github.com/golang/go/issues/16283
+#   is to enable "user_namespace".
+#
+#   On a Digital Ocean image, this can be achieved by updating
+#   `/etc/default/grub` so that the `GRUB_CMDLINE_LINUX` variable
+#   includes `user_namespace.enable=1`, re-cooking the grub
+#   configuration with `sudo grub2-mkconfig -o /boot/grub2/grub.cfg`,
+#   and then rebooting.
+#
+# - on CentOS 7 systems (and possibly others) you need to have the
+#   glibc package installed or various static cgo tests fail.
+#
 
 class Go(Package):
     """The golang compiler and build environment"""
     homepage = "https://golang.org"
-    url='https://storage.googleapis.com/golang/go1.7.3.src.tar.gz'
+    url='https://storage.googleapis.com/golang/go1.7.4.src.tar.gz'
 
     extendable = True
 
-    version('1.7.3', '83d1b7bd4281479ab7d153e5152c9fc9')
-    version('1.6.2', 'd1b50fa98d9a71eeee829051411e6207')
+    version('1.7.4', '49c1076428a5d3b5ad7ac65233fcca2f')
+    version('1.6.4', 'b023240be707b34059d2c114d3465c92')
 
     variant('test', default=True, description='Build and run tests as part of the build.')
 
@@ -49,10 +65,10 @@ class Go(Package):
     depends_on('go-bootstrap', type='build')
 
     # https://github.com/golang/go/issues/17545
-    patch('time_test.patch', when='@1.6.2:1.7.3')
+    patch('time_test.patch', when='@1.6.4:1.7.4')
 
     # https://github.com/golang/go/issues/17986
-    patch('misc-cgo-testcshared.patch', level=0, when='@1.6.2:1.7.3')
+    patch('misc-cgo-testcshared.patch', level=0, when='@1.6.4:1.7.4')
 
     # NOTE: Older versions of Go attempt to download external files that have
     # since been moved while running the test suite.  This patch modifies the

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -28,7 +28,6 @@ import glob
 import llnl.util.tty as tty
 from spack import *
 
-#
 # - vanilla CentOS 7, and possibly other systems, fail a test:
 #   TestCloneNEWUSERAndRemapRootDisableSetgroups
 #
@@ -43,7 +42,7 @@ from spack import *
 #
 # - on CentOS 7 systems (and possibly others) you need to have the
 #   glibc package installed or various static cgo tests fail.
-#
+
 
 class Go(Package):
     """The golang compiler and build environment"""


### PR DESCRIPTION
The go team recently rolled out two releases to address security
issues.  Details available on the [go release
site](https://golang.org/doc/devel/release.html).

This commit updates our explicitly supported versions.

It also includes a comment about two CentOS requirements (enable
user_namespace and ensure that the static c library is installed) that
are required for the pacakges to pass their tests.