### PR TITLE
documentation: build-system phases + build-time tests

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2022,8 +2022,8 @@ The classes that are currently provided by Spack are:
     |                                    | specialized for any build system |
     +------------------------------------+----------------------------------+
     |   :py:class:`.MakefilePackage`     | Specialized class for packages   |
-    |                                    | that are built invoking an       |
-    |                                    | hand-written Makefile            |
+    |                                    | that are built invoking          |
+    |                                    | hand-written Makefiles           |
     +------------------------------------+----------------------------------+
     |   :py:class:`.AutotoolsPackage`    | Specialized class for packages   |
     |                                    | that are built using GNU         |
@@ -2084,14 +2084,14 @@ using the ``spack info`` command:
     Description:
         GNU M4 is an implementation of the traditional Unix macro processor.
 
-Typically, phases have  default implementations that fit most of the common cases:
+Typically, phases have default implementations that fit most of the common cases:
 
 .. literalinclude:: ../../../lib/spack/spack/build_systems/autotools.py
     :pyobject: AutotoolsPackage.configure
     :linenos:
 
 making it just sufficient for a packager to override a few
-build-system specific helper methods or attributes to provide, for instance,
+build system specific helper methods or attributes to provide, for instance,
 configure arguments:
 
 .. literalinclude::  ../../../var/spack/repos/builtin/packages/m4/package.py
@@ -2099,7 +2099,7 @@ configure arguments:
     :linenos:
 
 .. note::
-    Each specific build-system has a list of attributes that can be overridden to
+    Each specific build system has a list of attributes that can be overridden to
     fine-tune the installation of a package without overriding an entire phase. To
     have more information on them the place to go is the API docs at the end of this manual.
 
@@ -2109,7 +2109,7 @@ Overriding an entire phase
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In extreme cases it may be necessary to override an entire phase. Regardless
-of the build-system in use the signature for it is:
+of the build system in use the signature for it is:
 
 .. code-block:: python
 
@@ -2761,8 +2761,8 @@ Build-time tests
 
 Sometimes packages finish to build "correctly" and issues with their run-time
 behavior are discovered only at a later stage, maybe after a full software stack
-relying on them has already been built. To avoid situation of that kind it's possible
-to code build-time tests that will be executed only if the option ``--run-tests``
+relying on them has already been built. To avoid situations of that kind it's possible
+to write build-time tests that will be executed only if the option ``--run-tests``
 of ``spack install`` has been activated.
 
 The proper way to write these tests is relying on two decorators that come with
@@ -2781,6 +2781,16 @@ function to be invoked after the ``build`` phase has been executed, while the
 second one makes the invocation  conditional on the fact that ``self.run_tests == True``.
 It is also possible to schedule a function to be invoked *before* a given phase
 using the ``MakefilePackage.precondition`` decorator.
+
+.. note::
+
+    Default implementations for build-time tests
+
+        Packages that are built using specific build systems may have already a
+        default implementation for build-time tests. For instance :py:class:`~.AutotoolsPackage`
+        based packages will try to invoke ``make test`` and ``make check`` if
+        Spack is asked to run tests. You'll find more information on each class
+        looking at the :py:mod:`~.build_systems` documentation.
 
 .. _file-manipulation:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1999,6 +1999,8 @@ the Python extensions provided by them: once for ``+python`` and once
 for ``~python``.  Other than using a little extra disk space, that
 solution has no serious problems.
 
+.. _installation_procedure:
+
 ---------------------------------------
 Implementing the installation procedure
 ---------------------------------------
@@ -2697,9 +2699,9 @@ build system.
 
 .. _sanity-checks:
 
--------------------------------
-Sanity checking an installation
--------------------------------
+------------------------
+Checking an installation
+------------------------
 
 By default, Spack assumes that a build has failed if nothing is
 written to the install prefix, and that it has succeeded if anything
@@ -2718,15 +2720,17 @@ Consider a simple autotools build like this:
 If you are using using standard autotools or CMake, ``configure`` and
 ``make`` will not write anything to the install prefix.  Only ``make
 install`` writes the files, and only once the build is already
