### PR TITLE
ghostcript-fonts: fix install on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class GhostscriptFonts(Package):
@@ -34,4 +35,9 @@ class GhostscriptFonts(Package):
     version('8.11', '6865682b095f8c4500c54b285ff05ef6')
 
     def install(self, spec, prefix):
-        install_tree('.', join_path(prefix.share, 'font'))
+        fdir = join_path(prefix.share, 'font')
+        mkdirp(fdir)
+        files = glob.glob('*')
+        for f in files:
+            if not f.startswith('spack-build'):
+                install(f, fdir)


### PR DESCRIPTION
Without this patch i had
```
==> Error: OSError: [Errno 2] No such file or directory: '/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/ghostscript-fonts-8.11-hjxcwsk5ll4h3iii6uk7z7bcndageeq2/share/font/spack-build.out'
/Users/davydden/spack/var/spack/repos/builtin/packages/ghostscript-fonts/package.py:37, in install:
     36       def install(self, spec, prefix):
  >> 37           install_tree('.', join_path(prefix.share, 'font'))
```