### PR TITLE
Add missing bzip2 dependency to freetype

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2026,8 +2026,8 @@ The last element of a package is its ``install()`` method.  This is
 where the real work of installation happens, and it's the main part of
 the package you'll need to customize for each piece of software.
 
-.. literalinclude::  ../../../var/spack/repos/builtin/packages/libpng/package.py
-   :pyobject: Libpng.install
+.. literalinclude::  ../../../var/spack/repos/builtin/packages/mpfr/package.py
+   :pyobject: Mpfr.install
    :linenos:
 
 ``install`` takes a ``spec``: a description of how the package should

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -25,17 +25,20 @@
 from spack import *
 
 
-class Freetype(Package):
-    """Font package"""
-    homepage = "http://http://www.freetype.org"
-    url      = "http://download.savannah.gnu.org/releases/freetype/freetype-2.5.3.tar.gz"
+class Freetype(AutotoolsPackage):
+    """FreeType is a freely available software library to render fonts.
+    It is written in C, designed to be small, efficient, highly customizable,
+    and portable while capable of producing high-quality output (glyph images)
+    of most vector and bitmap font formats."""
 
+    homepage = "https://www.freetype.org/index.html"
+    url      = "http://download.savannah.gnu.org/releases/freetype/freetype-2.7.tar.gz"
+
+    version('2.7',   '337139e5c7c5bd645fe130608e0fa8b5')
     version('2.5.3', 'cafe9f210e45360279c730d27bf071e9')
 
     depends_on('libpng')
+    depends_on('bzip2')
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix, "--with-harfbuzz=no")
-
-        make()
-        make("install")
+    def configure_args(self):
+        return ['--with-harfbuzz=no']

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -25,23 +25,18 @@
 from spack import *
 
 
-class Libpng(Package):
-    """libpng graphics file format"""
-    homepage = "http://www.libpng.org/pub/png/libpng.html"
-    url      = "http://download.sourceforge.net/libpng/libpng-1.6.16.tar.gz"
+class Libpng(AutotoolsPackage):
+    """libpng is the official PNG reference library."""
 
+    homepage = "http://www.libpng.org/pub/png/libpng.html"
+    url      = "http://download.sourceforge.net/libpng/libpng-1.6.26.tar.gz"
+
+    version('1.6.26', '236cd975520fc1f34cc0b8f0e615f7a0')
     version('1.6.24', '65213080dd30a9b16193d9b83adc1ee9')
-    version('1.6.16', '1a4ad377919ab15b54f6cb6a3ae2622d')
-    version('1.6.15', '829a256f3de9307731d4f52dc071916d')
-    version('1.6.14', '2101b3de1d5f348925990f9aa8405660')
-    version('1.5.26', '3ca98347a5541a2dad55cd6d07ee60a9')
-    version('1.4.19', '89bcbc4fc8b31f4a403906cf4f662330')
+
+    # Security vulnerabilities have been discovered in 1.6.19 an older
+
+    # Required for qt@3
     version('1.2.56', '9508fc59d10a1ffadd9aae35116c19ee')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended
-
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("check")
-        make("install")


### PR DESCRIPTION
In #2512, @kserradell reported the following error message when trying to build fontconig:
```
configure: error: Package requirements (freetype2) were not met: Package 'bzip2', required by 'freetype2', not found
```
Indeed, freetype was missing a dependency on bzip2. This PR includes the following modifications:

- [x] Add missing bzip2 dependency to freetype
- [x] Update freetype and libpng to AutotoolsPackage
- [x] Add latest versions of freetype and libpng
- [x] Remove most of older versions of libpng due to multiple security vulnerabilities
- [x] Fix freetype homepage
- [x] Add more detailed docstrings for freetype and libpng

After adding the bzip2 dependency, both freetype and fontconfig are correctly linking to Spack's bzip2 installation instead of the system installation. All packages in the stack passed `--run-tests` for me with GCC 6.1.0.