### PR TITLE
dealii: remove dependencies which are not needed

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -113,10 +113,6 @@ class Dealii(CMakePackage):
     depends_on("slepc@:3.6.3",     when='@:8.4.1+slepc+petsc+mpi')
     depends_on("trilinos",         when='+trilinos+mpi')
 
-    # developer dependnecies
-    depends_on("numdiff",     when='@develop')
-    depends_on("astyle@2.04", when='@develop')
-
     def build_type(self):
         # CMAKE_BUILD_TYPE should be DebugRelease | Debug | Release
         return 'DebugRelease'


### PR DESCRIPTION
to clarify, one may use `astyle` to indent the code when writing patches/contributing to deal.II, but it's not really a dependency. Similar with `numdiff`, it's not needed to build `@develop` versions, but may during development to run huge test suite.

@jppelteret @Rombur ping.