### PR TITLE
Show deptypes in `spack spec` 

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -49,6 +49,9 @@ def setup_parser(subparser):
              'installed [+], missing and needed by an installed package [-], '
              'or not installed (no annotation).')
     subparser.add_argument(
+        '-t', '--types', action='store_true', default=False,
+        help='Show dependency types.')
+    subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
 
 
@@ -59,6 +62,7 @@ def spec(parser, args):
               'format': name_fmt + '$@$%@+$+$=',
               'hashes': args.long or args.very_long,
               'hashlen': None if args.very_long else 7,
+              'show_types': args.types,
               'install_status': args.install_status}
 
     for spec in spack.cmd.parse_specs(args.specs):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2595,17 +2595,22 @@ class Spec(object):
         indent = kwargs.pop('indent', 0)
         fmt = kwargs.pop('format', '$_$@$%@+$+$=')
         prefix = kwargs.pop('prefix', None)
+        show_types = kwargs.pop('show_types', False)
         deptypes = kwargs.pop('deptypes', ('build', 'link'))
         check_kwargs(kwargs, self.tree)
 
         out = ""
-        for d, node in self.traverse(
+        for d, dep_spec in self.traverse_with_deptype(
                 order='pre', cover=cover, depth=True, deptypes=deptypes):
+            node = dep_spec.spec
+
             if prefix is not None:
                 out += prefix(node)
             out += " " * indent
+
             if depth:
                 out += "%-4d" % d
+
             if install_status:
                 status = node._install_status()
                 if status is None:
@@ -2617,6 +2622,16 @@ class Spec(object):
 
             if hashes:
                 out += colorize('@K{%s}  ', color=color) % node.dag_hash(hlen)
+
+            if show_types:
+                out += '['
+                if dep_spec.deptypes:
+                    for t in alldeps:
+                        out += ''.join(t[0] if t in dep_spec.deptypes else ' ')
+                else:
+                    out += ' ' * len(alldeps)
+                out += ']  '
+
             out += ("    " * d)
             if d > 0:
                 out += "^"


### PR DESCRIPTION
Adds a the `-t | --types` option to `spack spec` to show dependency types.

Dependency types are shown as `[blr]`, for `build`, `link`, `run`.

```console
$ spack spec -lt mpileaks
Input spec
--------------------------------
lj565rd  [   ]  mpileaks

Normalized
--------------------------------
6gbjljg  [   ]  mpileaks
xnlwovc  [bl ]      ^adept-utils
e4oi6l7  [bl ]          ^boost@1.42:
k6c3t2d  [b  ]          ^cmake
2xnea7r  [bl ]          ^mpi
ri2w52n  [bl ]      ^callpath
hek2pe7  [bl ]          ^dyninst
budp73h  [bl ]              ^libdwarf
pls4ef2  [bl ]                  ^libelf

Concretized
--------------------------------
madlbmz  [   ]  mpileaks@1.0%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
c4a74q6  [bl ]      ^adept-utils@1.0.1%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
kpla7fk  [bl ]          ^boost@1.62.0%clang@7.0.2-apple+atomic+chrono+date_time~debug+filesystem~graph~icu+iostreams+locale+log+math~mpi+multithreaded+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer+wave arch=darwin-elcapitan-x86_64
n2rdauh  [bl ]              ^bzip2@1.0.6%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
ihqqnwm  [bl ]              ^zlib@1.2.8%clang@7.0.2-apple+pic arch=darwin-elcapitan-x86_64
kd5xszy  [b  ]          ^cmake@3.7.1%clang@7.0.2-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-elcapitan-x86_64
hdxq2fj  [bl ]              ^ncurses@6.0%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
hwkw5gd  [bl ]              ^openssl@1.0.2j%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
w2dxjnq  [bl ]          ^openmpi@2.0.1%clang@7.0.2-apple~java~mxm~pmi~psm~psm2~slurm~sqlite3~thread_multiple~tm~verbs+vt arch=darwin-elcapitan-x86_64
6w2picp  [bl ]              ^hwloc@1.11.4%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
osgk2ir  [bl ]                  ^libpciaccess@0.13.4%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
kzmnsf4  [b  ]                      ^libtool@2.4.6%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
unwqvpp  [b  ]                          ^m4@1.4.17%clang@7.0.2-apple+sigsegv arch=darwin-elcapitan-x86_64
zilbzv7  [bl ]                              ^libsigsegv@2.10%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
ts5ta54  [b  ]                      ^pkg-config@0.29.1%clang@7.0.2-apple+internal_glib arch=darwin-elcapitan-x86_64
podueew  [b  ]                      ^util-macros@1.19.0%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
3slbd57  [bl ]      ^callpath@1.0.2%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
noqzvre  [bl ]          ^dyninst@9.2.1b%clang@7.0.2-apple~stat_dysect arch=darwin-elcapitan-x86_64
pss2ry6  [bl ]              ^libdwarf@20160507%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
5iqi6kr  [bl ]                  ^libelf@0.8.13%clang@7.0.2-apple arch=darwin-elcapitan-x86_64
```