### PR TITLE
db and concretization of packages modified after installation: fixes #2911

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -340,6 +340,7 @@ class Database(object):
         # cached prematurely.
         for hash_key, rec in data.items():
             rec.spec._mark_concrete()
+            rec.spec.package.spec._mark_concrete()
 
         self._data = data
 


### PR DESCRIPTION
Fixes #2911.

@tgamblin @adamjstewart This should fix the behavior seen in #2911 from a user point of view. Take this as an hotfix, because I have the feeling that there are deeper inconsistencies that should be taken care of in the long term, e.g.

1. `spec is not spec.package.spec` holds also after this PR, I just cured the symptoms
2. `package.module` is inconsistent with the reality of things as it always points to a `package.py` in the current repo (while it should point imho to the `package.py` stored under `<prefix>/.spack`)

Let me know if you want me to open new issues to keep track of the things above