### PR TITLE
build system modules: decorators are now free-standing (and renamed)

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2775,17 +2775,17 @@ any base class listed in :ref:`installation_procedure`.
 
 .. code-block:: python
 
-   @MakefilePackage.sanity_check('build')
-   @MakefilePackage.on_package_attributes(run_tests=True)
+   @run_after('build')
+   @on_package_attributes(run_tests=True)
    def check_build(self):
         # Custom implementation goes here
         pass
 
-The first decorator ``MakefilePackage.sanity_check('build')`` schedules this
+The first decorator ``run_after('build')`` schedules this
 function to be invoked after the ``build`` phase has been executed, while the
 second one makes the invocation  conditional on the fact that ``self.run_tests == True``.
 It is also possible to schedule a function to be invoked *before* a given phase
-using the ``MakefilePackage.precondition`` decorator.
+using the ``run_before`` decorator.
 
 .. note::
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -156,14 +156,24 @@ dirty = _config.get('dirty', False)
 #-----------------------------------------------------------------------------
 __all__ = []
 
-from spack.package import Package
+from spack.package import Package, run_before, run_after, on_package_attributes
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.python import PythonPackage
 from spack.build_systems.r import RPackage
-__all__ += ['Package', 'CMakePackage', 'AutotoolsPackage', 'MakefilePackage',
-            'PythonPackage', 'RPackage']
+
+__all__ += [
+    'run_before',
+    'run_after',
+    'on_package_attributes',
+    'Package',
+    'CMakePackage',
+    'AutotoolsPackage',
+    'MakefilePackage',
+    'PythonPackage',
+    'RPackage'
+]
 
 from spack.version import Version, ver
 __all__ += ['Version', 'ver']

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -168,7 +168,7 @@ class AutotoolsPackage(PackageBase):
         """Not needed usually, configure should be already there"""
         pass
 
-    @PackageBase.sanity_check('autoreconf')
+    @PackageBase.run_after('autoreconf')
     def is_configure_or_die(self):
         """Checks the presence of a `configure` file after the
         :py:meth:`.autoreconf` phase.
@@ -211,7 +211,7 @@ class AutotoolsPackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @PackageBase.sanity_check('build')
+    @PackageBase.run_after('build')
     @PackageBase.on_package_attributes(run_tests=True)
     def _run_default_function(self):
         """This function is run after build if ``self.run_tests == True``
@@ -235,4 +235,4 @@ class AutotoolsPackage(PackageBase):
             self._if_make_target_execute('check')
 
     # Check that self.prefix is there after installation
-    PackageBase.sanity_check('install')(PackageBase.sanity_check_prefix)
+    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -30,9 +30,8 @@ import shutil
 from subprocess import PIPE
 from subprocess import check_call
 
-import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
-from spack.package import PackageBase, run_after, on_package_attributes
+from spack.package import PackageBase, run_after
 
 
 class AutotoolsPackage(PackageBase):
@@ -79,6 +78,8 @@ class AutotoolsPackage(PackageBase):
     #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.install`
     #: phase
     install_targets = ['install']
+
+    build_time_test_callbacks = ['check']
 
     def _do_patch_config_guess(self):
         """Some packages ship with an older config.guess and need to have
@@ -211,20 +212,7 @@ class AutotoolsPackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @run_after('build')
-    @on_package_attributes(run_tests=True)
-    def _run_default_function(self):
-        """This function is run after build if ``self.run_tests == True``
-
-        It will search for a method named :py:meth:`.check` and run it. A
-        sensible default is provided in the base class.
-        """
-        try:
-            fn = getattr(self, 'check')
-            tty.msg('Trying default sanity checks [check]')
-            fn()
-        except AttributeError:
-            tty.msg('Skipping default sanity checks [method `check` not implemented]')  # NOQA: ignore=E501
+    run_after('build')(PackageBase._run_default_build_time_test_callbacks)
 
     def check(self):
         """Searches the Makefile for targets ``test`` and ``check``

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -32,7 +32,7 @@ from subprocess import check_call
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
-from spack.package import PackageBase
+from spack.package import PackageBase, run_after, on_package_attributes
 
 
 class AutotoolsPackage(PackageBase):
