### PR TITLE
Fix missing debug parameter for parse_version()

### DIFF
--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -266,11 +266,11 @@ def parse_version_offset(path, debug=False):
     raise UndetectableVersionError(original_path)
 
 
-def parse_version(path):
+def parse_version(path, debug=False):
     """Given a URL or archive name, extract a version from it and return
        a version object.
     """
-    ver, start, l = parse_version_offset(path)
+    ver, start, l = parse_version_offset(path, debug=debug)
     return Version(ver)
 
 


### PR DESCRIPTION
@tgamblin I believe this bug was introduced in #2525. [Line 279](https://github.com/LLNL/spack/blob/develop/lib/spack/spack/url.py#L279) calls `parse_version()` with a `debug` parameter, but `parse_version()` doesn't accept that parameter.