### PR TITLE
DOCS: Examplify what file types are automatically extracted

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -535,9 +535,9 @@ These links currently redirect back to `pypi.python.org
 Skipping the expand step
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Spack normally expands archives automatically after downloading
-them. If you want to skip this step (e.g., for self-extracting
-executables and other custom archive types), you can add
+Spack normally expands archives (e.g. `*.tar.gz` and `*.zip`) automatically
+after downloading them. If you want to skip this step (e.g., for
+self-extracting executables and other custom archive types), you can add
 ``expand=False`` to a ``version`` directive.
 
 .. code-block:: python


### PR DESCRIPTION
I only know of `*.tar.gz` and `*.zip`, but should really list the full set offile extensions that are recognized.