### PR TITLE
oce: fix fetching

### DIFF
--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -47,8 +47,8 @@ class Oce(Package):
     depends_on('tbb', when='+tbb')
 
     def url_for_version(self, version):
-        return 'https://github.com/tpaviot/oce/archive/OCE-%s.tar.gz' % \
-            (version.dotted)
+        return 'https://github.com/tpaviot/oce/archive/OCE-%s.tar.gz' % (
+            version.dotted)
 
     # There is a bug in OCE which appears with Clang (version?) or GCC 6.0
     # and has to do with compiler optimization, see

--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -32,7 +32,6 @@ class Oce(Package):
     Open CASCADE library.
     """
     homepage = "https://github.com/tpaviot/oce"
-    url      = "https://github.com/tpaviot/oce/archive/OCE-0.18.tar.gz"
 
     version('0.18',   '226e45e77c16a4a6e127c71fefcd171410703960ae75c7ecc7eb68895446a993')
     version('0.17.2', 'bf2226be4cd192606af677cf178088e5')
@@ -46,6 +45,10 @@ class Oce(Package):
 
     depends_on('cmake@2.8:', type='build')
     depends_on('tbb', when='+tbb')
+
+    def url_for_version(self, version):
+        return 'https://github.com/tpaviot/oce/archive/OCE-%s.tar.gz' % \
+            (version.dotted)
 
     # There is a bug in OCE which appears with Clang (version?) or GCC 6.0
     # and has to do with compiler optimization, see


### PR DESCRIPTION
apparently the fetcher is confused when there is a mixture of 3-digits
versions and 2-digits versions, i.e. 0.18 and 0.17.2

AFAICT fixes https://github.com/LLNL/spack/issues/2840