### PR TITLE
R: Using official cloud URL for CRAN

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -36,7 +36,7 @@ class R(AutotoolsPackage):
     Please consult the R project homepage for further information."""
 
     homepage = "https://www.r-project.org"
-    url = "http://cran.cnr.berkeley.edu/src/base/R-3/R-3.1.2.tar.gz"
+    url = "https://cloud.r-project.org/src/base/R-3/R-3.3.2.tar.gz"
 
     extendable = True
 


### PR DESCRIPTION
cran.r-project.org runs on a single old-school server in Austria
and could potentially be overloaded if "everyone" used it.

cloud.r-project.org is a cloud-based repository that "automatic redirection to servers worldwide [...]", cf. https://cran.r-project.org/mirrors.html.

I assume, that cloud.* can be scale up as needed. Out of the official CRAN mirror, this should be the safest one to pick if a static CRAN mirror is needed.