-complete.  Not all builds are like this.  Many builds of scientific
-software modify the install prefix *before* ``make install``. Builds
-like this can falsely report that they were successfully installed if
-an error occurs before the install is complete but after files have
-been written to the ``prefix``.
+complete.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ``sanity_check_is_file`` and ``sanity_check_is_dir``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Not all builds are like this.  Many builds of scientific
+software modify the install prefix *before* ``make install``. Builds
+like this can falsely report that they were successfully installed if
+an error occurs before the install is complete but after files have
+been written to the ``prefix``.
 
 You can optionally specify *sanity checks* to deal with this problem.
 Add properties like this to your package:
@@ -2750,6 +2754,33 @@ Now, after ``install()`` runs, Spack will check whether
 the build will fail and the install prefix will be removed.  If they
 succeed, Spack considers the build successful and keeps the prefix in
 place.
+
+^^^^^^^^^^^^^^^^
+Build-time tests
+^^^^^^^^^^^^^^^^
+
+Sometimes packages finish to build "correctly" and issues with their run-time
+behavior are discovered only at a later stage, maybe after a full software stack
+relying on them has already been built. To avoid situation of that kind it's possible
+to code build-time tests that will be executed only if the option ``--run-tests``
+of ``spack install`` has been activated.
+
+The proper way to write these tests is relying on two decorators that come with
+any base class listed in :ref:`installation_procedure`.
+
+.. code-block:: python
+
+   @MakefilePackage.sanity_check('build')
+   @MakefilePackage.on_package_attributes(run_tests=True)
+   def check_build(self):
+        # Custom implementation goes here
+        pass
+
+The first decorator ``MakefilePackage.sanity_check('build')`` schedules this
+function to be invoked after the ``build`` phase has been executed, while the
+second one makes the invocation  conditional on the fact that ``self.run_tests == True``.
+It is also possible to schedule a function to be invoked *before* a given phase
+using the ``MakefilePackage.precondition`` decorator.
 
 .. _file-manipulation:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2035,6 +2035,11 @@ The classes that are currently provided by Spack are:
     |  :py:class:`.RPackage`             | Specialized class for            |
     |                                    | :py:class:`.R` extensions        |
     +------------------------------------+----------------------------------+
+    |  :py:class:`.PythonPackage`        | Specialized class for            |
+    |                                    | :py:class:`.Python` extensions   |
+    +------------------------------------+----------------------------------+
+
+
 
 .. note::
     Choice of the appropriate base class for a package

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2036,15 +2036,24 @@ The classes that are currently provided by Spack are:
     |                                    | :py:class:`.R` extensions        |
     +------------------------------------+----------------------------------+
 
+.. note::
+    Choice of the appropriate base class for a package
+        In most cases packagers don't have to worry about the selection of the right base class
+        for a package, as ``spack create`` will make the appropriate choice on their behalf. In those
+        rare cases where manual intervention is needed we need to stress that a
+        package base class depends on the *build system* being used, not the language of the package.
+        For example, a Python extension installed with CMake would ``extends('python')`` and
+        subclass from :py:class:`.CMakePackage`.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Mechanics of an installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When a user runs ``spack install``, Spack:
 
-* fetches an archive for the correct version of the software
-* expands the archive
-* sets the current working directory to the root directory of the expanded archive
+* Fetches an archive for the correct version of the software
+* Expands the archive
+* Sets the current working directory to the root directory of the expanded archive
 
 Then, depending on the base class of the package under consideration, it will execute
 a certain number of **phases** that reflect the way a package of that type is usually built.
@@ -2101,8 +2110,8 @@ configure arguments:
 .. note::
     Each specific build system has a list of attributes that can be overridden to
     fine-tune the installation of a package without overriding an entire phase. To
-    have more information on them the place to go is the API docs at the end of this manual.
-
+    have more information on them the place to go is the API docs of the :py:mod:`~.build_systems`
+    module.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Overriding an entire phase

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2011,8 +2011,8 @@ the package you'll need to customize for each piece of software.
 
 Defining an installation procedure means overriding a set of methods or attributes
 that will be called at some point during the installation of the package.
-What determines the actual set of entities that are available for overriding
-is the package base class, which is usually specialized for a given build system.
+The package base class, usually specialized for a given build system, determines the
+actual set of entities available for overriding.
 The classes that are currently provided by Spack are:
 
     +------------------------------------+----------------------------------+
@@ -2022,15 +2022,14 @@ The classes that are currently provided by Spack are:
     |                                    | specialized for any build system |
     +------------------------------------+----------------------------------+
     |   :py:class:`.MakefilePackage`     | Specialized class for packages   |
