### PR TITLE
Change spack create UI to default to name instead of URL

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -50,7 +50,7 @@ Here's an example:
 
 .. code-block:: console
 
-   $ spack create https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+   $ spack create --url https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 
 Spack examines the tarball URL and tries to figure out the name of the package
 to be created. If the name contains uppercase letters, these are automatically
@@ -63,7 +63,7 @@ you how many you would like to download and checksum:
 
 .. code-block:: console
 
-   $ spack create https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+   $ spack create --url https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
    ==> This looks like a URL for gmp
    ==> Found 16 versions of gmp:
 
@@ -199,21 +199,21 @@ cannot be downloaded from a URL? You can still create a boilerplate
 
 .. code-block:: console
 
-   $ spack create --name intel
+   $ spack create intel
 
 This will create a simple ``intel`` package with an ``install()``
 method that you can craft to install your package.
 
-What if ``spack create <url>`` guessed the wrong name or build system?
+What if ``spack create --url <url>`` guessed the wrong name or build system?
 For example, if your package uses the Autotools build system but does
 not come with a ``configure`` script, Spack won't realize it uses
 Autotools. You can overwrite the old package with ``--force`` and specify
-a name with ``--name`` or a build system template to use with ``--template``:
+a name or specify a build system template to use with ``--template``:
 
 .. code-block:: console
 
-   $ spack create --name gmp https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
-   $ spack create --force --template autotools https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+   $ spack create gmp --url https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+   $ spack create --force --template autotools --url https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
 
 .. note::
 
@@ -1490,7 +1490,7 @@ Additional hybrid dependency types are (note the lack of quotes):
 
   * **<not specified>**: ``type`` assumed to be ``("build",
     "link")``. This is the common case for compiled language usage.
- 
+
 """""""""""""""""""
 Dependency Formulas
 """""""""""""""""""

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -282,14 +282,14 @@ templates = {
 
 def setup_parser(subparser):
     subparser.add_argument(
-        'url', nargs='?',
+        'name', nargs='?',
+        help="name of the package to create")
+    subparser.add_argument(
+        '-u', '--url',
         help="url of package archive")
     subparser.add_argument(
         '--keep-stage', action='store_true',
         help="Don't clean up staging area when command completes.")
-    subparser.add_argument(
-        '-n', '--name',
-        help="name of the package to create")
     subparser.add_argument(
         '-t', '--template', metavar='TEMPLATE', choices=templates.keys(),
         help="build system template to use. options: %(choices)s")


### PR DESCRIPTION
This PR implements @citibeth's idea from #1108 to change the UI for `spack create` from:
```
$ spack create --name <name> <url>
```
to:
```
$ spack create --url <url> <name>
```
I decided to separate this change from #2707 because it was a fairly controversial change. Yes, the UI now becomes more consistent with other commands in Spack (`spack subcommand packagename`), but for 99% of packages that I've created, I've only needed to specify the URL. Honestly, I'm not even sure if I like this change, but, well, here it is. I'll let @citibeth state her case as to whether or not this change should be merged.