### PR TITLE
Fix spec hash printing

### DIFF
--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -45,7 +45,7 @@ def dependents(parser, args):
         tty.die("spack dependents takes only one spec.")
     spec = spack.cmd.disambiguate_spec(specs[0])
 
-    tty.msg("Dependents of %s" % spec.format('$_$@$%@$#', color=True))
+    tty.msg("Dependents of %s" % spec.format('$_$@$%@$/', color=True))
     deps = spack.store.db.installed_dependents(spec)
     if deps:
         spack.cmd.display_specs(deps)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -177,7 +177,7 @@ def get_uninstall_list(args):
     if dependent_list and not args.dependents and not args.force:
         for spec, lst in dependent_list.items():
             tty.error("Will not uninstall %s" %
-                      spec.format("$_$@$%@$#", color=True))
+                      spec.format("$_$@$%@$/", color=True))
             print('')
             print("The following packages depend on it:")
             spack.cmd.display_specs(lst, **display_args)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -239,7 +239,7 @@ class Database(object):
                 if dhash not in data:
                     tty.warn("Missing dependency not in database: ",
                              "%s needs %s-%s" % (
-                                 spec.format('$_$#'), dname, dhash[:7]))
+                                 spec.format('$_$/'), dname, dhash[:7]))
                     continue
 
                 child = data[dhash].spec

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -571,7 +571,7 @@ def graph_dot(specs, deptype=None, static=False, out=None):
 
         else:
             def key_label(s):
-                return s.dag_hash(), "%s-%s" % (s.name, s.dag_hash(7))
+                return s.dag_hash(), "%s/%s" % (s.name, s.dag_hash(7))
 
             for s in spec.traverse(deptype=deptype):
                 skey, slabel = key_label(s)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2456,7 +2456,7 @@ class Spec(object):
                         a_str = ' arch' + c + str(self.architecture) + ' '
                         write(fmt % (a_str), c)
                 elif c == '#':
-                    out.write('-' + fmt % (self.dag_hash(7)))
+                    out.write('/' + fmt % (self.dag_hash(7)))
                 elif c == '$':
                     if fmt != '%s':
                         raise ValueError("Can't use format width with $$.")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1145,13 +1145,13 @@ class Spec(object):
     def short_spec(self):
         """Returns a version of the spec with the dependencies hashed
            instead of completely enumerated."""
-        return self.format('$_$@$%@$+$=$#')
+        return self.format('$_$@$%@$+$=$/')
 
     @property
     def cshort_spec(self):
         """Returns a version of the spec with the dependencies hashed
            instead of completely enumerated."""
-        return self.format('$_$@$%@$+$=$#', color=True)
+        return self.format('$_$@$%@$+$=$/', color=True)
 
     @property
     def prefix(self):
@@ -2374,7 +2374,7 @@ class Spec(object):
                  prefixes as above
             $+   Options
             $=   Architecture prefixed by 'arch='
-            $#   7-char prefix of DAG hash with '-' prefix
+            $/   7-char prefix of DAG hash with '-' prefix
             $$   $
 
         You can also use full-string versions, which elide the prefixes::
@@ -2408,7 +2408,7 @@ class Spec(object):
         of the package, but no dependencies, arch, or compiler.
 
         TODO: allow, e.g., ``$6#`` to customize short hash length
-        TODO: allow, e.g., ``$##`` for full hash.
+        TODO: allow, e.g., ``$//`` for full hash.
         """
         color = kwargs.get('color', False)
         length = len(format_string)
@@ -2455,7 +2455,7 @@ class Spec(object):
                     if self.architecture and str(self.architecture):
                         a_str = ' arch' + c + str(self.architecture) + ' '
                         write(fmt % (a_str), c)
-                elif c == '#':
+                elif c == '/':
                     out.write('/' + fmt % (self.dag_hash(7)))
                 elif c == '$':
                     if fmt != '%s':
@@ -3151,7 +3151,7 @@ class UnsatisfiableDependencySpecError(UnsatisfiableSpecError):
 
 class AmbiguousHashError(SpecError):
     def __init__(self, msg, *specs):
-        specs_str = '\n  ' + '\n  '.join(spec.format('$.$@$%@+$+$=$#')
+        specs_str = '\n  ' + '\n  '.join(spec.format('$.$@$%@+$+$=$/')
                                          for spec in specs)
         super(AmbiguousHashError, self).__init__(msg + specs_str)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2529,7 +2529,7 @@ class Spec(object):
                         hashlen = int(hashlen)
                     else:
                         hashlen = None
-                    out.write(fmt % (self.dag_hash(hashlen)))
+                    out.write('/' + fmt % (self.dag_hash(hashlen)))
 
                 named = False
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -84,16 +84,16 @@ def test_dynamic_dot_graph_mpileaks(builtin_mock):
 
     dot = stream.getvalue()
 
-    mpileaks_hash, mpileaks_lbl = s.dag_hash(), s.format('$_$#')
-    mpi_hash, mpi_lbl = s['mpi'].dag_hash(), s['mpi'].format('$_$#')
+    mpileaks_hash, mpileaks_lbl = s.dag_hash(), s.format('$_$/')
+    mpi_hash, mpi_lbl = s['mpi'].dag_hash(), s['mpi'].format('$_$/')
     callpath_hash, callpath_lbl = (
-        s['callpath'].dag_hash(), s['callpath'].format('$_$#'))
+        s['callpath'].dag_hash(), s['callpath'].format('$_$/'))
     dyninst_hash, dyninst_lbl = (
-        s['dyninst'].dag_hash(), s['dyninst'].format('$_$#'))
+        s['dyninst'].dag_hash(), s['dyninst'].format('$_$/'))
     libdwarf_hash, libdwarf_lbl = (
-        s['libdwarf'].dag_hash(), s['libdwarf'].format('$_$#'))
+        s['libdwarf'].dag_hash(), s['libdwarf'].format('$_$/'))
     libelf_hash, libelf_lbl = (
-        s['libelf'].dag_hash(), s['libelf'].format('$_$#'))
+        s['libelf'].dag_hash(), s['libelf'].format('$_$/'))
 
     assert '  "%s" [label="%s"]\n' % (mpileaks_hash, mpileaks_lbl) in dot
     assert '  "%s" [label="%s"]\n' % (callpath_hash, callpath_lbl) in dot


### PR DESCRIPTION
Previously the shortened format printed '-hash' and the full-name version printed 'hash'.

Now both print '/hash' so that format-printed strings are in a format accepted by the spec parser.