-    |                                    | that are built invoking          |
+    |                                    | built invoking                   |
     |                                    | hand-written Makefiles           |
     +------------------------------------+----------------------------------+
     |   :py:class:`.AutotoolsPackage`    | Specialized class for packages   |
-    |                                    | that are built using GNU         |
-    |                                    | Autotools                        |
+    |                                    | built using GNU Autotools        |
     +------------------------------------+----------------------------------+
     |  :py:class:`.CMakePackage`         | Specialized class for packages   |
-    |                                    | that are built using CMake       |
+    |                                    | built using CMake                |
     +------------------------------------+----------------------------------+
     |  :py:class:`.RPackage`             | Specialized class for            |
     |                                    | :py:class:`.R` extensions        |
@@ -2056,14 +2055,14 @@ Installation pipeline
 
 When a user runs ``spack install``, Spack:
 
-* Fetches an archive for the correct version of the software
-* Expands the archive
-* Sets the current working directory to the root directory of the expanded archive
+1. Fetches an archive for the correct version of the software.
+2. Expands the archive.
+3. Sets the current working directory to the root directory of the expanded archive.
 
 Then, depending on the base class of the package under consideration, it will execute
 a certain number of **phases** that reflect the way a package of that type is usually built.
-The name and order in which the phases will be executed can be obtained either reading the API docs in this manual, or
-using the ``spack info`` command:
+The name and order in which the phases will be executed can be obtained either reading the API
+docs at :py:mod:`~.spack.build_systems`, or using the ``spack info`` command:
 
 .. code-block:: console
     :emphasize-lines: 13,14
@@ -2086,17 +2085,8 @@ using the ``spack info`` command:
     Build Dependencies:
         libsigsegv
 
-    Link Dependencies:
-        libsigsegv
+    ...
 
-    Run Dependencies:
-        None
-
-    Virtual Packages:
-        None
-
-    Description:
-        GNU M4 is an implementation of the traditional Unix macro processor.
 
 Typically, phases have default implementations that fit most of the common cases:
 
@@ -2104,7 +2094,7 @@ Typically, phases have default implementations that fit most of the common cases
     :pyobject: AutotoolsPackage.configure
     :linenos:
 
-making it just sufficient for a packager to override a few
+It is thus just sufficient for a packager to override a few
 build system specific helper methods or attributes to provide, for instance,
 configure arguments:
 
@@ -2123,7 +2113,8 @@ Overriding an entire phase
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In extreme cases it may be necessary to override an entire phase. Regardless
-of the build system in use the signature for it is:
+of the build system, the signature is the same. For example, the signature
+for the install phase is:
 
 .. code-block:: python
 
@@ -2800,11 +2791,12 @@ using the ``MakefilePackage.precondition`` decorator.
 
     Default implementations for build-time tests
 
-        Packages that are built using specific build systems may have already a
+        Packages that are built using specific build systems may already have a
         default implementation for build-time tests. For instance :py:class:`~.AutotoolsPackage`
         based packages will try to invoke ``make test`` and ``make check`` if
-        Spack is asked to run tests. You'll find more information on each class
-        looking at the :py:mod:`~.spack.build_systems` documentation.
+        Spack is asked to run tests.
+        More information on each class is available in the the :py:mod:`~.spack.build_systems`
+        documentation.
 
 .. warning::
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2110,7 +2110,7 @@ configure arguments:
 .. note::
     Each specific build system has a list of attributes that can be overridden to
     fine-tune the installation of a package without overriding an entire phase. To
-    have more information on them the place to go is the API docs of the :py:mod:`~.build_systems`
+    have more information on them the place to go is the API docs of the :py:mod:`~.spack.build_systems`
     module.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2799,7 +2799,7 @@ using the ``MakefilePackage.precondition`` decorator.
         default implementation for build-time tests. For instance :py:class:`~.AutotoolsPackage`
         based packages will try to invoke ``make test`` and ``make check`` if
         Spack is asked to run tests. You'll find more information on each class
-        looking at the :py:mod:`~.build_systems` documentation.
+        looking at the :py:mod:`~.spack.build_systems` documentation.
 
 .. _file-manipulation:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2011,7 +2011,7 @@ Defining an installation procedure means overriding a set of methods or attribut
 that will be called at some point during the installation of the package.
 What determines the actual set of entities that are available for overriding
 is the package base class, which is usually specialized for a given build system.
