### PR TITLE
Different versions of cmake need diff vers of openssl

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -63,8 +63,8 @@ class Cmake(Package):
     depends_on('qt',             when='+qt')
     depends_on('python@2.7.11:', when='+doc', type='build')
     depends_on('py-sphinx',      when='+doc', type='build')
+    depends_on("openssl", when='+openssl')
     depends_on("openssl@:1.0.99", when='@:3.6.9+openssl')
-    depends_on("openssl", when='@3.7:+openssl')
     depends_on('ncurses',        when='+ncurses')
 
     # Cannot build with Intel, should be fixed in 3.6.2

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -63,7 +63,8 @@ class Cmake(Package):
     depends_on('qt',             when='+qt')
     depends_on('python@2.7.11:', when='+doc', type='build')
     depends_on('py-sphinx',      when='+doc', type='build')
-    depends_on('openssl',        when='+openssl')
+    depends_on("openssl@:1.0.99", when='@:3.6.9+openssl')
+    depends_on("openssl", when='@3.7:+openssl')
     depends_on('ncurses',        when='+ncurses')
 
     # Cannot build with Intel, should be fixed in 3.6.2


### PR DESCRIPTION
See Issue [2990](https://github.com/LLNL/spack/issues/2990) for background.

Versions of cmake through 3.6.9 seem to need OpenSSL up to 1.0.99.  Later
versions can use the current release (thanks to @citibeth for
[digging up details](https://cmake.org/pipermail/cmake/2016-November/064631.html)).

@davydden suggested this change.

Without it I *am not* able to build `cmake@3.6.1` on CentOS 7 and I *am*
able to build `cmake@3.7.2`.

With this change I am able to build both `cmake@3.6.1` and `cmake@3.7.2`
on CentOS 7.

Closes #2990.