### PR TITLE
Various updates to the NCO package and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Antlr(Package):
+class Antlr(AutotoolsPackage):
     """ANTLR (ANother Tool for Language Recognition) is a powerful parser
     generator for reading, processing, executing, or translating structured
     text or binary files. It's widely used to build languages, tools, and
@@ -34,9 +34,6 @@ class Antlr(Package):
 
     homepage = "http://www.antlr.org"
     url      = "https://github.com/antlr/antlr/tarball/v2.7.7"
-
-    # NOTE: This requires that a system Java be available.
-    # Spack does not yet know how to install Java compilers
 
     # Notes from http://nco.sourceforge.net/#bld
     # The first steps to build (i.e., compile, for the most part) NCO from
@@ -52,27 +49,19 @@ class Antlr(Package):
     # Unpatched version
     # url='http://dust.ess.uci.edu/nco/antlr-2.7.7.tar.gz')
 
-    variant('cxx', default=False, description='Enable ANTLR for C++')
-    variant('java', default=False, description='Enable ANTLR for Java')
+    variant('cxx',    default=True,  description='Enable ANTLR for C++')
+    variant('java',   default=False, description='Enable ANTLR for Java')
     variant('python', default=False, description='Enable ANTLR for Python')
-    variant('csharp', default=False, description='Enable ANTLR for Csharp')
 
-    def install(self, spec, prefix):
-        # Check for future enabling of variants
-        for v in ('+java', '+python', '+csharp'):
-            if v in spec:
-                raise Error(
-                    ('Illegal variant %s; ' % v) + 'for now, '
-                    'Spack only knows how to build antlr or antlr+cxx')
+    extends('python', when='+python')
+    depends_on('jdk', when='+java')
 
-        config_args = [
-            '--prefix=%s' % prefix,
-            '--%s-cxx' % ('enable' if '+cxx' in spec else 'disable'),
-            '--%s-java' % ('enable' if '+java' in spec else 'disable'),
-            '--%s-python' % ('enable' if '+python' in spec else 'disable'),
-            '--%s-csharp' % ('enable' if '+csharp' in spec else 'disable')]
+    def configure_args(self):
+        spec = self.spec
 
-        # which('autoreconf')('-iv')
-        configure(*config_args)
-        make()
-        make("install")
+        return [
+            '--disable-csharp',
+            '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
+            '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
+            '--{0}-python'.format('enable' if '+python' in spec else 'disable')
+        ]

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -54,13 +54,12 @@ class Antlr(AutotoolsPackage):
     variant('python', default=False, description='Enable ANTLR for Python')
 
     extends('python', when='+python')
-    depends_on('jdk', when='+java')
+    depends_on('jdk', type='nolink', when='+java')
 
     def configure_args(self):
         spec = self.spec
 
         return [
-            '--disable-csharp',
             '--{0}-cxx'.format('enable' if '+cxx' in spec else 'disable'),
             '--{0}-java'.format('enable' if '+java' in spec else 'disable'),
             '--{0}-python'.format('enable' if '+python' in spec else 'disable')

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -25,19 +25,9 @@
 from spack import *
 
 
-class Expat(Package):
-    """<eXpat/> is an XML parser library written in C"""
+class Expat(AutotoolsPackage):
+    """Expat is an XML parser library written in C."""
     homepage = "http://expat.sourceforge.net/"
+    url = "http://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2"
 
-    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2',
-            url="http://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2")
-    version('2.1.0', 'dd7dab7a5fea97d2a6a43f511449b7cd',
-            url="http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz")
-
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
-
-        make()
-        if self.run_tests:
-            make('check')
-        make('install')
+    version('2.2.0', '2f47841c829facb346eb6e3fab5212e2')

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -29,7 +29,7 @@ class Nco(AutotoolsPackage):
     """The NCO toolkit manipulates and analyzes data stored in
     netCDF-accessible formats"""
 
-    homepage = "https://sourceforge.net/projects/nco"
+    homepage = "http://nco.sourceforge.net/"
     url      = "https://github.com/nco/nco/archive/4.6.2.tar.gz"
 
     version('4.6.2', 'b7471acf0cc100343392f4171fb56113')
@@ -44,9 +44,5 @@ class Nco(AutotoolsPackage):
     depends_on('udunits2')         # allows dimensional unit transformations
     # depends_on('opendap')        # enables network transparency
 
-    def configure_args(self):
-        return [
-            '--disable-openmp',  # TODO: Make this a variant
-            '--disable-dap',     # TODO: Make this a variant
-            '--disable-esmf'
-        ]
+    depends_on('flex',  type='build')
+    depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -37,6 +37,8 @@ class Nco(AutotoolsPackage):
     version('4.6.1', 'ef43cc989229c2790a9094bd84728fd8')
     version('4.5.5', '9f1f1cb149ad6407c5a03c20122223ce')
 
+    variant('doc', default=False, description='Build/install NCO TexInfo-based documentation')
+
     # See "Compilation Requirements" at:
     # http://nco.sourceforge.net/#bld
     depends_on('netcdf')
@@ -44,5 +46,10 @@ class Nco(AutotoolsPackage):
     depends_on('gsl')              # desirable for ncap2
     depends_on('udunits2')         # allows dimensional unit transformations
 
-    depends_on('flex',  type='build')
+    depends_on('flex', type='build')
     depends_on('bison', type='build')
+    depends_on('texinfo@4.12:', type='build', when='+doc')
+
+    def configure_args(self):
+        spec = self.spec
+        return ['--{0}-doc'.format('enable' if '+doc' in spec else 'disable')]

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -43,7 +43,6 @@ class Nco(AutotoolsPackage):
     depends_on('antlr@2.7.7+cxx')  # required for ncap2
     depends_on('gsl')              # desirable for ncap2
     depends_on('udunits2')         # allows dimensional unit transformations
-    # depends_on('opendap')        # enables network transparency
 
     depends_on('flex',  type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -38,22 +38,11 @@ class Nco(AutotoolsPackage):
 
     # See "Compilation Requirements" at:
     # http://nco.sourceforge.net/#bld
-    variant('mpi', default=True)
-
     depends_on('netcdf')
     depends_on('antlr@2.7.7+cxx')  # required for ncap2
     depends_on('gsl')              # desirable for ncap2
     depends_on('udunits2')         # allows dimensional unit transformations
     # depends_on('opendap')        # enables network transparency
-
-    @AutotoolsPackage.precondition('configure')
-    def validate(self):
-        """Ensures that dependents were built with the right variants."""
-        # Workaround until variant forwarding works properly
-        spec = self.spec
-        if '+mpi' in spec and spec.satisfies('^netcdf~mpi'):
-            raise RuntimeError('Invalid spec. Package netcdf requires '
-                               'netcdf+mpi, but spec asked for netcdf~mpi.')
 
     def configure_args(self):
         return [

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -32,6 +32,7 @@ class Nco(AutotoolsPackage):
     homepage = "http://nco.sourceforge.net/"
     url      = "https://github.com/nco/nco/archive/4.6.2.tar.gz"
 
+    version('4.6.3', '0e1d6616c65ed3a30c54cc776da4f987')
     version('4.6.2', 'b7471acf0cc100343392f4171fb56113')
     version('4.6.1', 'ef43cc989229c2790a9094bd84728fd8')
     version('4.5.5', '9f1f1cb149ad6407c5a03c20122223ce')

--- a/var/spack/repos/builtin/packages/netcdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class NetcdfCxx(Package):
+class NetcdfCxx(AutotoolsPackage):
     """Deprecated C++ compatibility bindings for NetCDF.
     These do NOT read or write NetCDF-4 files, and are no longer
     maintained by Unidata.  Developers should migrate to current
