### PR TITLE
Update cmake to work with the IBM XL compilers (xl and xl_r)

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/ibm-xl.patch
+++ b/var/spack/repos/builtin/packages/cmake/ibm-xl.patch
@@ -1,0 +1,56 @@
+diff -Naur cmake-3.5.2/Modules/FortranCInterface/call_mod.f90 cmake-3.5.2-patched/Modules/FortranCInterface/call_mod.f90
+--- cmake-3.5.2/Modules/FortranCInterface/call_mod.f90	2016-04-15 09:41:21.000000000 -0400
++++ cmake-3.5.2-patched/Modules/FortranCInterface/call_mod.f90	2016-07-05 16:58:46.165087149 -0400
+@@ -1,6 +1,6 @@
+-subroutine call_mod
+-  use mymodule
+-  use my_module
+-  call mysub()
+-  call my_sub()
+-end subroutine call_mod
++      subroutine call_mod
++        use mymodule
++        use my_module
++        call mysub()
++        call my_sub()
++      end subroutine call_mod
+diff -Naur cmake-3.5.2/Modules/FortranCInterface/my_module.f90 cmake-3.5.2-patched/Modules/FortranCInterface/my_module.f90
+--- cmake-3.5.2/Modules/FortranCInterface/my_module.f90	2016-04-15 09:41:21.000000000 -0400
++++ cmake-3.5.2-patched/Modules/FortranCInterface/my_module.f90	2016-07-05 16:59:06.241523596 -0400
+@@ -1,8 +1,8 @@
+-module my_module
+-  interface my_interface
+-     module procedure my_sub
+-  end interface
+-contains
+-  subroutine my_sub
+-  end subroutine my_sub
+-end module my_module
++      module my_module
++        interface my_interface
++           module procedure my_sub
++        end interface
++      contains
++        subroutine my_sub
++        end subroutine my_sub
++      end module my_module
+diff -Naur cmake-3.5.2/Modules/FortranCInterface/mymodule.f90 cmake-3.5.2-patched/Modules/FortranCInterface/mymodule.f90
+--- cmake-3.5.2/Modules/FortranCInterface/mymodule.f90	2016-04-15 09:41:21.000000000 -0400
++++ cmake-3.5.2-patched/Modules/FortranCInterface/mymodule.f90	2016-07-05 16:59:44.344167637 -0400
+@@ -1,8 +1,8 @@
+-module mymodule
+-  interface myinterface
+-     module procedure mysub
+-  end interface
+-contains
+-  subroutine mysub
+-  end subroutine mysub
+-end module mymodule
++      module mymodule
++        interface myinterface
++           module procedure mysub
++        end interface
++      contains
++        subroutine mysub
++        end subroutine mysub
++      end module mymodule

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -69,6 +69,8 @@ class Cmake(Package):
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
     patch('intel-c-gnu11.patch', when='@3.6.0:3.6.1')
+    patch('ibm-xl.patch', when='%xl')
+    patch('ibm-xl.patch', when='%xl_r')
 
     def url_for_version(self, version):
         """Handle CMake's version-based custom URLs."""


### PR DESCRIPTION
Due to differences in how the -qstrict flag is handled in the f77 and
f90 XL compilers, we created some uniformity by using the -qstrict
Fortran compiler flag by default. The package files can undo the default
setting by using the -qfree option (as the last option wins.)
The problem occurs when cmake builds test programs to detect compiler
capabilities, as it uses the default flags.  Consequently, f90 test
programs in free form will fail to build with the -qstrict flag.

This commit changes the free form for the cmake test programs to strict
form, to allow the use of both f77 and f90 compilers.

Install cmake under spack for XL compilers as follows:

spack install cmake%xl_r+openssl+ncurses^openssl%gcc^ncurses%gcc

This will build openssl and ncurses with the gcc compiler (there is
no openssl and ncurses code in the final math library) and cmake with
the xl(_r) compiler.