### PR TITLE
spectrum-mpi: Add url info to spectrum-mpi package file

### DIFF
--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -32,6 +32,7 @@ class SpectrumMpi(Package):
     """
 
     homepage = "http://www-03.ibm.com/systems/spectrum-computing/products/mpi"
+    url = "http://www-03.ibm.com/systems/spectrum-computing/products/mpi"
 
     provides('mpi')
 


### PR DESCRIPTION
Spack wants URL info even for external packages.  Without it, I get
the following error:

NoURLError: Package SpectrumMpi has no version with a URL.
  File "/home_local/serbanspack/spack/lib/spack/spack/repository.py", line 580, in get
    self._instances[key] = package_class(copy)
  File "/home_local/serbanspack/spack/lib/spack/spack/package.py", line 562, in __init__
    f = fs.for_package_version(self, self.version)
  File "/home_local/serbanspack/spack/lib/spack/spack/fetch_strategy.py", line 878, in for_package_version
    url = pkg.url_for_version(version)
  File "/home_local/serbanspack/spack/lib/spack/spack/package.py", line 682, in url_for_version
    raise NoURLError(cls)