### PR TITLE
Another parser fix

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2860,6 +2860,15 @@ class SpecParser(spack.parse.Parser):
                     # We've found the start of a new spec. Go back to do_parse
                     break
 
+            elif self.accept(HASH):
+                # Get spec by hash and confirm it matches what we already have
+                hash_spec = self.spec_by_hash()
+                if hash_spec.satisfies(spec):
+                    spec = hash_spec
+                    break
+                else:
+                    raise InvalidHashError(spec, hash_spec.dag_hash())
+
             else:
                 break
 
@@ -3139,3 +3148,9 @@ class AmbiguousHashError(SpecError):
         super(AmbiguousHashError, self).__init__(msg)
         for spec in specs:
             print('    ', spec.format('$.$@$%@+$+$=$#'))
+
+class InvalidHashError(SpecError):
+    def __init__(self, spec, hash):
+        super(InvalidHashError, self).__init__(
+            "The spec specified by %s does not match provided spec %s"
+            % (hash, spec))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -153,6 +153,7 @@ __all__ = [
     'UnsatisfiableProviderSpecError',
     'UnsatisfiableDependencySpecError',
     'AmbiguousHashError',
+    'InvalidHashError',
     'RedundantSpecError']
 
 # Valid pattern for an identifier in Spack
@@ -2716,7 +2717,7 @@ class SpecParser(spack.parse.Parser):
                         self.expect(VAL)
                         # Raise an error if the previous spec is already
                         # concrete (assigned by hash)
