### PR TITLE
Remove intel-parallel-studio +all checks

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -127,20 +127,7 @@ class IntelParallelStudio(IntelInstaller):
 
         return url + ".tgz"
 
-    def check_variants(self, spec):
-        error_message = '\t{variant} can not be turned off if "+all" is set'
-
-        if self.spec.satisfies('+all'):
-            errors = [error_message.format(variant=x)
-                      for x in ('mpi', 'mkl', 'daal', 'ipp', 'tools')
-                      if ('~' + x) in self.spec]
-            if errors:
-                errors = ['incompatible variants given'] + errors
-                raise InstallError('\n'.join(errors))
-
     def install(self, spec, prefix):
-        self.check_variants(spec)
-
         base_components = "ALL"  # when in doubt, install everything
         mpi_components = ""
         mkl_components = ""


### PR DESCRIPTION
When I tried installing `intel-parallel-studio@professional.2017.1 +all`, it crashed during `check_variants` and told me that I cannot use `+all` without specifying `+mpi`. There are two problems with that:

1. The professional edition does not provide `+mpi`, so installing `+mpi` would be misleading
2. What's the point of an `+all` variant that doesn't work unless you manually activate everything else by hand?

The main reason I use `+all` is because the default behavior is broken (see https://github.com/LLNL/spack/pull/2151#issue-185754092).

Honestly, why don't we just remove all of the variants and always install everything? I can't think of a reason someone would want to install the parallel studio suite but not install mkl, for example. We could provide MPI when `@cluster`. It would also prevent bugs like installing `@cluster+all~mpi`, which technically doesn't provide MPI even though it gets installed.

@lee218llnl 