### PR TITLE
Boostrapping the lammps package

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/Makefile.inc
+++ b/var/spack/repos/builtin/packages/lammps/Makefile.inc
@@ -1,0 +1,49 @@
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# do not edit this section
+
+include	Makefile.package.settings
+include	Makefile.package
+
+EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE):	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
+	$(SIZE) $(EXE)
+
+# Library targets
+
+lib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
+
+shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+
+# Compilation rules
+
+%.o:%.cpp
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+# Individual dependencies
+
+depend : fastdep.exe $(SRC)
+	@./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+	cc -O -o $@ $<
+
+sinclude .depend

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -147,8 +147,8 @@ class Lammps(Package):
                         'Makefile.icc')
 
             mpi_include = self.spec['mpi'].prefix.include
-            if 'intelmpi' in self.spec:
-                mpi_include = self.spec['mpi'].prefix.include + '64'
+#            if 'intelmpi' in self.spec:
+#                mpi_include = self.spec['mpi'].prefix.include + '64'
             filter_file(r'CCFLAGS = *',
                         'CCFLAGS = -I{0} '.format(mpi_include),
                         'Makefile.icc')
@@ -159,9 +159,11 @@ class Lammps(Package):
 
             make('lib', '-f', 'Makefile.icc')
             with open('Makefile.lammps', 'w') as fh:
+                lapack_blas = (self.spec['lapack'].lapack_libs +
+                               self.spec['blas'].blas_libs)
                 makefile = ['user-atc_SYSINC =',
-                            'user-atc_SYSLIB = {0}'.format(self.spec['lapack'].lapack_ld_flags),
-                            'user-atc_SYSPATH =']
+                            'user-atc_SYSLIB = {0}'.format(lapack_blas.ld_flags),
+                            'user-atc_SYSPATH = ']
                 fh.write('\n'.join(makefile))
 
     def build_voronoi(self):

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -30,7 +30,7 @@ import string
 class Lammps(Package):
     """LAMMPS stands for Large-scale Atomic/Molecular Massively
     Parallel Simulator."""
