### PR TITLE
openjpeg: fixes url

### DIFF
--- a/var/spack/repos/builtin/packages/openjpeg/package.py
+++ b/var/spack/repos/builtin/packages/openjpeg/package.py
@@ -43,3 +43,7 @@ class Openjpeg(CMakePackage):
     version('2.0',   'cdf266530fee8af87454f15feb619609')
     version('1.5.2', '545f98923430369a6b046ef3632ef95c')
     version('1.5.1', 'd774e4b5a0db5f0f171c4fc0aabfa14e')
+
+    def url_for_version(self, version):
+        fmt = 'https://github.com/uclouvain/openjpeg/archive/version.{0}.tar.gz'
+        return fmt.format(version.dotted)


### PR DESCRIPTION
Without this PR I get:
```console
$ spack install openjpeg
==> Installing openjpeg
==> cmake is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-ubuntu14-x86_64/gcc-4.8/cmake-3.7.1-uibq42knjyr22hm7l44emyo7cpwmzneb
==> Fetching file:///home/mculpo/production/spack-mirror/openjpeg/openjpeg-2.1.tar.gz
curl: (37) Couldn't open file /home/mculpo/production/spack-mirror/openjpeg/openjpeg-2.1.tar.gz
==> Fetching from file:///home/mculpo/production/spack-mirror/openjpeg/openjpeg-2.1.tar.gz failed.
==> Fetching https://github.com/uclouvain/openjpeg/archive/v2.1.tar.gz
######################################################################## 100,0%
curl: (22) The requested URL returned error: 404 Not Found
==> Fetching from https://github.com/uclouvain/openjpeg/archive/v2.1.tar.gz failed.
==> Error: FetchError: All fetchers failed for openjpeg-2.1-7t3i5lhnszqcvfzvsc3irdwsrr33ckkb
```

It seems that the url mechanism changed at some point and `openjpeg` was left behind.