@@ -37,8 +37,3 @@ class NetcdfCxx(Package):
     version('4.2', 'd32b20c00f144ae6565d9e98d9f6204c')
 
     depends_on('netcdf')
-
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class NetcdfCxx4(Package):
+class NetcdfCxx4(AutotoolsPackage):
     """C++ interface for NetCDF4"""
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "https://www.github.com/unidata/netcdf-cxx4/tarball/v4.3.0"
@@ -34,7 +34,7 @@ class NetcdfCxx4(Package):
     version('4.2.1', 'd019853802092cf686254aaba165fc81')
 
     depends_on('netcdf')
-    depends_on("autoconf", type='build')
+    depends_on('autoconf', type='build')
 
     def autoreconf(self, spec, prefix):
         # Rebuild to prevent problems of inconsistency in git repo

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -36,9 +36,6 @@ class NetcdfCxx4(Package):
     depends_on('netcdf')
     depends_on("autoconf", type='build')
 
-    def install(self, spec, prefix):
+    def autoreconf(self, spec, prefix):
         # Rebuild to prevent problems of inconsistency in git repo
         which('autoreconf')('-ivf')
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class NetcdfFortran(Package):
+class NetcdfFortran(AutotoolsPackage):
     """Fortran interface for NetCDF4"""
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
@@ -35,8 +35,3 @@ class NetcdfFortran(Package):
     version('4.4.3', 'bfd4ae23a34635b273d3eb0d91cbde9e')
 
     depends_on('netcdf')