@@ -168,7 +168,7 @@ class AutotoolsPackage(PackageBase):
         """Not needed usually, configure should be already there"""
         pass
 
-    @PackageBase.run_after('autoreconf')
+    @run_after('autoreconf')
     def is_configure_or_die(self):
         """Checks the presence of a `configure` file after the
         :py:meth:`.autoreconf` phase.
@@ -211,8 +211,8 @@ class AutotoolsPackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @PackageBase.run_after('build')
-    @PackageBase.on_package_attributes(run_tests=True)
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
     def _run_default_function(self):
         """This function is run after build if ``self.run_tests == True``
 
@@ -235,4 +235,4 @@ class AutotoolsPackage(PackageBase):
             self._if_make_target_execute('check')
 
     # Check that self.prefix is there after installation
-    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -155,7 +155,7 @@ class CMakePackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @PackageBase.sanity_check('build')
+    @PackageBase.run_after('build')
     @PackageBase.on_package_attributes(run_tests=True)
     def _run_default_function(self):
         """This function is run after build if ``self.run_tests == True``
@@ -178,4 +178,4 @@ class CMakePackage(PackageBase):
             self._if_make_target_execute('test')
 
     # Check that self.prefix is there after installation
-    PackageBase.sanity_check('install')(PackageBase.sanity_check_prefix)
+    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -26,11 +26,10 @@
 import inspect
 import platform
 
-import llnl.util.tty as tty
 import spack.build_environment
 from llnl.util.filesystem import working_dir, join_path
 from spack.directives import depends_on
-from spack.package import PackageBase, run_after, on_package_attributes
+from spack.package import PackageBase, run_after
 
 
 class CMakePackage(PackageBase):
@@ -71,6 +70,8 @@ class CMakePackage(PackageBase):
 
     build_targets = []
     install_targets = ['install']
+
+    build_time_test_callbacks = ['check']
 
     depends_on('cmake', type='build')
 
@@ -155,20 +156,7 @@ class CMakePackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @run_after('build')
-    @on_package_attributes(run_tests=True)
-    def _run_default_function(self):
-        """This function is run after build if ``self.run_tests == True``
-
-        It will search for a method named ``check`` and run it. A sensible
-        default is provided in the base class.
-        """
-        try:
-            fn = getattr(self, 'check')
-            tty.msg('Trying default build sanity checks [check]')
-            fn()
-        except AttributeError:
-            tty.msg('Skipping default build sanity checks [method `check` not implemented]')  # NOQA: ignore=E501
+    run_after('build')(PackageBase._run_default_build_time_test_callbacks)
 
     def check(self):
         """Searches the CMake-generated Makefile for the target ``test``

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -30,7 +30,7 @@ import llnl.util.tty as tty
 import spack.build_environment
 from llnl.util.filesystem import working_dir, join_path
 from spack.directives import depends_on
-from spack.package import PackageBase
+from spack.package import PackageBase, run_after, on_package_attributes
 
 
 class CMakePackage(PackageBase):
@@ -155,8 +155,8 @@ class CMakePackage(PackageBase):
         with working_dir(self.build_directory()):
             inspect.getmodule(self).make(*self.install_targets)
 
