### PR TITLE
Concretization preserves deptypes

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -158,23 +158,22 @@ dirty = _config.get('dirty', False)
 #       for packages.
 #
 #-----------------------------------------------------------------------------
-__all__ = ['PackageBase',
-           'Package',
-           'CMakePackage',
-           'AutotoolsPackage',
-           'MakefilePackage',
-           'Version',
-           'when',
-           'ver',
-           'alldeps',
-           'nolink']
-from spack.package import Package, PackageBase, ExtensionConflictError
+__all__ = []
+
+from spack.package import Package
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
+__all__ += ['Package', 'CMakePackage', 'AutotoolsPackage', 'MakefilePackage']
+
 from spack.version import Version, ver
-from spack.spec import DependencySpec, alldeps, nolink
+__all__ += ['Version', 'ver']
+
+from spack.spec import Spec, alldeps, nolink
+__all__ += ['Spec', 'alldeps', 'nolink']
+
 from spack.multimethod import when
+__all__ += ['when']
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -84,7 +84,7 @@ def graph(parser, args):
         setup_parser.parser.print_help()
         return 1
 
-    deptype = nobuild
+    deptype = alldeps
     if args.deptype:
         deptype = tuple(args.deptype.split(','))
         validate_deptype(deptype)

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -90,7 +90,7 @@ def topological_sort(spec, reverse=False, deptype=None):
 
     # Work on a copy so this is nondestructive.
     spec = spec.copy(deps=deptype)
-    nodes = spec.index()
+    nodes = spec.index(deptype=deptype)
 
     topo_order = []
     par = dict((name, parents(nodes[name])) for name in nodes.keys())

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1079,9 +1079,7 @@ class Spec(object):
         direction = kwargs.get('direction', 'children')
         order = kwargs.get('order', 'pre')
 
