### PR TITLE
Simplifying gbenchmark 

### DIFF
--- a/var/spack/repos/builtin/packages/gbenchmark/package.py
+++ b/var/spack/repos/builtin/packages/gbenchmark/package.py
@@ -48,12 +48,3 @@ class Gbenchmark(CMakePackage):
             r'##### add_cxx_compiler_flag(-Werror',
             'CMakeLists.txt'
         )
-
-    def cmake_args(self, spec, prefix):
-        if self.compiler.name == 'intel':
-            return [
-                "-DCMAKE_CXX_FLAGS=-no-ansi-alias -fno-strict-aliasing",
-                "-DCMAKE_C_FLAGS=-no-ansi-alias -fno-strict-aliasing",
-                "-DBENCHMARK_ENABLE_TESTING=OFF"
-            ]
-        return []


### PR DESCRIPTION
Removes the cmake args, since it seems to work without, and the API seems to have changed (spec and prefix are no longer arguments)