### PR TITLE
modules.py: adding 'include' logic to TCL module generation.

### DIFF
--- a/lib/spack/spack/modules.py
+++ b/lib/spack/spack/modules.py
@@ -628,6 +628,18 @@ class TclModule(EnvModule):
                         raise SystemExit('Module generation aborted.')
                 line = self.spec.format(line)
             yield line
+        # Include File (source)
+        include_format = configuration.get('include', [])
+        f = string.Formatter()
+        for item in include_format:
+            line = 'source ' + item + '\n'
+            if not os.path.isfile(item):
+                message = 'Include file must exist!'
+                message += '** You may want to check your '
+                message += '`modules.yaml` configuration file **\n'
+                tty.error(message.format(spec=self.spec))
+                raise SystemExit('Module generation aborted.')
+            yield line
 
 # To construct an arbitrary hierarchy of module files:
 # 1. Parse the configuration file and check that all the items in


### PR DESCRIPTION
Enable arbitrary TCL code to be included in the module files via the `modules.yaml` config file.

For example, I want to include `/shared/modulefiles/include/logging.tcl` on every TCL modulefile generated via spack.

`modules.yaml`:
```
modules:
  tcl:
    all:
      include:
        - '/shared/modulefiles/include/logging.tcl'
```

Module file generated after fake installing `htop`:
```
[vagrant@localhost spack]$ spack install --fake htop
==> Installing htop
==> Building htop [Package]
==> Successfully installed htop
  Fetch: .  Build: 0.04s.  Total: 0.04s.
[+] /home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd
[vagrant@localhost spack]$ cat /home/vagrant/spack/share/spack/modules/linux-centos7-x86_64/htop-2.0.0-gcc-4.8.5-7jzqvbb
#%Module1.0
## Module file created by spack (https://github.com/LLNL/spack) on 2017-01-22 22:46:47.997359
##
## htop@2.0.0%gcc@4.8.5 arch=linux-centos7-x86_64 -7jzqvbb
##
module-whatis "htop @2.0.0"

proc ModulesHelp { } {
puts stderr "This is htop, an interactive process viewer for Unix systems. It is a"
puts stderr "text-mode application (for console or X terminals) and requires ncurses."
}

prepend-path PATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/bin"
prepend-path CMAKE_PREFIX_PATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/"
prepend-path LIBRARY_PATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/lib"
prepend-path LD_LIBRARY_PATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/lib"
prepend-path CPATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/include"
prepend-path MANPATH "/home/vagrant/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/htop-2.0.0-7jzqvbbs5m3t6u5m2sovnbxkqz7iargd/man"
source /shared/modulefiles/include/logging.tcl
```

Currently, the logic only checks if the file to include exists, and fails if it does not.
```
[vagrant@localhost spack]$ sudo rm /shared/modulefiles/include/logging.tcl
[vagrant@localhost spack]$ spack module refresh --module-type tcl --delete-tree -y
==> Regenerating tcl module files
==> Error: Include file must exist!** You may want to check your `modules.yaml` configuration file **

Module generation aborted.
```

I chose the word `include` for use in `modules.yaml` because that is what I thought the TCL command was called when I started this feature...but after testing I discovered it is `source`.  I'm not sure if I like `include` or `source` better for the config yaml...

I brought up this feature request during SC16 at one of the Spack talks (which were all awesome btw) and no one seemed too opposed to it.  So I finally decided to sit down and attempt to add the feature.

I'm pretty new to Python development, so I'm sorry for any glaring issues you see with this PR :expressionless: 