### PR TITLE
Updated cc wrapper: switch from ld to vcheck if version is requested.

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -133,7 +133,7 @@ esac
 # If any of the arguments below are present, then the mode is vcheck.
 # In vcheck mode, nothing is added in terms of extra search paths or
 # libraries.
-if [[ -z $mode ]]; then
+if [[ -z $mode ]] || [[ $mode == ld ]]; then
     for arg in "$@"; do
         if [[ $arg == -v || $arg == -V || $arg == --version || $arg == -dumpversion ]]; then
             mode=vcheck


### PR DESCRIPTION
A configure script might want to check the presence of a linker by requesting its version. The GNU linker ignores -rpath arguments if -v argument is given. This is not the case for Xcode (MacOS) linker, for example. The latter outputs its version and tries to process the rest of the arguments, which leads to a non-zero exit status because of the rpathes appended by the Spack's wrapper.