### PR TITLE
Modify github archive regex to support luaposix

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -345,3 +345,8 @@ class UrlParseTest(unittest.TestCase):
         self.check(
             'yorick', '2_2_04',
             'https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz')
+
+    def test_luaposix_version(self):
+        self.check(
+            'luaposix', '33.4.0',
+            'https://github.com/luaposix/luaposix/archive/release-v33.4.0.tar.gz')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -193,7 +193,7 @@ def parse_version_offset(path, debug=False):
         (r'github.com/[^/]+/yorick/archive/y_(\d+(?:_\d+)*)$', path),
 
         # e.g. https://github.com/hpc/lwgrp/archive/v1.0.1.tar.gz
-        (r'github.com/[^/]+/[^/]+/archive/v?(\w+(?:[.-]\w+)*)$', path),
+        (r'github.com/[^/]+/[^/]+/archive/(?:release-)?v?(\w+(?:[.-]\w+)*)$', path),  # noqa
 
         # e.g. https://github.com/erlang/otp/tarball/OTP_R15B01 (erlang style)
         (r'[-_](R\d+[AB]\d*(-\d+)?)', path),


### PR DESCRIPTION
Fixes #2660 and #2676.
```
$ spack url-parse https://github.com/luaposix/luaposix/archive/release-v33.4.0.tar.gz
==> Parsing URL: https://github.com/luaposix/luaposix/archive/release-v33.4.0
    Matched regex 5: r'github.com/[^/]+/[^/]+/archive/(?:release-)?v?(\w+(?:[.-]\w+)*)$'

==> Detected:
    https://github.com/luaposix/luaposix/archive/release-v33.4.0.tar.gz
                                --------                  ~~~~~~
    name:     luaposix
    version:  33.4.0

==> Substituting version 9.9.9b:
    https://github.com/luaposix/luaposix/archive/release-v9.9.9b.tar.gz
                                --------                  ~~~~~~
```
@trmwzm @hartzell 