### PR TITLE
Standardize argparse help messages

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -102,19 +102,19 @@ spec expressions:
       [^DEPENDENCY [CONSTRAINTS] ...]"""))
 
 parser.add_argument('-d', '--debug', action='store_true',
-                    help="Write out debug logs during compile")
+                    help="write out debug logs during compile")
 parser.add_argument('-D', '--pdb', action='store_true',
-                    help="Run spack under the pdb debugger")
+                    help="run spack under the pdb debugger")
 parser.add_argument('-k', '--insecure', action='store_true',
-                    help="Do not check ssl certificates when downloading.")
+                    help="do not check ssl certificates when downloading")
 parser.add_argument('-m', '--mock', action='store_true',
-                    help="Use mock packages instead of real ones.")
+                    help="use mock packages instead of real ones")
 parser.add_argument('-p', '--profile', action='store_true',
-                    help="Profile execution using cProfile.")
+                    help="profile execution using cProfile")
 parser.add_argument('-v', '--verbose', action='store_true',
-                    help="Print additional output during builds")
+                    help="print additional output during builds")
 parser.add_argument('-s', '--stacktrace', action='store_true',
-                    help="Add stacktrace information to all printed statements")
+                    help="add stacktrace information to all printed statements")
 parser.add_argument('-V', '--version', action='version',
                     version="%s" % spack.spack_version)
 

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -27,16 +27,16 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 
-description = "Activate a package extension."
+description = "activate a package extension"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true',
-        help="Activate without first activating dependencies.")
+        help="activate without first activating dependencies")
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="spec of package extension to activate.")
+        help="spec of package extension to activate")
 
 
 def activate(parser, args):

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -24,14 +24,14 @@
 ##############################################################################
 import spack.architecture as architecture
 
-description = "Print architecture information about this machine."
+description = "print architecture information about this machine"
 
 
 def setup_parser(subparser):
     parts = subparser.add_mutually_exclusive_group()
     parts.add_argument(
         '-p', '--platform', action='store_true', default=False,
-        help="Print only the platform.")
+        help="print only the platform")
 
 
 def arch(parser, args):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -32,7 +32,7 @@ from spack.util.executable import ProcessError, which
 
 _SPACK_UPSTREAM = 'https://github.com/llnl/spack'
 
-description = "Create a new installation of spack in another prefix"
+description = "create a new installation of spack in another prefix"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/build.py
+++ b/lib/spack/spack/cmd/build.py
@@ -26,7 +26,7 @@ import spack.cmd.configure as cfg
 
 from spack import *
 
-description = 'Stops at build stage when installing a package, if possible'
+description = 'stops at build stage when installing a package, if possible'
 
 build_system_to_phase = {
     CMakePackage: 'build',

--- a/lib/spack/spack/cmd/cd.py
+++ b/lib/spack/spack/cmd/cd.py
@@ -25,7 +25,7 @@
 import spack.cmd.location
 import spack.modules
 
-description = "cd to spack directories in the shell."
+description = "cd to spack directories in the shell"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -35,19 +35,19 @@ from spack.stage import Stage, FailedDownloadError
 from spack.util.naming import *
 from spack.version import *
 
-description = "Checksum available versions of a package."
+description = "checksum available versions of a package"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         'package',
-        help='Package to checksum versions for')
+        help='package to checksum versions for')
     subparser.add_argument(
         '--keep-stage', action='store_true',
-        help="Don't clean up staging area when command completes.")
+        help="don't clean up staging area when command completes")
     subparser.add_argument(
         'versions', nargs=argparse.REMAINDER,
-        help='Versions to generate checksums for')
+        help='versions to generate checksums for')
 
 
 def get_checksums(url_dict, name, **kwargs):

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -29,7 +29,7 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 
-description = "Remove build stage and source tarball for packages."
+description = "remove build stage and source tarball for packages"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -76,32 +76,32 @@ class ConstraintAction(argparse.Action):
 
 _arguments['constraint'] = Args(
     'constraint', nargs=argparse.REMAINDER, action=ConstraintAction,
-    help='Constraint to select a subset of installed packages')
+    help='constraint to select a subset of installed packages')
 
 _arguments['module_type'] = Args(
-    '-m', '--module-type', help='Type of module files',
+    '-m', '--module-type', help='type of module files',
     default='tcl', choices=spack.modules.module_types)
 
 _arguments['yes_to_all'] = Args(
     '-y', '--yes-to-all', action='store_true', dest='yes_to_all',
-    help='Assume "yes" is the answer to every confirmation request.')
+    help='assume "yes" is the answer to every confirmation request')
 
 _arguments['recurse_dependencies'] = Args(
     '-r', '--dependencies', action='store_true', dest='recurse_dependencies',
-    help='Recursively traverse spec dependencies')
+    help='recursively traverse spec dependencies')
 
 _arguments['clean'] = Args(
     '--clean', action='store_false', dest='dirty',
-    help='Clean environment before installing package.')
+    help='clean environment before installing package')
 
 _arguments['dirty'] = Args(
     '--dirty', action='store_true', dest='dirty',
-    help='Do NOT clean environment before installing.')
+    help='do NOT clean environment before installing')
 
 _arguments['long'] = Args(
     '-l', '--long', action='store_true',
-    help='Show dependency hashes as well as versions.')
+    help='show dependency hashes as well as versions')
 
 _arguments['very_long'] = Args(
     '-L', '--very-long', action='store_true',
-    help='Show full dependency hashes as well as versions.')
+    help='show full dependency hashes as well as versions')

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -35,7 +35,7 @@ from llnl.util.tty.color import colorize
 from spack.spec import CompilerSpec, ArchSpec
 from spack.util.environment import get_path
 
-description = "Manage compilers"
+description = "manage compilers"
 
 
 def setup_parser(subparser):
@@ -47,35 +47,35 @@ def setup_parser(subparser):
     # Find
     find_parser = sp.add_parser(
         'find', aliases=['add'],
-        help='Search the system for compilers to add to Spack configuration.')
+        help='search the system for compilers to add to Spack configuration')
     find_parser.add_argument('add_paths', nargs=argparse.REMAINDER)
     find_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
     # Remove
     remove_parser = sp.add_parser(
-        'remove', aliases=['rm'], help='Remove compiler by spec.')
+        'remove', aliases=['rm'], help='remove compiler by spec')
     remove_parser.add_argument(
         '-a', '--all', action='store_true',
-        help='Remove ALL compilers that match spec.')
+        help='remove ALL compilers that match spec')
     remove_parser.add_argument('compiler_spec')
     remove_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help='list available compilers')
     list_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_list_scope,
-        help="Configuration scope to read from.")
+        help="configuration scope to read from")
 
     # Info
-    info_parser = sp.add_parser('info', help='Show compiler paths.')
+    info_parser = sp.add_parser('info', help='show compiler paths')
     info_parser.add_argument('compiler_spec')
     info_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_list_scope,
-        help="Configuration scope to read from.")
+        help="configuration scope to read from")
 
 
 def compiler_find(args):

--- a/lib/spack/spack/cmd/compilers.py
+++ b/lib/spack/spack/cmd/compilers.py
@@ -25,12 +25,12 @@
 import spack
 from spack.cmd.compiler import compiler_list
 
-description = "List available compilers. Same as 'spack compiler list'."
+description = "list available compilers, same as 'spack compiler list'"
 
 
 def setup_parser(subparser):
     subparser.add_argument('--scope', choices=spack.config.config_scopes,
-                           help="Configuration scope to read/modify.")
+                           help="configuration scope to read/modify")
 
 
 def compilers(parser, args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -24,27 +24,27 @@
 ##############################################################################
 import spack.config
 
-description = "Get and set configuration options."
+description = "get and set configuration options"
 
 
 def setup_parser(subparser):
     # User can only choose one
     subparser.add_argument('--scope', choices=spack.config.config_scopes,
-                           help="Configuration scope to read/modify.")
+                           help="configuration scope to read/modify")
 
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='config_command')
 
-    get_parser = sp.add_parser('get', help='Print configuration values.')
+    get_parser = sp.add_parser('get', help='print configuration values')
     get_parser.add_argument('section',
-                            help="Configuration section to print. "
-                                 "Options: %(choices)s.",
+                            help="configuration section to print. "
+                                 "options: %(choices)s",
                             metavar='SECTION',
                             choices=spack.config.section_schemas)
 
-    edit_parser = sp.add_parser('edit', help='Edit configuration file.')
+    edit_parser = sp.add_parser('edit', help='edit configuration file')
     edit_parser.add_argument('section',
-                             help="Configuration section to edit. "
-                                  "Options: %(choices)s.",
+                             help="configuration section to edit. "
+                                  "options: %(choices)s",
                              metavar='SECTION',
                              choices=spack.config.section_schemas)
 

--- a/lib/spack/spack/cmd/configure.py
+++ b/lib/spack/spack/cmd/configure.py
@@ -31,7 +31,7 @@ import spack.cmd.install as inst
 
 from spack import *
 
-description = 'Stops at configuration stage when installing a package, if possible'  # NOQA: ignore=E501
+description = 'stops at configuration stage when installing a package, if possible'  # NOQA: ignore=E501
 
 
 build_system_to_phase = {
@@ -49,7 +49,7 @@ def setup_parser(subparser):
     subparser.add_argument(
         '-v', '--verbose',
         action='store_true',
-        help="Print additional output during builds"
+        help="print additional output during builds"
     )
 
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -39,7 +39,7 @@ from spack.spec import Spec
 from spack.util.executable import which
 from spack.util.naming import *
 
-description = "Create a new package file"
+description = "create a new package file"
 
 package_template = '''\
 ##############################################################################
@@ -286,7 +286,7 @@ def setup_parser(subparser):
         help="url of package archive")
     subparser.add_argument(
         '--keep-stage', action='store_true',
-        help="Don't clean up staging area when command completes.")
+        help="don't clean up staging area when command completes")
     subparser.add_argument(
         '-n', '--name',
         help="name of the package to create")
@@ -295,14 +295,14 @@ def setup_parser(subparser):
         help="build system template to use. options: %(choices)s")
     subparser.add_argument(
         '-r', '--repo',
-        help="Path to a repository where the package should be created.")
+        help="path to a repository where the package should be created")
     subparser.add_argument(
         '-N', '--namespace',
-        help="Specify a namespace for the package. Must be the namespace of "
-        "a repository registered with Spack.")
+        help="specify a namespace for the package. must be the namespace of "
+        "a repository registered with Spack")
     subparser.add_argument(
         '-f', '--force', action='store_true',
-        help="Overwrite any existing package file with the same name.")
+        help="overwrite any existing package file with the same name")
 
 
 class BuildSystemGuesser:

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -30,20 +30,20 @@ import spack.cmd
 import spack.store
 from spack.graph import topological_sort
 
-description = "Deactivate a package extension."
+description = "deactivate a package extension"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true',
-        help="Run deactivation even if spec is NOT currently activated.")
+        help="run deactivation even if spec is NOT currently activated")
     subparser.add_argument(
         '-a', '--all', action='store_true',
-        help="Deactivate all extensions of an extendable package, or "
-        "deactivate an extension AND its dependencies.")
+        help="deactivate all extensions of an extendable package, or "
+        "deactivate an extension AND its dependencies")
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="spec of package extension to deactivate.")
+        help="spec of package extension to deactivate")
 
 
 def deactivate(parser, args):

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -33,13 +33,13 @@ from llnl.util.filesystem import working_dir
 import spack
 from spack.util.executable import which
 
-description = "Debugging commands for troubleshooting Spack."
+description = "debugging commands for troubleshooting Spack"
 
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='debug_command')
     sp.add_parser('create-db-tarball',
-                  help="Create a tarball of Spack's installation metadata.")
+                  help="create a tarball of Spack's installation metadata")
 
 
 def _debug_tarball_suffix():

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -30,13 +30,13 @@ import spack
 import spack.store
 import spack.cmd
 
-description = "Show installed packages that depend on another."
+description = "show installed packages that depend on another"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="specs to list dependencies of.")
+        help="specs to list dependencies of")
 
 
 def dependents(parser, args):

--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -33,25 +33,25 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 from spack.stage import DIYStage
 
-description = "Do-It-Yourself: build from an existing source directory."
+description = "do-it-yourself: build from an existing source directory"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
-        help="Do not try to install dependencies of requested packages.")
+        help="don't try to install dependencies of requested packages")
     subparser.add_argument(
         '--keep-prefix', action='store_true',
-        help="Don't remove the install prefix if installation fails.")
+        help="do not remove the install prefix if installation fails")
     subparser.add_argument(
         '--skip-patch', action='store_true',
-        help="Skip patching for the DIY build.")
+        help="skip patching for the DIY build")
     subparser.add_argument(
         '-q', '--quiet', action='store_true', dest='quiet',
-        help="Do not display verbose build output while installing.")
+        help="do not display verbose build output while installing")
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="specs to use for install.  Must contain package AND version.")
+        help="specs to use for install. must contain package AND version")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])

--- a/lib/spack/spack/cmd/doc.py
+++ b/lib/spack/spack/cmd/doc.py
@@ -23,11 +23,11 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 
-description = "Run pydoc from within spack."
+description = "run pydoc from within spack"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('entity', help="Run pydoc help on entity")
+    subparser.add_argument('entity', help="run pydoc help on entity")
 
 
 def doc(parser, args):

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -32,7 +32,7 @@ import spack.cmd
 from spack.spec import Spec
 from spack.repository import Repo
 
-description = "Open package files in $EDITOR"
+description = "open package files in $EDITOR"
 
 
 def edit_package(name, repo_path, namespace):
@@ -72,23 +72,23 @@ def setup_parser(subparser):
     excl_args.add_argument(
         '-c', '--command', dest='path', action='store_const',
         const=spack.cmd.command_path,
-        help="Edit the command with the supplied name.")
+        help="edit the command with the supplied name")
     excl_args.add_argument(
         '-t', '--test', dest='path', action='store_const',
         const=spack.test_path,
-        help="Edit the test with the supplied name.")
+        help="edit the test with the supplied name")
     excl_args.add_argument(
         '-m', '--module', dest='path', action='store_const',
         const=spack.module_path,
-        help="Edit the main spack module with the supplied name.")
+        help="edit the main spack module with the supplied name")
 
     # Options for editing packages
     excl_args.add_argument(
         '-r', '--repo', default=None,
-        help="Path to repo to edit package in.")
+        help="path to repo to edit package in")
     excl_args.add_argument(
         '-N', '--namespace', default=None,
-        help="Namespace of package to edit.")
+        help="namespace of package to edit")
 
     subparser.add_argument(
         'name', nargs='?', default=None,

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -28,13 +28,13 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.build_environment as build_env
 
-description = "Run a command with the install environment for a spec."
+description = "run a command with the install environment for a spec"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="specs of package environment to emulate.")
+        help="specs of package environment to emulate")
 
 
 def env(parser, args):

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -32,24 +32,24 @@ import spack.cmd
 import spack.cmd.find
 import spack.store
 
-description = "List extensions for package."
+description = "list extensions for package"
 
 
 def setup_parser(subparser):
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
         '-l', '--long', action='store_true', dest='long',
-        help='Show dependency hashes as well as versions.')
+        help='show dependency hashes as well as versions')
     format_group.add_argument(
         '-p', '--paths', action='store_const', dest='mode', const='paths',
-        help='Show paths to extension install directories')
+        help='show paths to extension install directories')
     format_group.add_argument(
         '-d', '--deps', action='store_const', dest='mode', const='deps',
-        help='Show full dependency DAG of extensions')
+        help='show full dependency DAG of extensions')
 
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help='Spec of package to list extensions for')
+        help='spec of package to list extensions for')
 
 
 def extensions(parser, args):

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -27,19 +27,19 @@ import argparse
 import spack
 import spack.cmd
 
-description = "Fetch archives for packages"
+description = "fetch archives for packages"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
-        help="Do not check packages against checksum")
+        help="do not check packages against checksum")
     subparser.add_argument(
         '-m', '--missing', action='store_true',
-        help="Also fetch all missing dependencies")
+        help="also fetch all missing dependencies")
     subparser.add_argument(
         '-D', '--dependencies', action='store_true',
-        help="Also fetch all dependencies")
+        help="also fetch all dependencies")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to fetch")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -29,7 +29,7 @@ import spack.cmd.common.arguments as arguments
 
 from spack.cmd import display_specs
 
-description = "Find installed spack packages"
+description = "find installed spack packages"
 
 
 def setup_parser(subparser):
@@ -39,56 +39,56 @@ def setup_parser(subparser):
                               dest='mode',
                               const='short',
                               default='short',
-                              help='Show only specs (default)')
+                              help='show only specs (default)')
     format_group.add_argument('-p', '--paths',
                               action='store_const',
                               dest='mode',
                               const='paths',
-                              help='Show paths to package install directories')
+                              help='show paths to package install directories')
     format_group.add_argument(
         '-d', '--deps',
         action='store_const',
         dest='mode',
         const='deps',
-        help='Show full dependency DAG of installed packages')
+        help='show full dependency DAG of installed packages')
 
     arguments.add_common_arguments(subparser, ['long', 'very_long'])
 
     subparser.add_argument('-f', '--show-flags',
                            action='store_true',
                            dest='show_flags',
-                           help='Show spec compiler flags.')
+                           help='show spec compiler flags')
     implicit_explicit = subparser.add_mutually_exclusive_group()
     implicit_explicit.add_argument(
         '-e', '--explicit',
         action='store_true',
-        help='Show only specs that were installed explicitly')
+        help='show only specs that were installed explicitly')
     implicit_explicit.add_argument(
         '-E', '--implicit',
         action='store_true',
-        help='Show only specs that were installed as dependencies')
+        help='show only specs that were installed as dependencies')
     subparser.add_argument(
         '-u', '--unknown',
         action='store_true',
         dest='unknown',
-        help='Show only specs Spack does not have a package for.')
+        help='show only specs Spack does not have a package for')
     subparser.add_argument(
         '-m', '--missing',
         action='store_true',
         dest='missing',
-        help='Show missing dependencies as well as installed specs.')
+        help='show missing dependencies as well as installed specs')
     subparser.add_argument(
         '-v', '--variants',
         action='store_true',
         dest='variants',
-        help='Show variants in output (can be long)')
+        help='show variants in output (can be long)')
     subparser.add_argument('-M', '--only-missing',
                            action='store_true',
                            dest='only_missing',
-                           help='Show only missing dependencies.')
+                           help='show only missing dependencies')
     subparser.add_argument('-N', '--namespace',
                            action='store_true',
-                           help='Show fully qualified package names.')
+                           help='show fully qualified package names')
 
     arguments.add_common_arguments(subparser, ['constraint'])
 

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -34,7 +34,7 @@ from llnl.util.filesystem import *
 import spack
 from spack.util.executable import *
 
-description = "Runs source code style checks on Spack. Requires flake8."
+description = "runs source code style checks on Spack. requires flake8"
 flake8 = None
 include_untracked = True
 
@@ -138,17 +138,17 @@ def filter_file(source, dest, output=False):
 def setup_parser(subparser):
     subparser.add_argument(
         '-k', '--keep-temp', action='store_true',
-        help="Do not delete temporary directory where flake8 runs. "
-             "Use for debugging, to see filtered files.")
+        help="do not delete temporary directory where flake8 runs. "
+             "use for debugging, to see filtered files")
     subparser.add_argument(
         '-o', '--output', action='store_true',
-        help="Send filtered files to stdout as well as temp files.")
+        help="send filtered files to stdout as well as temp files")
     subparser.add_argument(
         '-r', '--root-relative', action='store_true', default=False,
         help="print root-relative paths (default is cwd-relative)")
     subparser.add_argument(
         '-U', '--no-untracked', dest='untracked', action='store_false',
-        default=True, help="Exclude untracked files from checks.")
+        default=True, help="exclude untracked files from checks")
     subparser.add_argument(
         'files', nargs=argparse.REMAINDER, help="specific files to check")
 

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -32,7 +32,7 @@ import spack.store
 from spack.spec import *
 from spack.graph import *
 
-description = "Generate graphs of package dependency relationships."
+description = "generate graphs of package dependency relationships"
 
 
 def setup_parser(subparser):
@@ -41,31 +41,31 @@ def setup_parser(subparser):
     method = subparser.add_mutually_exclusive_group()
     method.add_argument(
         '-a', '--ascii', action='store_true',
-        help="Draw graph as ascii to stdout (default).")
+        help="draw graph as ascii to stdout (default)")
     method.add_argument(
         '-d', '--dot', action='store_true',
-        help="Generate graph in dot format and print to stdout.")
+        help="generate graph in dot format and print to stdout")
 
     subparser.add_argument(
         '-n', '--normalize', action='store_true',
-        help="Skip concretization; only print normalized spec.")
+        help="skip concretization; only print normalized spec")
 
     subparser.add_argument(
         '-s', '--static', action='store_true',
-        help="Use static information from packages, not dynamic spec info.")
+        help="use static information from packages, not dynamic spec info")
 
     subparser.add_argument(
         '-i', '--installed', action='store_true',
-        help="Graph all installed specs in dot format (implies --dot).")
+        help="graph all installed specs in dot format (implies --dot)")
 
     subparser.add_argument(
         '-t', '--deptype', action='store',
-        help="Comma-separated list of deptypes to traverse. default=%s."
+        help="comma-separated list of deptypes to traverse. default=%s"
         % ','.join(alldeps))
 
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER,
-        help="specs of packages to graph.")
+        help="specs of packages to graph")
 
 
 def graph(parser, args):

--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -22,7 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-description = "Get help on spack and its commands"
+description = "get help on spack and its commands"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -27,7 +27,7 @@ from llnl.util.tty.colify import *
 import spack
 import spack.fetch_strategy as fs
 
-description = "Get detailed information on a particular package"
+description = "get detailed information on a particular package"
 
 
 def padder(str_list, extra=0):
@@ -43,7 +43,7 @@ def padder(str_list, extra=0):
 
 def setup_parser(subparser):
     subparser.add_argument(
-        'name', metavar="PACKAGE", help="Name of package to get info for.")
+        'name', metavar="PACKAGE", help="name of package to get info for")
 
 
 def print_text_info(pkg):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -40,7 +40,7 @@ from spack.build_environment import InstallError
 from spack.fetch_strategy import FetchError
 from spack.package import PackageBase
 
-description = "Build and install packages"
+description = "build and install packages"
 
 
 def setup_parser(subparser):
@@ -49,29 +49,29 @@ def setup_parser(subparser):
         default='package,dependencies',
         dest='things_to_install',
         choices=['package', 'dependencies'],
-        help="""Select the mode of installation.
-The default is to install the package along with all its dependencies.
-Alternatively one can decide to install only the package or only
-the dependencies."""
+        help="""select the mode of installation.
+the default is to install the package along with all its dependencies.
+alternatively one can decide to install only the package or only
+the dependencies"""
     )
     subparser.add_argument(
         '-j', '--jobs', action='store', type=int,
-        help="Explicitly set number of make jobs.  Default is #cpus.")
+        help="explicitly set number of make jobs. default is #cpus")
     subparser.add_argument(
         '--keep-prefix', action='store_true', dest='keep_prefix',
-        help="Don't remove the install prefix if installation fails.")
+        help="don't remove the install prefix if installation fails")
     subparser.add_argument(
         '--keep-stage', action='store_true', dest='keep_stage',
-        help="Don't remove the build stage if installation succeeds.")
+        help="don't remove the build stage if installation succeeds")
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
-        help="Do not check packages against checksum")
+        help="do not check packages against checksum")
     subparser.add_argument(
         '-v', '--verbose', action='store_true', dest='verbose',
-        help="Display verbose build output while installing.")
+        help="display verbose build output while installing")
     subparser.add_argument(
         '--fake', action='store_true', dest='fake',
-        help="Fake install. Just remove prefix and create a fake file.")
+        help="fake install. just remove prefix and create a fake file")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -83,18 +83,18 @@ the dependencies."""
     )
     subparser.add_argument(
         '--run-tests', action='store_true', dest='run_tests',
-        help="Run package level tests during installation."
+        help="run package level tests during installation"
     )
     subparser.add_argument(
         '--log-format',
         default=None,
         choices=['junit'],
-        help="Format to be used for log files."
+        help="format to be used for log files"
     )
     subparser.add_argument(
         '--log-file',
         default=None,
-        help="Filename for the log file. If not passed a default will be used."
+        help="filename for the log file. if not passed a default will be used"
     )
 
 

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -33,7 +33,7 @@ import llnl.util.tty as tty
 import spack
 from llnl.util.tty.colify import colify
 
