### PR TITLE
Fix the fontconfig install step.

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -42,5 +42,5 @@ class Fontconfig(AutotoolsPackage):
                 "--enable-libxml2",
                 "--disable-docs",
                 "--with-default-fonts=%s" %
-                spec['font-util'].prefix + "/share/fonts"]
+                self.spec['font-util'].prefix + "/share/fonts"]
         return args


### PR DESCRIPTION
I'm not sure how this ever worked, perhaps spec was defined in
bits that have since disappeared.

In any case, need to get the spec from self before accessing
it.