-                        if specs[-1].concrete:
+                        if specs[-1]._hash:
                             raise RedundantSpecError(specs[-1],
                                                      'key-value pair')
                         specs[-1]._add_flag(
@@ -2746,7 +2747,7 @@ class SpecParser(spack.parse.Parser):
 
                     # Raise an error if the previous spec is already concrete
                     # (assigned by hash)
-                    if specs[-1].concrete:
+                    if specs[-1]._hash:
                         raise RedundantSpecError(specs[-1], 'dependency')
                     # command line deps get empty deptypes now.
                     # Real deptypes are assigned later per packages.
@@ -2758,7 +2759,7 @@ class SpecParser(spack.parse.Parser):
                     if self.next.type in (AT, ON, OFF, PCT):
                         # Raise an error if the previous spec is already
                         # concrete (assigned by hash)
-                        if specs and specs[-1].concrete:
+                        if specs and specs[-1]._hash:
                             raise RedundantSpecError(specs[-1],
                                                      'compiler, version, '
                                                      'or variant')
@@ -2876,7 +2877,7 @@ class SpecParser(spack.parse.Parser):
                 break
 
         # If there was no version in the spec, consier it an open range
-        if not added_version:
+        if not added_version and not spec._hash:
             spec.versions = VersionList(':')
 
         return spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2724,9 +2724,8 @@ class SpecParser(spack.parse.Parser):
                         self.previous = None
                     else:
                         # We're parsing a new spec by name
-                        value = self.previous.value
                         self.previous = None
-                        specs.append(self.spec(value))
+                        specs.append(self.spec(self.token.value))
                 elif self.accept(HASH):
                     # We're finding a spec by hash
                     specs.append(self.spec_by_hash())

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2692,24 +2692,17 @@ class SpecParser(spack.parse.Parser):
     def __init__(self):
         super(SpecParser, self).__init__(_lexer)
         self.previous = None
-        self.hash_spec = None
 
     def do_parse(self):
         specs = []
 
         try:
             while self.next or self.previous:
-                # Note: Whenever we start a new spec, we verify the previous
-                # spec against the hash spec if one exists.
                 # TODO: clean this parsing up a bit
                 if self.previous:
                     # We picked up the name of this spec while finishing the
                     # previous spec
-                    specs[-1] = self.verify_hash_spec(specs[-1])
-                    if self.previous.type == HASH:
-                        specs.append(self.spec_by_hash())
-                    else:
-                        specs.append(self.spec(self.previous.value))
+                    specs.append(self.spec(self.previous.value))
                     self.previous = None
                 elif self.accept(ID):
                     self.previous = self.token
@@ -2727,13 +2720,9 @@ class SpecParser(spack.parse.Parser):
                         # We're parsing a new spec by name
                         value = self.previous.value
                         self.previous = None
-                        if specs:
-                            self.verify_hash_spec(specs[-1])
                         specs.append(self.spec(value))
                 elif self.accept(HASH):
                     # We're finding a spec by hash
-                    if specs:
-                        specs[-1] = self.verify_hash_spec(specs[-1])
                     specs.append(self.spec_by_hash())
 
                 elif self.accept(DEP):
@@ -2758,8 +2747,6 @@ class SpecParser(spack.parse.Parser):
                     # If the next token can be part of a valid anonymous spec,
                     # create the anonymous spec
                     if self.next.type in (AT, ON, OFF, PCT):
-                        if specs:
-                            specs[-1] = self.verify_hash_spec(specs[-1])
                         specs.append(self.spec(None))
                     else:
                         self.unexpected_token()
@@ -2775,18 +2762,7 @@ class SpecParser(spack.parse.Parser):
                 if s.architecture and not s.architecture.platform and \
                         (s.architecture.platform_os or s.architecture.target):
                     s._set_architecture(platform=platform_default)
-
-        if specs:
-            specs[-1] = self.verify_hash_spec(specs[-1])
         return specs
-
-    def verify_hash_spec(self, spec):
-        if self.hash_spec:
-            if not self.hash_spec.satisfies(spec):
-                raise InvalidHashError(spec, self.hash_spec.dag_hash())
-            spec = self.hash_spec
-            self.hash_spec = None
-        return spec
 
     def parse_compiler(self, text):
         self.setup(text)
@@ -2873,11 +2849,13 @@ class SpecParser(spack.parse.Parser):
                     break
 
             elif self.accept(HASH):
-                # Get spec by hash and save to verify later against rest of spec
-                if self.hash_spec:
-                    self.previous = self.token
+                # Get spec by hash and confirm it matches what we already have
+                hash_spec = self.spec_by_hash()
+                if hash_spec.satisfies(spec):
+                    spec = hash_spec
                     break
-                self.hash_spec = self.spec_by_hash()
+                else:
+                    raise InvalidHashError(spec, hash_spec.dag_hash())
 
             else:
                 break

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2086,9 +2086,10 @@ class Spec(object):
             if other._dependencies and not self._dependencies:
                 return False
 
-            alldeps = set(d.name for d in self.traverse(root=False))
-            if not all(dep.name in alldeps
-                       for dep in other.traverse(root=False)):
+            selfdeps = self.traverse(root=False)
+            otherdeps = other.traverse(root=False)
+            if not all(any(d.satisfies(dep) for d in selfdeps)
+                       for dep in otherdeps):
                 return False
 
         elif not self._dependencies or not other._dependencies:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2736,16 +2736,16 @@ class SpecParser(spack.parse.Parser):
                         specs.append(self.spec(None))
                     else:
                         if self.accept(HASH):
-                            # We're finding a dependency by hash for an anonymous
-                            # spec
+                            # We're finding a dependency by hash for an
+                            # anonymous spec
                             dep = self.spec_by_hash()
                         else:
                             # We're adding a dependency to the last spec
                             self.expect(ID)
                             dep = self.spec(self.token.value)
 
-                        # Raise an error if the previous spec is already concrete
-                        # (assigned by hash)
+                        # Raise an error if the previous spec is already
+                        # concrete (assigned by hash)
                         if specs[-1]._hash:
                             raise RedundantSpecError(specs[-1], 'dependency')
                         # command line deps get empty deptypes now.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2729,9 +2729,7 @@ class SpecParser(spack.parse.Parser):
                     if not specs:
                         # We're parsing an anonymous spec beginning with a
                         # dependency
-                        self.previous = self.token
                         specs.append(self.spec(None))
-                        self.previous = None
                     if self.accept(HASH):
                         # We're finding a dependency by hash for an anonymous
                         # spec
@@ -2822,16 +2820,6 @@ class SpecParser(spack.parse.Parser):
         # record this so that we know whether version is
         # unspecified or not.
         added_version = False
-
-        if self.previous and self.previous.value == DEP:
-            if self.accept(HASH):
-                spec.add_dependency(self.spec_by_hash())
-            else:
-                self.expect(ID)
-                if self.accept(EQ):
-                    raise SpecParseError(spack.parse.ParseError(
-                        "", "", "Expected dependency received anonymous spec"))
-                spec.add_dependency(self.spec(self.token.value))
 
         while self.next:
             if self.accept(AT):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2070,7 +2070,7 @@ class Spec(object):
         if deps:
             deps_strict = strict
             if self.concrete and not other.name:
-                #We're dealing with existing specs
+                # We're dealing with existing specs
                 deps_strict = True
             return self.satisfies_dependencies(other, strict=deps_strict)
         else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1995,7 +1995,7 @@ class Spec(object):
         except SpecError:
             return parse_anonymous_spec(spec_like, self.name)
 
-    def satisfies(self, other, deps=True, strict=False):
+    def satisfies(self, other, deps=True, strict=False, strict_deps=False):
         """Determine if this spec satisfies all constraints of another.
 
         There are two senses for satisfies:
@@ -2069,6 +2069,9 @@ class Spec(object):
         # If we need to descend into dependencies, do it, otherwise we're done.
         if deps:
             deps_strict = strict
+            if self.concrete and not other.name:
+                #We're dealing with existing specs
+                deps_strict = True
             return self.satisfies_dependencies(other, strict=deps_strict)
         else:
             return True

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -268,7 +268,7 @@ class TestSpecSyntax(object):
                           ' ' + specs[2].name)
         assert len(output) == 3
         output = sp.parse('/' + hashes[0] +
-                              ' ' + specs[1].name + ' ' + specs[2].name)
+                          ' ' + specs[1].name + ' ' + specs[2].name)
         assert len(output) == 3
         output = sp.parse('/' + hashes[0] + ' ' +
                           specs[1].name + ' / ' + hashes[1])

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -218,6 +218,114 @@ class TestSpecSyntax(object):
         errors = ['x@@1.2', 'x ^y@@1.2', 'x@1.2::', 'x::']
         self._check_raises(SpecParseError, errors)
 
+    def test_spec_by_hash(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is still the shape we expect
+        assert len(specs) > 3
+
+        self.check_parse(str(specs[0]), '/' + hashes[0])
+        self.check_parse(str(specs[1]), '/ ' + hashes[1][:5])
+        self.check_parse(str(specs[2]), specs[2].name + '/' + hashes[2])
+        self.check_parse(str(specs[3]),
+                         specs[3].name + '@' + str(specs[3].version)
+                         + ' /' + hashes[3][:6])
+
+    def test_dep_spec_by_hash(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is still the shape we expect
+        assert len(specs) > 10
+        assert specs[4].name in specs[10]
+        assert specs[-1].name in specs[10]
+
+        spec1 = sp.Spec(specs[10].name + '^/' + hashes[4])
+        assert specs[4].name in spec1 and spec1[specs[4].name] == specs[4]
+        spec2 = sp.Spec(specs[10].name + '%' + str(specs[10].compiler)
+                       + ' ^ / ' + hashes[-1])
+        assert (specs[-1].name in spec2 and spec2[specs[-1].name] == specs[-1]
+                and spec2.compiler == specs[10].compiler)
+        spec3 = sp.Spec(specs[10].name + '^/' + hashes[4][:4]
+                       + '^ / ' + hashes[-1][:5])
+        assert (specs[-1].name in spec3 and spec3[specs[-1].name] == specs[-1]
+                and specs[4].name in spec3 and spec3[specs[4].name] == specs[4])
+
+    def test_multiple_specs_with_hash(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        assert len(specs) > 3
+
+        output = sp.parse(specs[0].name + '/' + hashes[0] + '/' + hashes[1])
+        assert len(output) == 2
+        output = sp.parse('/' + hashes[0] + '/' + hashes[1])
+        assert len(output) == 2
+        output = sp.parse('/' + hashes[0] + '/' + hashes[1]
+                          + ' ' + specs[2].name)
+        assert len(output) == 3
+        output = sp.parse('/' + hashes[0]
+                          + ' ' + specs[1].name + ' ' + specs[2].name)
+        assert len(output) == 3
+        output = sp.parse('/' + hashes[0] + ' ' + specs[1].name
+                          + ' / ' + hashes[1])
+        assert len(output) == 2
+
+    def test_ambiguous_hash(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is as expected
+        assert hashes[1][:1] == hashes[2][:1] == 'b'
+
+        ambiguous_hashes = ['/b',
+                      specs[1].name + '/b',
+                      specs[0].name + '^/b',
+                      specs[0].name + '^' + specs[1].name + '/b']
+        self._check_raises(AmbiguousHashError, ambiguous_hashes)
+
+    def test_invalid_hash(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is as expected
+        assert (hashes[0] != hashes[3]
+                and hashes[1] != hashes[4] and len(specs) > 4)
+
+        inputs = [specs[0].name + '/' + hashes[3],
+                  specs[1].name + '^' + specs[4].name + '/' + hashes[0],
+                  specs[1].name + '^' + specs[4].name + '/' + hashes[1]]
+        self._check_raises(InvalidHashError, inputs)
+
+
+    def test_nonexistent_hash(self, database):
+        # This test uses database to make sure we don't accidentally access
+        # real installs, however unlikely
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is as expected
+        assert 'abc123' not in [h[:6] for h in hashes]
+
+        nonexistant_hashes = ['/abc123',
+                              specs[0].name + '/abc123']
+        self._check_raises(SystemExit, nonexistant_hashes)
+
+    def test_redundant_spec(self, database):
+        specs = database.mock.db.query()
+        hashes = [s._hash for s in specs]  # Preserves order of elements
+
+        # Make sure the database is as expected
+        assert len(specs) > 3
+
+        redundant_specs = ['/' + hashes[0] + '%' + str(specs[0].compiler),
+                           specs[1].name + '/' + hashes[1]
+                               + '@' + str(specs[1].version),
+                           specs[2].name + '/' + hashes[2] + '^ libelf',
+                           '/' + hashes[3] + ' cflags="-O3 -fPIC"']
+        self._check_raises(RedundantSpecError, redundant_specs)
+
     def test_duplicate_variant(self):
         duplicates = [
             'x@1.2+debug+debug',

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -132,6 +132,13 @@ class TestSpecSyntax(object):
         self.check_parse("mvapich_foo")
         self.check_parse("_mvapich_foo")
 
+    def test_anonymous_specs(self):
+        self.check_parse("%intel")
+        self.check_parse("@2.7")
+        self.check_parse("^zlib")
+        self.check_parse("+foo")
+        self.check_parse("arch=test-None-None", "platform=test")
+
     def test_simple_dependence(self):
         self.check_parse("openmpi^hwloc")
         self.check_parse("openmpi^hwloc^libunwind")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -229,8 +229,8 @@ class TestSpecSyntax(object):
         self.check_parse(str(specs[1]), '/ ' + hashes[1][:5])
         self.check_parse(str(specs[2]), specs[2].name + '/' + hashes[2])
         self.check_parse(str(specs[3]),
-                         specs[3].name + '@' + str(specs[3].version)
-                         + ' /' + hashes[3][:6])
+                         specs[3].name + '@' + str(specs[3].version) +
+                         ' /' + hashes[3][:6])
 
     def test_dep_spec_by_hash(self, database):
         specs = database.mock.db.query()
@@ -243,14 +243,16 @@ class TestSpecSyntax(object):
 
         spec1 = sp.Spec(specs[10].name + '^/' + hashes[4])
         assert specs[4].name in spec1 and spec1[specs[4].name] == specs[4]
-        spec2 = sp.Spec(specs[10].name + '%' + str(specs[10].compiler)
-                       + ' ^ / ' + hashes[-1])
-        assert (specs[-1].name in spec2 and spec2[specs[-1].name] == specs[-1]
-                and spec2.compiler == specs[10].compiler)
-        spec3 = sp.Spec(specs[10].name + '^/' + hashes[4][:4]
-                       + '^ / ' + hashes[-1][:5])
-        assert (specs[-1].name in spec3 and spec3[specs[-1].name] == specs[-1]
-                and specs[4].name in spec3 and spec3[specs[4].name] == specs[4])
+        spec2 = sp.Spec(specs[10].name + '%' + str(specs[10].compiler) +
+                        ' ^ / ' + hashes[-1])
+        assert (specs[-1].name in spec2 and
+                spec2[specs[-1].name] == specs[-1] and
+                spec2.compiler == specs[10].compiler)
+        spec3 = sp.Spec(specs[10].name + '^/' + hashes[4][:4] +
+                        '^ / ' + hashes[-1][:5])
+        assert (specs[-1].name in spec3 and
+                spec3[specs[-1].name] == specs[-1] and
+                specs[4].name in spec3 and spec3[specs[4].name] == specs[4])
 
     def test_multiple_specs_with_hash(self, database):
         specs = database.mock.db.query()
@@ -262,14 +264,14 @@ class TestSpecSyntax(object):
         assert len(output) == 2
         output = sp.parse('/' + hashes[0] + '/' + hashes[1])
         assert len(output) == 2
-        output = sp.parse('/' + hashes[0] + '/' + hashes[1]
-                          + ' ' + specs[2].name)
+        output = sp.parse('/' + hashes[0] + '/' + hashes[1] +
+                          ' ' + specs[2].name)
         assert len(output) == 3
-        output = sp.parse('/' + hashes[0]
-                          + ' ' + specs[1].name + ' ' + specs[2].name)
+        output = sp.parse('/' + hashes[0] +
+                              ' ' + specs[1].name + ' ' + specs[2].name)
         assert len(output) == 3
-        output = sp.parse('/' + hashes[0] + ' ' + specs[1].name
-                          + ' / ' + hashes[1])
+        output = sp.parse('/' + hashes[0] + ' ' +
+                          specs[1].name + ' / ' + hashes[1])
         assert len(output) == 2
 
     def test_ambiguous_hash(self, database):
@@ -280,9 +282,9 @@ class TestSpecSyntax(object):
         assert hashes[1][:1] == hashes[2][:1] == 'b'
 
         ambiguous_hashes = ['/b',
-                      specs[1].name + '/b',
-                      specs[0].name + '^/b',
-                      specs[0].name + '^' + specs[1].name + '/b']
+                            specs[1].name + '/b',
+                            specs[0].name + '^/b',
+                            specs[0].name + '^' + specs[1].name + '/b']
         self._check_raises(AmbiguousHashError, ambiguous_hashes)
 
     def test_invalid_hash(self, database):
@@ -290,8 +292,8 @@ class TestSpecSyntax(object):
         hashes = [s._hash for s in specs]  # Preserves order of elements
 
         # Make sure the database is as expected
-        assert (hashes[0] != hashes[3]
-                and hashes[1] != hashes[4] and len(specs) > 4)
+        assert (hashes[0] != hashes[3] and
+                hashes[1] != hashes[4] and len(specs) > 4)
 
         inputs = [specs[0].name + '/' + hashes[3],
                   specs[1].name + '^' + specs[4].name + '/' + hashes[0],
@@ -319,8 +321,8 @@ class TestSpecSyntax(object):
         assert len(specs) > 3
 
         redundant_specs = ['/' + hashes[0] + '%' + str(specs[0].compiler),
-                           specs[1].name + '/' + hashes[1]
-                               + '@' + str(specs[1].version),
+                           specs[1].name + '/' + hashes[1] +
+                           '@' + str(specs[1].version),
                            specs[2].name + '/' + hashes[2] + '^ libelf',
                            '/' + hashes[3] + ' cflags="-O3 -fPIC"']
         self._check_raises(RedundantSpecError, redundant_specs)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -298,7 +298,6 @@ class TestSpecSyntax(object):
                   specs[1].name + '^' + specs[4].name + '/' + hashes[1]]
         self._check_raises(InvalidHashError, inputs)
 
-
     def test_nonexistent_hash(self, database):
         # This test uses database to make sure we don't accidentally access
         # real installs, however unlikely


### PR DESCRIPTION
- Allows hashes to be specified after other parts of the spec
- Does not allow other parts of the spec to be specified after the hash
- The hash must either end input or be followed by another separate spec
       - The next spec cannot be an anonymous spec (it must start with a package name or a hash)

See #2769 (after it was merged) for further discussion of this interface addition. That discussion resulted in the specification
```
python                     # 1 spec
/abc123                    # 1 spec
python /abc123             # 1 spec
/456789                    # 1 spec
python /abc123 /456789     # 2 specs
python /456789 /abc123     # 2 specs
/abc123 /456789            # 2 specs
/456789 /abc123            # 2 specs
/456789 /abc123 python     # 3 specs
```
assuming `abc123` and `456789` are both hashes of different python specs.
 