### PR TITLE
[WIP] Fix R activation

### DIFF
--- a/var/spack/repos/builtin/packages/r-adabag/package.py
+++ b/var/spack/repos/builtin/packages/r-adabag/package.py
@@ -34,6 +34,5 @@ class RAdabag(RPackage):
 
     version('4.1', '2e019f053d49f62ebb3b1697bbb50afa')
 
-    depends_on('r-rpart', type=('build', 'run'))
     depends_on('r-mlbench', type=('build', 'run'))
     depends_on('r-caret', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-car/package.py
+++ b/var/spack/repos/builtin/packages/r-car/package.py
@@ -36,8 +36,5 @@ class RCar(RPackage):
     version('2.1-4', 'a66c307e8ccf0c336ed197c0f1799565')
     version('2.1-2', '0f78ad74ef7130126d319acec23951a0')
 
-    depends_on('r-mass', type=('build', 'run'))
-    depends_on('r-mgcv', type=('build', 'run'))
-    depends_on('r-nnet', type=('build', 'run'))
     depends_on('r-pbkrtest', type=('build', 'run'))
     depends_on('r-quantreg', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-caret/package.py
+++ b/var/spack/repos/builtin/packages/r-caret/package.py
@@ -38,11 +38,9 @@ class RCaret(RPackage):
 
     depends_on('r@2.10:')
 
-    depends_on('r-lattice@0.20:', type=('build', 'run'))
     depends_on('r-ggplot2', type=('build', 'run'))
     depends_on('r-car', type=('build', 'run'))
     depends_on('r-foreach', type=('build', 'run'))
     depends_on('r-plyr', type=('build', 'run'))
     depends_on('r-modelmetrics@1.1.0:', type=('build', 'run'))
-    depends_on('r-nlme', type=('build', 'run'))
     depends_on('r-reshape2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-class/package.py
+++ b/var/spack/repos/builtin/packages/r-class/package.py
@@ -34,5 +34,3 @@ class RClass(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/class"
 
     version('7.3-14', '6a21dd206fe4ea29c55faeb65fb2b71e')
-
-    depends_on('r-mass', type=('build','run'))

--- a/var/spack/repos/builtin/packages/r-coin/package.py
+++ b/var/spack/repos/builtin/packages/r-coin/package.py
@@ -38,7 +38,6 @@ class RCoin(RPackage):
 
     depends_on('r@2.14.0:')
 
-    depends_on('r-survival', type=('build', 'run'))
     depends_on('r-modeltools@0.2-9:', type=('build', 'run'))
     depends_on('r-mvtnorm@1.0-5:', type=('build', 'run'))
     depends_on('r-multcomp', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-cubist/package.py
+++ b/var/spack/repos/builtin/packages/r-cubist/package.py
@@ -34,5 +34,4 @@ class RCubist(RPackage):
 
     version('0.0.19', 'bf9364f655536ec03717fd2ad6223a47')
 
-    depends_on('r-lattice', type=('build', 'run'))
     depends_on('r-reshape2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-e1071/package.py
+++ b/var/spack/repos/builtin/packages/r-e1071/package.py
@@ -35,5 +35,3 @@ class RE1071(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/e1071"
 
     version('1.6-7', 'd109a7e3dd0c905d420e327a9a921f5a')
-
-    depends_on('r-class', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-foreach/package.py
+++ b/var/spack/repos/builtin/packages/r-foreach/package.py
@@ -40,5 +40,4 @@ class RForeach(RPackage):
 
     version('1.4.3', 'ef45768126661b259f9b8994462c49a0')
 
-    depends_on('r-codetools', type=('build', 'run'))
     depends_on('r-iterators', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-formatr/package.py
+++ b/var/spack/repos/builtin/packages/r-formatr/package.py
@@ -39,7 +39,6 @@ class RFormatr(RPackage):
 
     version('1.4', '98b9b64b2785b35f9df403e1aab6c73c')
 
-    depends_on('r-codetools', type=('build', 'run'))
     depends_on('r-shiny', type=('build', 'run'))
     depends_on('r-testit', type=('build', 'run'))
     # depends_on('r-knitr', type=('build', 'run')) - mutual dependency

--- a/var/spack/repos/builtin/packages/r-ggplot2/package.py
+++ b/var/spack/repos/builtin/packages/r-ggplot2/package.py
@@ -45,7 +45,6 @@ class RGgplot2(RPackage):
 
     depends_on('r-digest', type=('build', 'run'))
     depends_on('r-gtable@0.1.1:', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))
     depends_on('r-plyr@1.7.1:', type=('build', 'run'))
     depends_on('r-reshape2', type=('build', 'run'))
     depends_on('r-scales@0.4.1', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-glmnet/package.py
+++ b/var/spack/repos/builtin/packages/r-glmnet/package.py
@@ -39,5 +39,4 @@ class RGlmnet(RPackage):
 
     version('2.0-5', '049b18caa29529614cd684db3beaec2a')
 
-    depends_on('r-matrix', type=('build', 'run'))
     depends_on('r-foreach', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-hexbin/package.py
+++ b/var/spack/repos/builtin/packages/r-hexbin/package.py
@@ -35,5 +35,3 @@ class RHexbin(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/hexbin"
 
     version('1.27.1', '7f380390c6511e97df10a810a3b3bb7c')
-
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-igraph/package.py
+++ b/var/spack/repos/builtin/packages/r-igraph/package.py
@@ -36,7 +36,6 @@ class RIgraph(RPackage):
 
     version('1.0.1', 'ea33495e49adf4a331e4ba60ba559065')
 
-    depends_on('r-matrix', type=('build', 'run'))
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('r-nmf', type=('build', 'run'))
     depends_on('r-irlba', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-influencer/package.py
+++ b/var/spack/repos/builtin/packages/r-influencer/package.py
@@ -41,4 +41,3 @@ class RInfluencer(RPackage):
     version('0.1.0', '6c8b6decd78c341364b5811fb3050ba5')
 
     depends_on('r-igraph', type=('build', 'run'))
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-ipred/package.py
+++ b/var/spack/repos/builtin/packages/r-ipred/package.py
@@ -38,9 +38,4 @@ class RIpred(RPackage):
 
     depends_on('r@2.10:')
 
-    depends_on('r-rpart@3.1-8:', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))
-    depends_on('r-survival', type=('build', 'run'))
-    depends_on('r-nnet', type=('build', 'run'))
-    depends_on('r-class', type=('build', 'run'))
     depends_on('r-prodlim', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-irlba/package.py
+++ b/var/spack/repos/builtin/packages/r-irlba/package.py
@@ -36,5 +36,3 @@ class RIrlba(RPackage):
 
     version('2.1.2', '290940abf6662ed10c0c5a8db1bc6e88')
     version('2.0.0', '557674cf8b68fea5b9f231058c324d26')
-
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-kknn/package.py
+++ b/var/spack/repos/builtin/packages/r-kknn/package.py
@@ -38,4 +38,3 @@ class RKknn(RPackage):
     depends_on('r@2.10:')
 
     depends_on('r-igraph@1.0:', type=('build', 'run'))
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-lava/package.py
+++ b/var/spack/repos/builtin/packages/r-lava/package.py
@@ -37,4 +37,3 @@ class RLava(RPackage):
     depends_on('r@3.0:')
 
     depends_on('r-numderiv', type=('build', 'run'))
-    depends_on('r-survival', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-lme4/package.py
+++ b/var/spack/repos/builtin/packages/r-lme4/package.py
@@ -37,10 +37,6 @@ class RLme4(RPackage):
 
     version('1.1-12', 'da8aaebb67477ecb5631851c46207804')
 
-    depends_on('r-matrix', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))
-    depends_on('r-lattice', type=('build', 'run'))
-    depends_on('r-nlme', type=('build', 'run'))
     depends_on('r-minqa', type=('build', 'run'))
     depends_on('r-nloptr', type=('build', 'run'))
     depends_on('r-rcpp', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-maptools/package.py
+++ b/var/spack/repos/builtin/packages/r-maptools/package.py
@@ -39,5 +39,3 @@ class RMaptools(RPackage):
     version('0.8-39', '3690d96afba8ef22c8e27ae540ffb836')
 
     depends_on('r-sp', type=('build', 'run'))
-    depends_on('r-foreign', type=('build', 'run'))
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-matrix/package.py
+++ b/var/spack/repos/builtin/packages/r-matrix/package.py
@@ -35,5 +35,3 @@ class RMatrix(RPackage):
 
     version('1.2-8', '4a6406666bf97d3ec6b698eea5d9c0f5')
     version('1.2-6', 'f545307fb1284861e9266c4e9712c55e')
-
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-matrixmodels/package.py
+++ b/var/spack/repos/builtin/packages/r-matrixmodels/package.py
@@ -34,5 +34,3 @@ class RMatrixmodels(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/MatrixModels"
 
     version('0.4-1', '65b3ab56650c62bf1046a3eb1f1e19a0')
-
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-mda/package.py
+++ b/var/spack/repos/builtin/packages/r-mda/package.py
@@ -36,5 +36,3 @@ class RMda(RPackage):
     version('0.4-9', '2ce1446c4a013e0ebcc1099a00269ad9')
 
     depends_on('r@1.9.0:')
-
-    depends_on('r-class', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-mgcv/package.py
+++ b/var/spack/repos/builtin/packages/r-mgcv/package.py
@@ -37,6 +37,3 @@ class RMgcv(RPackage):
 
     version('1.8-16', '4c1d85e0f80b017bccb4b63395842911')
     version('1.8-13', '30607be3aaf44b13bd8c81fc32e8c984')
-
-    depends_on('r-nlme', type=('build', 'run'))
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-mlbench/package.py
+++ b/var/spack/repos/builtin/packages/r-mlbench/package.py
@@ -36,5 +36,3 @@ class RMlbench(RPackage):
     version('2.1-1', '9f06848b8e137b8a37417c92d8e57f3b')
 
     depends_on('r@2.10:')
-
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-multcomp/package.py
+++ b/var/spack/repos/builtin/packages/r-multcomp/package.py
@@ -39,7 +39,5 @@ class RMultcomp(RPackage):
     version('1.4-6', 'f1353ede2ed78b23859a7f1f1f9ebe88')
 
     depends_on('r-mvtnorm@1.0-3:', type=('build', 'run'))
-    depends_on('r-survival@2.39-4:', type=('build', 'run'))
     depends_on('r-th-data@1.0-2:', type=('build', 'run'))
     depends_on('r-sandwich@2.3-0:', type=('build', 'run'))
-    depends_on('r-codetools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-nlme/package.py
+++ b/var/spack/repos/builtin/packages/r-nlme/package.py
@@ -34,5 +34,3 @@ class RNlme(RPackage):
 
     version('3.1-130', '1935d6e308a8018ed8e45d25c8731288')
     version('3.1-128', '3d75ae7380bf123761b95a073eb55008')
-
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-nmf/package.py
+++ b/var/spack/repos/builtin/packages/r-nmf/package.py
@@ -42,7 +42,6 @@ class RNmf(RPackage):
     depends_on('r-pkgmaker', type=('build', 'run'))
     depends_on('r-registry', type=('build', 'run'))
     depends_on('r-rngtools', type=('build', 'run'))
-    depends_on('r-cluster', type=('build', 'run'))
     depends_on('r-stringr', type=('build', 'run'))
     depends_on('r-digest', type=('build', 'run'))
     depends_on('r-gridbase', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-np/package.py
+++ b/var/spack/repos/builtin/packages/r-np/package.py
@@ -40,5 +40,4 @@ class RNp(RPackage):
 
     version('0.60-2', 'e094d52ddff7280272b41e6cb2c74389')
 
-    depends_on('r-boot', type=('build', 'run'))
     depends_on('r-cubature', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-party/package.py
+++ b/var/spack/repos/builtin/packages/r-party/package.py
@@ -39,7 +39,6 @@ class RParty(RPackage):
     depends_on('r-mvtnorm@1.0-2:', type=('build', 'run'))
     depends_on('r-modeltools@0.1-21:', type=('build', 'run'))
     depends_on('r-strucchange', type=('build', 'run'))
-    depends_on('r-survival@2.37-7:', type=('build', 'run'))
     depends_on('r-coin@1.1-0:', type=('build', 'run'))
     depends_on('r-zoo', type=('build', 'run'))
     depends_on('r-sandwich@1.1-1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-partykit/package.py
+++ b/var/spack/repos/builtin/packages/r-partykit/package.py
@@ -42,5 +42,4 @@ class RPartykit(RPackage):
 
     version('1.1-1', '8fcb31d73ec1b8cd3bcd9789639a9277')
 
-    depends_on('r-survival', type=('build', 'run'))
     depends_on('r-formula', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-pbkrtest/package.py
+++ b/var/spack/repos/builtin/packages/r-pbkrtest/package.py
@@ -42,5 +42,3 @@ class RPbkrtest(RPackage):
     depends_on('r@3.2.3:')
 
     depends_on('r-lme4@1.1.10:', type=('build', 'run'))
-    depends_on('r-matrix@1.2.3:', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-pkgmaker/package.py
+++ b/var/spack/repos/builtin/packages/r-pkgmaker/package.py
@@ -41,7 +41,6 @@ class RPkgmaker(RPackage):
     version('0.22', '73a0c6d3e84c6dadf3de7582ef7e88a4')
 
     depends_on('r-registry', type=('build', 'run'))
-    depends_on('r-codetools', type=('build', 'run'))
     depends_on('r-digest', type=('build', 'run'))
     depends_on('r-stringr', type=('build', 'run'))
     depends_on('r-xtable', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-prodlim/package.py
+++ b/var/spack/repos/builtin/packages/r-prodlim/package.py
@@ -39,6 +39,4 @@ class RProdlim(RPackage):
     depends_on('r@2.9.0:')
 
     depends_on('r-rcpp@0.11.5:', type=('build', 'run'))
-    depends_on('r-survival', type=('build', 'run'))
-    depends_on('r-kernsmooth', type=('build', 'run'))
     depends_on('r-lava', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-quantreg/package.py
+++ b/var/spack/repos/builtin/packages/r-quantreg/package.py
@@ -41,5 +41,4 @@ class RQuantreg(RPackage):
     version('5.26', '1d89ed932fb4d67ae2d5da0eb8c2989f')
 
     depends_on('r-sparsem', type=('build', 'run'))
-    depends_on('r-matrix', type=('build', 'run'))
     depends_on('r-matrixmodels', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-rcppeigen/package.py
+++ b/var/spack/repos/builtin/packages/r-rcppeigen/package.py
@@ -47,5 +47,4 @@ class RRcppeigen(RPackage):
     version('0.3.2.9.0', '14a7786882a5d9862d53c4b2217df318')
     version('0.3.2.8.1', '4146e06e4fdf7f4d08db7839069d479f')
 
-    depends_on('r-matrix', type=('build', 'run'))
     depends_on('r-rcpp', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-rminer/package.py
+++ b/var/spack/repos/builtin/packages/r-rminer/package.py
@@ -37,13 +37,9 @@ class RRminer(RPackage):
     version('1.4.2', '7d5d90f4ae030cf647d67aa962412c05')
 
     depends_on('r-plotrix', type=('build', 'run'))
-    depends_on('r-lattice', type=('build', 'run'))
-    depends_on('r-nnet', type=('build', 'run'))
     depends_on('r-kknn', type=('build', 'run'))
     depends_on('r-pls', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))
     depends_on('r-mda', type=('build', 'run'))
-    depends_on('r-rpart', type=('build', 'run'))
     depends_on('r-randomforest', type=('build', 'run'))
     depends_on('r-adabag', type=('build', 'run'))
     depends_on('r-party', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-rpart-plot/package.py
+++ b/var/spack/repos/builtin/packages/r-rpart-plot/package.py
@@ -34,5 +34,3 @@ class RRpartPlot(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/rpart.plot"
 
     version('2.1.0', 'fb0f8edfe22c464683ee82aa429136f9')
-
-    depends_on('r-rpart@4.1-0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-sp/package.py
+++ b/var/spack/repos/builtin/packages/r-sp/package.py
@@ -36,5 +36,3 @@ class RSp(RPackage):
     list_url = "https://cran.r-project.org/src/contrib/Archive/sp"
 
     version('1.2-3', 'f0e24d993dec128642ee66b6b47b10c1')
-
-    depends_on('r-lattice', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-survival/package.py
+++ b/var/spack/repos/builtin/packages/r-survival/package.py
@@ -36,5 +36,3 @@ class RSurvival(RPackage):
 
     version('2.40-1', 'a2474b656cd723791268e3114481b8a7')
     version('2.39-5', 'a3cc6b5762e8c5c0bb9e64a276710be2')
-
-    depends_on('r-matrix', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-th-data/package.py
+++ b/var/spack/repos/builtin/packages/r-th-data/package.py
@@ -34,6 +34,3 @@ class RThData(RPackage):
 
     version('1.0-8', '2cc20acc8b470dff1202749b4bea55c4')
     version('1.0-7', '3e8b6b1a4699544f175215aed7039a94')
-
-    depends_on('r-survival', type=('build', 'run'))
-    depends_on('r-mass', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-threejs/package.py
+++ b/var/spack/repos/builtin/packages/r-threejs/package.py
@@ -37,5 +37,4 @@ class RThreejs(RPackage):
 
     depends_on('r-htmlwidgets', type=('build', 'run'))
     depends_on('r-base64enc', type=('build', 'run'))
-    depends_on('r-matrix', type=('build', 'run'))
     depends_on('r-jsonlite', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-vcd/package.py
+++ b/var/spack/repos/builtin/packages/r-vcd/package.py
@@ -39,6 +39,5 @@ class RVcd(RPackage):
 
     version('1.4-1', '7db150a77f173f85b69a1f86f73f8f02')
 
-    depends_on('r-mass', type=('build', 'run'))
     depends_on('r-colorspace', type=('build', 'run'))
     depends_on('r-lmtest', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/r-xgboost/package.py
@@ -45,7 +45,6 @@ class RXgboost(RPackage):
 
     depends_on('r@3.3.0:')
 
-    depends_on('r-matrix@1.1-0:', type=('build', 'run'))
     depends_on('r-data-table@1.9.6:', type=('build', 'run'))
     depends_on('r-magrittr@1.5:', type=('build', 'run'))
     depends_on('r-stringi@0.5.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-zoo/package.py
+++ b/var/spack/repos/builtin/packages/r-zoo/package.py
@@ -38,5 +38,3 @@ class RZoo(RPackage):
 
     version('1.7-14', '8c577a7c1e535c899ab14177b1039c32')
     version('1.7-13', '99521dfa4c668e692720cefcc5a1bf30')
-
-    depends_on('r-lattice', type=('build', 'run'))


### PR DESCRIPTION
As mentioned in https://github.com/LLNL/spack/issues/2951#issuecomment-277090597, R comes with a few pre-installed packages. These packages are also available on CRAN, and we have Spack packages for them. Unfortunately, these packages (and any that depend on them) can't be activated because they would conflict.

This PR removes any dependencies on these builtin packages. One last thing to do: should we remove the offending packages, or keep them there and turn them into "fake" packages that raise an error with a helpful error message? I vote for the latter, as it would prevent this problem from creeping back in.