### PR TITLE
Update gdal to 2.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -36,11 +36,12 @@ class Gdal(Package):
     """
 
     homepage   = "http://www.gdal.org/"
-    url        = "http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.gz"
+    url        = "http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.xz"
     list_url   = "http://download.osgeo.org/gdal/"
     list_depth = 2
 
-    version('2.0.2', '573865f3f59ba7b4f8f4cddf223b52a5')
+    version('2.1.2', 'ae85b78888514c75e813d658cac9478e')
+    version('2.0.2', '940208e737c87d31a90eaae43d0efd65')
 
     extends('python')
 


### PR DESCRIPTION
This PR updates gdal to version 2.1.2. The hash for 2.0.2 is changed due to the change to `.tar.xz`.