### PR TITLE
r-xml: Spack version does not match upstream version

### DIFF
--- a/var/spack/repos/builtin/packages/r-xml/package.py
+++ b/var/spack/repos/builtin/packages/r-xml/package.py
@@ -34,7 +34,7 @@ class RXml(Package):
     url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XML"
 
-    version('3.98-1', '1a7f3ce6f264eeb109bfa57bedb26c14')
+    version('3.98-1', 'aa373d6d301934e166e2a26a5ffe2a2e')
 
     extends('R')
 


### PR DESCRIPTION
The r-xml package seems to have changed.  This updates the digest
value.  I was worried that the curl was flapping between different
archive sites (see below) but it's been stable for 3 days.

Here's today's fetch output (with the updated digest value)

```
==> Fetching https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
==> Fetching from https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz failed.
==> Fetching https://cran.r-project.org/src/contrib/Archive/XML/XML_3.98-1.2.tar.gz
```