### PR TITLE
Force particular texlive repo to increase predictability

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -41,7 +41,7 @@ class Texlive(Package):
     # digest values, but don't be surprised if this package is
     # briefly unbuildable.
     #
-    version('live', '01461ec2cc49fe0b14812eb67abbea46',
+    version('live', 'ad230fa814d122084c13d75c0b135fda',
             url="http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz")
 
     # There does not seem to be a complete list of schemes.
@@ -59,9 +59,14 @@ class Texlive(Package):
     depends_on('perl', type='build')
 
     def install(self, spec, prefix):
+        # Using texlive's mirror system leads to mysterious problems,
+        # in lieu of being able to specify a repository as a variant, hardwire
+        # a particular (slow, but central) one for now.
+        _repository='http://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet/'
         env = os.environ
         env['TEXLIVE_INSTALL_PREFIX'] = prefix
         perl = which('perl')
         scheme = spec.variants['scheme'].value
         perl('./install-tl', '-scheme', scheme,
+             '-repository', _repository,
              '-portable', '-profile', '/dev/null')


### PR DESCRIPTION
The repository used by the texlive installer defaults to a redirector that sends one off to various URLs depending on <fill in the blank>.

This is problematic because all of the mirrors do not update in synchrony and bad tarballs often hang around for a while.

This leads to problems that are particularly hard to diagnose because you're likely to end up using a different repo the next time around.

This commit constraints the package to a particular, mainstream, repository.  It's not fast, but it's consistent and usually correct.

It also updates the installer digest, because no day is complete without updating it at least (sigh) once.

[what @tgamblin wants, @tgamblin gets... :smile:]