-    @PackageBase.run_after('build')
-    @PackageBase.on_package_attributes(run_tests=True)
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
     def _run_default_function(self):
         """This function is run after build if ``self.run_tests == True``
 
@@ -178,4 +178,4 @@ class CMakePackage(PackageBase):
             self._if_make_target_execute('test')
 
     # Check that self.prefix is there after installation
-    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -27,7 +27,7 @@ import inspect
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
-from spack.package import PackageBase
+from spack.package import PackageBase, run_after
 
 
 class MakefilePackage(PackageBase):
@@ -100,4 +100,4 @@ class MakefilePackage(PackageBase):
             inspect.getmodule(self).make(*self.install_targets)
 
     # Check that self.prefix is there after installation
-    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -100,4 +100,4 @@ class MakefilePackage(PackageBase):
             inspect.getmodule(self).make(*self.install_targets)
 
     # Check that self.prefix is there after installation
-    PackageBase.sanity_check('install')(PackageBase.sanity_check_prefix)
+    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -306,4 +306,4 @@ class PythonPackage(PackageBase):
         return []
 
     # Check that self.prefix is there after installation
-    PackageBase.sanity_check('install')(PackageBase.sanity_check_prefix)
+    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -26,7 +26,7 @@
 import inspect
 
 from spack.directives import extends
-from spack.package import PackageBase
+from spack.package import PackageBase, run_after
 
 from llnl.util.filesystem import working_dir
 
@@ -306,4 +306,4 @@ class PythonPackage(PackageBase):
         return []
 
     # Check that self.prefix is there after installation
-    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -26,7 +26,7 @@
 import inspect
 
 from spack.directives import extends
-from spack.package import PackageBase
+from spack.package import PackageBase, run_after
 
 
 class RPackage(PackageBase):
@@ -55,4 +55,4 @@ class RPackage(PackageBase):
             self.stage.source_path)
 
     # Check that self.prefix is there after installation
-    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -55,4 +55,4 @@ class RPackage(PackageBase):
             self.stage.source_path)
 
     # Check that self.prefix is there after installation
-    PackageBase.sanity_check('install')(PackageBase.sanity_check_prefix)
+    PackageBase.run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1709,6 +1709,27 @@ class PackageBase(object):
         """
         return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
 
+    build_time_test_callbacks = None
+
+    @on_package_attributes(run_tests=True)
+    def _run_default_build_time_test_callbacks(self):
+        """Tries to call all the methods that are listed in the attribute
+        ``build_time_test_callbacks`` if ``self.run_tests is True``.
+
+        If ``build_time_test_callbacks is None`` returns immediately.
+        """
+        if self.build_time_test_callbacks is None:
+            return
+
+        for name in self.build_time_test_callbacks:
+            try:
+                fn = getattr(self, name)
+                tty.msg('RUN-TESTS: build-time tests [{0}]'.format(name))
+                fn()
+            except AttributeError:
+                msg = 'RUN-TESTS: method not implemented [{0}]'
+                tty.warn(msg.format(name))
+
 
 class Package(PackageBase):
     """General purpose class with a single ``install``

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -219,9 +219,11 @@ class PackageMeta(spack.directives.DirectiveMetaMixin):
 
         if all([not hasattr(x, 'sanity_check') for x in bases]):
             attr_dict['sanity_check'] = sanity_check
+            attr_dict['run_after'] = sanity_check
 
         if all([not hasattr(x, 'precondition') for x in bases]):
             attr_dict['precondition'] = precondition
+            attr_dict['run_before'] = precondition
 
         if all([not hasattr(x, 'on_package_attributes') for x in bases]):
             attr_dict['on_package_attributes'] = on_package_attributes

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -22,8 +22,9 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
 import os
+
+from spack import *
 
 
 def check(condition, msg):
@@ -38,6 +39,28 @@ class CmakeClient(CMakePackage):
     url       = 'https://www.example.com/cmake-client-1.0.tar.gz'
 
     version('1.0', '4cb3ff35b2472aae70f542116d616e63')
+
+    callback_counter = 0
+
+    flipped = False
+    run_this = True
+    check_this_is_None = None
+    did_something = False
+
+    @run_after('cmake')
+    @run_before('cmake', 'build', 'install')
+    def increment(self):
+        self.callback_counter += 1
+
+    @run_after('cmake')
+    @on_package_attributes(run_this=True, check_this_is_None=None)
+    def flip(self):
+        self.flipped = True
+
+    @run_after('cmake')
+    @on_package_attributes(does_not_exist=None)
+    def do_not_execute(self):
+        self.did_something = True
 
     def setup_environment(self, spack_env, run_env):
         spack_cc    # Ensure spack module-scope variable is avaiabl
@@ -67,11 +90,15 @@ class CmakeClient(CMakePackage):
               "setup_dependent_package.")
 
     def cmake(self, spec, prefix):
-        pass
+        assert self.callback_counter == 1
 
-    build = cmake
+    def build(self, spec, prefix):
+        assert self.did_something is False
+        assert self.flipped is True
+        assert self.callback_counter == 3
 
     def install(self, spec, prefix):
+        assert self.callback_counter == 4
         # check that cmake is in the global scope.
         global cmake
         check(cmake is not None, "No cmake was in environment!")

--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -49,7 +49,7 @@ class Cmor(AutotoolsPackage):
     depends_on('python@:2.7', when='+python')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
 
-    @AutotoolsPackage.run_before('configure')
+    @run_before('configure')
     def validate(self):
         if '+fortran' in self.spec and not self.compiler.fc:
             msg = 'cannot build a fortran variant without a fortran compiler'

--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -49,7 +49,7 @@ class Cmor(AutotoolsPackage):
     depends_on('python@:2.7', when='+python')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
 
-    @AutotoolsPackage.precondition('configure')
+    @AutotoolsPackage.run_before('configure')
     def validate(self):
         if '+fortran' in self.spec and not self.compiler.fc:
             msg = 'cannot build a fortran variant without a fortran compiler'

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -47,7 +47,7 @@ class H5hut(AutotoolsPackage):
     # install: .libs/libH5hut.a: No such file or directory
     parallel = False
 
-    @AutotoolsPackage.precondition('configure')
+    @AutotoolsPackage.run_before('configure')
     def validate(self):
         """Checks if Fortran compiler is available."""
 

--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -47,7 +47,7 @@ class H5hut(AutotoolsPackage):
     # install: .libs/libH5hut.a: No such file or directory
     parallel = False
 
-    @AutotoolsPackage.run_before('configure')
+    @run_before('configure')
     def validate(self):
         """Checks if Fortran compiler is available."""
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -70,7 +70,7 @@ class Hdf5(AutotoolsPackage):
     depends_on('szip', when='+szip')
     depends_on('zlib@1.1.2:')
 
-    @AutotoolsPackage.precondition('configure')
+    @AutotoolsPackage.run_before('configure')
     def validate(self):
         """
         Checks if incompatible variants have been activated at the same time
