### PR TITLE
Neaten go build's env vars so that lua modules work for go package

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -75,6 +75,7 @@ class GoBootstrap(Package):
         env['CGO_ENABLED'] = '0'
         bash = which('bash')
         with working_dir('src'):
+            env['GOROOT_FINAL'] = self.spec.prefix
             bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
 
         try:
@@ -86,6 +87,3 @@ class GoBootstrap(Package):
                 shutil.copytree(f, os.path.join(prefix, f))
             else:
                 shutil.copy2(f, os.path.join(prefix, f))
-
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('GOROOT_FINAL', self.spec.prefix)

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -91,6 +91,8 @@ class Go(Package):
     def install(self, spec, prefix):
         bash = which('bash')
         with working_dir('src'):
+            env['GOROOT_FINAL'] = self.spec.prefix
+            env['GOROOT_BOOTSTRAP'] = self.spec['go-bootstrap'].prefix
             bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
 
         try:
@@ -102,10 +104,6 @@ class Go(Package):
                 shutil.copytree(f, os.path.join(prefix, f))
             else:
                 shutil.copy2(f, os.path.join(prefix, f))
-
-    def setup_environment(self, spack_env, run_env):
-        spack_env.set('GOROOT_FINAL', self.spec.prefix)
-        spack_env.set('GOROOT_BOOTSTRAP', self.spec['go-bootstrap'].prefix)
 
     def setup_dependent_package(self, module, ext_spec):
         """Called before go modules' install() methods.


### PR DESCRIPTION
See https://github.com/LLNL/spack/issues/2567 for additional details.

There's a problem generating lua modules for the go package, triggered
by setting an env var in setup_environment that refers to the go-bootstrap
package.

Those vars are only appropriate during the build phase, this change
sets them explicitly and gets rid of the setup_environment def'n.

Testing on CentOS 7 shows that go still builds and that I can generate
lua module files for it using the steps described in #2567 (linked above).