### PR TITLE
Simplify unit tests listed in Contribution Guide

### DIFF
--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -75,7 +75,10 @@ This allows you to develop iteratively: make a change, test that change, make
 another change, test that change, etc. To get a list of all available unit
 tests, run:
 
-.. command-output:: spack test --collect-only
+.. command-output:: spack test -l
+
+A more detailed list of available unit tests can be found by running
+``spack test -L``.
 
 Unit tests are crucial to making sure bugs aren't introduced into Spack. If you
 are modifying core Spack libraries or adding new functionality, please consider

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -75,10 +75,10 @@ This allows you to develop iteratively: make a change, test that change, make
 another change, test that change, etc. To get a list of all available unit
 tests, run:
 
-.. command-output:: spack test -l
+.. command-output:: spack test --list
 
 A more detailed list of available unit tests can be found by running
-``spack test -L``.
+``spack test --long-list``.
 
 Unit tests are crucial to making sure bugs aren't introduced into Spack. If you
 are modifying core Spack libraries or adding new functionality, please consider


### PR DESCRIPTION
If you check out the [Contribution Guide](http://spack.readthedocs.io/en/latest/contribution_guide.html#unit-tests), you'll notice that more than a third of the guide is the output of a single command, `spack test --collect-only`. This PR switches to `spack test --list`, which only lists the highest level of unit tests and saves space. @alalazo Does this seem okay to you?