### PR TITLE
py-beautifulsoup4: Added version 4.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-beautifulsoup4/package.py
+++ b/var/spack/repos/builtin/packages/py-beautifulsoup4/package.py
@@ -33,6 +33,9 @@ class PyBeautifulsoup4(Package):
     homepage = "https://www.crummy.com/software/BeautifulSoup"
     url = "https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.4.1.tar.gz"
 
+    version('4.5.1', '994abd90e691beaf7d42c00ffb2f3a67',
+            url='https://www.crummy.com/software/BeautifulSoup/bs4/'
+            'download/4.5/beautifulsoup4-4.5.1.tar.gz')
     version('4.4.1', '8fbd9a7cac0704645fa20d1419036815')
 
     extends('python')


### PR DESCRIPTION
Added version 4.5.1 of beautifulsoup4. I could not find a permanent link for its tarball on PyPI, so I used the one from the library website instead.