### PR TITLE
Updating udunits version.

### DIFF
--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -31,6 +31,7 @@ class Udunits2(AutotoolsPackage):
     homepage = "http://www.unidata.ucar.edu/software/udunits"
     url      = "ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.21.tar.gz"
 
+    version('2.2.23', '2b95241a6243296b8ba908385a84a141')
     version('2.2.21', '1f6d3375efc1f124790a4efb7102cdb7')
 
     depends_on('expat')

--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -29,7 +29,7 @@ class Udunits2(AutotoolsPackage):
     """Automated units conversion"""
 
     homepage = "http://www.unidata.ucar.edu/software/udunits"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.21.tar.gz"
+    url      = "https://github.com/Unidata/UDUNITS-2/archive/v2.2.23.tar.gz"
 
     version('2.2.23', '2b95241a6243296b8ba908385a84a141')
     version('2.2.21', '1f6d3375efc1f124790a4efb7102cdb7')

--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -31,10 +31,32 @@ class Udunits2(AutotoolsPackage):
     homepage = "http://www.unidata.ucar.edu/software/udunits"
     url      = "https://github.com/Unidata/UDUNITS-2/archive/v2.2.23.tar.gz"
 
-    version('2.2.23', '2b95241a6243296b8ba908385a84a141')
-    version('2.2.21', '1f6d3375efc1f124790a4efb7102cdb7')
+    version('2.2.25', '373106a0fcd20c40fc53a975c9fa4fca')
+    version('2.2.24', '316911493e3b5c28ff7019223b4e27ea')
+    version('2.2.23', '0c0d9b1ebd7ad066233bedf40e66f1ba')
+    version('2.2.21', '167738b3ec886da1b92239de9cbbbc39')
 
     depends_on('expat')
 
     depends_on('bison', type='build')
     depends_on('flex',  type='build')
+    depends_on('libtool', type='build')
+    depends_on('automake', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('pkg-config', type='build')
+
+    def autoreconf(self, spec, prefix):
+        # Work around autogen.sh oddities
+        # bash = which("bash")
+        # bash("./autogen.sh")
+        mkdirp("config")
+        autoreconf = which("autoreconf")
+        autoreconf("--install", "--verbose", "--force",
+                   "-I", "config",
+                   "-I", join_path(spec['pkg-config'].prefix,
+                                   "share", "aclocal"),
+                   "-I", join_path(spec['automake'].prefix,
+                                   "share", "aclocal"),
+                   "-I", join_path(spec['libtool'].prefix,
+                                   "share", "aclocal"),
+                   )


### PR DESCRIPTION
Udunits 2.2.21 is no longer on the unidata ftp site.
The latest is 2.2.23, adding that and it's md5sum.