-The classes that are currently provided by ``Spack`` are:
+The classes that are currently provided by Spack are:
 
     +------------------------------------+----------------------------------+
     |                                    |   **Base class purpose**         |

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2045,9 +2045,9 @@ The classes that are currently provided by Spack are:
         For example, a Python extension installed with CMake would ``extends('python')`` and
         subclass from :py:class:`.CMakePackage`.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Mechanics of an installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
+Installation pipeline
+^^^^^^^^^^^^^^^^^^^^^
 
 When a user runs ``spack install``, Spack:
 
@@ -2735,7 +2735,7 @@ complete.
 ``sanity_check_is_file`` and ``sanity_check_is_dir``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Not all builds are like this.  Many builds of scientific
+Unfortunately, many builds of scientific
 software modify the install prefix *before* ``make install``. Builds
 like this can falsely report that they were successfully installed if
 an error occurs before the install is complete but after files have
@@ -2800,6 +2800,10 @@ using the ``MakefilePackage.precondition`` decorator.
         based packages will try to invoke ``make test`` and ``make check`` if
         Spack is asked to run tests. You'll find more information on each class
         looking at the :py:mod:`~.spack.build_systems` documentation.
+
+.. warning::
+
+    The API for adding tests is not yet considered stable and may change drastically in future releases.
 
 .. _file-manipulation:
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -40,52 +40,47 @@ class AutotoolsPackage(PackageBase):
 
     This class provides four phases that can be overridden:
 
-        1. :py:meth:`.AutotoolsPackage.autoreconf`
-        2. :py:meth:`.AutotoolsPackage.configure`
-        3. :py:meth:`.AutotoolsPackage.build`
-        4. :py:meth:`.AutotoolsPackage.install`
+        1. :py:meth:`~.AutotoolsPackage.autoreconf`
+        2. :py:meth:`~.AutotoolsPackage.configure`
+        3. :py:meth:`~.AutotoolsPackage.build`
+        4. :py:meth:`~.AutotoolsPackage.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override :py:meth:`.configure_args`:
-
-    .. code-block:: python
-
-        def configure_args(self):
-            spec = self.spec
-            args = ['--enable-c++']
-            # ...
-            return args
-
-    For a finer tuning you may override:
+    necessary will be to override :py:meth:`.configure_args`. For a finer
+    tuning you may override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:attr:`.AutotoolsPackage.build_targets`    | Specify ``make``   |
+        | :py:attr:`~.AutotoolsPackage.build_targets`   | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | build phase        |
         +-----------------------------------------------+--------------------+
-        | :py:attr:`.AutotoolsPackage.install_targets`  | Specify ``make``   |
+        | :py:attr:`~.AutotoolsPackage.install_targets` | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | install phase      |
         +-----------------------------------------------+--------------------+
+        | :py:meth:`~.AutotoolsPackage.check`           | Run  build time    |
+        |                                               | tests if required  |
+        +-----------------------------------------------+--------------------+
 
     """
-    #: phases of a GNU Autotools package
+    #: Phases of a GNU Autotools package
     phases = ['autoreconf', 'configure', 'build', 'install']
-    #: this attribute is used in UI queries that require to know which
+    #: This attribute is used in UI queries that require to know which
     #: build-system class we are using
     build_system_class = 'AutotoolsPackage'
+    #: Whether to update or not ``config.guess`` on old architectures
     patch_config_guess = True
 
-    #: targets for ``make`` during the :py:meth:`.AutotoolsPackage.build`
+    #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.build`
     #: phase
     build_targets = []
-    #: targets for ``make`` during the :py:meth:`.AutotoolsPackage.install`
+    #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.install`
     #: phase
     install_targets = ['install']
 
-    def do_patch_config_guess(self):
+    def _do_patch_config_guess(self):
         """Some packages ship with an older config.guess and need to have
         this updated when installed on a newer architecture."""
 
@@ -111,7 +106,7 @@ class AutotoolsPackage(PackageBase):
                 check_call([my_config_guess], stdout=PIPE, stderr=PIPE)
                 # The package's config.guess already runs OK, so just use it
                 return True