@@ -170,7 +170,7 @@ class Hdf5(AutotoolsPackage):
                     arg for arg in m.group(1).split(' ') if arg != '-l'),
                 'libtool')
 
-    @AutotoolsPackage.sanity_check('install')
+    @AutotoolsPackage.run_after('install')
     def check_install(self):
         # Build and run a small program to test the installed HDF5 library
         spec = self.spec

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -70,7 +70,7 @@ class Hdf5(AutotoolsPackage):
     depends_on('szip', when='+szip')
     depends_on('zlib@1.1.2:')
 
-    @AutotoolsPackage.run_before('configure')
+    @run_before('configure')
     def validate(self):
         """
         Checks if incompatible variants have been activated at the same time
@@ -170,7 +170,7 @@ class Hdf5(AutotoolsPackage):
                     arg for arg in m.group(1).split(' ') if arg != '-l'),
                 'libtool')
 
-    @AutotoolsPackage.run_after('install')
+    @run_after('install')
     def check_install(self):
         # Build and run a small program to test the installed HDF5 library
         spec = self.spec

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -28,7 +28,7 @@ import sys
 
 
 class Hypre(Package):
-    """Hypre is a library of high performance preconditioners that
+    """Hypre is a library of high performance run_beforeers that
        features parallel multigrid methods for both structured and
        unstructured grid problems."""
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -28,7 +28,7 @@ import sys
 
 
 class Hypre(Package):
