### PR TITLE
Disallow vdeps in `packages.yaml`

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -77,7 +77,7 @@ import spack.error
 import spack.config
 import spack.fetch_strategy
 from spack.file_cache import FileCache
-from spack.preferred_packages import PreferredPackages
+from spack.package_prefs import PreferredPackages
 from spack.abi import ABI
 from spack.concretize import DefaultConcretizer
 from spack.version import Version
@@ -97,11 +97,6 @@ try:
     sys.meta_path.append(repo)
 except spack.error.SpackError, e:
     tty.die('while initializing Spack RepoPath:', e.message)
-
-
-# PreferredPackages controls preference sort order during concretization.
-# More preferred packages are sorted first.
-pkgsort = PreferredPackages()
 
 
 # Tests ABI compatibility between packages

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -199,6 +199,7 @@ class ConfigScope(object):
     def __repr__(self):
         return '<ConfigScope: %s: %s>' % (self.name, self.path)
 
+
 #
 # Below are configuration scopes.
 #

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -458,54 +458,6 @@ def print_section(section):
         raise ConfigError("Error reading configuration: %s" % section)
 
 
-def spec_externals(spec):
-    """Return a list of external specs (with external directory path filled in),
-       one for each known external installation."""
-    # break circular import.
-    from spack.build_environment import get_path_from_module
-
-    allpkgs = get_config('packages')
-    name = spec.name
-
-    external_specs = []
-    pkg_paths = allpkgs.get(name, {}).get('paths', None)
-    pkg_modules = allpkgs.get(name, {}).get('modules', None)
-    if (not pkg_paths) and (not pkg_modules):
-        return []
-
-    for external_spec, path in pkg_paths.iteritems():
-        if not path:
-            # skip entries without paths (avoid creating extra Specs)
-            continue
-
-        external_spec = spack.spec.Spec(external_spec, external=path)
-        if external_spec.satisfies(spec):
-            external_specs.append(external_spec)
-
-    for external_spec, module in pkg_modules.iteritems():
-        if not module:
-            continue
-
-        path = get_path_from_module(module)
-
-        external_spec = spack.spec.Spec(
-            external_spec, external=path, external_module=module)
-        if external_spec.satisfies(spec):
-            external_specs.append(external_spec)
-
-    return external_specs
-
-
-def is_spec_buildable(spec):
-    """Return true if the spec pkgspec is configured as buildable"""
-    allpkgs = get_config('packages')
-    if spec.name not in allpkgs:
-        return True
-    if 'buildable' not in allpkgs[spec.name]:
-        return True
-    return allpkgs[spec.name]['buildable']
-
-
 class ConfigError(SpackError):
     pass
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -300,12 +300,14 @@ def cmp_specs(lhs, rhs):
     return 0
 
 
+_pkgsort = None
+
+
 def pkgsort():
     global _pkgsort
     if _pkgsort is None:
         _pkgsort = PreferredPackages()
     return _pkgsort
-_pkgsort = None
 
 
 class VirtualInPackagesYAMLError(spack.error.SpackError):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -337,6 +337,10 @@ class RepoPath(object):
         return self.repo_for_pkg(pkg_name).filename_for_package_name(pkg_name)
 
     def exists(self, pkg_name):
+        """Whether package with the give name exists in the path's repos.
+
+        Note that virtual packages do not "exist".
+        """
         return any(repo.exists(pkg_name) for repo in self.repos)
 
     def __contains__(self, pkg_name):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -343,6 +343,10 @@ class RepoPath(object):
         """
         return any(repo.exists(pkg_name) for repo in self.repos)
 
+    def is_virtual(self, pkg_name):
+        """True if the package with this name is virtual, False otherwise."""
+        return pkg_name in self.provider_index
+
     def __contains__(self, pkg_name):
         return self.exists(pkg_name)
 
@@ -775,6 +779,10 @@ class Repo(object):
         # Just check whether the file exists.
         filename = self.filename_for_package_name(pkg_name)
         return os.path.exists(filename)
+
+    def is_virtual(self, pkg_name):
+        """True if the package with this name is virtual, False otherwise."""
+        return self.provider_index.contains(pkg_name)
 
     def _get_pkg_module(self, pkg_name):
         """Create a module for a particular package.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2546,6 +2546,8 @@ class Spec(object):
         return ''.join("^" + dep.format() for dep in self.sorted_deps())
 
     def __cmp__(self, other):
