### PR TITLE
Add dependency on perl

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -53,7 +53,8 @@ class Openssl(Package):
     version('1.0.1h', '8d6d684a9430d5cc98a62a5d8fbda8cf')
 
     depends_on("zlib")
-    # Also requires make and perl
+    depends_on("perl", type='build')
+    # Also requires make
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -54,7 +54,6 @@ class Openssl(Package):
 
     depends_on("zlib")
     depends_on("perl", type='build')
-    # Also requires make
 
     parallel = False
 


### PR DESCRIPTION
The build process uses perl and also needs `Test::More`.

Some distros, e.g. CentOS, break the core Perl distribution
into separate packages, so it's possible to "have perl" but
not have all the bits one needs to build OpenSSL.

We'll just install one of ours, which comes with all of its
factory parts included.