### PR TITLE
oce & trilinos: force rpath on Sierra to avoid issues with load commands size

### DIFF
--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -87,7 +87,11 @@ class Oce(Package):
                 '-DOCE_OSX_USE_COCOA:BOOL=ON',
             ])
 
-        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
+        if '.'.join(platform.mac_ver()[0].split('.')[:2]) == '10.12':
+            # use @rpath on Sierra due to limit of dynamic loader
+            options.append('-DCMAKE_MACOSX_RPATH=ON')
+        else:
+            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
 
         cmake('.', *options)
         make("install/strip")

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import os
 import sys
+import platform
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
@@ -167,9 +168,14 @@ class Trilinos(CMakePackage):
             '-DLAPACK_LIBRARY_DIRS=%s' % ';'.join(lapack.directories),
             '-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON',
             '-DTrilinos_ENABLE_CXX11:BOOL=ON',
-            '-DTPL_ENABLE_Netcdf:BOOL=ON',
-            '-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % self.prefix
+            '-DTPL_ENABLE_Netcdf:BOOL=ON'
         ])
+
+        if '.'.join(platform.mac_ver()[0].split('.')[:2]) == '10.12':
+            # use @rpath on Sierra due to limit of dynamic loader
+            options.append('-DCMAKE_MACOSX_RPATH=ON')
+        else:
+            options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
 
         # Force Trilinos to use the MPI wrappers instead of raw compilers
         # this is needed on Apple systems that require full resolution of


### PR DESCRIPTION
This is a continuation of https://github.com/LLNL/spack/issues/1874.
In a nutshell: macOS Sierra lowered the maximum total size of load commands for shared libraries. In Spack land, the size of those commands are mostly due to the full paths which are recorded in the install names of dependent shared libraries. An example of the load command is
```
Load command 150
          cmd LC_LOAD_DYLIB
      cmdsize 168
         name /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/p4est-1.1-kup7uhxn4wk4nlsxxrmy52kx7xsmopfq/lib/libp4est-1.1.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 0.0.0
compatibility version 0.0.0
```

With this change, the two packages  (`trilinos` and `oce`) are now using `@rpath`. Consequently those load commands for any package (like `dealii`) which links in other libraries from `trilinos` and `oce` become
```
Load command 149
          cmd LC_LOAD_DYLIB
      cmdsize 56
         name @rpath/lib/libTKXSBase.11.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 11.0.0
compatibility version 11.0.0
```
which is roughly 1/3 of the size.  Of course, there is a load command for each `rpath`, i.e. 
```
          cmd LC_RPATH
      cmdsize 136
         path /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/oce-0.18-cjpsyzsypwwzajwjbbrhnvp5suahrdf5/lib (offset 12)
```
but savings come from the fact that both `trilinos` and `oce` have huge number of libs (`277` and `108`, respectively, reported from `ls -F | wc -l`).

End results is that one does not hit the limit of load commands anymore when running executables:
```
dyld: Library not loaded: /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/dealii-develop-cdqavnwshvx6lrmvqjogz64ukkghj2ui/lib/libdeal_II.g.8.5.0-pre.dylib
  Referenced from: /Users/davydden/Desktop/work/C++/my_executable
  Reason: no suitable image found.  Did find:
	/Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/dealii-develop-cdqavnwshvx6lrmvqjogz64ukkghj2ui/lib/libdeal_II.g.8.5.0-pre.dylib: malformed mach-o: load commands size (35112) > 32768
```