### PR TITLE
Blacklist implicit packages for modulefile generation

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -327,6 +327,10 @@ class EnvModule(object):
         blacklist_matches = [x
                              for x in configuration.get('blacklist', [])
                              if self.spec.satisfies(x)]
+        blacklist_implicits = configuration.get('blacklist_implicits')
+        installed_implicitly = not self.spec._installed_explicitly()
+        blacklisted_as_implicit = blacklist_implicits and installed_implicitly
+
         if whitelist_matches:
             message = '\tWHITELIST : %s [matches : ' % self.spec.cshort_spec
             for rule in whitelist_matches:
@@ -341,7 +345,13 @@ class EnvModule(object):
             message += ' ]'
             tty.debug(message)
 
-        if not whitelist_matches and blacklist_matches:
+        if blacklisted_as_implicit:
+            message = '\tBLACKLISTED_AS_IMPLICIT : %s' % \
+                      self.spec.cshort_spec
+            tty.debug(message)
+
+        is_blacklisted = blacklist_matches or blacklisted_as_implicit
+        if not whitelist_matches and is_blacklisted:
             return True
 
         return False

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2594,6 +2594,16 @@ class Spec(object):
         except KeyError:
             return None
 
+    def _installed_explicitly(self):
+        """Helper for tree to print DB install status."""
+        if not self.concrete:
+            return None
+        try:
+            record = spack.store.db.get_record(self)
+            return record.explicit
+        except KeyError:
+            return None
+
     def tree(self, **kwargs):
         """Prints out this spec and its dependencies, tree-formatted
            with indentation."""


### PR DESCRIPTION
[I'm not much of a python programmer; pythonism feedback encouraged]  
[I'm not much of a spack programmer; spack-ist feedback encouraged]  

I thought it might be nice if I could avoid confusing my users by presenting them with a bunch of modules that were only installed as prerequisites to the ones that they've explicitly asked us to install and maintain.

Here's a way to do it.

It's entirely based on transmogrified bits of existing functionality.  If it looks like I ripped off your code, you're probably right....

This is where someone is bound to point out the existing ways to achieve this.... ;)

I'm not sure what documentation additions to make.

---

Add the ability to the modules generation process to blacklist
packages that were installed implicitly.  One can still whitelist
modules that were installed implicitly.

This changes adds a `blacklist_implicts` boolean as a peer to the
`whitelist` and `blacklist` arrays, e.g.:

```
modules:
  enable::
    - lmod
  lmod:
    whitelist:
      - 'lua'
      - 'py-setuptools'
    blacklist:
      -  '%gcc@4.8.3'
    blacklist_implicits: True
```

It adds a small helper in `spec.py` and then touches up the package
filtering code in `modules.py`.