### PR TITLE
configure and build command: fix the stop iteration semantics 

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -553,6 +553,11 @@ def fork(pkg, function, dirty=False):
             setup_package(pkg, dirty=dirty)
             function(input_stream)
             child_connection.send(None)
+        except StopIteration as e:
+            # StopIteration is used to stop installations
+            # before the final stage, mainly for debug purposes
+            tty.msg(e.message)
+            child_connection.send(None)
         except:
             # catch ANYTHING that goes wrong in the child process
             exc_type, exc, tb = sys.exc_info()


### PR DESCRIPTION
In the current develop:
```console
$ spack  configure openjpeg
==> Checking dependencies for ['openjpeg']
==> cmake is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-ubuntu14-x86_64/gcc-4.8/cmake-3.7.1-uibq42knjyr22hm7l44emyo7cpwmzneb
==> Installing openjpeg
==> Using cached archive: /home/mculpo/PycharmProjects/spack/var/spack/cache/openjpeg/openjpeg-2.1.tar.gz
==> Already staged openjpeg-2.1-7t3i5lhnszqcvfzvsc3irdwsrr33ckkb in /home/mculpo/PycharmProjects/spack/var/spack/stage/openjpeg-2.1-7t3i5lhnszqcvfzvsc3irdwsrr33ckkb
==> No patches needed for openjpeg
==> Building openjpeg [CMakePackage]
==> Executing phase : 'cmake'
==> Error: StopIteration: Stopping at 'cmake' phase
/home/mculpo/PycharmProjects/spack/lib/spack/spack/package.py:1267, in build_process:
#
# Stack trace follows
#
```
with this PR
```console
$ spack configure openjpeg
==> Checking dependencies for ['openjpeg']
==> cmake is already installed in /home/mculpo/PycharmProjects/spack/opt/spack/linux-ubuntu14-x86_64/gcc-4.8/cmake-3.7.1-uibq42knjyr22hm7l44emyo7cpwmzneb
==> Installing openjpeg
==> Using cached archive: /home/mculpo/PycharmProjects/spack/var/spack/cache/openjpeg/openjpeg-2.1.tar.gz
==> Staging archive: /home/mculpo/PycharmProjects/spack/var/spack/stage/openjpeg-2.1-7t3i5lhnszqcvfzvsc3irdwsrr33ckkb/version.2.1.tar.gz
==> Created stage in /home/mculpo/PycharmProjects/spack/var/spack/stage/openjpeg-2.1-7t3i5lhnszqcvfzvsc3irdwsrr33ckkb
==> No patches needed for openjpeg
==> Building openjpeg [CMakePackage]
==> Executing phase : 'cmake'
==> Stopping at 'cmake' phase
```