-        if deptype is None:
-            deptype = alldeps
-
+        deptype = canonical_deptype(deptype)
         if deptype_query is None:
             deptype_query = ('link', 'run')
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -840,9 +840,8 @@ class Spec(object):
         deptype = canonical_deptype(deptype)
 
         return [dep for dep in where.values()
-                if deptype and (
-                        not dep.deptypes or
-                        any(d in deptype for d in dep.deptypes))]
+                if deptype and (not dep.deptypes or
+                                any(d in deptype for d in dep.deptypes))]
 
     def dependencies(self, deptype=None):
         return [d.spec
@@ -1028,7 +1027,7 @@ class Spec(object):
                 yield get_spec(dspec)
 
     def traverse_edges(self, visited=None, d=0, deptype=None,
-                              deptype_query=None, dep_spec=None, **kwargs):
+                       deptype_query=None, dep_spec=None, **kwargs):
         """Generic traversal of the DAG represented by this spec.
            This will yield each node in the spec.  Options:
 
@@ -2202,7 +2201,7 @@ class Spec(object):
         return changed
 
     def _dup_deps(self, other, deptypes):
-        new_specs = {self.name : self}
+        new_specs = {self.name: self}
         for dspec in other.traverse_edges(cover='edges', root=False):
             if (dspec.deptypes and
                 not any(d in deptypes for d in dspec.deptypes)):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -577,9 +577,10 @@ class DependencySpec(object):
     def __init__(self, parent, spec, deptypes):
         self.parent = parent
         self.spec = spec
-        self.deptypes = deptypes
+        self.deptypes = tuple(sorted(set(deptypes)))
 
     def update_deptypes(self, deptypes):
+        deptypes = tuple(sorted(set(deptypes)))
         changed = self.deptypes != deptypes
         self.deptypes = deptypes
         return changed
@@ -808,16 +809,16 @@ class Spec(object):
         for dep in dep_like:
             if isinstance(dep, Spec):
                 spec = dep
-            elif isinstance(dep, tuple):
+            elif isinstance(dep, (list, tuple)):
                 # Literals can be deptypes -- if there are tuples in the
                 # list, they will be used as deptypes for the following Spec.
-                deptypes = dep
+                deptypes = tuple(dep)
                 continue
             else:
                 spec = Spec(dep)
 
             spec = dep if isinstance(dep, Spec) else Spec(dep)
-            self._add_dependency(spec, ())
+            self._add_dependency(spec, deptypes)
             deptypes = ()
 
     def __getattr__(self, item):
@@ -1318,7 +1319,7 @@ class Spec(object):
             for dname, dhash, dtypes in Spec.read_yaml_dep_specs(yaml_deps):
                 # Fill in dependencies by looking them up by name in deps dict
                 deps[name]._dependencies[dname] = DependencySpec(
-                    deps[name], deps[dname], set(dtypes))
+                    deps[name], deps[dname], dtypes)
 
         return spec
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -126,7 +126,8 @@ def mock_fetch_log(path):
 
 specX = MockSpec('X', '1.2.0')
 specY = MockSpec('Y', '2.3.8')
-specX._dependencies['Y'] = spack.spec.DependencySpec(specY, spack.alldeps)
+specX._dependencies['Y'] = spack.spec.DependencySpec(
+    specX, specY, spack.alldeps)
 pkgX = MockPackage(specX, 'logX')
 pkgY = MockPackage(specY, 'logY')
 specX.package = pkgX

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -124,6 +124,7 @@ class MockPackageDb(object):
 def mock_fetch_log(path):
     return []
 
+
 specX = MockSpec('X', '1.2.0')
 specY = MockSpec('Y', '2.3.8')
 specX._dependencies['Y'] = spack.spec.DependencySpec(

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -126,7 +126,7 @@ def mock_fetch_log(path):
 
 specX = MockSpec('X', '1.2.0')
 specY = MockSpec('Y', '2.3.8')
-specX._dependencies['Y'] = spack.DependencySpec(specY, spack.alldeps)
+specX._dependencies['Y'] = spack.spec.DependencySpec(specY, spack.alldeps)
 pkgX = MockPackage(specX, 'logX')
 pkgY = MockPackage(specY, 'logY')
 specX.package = pkgX

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -94,8 +94,7 @@ def test_normalize(spec_and_expected, config, builtin_mock):
     spec, expected = spec_and_expected
     spec = Spec(spec)
     spec.normalize()
-    assert spec == expected
-    assert spec.eq_dag(expected)
+    assert spec.eq_dag(expected, deptypes=False)
 
 
 def test_default_variant(config, builtin_mock):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -610,3 +610,83 @@ class TestSpecDag(object):
 
         assert '^mpich2@1.1' in s2
         assert '^mpich2' in s2
+
+    def test_construct_spec_with_deptypes(self):
+        s = Spec('a',
+                 Spec('b',
+                      ['build'], Spec('c')),
+                 Spec('d',
+                      ['build', 'link'], Spec('e',
+                                              ['run'], Spec('f'))))
+
+        assert s['b']._dependencies['c'].deptypes == ('build',)
+        assert s['d']._dependencies['e'].deptypes == ('build', 'link')
+        assert s['e']._dependencies['f'].deptypes == ('run',)
+
+        assert s['b']._dependencies['c'].deptypes == ('build',)
+        assert s['d']._dependencies['e'].deptypes == ('build', 'link')
+        assert s['e']._dependencies['f'].deptypes == ('run',)
+
+        assert s['c']._dependents['b'].deptypes == ('build',)
+        assert s['e']._dependents['d'].deptypes == ('build', 'link')
+        assert s['f']._dependents['e'].deptypes == ('run',)
+
+        assert s['c']._dependents['b'].deptypes == ('build',)
+        assert s['e']._dependents['d'].deptypes == ('build', 'link')
+        assert s['f']._dependents['e'].deptypes == ('run',)
+
+    def check_diamond_deptypes(self, spec):
+        """Validate deptypes in dt-diamond spec."""
+        assert spec['dt-diamond']._dependencies[
+            'dt-diamond-left'].deptypes == ('build', 'link')
+
+        assert spec['dt-diamond']._dependencies[
+            'dt-diamond-right'].deptypes == ('build', 'link')
+
+        assert spec['dt-diamond-left']._dependencies[
+            'dt-diamond-bottom'].deptypes == ('build',)
+
+        assert spec['dt-diamond-right'] ._dependencies[
+            'dt-diamond-bottom'].deptypes == ('build', 'link', 'run')
+
+    def check_diamond_normalized_dag(self, spec):
+        bottom = Spec('dt-diamond-bottom')
+        dag = Spec('dt-diamond',
+                   ['build', 'link'], Spec('dt-diamond-left',
+                                           ['build'], bottom),
+                   ['build', 'link'], Spec('dt-diamond-right',
+                                           ['build', 'link', 'run'], bottom))
+        assert spec.eq_dag(dag)
+
+    def test_normalize_diamond_deptypes(self):
+        """Ensure that dependency types are preserved even if the same thing is
+           depended on in two different ways."""
+        s = Spec('dt-diamond')
+        s.normalize()
+
+        self.check_diamond_deptypes(s)
+        self.check_diamond_normalized_dag(s)
+
+    def test_concretize_deptypes(self):
+        """Ensure that dependency types are preserved after concretization."""
+        s = Spec('dt-diamond')
+        s.concretize()
+        self.check_diamond_deptypes(s)
+
+    def test_copy_deptypes(self):
+        """Ensure that dependency types are preserved by spec copy."""
+        s1 = Spec('dt-diamond')
+        s1.normalize()
+        self.check_diamond_deptypes(s1)
+        self.check_diamond_normalized_dag(s1)
+
+        s2 = s1.copy()
+        self.check_diamond_normalized_dag(s2)
+        self.check_diamond_deptypes(s2)
+
+        s3 = Spec('dt-diamond')
+        s3.concretize()
+        self.check_diamond_deptypes(s3)
+
+        s4 = s3.copy()
+        self.check_diamond_deptypes(s4)

--- a/var/spack/repos/builtin.mock/packages/dt-diamond-bottom/package.py
+++ b/var/spack/repos/builtin.mock/packages/dt-diamond-bottom/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class DtDiamondBottom(Package):
+    """This package has an indirect diamond dependency on dt-diamond-bottom"""
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dt-diamond-bottom-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/dt-diamond-left/package.py
+++ b/var/spack/repos/builtin.mock/packages/dt-diamond-left/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class DtDiamondLeft(Package):
+    """This package has an indirect diamond dependency on dt-diamond-bottom"""
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dt-diamond-left-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('dt-diamond-bottom', type='build')
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/dt-diamond-right/package.py
+++ b/var/spack/repos/builtin.mock/packages/dt-diamond-right/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class DtDiamondRight(Package):
+    """This package has an indirect diamond dependency on dt-diamond-bottom"""
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dt-diamond-right-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('dt-diamond-bottom', type=('build', 'link', 'run'))
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/dt-diamond/package.py
+++ b/var/spack/repos/builtin.mock/packages/dt-diamond/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class DtDiamond(Package):
+    """This package has an indirect diamond dependency on dt-diamond-bottom"""
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dt-diamond-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('dt-diamond-left')
+    depends_on('dt-diamond-right')
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
Fixes #1754. Fixes #1457.

- [x] Fixes issues with hashing where deptypes from one dependency would be
  overwritten by those of another dependency on the same package.

  - Copying specs (`Spec.copy()`, `Spec._dup()`) did not handle deptypes
     correctly:

  - Copying "flattened" dependencies, but in doing so it collapsed
    multiple dependency relationships into one, losing some edge
    information in the DAG.

- [x] This gets rid of the `flat_dependencies_with_deptypes()` method,
    which doesn't really make sense, as it collapses edges. It's now
    reverted the original `flat_dependnecies()`.

- [x] `traverse_with_deptypes()` is now called `traverse_edges()`, which is
    when edge information must be preserved.

- [x] This gets rid of the notion of "default deptypes" introduced in #2307.

  - Initially created Specs now have empty deptypes instead of "defaults".

  - Proper deptypes are added during normalization/concretization like
    everything else in the Spec class.  Empty deptypes mean deptypes are
    not yet specified, and the spec is abstract.

- [x] Updated tests.