-            except:
+            except Exception:
                 pass
         else:
             return True
@@ -129,7 +124,7 @@ class AutotoolsPackage(PackageBase):
                 check_call([config_guess], stdout=PIPE, stderr=PIPE)
                 shutil.copyfile(config_guess, my_config_guess)
                 return True
-            except:
+            except Exception:
                 pass
 
         # Look for the system's config.guess
@@ -146,7 +141,7 @@ class AutotoolsPackage(PackageBase):
                 check_call([config_guess], stdout=PIPE, stderr=PIPE)
                 shutil.copyfile(config_guess, my_config_guess)
                 return True
-            except:
+            except Exception:
                 pass
 
         return False
@@ -156,11 +151,17 @@ class AutotoolsPackage(PackageBase):
         return self.stage.source_path
 
     def patch(self):
-        """Perform any required patches."""
+        """Patches config.guess if
+        :py:attr:``~.AutotoolsPackage.patch_config_guess`` is True
+
+        :raise RuntimeError: if something goes wrong when patching
+            ``config.guess``
+        """
 
         if self.patch_config_guess and self.spec.satisfies(
-                'arch=linux-rhel7-ppc64le'):
-            if not self.do_patch_config_guess():
+                'arch=linux-rhel7-ppc64le'
+        ):
+            if not self._do_patch_config_guess():
                 raise RuntimeError('Failed to find suitable config.guess')
 
     def autoreconf(self, spec, prefix):
@@ -180,8 +181,10 @@ class AutotoolsPackage(PackageBase):
                     'configure script not found in {0}'.format(os.getcwd()))
 
     def configure_args(self):
-        """Returns a list containing all the arguments that must be passed to
+        """Produces a list containing all the arguments that must be passed to
         configure, except ``--prefix`` which will be pre-pended to the list.
+
+        :return: list of arguments for configure
         """
         return []
 
@@ -195,12 +198,16 @@ class AutotoolsPackage(PackageBase):
             inspect.getmodule(self).configure(*options)
 
     def build(self, spec, prefix):
-        """Makes the build targets"""
+        """Makes the build targets specified by
+        :py:attr:``~.AutotoolsPackage.build_targets``
+        """
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.build_targets)
 
     def install(self, spec, prefix):
-        """Makes the install targets"""
+        """Makes the install targets specified by
+        :py:attr:``~.AutotoolsPackage.install_targets``
+        """
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
@@ -220,8 +227,8 @@ class AutotoolsPackage(PackageBase):
             tty.msg('Skipping default sanity checks [method `check` not implemented]')  # NOQA: ignore=E501
 
     def check(self):
-        """Default test: search the Makefile for targets ``test`` and ``check``
-        and run them if found.
+        """Searches the Makefile for targets ``test`` and ``check``
+        and runs them if found.
         """
         with working_dir(self.build_directory()):
             self._if_make_target_execute('test')

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -36,7 +36,7 @@ from spack.package import PackageBase
 
 
 class AutotoolsPackage(PackageBase):
-    """Specialized class for packages that are built using GNU Autotools.
+    """Specialized class for packages built using GNU Autotools.
 
     This class provides four phases that can be overridden:
 
@@ -46,8 +46,8 @@ class AutotoolsPackage(PackageBase):
         4. :py:meth:`~.AutotoolsPackage.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override :py:meth:`.configure_args`. For a finer
-    tuning you may override:
+    necessary will be to override the helper method :py:meth:`.configure_args`.
+    For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
@@ -67,10 +67,10 @@ class AutotoolsPackage(PackageBase):
     """
     #: Phases of a GNU Autotools package
     phases = ['autoreconf', 'configure', 'build', 'install']
-    #: This attribute is used in UI queries that require to know which
-    #: build-system class we are using
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
     build_system_class = 'AutotoolsPackage'
-    #: Whether to update or not ``config.guess`` on old architectures
+    #: Whether or not to update ``config.guess`` on old architectures
     patch_config_guess = True
 
     #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.build`

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -34,7 +34,7 @@ from spack.package import PackageBase
 
 
 class CMakePackage(PackageBase):
-    """Specialized class for packages that are built using CMake
+    """Specialized class for packages built using CMake
 
     This class provides three phases that can be overridden:
 
