### PR TITLE
FFTW: Add SSE2 support to x86_64 target

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -89,14 +89,20 @@ class Fftw(Package):
             autoreconf = which('autoreconf')
             autoreconf('-ifv')
 
-        configure(*options)
+        float_options = []
+        double_options = []
+        if 'x86_64' in spec.architecture:
+            float_options.append('--enable-sse2')
+            double_options.append('--enable-sse2')
+
+        configure(*(options + double_options))
         make()
         if self.run_tests:
             make("check")
         make("install")
 
         if '+float' in spec:
-            configure('--enable-float', *options)
+            configure('--enable-float', *(options + float_options))
             make()
             if self.run_tests:
                 make("check")


### PR DESCRIPTION
FFTW is currently being installed without any SIMD support.
This PR adds SSE2 support on x86-64 targets, which is a safe assumption.