### PR TITLE
Support Yorick versions

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -340,3 +340,8 @@ class UrlParseTest(unittest.TestCase):
         self.check(
             'nco', '4.6.3-alpha04',
             'https://github.com/nco/nco/archive/4.6.3-alpha04.tar.gz')
+
+    def test_yorick_version(self):
+        self.check(
+            'yorick', '2_2_04',
+            'https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -188,6 +188,10 @@ def parse_version_offset(path, debug=False):
         # e.g. https://github.com/petdance/ack/tarball/1.93_02
         (r'github.com/.+/(?:zip|tar)ball/v?((\d+\.)+\d+_(\d+))$', path),
 
+        # Yorick is very special.
+        # e.g. https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz
+        (r'github.com/[^/]+/yorick/archive/y_(\d+(?:_\d+)*)$', path),
+
         # e.g. https://github.com/hpc/lwgrp/archive/v1.0.1.tar.gz
         (r'github.com/[^/]+/[^/]+/archive/v?(\w+(?:[.-]\w+)*)$', path),
 


### PR DESCRIPTION
```
$ spack url-parse https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz
==> Parsing URL: https://github.com/dhmunro/yorick/archive/y_2_2_04
    Matched regex 5: r'github.com/[^/]+/yorick/archive/y_(\d+(?:_\d+)*)$'

==> Detected:
    https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz
                               ------           ~~~~~~
    name:     yorick
    version:  2_2_04

==> Substituting version 9.9.9b:
    https://github.com/dhmunro/yorick/archive/y_9.9.9b.tar.gz
                               ------           ~~~~~~
```

@adamjstewart 