### PR TITLE
Add new command `concretize`

### DIFF
--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import argparse
+
+import llnl.util.tty as tty
+import spack
+
+description = "Concretize input spec for debugging purposes"
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        'package',
+        nargs=argparse.REMAINDER,
+        help="spec of the package to concretize"
+    )
+
+def concretize(parser, args, **kwargs):
+    tty.debug("concretizing package {}".format(args.package))
+    if not args.package:
+        tty.die("concretize requires at least one package argument")
+
+    # Spec from cli
+    specs = spack.cmd.parse_specs(args.package, concretize=True)
+    print("Specs concretized from '{}' were:".format(args.package))
+    for spec in specs:
+        print(spec)


### PR DESCRIPTION
This command will show the concretized spec if you pass it any spec.
This is very useful for determining what will be installed before
actually going through with the installation procedure.