@@ -44,7 +44,7 @@ class CMakePackage(PackageBase):
 
     They all have sensible defaults and for many packages the only thing
     necessary will be to override :py:meth:`~.CMakePackage.cmake_args`.
-    For a finer tuning you may override:
+    For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
@@ -54,9 +54,8 @@ class CMakePackage(PackageBase):
         |                                               | CMAKE_BUILD_TYPE   |
         |                                               | variable           |
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.CMakePackage.root_cmakelists_dir` | Directory where to |
-        |                                               | find the root      |
-        |                                               | CMakeLists.txt     |
+        | :py:meth:`~.CMakePackage.root_cmakelists_dir` | Location of the    |
+        |                                               | root CMakeLists.txt|
         +-----------------------------------------------+--------------------+
         | :py:meth:`~.CMakePackage.build_directory`     | Directory where to |
         |                                               | build the package  |
@@ -66,8 +65,8 @@ class CMakePackage(PackageBase):
     """
     #: Phases of a CMake package
     phases = ['cmake', 'build', 'install']
-    #: This attribute is used in UI queries that require to know which
-    #: build-system class we are using
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
     build_system_class = 'CMakePackage'
 
     build_targets = []
@@ -83,9 +82,9 @@ class CMakePackage(PackageBase):
         return 'RelWithDebInfo'
 
     def root_cmakelists_dir(self):
-        """Returns the directory where to find the root CMakeLists.txt
+        """Returns the location of the root CMakeLists.txt
 
-        :return: directory where the root CMakeLists.txt is located
+        :return: directory containing the root CMakeLists.txt
         """
         return self.stage.source_path
 
@@ -120,7 +119,7 @@ class CMakePackage(PackageBase):
         return args
 
     def build_directory(self):
-        """Returns the directory where to build the package
+        """Returns the directory to use when building the package
 
         :return: directory where to build the package
         """
@@ -172,8 +171,8 @@ class CMakePackage(PackageBase):
             tty.msg('Skipping default build sanity checks [method `check` not implemented]')  # NOQA: ignore=E501
 
     def check(self):
-        """Searches the Makefile for the target ``test`` and runs
-        it if found.
+        """Searches the CMake-generated Makefile for the target ``test``
+        and runs it if found.
         """
         with working_dir(self.build_directory()):
             self._if_make_target_execute('test')

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -38,19 +38,36 @@ class CMakePackage(PackageBase):
 
     This class provides three phases that can be overridden:
 
-    * cmake
-    * build
-    * install
+        1. :py:meth:`~.CMakePackage.cmake`
+        2. :py:meth:`~.CMakePackage.build`
+        3. :py:meth:`~.CMakePackage.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override ``cmake_args``
+    necessary will be to override :py:meth:`~.CMakePackage.cmake_args`.
+    For a finer tuning you may override:
 
-    Additionally, you may specify make targets for build and install
-    phases by overriding ``build_targets`` and ``install_targets``
+        +-----------------------------------------------+--------------------+
+        | **Method**                                    | **Purpose**        |
+        +===============================================+====================+
+        | :py:meth:`~.CMakePackage.build_type`          | Specify the value  |
+        |                                               | for the            |
+        |                                               | CMAKE_BUILD_TYPE   |
+        |                                               | variable           |
+        +-----------------------------------------------+--------------------+
+        | :py:meth:`~.CMakePackage.root_cmakelists_dir` | Directory where to |
+        |                                               | find the root      |
+        |                                               | CMakeLists.txt     |
+        +-----------------------------------------------+--------------------+
+        | :py:meth:`~.CMakePackage.build_directory`     | Directory where to |
+        |                                               | build the package  |
+        +-----------------------------------------------+--------------------+
+
+
     """
+    #: Phases of a CMake package
     phases = ['cmake', 'build', 'install']
-    # To be used in UI queries that require to know which
-    # build-system class we are using
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
     build_system_class = 'CMakePackage'
 
     build_targets = []
@@ -59,19 +76,25 @@ class CMakePackage(PackageBase):
     depends_on('cmake', type='build')
 
     def build_type(self):
-        """Override to provide the correct build_type in case a complex
-        logic is needed
+        """Returns the correct value for the ``CMAKE_BUILD_TYPE`` variable
+
+        :return: value for ``CMAKE_BUILD_TYPE``
         """
         return 'RelWithDebInfo'
 
     def root_cmakelists_dir(self):
