### PR TITLE
graphviz: fixed build error due to specifying ltdl lib but not include.

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -62,7 +62,6 @@ class Graphviz(AutotoolsPackage):
         #       include <X11/Xlib.h>
         if sys.platform == 'darwin':
             options.append('CFLAGS=-I/opt/X11/include')
-        options.append('--with-ltdl-lib=%s/lib' % self.spec['libtool'].prefix)
 
         # A hack to patch config.guess in the libltdl sub directory
         shutil.copyfile('./config/config.guess', 'libltdl/config/config.guess')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -48,7 +48,8 @@ class Graphviz(AutotoolsPackage):
     depends_on("python")
     depends_on("ghostscript")
     depends_on("freetype")
-    depends_on("libtool", type='build')
+    depends_on("expat")
+    depends_on("libtool")
     depends_on("pkg-config", type='build')
 
     def configure_args(self):


### PR DESCRIPTION
With the existing package file, configure complains about the `--with-ltdl-lib` flag being used. Apparently it must be accompanied by `--with-ltdl-include`. Neither of these seems to actually be necessary, so I removed the  `--with-ltdl-lib` flag.