### PR TITLE
boost: fixing boost-1.55.0 for gcc-5

### DIFF
--- a/var/spack/repos/builtin/packages/boost/boost_10125.patch
+++ b/var/spack/repos/builtin/packages/boost/boost_10125.patch
@@ -1,0 +1,51 @@
+--- a/boost/thread/pthread/once.hpp
++++ b/boost/thread/pthread/once.hpp
+@@ -42,7 +42,7 @@ namespace boost
+   }
+ 
+ #ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+     template<typename Function, class ...ArgTypes>
+     inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+ #else
+@@ -65,7 +65,7 @@ namespace boost
+   private:
+       volatile thread_detail::uintmax_atomic_t epoch;
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+       template<typename Function, class ...ArgTypes>
+       friend void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+ #else
+@@ -118,7 +118,7 @@ namespace boost
+     // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2444.html
+ 
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ 
+ 
+   template<typename Function, class ...ArgTypes>
+--- a/boost/thread/pthread/once_atomic.hpp
++++ b/boost/thread/pthread/once_atomic.hpp
+@@ -115,7 +115,7 @@ namespace boost
+ #endif
+ 
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ 
+   template<typename Function, class ...ArgTypes>
+   inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args)
+--- a/boost/thread/win32/once.hpp
++++ b/boost/thread/win32/once.hpp
+@@ -227,7 +227,7 @@ namespace boost
+         }
+     }
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined BOOST_NO_CXX11_VARIADIC_TEMPLATES && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ //#if defined(BOOST_THREAD_RVALUE_REFERENCES_DONT_MATCH_FUNTION_PTR)
+     inline void call_once(once_flag& flag, void (*f)())
+     {

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -130,6 +130,9 @@ class Boost(Package):
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11856
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
+    # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
+    patch('boost_10125.patch', when='@1.55.0%gcc@5.0:5.9')
+
     def url_for_version(self, version):
         """
         Handle Boost's weird URLs,


### PR DESCRIPTION
This is mostly the patch from the [boost ticket](https://svn.boost.org/trac/boost/ticket/10125).

The only caveat is I had to remove `include/` from the patch of the files to patch. Not sure why it was there, and what's the difference is.

Fixes #2821.