### PR TITLE
Fix issues linking HDF5 1.8.14 and below on Ubuntu.

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
 import shutil
 
@@ -48,6 +47,7 @@ class Hdf5(AutotoolsPackage):
     version('1.8.17', '7d572f8f3b798a628b8245af0391a0ca')
     version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618')
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
+    version('1.8.14', 'a482686e733514a51cde12d6fe5c5d95')
     version('1.8.13', 'c03426e9e77d7766944654280b467289')
     version('1.8.12', 'd804802feb99b87fc668a90e6fa34411')
 
@@ -155,6 +155,20 @@ class Hdf5(AutotoolsPackage):
             ])
 
         return ["--with-zlib=%s" % spec['zlib'].prefix] + extra_args
+
+    def configure(self, spec, prefix):
+        # Run the default autotools package configure
+        super(Hdf5, self).configure(spec, prefix)
+
+        if '@:1.8.14' in spec:
+            # On Ubuntu14, HDF5 1.8.12 (and maybe other versions)
+            # mysteriously end up with "-l -l" in the postdeps in the
+            # libtool script.  Patch this by removing the spurious -l's.
+            filter_file(
+                r'postdeps="([^"]*)"',
+                lambda m: 'postdeps="%s"' % ' '.join(
+                    arg for arg in m.group(1).split(' ') if arg != '-l'),
+                'libtool')
 
     @AutotoolsPackage.sanity_check('install')
     def check_install(self):


### PR DESCRIPTION
Fixes #2586.

HDF5 `1.8.14` and below have a weird `libtool` issue on Ubuntu where the postdeps in the generated `libtool` script end up with arg-less `-l`s.  This results in this error from #2586:

> FCLD libhdf5_fortran.la
> /usr/bin/ld: cannot find -l-L/nfs/software/linux-ubuntu_trusty_amd64/apps/packages/gcc/gcc-6.2.0/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0
> collect2: error: ld returned 1 exit status

This happens whether you build HDF5 inside or outside of Spack, and running `libtoolize` and `autoreconf -if` don't seem to fix it.  It's fixed in HDF5 `1.10` and later versions of `1.8`.

This adds a post-configure step to remove the spurious `-l`s from the `libtool` script, which makes `1.8.12`-`1.8.14` build correctly.