### PR TITLE
Use codecov for coverage instead of coveralls

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  precision: 2
+  round: nearest
+  range: 60...100
+
+ignore:
+  - lib/spack/spack/test/.*
+  - lib/spack/env/.*
+  - lib/spack/docs/.*
+  - lib/spack/external/.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 #=============================================================================
 # Project settings
 #=============================================================================
-language: python
-
 # Only build master and develop on push; do not build every branch.
 branches:
   only:
@@ -13,29 +11,27 @@ branches:
 #=============================================================================
 # Build matrix
 #=============================================================================
-python:
-  - 2.6
-  - 2.7
-
-env:
-  - TEST_SUITE=unit
-  - TEST_SUITE=flake8
-  - TEST_SUITE=doc
-
 matrix:
-  # Flake8 and Sphinx no longer support Python 2.6, and one run is enough.
-  exclude:
-  - python: 2.6
-    env: TEST_SUITE=flake8
-  - python: 2.6
-    env: TEST_SUITE=doc
-  # Explicitly include an OS X build with homebrew's python.
-  # Works around Python issues on Travis for OSX, described here:
-  # http://blog.fizyk.net.pl/blog/running-python-tests-on-traviss-osx-workers.html
   include:
-  - os: osx
-    language: generic
-    env: TEST_SUITE=unit
+    - python: '2.6'
+      os: linux
+      language: python
+      env: TEST_SUITE=unit
+    - python: '2.7'
+      os: linux
+      language: python
+      env: TEST_SUITE=unit
+    - python: '2.7'
+      os: linux
+      language: python
+      env: TEST_SUITE=flake8
+    - python: '2.7'
+      os: linux
+      language: python
+      env: TEST_SUITE=doc
+    - os: osx
+      language: generic
+      env: [ TEST_SUITE=unit, PYTHON_VERSION=2.7 ]
 
 #=============================================================================
 # Environment
@@ -61,7 +57,7 @@ before_install:
 
 # Install various dependencies
 install:
-  - pip install --upgrade coveralls
+  - pip install --upgrade codecov
   - pip install --upgrade flake8
   - pip install --upgrade sphinx
   - pip install --upgrade mercurial
@@ -80,7 +76,7 @@ before_script:
 script: share/spack/qa/run-$TEST_SUITE-tests
 
 after_success:
