### PR TITLE
Disable spec colorization when redirecting stdout and add command line flag to re-enable

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -154,9 +154,8 @@ def disambiguate_spec(spec):
     elif len(matching_specs) > 1:
         args = ["%s matches multiple packages." % spec,
                 "Matching packages:"]
-        color = sys.stdout.isatty()
-        args += [colorize("  @K{%s} " % s.dag_hash(7), color=color) +
-                 s.format('$_$@$%@$=', color=color) for s in matching_specs]
+        args += [colorize("  @K{%s} " % s.dag_hash(7)) +
+                 s.format('$_$@$%@$=') for s in matching_specs]
         args += ["Use a more specific spec."]
         tty.die(*args)
 
@@ -200,7 +199,7 @@ def display_specs(specs, **kwargs):
         specs = index[(architecture, compiler)]
         specs.sort()
 
-        abbreviated = [s.format(format_string, color=True) for s in specs]
+        abbreviated = [s.format(format_string) for s in specs]
         if mode == 'paths':
             # Print one spec per line along with prefix path
             width = max(len(s) for s in abbreviated)
@@ -215,7 +214,6 @@ def display_specs(specs, **kwargs):
             for spec in specs:
                 print(spec.tree(
                     format=format_string,
-                    color=True,
                     indent=4,
                     prefix=(lambda s: gray_hash(s, hlen)) if hashes else None))
 
@@ -227,7 +225,7 @@ def display_specs(specs, **kwargs):
                     string = ""
                     if hashes:
                         string += gray_hash(s, hlen) + ' '
-                    string += s.format('$-%s$@%s' % (nfmt, vfmt), color=True)
+                    string += s.format('$-%s$@%s' % (nfmt, vfmt))
 
                     return string
 
@@ -237,7 +235,7 @@ def display_specs(specs, **kwargs):
                 for spec in specs:
                     # Print the hash if necessary
                     hsh = gray_hash(spec, hlen) + ' ' if hashes else ''
-                    print(hsh + spec.format(format_string, color=True) + '\n')
+                    print(hsh + spec.format(format_string) + '\n')
 
         else:
             raise ValueError(

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -155,7 +155,7 @@ def disambiguate_spec(spec):
         args = ["%s matches multiple packages." % spec,
                 "Matching packages:"]
         args += [colorize("  @K{%s} " % s.dag_hash(7)) +
-                 s.format('$_$@$%@$=') for s in matching_specs]
+                 s.cformat('$_$@$%@$=') for s in matching_specs]
         args += ["Use a more specific spec."]
         tty.die(*args)
 
@@ -199,7 +199,7 @@ def display_specs(specs, **kwargs):
         specs = index[(architecture, compiler)]
         specs.sort()
 
-        abbreviated = [s.format(format_string) for s in specs]
+        abbreviated = [s.cformat(format_string) for s in specs]
         if mode == 'paths':
             # Print one spec per line along with prefix path
             width = max(len(s) for s in abbreviated)
@@ -225,7 +225,7 @@ def display_specs(specs, **kwargs):
                     string = ""
                     if hashes:
                         string += gray_hash(s, hlen) + ' '
-                    string += s.format('$-%s$@%s' % (nfmt, vfmt))
+                    string += s.cformat('$-%s$@%s' % (nfmt, vfmt))
 
                     return string
 
@@ -235,7 +235,7 @@ def display_specs(specs, **kwargs):
                 for spec in specs:
                     # Print the hash if necessary
                     hsh = gray_hash(spec, hlen) + ' ' if hashes else ''