-        """Directory where to find the root CMakeLists.txt"""
+        """Returns the directory where to find the root CMakeLists.txt
+
+        :return: directory where the root CMakeLists.txt is located
+        """
         return self.stage.source_path
 
     @property
     def std_cmake_args(self):
         """Standard cmake arguments provided as a property for
         convenience of package writers
+
+        :return: standard cmake arguments
         """
         # standard CMake arguments
         return CMakePackage._std_args(self)
@@ -97,20 +120,27 @@ class CMakePackage(PackageBase):
         return args
 
     def build_directory(self):
-        """Override to provide another place to build the package"""
+        """Returns the directory where to build the package
+
+        :return: directory where to build the package
+        """
         return join_path(self.stage.source_path, 'spack-build')
 
     def cmake_args(self):
-        """Method to be overridden. Should return an iterable containing
-        all the arguments that must be passed to configure, except:
+        """Produces a list containing all the arguments that must be passed to
+        cmake, except:
 
-        * CMAKE_INSTALL_PREFIX
-        * CMAKE_BUILD_TYPE
+            * CMAKE_INSTALL_PREFIX
+            * CMAKE_BUILD_TYPE
+
+        which will be set automatically.
+
+        :return: list of arguments for cmake
         """
         return []
 
     def cmake(self, spec, prefix):
-        """Run cmake in the build directory"""
+        """Runs ``cmake`` in the build directory"""
         options = [self.root_cmakelists_dir()] + self.std_cmake_args + \
             self.cmake_args()
         with working_dir(self.build_directory(), create=True):
@@ -142,8 +172,8 @@ class CMakePackage(PackageBase):
             tty.msg('Skipping default build sanity checks [method `check` not implemented]')  # NOQA: ignore=E501
 
     def check(self):
-        """Default test: search the Makefile for the target ``test``
-        and run them if found.
+        """Searches the Makefile for the target ``test`` and runs
+        it if found.
         """
         with working_dir(self.build_directory()):
             self._if_make_target_execute('test')

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -39,8 +39,8 @@ class MakefilePackage(PackageBase):
         2. :py:meth:`~.MakefilePackage.build`
         3. :py:meth:`~.MakefilePackage.install`
 
-    It is necessary to override the :py:meth:`~.MakefilePackage.edit` phase,
-    while :py:meth:`~.MakefilePackage.build` and
+    It is usually necessary to override the :py:meth:`~.MakefilePackage.edit`
+    phase, while :py:meth:`~.MakefilePackage.build` and
     :py:meth:`~.MakefilePackage.install` have sensible defaults.
     For a finer tuning you may override:
 
@@ -61,8 +61,8 @@ class MakefilePackage(PackageBase):
     """
     #: Phases of a package that is built with an hand-written Makefile
     phases = ['edit', 'build', 'install']
-    #: This attribute is used in UI queries that require to know which
-    #: build-system class we are using
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
     build_system_class = 'MakefilePackage'
 
     #: Targets for ``make`` during the :py:meth:`~.MakefilePackage.build`
@@ -73,7 +73,7 @@ class MakefilePackage(PackageBase):
     install_targets = ['install']
 
     def build_directory(self):
-        """Returns the directory where the main Makefile is located
+        """Returns the directory containing the main Makefile
 
         :return: build directory
         """
@@ -81,19 +81,19 @@ class MakefilePackage(PackageBase):
 
     def edit(self, spec, prefix):
         """Edits the Makefile before calling make. This phase cannot
-        be defaulted for obvious reasons.
+        be defaulted.
         """
         tty.msg('Using default implementation: skipping edit phase.')
 
     def build(self, spec, prefix):
-        """Calls make passing :py:attr:`~.MakefilePackage.build_targets`
+        """Calls make, passing :py:attr:`~.MakefilePackage.build_targets`
         as targets.
         """
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.build_targets)
 
     def install(self, spec, prefix):
-        """Calls make passing :py:attr:`~.MakefilePackage.install_targets`
+        """Calls make, passing :py:attr:`~.MakefilePackage.install_targets`
         as targets.
         """
         with working_dir(self.build_directory()):

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -35,36 +35,67 @@ class MakefilePackage(PackageBase):
 
     This class provides three phases that can be overridden:
 
