### PR TITLE
Downloading zlib tarballs from sourceforge.

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -31,12 +31,21 @@ class Zlib(AutotoolsPackage):
        data-compression library."""
 
     homepage = "http://zlib.net"
-    url = "http://zlib.net/zlib-1.2.8.tar.gz"
 
-    version('1.2.10', 'd9794246f853d15ce0fcbf79b9a3cf13')
-    version('1.2.8', '44d667c142d7cda120332623eab69f40',
-            url='http://pkgs.fedoraproject.org/repo/pkgs/mingw-zlib/zlib-1.2.8.tar.gz/44d667c142d7cda120332623eab69f40/zlib-1.2.8.tar.gz'
-           )
+    url = "https://downloads.sourceforge.net/project/libpng/zlib/1.2.10/zlib-1.2.10.tar.gz"
+
+    version('1.2.10', 'd9794246f853d15ce0fcbf79b9a3cf13', url="http://downloads.sourceforge.net/project/libpng/zlib/1.2.10/zlib-1.2.10.tar.gz")
+    version('1.2.9', '44d667c142d7cda120332623eab69f40', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz")
+    version('1.2.7', '60df6a37c56e7c1366cca812414f7b85', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.7/zlib-1.2.7.tar.gz")
+    version('1.2.6', '618e944d7c7cd6521551e30b32322f4a', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz")
+    version('1.2.5', 'c735eab2d659a96e5a594c9e8541ad63', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.5/zlib-1.2.5.tar.gz")
+    version('1.2.4', '47f6ed51b3c83a8534f9228531effa18', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.4/zlib-1.2.4.tar.gz")
+    version('1.2.3', 'debc62758716a169df9f62e6ab2bc634', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.3/zlib-1.2.3.tar.gz")
+    version('1.2.2', '68bd51aaa6558c3bc3fd4890e53413de', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.2/zlib-1.2.2.tar.gz")
+    version('1.2.1', 'ef1cb003448b4a53517b8f25adb12452', url="https://downloads.sourceforge.net/project/libpng/zlib/1.2.1/zlib-1.2.1.tar.gz")
+    version('1.1.4', 'abc405d0bdd3ee22782d7aa20e440f08', url="https://downloads.sourceforge.net/project/libpng/zlib/1.1.4/zlib-1.1.4.tar.gz")
+    version('1.1.3', 'ada18615d2a66dee4d6f5ff916ecd4c6', url="https://downloads.sourceforge.net/project/libpng/zlib/1.1.3/zlib-1.1.3.tar.gz")
+
 
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')


### PR DESCRIPTION
This is an alternative to #2731 with identical checksums as the original tallballs. All releases on the sourceforge page are included. Check #2730 for more information.