-description = "Print available spack packages to stdout in different formats"
+description = "print available spack packages to stdout in different formats"
 
 formatters = {}
 
@@ -47,13 +47,13 @@ def formatter(func):
 def setup_parser(subparser):
     subparser.add_argument(
         'filter', nargs=argparse.REMAINDER,
-        help='Optional case-insensitive glob patterns to filter results.')
+        help='optional case-insensitive glob patterns to filter results')
     subparser.add_argument(
         '-d', '--search-description', action='store_true', default=False,
-        help='Filtering will also search the description for a match.')
+        help='filtering will also search the description for a match')
     subparser.add_argument(
         '--format', default='name_only', choices=formatters,
-        help='Format to be used to print the output [default: name_only]')
+        help='format to be used to print the output [default: name_only]')
 
 
 def filter_by_name(pkgs, args):

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -25,7 +25,7 @@
 import argparse
 import spack.modules
 
-description = "Add package to environment using modules."
+description = "add package to environment using modules"
 
 
 def setup_parser(subparser):
@@ -33,8 +33,8 @@ def setup_parser(subparser):
        message with -h. """
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="Spec of package to load with modules. "
-             "(If -, read specs from STDIN)")
+        help="spec of package to load with modules "
+             "(if -, read specs from STDIN)")
 
 
 def load(parser, args):

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -29,7 +29,7 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 
-description = "Print out locations of various directories used by Spack"
+description = "print out locations of various directories used by Spack"
 
 
 def setup_parser(subparser):
@@ -38,34 +38,34 @@ def setup_parser(subparser):
 
     directories.add_argument(
         '-m', '--module-dir', action='store_true',
-        help="Spack python module directory.")
+        help="spack python module directory")
     directories.add_argument(
         '-r', '--spack-root', action='store_true',
-        help="Spack installation root.")
+        help="spack installation root")
 
     directories.add_argument(
         '-i', '--install-dir', action='store_true',
-        help="Install prefix for spec (spec need not be installed).")
+        help="install prefix for spec (spec need not be installed)")
     directories.add_argument(
         '-p', '--package-dir', action='store_true',
-        help="Directory enclosing a spec's package.py file.")
+        help="directory enclosing a spec's package.py file")
     directories.add_argument(
         '-P', '--packages', action='store_true',
-        help="Top-level packages directory for Spack.")
+        help="top-level packages directory for Spack")
     directories.add_argument(
         '-s', '--stage-dir', action='store_true',
-        help="Stage directory for a spec.")
+        help="stage directory for a spec")
     directories.add_argument(
         '-S', '--stages', action='store_true',
-        help="Top level Stage directory.")
+        help="top level stage directory")
     directories.add_argument(
         '-b', '--build-dir', action='store_true',
-        help="Checked out or expanded source directory for a spec "
-             "(requires it to be staged first).")
+        help="checked out or expanded source directory for a spec "
+             "(requires it to be staged first)")
 
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="spec of package to fetch directory for.")
+        help="spec of package to fetch directory for")
 
 
 def location(parser, args):

--- a/lib/spack/spack/cmd/md5.py
+++ b/lib/spack/spack/cmd/md5.py
@@ -31,13 +31,13 @@ import llnl.util.tty as tty
 import spack.util.crypto
 from spack.stage import Stage, FailedDownloadError
 
-description = "Calculate md5 checksums for files/urls."
+description = "calculate md5 checksums for files/urls"
 
 
 def setup_parser(subparser):
     setup_parser.parser = subparser
     subparser.add_argument('files', nargs=argparse.REMAINDER,
-                           help="Files/urls to checksum.")
+                           help="files/urls to checksum")
 
 
 def compute_md5_checksum(url):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -37,13 +37,13 @@ from spack.spec import Spec
 from spack.error import SpackError
 from spack.util.spack_yaml import syaml_dict
 
-description = "Manage mirrors."
+description = "manage mirrors"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
-        help="Do not check fetched packages against checksum")
+        help="do not check fetched packages against checksum")
 
     sp = subparser.add_subparsers(
         metavar='SUBCOMMAND', dest='mirror_command')
@@ -51,30 +51,30 @@ def setup_parser(subparser):
     # Create
     create_parser = sp.add_parser('create', help=mirror_create.__doc__)
     create_parser.add_argument('-d', '--directory', default=None,
-                               help="Directory in which to create mirror.")
+                               help="directory in which to create mirror")
     create_parser.add_argument(
         'specs', nargs=argparse.REMAINDER,
-        help="Specs of packages to put in mirror")
+        help="specs of packages to put in mirror")
     create_parser.add_argument(
-        '-f', '--file', help="File with specs of packages to put in mirror.")
+        '-f', '--file', help="file with specs of packages to put in mirror")
     create_parser.add_argument(
         '-D', '--dependencies', action='store_true',
-        help="Also fetch all dependencies")
+        help="also fetch all dependencies")
     create_parser.add_argument(
         '-o', '--one-version-per-spec', action='store_const',
         const=1, default=0,
-        help="Only fetch one 'preferred' version per spec, not all known.")
+        help="only fetch one 'preferred' version per spec, not all known")
 
     scopes = spack.config.config_scopes
 
     # Add
     add_parser = sp.add_parser('add', help=mirror_add.__doc__)
-    add_parser.add_argument('name', help="Mnemonic name for mirror.")
+    add_parser.add_argument('name', help="mnemonic name for mirror")
     add_parser.add_argument(
-        'url', help="URL of mirror directory from 'spack mirror create'.")
+        'url', help="url of mirror directory from 'spack mirror create'")
     add_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
     # Remove
     remove_parser = sp.add_parser('remove', aliases=['rm'],
@@ -82,13 +82,13 @@ def setup_parser(subparser):
     remove_parser.add_argument('name')
     remove_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
     # List
     list_parser = sp.add_parser('list', help=mirror_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_list_scope,
-        help="Configuration scope to read from.")
+        help="configuration scope to read from")
 
 
 def mirror_add(args):

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -35,7 +35,7 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 from spack.modules import module_types
 
-description = "Manipulate module files"
+description = "manipulate module files"
 
 # Dictionary that will be populated with the list of sub-commands
 # Each sub-command must be callable and accept 3 arguments :
@@ -57,10 +57,10 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='subparser_name')
 
     # spack module refresh
-    refresh_parser = sp.add_parser('refresh', help='Regenerate module files')
+    refresh_parser = sp.add_parser('refresh', help='regenerate module files')
     refresh_parser.add_argument(
         '--delete-tree',
-        help='Delete the module file tree before refresh',
+        help='delete the module file tree before refresh',
         action='store_true'
     )
     arguments.add_common_arguments(
@@ -68,11 +68,11 @@ def setup_parser(subparser):
     )
 
     # spack module find
-    find_parser = sp.add_parser('find', help='Find module files for packages')
+    find_parser = sp.add_parser('find', help='find module files for packages')
     arguments.add_common_arguments(find_parser, ['constraint', 'module_type'])
 
     # spack module rm
-    rm_parser = sp.add_parser('rm', help='Remove module files')
+    rm_parser = sp.add_parser('rm', help='remove module files')
     arguments.add_common_arguments(
         rm_parser, ['constraint', 'module_type', 'yes_to_all']
     )
@@ -80,19 +80,19 @@ def setup_parser(subparser):
     # spack module loads
     loads_parser = sp.add_parser(
         'loads',
-        help='Prompt the list of modules associated with a constraint'
+        help='prompt the list of modules associated with a constraint'
     )
     loads_parser.add_argument(
         '--input-only', action='store_false', dest='shell',
-        help='Generate input for module command (instead of a shell script)'
+        help='generate input for module command (instead of a shell script)'
     )
     loads_parser.add_argument(
         '-p', '--prefix', dest='prefix', default='',
-        help='Prepend to module names when issuing module load commands'
+        help='prepend to module names when issuing module load commands'
     )
     loads_parser.add_argument(
         '-x', '--exclude', dest='exclude', action='append', default=[],
-        help="Exclude package from output; may be specified multiple times"
+        help="exclude package from output; may be specified multiple times"
     )
     arguments.add_common_arguments(
         loads_parser, ['constraint', 'module_type', 'recurse_dependencies']

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -29,13 +29,13 @@ import spack.cmd
 import spack
 
 
-description = "Patch expanded archive sources in preparation for install"
+description = "patch expanded archive sources in preparation for install"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
-        help="Do not check downloaded packages against checksum")
+        help="do not check downloaded packages against checksum")
     subparser.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to stage")

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -31,7 +31,7 @@ from llnl.util.tty.colify import colify
 import spack
 from spack.util.executable import *
 
-description = "Query packages associated with particular git revisions."
+description = "query packages associated with particular git revisions"
 
 
 def setup_parser(subparser):
@@ -40,35 +40,35 @@ def setup_parser(subparser):
 
     add_parser = sp.add_parser('add', help=pkg_add.__doc__)
     add_parser.add_argument('packages', nargs=argparse.REMAINDER,
-                            help="Names of packages to add to git repo.")
+                            help="names of packages to add to git repo")
 
     list_parser = sp.add_parser('list', help=pkg_list.__doc__)
     list_parser.add_argument('rev', default='HEAD', nargs='?',
-                             help="Revision to list packages for.")
+                             help="revision to list packages for")
 
     diff_parser = sp.add_parser('diff', help=pkg_diff.__doc__)
     diff_parser.add_argument(
         'rev1', nargs='?', default='HEAD^',
-        help="Revision to compare against.")
+        help="revision to compare against")
     diff_parser.add_argument(
         'rev2', nargs='?', default='HEAD',
-        help="Revision to compare to rev1 (default is HEAD).")
+        help="revision to compare to rev1 (default is HEAD)")
 
     add_parser = sp.add_parser('added', help=pkg_added.__doc__)
     add_parser.add_argument(
         'rev1', nargs='?', default='HEAD^',
-        help="Revision to compare against.")
+        help="revision to compare against")
     add_parser.add_argument(
         'rev2', nargs='?', default='HEAD',
-        help="Revision to compare to rev1 (default is HEAD).")
+        help="revision to compare to rev1 (default is HEAD)")
 
     rm_parser = sp.add_parser('removed', help=pkg_removed.__doc__)
     rm_parser.add_argument(
         'rev1', nargs='?', default='HEAD^',
-        help="Revision to compare against.")
+        help="revision to compare against")
     rm_parser.add_argument(
         'rev2', nargs='?', default='HEAD',
-        help="Revision to compare to rev1 (default is HEAD).")
+        help="revision to compare to rev1 (default is HEAD)")
 
 
 def get_git():

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -29,13 +29,13 @@ from llnl.util.tty.colify import colify
 import spack
 import spack.cmd
 
-description = "List packages that provide a particular virtual package"
+description = "list packages that provide a particular virtual package"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         'vpkg_spec', metavar='VPACKAGE_SPEC', nargs=argparse.REMAINDER,
-        help='Find packages that provide this virtual package')
+        help='find packages that provide this virtual package')
 
 
 def providers(parser, args):

--- a/lib/spack/spack/cmd/purge.py
+++ b/lib/spack/spack/cmd/purge.py
@@ -25,22 +25,22 @@
 import spack
 import spack.stage as stage
 
-description = "Remove temporary build files and/or downloaded archives"
+description = "remove temporary build files and/or downloaded archives"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-s', '--stage', action='store_true', default=True,
-        help="Remove all temporary build stages (default).")
+        help="remove all temporary build stages (default)")
     subparser.add_argument(
         '-d', '--downloads', action='store_true',
-        help="Remove cached downloads.")
+        help="remove cached downloads")
     subparser.add_argument(
         '-m', '--misc-cache', action='store_true',
-        help="Remove long-lived caches, like the virtual package index.")
+        help="remove long-lived caches, like the virtual package index")
     subparser.add_argument(
         '-a', '--all', action='store_true',
-        help="Remove all of the above.")
+        help="remove all of the above")
 
 
 def purge(parser, args):

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -31,15 +31,15 @@ import platform
 import spack
 
 
+description = "launch an interpreter as spack would launch a command"
+
+
 def setup_parser(subparser):
     subparser.add_argument(
-        '-c', dest='python_command', help='Command to execute.')
+        '-c', dest='python_command', help='command to execute')
     subparser.add_argument(
         'python_args', nargs=argparse.REMAINDER,
-        help="File to run plus arguments.")
-
-
-description = "Launch an interpreter as spack would launch a command"
+        help="file to run plus arguments")
 
 
 def python(parser, args):

--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -24,7 +24,7 @@
 ##############################################################################
 import spack
 import spack.store
-description = "Rebuild Spack's package database."
+description = "rebuild Spack's package database"
 
 
 def reindex(parser, args):

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -30,7 +30,7 @@ import spack.spec
 import spack.config
 from spack.repository import *
 
-description = "Manage package source repositories."
+description = "manage package source repositories"
 
 
 def setup_parser(subparser):
@@ -40,34 +40,34 @@ def setup_parser(subparser):
     # Create
     create_parser = sp.add_parser('create', help=repo_create.__doc__)
     create_parser.add_argument(
-        'directory', help="Directory to create the repo in.")
+        'directory', help="directory to create the repo in")
     create_parser.add_argument(
-        'namespace', help="Namespace to identify packages in the repository. "
-        "Defaults to the directory name.", nargs='?')
+        'namespace', help="namespace to identify packages in the repository. "
+        "defaults to the directory name", nargs='?')
 
     # List
     list_parser = sp.add_parser('list', help=repo_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_list_scope,
-        help="Configuration scope to read from.")
+        help="configuration scope to read from")
 
     # Add
     add_parser = sp.add_parser('add', help=repo_add.__doc__)
     add_parser.add_argument(
-        'path', help="Path to a Spack package repository directory.")
+        'path', help="path to a Spack package repository directory")
     add_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
     # Remove
     remove_parser = sp.add_parser(
         'remove', help=repo_remove.__doc__, aliases=['rm'])
     remove_parser.add_argument(
         'path_or_namespace',
-        help="Path or namespace of a Spack package repository.")
+        help="path or namespace of a Spack package repository")
     remove_parser.add_argument(
         '--scope', choices=scopes, default=spack.cmd.default_modify_scope,
-        help="Configuration scope to modify.")
+        help="configuration scope to modify")
 
 
 def repo_create(args):

--- a/lib/spack/spack/cmd/restage.py
+++ b/lib/spack/spack/cmd/restage.py
@@ -29,7 +29,7 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 
-description = "Revert checked out package source code."
+description = "revert checked out package source code"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -38,19 +38,19 @@ from llnl.util.filesystem import set_executable
 from spack import which
 from spack.stage import DIYStage
 
-description = "Create a configuration script and module, but don't build."
+description = "create a configuration script and module, but don't build"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
-        help="Do not try to install dependencies of requested packages.")
+        help="do not try to install dependencies of requested packages")
     subparser.add_argument(
         '-v', '--verbose', action='store_true', dest='verbose',
-        help="Display verbose build output while installing.")
+        help="display verbose build output while installing")
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help="specs to use for install.  Must contain package AND version.")
+        help="specs to use for install. must contain package AND version")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -28,29 +28,29 @@ import spack
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 
-description = "print out abstract and concrete versions of a spec."
+description = "print out abstract and concrete versions of a spec"
 
 
 def setup_parser(subparser):
     arguments.add_common_arguments(subparser, ['long', 'very_long'])
     subparser.add_argument(
         '-y', '--yaml', action='store_true', default=False,
-        help='Print concrete spec as YAML.')
+        help='print concrete spec as YAML')
     subparser.add_argument(
         '-c', '--cover', action='store',
         default='nodes', choices=['nodes', 'edges', 'paths'],
-        help='How extensively to traverse the DAG. (default: nodes).')
+        help='how extensively to traverse the DAG (default: nodes)')
     subparser.add_argument(
         '-N', '--namespaces', action='store_true', default=False,
-        help='Show fully qualified package names.')
+        help='show fully qualified package names')
     subparser.add_argument(
         '-I', '--install-status', action='store_true', default=False,
-        help='Show install status of packages.  Packages can be: '
+        help='show install status of packages. packages can be: '
              'installed [+], missing and needed by an installed package [-], '
-             'or not installed (no annotation).')
+             'or not installed (no annotation)')
     subparser.add_argument(
         '-t', '--types', action='store_true', default=False,
-        help='Show dependency types.')
+        help='show dependency types')
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
 

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -28,16 +28,16 @@ import llnl.util.tty as tty
 import spack
 import spack.cmd
 
-description = "Expand downloaded archive in preparation for install"
+description = "expand downloaded archive in preparation for install"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
-        help="Do not check downloaded packages against checksum")
+        help="do not check downloaded packages against checksum")
     subparser.add_argument(
         '-p', '--path', dest='path',
-        help="Path to stage package, does not add to spack tree")
+        help="path to stage package, does not add to spack tree")
 
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages to stage")

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -34,24 +34,24 @@ from llnl.util.tty.colify import colify
 
 import spack
 
-description = "A thin wrapper around the pytest command."
+description = "a thin wrapper around the pytest command"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-H', '--pytest-help', action='store_true', default=False,
-        help="print full pytest help message, showing advanced options.")
+        help="print full pytest help message, showing advanced options")
 
     list_group = subparser.add_mutually_exclusive_group()
     list_group.add_argument(
         '-l', '--list', action='store_true', default=False,
-        help="list basic test names.")
+        help="list basic test names")
     list_group.add_argument(
         '-L', '--long-list', action='store_true', default=False,
-        help="list the entire hierarchy of tests.")
+        help="list the entire hierarchy of tests")
     subparser.add_argument(
         'tests', nargs=argparse.REMAINDER,
-        help="list of tests to run (will be passed to pytest -k).")
+        help="list of tests to run (will be passed to pytest -k)")
 
 
 def do_list(args, unknown_args):

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -32,7 +32,7 @@ import spack.cmd
 import spack.store
 import spack.repository
 
-description = "Remove an installed package"
+description = "remove an installed package"
 
 error_message = """You can either:
     a) Use a more specific spec, or
