### PR TITLE
Better cxx11/14/17 flags for GNU/Clang/Intel

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -183,6 +183,16 @@ class Compiler(object):
             "If you think it should, please edit the compiler subclass and",
             "submit a pull request or issue.")
 
+    # This property should be overridden in the compiler subclass if
+    # C++17 is supported by that compiler
+    @property
+    def cxx17_flag(self):
+        # If it is not overridden, assume it is not supported and warn the user
+        tty.die(
+            "The compiler you have chosen does not currently support C++17.",
+            "If you think it should, please edit the compiler subclass and",
+            "submit a pull request or issue.")
+
     #
     # Compiler classes have methods for querying the version of
     # specific compiler executables.  This is used when discovering compilers.

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -70,13 +70,35 @@ class Clang(Compiler):
     @property
     def cxx11_flag(self):
         if self.is_apple:
-            # FIXME: figure out from which version Apple's clang supports c++11
-            return "-std=c++11"
+            # Adapted from CMake's AppleClang-CXX rules
+            # Spack's AppleClang detection only valid form Xcode >= 4.6
+            if self.version < ver('4.0.0'):
+                tty.die("Only Apple LLVM 4.0 and above support c++11")
+            else:
+                return "-std=c++11"
         else:
             if self.version < ver('3.3'):
                 tty.die("Only Clang 3.3 and above support c++11.")
             else:
                 return "-std=c++11"
+
+    @property
+    def cxx14_flag(self):
+        if self.is_apple:
+            # Adapted from CMake's rules for AppleClang
+            if self.version < ver('5.1.0'):
+                tty.die("Only Apple LLVM 5.1 and above support c++14.")
+            elif self.version < ver('6.1.0'):
+                return "-std=c++1y"
+            else:
+                return "-std=c++14"
+        else:
+            if self.version < ver('3.4'):
+                tty.die("Only Clang 3.4 and above support c++14.")
+            elif self.version < ver('3.5'):
+                return "-std=c++1y"
+            else:
+                return "-std=c++14"
 
     @property
     def pic_flag(self):

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -101,6 +101,20 @@ class Clang(Compiler):
                 return "-std=c++14"
 
     @property
+    def cxx17_flag(self):
+        if self.is_apple:
+            # Adapted from CMake's rules for AppleClang
+            if self.version < ver('6.1.0'):
+                tty.die("Only Apple LLVM 6.1 and above support c++17.")
+            else:
+                return "-std=c++1z"
+        else:
+            if self.version < ver('3.5'):
+                tty.die("Only Clang 3.5 and above support c++17.")
+            else:
+                return "-std=c++1z"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -77,6 +77,13 @@ class Gcc(Compiler):
             return "-std=c++14"
 
     @property
+    def cxx17_flag(self):
+        if self.version < ver('5.0'):
+            tty.die("Only gcc 5.0 and above support c++17.")
+        else:
+            return "-std=c++1z"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -71,6 +71,8 @@ class Gcc(Compiler):
     def cxx14_flag(self):
         if self.version < ver('4.8'):
             tty.die("Only gcc 4.8 and above support c++14.")
+        elif self.version < ver('4.9'):
+            return "-std=c++1y"
         else:
             return "-std=c++14"
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -66,6 +66,16 @@ class Intel(Compiler):
             return "-std=c++11"
 
     @property
+    def cxx14_flag(self):
+        # Adapted from CMake's Intel-CXX rules.
+        if self.version < ver('15'):
+            tty.die("Only intel 15.0 and above support c++14.")
+        elif self.version < ver('15.0.2'):
+            return "-std=c++1y"
+        else:
+            return "-std=c++14"
+
+    @property
     def pic_flag(self):
         return "-fPIC"
 


### PR DESCRIPTION
This PR adds basic support for cxx11/cxx14 flags for Apple Clang with version checking, cxx14 flag support for Intel, and a small version correction in GCC's cxx14 flags. Version checks and flags used much of the logic/lore from CMake's standard setting so I believe the flags to be robust, but possibly conservative (earlier compiler versions than selected might provide some support).

All spack unit and flake8 tests seem to pass, though I couldn't see any obvious place to add or extend actual unit tests on setting these flags. Let me know if there's a good way or place to do this. I've been able to test by hand with gcc's 4.5 through 4.9, Intel 13 and 15, but only Xcode/Apple LLVM 8. This is only visually confirming that `self.compiler.cxx{11,14}_flag` has the right value though. 

This is a WIP given the above caveats, and also because I wondered about also adding a new `cxx17_flag` property in `lib/spack/spack/compiler.py` with overrides for GNU and Clang. These only provide partial support as yet, but current versions do allow the `-std=c++1z` flag. It's easy enough to add, but obviously needs discussion.