### PR TITLE
Update cairo to 1.14.8, gtkplus to 2.24.31 and pango to 1.40.3

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -29,9 +29,10 @@ class Cairo(AutotoolsPackage):
     """Cairo is a 2D graphics library with support for multiple output
     devices."""
     homepage = "http://cairographics.org"
-    url      = "http://cairographics.org/releases/cairo-1.14.0.tar.xz"
+    url      = "http://cairographics.org/releases/cairo-1.14.8.tar.xz"
 
-    version('1.14.0', 'fc3a5edeba703f906f2241b394f0cced')
+    version('1.14.8', 'c6f7b99986f93c9df78653c3e6a3b5043f65145e')
+    version('1.14.0', '53cf589b983412ea7f78feee2e1ba9cea6e3ebae')
 
     variant('X', default=False, description="Build with X11 support")
 

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -29,10 +29,10 @@ class Gtkplus(Package):
     """The GTK+ 2 package contains libraries used for creating graphical user
        interfaces for applications."""
     homepage = "http://www.gtk.org"
+    url = "http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.31.tar.xz"
 
-    version(
-        '2.24.25', '612350704dd3aacb95355a4981930c6f',
-        url="http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.25.tar.xz")
+    version('2.24.31', '68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658')
+    version('2.24.25', '38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3')
 
     variant('X', default=False, description="Enable an X toolkit")
 

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -31,12 +31,13 @@ class Pango(Package):
        that text layout is needed, though most of the work on Pango so
        far has been done in the context of the GTK+ widget toolkit."""
     homepage = "http://www.pango.org"
-    url      = "http://ftp.gnome.org/pub/gnome/sources/pango/1.36/pango-1.36.8.tar.xz"
+    url      = "http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.3.tar.xz"
     list_url = "http://ftp.gnome.org/pub/gnome/sources/pango/"
     list_depth = 2
 
-    version('1.36.8', '217a9a753006275215fa9fa127760ece')
-    version('1.40.1', '6fc88c6529890d6c8e03074d57a3eceb')
+    version('1.40.3', 'abba8b5ce728520c3a0f1535eab19eac3c14aeef7faa5aded90017ceac2711d3')
+    version('1.40.1', 'e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40')
+    version('1.36.8', '18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07')
 
     variant('X', default=False, description="Enable an X toolkit")
 


### PR DESCRIPTION
This PR updates cairo, gtkplus and pango to their latest versions.