@@ -50,24 +50,24 @@ display_args = {
 def setup_parser(subparser):
     subparser.add_argument(
         '-f', '--force', action='store_true', dest='force',
-        help="Remove regardless of whether other packages depend on this one.")
+        help="remove regardless of whether other packages depend on this one")
 
     subparser.add_argument(
         '-a', '--all', action='store_true', dest='all',
-        help="USE CAREFULLY. Remove ALL installed packages that match each "
+        help="USE CAREFULLY. remove ALL installed packages that match each "
              "supplied spec. i.e., if you say uninstall `libelf`,"
-             " ALL versions of `libelf` are uninstalled. If no spec is "
-             "supplied all installed software will be uninstalled. This "
-             "is both useful and dangerous, like rm -r.")
+             " ALL versions of `libelf` are uninstalled. if no spec is "
+             "supplied all installed software will be uninstalled. this "
+             "is both useful and dangerous, like rm -r")
 
     subparser.add_argument(
         '-d', '--dependents', action='store_true', dest='dependents',
-        help='Also uninstall any packages that depend on the ones given '
-             'via command line.')
+        help='also uninstall any packages that depend on the ones given '
+             'via command line')
 
     subparser.add_argument(
         '-y', '--yes-to-all', action='store_true', dest='yes_to_all',
-        help='Assume "yes" is the answer to every confirmation requested')
+        help='assume "yes" is the answer to every confirmation requested')
 
     subparser.add_argument(
         'packages',

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -25,7 +25,7 @@
 import argparse
 import spack.modules
 
-description = "Remove package from environment using module."
+description = "remove package from environment using module"
 
 
 def setup_parser(subparser):
@@ -33,7 +33,7 @@ def setup_parser(subparser):
        message with -h. """
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help='Spec of package to unload with modules.')
+        help='spec of package to unload with modules')
 
 
 def unload(parser, args):

--- a/lib/spack/spack/cmd/unuse.py
+++ b/lib/spack/spack/cmd/unuse.py
@@ -25,7 +25,7 @@
 import argparse
 import spack.modules
 
-description = "Remove package from environment using dotkit."
+description = "remove package from environment using dotkit"
 
 
 def setup_parser(subparser):
@@ -33,7 +33,7 @@ def setup_parser(subparser):
        message with -h. """
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help='Spec of package to unuse with dotkit.')
+        help='spec of package to unuse with dotkit')
 
 
 def unuse(parser, args):

