### PR TITLE
Replace FTP retrieval URLs with HTTP/HTTPS serving packages with identical checksum.

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -29,7 +29,7 @@ class Bash(Package):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    url      = "ftp://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz"
 
     version('4.3', '81348932d5da294953e15d4814c74dd1')
 

--- a/var/spack/repos/builtin/packages/cdd/package.py
+++ b/var/spack/repos/builtin/packages/cdd/package.py
@@ -33,7 +33,7 @@ class Cdd(Package):
     a general convex polyhedron given by a system of linear
     inequalities"""
     homepage = "https://www.inf.ethz.ch/personal/fukudak/cdd_home/cdd.html"
-    url      = "ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/cdd-061a.tar.gz"
+    url      = "http://www.cs.mcgill.ca/~fukuda/download/cdd/cdd-061a.tar.gz"
 
     version('0.61a', '22c24a7a9349dd7ec0e24531925a02d9')
 
@@ -42,7 +42,7 @@ class Cdd(Package):
     patch("Makefile.spack.patch")
 
     def url_for_version(self, version):
-        url = "ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/cdd-{0}.tar.gz"
+        url = "http://www.cs.mcgill.ca/~fukuda/download/cdd/cdd-{0}.tar.gz"
         return url.format(version.joined)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cfitsio/package.py
+++ b/var/spack/repos/builtin/packages/cfitsio/package.py
@@ -41,7 +41,7 @@ class Cfitsio(AutotoolsPackage):
     depends_on('bzip2', when='+bzip2')
 
     def url_for_version(self, version):
-        url = 'ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio{0}.tar.gz'
+        url = 'http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio{0}.tar.gz'
         return url.format(version.joined)
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -34,7 +34,7 @@ class DarshanRuntime(Package):
     systems where you intend to instrument MPI applications."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    url = "ftp://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
+    url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
 
     version('3.1.0', '439d717323e6265b2612ed127886ae52')
     version('3.0.0', '732577fe94238936268d74d7d74ebd08')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -32,7 +32,7 @@ class DarshanUtil(Package):
     log files produced by Darshan (runtime)."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    url = "ftp://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
+    url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
 
     version('3.1.0', '439d717323e6265b2612ed127886ae52')
     version('3.0.0', '732577fe94238936268d74d7d74ebd08')

--- a/var/spack/repos/builtin/packages/gconf/package.py
+++ b/var/spack/repos/builtin/packages/gconf/package.py
@@ -29,7 +29,7 @@ class Gconf(AutotoolsPackage):
     """GConf is a system for storing application preferences."""
 
     homepage = "https://projects.gnome.org/gconf/"
-    url      = "ftp://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
+    url      = "http://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
 
     version('3.2.6', '2b16996d0e4b112856ee5c59130e822c')
 

--- a/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
@@ -30,7 +30,7 @@ class GhostscriptFonts(Package):
     """Ghostscript Fonts"""
 
     homepage = "http://ghostscript.com/"
-    url = "ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/ghostscript-fonts-std-8.11.tar.gz"
+    url = "https://www.imagemagick.org/download/delegates/ghostscript-fonts-std-8.11.tar.gz"
 
     version('8.11', '6865682b095f8c4500c54b285ff05ef6')
 

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -29,7 +29,7 @@ class Gmake(Package):
     """GNU Make."""
 
     homepage = "http://gnu.org/gnu/make"
-    url      = "ftp://ftp.gnu.org/gnu/make/make-4.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/make/make-4.0.tar.gz"
 
     version('4.0', 'b5e558f981326d9ca1bfdb841640721a')
 

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -35,7 +35,7 @@ class Gnutls(AutotoolsPackage):
        with focus on security and interoperability."""
 
     homepage = "http://www.gnutls.org"
-    url      = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.3/gnutls-3.3.9.tar.xz"
+    url      = "http://www.ring.gr.jp/pub/net/gnupg/gnutls/v3.3/gnutls-3.3.9.tar.xz"
 
     version('3.3.9', 'ff61b77e39d09f1140ab5a9cf52c58b6')
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -39,7 +39,7 @@ class Gromacs(CMakePackage):
     """
 
     homepage = 'http://www.gromacs.org'
-    url = 'ftp://ftp.gromacs.org/pub/gromacs/gromacs-5.1.2.tar.gz'
+    url = 'http://ftp.gromacs.org/gromacs/gromacs-5.1.2.tar.gz'
 
     version('5.1.2', '614d0be372f1a6f1f36382b7a6fcab98')
 

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -30,7 +30,7 @@ class Guile(Package):
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    url      = "ftp://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz"
 
     version('2.0.11', 'e532c68c6f17822561e3001136635ddd')
 

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -33,7 +33,7 @@ class Libffi(AutotoolsPackage):
     homepage = "https://sourceware.org/libffi/"
 
     version('3.2.1', '83b89587607e3eb65c70d361f13bab43',
-            url="ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz")
+            url="https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.2.1.tar.gz")
     # version('3.1', 'f5898b29bbfd70502831a212d9249d10',url =
     # "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz") # Has a bug
     # $(lib64) instead of ${lib64} in libffi.pc

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -32,7 +32,7 @@ class Libgcrypt(AutotoolsPackage):
        key algorithms, large integer functions, random numbers and a lot
        of supporting functions. """
     homepage = "http://www.gnu.org/software/libgcrypt/"
