### PR TITLE
spectrum-mpi: Add new package file for external package

### DIFF
--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -1,35 +1,60 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at International Business Machines Corporation
+#
+# This file is part of Spack.
+# Created by Serban Maerean, serban@us.ibm.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
 from spack import *
 
-class Spectrum(Package):
-    """IBM MPI implementation from Spectrum MPI."""
 
-    homepage = "http://www.example.com"
-    url      = "http://www.example.com/ibm-mpi-10.1.0.tar.gz"
+class SpectrumMpi(Package):
+    """
+    IBM MPI implementation from Spectrum MPI.
 
-    version('10.1.0.2', '0123456789abcdef0123456789abcdef')
-    version('10.1.0', '0123456789abcdef0123456789abcdef')
+    """
 
-    provides('mpi')
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/ibm-mpi-10.1.0.2.tar.gz"
 
-    def install(self, spec, prefix):
-        raise InstallError('IBM MPI is not installable; it is vendor supplied')
+    provides('mpi')
+
+    def install(self, spec, prefix):
+        raise InstallError('IBM MPI is not installable; it is vendor supplied')
 
     def setup_dependent_package(self, module, dspec):
-        # get library name and directory
-        self.spec.mpi_base_dir = self.prefix
-        self.spec.mpi_library = join_path(self.prefix.lib, 'libmpi_ibm.so')
+        # get library name and directory
+        self.spec.mpi_base_dir = self.prefix
+        self.spec.mpi_library = join_path(self.prefix.lib, 'libmpi_ibm.so')
         self.spec.mpi_include_path = self.prefix.include
         self.spec.mpi_library_path = self.prefix.lib
         self.spec.mpi_exec = join_path(self.prefix.bin, 'mpirun')
         self.spec.mpi_np_flag = '-np'
         if '%xl' in dspec or '%xl_r' in dspec:
-            self.spec.mpicc = join_path(self.prefix.bin, 'mpixlc')
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpixlc')
             self.spec.mpicxx = join_path(self.prefix.bin, 'mpixlC')
             self.spec.mpif77 = join_path(self.prefix.bin, 'mpixlf')
             self.spec.mpif90 = join_path(self.prefix.bin, 'mpixlf')
             self.spec.mpifc = join_path(self.prefix.bin, 'mpixlf')
         else:
-            self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
             self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
             self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
             self.spec.mpif90 = join_path(self.prefix.bin, 'mpif90')
@@ -37,14 +62,14 @@ class Spectrum(Package):
 
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        if '%xl' in dependent_spec or '%xl_r' in dependent_spec:
-            spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpixlc'))
+        if '%xl' in dependent_spec or '%xl_r' in dependent_spec:
+            spack_env.set('MPICC', join_path(self.prefix.bin, 'mpixlc'))
             spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpixlC'))
             spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpixlf'))
             spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpixlf'))
         else:
