### PR TITLE
Added needed dependencies for bbcp

### DIFF
--- a/var/spack/repos/builtin/packages/bbcp/package.py
+++ b/var/spack/repos/builtin/packages/bbcp/package.py
@@ -32,6 +32,9 @@ class Bbcp(Package):
     version('git', git='http://www.slac.stanford.edu/~abh/bbcp/bbcp.git',
             branch="master")
 
+    depends_on('zlib')
+    depends_on('openssl')
+
     def install(self, spec, prefix):
         cd("src")
         make()


### PR DESCRIPTION
I tried installing bbcp on a new and very vanilla rhel7 box and these dependencies were needed to build bbcp.