-  - if [[ $TEST_SUITE == unit && $TRAVIS_PYTHON_VERSION == 2.7 && $TRAVIS_OS_NAME == "linux" ]]; then coveralls; fi
+  - if [[ $TEST_SUITE == unit && $TRAVIS_PYTHON_VERSION == 2.7 && $TRAVIS_OS_NAME == "linux" ]]; then codecov --env PY_VERSION; fi
 
 #=============================================================================
 # Notifications

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ============
 
 [![Build Status](https://travis-ci.org/LLNL/spack.svg?branch=develop)](https://travis-ci.org/LLNL/spack)
-[![Coverage Status](https://coveralls.io/repos/github/LLNL/spack/badge.svg?branch=develop)](https://coveralls.io/github/LLNL/spack?branch=develop)
+[![codecov](https://codecov.io/gh/LLNL/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/LLNL/spack)
 
 Spack is a package management tool designed to support multiple
 versions and configurations of software on a wide variety of platforms

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -138,7 +138,7 @@ class AsciiGraph(object):
     def __init__(self):
         # These can be set after initialization or after a call to
         # graph() to change behavior.
-        self.node_character = '*'
+        self.node_character = 'o'
         self.debug = False
         self.indent = 0
         self.deptype = alldeps
@@ -364,7 +364,7 @@ class AsciiGraph(object):
         self._set_state(EXPAND_RIGHT, index)
         self._out.write("\n")
 
-    def write(self, spec, **kwargs):
+    def write(self, spec, color=None, out=None):
         """Write out an ascii graph of the provided spec.
 
         Arguments:
@@ -378,14 +378,13 @@ class AsciiGraph(object):
                  based on output file.
 
         """
-        out = kwargs.get('out', None)
-        if not out:
+        if out is None:
             out = sys.stdout
 
-        color = kwargs.get('color', None)
-        if not color:
+        if color is None:
             color = out.isatty()
-        self._out = ColorStream(sys.stdout, color=color)
+
+        self._out = ColorStream(out, color=color)
 
         # We'll traverse the spec in topo order as we graph it.
         topo_order = topological_sort(spec, reverse=True, deptype=self.deptype)

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -1,0 +1,138 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from StringIO import StringIO
+
+from spack.spec import Spec
+from spack.graph import AsciiGraph, topological_sort, graph_dot
+
+
+def test_topo_sort(builtin_mock):
+    """Test topo sort gives correct order."""
+    s = Spec('mpileaks').normalized()
+
+    topo = topological_sort(s)
+
+    assert topo.index('mpileaks') < topo.index('callpath')
+    assert topo.index('mpileaks') < topo.index('mpi')
+    assert topo.index('mpileaks') < topo.index('dyninst')
+    assert topo.index('mpileaks') < topo.index('libdwarf')
+    assert topo.index('mpileaks') < topo.index('libelf')
+
+    assert topo.index('callpath') < topo.index('mpi')
+    assert topo.index('callpath') < topo.index('dyninst')
+    assert topo.index('callpath') < topo.index('libdwarf')
+    assert topo.index('callpath') < topo.index('libelf')
+
+    assert topo.index('dyninst') < topo.index('libdwarf')
+    assert topo.index('dyninst') < topo.index('libelf')
+
+    assert topo.index('libdwarf') < topo.index('libelf')
+
+
+def test_static_graph_mpileaks(builtin_mock):
+    """Test a static spack graph for a simple package."""
+    s = Spec('mpileaks').normalized()
+
+    stream = StringIO()
+    graph_dot([s], static=True, out=stream)
+
+    dot = stream.getvalue()
+
+    assert '  "mpileaks" [label="mpileaks"]\n' in dot
+    assert '  "dyninst" [label="dyninst"]\n'   in dot
+    assert '  "callpath" [label="callpath"]\n' in dot
+    assert '  "libelf" [label="libelf"]\n'     in dot
+    assert '  "libdwarf" [label="libdwarf"]\n' in dot
+
+    assert '  "dyninst" -> "libdwarf"\n'  in dot
+    assert '  "callpath" -> "dyninst"\n'  in dot
+    assert '  "mpileaks" -> "mpi"\n'      in dot
+    assert '  "libdwarf" -> "libelf"\n'   in dot
+    assert '  "callpath" -> "mpi"\n'      in dot
+    assert '  "mpileaks" -> "callpath"\n' in dot
+    assert '  "dyninst" -> "libelf"\n'    in dot
+
+
+def test_dynamic_dot_graph_mpileaks(builtin_mock):
+    """Test dynamically graphing the mpileaks package."""
+    s = Spec('mpileaks').normalized()
+
+    stream = StringIO()
+    graph_dot([s], static=False, out=stream)
+
+    dot = stream.getvalue()
+
+    mpileaks_hash, mpileaks_lbl = s.dag_hash(), s.format('$_$#')
+    mpi_hash, mpi_lbl = s['mpi'].dag_hash(), s['mpi'].format('$_$#')
+    callpath_hash, callpath_lbl = (
+        s['callpath'].dag_hash(), s['callpath'].format('$_$#'))
+    dyninst_hash, dyninst_lbl = (
+        s['dyninst'].dag_hash(), s['dyninst'].format('$_$#'))
+    libdwarf_hash, libdwarf_lbl = (
+        s['libdwarf'].dag_hash(), s['libdwarf'].format('$_$#'))
+    libelf_hash, libelf_lbl = (
+        s['libelf'].dag_hash(), s['libelf'].format('$_$#'))
+
+    assert '  "%s" [label="%s"]\n' % (mpileaks_hash, mpileaks_lbl) in dot
+    assert '  "%s" [label="%s"]\n' % (callpath_hash, callpath_lbl) in dot
+    assert '  "%s" [label="%s"]\n' % (mpi_hash,      mpi_lbl) in dot
+    assert '  "%s" [label="%s"]\n' % (dyninst_hash,  dyninst_lbl) in dot
+    assert '  "%s" [label="%s"]\n' % (libdwarf_hash, libdwarf_lbl) in dot
+    assert '  "%s" [label="%s"]\n' % (libelf_hash, libelf_lbl) in dot
+
+    assert '  "%s" -> "%s"\n' % (dyninst_hash, libdwarf_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (callpath_hash, dyninst_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (mpileaks_hash, mpi_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (libdwarf_hash, libelf_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (callpath_hash, mpi_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (mpileaks_hash, callpath_hash)  in dot
+    assert '  "%s" -> "%s"\n' % (dyninst_hash, libelf_hash)  in dot
+
+
+def test_ascii_graph_mpileaks(builtin_mock):
+    """Test dynamically graphing the mpileaks package."""
+    s = Spec('mpileaks').normalized()
+
+    stream = StringIO()
+    graph = AsciiGraph()
+    graph.write(s, out=stream, color=False)
+    string = stream.getvalue()
+
+    # Some lines in spack graph still have trailing space
+    # TODO: fix this.
+    string = '\n'.join([line.rstrip() for line in string.split('\n')])
+
+    assert string == r'''o  mpileaks
+|\
+| o  callpath
+|/|
+o |  mpi
+ /
+o  dyninst
+|\
+| o  libdwarf
+|/
+o  libelf
+'''


### PR DESCRIPTION
- [x] Switching the coverage reports from coveralls to codecov
  - The codecov interface is cleaner and easier to read/browse.
    - also shows more details clearly (partials, branches, etc.)
  - Can show coverage changes line by line in GitHub with [a browser plugin](https://chrome.google.com/webstore/detail/codecov-extension/keefkhehidemnokodkdkejapdgfjmijf)
- [x] Simplified `.travis.yml`
- [x] Added some tests for `spack graph`

Codecov seems to report lower coverage numbers than coveralls, but that's ok.