-            spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
-            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
+            spack_env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
+            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
             spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
             spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -31,52 +31,34 @@ class SpectrumMpi(Package):
 
     """
 
-    homepage = "http://www.example.com"
-    url      = "http://www.example.com/ibm-mpi-10.1.0.2.tar.gz"
+    homepage = "http://www-03.ibm.com/systems/spectrum-computing/products/mpi"
 
     provides('mpi')
 
     def install(self, spec, prefix):
         raise InstallError('IBM MPI is not installable; it is vendor supplied')
 
-    def setup_dependent_package(self, module, dspec):
-        # get library name and directory
-        self.spec.mpi_base_dir = self.prefix
-        self.spec.mpi_library = join_path(self.prefix.lib, 'libmpi_ibm.so')
-        self.spec.mpi_include_path = self.prefix.include
-        self.spec.mpi_library_path = self.prefix.lib
-        self.spec.mpi_exec = join_path(self.prefix.bin, 'mpirun')
-        self.spec.mpi_np_flag = '-np'
-        if '%xl' in dspec or '%xl_r' in dspec:
+    def setup_dependent_package(self, module, dependent_spec):
+        # get the compiler names
+        if '%xl' in dependent_spec or '%xl_r' in dependent_spec:
             self.spec.mpicc = join_path(self.prefix.bin, 'mpixlc')
-            self.spec.mpicxx = join_path(self.prefix.bin, 'mpixlC')
-            self.spec.mpif77 = join_path(self.prefix.bin, 'mpixlf')
-            self.spec.mpif90 = join_path(self.prefix.bin, 'mpixlf')
-            self.spec.mpifc = join_path(self.prefix.bin, 'mpixlf')
-        else:
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpixlC')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpixlf')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpixlf')
+        else:
             self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
-            self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
-            self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
-            self.spec.mpif90 = join_path(self.prefix.bin, 'mpif90')
-            self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
 
-
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         if '%xl' in dependent_spec or '%xl_r' in dependent_spec:
             spack_env.set('MPICC', join_path(self.prefix.bin, 'mpixlc'))
-            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpixlC'))
-            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpixlf'))
-            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpixlf'))
-        else:
+            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpixlC'))
+            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpixlf'))
+            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpixlf'))
+        else:
             spack_env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
             spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
-            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
-            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
-
-        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
-        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
-        spack_env.set('OMPI_LDFLAGS', dependent_spec.package.rpath_args)
-        spack_env.set('OMPI_CC', spack_cc)
-        spack_env.set('OMPI_CXX', spack_cxx)
-        spack_env.set('OMPI_FC', spack_fc)
-        spack_env.set('OMPI_F77', spack_f77)
+            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -1,0 +1,57 @@
+from spack import *
+
+class Spectrum(Package):
+    """IBM MPI implementation from Spectrum MPI."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/ibm-mpi-10.1.0.tar.gz"
+
+    version('10.1.0.2', '0123456789abcdef0123456789abcdef')
+    version('10.1.0', '0123456789abcdef0123456789abcdef')
+
+    provides('mpi')
+
+    def install(self, spec, prefix):
+        raise InstallError('IBM MPI is not installable; it is vendor supplied')
+
+    def setup_dependent_package(self, module, dspec):
+        # get library name and directory
+        self.spec.mpi_base_dir = self.prefix
+        self.spec.mpi_library = join_path(self.prefix.lib, 'libmpi_ibm.so')
+        self.spec.mpi_include_path = self.prefix.include
+        self.spec.mpi_library_path = self.prefix.lib
+        self.spec.mpi_exec = join_path(self.prefix.bin, 'mpirun')
+        self.spec.mpi_np_flag = '-np'
+        if '%xl' in dspec or '%xl_r' in dspec:
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpixlc')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpixlC')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpixlf')
+            self.spec.mpif90 = join_path(self.prefix.bin, 'mpixlf')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpixlf')
+        else:
+            self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+            self.spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
+            self.spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+            self.spec.mpif90 = join_path(self.prefix.bin, 'mpif90')
+            self.spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        if '%xl' in dependent_spec or '%xl_r' in dependent_spec:
+            spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpixlc'))
+            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpixlC'))
+            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpixlf'))
+            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpixlf'))
+        else:
+            spack_env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
+            spack_env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
+            spack_env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+            spack_env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+
+        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+        run_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+        spack_env.set('OMPI_LDFLAGS', dependent_spec.package.rpath_args)
+        spack_env.set('OMPI_CC', spack_cc)
+        spack_env.set('OMPI_CXX', spack_cxx)
+        spack_env.set('OMPI_FC', spack_fc)
+        spack_env.set('OMPI_F77', spack_f77)


### PR DESCRIPTION
IBM Spectrum MPI is a commercial implementation of MPI based on
OpenMPI.  It is usually install in /opt/ibm/spectrum_mpi.

Users need to add the Spectrum MPI package in their packages.yaml
file as follows:
```yaml
packages:
    spectrum-mpi:
        version: ['10.1.0.2']
        paths:
            spectrum-mpi@10.1.0.2: /opt/ibm/spectrum_mpi/
        buildable: False

    all:
        providers:
            mpi: [spectrum-mpi@10.1.0.2]
```