### PR TITLE
Add patch to allow PGI to build Bison

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -35,6 +35,8 @@ class Bison(AutotoolsPackage):
 
     version('3.0.4', 'a586e11cd4aff49c3ff6d3b6a4c9ccf8')
 
-    depends_on("m4", type='build')
+    depends_on('m4', type='build')
+
+    patch('pgi.patch', when='@3.0.4')
 
     build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/bison/pgi.patch
+++ b/var/spack/repos/builtin/packages/bison/pgi.patch
@@ -1,0 +1,10 @@
+--- a/lib/config.in.h
++++ b/lib/config.in.h
+@@ -2182,6 +2182,7 @@
+       ? defined __GNUC_STDC_INLINE__ && __GNUC_STDC_INLINE__ \
+       : (199901L <= __STDC_VERSION__ \
+          && !defined __HP_cc \
++         && !defined __PGI \
+          && !(defined __SUNPRO_C && __STDC__))) \
+      && !defined _GL_EXTERN_INLINE_STDHEADER_BUG)
+ # define _GL_INLINE inline


### PR DESCRIPTION
When building Bison with the PGI compilers, the following error occurs:
```
src/bison-InadequacyList.o: In function `xnmalloc':
/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/bison-3.0.4-qofkgp3xfpikbq7oj7khyo6sh6mmmmgj/bison-3.0.4/lib/xalloc.h:108: multiple definition of `xnmalloc'
src/bison-AnnotationList.o:/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/bison-3.0.4-qofkgp3xfpikbq7oj7khyo6sh6mmmmgj/bison-3.0.4/lib/xalloc.h:108: first defined here
src/bison-InadequacyList.o: In function `xnrealloc':
/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/bison-3.0.4-qofkgp3xfpikbq7oj7khyo6sh6mmmmgj/bison-3.0.4/lib/xalloc.h:121: multiple definition of `xnrealloc'
src/bison-AnnotationList.o:/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/bison-3.0.4-qofkgp3xfpikbq7oj7khyo6sh6mmmmgj/bison-3.0.4/lib/xalloc.h:121: first defined here
src/bison-InadequacyList.o: In function `xcharalloc':
/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/bison-3.0.4-qofkgp3xfpikbq7oj7khyo6sh6mmmmgj/bison-3.0.4/lib/xalloc.h:220: multiple definition of `xcharalloc'
```
This is the exact same problem that I reported to GNU M4 a year ago, and luckily has the exact same solution. This PR is basically a copy of #501 for Bison this time.

The developers say this patch will be included in the next release of Bison. But it's been 2 years since the last release, so who knows when that will be.