### PR TITLE
Adds catch, cppunit, spdlog, tinyxml(1 and 2), google benchmark

### DIFF
--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -1,0 +1,16 @@
+from spack import *
+
+class Catch(Package):
+    """Catch tests"""
+
+    homepage = "https://github.com/philsquared/Catch"
+    url      = "https://github.com/philsquared/Catch/archive/v1.3.0.tar.gz"
+
+    version('1.3.0', 'e13694aaff72817d02af8ed27d077cd261b6e857')
+
+    def install(self, spec, prefix):
+        from os.path import join
+        mkdirp(prefix.include)
+        install(join('single_include', 'catch.hpp'), prefix.include)
+        # fakes out spack so it installs a module file
+        mkdirp(join(prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -1,16 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
+
 
 class Catch(Package):
     """Catch tests"""
 
     homepage = "https://github.com/philsquared/Catch"
-    url      = "https://github.com/philsquared/Catch/archive/v1.3.0.tar.gz"
+    url = "https://github.com/philsquared/Catch/archive/v1.3.0.tar.gz"
 
     version('1.3.0', 'e13694aaff72817d02af8ed27d077cd261b6e857')
 
     def install(self, spec, prefix):
-        from os.path import join
         mkdirp(prefix.include)
-        install(join('single_include', 'catch.hpp'), prefix.include)
+        install(join_path('single_include', 'catch.hpp'), prefix.include)
         # fakes out spack so it installs a module file
-        mkdirp(join(prefix, 'bin'))
+        mkdirp(join_path(prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/cppunit/package.py
+++ b/var/spack/repos/builtin/packages/cppunit/package.py
@@ -1,0 +1,15 @@
+from spack import *
+
+class Cppunit(Package):
+    """Obsolete Unit testing framework for C++"""
+
+    homepage = "https://wiki.freedesktop.org/www/Software/cppunit/"
+    url      = "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
+
+    version('1.13.2', '0eaf8bb1dcf4d16b12bec30d0732370390d35e6f')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/cppunit/package.py
+++ b/var/spack/repos/builtin/packages/cppunit/package.py
@@ -1,15 +1,34 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
-class Cppunit(Package):
+
+class Cppunit(AutotoolsPackage):
     """Obsolete Unit testing framework for C++"""
 
     homepage = "https://wiki.freedesktop.org/www/Software/cppunit/"
-    url      = "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
+    url = "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
 
     version('1.13.2', '0eaf8bb1dcf4d16b12bec30d0732370390d35e6f')
-
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/gbenchmark/package.py
+++ b/var/spack/repos/builtin/packages/gbenchmark/package.py
@@ -1,15 +1,42 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
-class Gbenchmark(Package):
+
+class Gbenchmark(CMakePackage):
     """A microbenchmark support library"""
 
     homepage = "https://github.com/google/benchmark"
-    url      = "https://github.com/google/benchmark/archive/v1.0.0.tar.gz"
+    url = "https://github.com/google/benchmark/archive/v1.0.0.tar.gz"
 
     version('1.1.0', '8c539bbe2a212618fa87b6c38fba087100b6e4ae',
             url='https://github.com/google/benchmark/archive/v1.1.0.tar.gz')
     version('1.0.0', '4f778985dce02d2e63262e6f388a24b595254a93')
-    variant("debug", default=False, description="Installs with debug options")
+
+    def build_type(self):
+        return "Release"
 
     def patch(self):
         filter_file(
@@ -23,21 +50,11 @@ class Gbenchmark(Package):
             'CMakeLists.txt'
         )
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
+    def cmake_args(self, spec, prefix):
         if self.compiler.name == 'intel':
-            options.append("-DCMAKE_CXX_FLAGS='-no-ansi-alias -fno-strict-aliasing'")
-            options.append("-DCMAKE_C_FLAGS='-no-ansi-alias -fno-strict-aliasing'")
-            options.append("-DBENCHMARK_ENABLE_TESTING=OFF")
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+            return [
+                "-DCMAKE_CXX_FLAGS='-no-ansi-alias -fno-strict-aliasing'",
+                "-DCMAKE_C_FLAGS='-no-ansi-alias -fno-strict-aliasing'",
+                "-DBENCHMARK_ENABLE_TESTING=OFF"
+            ]
+        return []

--- a/var/spack/repos/builtin/packages/gbenchmark/package.py
+++ b/var/spack/repos/builtin/packages/gbenchmark/package.py
@@ -52,8 +52,8 @@ class Gbenchmark(CMakePackage):
     def cmake_args(self, spec, prefix):
         if self.compiler.name == 'intel':
             return [
-                "-DCMAKE_CXX_FLAGS='-no-ansi-alias -fno-strict-aliasing'",
-                "-DCMAKE_C_FLAGS='-no-ansi-alias -fno-strict-aliasing'",
+                "-DCMAKE_CXX_FLAGS=-no-ansi-alias -fno-strict-aliasing",
+                "-DCMAKE_C_FLAGS=-no-ansi-alias -fno-strict-aliasing",
                 "-DBENCHMARK_ENABLE_TESTING=OFF"
             ]
         return []

--- a/var/spack/repos/builtin/packages/gbenchmark/package.py
+++ b/var/spack/repos/builtin/packages/gbenchmark/package.py
@@ -31,8 +31,7 @@ class Gbenchmark(CMakePackage):
     homepage = "https://github.com/google/benchmark"
     url = "https://github.com/google/benchmark/archive/v1.0.0.tar.gz"
 
-    version('1.1.0', '8c539bbe2a212618fa87b6c38fba087100b6e4ae',
-            url='https://github.com/google/benchmark/archive/v1.1.0.tar.gz')
+    version('1.1.0', '8c539bbe2a212618fa87b6c38fba087100b6e4ae')
     version('1.0.0', '4f778985dce02d2e63262e6f388a24b595254a93')
 
     def build_type(self):

--- a/var/spack/repos/builtin/packages/gbenchmark/package.py
+++ b/var/spack/repos/builtin/packages/gbenchmark/package.py
@@ -1,0 +1,43 @@
+from spack import *
+
+class Gbenchmark(Package):
+    """A microbenchmark support library"""
+
+    homepage = "https://github.com/google/benchmark"
+    url      = "https://github.com/google/benchmark/archive/v1.0.0.tar.gz"
+
+    version('1.1.0', '8c539bbe2a212618fa87b6c38fba087100b6e4ae',
+            url='https://github.com/google/benchmark/archive/v1.1.0.tar.gz')
+    version('1.0.0', '4f778985dce02d2e63262e6f388a24b595254a93')
+    variant("debug", default=False, description="Installs with debug options")
+
+    def patch(self):
+        filter_file(
+            r'add_cxx_compiler_flag..fstrict.aliasing.',
+            r'##### add_cxx_compiler_flag(-fstrict-aliasing)',
+            'CMakeLists.txt'
+        )
+        filter_file(
+            r'add_cxx_compiler_flag..Werror',
+            r'##### add_cxx_compiler_flag(-Werror',
+            'CMakeLists.txt'
+        )
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+        if self.compiler.name == 'intel':
+            options.append("-DCMAKE_CXX_FLAGS='-no-ansi-alias -fno-strict-aliasing'")
+            options.append("-DCMAKE_C_FLAGS='-no-ansi-alias -fno-strict-aliasing'")
+            options.append("-DBENCHMARK_ENABLE_TESTING=OFF")
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -28,6 +28,9 @@ from spack import *
 class Spdlog(CMakePackage):
     """Very fast, header only, C++ logging library"""
 
-    homepage = "https://github.comg/abime/spdlog"
+    homepage = "https://github.com/gabime/spdlog"
+    url = "https://github.com/gabime/spdlog/archive/v0.9.0.tar.gz"
 
-    version('dev', git='https://github.com/gabime/spdlog.git')
+    version('0.11.0', '08232203f18a6f9ff47e083cc7a141a050805d3b')
+    version('0.10.0', '57b471ef97a23cc29c38b62e00e89a411a87ea7f')
+    version('0.9.0', 'dda741ef8e12d57d91f778d85e95a27d84a82ac4')

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -1,0 +1,25 @@
+from spack import *
+
+class Spdlog(Package):
+    """Very fast, header only, C++ logging library"""
+
+    homepage = "https://github.comg/abime/spdlog"
+
+    version('dev', git='https://github.com/gabime/spdlog.git')
+    variant("debug", default=False, description="Installs with debug options")
+
+    def install(self, spec, prefix):
+        # mkdirp(prefix.include)
+        options = [u for u in std_cmake_args]
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+        options.append('-DBUILD_TESTING=FALSE')
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -1,25 +1,33 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
-class Spdlog(Package):
+
+class Spdlog(CMakePackage):
     """Very fast, header only, C++ logging library"""
 
     homepage = "https://github.comg/abime/spdlog"
 
     version('dev', git='https://github.com/gabime/spdlog.git')
-    variant("debug", default=False, description="Installs with debug options")
-
-    def install(self, spec, prefix):
-        # mkdirp(prefix.include)
-        options = [u for u in std_cmake_args]
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
-        options.append('-DBUILD_TESTING=FALSE')
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")

--- a/var/spack/repos/builtin/packages/tinyxml/CMakeLists.txt
+++ b/var/spack/repos/builtin/packages/tinyxml/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.6)
+
+project(TinyXml)
+OPTION(TIXML_USE_STL "Use STL with TIXML" ON)
+if(TIXML_USE_STL)
+	add_definitions(-DTIXML_USE_STL)
+endif(TIXML_USE_STL)
+add_library(
+	tinyxml
+	tinyxml.cpp
+	tinystr.cpp
+	tinyxmlerror.cpp
+	tinyxmlparser.cpp
+)
+
+INSTALL( FILES tinyxml.h tinystr.h DESTINATION include )
+INSTALL( TARGETS tinyxml ARCHIVE DESTINATION lib )

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -1,0 +1,29 @@
+from spack import *
+
+class Tinyxml(Package):
+    """Simple, small, efficient, C++ XML parser"""
+
+    homepage = "http://grinninglizard.com/tinyxml/"
+    url      = "https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
+
+    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764', url=url)
+    variant("debug", default=False, description="Installs with debug options")
+
+    def install(self, spec, prefix):
+        from os.path import dirname
+        from shutil import copyfile
+        copyfile(join_path(dirname(__file__), "CMakeLists.txt"), "CMakeLists.txt")
+
+        options = []
+        options.extend(std_cmake_args)
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -1,29 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
+import os.path
+
 
 class Tinyxml(Package):
     """Simple, small, efficient, C++ XML parser"""
 
     homepage = "http://grinninglizard.com/tinyxml/"
-    url      = "https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
+    url = "https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
 
     version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764', url=url)
-    variant("debug", default=False, description="Installs with debug options")
 
-    def install(self, spec, prefix):
-        from os.path import dirname
-        from shutil import copyfile
-        copyfile(join_path(dirname(__file__), "CMakeLists.txt"), "CMakeLists.txt")
-
-        options = []
-        options.extend(std_cmake_args)
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+    def patch(self):
+        copyfile(join_path(os.path.dirname(__file__),
+                           "CMakeLists.txt"), "CMakeLists.txt")

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -26,7 +26,7 @@ from spack import *
 import os.path
 
 
-class Tinyxml(Package):
+class Tinyxml(CMakePackage):
     """Simple, small, efficient, C++ XML parser"""
 
     homepage = "http://grinninglizard.com/tinyxml/"

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -32,7 +32,7 @@ class Tinyxml(Package):
     homepage = "http://grinninglizard.com/tinyxml/"
     url = "https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
 
-    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764', url=url)
+    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764')
 
     def patch(self):
         copyfile(join_path(os.path.dirname(__file__),

--- a/var/spack/repos/builtin/packages/tinyxml2/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml2/package.py
@@ -1,10 +1,35 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
-class Tinyxml2(Package):
+
+class Tinyxml2(CMakePackage):
     """Simple, small, efficient, C++ XML parser"""
 
     homepage = "http://grinninglizard.com/tinyxml2/"
-    url      = "https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz"
+    url = "https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz"
 
     version('4.0.1', '08570d385788f6b02f50f5fd9df32a9d4f8482cc')
     version('4.0.0', '7a6f0858d75f360922f3ca272f7067e8cdf00489')
@@ -12,19 +37,3 @@ class Tinyxml2(Package):
     version('2.2.0', '7869aa08241ce16f93ba3732c1cde155b1f2b6a0')
     version('2.1.0', '70ef3221bdc190fd8fc50cdd4a6ef440f44b74dc')
     version('2.0.2', 'c78a4de58540e2a35f4775fd3e577299ebd15117')
-    variant("debug", default=False, description="Installs with debug options")
-
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")

--- a/var/spack/repos/builtin/packages/tinyxml2/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml2/package.py
@@ -1,0 +1,30 @@
+from spack import *
+
+class Tinyxml2(Package):
+    """Simple, small, efficient, C++ XML parser"""
+
+    homepage = "http://grinninglizard.com/tinyxml2/"
+    url      = "https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz"
+
+    version('4.0.1', '08570d385788f6b02f50f5fd9df32a9d4f8482cc')
+    version('4.0.0', '7a6f0858d75f360922f3ca272f7067e8cdf00489')
+    version('3.0.0', '07acaae49f7dd3dab790da4fe72d0c7ef0d116d1')
+    version('2.2.0', '7869aa08241ce16f93ba3732c1cde155b1f2b6a0')
+    version('2.1.0', '70ef3221bdc190fd8fc50cdd4a6ef440f44b74dc')
+    version('2.0.2', 'c78a4de58540e2a35f4775fd3e577299ebd15117')
+    variant("debug", default=False, description="Installs with debug options")
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
+        else:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *options)
+            make()
+            make("install")


### PR DESCRIPTION
Tinyxml comes in two flavors, 1 and 2. Each comes in several
versions... So they cannot be easily united into a single package.