### PR TITLE
spack mirror: fixed copying error 

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -104,6 +104,9 @@ def get_matching_versions(specs, **kwargs):
                 s = Spec(pkg.name)
                 s.versions = VersionList([v])
                 s.variants = spec.variants.copy()
+                # This is needed to avoid hanging references during the
+                # concretization phase
+                s.variants.spec = s
                 matching_spec.append(s)
 
         if not matching_spec:


### PR DESCRIPTION
In the current develop:
```console
$ spack mirror create -d ~/production/spack-mirror -D hdf5
Traceback (most recent call last):
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 212, in <module>
    main(sys.argv)
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 208, in main
    _main(args, unknown)
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 174, in _main
    return_val = command(parser, args)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/cmd/mirror.py", line 224, in mirror
    action[args.mirror_command](args)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/cmd/mirror.py", line 202, in mirror_create
    directory, specs, num_versions=args.one_version_per_spec)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/mirror.py", line 167, in create
    s.concretize()
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1520, in concretize
    changes = (self.normalize(force),
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1816, in normalize
    any_change = self._normalize_helper(visited, spec_deps, provider_index)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1765, in _normalize_helper
    pkg_dep = self._evaluate_dependency_conditions(dep_name)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1629, in _evaluate_dependency_conditions
    sat = self.satisfies(when_spec, strict=True)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2070, in satisfies
    return self.satisfies_dependencies(other, strict=deps_strict)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2100, in satisfies_dependencies
    self_index = ProviderIndex(self.traverse(), restrict=True)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/provider_index.py", line 87, in __init__
    self.update(spec)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/provider_index.py", line 106, in update
    if spec.satisfies(provider_spec, deps=False):
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2049, in satisfies
    if not self.variants.satisfies(other.variants, strict=var_strict):
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 627, in satisfies
    if strict or self.spec._concrete:
AttributeError: 'NoneType' object has no attribute '_concrete'
```
This happens because the `VariantMap` part of a spec does not get copied correctly. This PR is a quick fix to the issue. I think a more extensive refactoring is in order and I'll be willing to do it once #2386 is merged.