### PR TITLE
libmng: fix trying to run configure on an already configured directory

### DIFF
--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -42,3 +42,7 @@ class Libmng(AutotoolsPackage):
         # jpeg requires stdio to beincluded before its headrs.
         filter_file(r'^(\#include \<jpeglib\.h\>)',
                     '#include<stdio.h>\n\\1', 'libmng_types.h')
+
+    @run_before('configure')
+    def clean_configure_directory(self):
+        make('distclean')


### PR DESCRIPTION
 fixes #2959

@JavierCVilla Apparently `libmng` comes already configured. Trying to re-run configure without cleaning the build directory triggers the error. I don't understand why this was revealed by #2859 but this PR shoud fix the issue. Can you confirm ?