### PR TITLE
netlib-lapack: Update package file for netlib-lapack to work with IBM…

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
@@ -1,0 +1,22 @@
+diff -Naur lapack-3.6.1/CMAKE/CheckLAPACKCompilerFlags.cmake lapack-3.6.1-patched/CMAKE/CheckLAPACKCompilerFlags.cmake
+--- lapack-3.6.1/CMAKE/CheckLAPACKCompilerFlags.cmake	2017-01-27 17:14:37.414854283 -0500
++++ lapack-3.6.1-patched/CMAKE/CheckLAPACKCompilerFlags.cmake	2017-01-27 17:14:24.754719546 -0500
+@@ -43,12 +43,12 @@
+   if( "${CMAKE_Fortran_FLAGS}" MATCHES "-qflttrap=[a-zA-Z:]:enable" )
+     set( FPE_EXIT TRUE )
+   endif()
+-
+-  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "-qfixed") )
+-    message( STATUS "Enabling fixed format F90/F95 with -qfixed" )
+-    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
+-         CACHE STRING "Flags for Fortran compiler." FORCE )
+-  endif()
++#
++#  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "-qfixed") )
++#    message( STATUS "Enabling fixed format F90/F95 with -qfixed" )
++#    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
++#         CACHE STRING "Flags for Fortran compiler." FORCE )
++#  endif()
+ 
+ # HP Fortran
+ elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )

--- a/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
+++ b/var/spack/repos/builtin/packages/netlib-lapack/ibm-xl.patch
@@ -1,7 +1,7 @@
 diff -Naur lapack-3.6.1/CMAKE/CheckLAPACKCompilerFlags.cmake lapack-3.6.1-patched/CMAKE/CheckLAPACKCompilerFlags.cmake
 --- lapack-3.6.1/CMAKE/CheckLAPACKCompilerFlags.cmake	2017-01-27 17:14:37.414854283 -0500
 +++ lapack-3.6.1-patched/CMAKE/CheckLAPACKCompilerFlags.cmake	2017-01-27 17:14:24.754719546 -0500
-@@ -43,12 +43,12 @@
+@@ -43,12 +43,6 @@
    if( "${CMAKE_Fortran_FLAGS}" MATCHES "-qflttrap=[a-zA-Z:]:enable" )
      set( FPE_EXIT TRUE )
    endif()
@@ -11,12 +11,6 @@ diff -Naur lapack-3.6.1/CMAKE/CheckLAPACKCompilerFlags.cmake lapack-3.6.1-patche
 -    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
 -         CACHE STRING "Flags for Fortran compiler." FORCE )
 -  endif()
-+#
-+#  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "-qfixed") )
-+#    message( STATUS "Enabling fixed format F90/F95 with -qfixed" )
-+#    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
-+#         CACHE STRING "Flags for Fortran compiler." FORCE )
-+#  endif()
  
  # HP Fortran
  elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -52,6 +52,9 @@ class NetlibLapack(Package):
     variant('lapacke', default=True,
             description='Activates the build of the LAPACKE C interface')
 
+    patch('ibm-xl.patch', when='@3:6%xl')
+    patch('ibm-xl.patch', when='@3:6%xl_r')
+
     # virtual dependency
     provides('blas', when='~external-blas')
     provides('lapack')
@@ -96,7 +99,14 @@ class NetlibLapack(Package):
             cmake_args.extend(['-DCBLAS=OFF'])
             cmake_args.extend(['-DLAPACKE:BOOL=OFF'])
 
-        # deprecated routines are commonly need by, for example, suitesparse
+        if self.compiler.name == 'xl' or self.compiler.name == 'xl_r':
+            # use F77 compiler if IBM XL
+            cmake_args.extend([
+                '-DCMAKE_Fortran_COMPILER=%s' % self.compiler.f77,
+                '-DCMAKE_Fortran_FLAGS=-qzerosize'
+            ])
+
+        # deprecated routines are commonly needed by, for example, suitesparse
         # Note that OpenBLAS spack is built with deprecated routines
         cmake_args.extend(['-DBUILD_DEPRECATED:BOOL=ON'])
 


### PR DESCRIPTION
… XL compiler

The flag -qzerosize is redundant, as the IBM XL compiler should set this flag
by default in lib/spack/spack/compilers/xl*.py.
However, at this time the default flag appears to be ignore by spack.
Hence, I am setting it in the package file as well, as it has no negative
effect if set twice.