-
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -167,3 +167,7 @@ class Netcdf(AutotoolsPackage):
         config_args.append('LIBS=%s'     % ' '.join(LIBS))
 
         return config_args
+
+    def check(self):
+        # h5_test fails when run in parallel
+        make('check', parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -25,12 +25,10 @@
 from spack import *
 
 
-class Netcdf(Package):
+class Netcdf(AutotoolsPackage):
     """NetCDF is a set of software libraries and self-describing,
-       machine-independent data formats that support the creation, access,
-       and sharing of array-oriented scientific data.
-
-    """
+    machine-independent data formats that support the creation, access,
+    and sharing of array-oriented scientific data."""
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.tar.gz"
@@ -82,7 +80,8 @@ class Netcdf(Package):
         ff.filter(r'^(#define\s+NC_MAX_VARS\s+)\d+(.*)$',
                   r'\1{0}\2'.format(max_vars))
 
-    def install(self, spec, prefix):
+    def configure_args(self):
+        spec = self.spec
         # Workaround until variant forwarding works properly
         if '+mpi' in spec and spec.satisfies('^hdf5~mpi'):
             raise RuntimeError('Invalid spec. Package netcdf requires '
@@ -95,7 +94,6 @@ class Netcdf(Package):
         LIBS     = []
 
         config_args = [
-            "--prefix=%s" % prefix,
             "--enable-fsync",
             "--enable-v2",
             "--enable-utilities",
@@ -168,10 +166,4 @@ class Netcdf(Package):
         config_args.append('LDFLAGS=%s'  % ' '.join(LDFLAGS))
         config_args.append('LIBS=%s'     % ' '.join(LIBS))
 
-        configure(*config_args)
-        make()
-
-        if self.run_tests:
-            make("check")
-
-        make("install")
+        return config_args

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -26,24 +26,18 @@
 from spack import *
 
 
-class Texinfo(Package):
+class Texinfo(AutotoolsPackage):
     """Texinfo is the official documentation format of the GNU project.
 
     It was invented by Richard Stallman and Bob Chassell many years ago,
     loosely based on Brian Reid's Scribe and other formatting languages
-    of the time. It is used by many non-GNU projects as well.FIXME: put a
-    proper description of your package here.
+    of the time. It is used by many non-GNU projects as well."""
 
-    """
     homepage = "https://www.gnu.org/software/texinfo/"
     url      = "http://ftp.gnu.org/gnu/texinfo/texinfo-6.0.tar.gz"
 
+    version('6.3', '9b08daca9bf8eccae9b0f884aba41f9e')
     version('6.0', 'e1a2ef5dce5018b53f0f6eed45b247a7')
     version('5.2', '1b8f98b80a8e6c50422125e07522e8db')
     version('5.1', '54e250014fe698fb4832016158747c03')
     version('5.0', '918432285abe6fe96c98355594c5656a')
-
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Udunits2(Package):
+class Udunits2(AutotoolsPackage):
     """Automated units conversion"""
 
     homepage = "http://www.unidata.ucar.edu/software/udunits"
@@ -35,7 +35,5 @@ class Udunits2(Package):
 
     depends_on('expat')
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")
+    depends_on('bison', type='build')
+    depends_on('flex',  type='build')


### PR DESCRIPTION
More updates to NCO. This time I'm removing the `+mpi` variant, as it doesn't do anything for this package. If you want to build NCO with NetCDF MPI support, you need to run `spack install nco ^netcdf+mpi`.

P.S. I'm currently working with one of the NCO developers, Charlie Zender, to get this package installed properly on our clusters, so I may have further updates coming. Don't merge just yet.