### PR TITLE
Better tabulation for spack checksum

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -93,9 +93,13 @@ def checksum(parser, args):
 
     sorted_versions = sorted(versions, reverse=True)
 
+    # Find length of longest string in the list for padding
+    maxlen = max(len(str(v)) for v in versions)
+
     tty.msg("Found %s versions of %s" % (len(versions), pkg.name),
             *spack.cmd.elide_list(
-                ["%-10s%s" % (v, versions[v]) for v in sorted_versions]))
+                ["{0:{1}}  {2}".format(v, maxlen, versions[v])
+                 for v in sorted_versions]))
     print
     archives_to_fetch = tty.get_number(
         "How many would you like to checksum?", default=5, abort='q')


### PR DESCRIPTION
#### Before
```
$ spack checksum gcc
==> Found 77 versions of gcc
  6.3.0     http://ftp.gnu.org/gnu/gcc/gcc-6.3.0/gcc-6.3.0.tar.bz2
  6.2.0     http://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2
  6.1.0     http://ftp.gnu.org/gnu/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2
  5.4.0     http://ftp.gnu.org/gnu/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2
  5.3.0     http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2
  5.2.0     http://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2
  5.1.0     http://ftp.gnu.org/gnu/gcc/gcc-5.1.0/gcc-5.1.0.tar.bz2
  4.9.4     http://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2
  4.9.3     http://ftp.gnu.org/gnu/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2
  ...
  3.2.2     http://ftp.gnu.org/gnu/gcc/gcc-3.2.2/gcc-3.2.2.tar.bz2
```
```
$ spack checksum nco
==> Found 10 versions of nco
  4.6.4-alpha01https://github.com/nco/nco/archive/4.6.4-alpha01.tar.gz
  4.6.3-beta01https://github.com/nco/nco/archive/4.6.3-beta01.tar.gz
  4.6.3-alpha05https://github.com/nco/nco/archive/4.6.3-alpha05.tar.gz
  4.6.3-alpha04https://github.com/nco/nco/archive/4.6.3-alpha04.tar.gz
  4.6.3-alpha03https://github.com/nco/nco/archive/4.6.3-alpha03.tar.gz
  4.6.3-alpha02https://github.com/nco/nco/archive/4.6.3-alpha02.tar.gz
  4.6.3-alpha01https://github.com/nco/nco/archive/4.6.3-alpha01.tar.gz
  4.6.3     https://github.com/nco/nco/archive/4.6.3.tar.gz
  4.6.2-beta03https://github.com/nco/nco/archive/4.6.2-beta03.tar.gz
  4.6.2     https://github.com/nco/nco/archive/4.6.2.tar.gz
```
#### After
```
$ spack checksum gcc
==> Found 77 versions of gcc
  6.3.0  http://ftp.gnu.org/gnu/gcc/gcc-6.3.0/gcc-6.3.0.tar.bz2
  6.2.0  http://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2
  6.1.0  http://ftp.gnu.org/gnu/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2
  5.4.0  http://ftp.gnu.org/gnu/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2
  5.3.0  http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2
  5.2.0  http://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2
  5.1.0  http://ftp.gnu.org/gnu/gcc/gcc-5.1.0/gcc-5.1.0.tar.bz2
  4.9.4  http://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2
  4.9.3  http://ftp.gnu.org/gnu/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2
  ...
  3.2.2  http://ftp.gnu.org/gnu/gcc/gcc-3.2.2/gcc-3.2.2.tar.bz2
```
```
$ spack checksum nco
==> Found 10 versions of nco
  4.6.4-alpha01  https://github.com/nco/nco/archive/4.6.4-alpha01.tar.gz
  4.6.3-beta01   https://github.com/nco/nco/archive/4.6.3-beta01.tar.gz
  4.6.3-alpha05  https://github.com/nco/nco/archive/4.6.3-alpha05.tar.gz
  4.6.3-alpha04  https://github.com/nco/nco/archive/4.6.3-alpha04.tar.gz
  4.6.3-alpha03  https://github.com/nco/nco/archive/4.6.3-alpha03.tar.gz
  4.6.3-alpha02  https://github.com/nco/nco/archive/4.6.3-alpha02.tar.gz
  4.6.3-alpha01  https://github.com/nco/nco/archive/4.6.3-alpha01.tar.gz
  4.6.3          https://github.com/nco/nco/archive/4.6.3.tar.gz
  4.6.2-beta03   https://github.com/nco/nco/archive/4.6.2-beta03.tar.gz
  4.6.2          https://github.com/nco/nco/archive/4.6.2.tar.gz
```