### PR TITLE
Clang & Boost: No PCH

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -254,6 +254,13 @@ class Boost(Package):
                 'toolset=%s' % self.determine_toolset(spec)
             ])
 
+        # clang is not officially supported for pre-compiled headers
+        # and at least in clang 3.9 still fails to build
+        #   http://www.boost.org/build/doc/html/bbv2/reference/precompiled_headers.html
+        #   https://svn.boost.org/trac/boost/ticket/12496
+        if spec.satisfies('%clang'):
+            options.extend(['pch=off'])
+
         return threadingOpts
 
     def add_buildopt_symlinks(self, prefix):


### PR DESCRIPTION
Although it hurts a little: officially, *pre-compiled headers* (PCH) in boost are only supported for [gcc & msvc](http://www.boost.org/build/doc/html/bbv2/reference/precompiled_headers.html) and the latest clang release (3.9) still fails to build boost.

Therefore, I disabled building those to get boost build with clang 3.9.0 on an Ubuntu 14.04 (x86).

Links to documentation and [boost bug report](https://svn.boost.org/trac/boost/ticket/12496) are inline, so people can later on check if they still apply. Seems just to be a bug in `Boost.Build` which tries to set `-o` with multiple output files during PCH install.