-    """Hypre is a library of high performance run_beforeers that
+    """Hypre is a library of high performance preconditioners that
        features parallel multigrid methods for both structured and
        unstructured grid problems."""
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -86,7 +86,7 @@ class Mpich(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-    @AutotoolsPackage.precondition('autoreconf')
+    @AutotoolsPackage.run_before('autoreconf')
     def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -86,7 +86,7 @@ class Mpich(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-    @AutotoolsPackage.run_before('autoreconf')
+    @run_before('autoreconf')
     def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to
@@ -106,7 +106,7 @@ class Mpich(AutotoolsPackage):
             '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without')
         ]
 
-    @AutotoolsPackage.run_after('install')
+    @run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
         compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -106,7 +106,7 @@ class Mpich(AutotoolsPackage):
             '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without')
         ]
 
-    @AutotoolsPackage.sanity_check('install')
+    @AutotoolsPackage.run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
         compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -68,7 +68,7 @@ class Openblas(MakefilePackage):
     def lapack_libs(self):
         return self.blas_libs
 
-    @MakefilePackage.run_before('edit')
+    @run_before('edit')
     def check_compilers(self):
         # As of 06/2016 there is no mechanism to specify that packages which
         # depends on Blas/Lapack need C or/and Fortran symbols. For now
@@ -126,7 +126,7 @@ class Openblas(MakefilePackage):
 
         return self.make_defs + targets
 
-    @MakefilePackage.run_after('build')
+    @run_after('build')
     def check_build(self):
         make('tests', *self.make_defs)
 
@@ -138,7 +138,7 @@ class Openblas(MakefilePackage):
         ]
         return make_args + self.make_defs
 
-    @MakefilePackage.run_after('install')
+    @run_after('install')
     def check_install(self):
         spec = self.spec
         # Openblas may pass its own test but still fail to compile Lapack

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -68,7 +68,7 @@ class Openblas(MakefilePackage):
     def lapack_libs(self):
         return self.blas_libs
 
-    @MakefilePackage.precondition('edit')
+    @MakefilePackage.run_before('edit')
     def check_compilers(self):
         # As of 06/2016 there is no mechanism to specify that packages which
         # depends on Blas/Lapack need C or/and Fortran symbols. For now
@@ -126,7 +126,7 @@ class Openblas(MakefilePackage):
 
         return self.make_defs + targets
 
-    @MakefilePackage.sanity_check('build')
+    @MakefilePackage.run_after('build')
     def check_build(self):
         make('tests', *self.make_defs)
 
@@ -138,7 +138,7 @@ class Openblas(MakefilePackage):
         ]
         return make_args + self.make_defs
 
-    @MakefilePackage.sanity_check('install')
+    @MakefilePackage.run_after('install')
     def check_install(self):
         spec = self.spec
         # Openblas may pass its own test but still fail to compile Lapack

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -239,7 +239,7 @@ class Openmpi(AutotoolsPackage):
 
         return config_args
 
-    @AutotoolsPackage.sanity_check('install')
+    @AutotoolsPackage.run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -145,7 +145,7 @@ class Openmpi(AutotoolsPackage):
         elif self.spec.satisfies('@1.7:'):
             return 'verbs'
 
-    @AutotoolsPackage.run_before('autoreconf')
+    @run_before('autoreconf')
     def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to
@@ -239,7 +239,7 @@ class Openmpi(AutotoolsPackage):
 
         return config_args
 
-    @AutotoolsPackage.run_after('install')
+    @run_after('install')
     def filter_compilers(self):
         """Run after install to make the MPI compilers use the
            compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -145,7 +145,7 @@ class Openmpi(AutotoolsPackage):
         elif self.spec.satisfies('@1.7:'):
             return 'verbs'
 
-    @AutotoolsPackage.precondition('autoreconf')
+    @AutotoolsPackage.run_before('autoreconf')
     def die_without_fortran(self):
         # Until we can pass variants such as +fortran through virtual
         # dependencies depends_on('mpi'), require Fortran compiler to

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -44,7 +44,7 @@ class PyBasemap(PythonPackage):
     def setup_environment(self, spack_env, run_env):
         spack_env.set('GEOS_DIR', self.spec['geos'].prefix)
 
-    @PythonPackage.sanity_check('install')
+    @PythonPackage.run_after('install')
     def post_install_patch(self):
         spec = self.spec
         # We are not sure if this fix is needed before Python 3.5.2.

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -44,7 +44,7 @@ class PyBasemap(PythonPackage):
     def setup_environment(self, spack_env, run_env):
         spack_env.set('GEOS_DIR', self.spec['geos'].prefix)
 