-    * edit
-    * build
-    * install
+        1. :py:meth:`~.MakefilePackage.edit`
+        2. :py:meth:`~.MakefilePackage.build`
+        3. :py:meth:`~.MakefilePackage.install`
 
-    It is necessary to override the 'edit' phase, while 'build' and 'install'
-    have sensible defaults.
+    It is necessary to override the :py:meth:`~.MakefilePackage.edit` phase,
+    while :py:meth:`~.MakefilePackage.build` and
+    :py:meth:`~.MakefilePackage.install` have sensible defaults.
+    For a finer tuning you may override:
+
+        +-----------------------------------------------+--------------------+
+        | **Method**                                    | **Purpose**        |
+        +===============================================+====================+
+        | :py:attr:`~.MakefilePackage.build_targets`    | Specify ``make``   |
+        |                                               | targets for the    |
+        |                                               | build phase        |
+        +-----------------------------------------------+--------------------+
+        | :py:attr:`~.MakefilePackage.install_targets`  | Specify ``make``   |
+        |                                               | targets for the    |
+        |                                               | install phase      |
+        +-----------------------------------------------+--------------------+
+        | :py:meth:`~.MakefilePackage.build_directory`  | Directory where the|
+        |                                               | Makefile is located|
+        +-----------------------------------------------+--------------------+
     """
+    #: Phases of a package that is built with an hand-written Makefile
     phases = ['edit', 'build', 'install']
-    # To be used in UI queries that require to know which
-    # build-system class we are using
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
     build_system_class = 'MakefilePackage'
 
+    #: Targets for ``make`` during the :py:meth:`~.MakefilePackage.build`
+    #: phase
     build_targets = []
+    #: Targets for ``make`` during the :py:meth:`~.MakefilePackage.install`
+    #: phase
     install_targets = ['install']
 
     def build_directory(self):
-        """Directory where the main Makefile is located"""
+        """Returns the directory where the main Makefile is located
+
+        :return: build directory
+        """
         return self.stage.source_path
 
     def edit(self, spec, prefix):
-        """This phase cannot be defaulted for obvious reasons..."""
+        """Edits the Makefile before calling make. This phase cannot
+        be defaulted for obvious reasons.
+        """
         tty.msg('Using default implementation: skipping edit phase.')
 
     def build(self, spec, prefix):
-        """Make the build targets"""
+        """Calls make passing :py:attr:`~.MakefilePackage.build_targets`
+        as targets.
+        """
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.build_targets)
 
     def install(self, spec, prefix):
-        """Make the install targets"""
+        """Calls make passing :py:attr:`~.MakefilePackage.install_targets`
+        as targets.
+        """
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -34,7 +34,7 @@ class RPackage(PackageBase):
 
     This class provides a single phase that can be overridden:
 
-    * install
+        1. :py:meth:`~.RPackage.install`
 
     It has sensible defaults and for many packages the only thing
     necessary will be to add dependencies
@@ -48,7 +48,7 @@ class RPackage(PackageBase):
     extends('r')
 
     def install(self, spec, prefix):
-        """Install the R package"""
+        """Installs an R package."""
         inspect.getmodule(self).R(
             'CMD', 'INSTALL',
             '--library={0}'.format(self.module.r_lib_dir),

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -36,13 +36,13 @@ class RPackage(PackageBase):
 
         1. :py:meth:`~.RPackage.install`
 
-    It has sensible defaults and for many packages the only thing
+    It has sensible defaults, and for many packages the only thing
     necessary will be to add dependencies
     """
     phases = ['install']
 
-    # To be used in UI queries that require to know which
-    # build-system class we are using
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
     build_system_class = 'RPackage'
 
     extends('r')

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1706,9 +1706,13 @@ class PackageBase(object):
 
 
 class Package(PackageBase):
+    """General purpose class with a single ``install``
+    phase that needs to be coded by packagers.
+    """
+    #: The one and only phase
     phases = ['install']
-    # To be used in UI queries that require to know which
-    # build-system class we are using
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
     build_system_class = 'Package'
     # This will be used as a registration decorator in user
     # packages, if need be


### PR DESCRIPTION
This PR adds the information needed to grasp how build-system base classes work, and how to code functions that implement build-time checks activated by the `--run-tests` option of `spack install`. It also improves the formatting of in-code documentation for build_system classes.

##### Modifications

- [x] fixes #2606 
- [x] fixes #2605 


