### PR TITLE
Ocaml fails as an AutotoolsPackage

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Ocaml(AutotoolsPackage):
+class Ocaml(Package):
     """OCaml is an industrial strength programming language supporting
        functional, imperative and object-oriented styles"""
 
@@ -36,4 +36,8 @@ class Ocaml(AutotoolsPackage):
 
     depends_on('ncurses')
 
-    build_targets = ['world.opt']
+    def install(self, spec, prefix):
+        configure('-prefix', '{0}'.format(prefix))
+        
+        make('world.opt')
+        make('install')


### PR DESCRIPTION
Closes #2994. See that issue for the backstory.

Switch the ocaml install bit back to being a Package
with it's own little install method.

This fix allows me to build Unison on CentOS 7.

