### PR TITLE
Modify github regex to support NCO.

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -331,3 +331,12 @@ class UrlParseTest(unittest.TestCase):
         self.check(
             'xml', '3.98-1.4',
             'https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz')
+
+    def test_nco_version(self):
+        self.check(
+            'nco', '4.6.2-beta03',
+            'https://github.com/nco/nco/archive/4.6.2-beta03.tar.gz')
+
+        self.check(
+            'nco', '4.6.3-alpha04',
+            'https://github.com/nco/nco/archive/4.6.3-alpha04.tar.gz')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -189,7 +189,7 @@ def parse_version_offset(path, debug=False):
         (r'github.com/.+/(?:zip|tar)ball/v?((\d+\.)+\d+_(\d+))$', path),
 
         # e.g. https://github.com/hpc/lwgrp/archive/v1.0.1.tar.gz
-        (r'github.com/[^/]+/[^/]+/archive/v?(\d+(?:\.\d+)*)$', path),
+        (r'github.com/[^/]+/[^/]+/archive/v?(\w+(?:[.-]\w+)*)$', path),
 
         # e.g. https://github.com/erlang/otp/tarball/OTP_R15B01 (erlang style)
         (r'[-_](R\d+[AB]\d*(-\d+)?)', path),


### PR DESCRIPTION
Fixes #2628.

```
$ spack url-parse https://github.com/nco/nco/archive/4.6.2-beta03.tar.gz
==> Parsing URL: https://github.com/nco/nco/archive/4.6.2-beta03
    Matched regex 4: r'github.com/[^/]+/[^/]+/archive/v?(\w+(?:[.-]\w+)*)$'

==> Detected:
    https://github.com/nco/nco/archive/4.6.2-beta03.tar.gz
                           ---         ~~~~~~~~~~~~
    name:     nco
    version:  4.6.2-beta03

==> Substituting version 9.9.9b:
    https://github.com/nco/nco/archive/9.9.9b.tar.gz
                           ---         ~~~~~~

```
@adamjstewart 