### PR TITLE
Building lua-luafilesystem requires a newish-git

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
+++ b/var/spack/repos/builtin/packages/lua-luafilesystem/package.py
@@ -40,6 +40,7 @@ class LuaLuafilesystem(Package):
 
     version('1_6_3', 'd0552c7e5a082f5bb2865af63fb9dc95')
 
+    depends_on('git@2.9.3:', type='build')
     extends('lua')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
See #2059 for background.

I'm unable to install `lmod` because `lua-luafilesystem` fails.

The luarocks install bits attempt to do a shallow clone of the luafilesystem
sources and the default git on my CentOS 7 test box (`git version 1.8.3.1`)
fails.

This adds a build dependency that ensures that a relatively modern git is
available.