### PR TITLE
GSL: Add latest version, update to AutotoolsPackage

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -26,24 +26,18 @@
 from spack import *
 
 
-class Gsl(Package):
+class Gsl(AutotoolsPackage):
     """The GNU Scientific Library (GSL) is a numerical library for C and C++
-       programmers. It is free software under the GNU General Public
-       License. The library provides a wide range of mathematical
-       routines such as random number generators, special functions and
-       least-squares fitting. There are over 1000 functions in total with
-       an extensive test suite.
+    programmers. It is free software under the GNU General Public License. The
+    library provides a wide range of mathematical routines such as random
+    number generators, special functions and least-squares fitting. There are
+    over 1000 functions in total with an extensive test suite."""
 
-    """
     homepage = "http://www.gnu.org/software/gsl"
-    url      = "http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-2.1.tar.gz"
+    url      = "http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-2.3.tar.gz"
 
+    version('2.3',   '905fcbbb97bc552d1037e34d200931a0')
     version('2.2.1', '3d90650b7cfe0a6f4b29c2d7b0f86458')
-    version('2.1', 'd8f70abafd3e9f0bae03c52d1f4e8de5')
-    version('2.0', 'ae44cdfed78ece40e73411b63a78c375')
-    version('1.16', 'e49a664db13d81c968415cd53f62bc8b')
-
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")
+    version('2.1',   'd8f70abafd3e9f0bae03c52d1f4e8de5')
+    version('2.0',   'ae44cdfed78ece40e73411b63a78c375')
+    version('1.16',  'e49a664db13d81c968415cd53f62bc8b')


### PR DESCRIPTION
**Note**: GSL 2.3 built with Intel 17.0.0 didn't pass `make check` for me so I sent a note to the developers.