### PR TITLE
isl: add latest version (0.18)

### DIFF
--- a/var/spack/repos/builtin/packages/isl/package.py
+++ b/var/spack/repos/builtin/packages/isl/package.py
@@ -31,6 +31,7 @@ class Isl(Package):
     homepage = "http://isl.gforge.inria.fr"
     url      = "http://isl.gforge.inria.fr/isl-0.14.tar.bz2"
 
+    version('0.18', '11436d6b205e516635b666090b94ab32')
     version('0.14', 'acd347243fca5609e3df37dba47fd0bb')
 
     depends_on("gmp")


### PR DESCRIPTION
Added latest stable version of `isl`. Needed a newer version of `isl` to get llvm/clang in the current trunk to build via spack, but there are more versions available.

What is the policy regarding those ~7 other intermediate versions? Just add the latest stable for now?

P.S.: still problems installing `libc++` in `llvm@trunk`