### PR TITLE
[HACK] Make concretization great again!

### DIFF
--- a/var/spack/repos/builtin/packages/R/package.py
+++ b/var/spack/repos/builtin/packages/R/package.py
@@ -50,7 +50,7 @@ class R(Package):
 
     variant('external-lapack', default=False,
             description='Links to externally installed BLAS/LAPACK')
-    variant('X', default=True,
+    variant('X', default=False,
             description='Enable X11 support (call configure --with-x)')
 
     # Virtual dependencies

--- a/var/spack/repos/builtin/packages/arpack-ng/package.py
+++ b/var/spack/repos/builtin/packages/arpack-ng/package.py
@@ -61,7 +61,7 @@ class ArpackNg(Package):
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')
-    variant('mpi', default=False, description='Activates MPI support')
+    variant('mpi', default=True, description='Activates MPI support')
 
     # The function pdlamch10 does not set the return variable.
     # This is fixed upstream

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -33,7 +33,7 @@ class Cairo(AutotoolsPackage):
 
     version('1.14.0', 'fc3a5edeba703f906f2241b394f0cced')
 
-    variant('X', default=True, description="Build with X11 support")
+    variant('X', default=False, description="Build with X11 support")
 
     depends_on('libx11', when='+X')
     depends_on('libxext', when='+X')

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -36,7 +36,7 @@ class Caliper(Package):
 
     version('master', git='https://github.com/LLNL/Caliper.git')
 
-    variant('mpi', default=False, description='Enable MPI function wrappers.')
+    variant('mpi', default=True, description='Enable MPI function wrappers.')
 
     depends_on('libunwind')
     depends_on('papi')

--- a/var/spack/repos/builtin/packages/charm/package.py
+++ b/var/spack/repos/builtin/packages/charm/package.py
@@ -53,7 +53,7 @@ class Charm(Package):
 
     # Communication mechanisms (choose exactly one)
     # TODO: Support Blue Gene/Q PAMI, Cray GNI, Cray shmem, CUDA
-    variant("mpi", default=False,
+    variant("mpi", default=True,
             description="Use MPI as communication mechanism")
     variant("multicore", default=False,
             description="Disable inter-node communication")

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -53,7 +53,7 @@ class Fftw(Package):
         description='Produces a quad precision version of the library '
                     '(works only with GCC and libquadmath)')
     variant('openmp', default=False, description="Enable OpenMP support.")
-    variant('mpi', default=False, description='Activate MPI support')
+    variant('mpi', default=True, description='Activate MPI support')
     variant(
         'pfft_patches', default=False,
         description='Add extra transpose functions for PFFT compatibility')

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -45,7 +45,7 @@ class Gmsh(Package):
             description='Enables the build of shared libraries')
     variant('debug',       default=False,
             description='Builds the library in debug mode')
-    variant('mpi',         default=False,
+    variant('mpi',         default=True,
             description='Builds MPI support for parser and solver')
     variant('fltk',        default=False,
             description='Enables the build of the FLTK GUI')

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -34,7 +34,7 @@ class Gtkplus(Package):
         '2.24.25', '612350704dd3aacb95355a4981930c6f',
         url="http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.25.tar.xz")
 
-    variant('X', default=True, description="Enable an X toolkit")
+    variant('X', default=False, description="Enable an X toolkit")
 
     depends_on("atk")
     depends_on("gdk-pixbuf")

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -37,7 +37,7 @@ class H5hut(Package):
     version("1.99.13", "2a07a449afe50534de006ac6954a421a")
 
     variant("fortran", default=True, description="Enable Fortran support")
