### PR TITLE
Add lmod support for `spack module loads`

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -128,6 +128,7 @@ def loads(mtype, specs, args):
 
     module_commands = {
         'tcl': 'module load ',
+        'lmod': 'module load ',
         'dotkit': 'dotkit use '
     }
 


### PR DESCRIPTION
The `spack module loads` command only supported tcl and dotkit.
This adds support for lmod.

Are there other points at which lmod support should be added?