### PR TITLE
Fix Python issue with build failures; Add test case for build failures.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -60,9 +60,10 @@ import traceback
 
 import llnl.util.lang as lang
 import llnl.util.tty as tty
+from llnl.util.filesystem import *
+
 import spack
 import spack.store
-from llnl.util.filesystem import *
 from spack.environment import EnvironmentModifications, validate
 from spack.util.environment import *
 from spack.util.executable import Executable, which
@@ -450,7 +451,8 @@ def parent_class_modules(cls):
     """
     Get list of super class modules that are all descend from spack.Package
     """
-    if not issubclass(cls, spack.Package) or issubclass(spack.Package, cls):
+    if (not issubclass(cls, spack.package.Package) or
+        issubclass(spack.package.Package, cls)):
         return []
     result = []
     module = sys.modules.get(cls.__module__)
@@ -622,9 +624,9 @@ def get_package_context(traceback):
     for tb in stack:
         frame = tb.tb_frame
         if 'self' in frame.f_locals:
-            # Find the first proper subclass of spack.PackageBase.
+            # Find the first proper subclass of PackageBase.
             obj = frame.f_locals['self']
-            if isinstance(obj, spack.PackageBase):
+            if isinstance(obj, spack.package.PackageBase):
                 break
 
     # we found obj, the Package implementation we care about.

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -90,3 +90,15 @@ def test_store(mock_archive):
     except Exception:
         pkg.remove_prefix()
         raise
+
+
+@pytest.mark.usefixtures('install_mockery')
+def test_failing_build(mock_archive):
+    spec = Spec('failing-build').concretized()
+
+    for s in spec.traverse():
+        fake_fetchify(mock_archive.url, s.package)
+
+    pkg = spec.package
+    with pytest.raises(spack.build_environment.ChildError):
+        pkg.do_install()

--- a/var/spack/repos/builtin.mock/packages/failing-build/package.py
+++ b/var/spack/repos/builtin.mock/packages/failing-build/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class FailingBuild(Package):
+    """This package has a trivial install method that fails."""
+
+    homepage = "http://www.example.com/trivial_install"
+    url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version('1.0', 'foobarbaz')
+
+    def install(self, spec, prefix):
+        raise InstallError("Expected failure.")


### PR DESCRIPTION
Fixes issue reported by @schulzm.  Fixes #2688.

```
==> Executing phase : 'install'
Process Process-1:
Traceback (most recent call last):
  File "/usr/apps/python/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/apps/python/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/g/g23/schulz/projects/spack/lib/spack/spack/build_environment.py", line 564, in child_execution
    package_context = get_package_context(tb)
  File "/g/g23/schulz/projects/spack/lib/spack/spack/build_environment.py", line 627, in get_package_context
    if isinstance(obj, spack.PackageBase):
AttributeError: 'module' object has no attribute 'PackageBase'
```

- [x] Fix bug from imports cleaned up in #2681.
- [x] Add this issue to the regression tests with a new mock package that raises an `InstallError`.

@schulzm: can you please verify?