### PR TITLE
mumps: fix compilation with MKL

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -81,7 +81,7 @@ class Mumps(Package):
 
         lapack_blas = (self.spec['lapack'].lapack_libs +
                        self.spec['blas'].blas_libs)
-        makefile_conf = ["LIBBLAS = %s" % lapack_blas.joined()]
+        makefile_conf = ["LIBBLAS = %s" % lapack_blas.ld_flags]
 
         orderings = ['-Dpord']
 


### PR DESCRIPTION
fixes https://github.com/LLNL/spack/issues/2934

@Zzzoom ping.

**note**:  Looking at [Homebrew](https://github.com/Homebrew/homebrew-science/blob/master/mumps.rb#L112-L118), i would say specifying `ldflags` should be ok.