### PR TITLE
Add .codecov.yml sections for commit statuses, fix ignore section.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,10 +3,19 @@ coverage:
   round: nearest
   range: 60...100
 
-ignore:
-  - lib/spack/spack/test/.*
-  - lib/spack/env/.*
-  - lib/spack/docs/.*
-  - lib/spack/external/.*
+  status:
+    project:
+      default:
+        target: auto
+
+    patch:
+      default:
+        target: auto
+
+  ignore:
+    - lib/spack/spack/test/.*
+    - lib/spack/env/.*
+    - lib/spack/docs/.*
+    - lib/spack/external/.*
 
 comment: off


### PR DESCRIPTION
I think the comments are kind of spammy.  I would like codecov to just post commit statuses with links to detailed reports.

- [x] Try to get rid of comments on PRs (format of `.codecov.yml` was slightly off)
- [x] Add sections for commit statuses explicitly to `codecov.yml`

