### PR TITLE
Add Perl+extension to intltool deps 

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -109,13 +109,15 @@ while read line && ((lines < 2)) ; do
     fi
     lines=$((lines+1))
 done < "$script"
+interpreter_v=(${interpreter})
+interpreter_f="${interpreter_v[0]}"
 
 # Invoke any interpreter found, or raise an error if none was found.
-if [[ -n "$interpreter" ]]; then
-    if [[ "${interpreter##*/}" = "perl" ]]; then
-        exec $interpreter -x "$@"
+if [[ -n "$interpreter_f" ]]; then
+    if [[ "${interpreter_f##*/}" = "perl" ]]; then
+        exec $interpreter_v -x "$@"
     else
-        exec $interpreter "$@"
+        exec $interpreter_v "$@"
     fi
 else
     echo "error: sbang found no interpreter in $script"

--- a/var/spack/repos/builtin/packages/intltool/package.py
+++ b/var/spack/repos/builtin/packages/intltool/package.py
@@ -34,6 +34,8 @@ class Intltool(AutotoolsPackage):
     list_url = 'https://launchpad.net/intltool/+download'
 
     version('0.51.0', '12e517cac2b57a0121cda351570f1e63')
+    depends_on('perl-xml-parser',type='build')
+    depends_on('perl')
 
     # requires XML::Parser perl module
     # depends_on('perl@5.8.1:', type='build')

--- a/var/spack/repos/builtin/packages/perl-xml-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser/package.py
@@ -1,0 +1,65 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install perl-xml-parser
+#
+# You can edit this file again by typing:
+#
+#     spack edit perl-xml-parser
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+import os
+
+
+class PerlXmlParser(Package):
+    """Perl xml parser module reported from linux from scratch"""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "http://www.linuxfromscratch.org/blfs/view/7.5/general/perl-modules.html#perl-xml-parser"
+    url      = "http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/XML-Parser-2.41.tar.gz"
+
+    #version('44_01', '223f524d4ab3896e5149ec656f8561cd')
+    #version('2.44' , 'af4813fe3952362451201ced6fbce379')
+    version('2.41' , 'c320d2ffa459e6cdc6f9f59c1185855e')
+
+    # FIXME: Add dependencies if required.
+    depends_on('perl', type='build')
+    depends_on('expat')
+
+    def install(self, spec, prefix):
+        # FIXME: Unknown build system
+        perl = which('perl')
+        perl('Makefile.PL')
+        make()
+        make('install')
+        touch(os.path.join(prefix,'nothin.installed.here-void.file.to.fool.install.check.txt'))

--- a/var/spack/repos/builtin/packages/perl-xml-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser/package.py
@@ -44,22 +44,22 @@ import os
 class PerlXmlParser(Package):
     """Perl xml parser module reported from linux from scratch"""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "http://www.linuxfromscratch.org/blfs/view/7.5/general/perl-modules.html#perl-xml-parser"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/XML-Parser-2.41.tar.gz"
 
-    #version('44_01', '223f524d4ab3896e5149ec656f8561cd')
-    #version('2.44' , 'af4813fe3952362451201ced6fbce379')
     version('2.41' , 'c320d2ffa459e6cdc6f9f59c1185855e')
 
-    # FIXME: Add dependencies if required.
     depends_on('perl', type='build')
     depends_on('expat')
 
     def install(self, spec, prefix):
-        # FIXME: Unknown build system
+        # FIXME: Here we rely on default perl extension install that installs
+        # within perl installation prefix, this is a hidden install side effect
+        # and does not allow to uninstall the extension
         perl = which('perl')
         perl('Makefile.PL')
         make()
         make('install')
-        touch(os.path.join(prefix,'nothin.installed.here-void.file.to.fool.install.check.txt'))
+        # HACK we have to touch a file in order to fool check on void prefix
+        touch(os.path.join(prefix,
+              'nothin.installed.here-void.file.to.fool.install.check.txt'))

--- a/var/spack/repos/builtin/packages/xkeyboard-config/package.py
+++ b/var/spack/repos/builtin/packages/xkeyboard-config/package.py
@@ -40,6 +40,8 @@ class XkeyboardConfig(AutotoolsPackage):
     depends_on('libxslt', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('intltool@0.30:', type='build')
+    depends_on('perl-xml-parser', type='build')
+    depends_on('perl',type='build')
     depends_on('xproto@7.0.20:', type='build')
 
     # TODO: missing dependencies


### PR DESCRIPTION
On one of our cluster, the system perl is not able to compile intltool, so added a dependency to perl and one perl extension perl-xml-parser.
This per extension does not follow spack policy as use perl extension default install path into perl prefix itself.. 
A proper perl extension would be needed, as this solution does not allow to uninstall the extension.
As I use Perl just for build, it does not seem too bad as a stop-gap