### PR TITLE
Update  Open MPI to 2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -63,6 +63,7 @@ class Openmpi(AutotoolsPackage):
     list_url = "http://www.open-mpi.org/software/ompi/"
     list_depth = 3
 
+    version('2.0.2', 'ecd99aa436a1ca69ce936a96d6a3fa48')
     version('2.0.1', '6f78155bd7203039d2448390f3b51c96')
     version('2.0.0', 'cdacc800cb4ce690c1f1273cb6366674')
     version('1.10.3', 'e2fe4513200e2aaa1500b762342c674b')


### PR DESCRIPTION
We just released 2.0.2 yesterday, so add in that release for
spack.  Don't need the PMI patch for this release.

@tgamblin 

stopped listening to your talk and started doing something with spack.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>