### PR TITLE
Remove cmake build dep from CMakePackages

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -155,10 +155,6 @@ class CMakeGuess(DefaultGuess):
     """Provides appropriate overrides for cmake-based packages"""
     base_class_name = 'CMakePackage'
 
-    dependencies = """\
-    # FIXME: Add additional dependencies if required.
-    depends_on('cmake', type='build')"""
-
     body = """\
     def cmake_args(self):
         # FIXME: Add arguments other than

--- a/var/spack/repos/builtin/packages/everytrace-example/package.py
+++ b/var/spack/repos/builtin/packages/everytrace-example/package.py
@@ -33,7 +33,6 @@ class EverytraceExample(CMakePackage):
             git='https://github.com/citibeth/everytrace-example.git',
             branch='develop')
 
-    depends_on('cmake', type='build')
     depends_on('everytrace+mpi+fortran')
 
     # Currently the only MPI this everytrace works with.

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -39,7 +39,6 @@ class Everytrace(CMakePackage):
     variant('fortran', default=True,
             description='Enable use with Fortran programs')
 
-    depends_on('cmake', type='build')
     depends_on('mpi', when='+mpi')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -64,7 +64,6 @@ class Ibmisc(CMakePackage):
     depends_on('boost', when='+boost')
 
     # Build dependencies
-    depends_on('cmake', type='build')
     depends_on('doxygen', type='build')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -36,7 +36,6 @@ class Icet(CMakePackage):
             git='https://gitlab.kitware.com/icet/icet.git')
     version('2.1.1', '4f971c51105a64937460d482adca2a6c')
 
-    depends_on('cmake', type='build')
     depends_on('mpi')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/jansson/package.py
+++ b/var/spack/repos/builtin/packages/jansson/package.py
@@ -33,5 +33,3 @@ class Jansson(CMakePackage):
     url      = "https://github.com/akheron/jansson/archive/v2.9.tar.gz"
 
     version('2.9', 'd2db25c437b359fc5a065ed938962237')
-
-    depends_on('cmake', type='build')

--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -30,5 +30,3 @@ class Libspatialindex(CMakePackage):
     url      = "https://github.com/libspatialindex/libspatialindex/tarball/1.8.5"
 
     version('1.8.5', 'a95d8159714dbda9a274792cd273d298')
-
-    depends_on("cmake", type='build')

--- a/var/spack/repos/builtin/packages/libwebsockets/package.py
+++ b/var/spack/repos/builtin/packages/libwebsockets/package.py
@@ -35,6 +35,5 @@ class Libwebsockets(CMakePackage):
     version('2.0.3', 'a025156d606d90579e65d53ccd062a94')
     version('1.7.9', '7b3692ead5ae00fd0e1d56c080170f07')
 
-    depends_on('cmake', type='build')
     depends_on('zlib')
     depends_on('openssl')

--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -39,7 +39,6 @@ class Opencoarrays(CMakePackage):
     version('1.7.4', '85ba87def461e3ff5a164de2e6482930')
     version('1.6.2', '5a4da993794f3e04ea7855a6678981ba')
 
-    depends_on('cmake', type='build')
     depends_on('mpi')
 
     provides('coarrays')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -90,8 +90,6 @@ class Trilinos(CMakePackage):
             description='Builds a debug version of the libraries')
     variant('boost',        default=True, description='Compile with Boost')
 
-    depends_on('cmake', type='build')
-
     # Everything should be compiled with -fpic
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/xsdktrilinos/package.py
+++ b/var/spack/repos/builtin/packages/xsdktrilinos/package.py
@@ -28,7 +28,7 @@ import os
 
 class Xsdktrilinos(CMakePackage):
     """xSDKTrilinos contains the portions of Trilinos that depend on PETSc
-    because they would cause a circular dependency if built as part of 
+    because they would cause a circular dependency if built as part of
     Trilinos.
     """
     homepage = "https://trilinos.org/"
@@ -50,8 +50,6 @@ class Xsdktrilinos(CMakePackage):
             description='Enables the build of shared libraries')
     variant('debug',        default=False,
             description='Builds a debug version of the libraries')
-
-    depends_on('cmake', type='build')
 
     # MPI related dependencies
     depends_on('mpi')


### PR DESCRIPTION
This is a direct continuation of #2623 and #2466. It removes `depends_on('cmake', type='build')` from all remaining `CMakePackages` and prevents it from being added when `spack create` creates new `CMakePackages`.