### PR TITLE
Fix unexpected keyword error in Python 2.6

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -199,8 +199,7 @@ def main(args):
 
     if args.profile:
         import cProfile
-        cProfile.runctx('_main(args, unknown)', globals(), locals(),
-                        sort='time')
+        cProfile.runctx('_main(args, unknown)', globals(), locals())
     elif args.pdb:
         import pdb
         pdb.runctx('_main(args, unknown)', globals(), locals())


### PR DESCRIPTION
When running `spack --profile` in Python 2.6, it would crash with the following error:
```
TypeError: runctx() got an unexpected keyword argument 'sort'
```
@alalazo It looks like this was introduced in [#2502](https://github.com/LLNL/spack/commit/7ea10e768ee1a7deab98ae538d916bbeeb0346b8#diff-2ab958d4c46d792e62ac6ba4f9146173R211). According to the [documentation](https://docs.python.org/2/library/profile.html#profile.runctx), `run` takes this parameter but `runctx` does not. Interestingly enough, it actually works in Python 2.7 even though it isn't in the documentation. But it makes the profiler crash in Python 2.6.