### PR TITLE
add ACLOCAL_PATH updates for packages that register m4 macros

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -24,6 +24,8 @@ modules:
       - MANPATH
     share/man:
       - MANPATH
+    share/aclocal:
+      - ACLOCAL_PATH
     lib:
       - LIBRARY_PATH
       - LD_LIBRARY_PATH


### PR DESCRIPTION
Fixes #2400.  This is a rare issue, but shows up with new autotools and very old or missing system libtool.  Basically just adds paths to the environment for packages that register global aclocal macros.