+        from package_prefs import pkgsort
+
         # Package name sort order is not configurable, always goes alphabetical
         if self.name != other.name:
             return cmp(self.name, other.name)
@@ -2553,22 +2555,22 @@ class Spec(object):
         # Package version is second in compare order
         pkgname = self.name
         if self.versions != other.versions:
-            return spack.pkgsort.version_compare(
+            return pkgsort().version_compare(
                 pkgname, self.versions, other.versions)
 
         # Compiler is third
         if self.compiler != other.compiler:
-            return spack.pkgsort.compiler_compare(
+            return pkgsort().compiler_compare(
                 pkgname, self.compiler, other.compiler)
 
         # Variants
         if self.variants != other.variants:
-            return spack.pkgsort.variant_compare(
+            return pkgsort().variant_compare(
                 pkgname, self.variants, other.variants)
 
         # Target
         if self.architecture != other.architecture:
-            return spack.pkgsort.architecture_compare(
+            return pkgsort().architecture_compare(
                 pkgname, self.architecture, other.architecture)
 
         # Dependency is not configurable

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -26,6 +26,7 @@ import pytest
 
 import spack
 from spack.spec import Spec
+from spack.package_prefs import PreferredPackages
 
 
 @pytest.fixture()
@@ -39,7 +40,7 @@ def concretize_scope(config, tmpdir):
     # This is kind of weird, but that's how config scopes are
     # set in ConfigScope.__init__
     spack.config.config_scopes.pop('concretize')
-    spack.pkgsort = spack.PreferredPackages()
+    spack.package_prefs._pkgsort = PreferredPackages()
 
 
 def concretize(abstract_spec):
@@ -50,7 +51,7 @@ def update_packages(pkgname, section, value):
     """Update config and reread package list"""
     conf = {pkgname: {section: value}}
     spack.config.update_config('packages', conf, 'concretize')
-    spack.pkgsort = spack.PreferredPackages()
+    spack.package_prefs._pkgsort = PreferredPackages()
 
 
 def assert_variant_values(spec, **variants):

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -25,6 +25,7 @@
 import pytest
 
 import spack
+import spack.util.spack_yaml as syaml
 from spack.spec import Spec
 from spack.package_prefs import PreferredPackages
 
@@ -115,3 +116,30 @@ class TestConcretizePreferences(object):
         spec = Spec('builtin.mock.develop-test')
         spec.concretize()
         assert spec.version == spack.spec.Version('0.2.15')
+
+    def test_no_virtuals_in_packages_yaml(self):
+        """Verify that virtuals are not allowed in packages.yaml."""
+
+        # set up a packages.yaml file with a vdep as a key.  We use
+        # syaml.load here to make sure source lines in the config are
+        # attached to parsed strings, as the error message uses them.
+        conf = syaml.load("""mpi:
+    paths:
+      mpi-with-lapack@2.1: /path/to/lapack
+""")
+        spack.config.update_config('packages', conf, 'concretize')
+
+        # now when we get the packages.yaml config, there should be an error
+        with pytest.raises(spack.package_prefs.VirtualInPackagesYAMLError):
+            spack.package_prefs.get_packages_config()
+
+    def test_all_is_not_a_virtual(self):
+        """Verify that `all` is allowed in packages.yaml."""
+        conf = syaml.load("""all:
+        variants: [+mpi]
+""")
+        spack.config.update_config('packages', conf, 'concretize')
+
+        # should be no error for 'all':
+        spack.package_prefs._pkgsort = PreferredPackages()
+        spack.package_prefs.get_packages_config()


### PR DESCRIPTION
Fixes #2069.

Spack will now validate whether packages in `packages.yaml` exist or not, and it won't let you inadvertently put a virtual in `packages.yaml`.  See #2069 for details.

- Small refactoring:
  - [x] rename `preferred_packages` to `package_prefs` -- latter encompassed better all the things `packages.yaml` can do.
  - [x] Consolidate all code to handle `packages.yaml` into `packages_prefs.py`
- Fix bugs
  - [x] Spack validates and dies now if you specify something virtual in `packages.yaml`.
  - [x] Add tests to verify this.

@alalazo @davydden