### PR TITLE
Add latest version of Python 2

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -41,6 +41,8 @@ class Python(Package):
 
     homepage = "http://www.python.org"
     url = "http://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz"
+    list_url = "https://www.python.org/downloads/"
+    list_depth = 2
 
     version('3.5.2', '3fe8434643a78630c61c6464fe2e7e72')
     version('3.5.1', 'be78e48cdfc1a7ad90efff146dce6cfe')
@@ -49,7 +51,8 @@ class Python(Package):
     version('3.3.6', 'cdb3cd08f96f074b3f3994ccb51063e9')
     version('3.2.6', '23815d82ae706e9b781ca65865353d39')
     version('3.1.5', '02196d3fc7bc76bdda68aa36b0dd16ab')
-    version('2.7.12', '88d61f82e3616a4be952828b3694109d', preferred=True)
+    version('2.7.13', '17add4bf0ad0ec2f08e0cae6d205c700', preferred=True)
+    version('2.7.12', '88d61f82e3616a4be952828b3694109d')
     version('2.7.11', '6b6076ec9e93f05dd63e47eb9c15728b')
     version('2.7.10', 'd7547558fd673bd9d38e2108c6b42521')
     version('2.7.9', '5eebcaa0030dc4061156d3429657fb83')


### PR DESCRIPTION
Also adds a `list_url` and `list_depth` for Python.

#### Before
```
$ spack versions python
==> Safe versions (already checksummed):
  3.5.2  3.5.1  3.5.0  3.4.3  3.3.6  3.2.6  3.1.5  2.7.13  2.7.12  2.7.11  2.7.10  2.7.9  2.7.8
==> Remote versions (not yet checksummed):
  Found no unckecksummed versions for python
```
#### After
```
$ spack versions python
==> Safe versions (already checksummed):
  3.5.2  3.5.1  3.5.0  3.4.3  3.3.6  3.2.6  3.1.5  2.7.13  2.7.12  2.7.11  2.7.10  2.7.9  2.7.8
==> Remote versions (not yet checksummed):
  3.4.5  3.4.0  3.3.2  3.2.4  3.2    3.1.1  2.7.7  2.7.3  2.6.9  2.6.5  2.6.1  2.5.4  2.5    2.4.3  2.3.7  2.3.3  2.2.3  2.1.3
  3.4.4  3.3.5  3.3.1  3.2.3  3.1.4  3.1    2.7.6  2.7.2  2.6.8  2.6.4  2.6    2.5.3  2.4.6  2.4.2  2.3.6  2.3.2  2.2.2  2.0.1
  3.4.2  3.3.4  3.3.0  3.2.2  3.1.3  3.0.1  2.7.5  2.7.1  2.6.7  2.6.3  2.5.6  2.5.2  2.4.5  2.4.1  2.3.5  2.3.1  2.2.1
  3.4.1  3.3.3  3.2.5  3.2.1  3.1.2  3.0    2.7.4  2.7    2.6.6  2.6.2  2.5.5  2.5.1  2.4.4  2.4    2.3.4  2.3    2.2
```