### PR TITLE
Update digest for vim@8.0 tarball.

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -35,21 +35,10 @@ class Vim(Package):
     """
 
     homepage = "http://www.vim.org"
-    url      = "ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2"
-    list_url = "http://ftp.vim.org/pub/vim/unix/"
+    url      = "https://github.com/vim/vim/archive/v8.0.0134.tar.gz"
 
-    version('8.0',     '457543a7754b0d3c1c0aa4d4c3bb4070')
-    version('7.4',     '607e135c559be642f210094ad023dc65')
-    version('7.3',     '5b9510a17074e2b37d8bb38ae09edbf2')
-    version('7.2',     'f0901284b338e448bfd79ccca0041254')
-    version('7.1',     '44c6b4914f38d6f9aa959640b89da329')
-    version('7.0',     '4ca69757678272f718b1041c810d82d8')
-    version('6.4',     '774c14d93ce58674b3b2c880edd12d77')
-    version('6.3',     '821fda8f14d674346b87e3ef9cb96389')
-    version('6.2',     'c49d360bbd069d00e2a57804f2a123d9')
-    version('6.1.405', 'd220ff58f2c72ed606e6d0297c2f2a7c')
-    version('6.1',     '7fd0f915adc7c0dab89772884268b030')
-    version('6.0',     '9d9ca84d489af6b3f54639dd97af3774')
+    version('8.0.0134', 'c74668d25c2acc85d655430dd60886cd')
+    version('7.4.2367', 'a0a7bc394f7ab1d95571fe6ab05da3ea')
 
     feature_sets = ('huge', 'big', 'normal', 'small', 'tiny')
     for fs in feature_sets:
@@ -67,7 +56,7 @@ class Vim(Package):
     variant('gui', default=False, description="build with gui (gvim)")
     # virtual dependency?
 
-    depends_on('ncurses', when="@8.0:")
+    depends_on('ncurses', when="@7.4:")
 
     def install(self, spec, prefix):
         feature_set = None

--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -38,7 +38,7 @@ class Vim(Package):
     url      = "ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2"
     list_url = "http://ftp.vim.org/pub/vim/unix/"
 
-    version('8.0',     '808d2ebdab521e18bc5e0eaede0db867')
+    version('8.0',     '457543a7754b0d3c1c0aa4d4c3bb4070')
     version('7.4',     '607e135c559be642f210094ad023dc65')
     version('7.3',     '5b9510a17074e2b37d8bb38ae09edbf2')
     version('7.2',     'f0901284b338e448bfd79ccca0041254')


### PR DESCRIPTION
The digest appears to have changed.

The new digest value matches the value in their MD5SUMS (ftp://ftp.vim.org/pub/vim/unix/MD5SUMS) file.