### PR TITLE
Bugfix: restore `__contains__` method after ArchSpec refactor.

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -449,6 +449,9 @@ class ArchSpec(object):
     def __repr__(self):
         return str(self)
 
+    def __contains__(self, string):
+        return string in str(self)
+
 
 @key_ordering
 class CompilerSpec(object):


### PR DESCRIPTION
Fixes #2480.

`__contains__` method was lost in the `Architecture` -> `ArchSpec` refactor introduced in #2261.

@hartzell 