-    variant("mpi", default=False, description="Enable MPI support")
+    variant("mpi", default=True, description="Enable MPI support")
 
     depends_on("autoconf @2.60:", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -48,7 +48,7 @@ class Julia(Package):
     # TODO: Split these out into jl-hdf5, jl-mpi packages etc.
     variant("cxx", default=False, description="Prepare for Julia Cxx package")
     variant("hdf5", default=False, description="Install Julia HDF5 package")
-    variant("mpi", default=False, description="Install Julia MPI package")
+    variant("mpi", default=True, description="Install Julia MPI package")
     variant("plot", default=False,
             description="Install Julia plotting packages")
     variant("python", default=False,

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -45,7 +45,7 @@ class Mfem(Package):
     variant('hypre', default=False, description='Activate support for hypre')
     variant('suite-sparse', default=False,
             description='Activate support for SuiteSparse')
-    variant('mpi', default=False, description='Activate support for MPI')
+    variant('mpi', default=True, description='Activate support for MPI')
     variant('superlu-dist', default=False,
             description='Activate support for SuperLU_Dist')
     variant('lapack', default=False, description='Activate support for LAPACK')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -37,7 +37,7 @@ class Paraview(Package):
 
     variant('tcl', default=False, description='Enable TCL support')
 
-    variant('mpi', default=False, description='Enable MPI support')
+    variant('mpi', default=True, description='Enable MPI support')
 
     variant('osmesa', default=False, description='Enable OSMesa support')
     variant('qt', default=False, description='Enable Qt support')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -36,7 +36,7 @@ class PyH5py(Package):
     version('2.5.0', '6e4301b5ad5da0d51b0a1e5ac19e3b74')
     version('2.4.0', '80c9a94ae31f84885cc2ebe1323d6758')
 
-    variant('mpi', default=False, description='Build with MPI support')
+    variant('mpi', default=True, description='Build with MPI support')
 
     extends('python')
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -40,7 +40,7 @@ class Scotch(Package):
     version('6.0.0', 'c50d6187462ba801f9a82133ee666e8e')
     version('5.1.10b', 'f587201d6cf5cf63527182fbfba70753')
 
-    variant('mpi', default=False,
+    variant('mpi', default=True,
             description='Activate the compilation of parallel libraries')
     variant('compression', default=True,
             description='Activate the posibility to use compressed files')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -37,7 +37,7 @@ class Tk(Package):
     version('8.6.5', '11dbbd425c3e0201f20d6a51482ce6c4')
     version('8.6.3', '85ca4dbf4dcc19777fd456f6ee5d0221')
 
-    variant('X', default=True, description='Enable X11 support')
+    variant('X', default=False, description='Enable X11 support')
 
     depends_on("tcl")
     depends_on("libx11", when='+X')

--- a/var/spack/repos/builtin/packages/turbomole/package.py
+++ b/var/spack/repos/builtin/packages/turbomole/package.py
@@ -43,7 +43,7 @@ class Turbomole(Package):
     version('7.0.2', '92b97e1e52e8dcf02a4d9ac0147c09d6',
             url="file://%s/turbolinux702.tar.gz" % os.getcwd())
 
-    variant('mpi', default=False, description='Set up MPI environment')
+    variant('mpi', default=True, description='Set up MPI environment')
     variant('smp', default=False, description='Set up SMP environment')
 
     # Turbomole's install is odd. There are three variants


### PR DESCRIPTION
I _really_ didn't want to have to do this, but I've been left with no other choice. Spack's concretization algorithm is so crippled at the moment that simple commands no longer work more often than I would like. This PR does not fix the concretizer, as I wouldn't even no where to begin.

So what does this PR do?

- [x] Always default to `+mpi` and `~X` for _every_ package
- [x] Never even try to forward variants, as it doesn't work anyway

Why in the world would you want to do something so drastic?

Try checking out a fresh copy of Spack, and with no `packages.yaml`, run the following command:
```
$ spack spec gtkplus
...
==> Error: Invalid spec: 'pango@1.40.1%gcc@6.2.1~X arch=linux-fedora25-x86_64'. Package pango requires variant +X, but spec asked for ~X
```
The problem here is that `gtkplus` and `cairo` default to `+X` while `pango` defaults to `~X`. Spack's concretization algorithm is incapable of resolving this conflict because it settles on the default value for all dependencies. This bug has been reported over and over and over again (see #2546, #2574, #1552, etc.).

The solution that I decided on in this PR is to make sure common variants like `+X` and `+mpi` are at least consistent. Of course, as soon as you run `spack spec gtkplus+X`, everything breaks again, but at least `spack spec gtkplus` works.

What solutions have we used in the past?

When going through the packages, I noticed a lot of packages that looked like:
```python
depends_on('hdf5+mpi', when='+mpi')
depends_on('hdf5~mpi', when='~mpi')
```
What's wrong with this? Well, first of all, it doesn't forward the variants properly, as seen with `spack spec gtkplus`. Second, try running the following:
```
spack spec packageA ^hdf5@1.8.12
```
With a packageA containing those two lines, it will inform you that packageA does not depend on hdf5. This is because Spack doesn't concretize default variants before it concretizes dependency versions. Either of the following commands will work:
```
spack spec packageA +mpi ^hdf5@1.8.12
spack spec packageA -mpi ^hdf5@1.8.12
```
but the original won't. So what if we always do:
```python
depends_on('hdf5')
depends_on('hdf5+mpi', when='+mpi')
depends_on('hdf5~mpi', when='~mpi')
```
Ok, first of all, that's a pain in the ass. Second of all, it doesn't work, as evidenced by `spack spec gtkplus`. But what if we did:
```python
depends_on('hdf5')
depends_on('hdf5+mpi', when='+mpi')
```
Doesn't work either. I just tried it with the `gtkplus`, `cairo`, `pango` chain and you still see the problem with a conflict between `+X` and `~X`.

But won't everything be happy if we keep variant forwarding and make sure all of the variants have the same default? Nope. Things like `spack spec gtkplus` will work, but `spack spec gtkplus +X` won't. And if you decide to change the default for any package in `packages.yaml`, we're right back to square one, except it's harder to debug now unless you tell us what is in your `packages.yaml`.

There is another standing issue that this PR does not address. Try running the following:
```
spack spec python+tk
...
==> Error: +tk does not satisfy ~tk
```
This may look like the problem we just solved, but it's not that simple. Here is the dependency chain:

python+tk -> tk -> libx11 -> libxcb -> python~tk

Since libxcb has a build dependency on python~tk, it says it doesn't satisfy python+tk. Of course, if you try to fix this by setting the default to `python+tk`, you end up in infinite recursion hell, as seen in #2495 and #2565. Even more fun, if you try to build py-matplotlib for Python 3, it requires python+tk, and you end up with the problem that xcb-proto, another dependency of libxcb, depends on Python 2, which is most certainly not Python 3. 

This will hopefully be fixed when we start resolving build dependencies separately, but for now it is an absolute nightmare.

I _really_ hope this PR won't be merged, but it does provide immediate relief for a lot of open issues. In my opinion, these issues should block the release of `0.10`. If users can't build `python+tk` or `gtkplus` without hacking up Spack, we have a real problem.