### PR TITLE
opencoarrays: new version

### DIFF
--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -36,6 +36,7 @@ class Opencoarrays(CMakePackage):
     homepage = "http://www.opencoarrays.org/"
     url      = "https://github.com/sourceryinstitute/opencoarrays/releases/download/1.7.4/OpenCoarrays-1.7.4.tar.gz"
 
+    version('1.8.0', 'ca78d1507b2a118c75128c6c2e093e27')
     version('1.7.4', '85ba87def461e3ff5a164de2e6482930')
     version('1.6.2', '5a4da993794f3e04ea7855a6678981ba')
 

--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -40,7 +40,6 @@ class Opencoarrays(CMakePackage):
     version('1.7.4', '85ba87def461e3ff5a164de2e6482930')
     version('1.6.2', '5a4da993794f3e04ea7855a6678981ba')
 
-    depends_on('cmake', type='build')
     depends_on('mpi')
 
     provides('coarrays')

--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -42,8 +42,6 @@ class Opencoarrays(CMakePackage):
 
     depends_on('mpi')
 
-    provides('coarrays')
-
     def cmake_args(self):
         args = []
         args.append("-DCMAKE_C_COMPILER=%s" % self.spec['mpi'].mpicc)


### PR DESCRIPTION
also removed `depends_on('cmake', type='build')` as it is no longer necessary with `CMakePackage`