### PR TITLE
Patch OpenMPI 2.0.x to fix pmi_opcaddy_t_class issue.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/fix_multidef_pmi_class.patch
+++ b/var/spack/repos/builtin/packages/openmpi/fix_multidef_pmi_class.patch
@@ -1,0 +1,54 @@
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/cray/pmix_cray.c openmpi-2.0.1/opal/mca/pmix/cray/pmix_cray.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/cray/pmix_cray.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/cray/pmix_cray.c	2017-01-31 01:05:34.302807465 +0800
+@@ -6,7 +6,7 @@
+  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All
+  *                         rights reserved.
+  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
+- * Copyright (c) 2014-2015 Research Organization for Information Science
++ * Copyright (c) 2014-2016 Research Organization for Information Science
+  *                         and Technology (RIST). All rights reserved.
+  * $COPYRIGHT$
+  *
+@@ -127,7 +127,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/s1/pmix_s1.c openmpi-2.0.1/opal/mca/pmix/s1/pmix_s1.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/s1/pmix_s1.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/s1/pmix_s1.c	2017-01-31 01:06:08.014808847 +0800
+@@ -1,7 +1,7 @@
+ /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+ /*
+  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+- * Copyright (c) 2014-2015 Research Organization for Information Science
++ * Copyright (c) 2014-2016 Research Organization for Information Science
+  *                         and Technology (RIST). All rights reserved.
+  * $COPYRIGHT$
+  *
+@@ -88,7 +88,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/s2/pmix_s2.c openmpi-2.0.1/opal/mca/pmix/s2/pmix_s2.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/s2/pmix_s2.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/s2/pmix_s2.c	2017-01-31 01:06:27.718809655 +0800
+@@ -95,7 +95,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -75,6 +75,7 @@ class Openmpi(AutotoolsPackage):
     patch('ad_lustre_rwcontig_open_source.patch', when="@1.6.5")
     patch('llnl-platforms.patch', when="@1.6.5")
     patch('configure.patch', when="@1.10.0:1.10.1")
+    patch('fix_multidef_pmi_class.patch', when="@2.0.0:2.0.1")
 
     # Fabrics
     variant('psm', default=False, description='Build support for the PSM library')


### PR DESCRIPTION
This patch fix the issue of "multiple definition of `pmi_opcaddy_t_class'" when building OpenMPI 2.0.0 and 2.0.1. It has been merged into OpenMPI code but hasn't released on the latest 2.0.1. More discussion can be seen on https://www.mail-archive.com/users@lists.open-mpi.org/msg30048.html and https://github.com/open-mpi/ompi/pull/2131/files . Also see #2950 .

I've sucessfully built OpenMPI 2.0.1 with both gcc 5.4.0 and intel 16.0.3 after patching.

Patch credits go to Gilles Gouaillardet and Limin Gu. I just regenerated a patch file locally according to that git commit after my failing attempts to apply the pre-configured patch file.