### PR TITLE
fontconfig : fixed undefined variable error

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -38,9 +38,9 @@ class Fontconfig(AutotoolsPackage):
     depends_on('font-util', type='build')
 
     def configure_args(self):
-        args = ["--prefix=%s" % prefix,
+        font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')
+
+        return ["--prefix={0}".format(self.prefix),
                 "--enable-libxml2",
                 "--disable-docs",
-                "--with-default-fonts=%s" %
-                spec['font-util'].prefix + "/share/fonts"]
-        return args
+                "--with-default-fonts={0}".format(font_path)]


### PR DESCRIPTION
The changes in this pull request fix an undefined variable bug in the `fontconfig` package (which was previously causing the install script to crash on some platforms) and modernize the string substitution methods used in this package.  I've verified that the `fontconfig %gcc@4.7.2 arch=linux-rhel6-x86_64` variant of this package installs properly.

@hartzell: Could you verify that this updated version of `fontconfig` still works for you when you get a chance?  Thanks in advance for your help.