### PR TITLE
Adding some fixes to packages that use `configure_args` function without setting spec set or directly referencing it

### DIFF
--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -56,10 +56,9 @@ class Cmor(AutotoolsPackage):
             raise RuntimeError(msg)
 
     def configure_args(self):
-        spec = self.spec
         extra_args = ['--disable-debug']
 
-        if '+fortran' in spec:
+        if '+fortran' in self.spec:
             extra_args.append('--enable-fortran')
         else:
             extra_args.append('--disable-fortran')

--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -56,9 +56,10 @@ class Cmor(AutotoolsPackage):
             raise RuntimeError(msg)
 
     def configure_args(self):
+        spec = self.spec
         extra_args = ['--disable-debug']
 
-        if '+fortran' in self.spec:
+        if '+fortran' in spec:
             extra_args.append('--enable-fortran')
         else:
             extra_args.append('--disable-fortran')

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -48,6 +48,7 @@ class Emacs(AutotoolsPackage):
     depends_on('gtkplus+X', when='+X toolkit=gtk')
 
     def configure_args(self):
+        spec = self.spec
         args = []
         toolkit = spec.variants['toolkit'].value
         if '+X' in spec:

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -38,6 +38,7 @@ class Libcerf(AutotoolsPackage):
     version('1.3', 'b3504c467204df71e62aeccf73a25612')
 
     def configure_args(self):
+        spec = self.spec
         options = []
         # Clang reports unused functions as errors, see
         # http://clang.debian.net/status.php?version=3.8.1&key=UNUSED_FUNCTION

--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -53,6 +53,7 @@ class Libevent(AutotoolsPackage):
     depends_on('openssl', when='+openssl')
 
     def configure_args(self):
+        spec = self.spec
         configure_args = []
         if '+openssl' in spec:
             configure_args.append('--enable-openssl')

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -46,7 +46,8 @@ class Libxml2(AutotoolsPackage):
     depends_on('pkg-config@0.9.0:', type='build')
 
     def configure_args(self):
-        if '+python' in self.spec:
+        spec = self.spec
+        if '+python' in spec:
             python_args = [
                 '--with-python={0}'.format(spec['python'].prefix),
                 '--with-python-install-dir={0}'.format(site_packages_dir)

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -46,7 +46,7 @@ class Libxml2(AutotoolsPackage):
     depends_on('pkg-config@0.9.0:', type='build')
 
     def configure_args(self):
-        if '+python' in spec:
+        if '+python' in self.spec:
             python_args = [
                 '--with-python={0}'.format(spec['python'].prefix),
                 '--with-python-install-dir={0}'.format(site_packages_dir)


### PR DESCRIPTION
Pulled down a fresh copy of Spack and attempted to install emacs and was met with "**Error: NameError: global name 'spec' is not defined**":
```
==> Installing emacs
==> ncurses is already installed in /home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/ncurses-6.0-jfac4tqswyeppf5jphk2lxew7bpqx4z6
==> Using cached archive: /home/vagrant/spack/var/spack/cache/emacs/emacs-25.1.tar.gz
==> Staging archive: /home/vagrant/spack/var/spack/stage/emacs-25.1-k5preh7xr6tciuhbf2t42dj5ennepor5/emacs-25.1.tar.gz
==> Created stage in /home/vagrant/spack/var/spack/stage/emacs-25.1-k5preh7xr6tciuhbf2t42dj5ennepor5
==> Ran patch() for emacs
==> Building emacs [AutotoolsPackage]
==> Executing phase : 'autoreconf'
==> Executing phase : 'configure'
==> Error: NameError: global name 'spec' is not defined
/home/vagrant/spack/var/spack/repos/builtin/packages/emacs/package.py:52, in configure_args:
     50       def configure_args(self):
     51           args = []
  >> 52           toolkit = spec.variants['toolkit'].value
     53           if '+X' in spec:
     54               if toolkit not in ('gtk', 'athena'):
     55                   raise InstallError("toolkit must be in (gtk, athena), not %s" %
     56                                      toolkit)
     57               args = [
     58                   '--with-x',
     59                   '--with-x-toolkit={0}'.format(toolkit)
     60               ]
     61           else:
     62               args = ['--without-x']
     63
     64           return args

See build log for details:
  /tmp/vagrant/spack-stage/spack-stage-dWYAqz/emacs-25.1/spack-build.out
```

After a quick search of open issues, I was not able to locate a reference to this.  I did find a similar issue in #2113.

After reading that, it seems there is some conflicting preferences...or at least that's how I read it...on when to use passing `spec` to the `configure_args()` function vs `self.spec` and not passing `spec` to said function.

I opted for defining `spec` as `self.spec`.