--- a/lib/spack/spack/cmd/url_parse.py
+++ b/lib/spack/spack/cmd/url_parse.py
@@ -28,14 +28,14 @@ import spack
 import spack.url
 from spack.util.web import find_versions_of_archive
 
-description = "Show parsing of a URL, optionally spider web for versions."
+description = "show parsing of a URL, optionally spider web for versions"
 
 
 def setup_parser(subparser):
     subparser.add_argument('url', help="url of a package archive")
     subparser.add_argument(
         '-s', '--spider', action='store_true',
-        help="Spider the source page for versions.")
+        help="spider the source page for versions")
 
 
 def print_name_and_version(url):

--- a/lib/spack/spack/cmd/urls.py
+++ b/lib/spack/spack/cmd/urls.py
@@ -25,18 +25,18 @@
 import spack
 import spack.url
 
-description = "Inspect urls used by packages in spack."
+description = "inspect urls used by packages in spack"
 
 
 def setup_parser(subparser):
     subparser.add_argument(
         '-c', '--color', action='store_true',
-        help="Color the parsed version and name in the urls shown.  "
-             "Version will be cyan, name red.")
+        help="color the parsed version and name in the urls shown. "
+             "version will be cyan, name red")
     subparser.add_argument(
         '-e', '--extrapolation', action='store_true',
-        help="Color the versions used for extrapolation as well."
-             "Additional versions are green, names magenta.")
+        help="color the versions used for extrapolation as well. "
+             "additional versions are green, names magenta")
 
 
 def urls(parser, args):

