### PR TITLE
Revert to-string for CNL operating system

### DIFF
--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -22,7 +22,7 @@ class Cnl(OperatingSystem):
         super(Cnl, self).__init__(name, version)
 
     def __str__(self):
-        return self.name + self.version
+        return self.name
 
     def find_compilers(self, *paths):
         types = spack.compilers.all_compiler_types()

--- a/lib/spack/spack/test/mock_packages_test.py
+++ b/lib/spack/spack/test/mock_packages_test.py
@@ -66,7 +66,7 @@ compilers:
     modules: 'None'
 - compiler:
     spec: clang@3.3
-    operating_system: CNL10
+    operating_system: CNL
     paths:
       cc: /path/to/clang
       cxx: /path/to/clang++
@@ -97,7 +97,7 @@ compilers:
       cxx: /path/to/g++
       f77: /path/to/gfortran
       fc: /path/to/gfortran
-    operating_system: CNL10
+    operating_system: CNL
     spec: gcc@4.5.0
     modules: 'None'
 - compiler:


### PR DESCRIPTION
This reverts to just returning the name (and omitting the version) for the CNL operating system ```__str__``` method. The mock compiler configuration in mock_packages_test is updated accordingly.