### PR TITLE
Convert 3 more new packages to PythonPackage

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipdb/package.py
+++ b/var/spack/repos/builtin/packages/py-ipdb/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class PyIpdb(Package):
+class PyIpdb(PythonPackage):
     """ipdb is the iPython debugger and has many additional features, including
     a better interactive debugging experience via colorized output."""
 
@@ -39,7 +39,6 @@ class PyIpdb(Package):
     # this the original packager does not know what they are. See the 3rd party
     # section on ipdb's GitHub:
     #     https://github.com/gotcha/ipdb#third-party-support
-    extends('python')
     depends_on('python@2.6:2.7,3.2:')
 
     # Dependencies gathered from:
@@ -52,7 +51,3 @@ class PyIpdb(Package):
     depends_on('py-six',             type=('build', 'link'))
     depends_on('py-pexpect',         type=('build', 'link'))
     depends_on('py-prompt-toolkit',  type=('build', 'link'))
-
-    def install(self, spec, prefix):
-        # Installation is uncomplicated, this should suffice.
-        setup_py('install', '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-psutil/package.py
+++ b/var/spack/repos/builtin/packages/py-psutil/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class PyPsutil(Package):
+class PyPsutil(PythonPackage):
     """psutil is a cross-platform library for retrieving information on
     running processes and system utilization (CPU, memory, disks, network)
     in Python."""
@@ -35,9 +35,5 @@ class PyPsutil(Package):
 
     version('5.0.1', '153dc8be94badc4072016ceeac7808dc')
 
-    extends('python')
     depends_on('python@2.6:')
     depends_on('py-setuptools', type='build')
-
-    def install(self, spec, prefix):
-        setup_py('install', '--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/py-sphinx-bootstrap-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-bootstrap-theme/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class PySphinxBootstrapTheme(Package):
+class PySphinxBootstrapTheme(PythonPackage):
     """Sphinx Bootstrap Theme."""
 
     homepage = "https://pypi.python.org/pypi/sphinx-bootstrap-theme/"
@@ -33,9 +33,4 @@ class PySphinxBootstrapTheme(Package):
 
     version('0.4.13', '32e513a9c8ffbb8c1e4b036e8f74fb51')
 
-    extends('python')
-
     depends_on('py-setuptools', type='build')
-
-    def install(self, spec, prefix):
-        setup_py('install', '--prefix={0}'.format(prefix))


### PR DESCRIPTION
These are 3 new packages that slipped in while I was working on the new `PythonPackage` base class. At this point, everything that should probably be `PythonPackage` is.