### PR TITLE
Add comment explaining why patch is still needed

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -73,6 +73,7 @@ class Go(Package):
     patch('time_test.patch', when='@1.6.4:1.7.4')
 
     # https://github.com/golang/go/issues/17986
+    # The fix for this issue has been merged into the 1.8 tree.
     patch('misc-cgo-testcshared.patch', level=0, when='@1.6.4:1.7.5')
 
     # NOTE: Older versions of Go attempt to download external files that have


### PR DESCRIPTION
[The fix](https://github.com/golang/go/issues/17986) for the small buglet addressed by `misc-cgo-testcshared.patch` has been merged into the tree a while back.  I was surprised to see that it wasn't in 1.7.5 and did a bit of digging.  It is *has not* been merged into the 1.7 branch but it *has* been merged into 1.8 (and therefor the patch will no longer be necessary).

Figured I'd document my digging for the next person to come along.