### PR TITLE
hwloc: Disable OpenCL

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -53,3 +53,12 @@ class Hwloc(AutotoolsPackage):
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/hwloc/v%s/downloads/hwloc-%s.tar.gz" % (version.up_to(2), version)
+
+    def install(self, spec, prefix):
+        # Disable OpenCL, since hwloc might pick up an OpenCL library
+        # at build time that is then not found at run time
+        configure("--prefix=%s" % prefix,
+                  "--disable-opencl")
+
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -54,11 +54,8 @@ class Hwloc(AutotoolsPackage):
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/hwloc/v%s/downloads/hwloc-%s.tar.gz" % (version.up_to(2), version)
 
-    def install(self, spec, prefix):
+    def configure_args(self):
         # Disable OpenCL, since hwloc might pick up an OpenCL library
         # at build time that is then not found at run time
-        configure("--prefix=%s" % prefix,
-                  "--disable-opencl")
-
-        make()
-        make("install")
+        # (Alternatively, we could require OpenCL as dependency.)
+        return ["--disable-opencl"]


### PR DESCRIPTION
Disable OpenCL, since the OpenCL libraries found at build time might not work correctly at run time, and Spack does not (yet!) support OpenCL.