### PR TITLE
Make module autoload warnings configurable

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -70,6 +70,9 @@ _roots = spack.config.get_config('config').get('module_roots', {})
 """Specifics about modules are in modules.yaml"""
 _module_config = spack.config.get_config('modules')
 
+def verbose_autoload():
+    configuration = _module_config.get('lmod', {})
+    return configuration.get('verbose_autoload', True)
 
 def print_help():
     """
@@ -428,10 +431,6 @@ class EnvModule(object):
     def module_specific_content(self, configuration):
         return tuple()
 
-    def verbose_autoload(self):
-        configuration = _module_config.get('lmod', {})
-        return configuration.get('verbose_autoload', True)
-
     # Subclasses can return a fragment of module code that prints out
     # a warning that modules are being autoloaded.
     def autoload_warner(self):
@@ -538,7 +537,7 @@ class TclModule(EnvModule):
         _roots.get(name, join_path(spack.share_path, 'modules')))
 
     def autoload_warner(self):
-        if self.verbose_autoload():
+        if verbose_autoload():
             return 'puts stderr "Autoloading {module_file}"\n'
         return ''
 
@@ -671,7 +670,7 @@ class LmodModule(EnvModule):
     }
 
     def autoload_warner(self):
-        if self.verbose_autoload():
+        if verbose_autoload():
             return 'LmodMessage("Autoloading {module_file}")\n'
         return ''
 

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -70,9 +70,11 @@ _roots = spack.config.get_config('config').get('module_roots', {})
 """Specifics about modules are in modules.yaml"""
 _module_config = spack.config.get_config('modules')
 
+
 def verbose_autoload():
     configuration = _module_config.get('lmod', {})
     return configuration.get('verbose_autoload', True)
+
 
 def print_help():
     """

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -440,8 +440,8 @@ class EnvModule(object):
         else:
             module_file = spec
         return self.autoload_format.format(
-          module_file=module_file,
-          warner=self.autoload_warner().format(module_file=module_file))
+            module_file=module_file,
+            warner=self.autoload_warner().format(module_file=module_file))
 
     def prerequisite(self, spec):
         m = type(self)(spec)

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -71,7 +71,6 @@ _roots = spack.config.get_config('config').get('module_roots', {})
 _module_config = spack.config.get_config('modules')
 
 
-
 def print_help():
     """
     For use by commands to tell user how to activate shell support.
@@ -440,8 +439,9 @@ class EnvModule(object):
             module_file = m.use_name
         else:
             module_file = spec
-        return self.autoload_format.format(module_file=module_file,
-                                           warner=self.autoload_warner().format(module_file=module_file))
+        return self.autoload_format.format(
+          module_file=module_file,
+          warner=self.autoload_warner().format(module_file=module_file))
 
     def prerequisite(self, spec):
         m = type(self)(spec)
@@ -484,10 +484,8 @@ class EnvModule(object):
                 pass
 
     def verbose_autoload(self):
-        #luigi#configuration = _module_config.get('lmod', {})
         configuration = _module_config.get(self.name, {})
         return configuration.get('verbose_autoload', True)
-
 
 
 class Dotkit(EnvModule):

--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -71,10 +71,6 @@ _roots = spack.config.get_config('config').get('module_roots', {})
 _module_config = spack.config.get_config('modules')
 
 
-def verbose_autoload():
-    configuration = _module_config.get('lmod', {})
-    return configuration.get('verbose_autoload', True)
-
 
 def print_help():
     """
@@ -445,7 +441,7 @@ class EnvModule(object):
         else:
             module_file = spec
         return self.autoload_format.format(module_file=module_file,
-                                           warner=self.autoload_warner())
+                                           warner=self.autoload_warner().format(module_file=module_file))
 
     def prerequisite(self, spec):
         m = type(self)(spec)
@@ -486,6 +482,12 @@ class EnvModule(object):
             except OSError:
                 # removedirs throws OSError on first non-empty directory found
                 pass
+
+    def verbose_autoload(self):
+        #luigi#configuration = _module_config.get('lmod', {})
+        configuration = _module_config.get(self.name, {})
+        return configuration.get('verbose_autoload', True)
+
 
 
 class Dotkit(EnvModule):
@@ -539,7 +541,7 @@ class TclModule(EnvModule):
         _roots.get(name, join_path(spack.share_path, 'modules')))
 
     def autoload_warner(self):
-        if verbose_autoload():
+        if self.verbose_autoload():
             return 'puts stderr "Autoloading {module_file}"\n'
         return ''
 
@@ -672,7 +674,7 @@ class LmodModule(EnvModule):
     }
 
     def autoload_warner(self):
-        if verbose_autoload():
+        if self.verbose_autoload():
             return 'LmodMessage("Autoloading {module_file}")\n'
         return ''
 


### PR DESCRIPTION
Modules generated by the module creation machinery currently print out
a notice that warnts the user that things are being autoloaded.  In
some situations those warnings are problematic.  See #2754 for
discussion.

This is a first cut at optionally disabling the warning messages.

It:

- adds a helper tothe EnvModule base class that encapsulates the
  config file variable;
- adds a method to the base class that provides a default (empty)
  code fragment for generating a warning message;
- passes the warning fragment into the bit that formats the autoload
  string;
- adds specialized autload_warner() methods in the tcl and lmod
  subclasses;; and finally
- touches up the autoload_format strings in the specialized classes.

Closes #2754 