### PR TITLE
zlib: added 'pic' variant

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from os import environ
 
 
 class Zlib(AutotoolsPackage):
@@ -33,3 +34,14 @@ class Zlib(AutotoolsPackage):
     url = "http://zlib.net/zlib-1.2.8.tar.gz"
 
     version('1.2.8', '44d667c142d7cda120332623eab69f40')
+
+    variant('pic', default=True,
+            description='Produce position-independent code (for shared libs)')
+
+    def configure(self, spec, prefix):
+
+        if '+pic' in spec:
+            environ['CFLAGS'] = self.compiler.pic_flag
+
+        config_args = ['--prefix', prefix]
+        configure(*config_args)


### PR DESCRIPTION
It looks more complicated because zlib has custom configure which does
not support CFLAGS option. So instead, we take it from environment.