--- a/lib/spack/spack/cmd/use.py
+++ b/lib/spack/spack/cmd/use.py
@@ -25,7 +25,7 @@
 import argparse
 import spack.modules
 
-description = "Add package to environment using dotkit."
+description = "add package to environment using dotkit"
 
 
 def setup_parser(subparser):
@@ -33,7 +33,7 @@ def setup_parser(subparser):
        message with -h. """
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
-        help='Spec of package to use with dotkit.')
+        help='spec of package to use with dotkit')
 
 
 def use(parser, args):

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -26,12 +26,12 @@ from llnl.util.tty.colify import colify
 import llnl.util.tty as tty
 import spack
 
-description = "List available versions of a package"
+description = "list available versions of a package"
 
 
 def setup_parser(subparser):
     subparser.add_argument('package', metavar='PACKAGE',
-                           help='Package to list versions for')
+                           help='package to list versions for')
 
 
 def versions(parser, args):

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -69,7 +69,7 @@ import spack
 import spack.cmd
 import llnl.util.tty as tty
 
-description = "Produce a single-rooted directory view of a spec."
+description = "produce a single-rooted directory view of a spec"
 
 
 def setup_parser(sp):
@@ -77,40 +77,40 @@ def setup_parser(sp):
 
     sp.add_argument(
         '-v', '--verbose', action='store_true', default=False,
-        help="Display verbose output.")
+        help="display verbose output")
     sp.add_argument(
         '-e', '--exclude', action='append', default=[],
-        help="Exclude packages with names matching the given regex pattern.")
+        help="exclude packages with names matching the given regex pattern")
     sp.add_argument(
         '-d', '--dependencies', choices=['true', 'false', 'yes', 'no'],
         default='true',
-        help="Follow dependencies.")
+        help="follow dependencies")
 
     ssp = sp.add_subparsers(metavar='ACTION', dest='action')
 
     specs_opts = dict(metavar='spec', nargs='+',
-                      help="Seed specs of the packages to view.")
+                      help="seed specs of the packages to view")
 
     # The action parameterizes the command but in keeping with Spack
     # patterns we make it a subcommand.
     file_system_view_actions = [
         ssp.add_parser(
             'symlink', aliases=['add', 'soft'],
-            help='Add package files to a filesystem view via symbolic links.'),
+            help='add package files to a filesystem view via symbolic links'),
         ssp.add_parser(
             'hardlink', aliases=['hard'],
-            help='Add packages files to a filesystem via via hard links.'),
+            help='add packages files to a filesystem via via hard links'),
         ssp.add_parser(
             'remove', aliases=['rm'],
-            help='Remove packages from a filesystem view.'),
+            help='remove packages from a filesystem view'),
         ssp.add_parser(
             'statlink', aliases=['status', 'check'],
-            help='Check status of packages in a filesystem view.')
+            help='check status of packages in a filesystem view')
     ]
     # All these options and arguments are common to every action.
     for act in file_system_view_actions:
         act.add_argument('path', nargs=1,
-                         help="Path to file system view directory.")
+                         help="path to file system view directory")
         act.add_argument('specs', **specs_opts)
 
     return


### PR DESCRIPTION
If your run `spack help` on any particular command, you'll notice that some options start with a lowercase letter and end with a period, while others start with a capital letter and don't end with a period. This was really messing with my OCD, so I fixed it.

I decided to standardize on starting with a lowercase letter and not ending with a period. Why? Because argparse automatically adds the `-h / --help` option to every command, and that's what it uses. Yes, we could hack this if we really want to, but I don't see any reason to.