### PR TITLE
Scotch fails to build with latest flex

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -50,7 +50,7 @@ class Scotch(Package):
     variant('metis', default=True,
             description='Build metis and parmetis wrapper libraries')
 
-    depends_on('flex', type='build')
+    depends_on('flex@:2.6.1', type='build')
     depends_on('bison', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('zlib', when='+compression')


### PR DESCRIPTION
Fixes #2521. Thanks for figuring out the solution @svenevs.

P.S. Somebody should probably file a bug with the Scotch and/or Flex devs...