-                    print(hsh + spec.format(format_string) + '\n')
+                    print(hsh + spec.cformat(format_string) + '\n')
 
         else:
             raise ValueError(

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -47,7 +47,7 @@ def dependents(parser, args):
         tty.die("spack dependents takes only one spec.")
     spec = spack.cmd.disambiguate_spec(specs[0])
 
-    tty.msg("Dependents of %s" % spec.format('$_$@$%@$/'))
+    tty.msg("Dependents of %s" % spec.cformat('$_$@$%@$/'))
     deps = spack.store.db.installed_dependents(spec)
     if deps:
         spack.cmd.display_specs(deps)

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -47,7 +47,7 @@ def dependents(parser, args):
         tty.die("spack dependents takes only one spec.")
     spec = spack.cmd.disambiguate_spec(specs[0])
 
-    tty.msg("Dependents of %s" % spec.format('$_$@$%@$/', color=True))
+    tty.msg("Dependents of %s" % spec.format('$_$@$%@$/'))
     deps = spack.store.db.installed_dependents(spec)
     if deps:
         spack.cmd.display_specs(deps)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -213,7 +213,7 @@ def mirror_create(args):
         "  %-4d failed to fetch." % e)
     if error:
         tty.error("Failed downloads:")
-        colify(s.format("$_$@") for s in error)
+        colify(s.cformat("$_$@") for s in error)
 
 
 def mirror(parser, args):

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -236,7 +236,8 @@ def refresh(mtype, specs, args):
             if len(writer_list) > 1:
                 message += '\nfile: {0}\n'.format(filename)
                 for x in writer_list:
-                    message += 'spec: {0}\n'.format(x.spec.format(color=True))
+                    message += 'spec: {0}\n'.format(x.spec.format())
+
         tty.error(message)
         tty.error('Operation aborted')
         raise SystemExit(1)
@@ -269,7 +270,7 @@ def module(parser, args):
                    "and this is not allowed in this context")
         tty.error(message.format(query=constraint))
         for s in specs:
-            sys.stderr.write(s.format(color=True) + '\n')
+            sys.stderr.write(s.format() + '\n')
         raise SystemExit(1)
     except NoMatch:
         message = ("the constraint '{query}' matches no package, "

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -270,7 +270,7 @@ def module(parser, args):
                    "and this is not allowed in this context")
         tty.error(message.format(query=constraint))
         for s in specs:
-            sys.stderr.write(s.format() + '\n')
+            sys.stderr.write(s.cformat() + '\n')
         raise SystemExit(1)
     except NoMatch:
         message = ("the constraint '{query}' matches no package, "

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -60,8 +60,7 @@ def setup_parser(subparser):
 
 def spec(parser, args):
     name_fmt = '$.' if args.namespaces else '$_'
-    kwargs = {'color': True,
-              'cover': args.cover,
+    kwargs = {'cover': args.cover,
               'format': name_fmt + '$@$%@+$+$=',
               'hashes': args.long or args.very_long,
               'hashlen': None if args.very_long else 7,

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -180,8 +180,8 @@ def get_uninstall_list(args):
     has_error = False
     if dependent_list and not args.dependents and not args.force:
         for spec, lst in dependent_list.items():
-            tty.error('Will not uninstall {0}'.format(
-                      spec.format("$_$@$%@$/", color=True)))
+            tty.error("Will not uninstall %s" %
+                      spec.format("$_$@$%@$/"))
             print('')
             print('The following packages depend on it:')
             spack.cmd.display_specs(lst, **display_args)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -180,8 +180,7 @@ def get_uninstall_list(args):
     has_error = False
     if dependent_list and not args.dependents and not args.force:
         for spec, lst in dependent_list.items():
-            tty.error("Will not uninstall %s" %
-                      spec.format("$_$@$%@$/"))
+            tty.error("Will not uninstall %s" % spec.cformat("$_$@$%@$/"))
             print('')
             print('The following packages depend on it:')
             spack.cmd.display_specs(lst, **display_args)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -288,7 +288,7 @@ class Database(object):
                 if dhash not in data:
                     tty.warn("Missing dependency not in database: ",
                              "%s needs %s-%s" % (
-                                 spec.format('$_$/'), dname, dhash[:7]))
+                                 spec.cformat('$_$/'), dname, dhash[:7]))
                     continue
 
                 child = data[dhash].spec
@@ -440,8 +440,7 @@ class Database(object):
                     # just to be conservative in case a command like
                     # "autoremove" is run by the user after a reindex.
                     tty.debug(
-                        'RECONSTRUCTING FROM SPEC.YAML: {0}'.format(spec)
-                    )
+                        'RECONSTRUCTING FROM SPEC.YAML: {0}'.format(spec))
                     explicit = True
                     if old_data is not None:
                         old_info = old_data.get(spec.dag_hash())
