### PR TITLE
Bug fix : PDT expect "-prefix" argument with installation path and not "--prefix".

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -44,6 +44,5 @@ class Pdt(AutotoolsPackage):
     version('3.19',   '5c5e1e6607086aa13bf4b1b9befc5864')
     version('3.18.1', 'e401534f5c476c3e77f05b7f73b6c4f2')
 
-    def configure_args(self):
-        args = ['-prefix=%s' % self.spec.prefix]
-        return args
+    def configure(self, spec, prefix):
+        configure('-prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -43,3 +43,7 @@ class Pdt(AutotoolsPackage):
     version('3.20',   'c3edabe202926abe04552e33cd39672d')
     version('3.19',   '5c5e1e6607086aa13bf4b1b9befc5864')
     version('3.18.1', 'e401534f5c476c3e77f05b7f73b6c4f2')
+
+    def configure_args(self):
+        args = ['-prefix=%s' % self.spec.prefix]
+        return args


### PR DESCRIPTION
While installing PDT I am seeing : 

```
echo "*****DONE*****"
*****DONE*****
set :  /marconi/home/userexternal/pkumbhar/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/pdt-3.22.1-soagoesveycaveyrl3fqhr6ebgm5dotb ['.spack']
==> Error: InstallError: Install failed for pdt.  Nothing was installed!
```

This was introduced in #2845. PDT needs configure argument `-prefix` and not the default `--preifx`.

P.S. I see that the configure stage still adds `--preifx` argument (this doesn't hurt but may be cleaner to avoid it?).