### PR TITLE
Change nargs='*' to argparse.REMAINDER for constraint options.

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -75,7 +75,7 @@ class ConstraintAction(argparse.Action):
 
 
 _arguments['constraint'] = Args(
-    'constraint', nargs='*', action=ConstraintAction,
+    'constraint', nargs=argparse.REMAINDER, action=ConstraintAction,
     help='Constraint to select a subset of installed packages')
 
 _arguments['module_type'] = Args(

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -117,7 +117,8 @@ def find(parser, args):
 
     # Exit early if no package matches the constraint
     if not query_specs and args.constraint:
-        msg = "No package matches the query: {0}".format(args.constraint)
+        msg = "No package matches the query: {0}".format(
+            ' '.join(args.constraint))
         tty.msg(msg)
         return
 


### PR DESCRIPTION
Fixes #2796.

This reverts spec arguments to `spack find` and `spack module` to use `nargs=argparse.REMAINDER` instead of `nargs='*'`