### PR TITLE
Fetch tarballs from ant archive dir.

### DIFF
--- a/var/spack/repos/builtin/packages/ant/package.py
+++ b/var/spack/repos/builtin/packages/ant/package.py
@@ -32,9 +32,12 @@ class Ant(Package):
     """
 
     homepage = "http://ant.apache.org/"
-    url = "http://apache.claz.org/ant/source/apache-ant-1.9.7-src.tar.gz"
+    url = "https://archive.apache.org/dist/ant/source/apache-ant-1.9.7-src.tar.gz"
 
-    version('1.9.7', 'a2fd9458c76700b7be51ef12f07d4bb1')
+    # 1.10.0 requires newer Java, not yet tested....
+    # version('1.10.0', '2260301bb7734e34d8b96f1a5fd7979c')
+    version('1.9.8',  '16253d516d5c33c4af9ef8fafcf1004b')
+    version('1.9.7',  'a2fd9458c76700b7be51ef12f07d4bb1')
 
     depends_on('jdk')
 


### PR DESCRIPTION
There was a new release of Ant (1.9.8) which led to the v1.9.7
tarball disappearing.

This changes the URL to Ant's archive dir, which seems to contain
*everything* including the two current releases (1.9.8 and 1.10.0)

It adds a digest for 1.9.8.

It adds and comments out a digest for 1.10.0 (which requires Java 8),
as I have not tested it.