### PR TITLE
Fix target for compiler on CNL operating systems

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -117,7 +117,7 @@ class Compiler(object):
                  extra_rpaths=None, **kwargs):
         self.spec = cspec
         self.operating_system = str(operating_system)
-        self.target = str(target)
+        self.target = target
         self.modules = modules
         self.alias = alias
 

--- a/lib/spack/spack/operating_systems/cnl.py
+++ b/lib/spack/spack/operating_systems/cnl.py
@@ -58,7 +58,7 @@ class Cnl(OperatingSystem):
                 v = version
                 comp = cmp_cls(
                     spack.spec.CompilerSpec(name + '@' + v),
-                    self, any,
+                    self, "any",
                     ['cc', 'CC', 'ftn'], [cmp_cls.PrgEnv, name + '/' + v])
 
                 compilers.append(comp)


### PR DESCRIPTION
Changes any to a string to avoid <built-in function any> being
incorrectly added to target in compilers.yaml.