### PR TITLE
Command Line Scopes

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -117,6 +117,8 @@ parser.add_argument('-s', '--stacktrace', action='store_true',
                     help="Add stacktrace information to all printed statements")
 parser.add_argument('-V', '--version', action='version',
                     version="%s" % spack.spack_version)
+parser.add_argument('-c', '--config', dest='configs', action='append', default=[],
+                    help="Add project config scopes (highest precedence last)")
 
 # each command module implements a parser() function, to which we pass its
 # subparser for setup.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -59,7 +59,13 @@ are three configuration scopes.  From lowest to highest:
    a common spack instance).
 
 3. **user**: Stored in the home directory: ``~/.spack/``. These settings
-   affect all instances of Spack and take the highest precedence.
+   affect all instances of Spack and take higher precedence than site or
+   default scopes.
+
+3. **command line**: Optionally specified by the user on the command
+   line.  These settings take the highest precedence.  If multiple
+   scopes are listed on the command line, they are ordered from lowest
+   to highest precedence.
 
 Each configuration directory may contain several configuration files,
 such as ``config.yaml``, ``compilers.yaml``, or ``mirrors.yaml``.  When
@@ -70,6 +76,116 @@ Commands that modify scopes (e.g., ``spack compilers``, ``spack repo``,
 etc.) take a ``--scope=<name>`` parameter that you can use to control
 which scope is modified.  By default they modify the highest-precedence
 scope.
+
+.. _command-line-scopes:
+
+^^^^^^^^^^^^^^^^^^^
+Command Line Scopes
+^^^^^^^^^^^^^^^^^^^
+
+User-supplied configuration scopes are specified on the command line,
+*before* the Spack subcommand, with ``--config
+</path/to/config/dir>``.  The user may place configuration files
+inside that tree as needed (eg, ``packages.yaml``).  If multiple
+scopes are provided:
+
+1. Each one must be preceded with the ``--config`` flag.
+2. They must be ordered from lowest to highest precedence.
+3. Their directory paths must end in a different leaf name.
+
+""""""""""""""""""""""""""""""""
+Example: Two Command-Line Scopes
+""""""""""""""""""""""""""""""""
+
+The following adds two configuration scopes, named `scopea` and
+`scopeb`, to a `spack spec` command.  `scopeb` has higher precedence:
+
+.. code-block:: console
+
+   $ spack --config ~/myscopes/scopea --config ~/myscopes/scopeb spec ncurses
+
+
+"""""""""""""""""""""""""""""""""""""""""""""
+Example: Simultaneous Release and Development
+"""""""""""""""""""""""""""""""""""""""""""""
+
+For example, suppose that one needs to support simultaneous building
+of release and development versions of a `mypackage`, where
+`mypackage` -> `A` -> `B`.  The following files could be created:
+
+.. code-block:: yaml
+
+   ~/myscopes/release/packages.yaml
+   --------------------------------
+   packages:
+       mypackage:
+           version: [1.7]
+       A:
+           version: [2.3]
+       B:
+           version: [0.8]
+
+.. code-block:: yaml
+
+   ~/myscopes/develop/packages.yaml
+   --------------------------------
+   packages:
+       mypackage:
+           version: [develop]
+       A:
+           version: [develop]
+       B:
+           version: [develop]
+
+For convenience, the preferred configuration scope could then be set
+in Bash aliases:
+
+.. code-block:: console
+
+   alias spack-release='spack --config ~/myscopes/release'
+   alias spack-develop='spack --config ~/myscopes/develop'
+
+.. note::
+
+   This example would be difficult to handle without command-line
+   scopes: concretization of ``mypackage ^A@develop ^B@develop`` will
+   typically fail because ``mypackage`` does not depend (directly) on
+   ``B``.  The situation is worse if ``A`` is a virtual package.
+
+
+""""""""""""""""""""""""""""""
+Example: Incompatible Projects
+""""""""""""""""""""""""""""""
+
+Suppose that one needs to build two software packages, `packagea` and
+`packageb`.  PackageA is Python2-based and PackageB is Python3-based.
+Moreover, PackageA only builds with OpenMPI and PackageB only builds
+with MPICH.  This problem can be solved elegantly by creating
+different configuration scopes for use with Package A and B:
+
+.. code-block:: yaml
+
+   ~/myscopes/packgea/packages.yaml
+   --------------------------------
+   packages:
+       python:
+           version: [2.7.11]
+       all:
+           providers:
+               mpi: [openmpi]
+
+.. code-block:: yaml
+
+   ~/myscopes/packageb/packages.yaml
+   --------------------------------
+   packages:
+       python:
+           version: [3.5.2]
+       all:
+           providers:
+               mpi: [mpich]
+
+
 
 .. _platform-scopes:
 
@@ -91,6 +207,8 @@ full scope precedence is:
 4. ``site/<platform>``
 5. ``user``
 6. ``user/<platform>``
+7. ``command-line``
+8. ``command-line/<platform>``
 
 You can get the name to use for ``<platform>`` by running ``spack arch
 --platform``.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -369,3 +369,19 @@ The merged configuration would look like this:
        - /lustre-scratch/$user
        - ~/mystage
    $ _
+
+
+-----------------------
+Resulting Configuration
+-----------------------
+
+With so many scopes overriding each other, Spack provides a way to
+view the final "merged" version of any configuration file, with the
+``spack config get`` command.  For example, the following shows the
+resulting ``packages.yaml`` file, taking into account one command-line
+scope:
+
+.. code-block:: console
+
+   $ spack --config ~/myscopes/develop config get packages
+

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -22,6 +22,8 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+from __future__ import print_function
+
 """This module implements Spack's configuration file handling.
 
 This implements Spack's configuration system, which handles merging
@@ -224,6 +226,25 @@ _user_path = spack.user_config_path
 ConfigScope('user', _user_path)
 ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
 
+# ----------------------------------------------------------------
+# Parse just the --config command line arguments; ignore the rest.
+# This cannot raise an error; if there are real errors in the command
+# line arguments, they will be caught later when the full parse is done.
+# But we need the --config flags NOW.
+import argparse
+from llnl.util.tty.color import *
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--config', dest='configs', action='append', default=[],
+                    help="Add project config scopes (highest precedence last)")
+
+# Parse args initially
+args0, _ = parser.parse_known_args()
+
+import spack.config
+for config_path in args0.configs:
+    _,config_name = os.path.split(config_path)
+    ConfigScope(config_name, config_path)
+# ----------------------------------------------------------------
 
 def highest_precedence_scope():
     """Get the scope with highest precedence (prefs will override others)."""
@@ -559,3 +580,5 @@ class ConfigFormatError(ConfigError):
 
 class ConfigSanityError(ConfigFormatError):
     """Same as ConfigFormatError, raised when config is written by Spack."""
+
+


### PR DESCRIPTION
Allows the user to add additional configuration scopes (beyond defaults/site/user) on the command line for all Spack commands.  Docs are included in the PR, should be self-explanatory.  I did this because I need it.
