### PR TITLE
yaml-cpp: add boost dependency

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -29,8 +29,7 @@ class YamlCpp(CMakePackage):
     """A YAML parser and emitter in C++"""
 
     homepage = "https://github.com/jbeder/yaml-cpp"
-    url      = \
-    "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz"
+    url      = "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz"
 
     version('0.5.3', '4e47733d98266e46a1a73ae0a72954eb')
 
@@ -39,11 +38,13 @@ class YamlCpp(CMakePackage):
 
     depends_on('cmake', type='build')
 
+    depends_on('boost', when='@:0.5.3')
+
     def cmake_args(self):
         spec = self.spec
         options = []
 
-        if '+fpic' in spec: 
+        if '+fpic' in spec:
             options.extend([
                 '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true'
             ])


### PR DESCRIPTION
yaml-cpp has a boost dependency, and according to [yaml-cpp
page](https://github.com/jbeder/yaml-cpp):

    yaml-cpp 0.5.3 has been released! This is a bug fix release. It also
    will be the last release that uses Boost; futures releases will require
    C++11 instead.