-    @PythonPackage.run_after('install')
+    @run_after('install')
     def post_install_patch(self):
         spec = self.spec
         # We are not sure if this fix is needed before Python 3.5.2.

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -95,7 +95,7 @@ class PyMatplotlib(PythonPackage):
     # depends_on('ttconv')
     depends_on('py-six@1.9.0:', type=('build', 'run'))
 
-    @PythonPackage.run_after('install')
+    @run_after('install')
     def set_backend(self):
         spec = self.spec
         prefix = self.prefix

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -95,7 +95,7 @@ class PyMatplotlib(PythonPackage):
     # depends_on('ttconv')
     depends_on('py-six@1.9.0:', type=('build', 'run'))
 
-    @PythonPackage.sanity_check('install')
+    @PythonPackage.run_after('install')
     def set_backend(self):
         spec = self.spec
         prefix = self.prefix

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -65,7 +65,7 @@ class PyYt(PythonPackage):
     depends_on("py-sympy", type=('build', 'run'))
     depends_on("python @2.7:2.999,3.4:")
 
-    @PythonPackage.run_after('install')
+    @run_after('install')
     def check_install(self):
         # The Python interpreter path can be too long for this
         # yt = Executable(join_path(prefix.bin, "yt"))

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -65,7 +65,7 @@ class PyYt(PythonPackage):
     depends_on("py-sympy", type=('build', 'run'))
     depends_on("python @2.7:2.999,3.4:")
 
-    @PythonPackage.sanity_check('install')
+    @PythonPackage.run_after('install')
     def check_install(self):
         # The Python interpreter path can be too long for this
         # yt = Executable(join_path(prefix.bin, "yt"))

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -113,7 +113,7 @@ class R(AutotoolsPackage):
 
         return config_args
 
-    @AutotoolsPackage.sanity_check('install')
+    @run_after('install')
     def copy_makeconf(self):
         # Make a copy of Makeconf because it will be needed to properly build R
         # dependencies in Spack.
@@ -121,7 +121,7 @@ class R(AutotoolsPackage):
         dst_makeconf = join_path(self.etcdir, 'Makeconf.spack')
         shutil.copy(src_makeconf, dst_makeconf)
 
-    @AutotoolsPackage.sanity_check('install')
+    @run_after('install')
     def filter_compilers(self):
         """Run after install to tell the configuration files and Makefiles
         to use the compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -55,7 +55,7 @@ class Tcl(AutotoolsPackage):
     def build_directory(self):
         return 'unix'
 
-    @AutotoolsPackage.run_after('install')
+    @run_after('install')
     def symlink_tclsh(self):
         with working_dir(self.prefix.bin):
             symlink('tclsh{0}'.format(self.version.up_to(2)), 'tclsh')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -55,7 +55,7 @@ class Tcl(AutotoolsPackage):
     def build_directory(self):
         return 'unix'
 
-    @AutotoolsPackage.sanity_check('install')
+    @AutotoolsPackage.run_after('install')
     def symlink_tclsh(self):
         with working_dir(self.prefix.bin):
             symlink('tclsh{0}'.format(self.version.up_to(2)), 'tclsh')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -379,7 +379,7 @@ class Trilinos(CMakePackage):
             ])
         return options
 
-    @CMakePackage.run_after('install')
+    @run_after('install')
     def filter_python(self):
         # When trilinos is built with Python, libpytrilinos is included
         # through cmake configure files. Namely, Trilinos_LIBRARIES in

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -379,7 +379,7 @@ class Trilinos(CMakePackage):
             ])
         return options
 
-    @CMakePackage.sanity_check('install')
+    @CMakePackage.run_after('install')
     def filter_python(self):
         # When trilinos is built with Python, libpytrilinos is included
         # through cmake configure files. Namely, Trilinos_LIBRARIES in


### PR DESCRIPTION
##### Modifications
- [x] `@run_before` is the substitute for `@*.precondition`
- [x] `@run_after` is the substitute for `@*.sanity_check`
- [x] `@on_package_attributes` is the substitute for `@*.on_package_attributes`
- [x] added in code documentation

