### PR TITLE
Update wx to 3.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -35,17 +35,24 @@ class Wx(Package):
        rather than emulating the GUI. It's also extensive, free,
        open-source and mature."""
     homepage = "http://www.wxwidgets.org/"
+    url      = "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
 
-    version('2.8.12', '2fa39da14bc06ea86fe902579fedc5b1',
-            url="https://sourceforge.net/projects/wxwindows/files/2.8.12/wxWidgets-2.8.12.tar.gz")
-    version('3.0.1', 'dad1f1cd9d4c370cbc22700dc492da31',
-            url="https://sourceforge.net/projects/wxwindows/files/3.0.1/wxWidgets-3.0.1.tar.bz2")
+    version('3.1.0', '2170839cfa9d9322e8ee8368b21a15a2497b4f11')
+    version('3.0.2', '6461eab4428c0a8b9e41781b8787510484dea800')
+    version('3.0.1', '73e58521d6871c9f4d1e7974c6e3a81629fddcf8')
 
     depends_on('gtkplus')
+
+    def make_wx(self):
+        make()
+
+    @when('@:3.0.2')
+    def make_wx(self):
+        make(parallel=False)
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix, "--enable-unicode",
                   "--disable-precomp-headers")
 
-        make(parallel=False)
+        self.make_wx()
         make("install")


### PR DESCRIPTION
This PR updates wx to version 3.1.0, which is required to compile with GCC 6. It also adds the newest versions for the current (3.0) and previous (2.8) stable branches.

I tried building it in parallel and it seemed to work fine (at least for 3.1.0).