@@ -467,8 +466,7 @@ class Database(object):
                     # installed compilers or externally installed
                     # applications.
                     tty.debug(
-                        'RECONSTRUCTING FROM OLD DB: {0}'.format(entry.spec)
-                    )
+                        'RECONSTRUCTING FROM OLD DB: {0}'.format(entry.spec))
                     try:
                         layout = spack.store.layout
                         if entry.spec.external:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -168,7 +168,9 @@ class YamlDirectoryLayout(DirectoryLayout):
         self.metadata_dir   = kwargs.get('metadata_dir', '.spack')
         self.hash_len       = kwargs.get('hash_len')
         self.path_scheme    = kwargs.get('path_scheme') or (
-            "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}")  # NOQA: E501
+            "${ARCHITECTURE}/"
+            "${COMPILERNAME}-${COMPILERVER}/"
+            "${PACKAGE}-${VERSION}-${HASH}")
         if self.hash_len is not None:
             if re.search('\${HASH:\d+}', self.path_scheme):
                 raise InvalidDirectoryLayoutParametersError(

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -87,13 +87,6 @@ section_order = {
 # Properties that commands are required to set.
 required_command_properties = ['level', 'section', 'description']
 
-# Mapping from color arguments to values for tty.set_color
-color_type = {
-    'always': True,
-    'auto': None,
-    'never': False
-}
-
 
 def set_working_dir():
     """Change the working directory to getcwd, or spack prefix if no cwd."""
@@ -335,8 +328,8 @@ def setup_main_options(args):
         tty.warn("You asked for --insecure. Will NOT check SSL certificates.")
         spack.insecure = True
 
-    # when to use color
-    tty.set_color(color_type[args.color])
+    # when to use color (takes always, auto, or never)
+    tty.color.set_color_when(args.color)
 
 
 def allows_unknown_args(command):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -58,7 +58,7 @@ intro_by_level = {
 
 # control top-level spack options shown in basic vs. advanced help
 options_by_level = {
-    'short': 'hkV',
+    'short': ['h', 'k', 'V', 'color'],
     'long': 'all'
 }
 
@@ -86,6 +86,13 @@ section_order = {
 
 # Properties that commands are required to set.
 required_command_properties = ['level', 'section', 'description']
+
+# Mapping from color arguments to values for tty.set_color
+color_type = {
+    'always': True,
+    'auto': None,
+    'never': False
+}
 
 
 def set_working_dir():
@@ -280,6 +287,9 @@ def make_argument_parser():
 
     parser.add_argument('-h', '--help', action='store_true',
                         help="show this help message and exit")
+    parser.add_argument('--color', action='store', default='auto',
+                        choices=('always', 'never', 'auto'),
+                        help="when to colorize output; default is auto")
     parser.add_argument('-d', '--debug', action='store_true',
                         help="write out debug logs during compile")
     parser.add_argument('-D', '--pdb', action='store_true',
@@ -324,6 +334,9 @@ def setup_main_options(args):
     if args.insecure:
         tty.warn("You asked for --insecure. Will NOT check SSL certificates.")
         spack.insecure = True
+
+    # when to use color
+    tty.set_color(color_type[args.color])
 
 
 def allows_unknown_args(command):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -224,14 +224,14 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
                     # create a subdirectory for the current package@version
                     archive_path = os.path.abspath(join_path(
                         mirror_root, mirror_archive_path(spec, fetcher)))
-                    name = spec.format("$_$@")
+                    name = spec.cformat("$_$@")
                 else:
                     resource = stage.resource
                     archive_path = os.path.abspath(join_path(
                         mirror_root,
                         mirror_archive_path(spec, fetcher, resource.name)))
                     name = "{resource} ({pkg}).".format(
-                        resource=resource.name, pkg=spec.format("$_$@"))
+                        resource=resource.name, pkg=spec.cformat("$_$@"))
                 subdir = os.path.dirname(archive_path)
                 mkdirp(subdir)
 
@@ -258,8 +258,8 @@ def add_single_spec(spec, mirror_root, categories, **kwargs):
         if spack.debug:
             sys.excepthook(*sys.exc_info())
         else:
-            tty.warn("Error while fetching %s"
-                     % spec.format('$_$@'), e.message)
+            tty.warn(
+                "Error while fetching %s" % spec.cformat('$_$@'), e.message)
         categories['error'].append(spec)
 
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -905,7 +905,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         start_time = time.time()
         if spack.do_checksum and self.version not in self.versions:
             tty.warn("There is no checksum on file to fetch %s safely." %
-                     self.spec.format('$_$@'))
+                     self.spec.cformat('$_$@'))
 
             # Ask the user whether to skip the checksum if we're
             # interactive, but just fail if non-interactive.
@@ -1649,8 +1649,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         self.extendee_spec.package.activate(self, **self.extendee_args)
 
         spack.store.layout.add_extension(self.extendee_spec, self.spec)
-        tty.msg("Activated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        tty.msg(
+            "Activated extension %s for %s" %
+            (self.spec.short_spec, self.extendee_spec.cformat("$_$@$+$%@")))
 
     def dependency_activations(self):
         return (spec for spec in self.spec.traverse(root=False, deptype='run')
@@ -1708,8 +1709,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             spack.store.layout.remove_extension(
                 self.extendee_spec, self.spec)
 
-        tty.msg("Deactivated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        tty.msg(
+            "Deactivated extension %s for %s" %
+            (self.spec.short_spec, self.extendee_spec.cformat("$_$@$+$%@")))
 
     def deactivate(self, extension, **kwargs):
         """Unlinks all files from extension out of this package's install dir.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2718,7 +2718,9 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        color = kwargs.get('color', False)
+        color = kwargs.get('color', None)
+        if color is None:
+            color = spack.tty.get_color()
         length = len(format_string)
         out = StringIO()
         named = escape = compiler = False
@@ -2882,7 +2884,9 @@ class Spec(object):
     def tree(self, **kwargs):
         """Prints out this spec and its dependencies, tree-formatted
            with indentation."""
-        color = kwargs.pop('color', False)
+        color = kwargs.pop('color', None)
+        if color is None:
+            color = spack.tty.get_color()
         depth = kwargs.pop('depth', False)
         hashes = kwargs.pop('hashes', False)
         hlen = kwargs.pop('hashlen', None)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -108,6 +108,10 @@ from six import StringIO
 from six import string_types
 from six import iteritems
 
+from llnl.util.filesystem import find_headers, find_libraries, is_exe
+from llnl.util.lang import *
+from llnl.util.tty.color import *
+
 import spack
 import spack.architecture
 import spack.compilers as compilers
@@ -117,9 +121,6 @@ import spack.store
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
-from llnl.util.filesystem import find_headers, find_libraries, is_exe
-from llnl.util.lang import *
-from llnl.util.tty.color import *
 from spack.util.module_cmd import get_path_from_module, load_module
 from spack.error import SpecError, UnsatisfiableSpecError
 from spack.provider_index import ProviderIndex
@@ -2720,7 +2721,7 @@ class Spec(object):
         """
         color = kwargs.get('color', None)
         if color is None:
-            color = spack.tty.get_color()
+            color = get_color_when()
         length = len(format_string)
         out = StringIO()
         named = escape = compiler = False
@@ -2886,7 +2887,7 @@ class Spec(object):
            with indentation."""
         color = kwargs.pop('color', None)
         if color is None:
-            color = spack.tty.get_color()
+            color = get_color_when()
         depth = kwargs.pop('depth', False)
         hashes = kwargs.pop('hashes', False)
         hlen = kwargs.pop('hashlen', None)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1364,9 +1364,8 @@ class Spec(object):
 
     @property
     def cshort_spec(self):
-        """Returns a version of the spec with the dependencies hashed
-           instead of completely enumerated."""
-        return self.format('$_$@$%@$+$=$/', color=True)
+        """Returns an auto-colorized version of ``self.short_spec``."""
+        return self.cformat('$_$@$%@$+$=$/')
 
     @property
     def prefix(self):
@@ -2719,9 +2718,7 @@ class Spec(object):
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
-        color = kwargs.get('color', None)
-        if color is None:
-            color = get_color_when()
+        color = kwargs.get('color', False)
         length = len(format_string)
         out = StringIO()
         named = escape = compiler = False
@@ -2855,6 +2852,12 @@ class Spec(object):
         result = out.getvalue()
         return result
 
+    def cformat(self, *args, **kwargs):
+        """Same as format, but color defaults to auto instead of False."""
+        kwargs = kwargs.copy()
+        kwargs.setdefault('color', None)
+        return self.format(*args, **kwargs)
+
     def dep_string(self):
         return ''.join("^" + dep.format() for dep in self.sorted_deps())
 
@@ -2885,9 +2888,7 @@ class Spec(object):
     def tree(self, **kwargs):
         """Prints out this spec and its dependencies, tree-formatted
            with indentation."""
-        color = kwargs.pop('color', None)
-        if color is None:
-            color = get_color_when()
+        color = kwargs.pop('color', get_color_when())
         depth = kwargs.pop('depth', False)
         hashes = kwargs.pop('hashes', False)
         hlen = kwargs.pop('hashlen', None)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -115,7 +115,8 @@ function _spack {
     if $list_options
     then
         compgen -W "-h --help -d --debug -D --pdb -k --insecure -m --mock -p
-                    --profile -v --verbose -s --stacktrace -V --version" -- "$cur"
+                    --profile -v --verbose -s --stacktrace -V --version
+                    --color --color=always --color=auto --color=never" -- "$cur"
     else
         compgen -W "$(_subcommands)" -- "$cur"
     fi


### PR DESCRIPTION
Fixes #1369.
Fixes #4761.

This PR disables spec colorization when piping or redirecting stdout and adds a global option to either enable it again, or always disable it. Here is an example using find

```
$ spack find -lvf libxml2 | cat -v
-- linux-ubuntu16-x86_64 / gcc@5.4.0 ----------------------------
ivzisvs libxml2@2.9.4%gcc~python
vmkp7vv libxml2@2.9.4%gcc~python
4sypony libxml2@2.9.4%gcc+python
```

```bash
$ spack --color find -lvf libxml2 | cat -v
-- ^[[0;35mlinux-ubuntu16-x86_64^[[0m / ^[[0;32mgcc@5.4.0^[[0m ----------------------------
^[[0;90mivzisvs^[[0m libxml2^[[0;36m@2.9.4^[[0m^[[0;32m%gcc^[[0m^[[0;32m^[[0m^[[0;94m~python^[[0m
^[[0;90mvmkp7vv^[[0m libxml2^[[0;36m@2.9.4^[[0m^[[0;32m%gcc^[[0m^[[0;32m^[[0m^[[0;94m~python^[[0m
^[[0;90m4sypony^[[0m libxml2^[[0;36m@2.9.4^[[0m^[[0;32m%gcc^[[0m^[[0;32m^[[0m^[[0;94m+python^[[0m
```

For users who always prefer colored output then having command defaults, #2705, could be useful.