-    url      = "ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.2.tar.bz2"
+    url      = "http://gd.tuwien.ac.at/pub/gnupg/libgcrypt/libgcrypt-1.6.2.tar.bz2"
 
     version('1.6.2', 'b54395a93cb1e57619943c082da09d5f')
 

--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
+++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
@@ -32,7 +32,7 @@ class LibgpgError(AutotoolsPackage):
        SmartCard Daemon and possibly more in the future. """
 
     homepage = "https://www.gnupg.org/related_software/libgpg-error"
-    url      = "ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.18.tar.bz2"
+    url      = "http://gd.tuwien.ac.at/pub/gnupg/libgpg-error/libgpg-error-1.18.tar.bz2"
 
     version('1.21', 'ab0b5aba6d0a185b41d07bda804fd8b2')
     version('1.18', '12312802d2065774b787cbfc22cc04e9')

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -29,7 +29,7 @@ class Libsigsegv(AutotoolsPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
 
     homepage = "https://www.gnu.org/software/libsigsegv/"
-    url      = "ftp://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz"
 
     patch('patch.new_config_guess', when='@2.10')
 

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Libtiff(AutotoolsPackage):
     """libtiff graphics format library"""
     homepage = "http://www.simplesystems.org/libtiff/"
-    url      = "ftp://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz"
+    url      = "http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz"
 
     version('4.0.6', 'd1d2e940dea0b5ad435f21f03d96dd72')
     version('4.0.3', '051c1068e6a0627f461948c365290410')

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -29,7 +29,7 @@ class M4(AutotoolsPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
 
     homepage = "https://www.gnu.org/software/m4/m4.html"
-    url      = "ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz"
 
     version('1.4.18', 'a077779db287adf4e12a035029002d28')
     version('1.4.17', 'a5e9954b1dae036762f7b13673a2cf76')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -30,7 +30,7 @@ class Mesa(AutotoolsPackage):
     specification - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
+    url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
 
     version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
 

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -30,7 +30,7 @@ class Mpc(AutotoolsPackage):
        with arbitrarily high precision and correct rounding of the
        result."""
     homepage = "http://www.multiprecision.org"
-    url      = "ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz"
 
     version('1.0.3', 'd6a1d5f8ddea3abd2cc3e98f58352d26')
     version('1.0.2', '68fadff3358fb3e7976c7a398a0af4c3')
@@ -42,4 +42,4 @@ class Mpc(AutotoolsPackage):
         if version < Version("1.0.1"):
             return "http://www.multiprecision.org/mpc/download/mpc-%s.tar.gz" % version
         else:
-            return "ftp://ftp.gnu.org/gnu/mpc/mpc-%s.tar.gz" % version
+            return "https://ftp.gnu.org/gnu/mpc/mpc-%s.tar.gz" % version

--- a/var/spack/repos/builtin/packages/mpe2/package.py
+++ b/var/spack/repos/builtin/packages/mpe2/package.py
@@ -29,7 +29,7 @@ class Mpe2(Package):
     """Message Passing Extensions (MPE): Parallel, shared X window graphics"""
 
     homepage = "http://www.mcs.anl.gov/research/projects/perfvis/software/MPE/"
-    url      = "ftp://ftp.mcs.anl.gov/pub/mpi/mpe/mpe2-1.3.0.tar.gz"
+    url      = "http://ftp.mcs.anl.gov/pub/mpi/mpe/mpe2-1.3.0.tar.gz"
 
     version('1.3.0', '67bf0c7b2e573df3ba0d2059a96c2f7b')
 

--- a/var/spack/repos/builtin/packages/mrnet/package.py
+++ b/var/spack/repos/builtin/packages/mrnet/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Mrnet(AutotoolsPackage):
     """The MRNet Multi-Cast Reduction Network."""
     homepage = "http://paradyn.org/mrnet"
