### PR TITLE
Add MATLAB package

### DIFF
--- a/var/spack/repos/builtin/packages/matlab/package.py
+++ b/var/spack/repos/builtin/packages/matlab/package.py
@@ -1,0 +1,81 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class Matlab(Package):
+    """MATLAB (MATrix LABoratory) is a multi-paradigm numerical computing
+    environment and fourth-generation programming language. A proprietary
+    programming language developed by MathWorks, MATLAB allows matrix
+    manipulations, plotting of functions and data, implementation of
+    algorithms, creation of user interfaces, and interfacing with programs
+    written in other languages, including C, C++, C#, Java, Fortran and Python.
+
+    Note: MATLAB is licensed software. You will need to create an account on
+    the MathWorks homepage and download MATLAB yourself. Spack will search your
+    current directory for the download file. Alternatively, add this file to a
+    mirror so that Spack can find it. For instructions on how to set up a
+    mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
+
+    homepage = "https://www.mathworks.com/products/matlab.html"
+
+    version('R2016b', 'b0e0b688894282139fa787b5a86a5cf7')
+
+    variant('mode', default='interactive', description='Installation mode (interactive, silent, or automated)')
+    variant('key', default='', description='The file installation key to use')
+
+    # Licensing
+    license_required = True
+    license_comment = '#'
+    license_files = ['licenses/license.dat']
+    license_vars = ['LM_LICENSE_FILE']
+    license_url = 'https://www.mathworks.com/help/install/index.html'
+
+    def url_for_version(self, version):
+        return "file://{0}/matlab_{1}_glnxa64.zip".format(os.getcwd(), version)
+
+    def configure(self, spec, prefix):
+        config = {
+            'destinationFolder':   prefix,
+            'agreeToLicense':      'yes',
+            'mode':                spec.variants['mode'].value,
+            'fileInstallationKey': spec.variants['key'].value,
+            'licensePath':         self.global_license_file
+        }
+
+        # Store values requested by the installer in a file
+        with open('spack_installer_input.txt', 'w') as inputFile:
+            for key in config:
+                inputFile.write('{0}={1}\n'.format(key, config[key]))
+
+    def install(self, spec, prefix):
+        self.configure(spec, prefix)
+
+        # Run silent installation script
+        # Full path required
+        inputFile = join_path(self.stage.source_path,
+                              'spack_installer_input.txt')
+        os.system('./install -inputFile {0}'.format(inputFile))

--- a/var/spack/repos/builtin/packages/matlab/package.py
+++ b/var/spack/repos/builtin/packages/matlab/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 import os
+import subprocess
 
 
 class Matlab(Package):
@@ -45,14 +46,14 @@ class Matlab(Package):
     version('R2016b', 'b0e0b688894282139fa787b5a86a5cf7')
 
     variant('mode', default='interactive', description='Installation mode (interactive, silent, or automated)')
-    variant('key', default='', description='The file installation key to use')
+    variant('key',  default='',            description='The file installation key to use')
 
     # Licensing
     license_required = True
-    license_comment = '#'
-    license_files = ['licenses/license.dat']
-    license_vars = ['LM_LICENSE_FILE']
-    license_url = 'https://www.mathworks.com/help/install/index.html'
+    license_comment  = '#'
+    license_files    = ['licenses/license.dat']
+    license_vars     = ['LM_LICENSE_FILE']
+    license_url      = 'https://www.mathworks.com/help/install/index.html'
 
     def url_for_version(self, version):
         return "file://{0}/matlab_{1}_glnxa64.zip".format(os.getcwd(), version)
@@ -60,7 +61,6 @@ class Matlab(Package):
     def configure(self, spec, prefix):
         config = {
             'destinationFolder':   prefix,
-            'agreeToLicense':      'yes',
             'mode':                spec.variants['mode'].value,
             'fileInstallationKey': spec.variants['key'].value,
             'licensePath':         self.global_license_file
@@ -78,4 +78,4 @@ class Matlab(Package):
         # Full path required
         inputFile = join_path(self.stage.source_path,
                               'spack_installer_input.txt')
-        os.system('./install -inputFile {0}'.format(inputFile))
+        subprocess.call(['./install', '-inputFile', inputFile])


### PR DESCRIPTION
This is a rough first draft of a MATLAB package. Honestly, I'm surprised no one has done this yet.

**Caveats**

MATLAB is very picky about how you install it. You need to provide it with a license file, and either log in to your MathWorks account through the GUI or provide a file installation key, and maybe a separate activation phase? This is my first time installing MATLAB from the command line, so if you have more experience than I do, please chime in.

1. I couldn't get the silent installation working. The silent installation is the only way to install MATLAB if you don't have internet access or you can't open the GUI, so I would love to figure it out. It basically told me it didn't find any files to install, leading me to believe that you have to download them manually first. A good use case for resources, if we could download them easily.
2. If you run the automated installation, it skips over the steps you specify, but also skips over some that you don't, making it impossible to log in to your MathWorks account. I couldn't get a working file installation key, so this is as far as I got.
3. The interactive installation is the only one I've had any luck with. Unfortunately, depending on your OS and X11 support, none of the text in the GUI will show up for you. I had to run it on two separate machines just so I could tell what each button and text field meant.
4. Eventually I finally got it to install. It made it to the post_install hooks and symlinked the license properly. And then Spack hung. I have no idea what is preventing it from finishing properly. @tgamblin Any ideas? Could the GUI not be completely dead, and that's causing the forked process not to terminate?
5. Eventually we will need to make MATLAB extendable, although it doesn't need to be done in this PR.
6. Even once this is all working, I'm not sure variants are the right way to do things. The `mode` you choose doesn't really affect the installation. And the `key` results in your file installation key being preserved in the hash. Although this lets you install multiple installations if you have more than one license like we do. I suggested an [alternative solution](https://github.com/LLNL/spack/issues/2566#issuecomment-266521694), but it sounds like this isn't the easiest thing to get working.