### PR TITLE
Improve Ubuntu arch detection

### DIFF
--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -48,6 +48,11 @@ class LinuxDistro(OperatingSystem):
         # grab the first legal identifier in the version field.  On
         # debian you get things like 'wheezy/sid'; sid means unstable.
         # We just record 'wheezy' and don't get quite so detailed.
-        version = re.split(r'[^\w-]', version)[0]
+        version = re.split(r'[^\w-]', version)
+
+        if 'ubuntu' in distname:
+            version = '.'.join(version[0:2])
+        else:
+            version = version[0]
 
         super(LinuxDistro, self).__init__(distname, version)


### PR DESCRIPTION
Since #1329 was closed, here is an updated version of the PR.

Ubuntu uses a YY.{04,10} release scheme, where YY.04 is not necessarily binary-compatible with YY.10. Therefore, it makes sense to also use the month part of the version.