### PR TITLE
p4est: remove unneded lua dependency

### DIFF
--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -39,7 +39,6 @@ class P4est(Package):
     depends_on('libtool@2.4.2:', type='build')
 
     # other dependencies
-    depends_on('lua')  # Needed for the submodule sc
     depends_on('mpi')
     depends_on('zlib')
 


### PR DESCRIPTION
@Rombur ping.

```
$ otool -L ~/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libsc.dylib
/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libsc.dylib:
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libsc-1.1.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/zlib-1.2.8-qulx2xl3xmyrce2dk6cqs47uedchyilb/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openmpi-2.0.1-zgppod67vns7ojjqtw3qqwfid64jcclg/lib/libmpi.20.dylib (compatibility version 21.0.0, current version 21.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```
and
```
$ otool -L ~/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libp4est.dylib
/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libp4est.dylib:
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-oddbc2jpxly6a3cpsgp6a4ocopmwfuzt/lib/libp4est-1.1.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/zlib-1.2.8-qulx2xl3xmyrce2dk6cqs47uedchyilb/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/openmpi-2.0.1-zgppod67vns7ojjqtw3qqwfid64jcclg/lib/libmpi.20.dylib (compatibility version 21.0.0, current version 21.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```