### PR TITLE
Add support for parsing R-XML URL versions.

### DIFF
--- a/lib/spack/spack/cmd/url_parse.py
+++ b/lib/spack/spack/cmd/url_parse.py
@@ -36,9 +36,6 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-s', '--spider', action='store_true',
         help="Spider the source page for versions.")
-    subparser.add_argument(
-        '-d', '--debug', action='store_true',
-        help="Print debug output from the URL parsing.")
 
 
 def print_name_and_version(url):
@@ -56,16 +53,18 @@ def print_name_and_version(url):
 def url_parse(parser, args):
     url = args.url
 
-    ver,  vs, vl = spack.url.parse_version_offset(url, debug=args.debug)
-    name, ns, nl = spack.url.parse_name_offset(url, ver, debug=args.debug)
-    if args.debug:
-        print
+    ver,  vs, vl = spack.url.parse_version_offset(url, debug=True)
+    name, ns, nl = spack.url.parse_name_offset(url, ver, debug=True)
+    print
 
-    tty.msg("Parsing URL:")
+    tty.msg("Detected:")
     try:
         print_name_and_version(url)
     except spack.url.UrlParseError as e:
         tty.error(str(e))
+
+    print '    name:     %s' % name
+    print '    version:  %s' % ver
 
     print
     tty.msg("Substituting version 9.9.9b:")

--- a/lib/spack/spack/cmd/url_parse.py
+++ b/lib/spack/spack/cmd/url_parse.py
@@ -36,6 +36,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-s', '--spider', action='store_true',
         help="Spider the source page for versions.")
+    subparser.add_argument(
+        '-d', '--debug', action='store_true',
+        help="Print debug output from the URL parsing.")
 
 
 def print_name_and_version(url):
@@ -53,8 +56,10 @@ def print_name_and_version(url):
 def url_parse(parser, args):
     url = args.url
 
-    ver,  vs, vl = spack.url.parse_version_offset(url)
-    name, ns, nl = spack.url.parse_name_offset(url, ver)
+    ver,  vs, vl = spack.url.parse_version_offset(url, debug=args.debug)
+    name, ns, nl = spack.url.parse_name_offset(url, ver, debug=args.debug)
+    if args.debug:
+        print
 
     tty.msg("Parsing URL:")
     try:

--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -326,3 +326,8 @@ class UrlParseTest(unittest.TestCase):
         self.check(
             'powerparser', '2.0.7',
             'https://github.com/losalamos/CLAMR/blob/packages/PowerParser_v2.0.7.tgz?raw=true')
+
+    def test_r_xml_version(self):
+        self.check(
+            'xml', '3.98-1.4',
+            'https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -163,7 +163,7 @@ def determine_url_file_extension(path):
     return ext
 
 
-def parse_version_offset(path):
+def parse_version_offset(path, debug=False):
     """Try to extract a version string from a filename or URL.  This is taken
        largely from Homebrew's Version class."""
     original_path = path
@@ -209,8 +209,8 @@ def parse_version_offset(path):
         # e.g. lame-398-1
         (r'-((\d)+-\d)', stem),
 
-        # e.g. foobar_1.2-3
-        (r'_((\d+\.)+\d+(-\d+)?[a-z]?)', stem),
+        # e.g. foobar_1.2-3 or 3.98-1.4
+        (r'_((\d+\.)+\d+(-(\d+(\.\d+)?))?[a-z]?)', stem),
 
         # e.g. foobar-4.5.1
         (r'-((\d+\.)*\d+)$', stem),
@@ -246,6 +246,10 @@ def parse_version_offset(path):
         regex, match_string = vtype
         match = re.search(regex, match_string)
         if match and match.group(1) is not None:
+            if debug:
+                tty.msg("Parsing URL: %s" % path,
+                        "Matched %d: r'%s'" % (i, regex))
+
             version = match.group(1)
             start   = match.start(1)
 
@@ -266,9 +270,9 @@ def parse_version(path):
     return Version(ver)
 
 
-def parse_name_offset(path, v=None):
+def parse_name_offset(path, v=None, debug=False):
     if v is None:
-        v = parse_version(path)
+        v = parse_version(path, debug=debug)
 
     path, ext, suffix = split_url_extension(path)
 

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -248,7 +248,7 @@ def parse_version_offset(path, debug=False):
         if match and match.group(1) is not None:
             if debug:
                 tty.msg("Parsing URL: %s" % path,
-                        "Matched %d: r'%s'" % (i, regex))
+                        "  Matched regex %d: r'%s'" % (i, regex))
 
             version = match.group(1)
             start   = match.start(1)

--- a/var/spack/repos/builtin/packages/r-xml/package.py
+++ b/var/spack/repos/builtin/packages/r-xml/package.py
@@ -34,7 +34,8 @@ class RXml(Package):
     url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz"
     list_url = "https://cran.r-project.org/src/contrib/Archive/XML"
 
-    version('3.98-1', '1a7f3ce6f264eeb109bfa57bedb26c14')
+    version('3.98-1.5', 'd1cfcd56f7aec96a84ffca91aea507ee')
+    version('3.98-1.4', '1a7f3ce6f264eeb109bfa57bedb26c14')
 
     extends('R')
 


### PR DESCRIPTION
Fixes #2513.

@adamjstewart @hartzell 

- [x] Parse R-XML URLs correctly.
- [x] Add a debug print out to the URL parsing, so you can see what got parsed more easily (see below)

```console
$ spack url-parse  https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz
==> Parsing URL: https://cran.r-project.org/src/contrib/XML_3.98-1.4
    Matched regex 10: r'_((\d+\.)+\d+(-(\d+(\.\d+)?))?[a-z]?)'

==> Detected:
    https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz
                                           --- ~~~~~~~~
    name:     xml
    version:  3.98-1.4

==> Substituting version 9.9.9b:
    https://cran.r-project.org/src/contrib/XML_9.9.9b.tar.gz
                                           --- ~~~~~~
```