### PR TITLE
openssl: add extra url to download old versions

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -33,13 +33,17 @@ class Openssl(Package):
        Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.
        It is also a general-purpose cryptography library."""
     homepage = "http://www.openssl.org"
-    url = "http://openssl.org/source/openssl-1.0.1h.tar.gz"
+    url      = "http://www.openssl.org/source/openssl-1.0.1h.tar.gz"
+    list_url = "https://www.openssl.org/source/old/"
+    list_depth = 2
 
     # Note: Version 1.0.2 is the "long-term support" version that will
     # remain supported until 2019. We could thus make this version the
     # preferred version, if we find that many packages cannot handle
     # version 1.1.
+    version('1.1.0d', '711ce3cd5f53a99c0e12a7d5804f0f63')
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
+    version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')
     version('1.0.2j', '96322138f0b69e61b7212bc53d5e912b')
     version('1.0.2i', '678374e63f8df456a697d3e5e5a931fb')
     version('1.0.2h', '9392e65072ce4b614c1392eefc1f23d0')


### PR DESCRIPTION
... and add `1.1.0d`.

p.s. see the available versions at `ftp://openssl.org/source/`.