### PR TITLE
Add Astra package

### DIFF
--- a/var/spack/repos/builtin/packages/astra/package.py
+++ b/var/spack/repos/builtin/packages/astra/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Astra(Package):
+    """A Space Charge Tracking Algorithm."""
+
+    homepage = "http://www.desy.de/~mpyflo/"
+
+    version('2016-11-30', '17135b7a4adbacc1843a50a6a2ae2c25', expand=False,
+            url='http://www.desy.de/~mpyflo/Astra_for_64_Bit_Linux/Astra')
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install('Astra', prefix.bin)
+
+        chmod = which('chmod')
+        chmod('+x', join_path(prefix.bin, 'Astra'))


### PR DESCRIPTION
A couple hurdles with this package. If you check the download directory, you'll see that the developer does not provide any tarballs for Astra. I'm not sure if any of the other files in http://www.desy.de/~mpyflo/Astra_for_64_Bit_Linux/ are important or not.

Since the software is unversioned, I just used the date it was last updated on as the version number.