### PR TITLE
Export spack function so it works in subshells

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -167,6 +167,11 @@ function _spack_pathadd {
     fi
 }
 
+# Export spack function so it is available in subshells (only works with bash)
+if [ -n "${BASH_VERSION:-}" ]; then
+	export -f spack
+fi
+
 #
 # Figure out where this file is.  Below code needs to be portable to
 # bash and zsh.


### PR DESCRIPTION
Currently, loading the shell integration and executing another shell script causes the shell integration to be lost within the script because the `spack` function is not available in subshells. Bash has a feature to export functions, so make use of that (this is also what `module` does).