### PR TITLE
Don't duplicate spack test in spack help

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -39,10 +39,10 @@ import spack.store
 #
 # Settings for commands that modify configuration
 #
-# Commands that modify confguration By default modify the *highest*
+# Commands that modify configuration by default modify the *highest*
 # priority scope.
 default_modify_scope = spack.config.highest_precedence_scope().name
-# Commands that list confguration list *all* scopes by default.
+# Commands that list configuration list *all* scopes by default.
 default_list_scope = None
 
 # cmd has a submodule called "list" so preserve the python list module
@@ -61,7 +61,6 @@ for file in os.listdir(command_path):
     if file.endswith(".py") and not re.search(ignore_files, file):
         cmd = re.sub(r'.py$', '', file)
         commands.append(cmd)
-commands.append('test')
 commands.sort()
 
 


### PR DESCRIPTION
If you run `spack help`, you'll notice that the `test` subcommand is duplicated:
```
$ spack help
...
    stage           Expand downloaded archive in preparation for install
    test            A thin wrapper around the pytest command.
    test            A thin wrapper around the pytest command.
    uninstall       Remove an installed package
...
```
This PR fixes that. I believe this line was leftover from when `spack test` actually _was_ a thin wrapper around `pytest`, but since then we've added a dedicated `cmd/test.py` module. @alalazo Can you confirm?