### PR TITLE
Let OS classes to define default behavior when finding compilers.

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -254,7 +254,7 @@ class OperatingSystem(object):
 
     def find_compilers(self, *paths):
         """
-        Return a list of compilers found in the suppied paths.
+        Return a list of compilers found in the supplied paths.
         This invokes the find() method for each Compiler class,
         and appends the compilers detected to a list.
         """

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -33,7 +33,6 @@ from llnl.util.lang import index_by
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 from spack.spec import CompilerSpec, ArchSpec
-from spack.util.environment import get_path
 
 description = "Manage compilers"
 
@@ -84,8 +83,6 @@ def compiler_find(args):
 
     """
     paths = args.add_paths
-    if not paths:
-        paths = get_path('PATH')
 
     # Don't initialize compilers config via compilers.get_compiler_config.
     # Just let compiler_find do the

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -167,7 +167,7 @@ def all_compilers(scope=None, init_config=True):
 
 
 def find_compilers(*paths):
-    """Return a list of compilers found in the suppied paths.
+    """Return a list of compilers found in the supplied paths.
        This invokes the find_compilers() method for each operating
        system associated with the host platform, and appends
        the compilers detected to a list.


### PR DESCRIPTION
This PR slightly changes the semantics of the find_compilers() method of the OperatingSystem class. It makes it possible to understand if the list of paths that is provided to the method was given by users explicitly or they just expect the default behavior.

For example, this prevents Cnl class from looking for module files in directories that are listed in the $PATH when a user calls 'spack compiler find' without specifying additional paths.