### PR TITLE
[WIP] Add a PyPiFetchStrategy to properly download Python packages

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -218,6 +218,8 @@ def version(ver, checksum=None, **kwargs):
         if checksum:
             kwargs['md5'] = checksum
 
+        kwargs['version'] = ver
+
         # Store kwargs for the package to later with a fetch_strategy.
         pkg.versions[Version(ver)] = kwargs
     return _execute

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -67,6 +67,14 @@ from spack.util.crypto import bit_length
 from spack.util.environment import dump_environment
 from spack.version import *
 
+# The xmlrpclib module has been renamed to xmlrpc.client in Python 3
+# Spack does not yet support Python 3, but there's no reason not to be
+# future-proof
+try:
+    import xmlrpclib
+except ImportError:
+    import xmlrpc.client as xmlrpclib
+
 """Allowed URL schemes for spack packages."""
 _ALLOWED_URL_SCHEMES = ["http", "https", "ftp", "file", "git"]
 
@@ -673,17 +681,40 @@ class PackageBase(object):
             version = Version(version)
 
         cls = self.__class__
-        if not (hasattr(cls, 'url') or self.version_urls()):
+
+        if hasattr(cls, 'url') or self.version_urls():
+            # If we have a specific URL for this version, don't extrapolate.
+            version_urls = self.version_urls()
+            if version in version_urls:
+                return version_urls[version]
+
+            # If we have no idea, try to substitute the version.
+            return spack.url.substitute_version(
+                self.nearest_url(version), self.url_version(version))
+        elif hasattr(cls, 'pypi') or hasattr(self, 'pypi'):
+            client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
+            releases = client.release_urls(cls.pypi, str(version))
+
+            # Each release may contain dozens of different download URLs
+            # for wheels, tarballs, or zipballs. We don't really have a good
+            # way to tell which version the package needs to download.
+            # Tarballs have the highest preference
+            for release in releases:
+                if release['filename'].endswith('.tar.gz'):
+                    return release['url']
+
+            # Zipballs have a lower preference
+            for release in releases:
+                if release['filename'].endswith('.zip'):
+                    return release['url']
+
+            # Are there any source distributions at all?
+            for release in releases:
+                if release['packagetype']    == 'sdist' or \
+                   release['python_version'] == 'source':
+                    return release['url']
+        else:
             raise NoURLError(cls)
-
-        # If we have a specific URL for this version, don't extrapolate.
-        version_urls = self.version_urls()
-        if version in version_urls:
-            return version_urls[version]
-
-        # If we have no idea, try to substitute the version.
-        return spack.url.substitute_version(
-            self.nearest_url(version), self.url_version(version))
 
     def _make_resource_stage(self, root_stage, fetcher, resource):
         resource_stage_folder = self._resource_stage(resource)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -31,13 +31,12 @@ class PyScipy(Package):
     as routines for numerical integration and optimization."""
 
     homepage = "http://www.scipy.org/"
-    url = "https://pypi.python.org/packages/source/s/scipy/scipy-0.15.0.tar.gz"
+    pypi = 'scipy'
 
-    version('0.18.1', '5fb5fb7ccb113ab3a039702b6c2f3327',
-            url="https://pypi.python.org/packages/22/41/b1538a75309ae4913cdbbdc8d1cc54cae6d37981d2759532c1aa37a41121/scipy-0.18.1.tar.gz")
-    version('0.17.0', '5ff2971e1ce90e762c59d2cd84837224')
-    version('0.15.1', 'be56cd8e60591d6332aac792a5880110')
-    version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a')
+    version('0.18.1', '5fb5fb7ccb113ab3a039702b6c2f3327', pypi='scipy')
+    version('0.17.0', '5ff2971e1ce90e762c59d2cd84837224', pypi='scipy')
+    version('0.15.1', 'be56cd8e60591d6332aac792a5880110', pypi='scipy')
+    version('0.15.0', '639112f077f0aeb6d80718dc5019dc7a', pypi='scipy')
 
     extends('python')
     depends_on('python@2.6:2.8,3.2:')


### PR DESCRIPTION
Resolves #2281.

This PR is pretty hacky at the moment, so it will need a lot of work before it is properly integrated. But it is a totally working proof of concept:
```
$ spack fetch py-scipy
==> Fetching https://pypi.python.org/packages/22/41/b1538a75309ae4913cdbbdc8d1cc54cae6d37981d2759532c1aa37a41121/scipy-0.18.1.tar.gz
######################################################################## 100.0%
```

In the end, I'm hoping to support the following modes:

#### 1. `pypi` passed to the version directive

Packages should be able to have multiple versions, some that download from git and some that download from PyPi. The following should work:
```python
url = 'url'

version('1.2.3', 'hash')
version('1.2.4', 'hash', pypi='name')
version('1.2.5', 'hash', url='url')
version('1.2.6', 'hash', git='url', branch='branch')
```
#### 2. `pypi` declared at the package level

If you have ten versions, you don't want to add `pypi='name'` to every single version directive. You should be able to declare it once at the package level.

#### 3. packages named `py-*` without a URL?

If a URL isn't provided and the package starts with `py-`, why not call `PyPiFetchStrategy`?

#### 4. packages that subclass `PythonPackage` without a URL?

Same as above. See #2709