### PR TITLE
update flux dependencies and package

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -36,6 +36,8 @@ class Asciidoc(Package):
 
     depends_on('libxml2')
     depends_on('libxslt')
+    depends_on('docbook-xml')
+    depends_on('docbook-xsl')
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -41,3 +41,11 @@ class DocbookXml(Package):
                 install_tree(src, dst, symlinks=True)
             else:
                 install(src, dst)
+
+    def setup_dependent_environment(self, spack_env, run_env, extension_spec):
+        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
+        spack_env.set('XML_CATALOG_FILES', catalog, separator=' ')
+
+    def setup_environment(self, spack_env, run_env):
+        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
+        run_env.set('XML_CATALOG_FILES', catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -22,21 +22,32 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
 import os
+from spack import *
 
 
-class Munge(AutotoolsPackage):
-    """ MUNGE Uid 'N' Gid Emporium """
-    homepage = "https://code.google.com/p/munge/"
-    url      = "https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2"
+class DocbookXsl(Package):
+    """Docbook XSL vocabulary."""
+    homepage = "http://docbook.sourceforge.net/"
+    url = "https://downloads.sourceforge.net/project/docbook/docbook-xsl/1.79.1/docbook-xsl-1.79.1.tar.bz2"
 
-    version('0.5.11', 'bd8fca8d5f4c1fcbef1816482d49ee01',
-            url='https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2')
+    version('1.79.1', 'b48cbf929a2ad85e6672f710777ca7bc')
 
-    depends_on('openssl')
-    depends_on('libgcrypt')
+    depends_on('docbook-xml')
 
     def install(self, spec, prefix):
-        os.makedirs(os.path.join(prefix, "lib/systemd/system"))
-        super(Munge, self).install(spec, prefix)
+        for item in os.listdir('.'):
+            src = os.path.abspath(item)
+            dst = os.path.join(prefix, item)
+            if os.path.isdir(item):
+                install_tree(src, dst, symlinks=True)
+            else:
+                install(src, dst)
+
+    def setup_dependent_environment(self, spack_env, run_env, extension_spec):
+        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
+        spack_env.set('XML_CATALOG_FILES', catalog, separator=' ')
+
+    def setup_environment(self, spack_env, run_env):
+        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
+        run_env.set('XML_CATALOG_FILES', catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -36,6 +36,8 @@ class Flux(AutotoolsPackage):
     version('master', branch='master',
             git='https://github.com/flux-framework/flux-core')
 
+    variant('docs', default=True, description='Build flux manpages')
+
     # Also needs autotools, but should use the system version if available
     depends_on("zeromq@4.0.4:")
     depends_on("czmq@2.2:")
@@ -47,6 +49,8 @@ class Flux(AutotoolsPackage):
     depends_on("python")
     depends_on("py-cffi")
     depends_on("jansson")
+
+    depends_on("asciidoc", type='build', when="+docs")
 
     depends_on("autoconf", type='build', when='@master')
     depends_on("automake", type='build', when='@master')
@@ -60,7 +64,4 @@ class Flux(AutotoolsPackage):
             bash('./autogen.sh')  # yes, twice, intentionally
 
     def configure_args(self):
-        return ['--disable-docs']
-
-    def install(self, spec, prefix):
-        make("install", "V=1")
+        return ['--disable-docs'] if '+docs' not in self.spec else []

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -26,12 +26,13 @@ from spack import *
 import os
 
 
-class Flux(Package):
+class Flux(AutotoolsPackage):
     """ A next-generation resource manager (pre-alpha) """
 
     homepage = "https://github.com/flux-framework/flux-core"
-    url      = "https://github.com/flux-framework/flux-core"
+    url      = "https://github.com/flux-framework/flux-core/releases/download/v0.6.0/flux-core-0.6.0.tar.gz"
 
+    version('0.6.0', md5='d44a0f719744771d168edd205bd8e74e')
     version('master', branch='master',
             git='https://github.com/flux-framework/flux-core')
 
@@ -45,20 +46,30 @@ class Flux(Package):
     depends_on("libxslt")
     depends_on("python")
     depends_on("py-cffi")
+    depends_on("jansson")
 
     # TODO: This provides a catalog, hacked with environment below for now
-    depends_on("docbook-xml", type='build')
-    depends_on("asciidoc", type='build')
+    # depends_on("docbook-xml", type='build')
+    # depends_on("asciidoc", type='build')
+
+    depends_on("autoconf", type='build')
+    depends_on("automake", type='build')
+    depends_on("libtool", type='build')
+
+    def autoreconf(self, spec, prefix):
+        if os.path.exists('autogen.sh'):
+            # Bootstrap with autotools
+            bash = which('bash')
+            bash('./autogen.sh')
+            bash('./autogen.sh')  # yes, twice, intentionally
+
+    def configure_args(self):
+        return ['--disable-docs', ]
 
     def install(self, spec, prefix):
-        # Bootstrap with autotools
-        bash = which('bash')
-        bash('./autogen.sh')
-        bash('./autogen.sh')  # yes, twice, intentionally
-
         # Fix asciidoc dependency on xml style sheets and whatnot
-        os.environ['XML_CATALOG_FILES'] = os.path.join(
-            spec['docbook-xml'].prefix, 'catalog.xml')
+        # os.environ['XML_CATALOG_FILES'] = os.path.join(
+        #    spec['docbook-xml'].prefix, 'catalog.xml')
         # Configure, compile & install
-        configure("--prefix=" + prefix)
+        # configure("--prefix=" + prefix)
         make("install", "V=1")

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -48,13 +48,9 @@ class Flux(AutotoolsPackage):
     depends_on("py-cffi")
     depends_on("jansson")
 
-    # TODO: This provides a catalog, hacked with environment below for now
-    # depends_on("docbook-xml", type='build')
-    # depends_on("asciidoc", type='build')
-
-    depends_on("autoconf", type='build')
-    depends_on("automake", type='build')
-    depends_on("libtool", type='build')
+    depends_on("autoconf", type='build', when='@master')
+    depends_on("automake", type='build', when='@master')
+    depends_on("libtool", type='build', when='@master')
 
     def autoreconf(self, spec, prefix):
         if os.path.exists('autogen.sh'):
@@ -64,12 +60,7 @@ class Flux(AutotoolsPackage):
             bash('./autogen.sh')  # yes, twice, intentionally
 
     def configure_args(self):
-        return ['--disable-docs', ]
+        return ['--disable-docs']
 
     def install(self, spec, prefix):
-        # Fix asciidoc dependency on xml style sheets and whatnot
-        # os.environ['XML_CATALOG_FILES'] = os.path.join(
-        #    spec['docbook-xml'].prefix, 'catalog.xml')
-        # Configure, compile & install
-        # configure("--prefix=" + prefix)
         make("install", "V=1")

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Libffi(Package):
+class Libffi(AutotoolsPackage):
     """The libffi library provides a portable, high level programming
     interface to various calling conventions. This allows a programmer
     to call any function specified by a call interface description at
@@ -38,7 +38,3 @@ class Libffi(Package):
     # "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz") # Has a bug
     # $(lib64) instead of ${lib64} in libffi.pc
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -37,4 +37,3 @@ class Libffi(AutotoolsPackage):
     # version('3.1', 'f5898b29bbfd70502831a212d9249d10',url =
     # "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz") # Has a bug
     # $(lib64) instead of ${lib64} in libffi.pc
-

--- a/var/spack/repos/builtin/packages/libjson-c/package.py
+++ b/var/spack/repos/builtin/packages/libjson-c/package.py
@@ -33,4 +33,3 @@ class LibjsonC(AutotoolsPackage):
     parallel = False
 
     version('0.11', 'aa02367d2f7a830bf1e3376f77881e98')
-

--- a/var/spack/repos/builtin/packages/libjson-c/package.py
+++ b/var/spack/repos/builtin/packages/libjson-c/package.py
@@ -25,15 +25,12 @@
 from spack import *
 
 
-class LibjsonC(Package):
+class LibjsonC(AutotoolsPackage):
     """ A JSON implementation in C """
     homepage = "https://github.com/json-c/json-c/wiki"
     url      = "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz"
 
+    parallel = False
+
     version('0.11', 'aa02367d2f7a830bf1e3376f77881e98')
 
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-
-        make(parallel=False)
-        make("install")

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -37,9 +37,9 @@ class Libxslt(AutotoolsPackage):
     url      = "http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz"
 
     version('1.1.28', '9667bf6f9310b957254fdcf6596600b7')
+    version('1.1.29', 'a129d3c44c022de3b9dcf6d6f288d72e')
 
     depends_on("libxml2")
     depends_on("xz")
     depends_on("zlib")
     depends_on("libgcrypt")
-

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Libxslt(Package):
+class Libxslt(AutotoolsPackage):
     """Libxslt is the XSLT C library developed for the GNOME
        project. XSLT itself is a an XML language to define
        transformation for XML. Libxslt is based on libxml2 the XML C
@@ -43,7 +43,3 @@ class Libxslt(Package):
     depends_on("zlib")
     depends_on("libgcrypt")
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/munge/package.py
+++ b/var/spack/repos/builtin/packages/munge/package.py
@@ -26,7 +26,7 @@ from spack import *
 import os
 
 
-class Munge(Package):
+class Munge(AutotoolsPackage):
     """ MUNGE Uid 'N' Gid Emporium """
     homepage = "https://code.google.com/p/munge/"
     url      = "https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2"
@@ -39,7 +39,5 @@ class Munge(Package):
 
     def install(self, spec, prefix):
         os.makedirs(os.path.join(prefix, "lib/systemd/system"))
-        configure("--prefix=%s" % prefix)
+        super(Munge, self).install(spec, prefix)
 
-        make()
-        make("install")


### PR DESCRIPTION
Fixes the flux package for new dependencies, also updates several dependent packages to use the new typed packages and work around a parallel build issue in libjson-c that only seems to appear on little-endian powerpc.