-    homepage = "http://www.example.com"
+    homepage = "http://lammps.sandia.gov/"
     url      = "https://github.com/lammps/lammps/archive/stable_17Nov2016.tar.gz"
 
     version('17Nov2016', '8aecc58a39f9775203517c62a592d13b',
@@ -50,7 +50,7 @@ class Lammps(Package):
     depends_on('voropp', when='+voronoi')
     depends_on('netcdf+mpi', when='+user-nc-dump')
     depends_on('blas', when='+user-atc')
-    depends_on('lapack', when='+user-atc')7
+    depends_on('lapack', when='+user-atc')
 
     def setup_environment(self, spack_env, run_env):
         self.target_name = self.compiler.name

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -1,0 +1,198 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+#
+# Please also see the LICENSE file for our notice and the LGPL.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import string
+
+
+class Lammps(Package):
+    """LAMMPS stands for Large-scale Atomic/Molecular Massively Parallel Simulator."""
+    homepage = "http://www.example.com"
+    url      = "https://github.com/lammps/lammps/archive/stable_17Nov2016.tar.gz"
+
+    version('17Nov2016', '8aecc58a39f9775203517c62a592d13b',
+            url="https://github.com/lammps/lammps/archive/stable_17Nov2016.tar.gz")
+
+    supported_packages = ['voronoi', 'rigid', 'user-nc-dump', 'user-atc', 'meam', 'manybody']
+
+    for pkg in supported_packages:
+        variant(pkg, default=False, description='Activate the {0} package'.format(pkg))
+    variant('lib', default=True, description='Build the liblammps in addition to the lammps executable')
+
+    depends_on('mpi')
+    depends_on('fftw')
+    depends_on('voropp', when='+voronoi')
+    depends_on('netcdf+mpi', when='+nc-dump')
+    depends_on('blas', when='+user-atc')
+    depends_on('lapack', when='+user-atc')
+
+    def setup_environment(self, spack_env, run_env):
+        self.target_name = self.compiler.name
+
+    def patch(self):
+        config = []
+
+        config.append('CC = c++')
+        if self.compiler.name == 'intel':
+            # This is taken from MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
+            config.append('OPTFLAGS = -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits')
+            config.append('CCFLAGS = -g -qopenmp -DLAMMPS_MEMALIGN=64 -no-offload -fno-alias -ansi-alias -restrict $(OPTFLAGS)')
+            config.append('LINKFLAGS = -qopenmp $(OPTFLAGS)')
+        else:
+            # This is taken from MAKE/OPTIONS/Makefile.g++
+            config.append('OPTFLAGS = -O3')
+            config.append('CCFLAGS = -fopenmp')
+            config.append('LINKFLAGS = -fopenmp $(OPTFLAGS)')
+
+        config.append('SHFLAGS = -fPIC')
+        config.append('DEPFLAGS = -M')
+        config.append('LINK = c++')
+
+        config.append('LIB = ')
+        config.append('SIZE = size')
+
+        config.append('ARCHIVE = ar')
+        config.append('ARFLAGS = -rc')
+        config.append('SHLIBFLAGS = -shared')
+
+        config.append('LMP_INC = -DLAMMPS_GZIP')
+
+
+        mpi_path = self.spec['mpi'].prefix.lib
+        mpi_inc = self.spec['mpi'].prefix.include
+
+        # specific to EPFL installation, remove before PR upstream
+        if 'intelmpi' in self.spec:
+            mpi_path = self.spec['mpi'].prefix.lib64
+            mpi_inc = self.spec['mpi'].prefix.include + '64'
+
+        config.append(
+            'MPI_INC = -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I{0}'.format(
+                mpi_inc))
+        config.append('MPI_PATH = -L{0}'.format(mpi_path))
+        config.append('MPI_LIB = {0}'.format(
+            ' '.join(self.spec['mpi'].mpicxx_shared_libs)))
+
+        config.append('FFT_INC = -DFFT_FFTW3 -L{0}'.format(
+            self.spec['fftw'].prefix.include))
+        config.append('FFT_PATH = -L{0}'.format(self.spec['fftw'].prefix.lib))
+        config.append('FFT_LIB = -lfftw3')
+
+        config.append('JPG_INC = ')
+        config.append('JPG_PATH = ')
+        config.append('JPG_LIB = ')
+
+        makefile_inc_template = \
+            join_path(os.path.dirname(self.module.__file__),
+                      'Makefile.inc')
+        with open(makefile_inc_template, "r") as fhr:
+            config.extend(fhr.read().split('\n'))
+
+        with working_dir('src/MAKE/'):
+            with open('Makefile.{0}'.format(self.target_name), 'w') as fh:
+                fh.write('\n'.join(config))
+
+    def build_meam(self):
+        with working_dir('lib/meam'):
+            filter_file(r'EXTRAMAKE = Makefile.lammps.ifort',
+                        'EXTRAMAKE = Makefile.lammps.spack',
+                        'Makefile.ifort')
+            filter_file('F90 = *ifort',
+                        'F90 = {0}'.format(self.compiler.fc),
+                        'Makefile.ifort')
+
+            with open('Makefile.lammps.spack', 'w') as fh:
+                syslib = ''
+                syspath = ''
+                if self.compiler.name == 'gcc':
+                    syslib = '-lgfortran'
+                elif self.compiler.name == 'intel':
+                    syslib = '-lifcore'
+                    #syspath = '-L{0}'.format(self.spec['intel'].prefix.lib)
+
+                makefile = ['meam_SYSINC =',
+                            'meam_SYSLIB = {0}'.format(syslib),
+                            'meam_SYSPATH = {0}'.format(syspath)]
+
+                fh.write('\n'.join(makefile))
+
+            make('lib', '-f', 'Makefile.ifort')
+
+    def build_user_atc(self):
+        with working_dir('lib/atc'):
+            filter_file(r'CC =.*',
+                        'CC = {0}'.format(self.compiler.cxx),
+                        'Makefile.icc')
+
+            mpi_include = self.spec['mpi'].prefix.include
+            if 'intelmpi' in self.spec:
+                mpi_include = self.spec['mpi'].prefix.include + '64'
+            filter_file(r'CCFLAGS = *',
+                        'CCFLAGS = -I{0} '.format(mpi_include),
+                        'Makefile.icc')
+
+            filter_file('LINK =.*',
+                        'LINK = {0}'.format(self.compiler.cxx),
+                        'Makefile.icc')
+
+            make('lib', '-f', 'Makefile.icc')
+            with open('Makefile.lammps', 'w') as fh:
+                makefile = ['user-atc_SYSINC =',
+                            'user-atc_SYSLIB = {0}'.format(self.spec['lapack'].lapack_ld_flags),
+                            'user-atc_SYSPATH =']
+                fh.write('\n'.join(makefile))
+
+    def build_voronoi(self):
+        # no need to set the voronoi_SYS variable in Makefile.lammps
+        # since the spack wrapper takes care of the path
+        with working_dir('src/VORONOI'):
+            filter_file(r'#include "voro\+\+\.hh"',
+                        '#include <voro++/voro++.hh>',
+                        'compute_voronoi_atom.h')
+
+    def install(self, spec, prefix):
+        for pkg in self.supported_packages:
+            _build_pkg_name = string.replace('build_{0}'.format(pkg), '-', '_')
+            if hasattr(self, _build_pkg_name):
+                _build_pkg = getattr(self, _build_pkg_name)
+                _build_pkg()
+
+        print(os.getcwd())
+        with working_dir('src'):
+            for pkg in self.supported_packages:
+                if '+{0}'.format(pkg) in spec:
+                    make('yes-{0}'.format(pkg))
+
+            make(self.target_name)
+            mkdirp(prefix.bin)
+            install('lmp_{0}'.format(self.target_name), prefix.bin)
+
+            if '+lib' in spec:
+                mkdirp(prefix.lib)
+                install('liblammps_{0}.{1}'.format(self.target_name,
+                                                   dso_suffix), prefix.lib)
+
+                # TODO: install the necessary headers
+                mkdirp(prefix.include)

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -198,7 +198,6 @@ class Lammps(MakefilePackage):
             mkdirp(prefix.bin)
             install('lmp_{0}'.format(self.target_name), prefix.bin)
 
-
             if '+lib' in spec:
                 mkdirp(prefix.lib)
                 install('liblammps_{0}.{1}'.format(self.target_name,

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -44,7 +44,7 @@ class Lammps(Package):
     depends_on('mpi')
     depends_on('fftw')
     depends_on('voropp', when='+voronoi')
-    depends_on('netcdf+mpi', when='+nc-dump')
+    depends_on('netcdf+mpi', when='+user-nc-dump')
     depends_on('blas', when='+user-atc')
     depends_on('lapack', when='+user-atc')
 

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -28,25 +28,29 @@ import string
 
 
 class Lammps(Package):
-    """LAMMPS stands for Large-scale Atomic/Molecular Massively Parallel Simulator."""
+    """LAMMPS stands for Large-scale Atomic/Molecular Massively
+    Parallel Simulator."""
     homepage = "http://www.example.com"
     url      = "https://github.com/lammps/lammps/archive/stable_17Nov2016.tar.gz"
 
     version('17Nov2016', '8aecc58a39f9775203517c62a592d13b',
             url="https://github.com/lammps/lammps/archive/stable_17Nov2016.tar.gz")
 
-    supported_packages = ['voronoi', 'rigid', 'user-nc-dump', 'user-atc', 'meam', 'manybody']
+    supported_packages = ['voronoi', 'rigid', 'user-nc-dump',
+                          'user-atc', 'meam', 'manybody']
 
     for pkg in supported_packages:
-        variant(pkg, default=False, description='Activate the {0} package'.format(pkg))
-    variant('lib', default=True, description='Build the liblammps in addition to the lammps executable')
+        variant(pkg, default=False,
+                description='Activate the {0} package'.format(pkg))
+    variant('lib', default=True,
+            description='Build the liblammps in addition to the executable')
 
     depends_on('mpi')
     depends_on('fftw')
     depends_on('voropp', when='+voronoi')
     depends_on('netcdf+mpi', when='+user-nc-dump')
     depends_on('blas', when='+user-atc')
-    depends_on('lapack', when='+user-atc')
+    depends_on('lapack', when='+user-atc')7
 
     def setup_environment(self, spack_env, run_env):
         self.target_name = self.compiler.name
@@ -57,8 +61,8 @@ class Lammps(Package):
         config.append('CC = c++')
         if self.compiler.name == 'intel':
             # This is taken from MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
-            config.append('OPTFLAGS = -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits')
-            config.append('CCFLAGS = -g -qopenmp -DLAMMPS_MEMALIGN=64 -no-offload -fno-alias -ansi-alias -restrict $(OPTFLAGS)')
+            config.append('OPTFLAGS = -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits')  # noqa: E501
+            config.append('CCFLAGS = -g -qopenmp -DLAMMPS_MEMALIGN=64 -no-offload -fno-alias -ansi-alias -restrict $(OPTFLAGS)')  # noqa: E501
             config.append('LINKFLAGS = -qopenmp $(OPTFLAGS)')
         else:
             # This is taken from MAKE/OPTIONS/Makefile.g++
@@ -79,14 +83,8 @@ class Lammps(Package):
 
         config.append('LMP_INC = -DLAMMPS_GZIP')
 
-
         mpi_path = self.spec['mpi'].prefix.lib
         mpi_inc = self.spec['mpi'].prefix.include
-
-        # specific to EPFL installation, remove before PR upstream
-        if 'intelmpi' in self.spec:
-            mpi_path = self.spec['mpi'].prefix.lib64
-            mpi_inc = self.spec['mpi'].prefix.include + '64'
 
         config.append(
             'MPI_INC = -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I{0}'.format(
@@ -130,7 +128,6 @@ class Lammps(Package):
                     syslib = '-lgfortran'
                 elif self.compiler.name == 'intel':
                     syslib = '-lifcore'
-                    #syspath = '-L{0}'.format(self.spec['intel'].prefix.lib)
 
                 makefile = ['meam_SYSINC =',
                             'meam_SYSLIB = {0}'.format(syslib),
@@ -147,8 +144,7 @@ class Lammps(Package):
                         'Makefile.icc')
 
             mpi_include = self.spec['mpi'].prefix.include
-#            if 'intelmpi' in self.spec:
-#                mpi_include = self.spec['mpi'].prefix.include + '64'
+
             filter_file(r'CCFLAGS = *',
                         'CCFLAGS = -I{0} '.format(mpi_include),
                         'Makefile.icc')
@@ -161,9 +157,10 @@ class Lammps(Package):
             with open('Makefile.lammps', 'w') as fh:
                 lapack_blas = (self.spec['lapack'].lapack_libs +
                                self.spec['blas'].blas_libs)
-                makefile = ['user-atc_SYSINC =',
-                            'user-atc_SYSLIB = {0}'.format(lapack_blas.ld_flags),
-                            'user-atc_SYSPATH = ']
+                makefile = [
+                    'user-atc_SYSINC =',
+                    'user-atc_SYSLIB = {0}'.format(lapack_blas.ld_flags),
+                    'user-atc_SYSPATH = ']
                 fh.write('\n'.join(makefile))
 
     def build_voronoi(self):

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Voropp(Package):
+    """Voro++ is a open source software library for the computation of the Voronoi diagram, a widely-used tessellation that has applications in many scientific fields."""
+    homepage = "http://math.lbl.gov/voro++/about.html"
+    url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
+
+    version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9', url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
+
+    def patch(self):
+        filter_file(r'CC=g\+\+',  'CC={0}'.format(self.compiler.cxx), 'config.mk')
+        filter_file(r'PREFIX=/usr/local',  'PREFIX={0}'.format(self.prefix), 'config.mk')
+
+    def install(self, spec, prefix):
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -26,15 +26,21 @@ from spack import *
 
 
 class Voropp(Package):
-    """Voro++ is a open source software library for the computation of the Voronoi diagram, a widely-used tessellation that has applications in many scientific fields."""
+    """Voro++ is a open source software library for the computation of the
+    Voronoi diagram, a widely-used tessellation that has applications in many
+    scientific fields."""
     homepage = "http://math.lbl.gov/voro++/about.html"
     url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
 
     version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9', url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
 
     def patch(self):
-        filter_file(r'CC=g\+\+',  'CC={0}'.format(self.compiler.cxx), 'config.mk')
-        filter_file(r'PREFIX=/usr/local',  'PREFIX={0}'.format(self.prefix), 'config.mk')
+        filter_file(r'CC=g\+\+',
+                    'CC={0}'.format(self.compiler.cxx),
+                    'config.mk')
+        filter_file(r'PREFIX=/usr/local',
+                    'PREFIX={0}'.format(self.prefix),
+                    'config.mk')
 
     def install(self, spec, prefix):
         make()

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Voropp(Package):
+class Voropp(MakefilePackage):
     """Voro++ is a open source software library for the computation of the
     Voronoi diagram, a widely-used tessellation that has applications in many
     scientific fields."""
@@ -35,14 +35,10 @@ class Voropp(Package):
     version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9',
             url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
 
-    def patch(self):
+    def edit(self, spec, prefix):
         filter_file(r'CC=g\+\+',
                     'CC={0}'.format(self.compiler.cxx),
                     'config.mk')
         filter_file(r'PREFIX=/usr/local',
                     'PREFIX={0}'.format(self.prefix),
                     'config.mk')
-
-    def install(self, spec, prefix):
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -32,8 +32,12 @@ class Voropp(MakefilePackage):
     homepage = "http://math.lbl.gov/voro++/about.html"
     url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
 
-    version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9',
-            url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
+    version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9')
+
+    def url_for_version(self, version):
+        url = "http://math.lbl.gov/voro++/download/dir/voro++-{0}.tar.gz".format(  # noqa: E501
+            str(version))
+        return url
 
     def edit(self, spec, prefix):
         filter_file(r'CC=g\+\+',

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -32,7 +32,8 @@ class Voropp(Package):
     homepage = "http://math.lbl.gov/voro++/about.html"
     url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
 
-    version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9', url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
+    version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9',
+            url="http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz")
 
     def patch(self):
         filter_file(r'CC=g\+\+',

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -29,8 +29,13 @@ class Voropp(MakefilePackage):
     """Voro++ is a open source software library for the computation of the
     Voronoi diagram, a widely-used tessellation that has applications in many
     scientific fields."""
+
     homepage = "http://math.lbl.gov/voro++/about.html"
-    url      = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
+
+    # This url is wrong but it passes the test the ++ make the url parser fail,
+    # the correct url is constructed by url_for_version that has to be used in
+    # any case due to the difference between the package name and the url
+    url      = "http://math.lbl.gov/voropp/download/dir/voropp-0.4.6.tar.gz"
 
     version('0.4.6', '2338b824c3b7b25590e18e8df5d68af9')
 


### PR DESCRIPTION
This compiles lammps with a few dependencies as variants,
voronoi, rigid, meam,  manybody, user-atc, user-nc-dump
I didn't know how to enforce the dependencies between variants. 