-    url      = "ftp://ftp.cs.wisc.edu/paradyn/mrnet/mrnet_5.0.1.tar.gz"
+    url      = "http://ftp.cs.wisc.edu/pub/paradyn/mrnet/mrnet_5.0.1.tar.gz"
     list_url = "http://ftp.cs.wisc.edu/paradyn/mrnet"
 
     version('5.0.1-2', git='https://github.com/dyninst/mrnet.git',

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Ncview(AutotoolsPackage):
     """Simple viewer for NetCDF files."""
     homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
-    url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
+    url      = "https://fossies.org/linux/misc/ncview-2.1.7.tar.gz"
 
     version('2.1.7', 'debd6ca61410aac3514e53122ab2ba07')
 

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -31,7 +31,7 @@ class Netcdf(AutotoolsPackage):
     and sharing of array-oriented scientific data."""
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.tar.gz"
+    url      = "http://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-4.3.3.tar.gz"
 
     version('4.4.1.1', '503a2d6b6035d116ed53b1d80c811bda')
     version('4.4.1',   '7843e35b661c99e1d49e60791d5072d8')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -34,7 +34,7 @@ class Octave(AutotoolsPackage):
     Matlab. It may also be used as a batch-oriented language."""
 
     homepage = "https://www.gnu.org/software/octave/"
-    url      = "ftp://ftp.gnu.org/gnu/octave/octave-4.0.0.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/octave/octave-4.0.0.tar.gz"
 
     extendable = True
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -33,7 +33,7 @@ class Openssl(Package):
        Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.
        It is also a general-purpose cryptography library."""
     homepage = "http://www.openssl.org"
-    url = "ftp://openssl.org/source/openssl-1.0.1h.tar.gz"
+    url = "http://openssl.org/source/openssl-1.0.1h.tar.gz"
 
     # Note: Version 1.0.2 is the "long-term support" version that will
     # remain supported until 2019. We could thus make this version the

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -30,7 +30,7 @@ class Pcre(Package):
        libraries. These are useful for implementing regular expression
        pattern matching using the same syntax and semantics as Perl 5."""
     homepage = "http://www.pcre.org"""
-    url      = "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.36.tar.bz2"
+    url      = "https://ftp.pcre.org/pub/pcre/pcre-8.36.tar.bz2"
 
     version('8.39', 'e3fca7650a0556a2647821679d81f585')
     version('8.38', '00aabbfe56d5a48b270f999b508c5ad2')

--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -30,6 +30,6 @@ class Pcre2(AutotoolsPackage):
        libraries. These are useful for implementing regular expression
        pattern matching using the same syntax and semantics as Perl 5."""
     homepage = "http://www.pcre.org"""
-    url      = "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.20.tar.bz2"
+    url      = "https://ftp.pcre.org/pub/pcre/pcre2-10.20.tar.bz2"
 
     version('10.20', 'dcd027c57ecfdc8a6c3af9d0acf5e3f7')

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -34,7 +34,7 @@ class Readline(AutotoolsPackage):
        recall and perhaps reedit those lines, and perform csh-like
        history expansion on previous commands."""
     homepage = "http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
-    url      = "ftp://ftp.cwru.edu/pub/bash/readline-6.3.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz"
 
     version('6.3', '33c8fb279e981274f485fd91da77e94a')
 

--- a/var/spack/repos/builtin/packages/unixodbc/package.py
+++ b/var/spack/repos/builtin/packages/unixodbc/package.py
@@ -31,6 +31,6 @@ class Unixodbc(AutotoolsPackage):
     SQL Servers and any Data Source with an ODBC Driver."""
 
     homepage = "http://www.unixodbc.org/"
-    url      = "ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.4.tar.gz"
+    url      = "http://www.unixodbc.org/unixODBC-2.3.4.tar.gz"
 
     version('2.3.4', 'bd25d261ca1808c947cb687e2034be81')

--- a/var/spack/repos/builtin/packages/xterm/package.py
+++ b/var/spack/repos/builtin/packages/xterm/package.py
@@ -31,7 +31,7 @@ class Xterm(AutotoolsPackage):
     that can't use the window system directly."""
 
     homepage = "http://invisible-island.net/xterm/"
-    url      = "ftp://invisible-island.net/xterm/xterm-327.tgz"
+    url      = "http://invisible-island.net/xterm/xterm-327.tgz"
 
     version('327', '3c32e931adcad44e64e57892e75d9e02')
 


### PR DESCRIPTION
Send a new PR after #2957 is closed.

As discussed in #2716 , HTTP/HTTPS retrieval URLs work better behind a firewall. This commit repalcse FTP retrieval URLs with HTTP ones serving packages with identical checksum. Luckily, all FTP urls in spack packages seem to have alternative HTTP/HTTPS urls.

These chages have been made manually and no checksum changes are made. Tests run sucessfully against spack test package.

To proceed, I plan to add a test in package_sanity to check if HTTP/HTTPS is favored over FTP when HTTP/HTTPS is available for the retrieval site.