### PR TITLE
Bootstrap environment-modules

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -849,6 +849,10 @@ well.  They can generally be activated as in the ``curl`` example above;
 or some systems might already have an appropriate hand-built
 environment module that may be loaded.  Either way works.
 
+If you find that you are missing some of these programs, ``spack`` can
+build some of them for you with ``spack bootstrap``. Currently supported
+programs are ``environment-modules``.
+
 A few notes on specific programs in this list:
 
 """"""""""""""""""""""""""

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -902,9 +902,8 @@ What follows are three steps describing how to install and use environment-modul
 
 #. Install ``environment-modules``.
 
-   * Spack can build and install ``environment-modules`` for you.
-     Call ``spack bootstrap`` which will install ``environment-modules`` and it's 
-     dependencies.
+   * ``spack bootstrap`` will build ``environment-modules`` for you (and may build
+     other packages that are useful to the operation of Spack)
 
    * Install ``environment-modules`` using ``spack install`` with
      ``spack install environment-modules~X`` (The ``~X`` variant builds without Xorg

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -894,8 +894,11 @@ Environment Modules
 In order to use Spack's generated environment modules, you must have
 installed one of *Environment Modules* or *Lmod*.  On many Linux
 distributions, this can be installed from the vendor's repository.  For
-example: ``yum install environment-modules`` (Fedora/RHEL/CentOS).  If
-your Linux distribution does not have Environment Modules, Spack can build it for you!
+example: ``yum install environment-modules`` (Fedora/RHEL/CentOS). If
+your Linux distribution does not have Environment Modules, Spack can
+build it for you!
+
+What follows are three steps describing how to install and use environment-modules with spack.
 
 #. Install ``environment-modules``.
 
@@ -929,9 +932,10 @@ your Linux distribution does not have Environment Modules, Spack can build it fo
 #. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. 
 
    * If you are using bash/zsh, Spack can currently do this for you as well.
-     Simply source Spack's shell integration script again. This will automatically
+     After installing ``environment-modules`` using spack following the step
+     above, source Spack's shell integration script. This will automatically
      detect the lack of ``modulecmd`` and ``module``, and use the installed
-     ``environment-modules`` from ``spack bootstrap``.
+     ``environment-modules`` from ``spack bootstrap`` or ``spack install``.
      
      .. code-block:: console
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -52,7 +52,7 @@ For a richer experience, use Spack's shell support:
 
 .. code-block:: console
 
-   # For bash users
+   # For bash/zsh users
    $ export SPACK_ROOT=/path/to/spack
    $ . $SPACK_ROOT/share/spack/setup-env.sh
 
@@ -886,50 +886,73 @@ In order to use Spack's generated environment modules, you must have
 installed one of *Environment Modules* or *Lmod*.  On many Linux
 distributions, this can be installed from the vendor's repository.  For
 example: ``yum install environment-modules`` (Fedora/RHEL/CentOS).  If
-your Linux distribution does not have Environment Modules, you can get it
-with Spack:
+your Linux distribution does not have Environment Modules, Spack can build it for you!
 
-#. Consider using system tcl (as long as your system has Tcl version 8.0 or later):
+#. Install ``environment-modules``.
 
-   #) Identify its location using ``which tclsh``
-   #) Identify its version using ``echo 'puts $tcl_version;exit 0' | tclsh``
-   #) Add to ``~/.spack/packages.yaml`` and modify as appropriate:
+   * Spack can build and install ``environment-modules`` for you.
+     Call ``spack bootstrap`` which will install ``environment-modules`` and it's 
+     dependencies.
 
-      .. code-block:: yaml
+   * If you wish to install ``environment-modules`` in a more manual way,
+     try the following procedure:
 
-         packages:
-             tcl:
-                 paths:
-                     tcl@8.5: /usr
-                 buildable: False
+      * Consider using system tcl (as long as your system has Tcl version 8.0 or later):
 
-#. Install with:
+         #) Identify its location using ``which tclsh``
+         #) Identify its version using ``echo 'puts $tcl_version;exit 0' | tclsh``
+         #) Add to ``~/.spack/packages.yaml`` and modify as appropriate:
+
+            .. code-block:: yaml
+
+               packages:
+                   tcl:
+                       paths:
+                           tcl@8.5: /usr
+                       buildable: False
+
+      #. Install with:
+
+         .. code-block:: console
+
+            $ spack install environment-modules
+
+#. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. 
+
+   * If you are using bash/zsh, Spack can currently do this for you as well.
+     Simply source Spack's shell integration script again. This will automatically
+     detect the lack of ``modulecmd`` and ``module``, and use the installed
+     ``environment-modules`` from ``spack bootstrap``.
+     
+     .. code-block:: console
+
+        # For bash/zsh users
+        $ export SPACK_ROOT=/path/to/spack
+        $ . $SPACK_ROOT/share/spack/setup-env.sh
+
+
+   * If you prefer to do it manually,  you can activate with the following 
+     script (or apply the updates to your ``.bashrc`` file manually):
+
+         .. code-block:: sh
+
+            TMP=`tempfile`
+            echo >$TMP
+            MODULE_HOME=`spack location --install-dir environment-modules`
+            MODULE_VERSION=`ls -1 $MODULE_HOME/Modules | head -1`
+            ${MODULE_HOME}/Modules/${MODULE_VERSION}/bin/add.modules <$TMP
+            cp .bashrc $TMP
+            echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
+            cat $TMP >>.bashrc
+
+      This adds to your ``.bashrc`` (or similar) files, enabling Environment
+      Modules when you log in.
+        
+#. Test that the ``module`` command is found with:
 
    .. code-block:: console
 
-      $ spack install environment-modules
-
-#. Activate with the following script (or apply the updates to your
-   ``.bashrc`` file manually):
-
-   .. code-block:: sh
-
-      TMP=`tempfile`
-      echo >$TMP
-      MODULE_HOME=`spack location --install-dir environment-modules`
-      MODULE_VERSION=`ls -1 $MODULE_HOME/Modules | head -1`
-      ${MODULE_HOME}/Modules/${MODULE_VERSION}/bin/add.modules <$TMP
-      cp .bashrc $TMP
-      echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
-      cat $TMP >>.bashrc
-
-This adds to your ``.bashrc`` (or similar) files, enabling Environment
-Modules when you log in.  Re-load your .bashrc (or log out and in
-again), and then test that the ``module`` command is found with:
-
-.. code-block:: console
-
-   $ module avail
+      $ module avail
 
 
 ^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -60,9 +60,14 @@ For a richer experience, use Spack's shell support:
    $ setenv SPACK_ROOT /path/to/spack
    $ source $SPACK_ROOT/share/spack/setup-env.csh
 
+
 This automatically adds Spack to your ``PATH`` and allows the ``spack``
-command to :ref:`load environment modules <shell-support>` and execute
+command to used to execute spack :ref:`commands <shell-support>` and
 :ref:`useful packaging commands <packaging-shell-support>`.
+
+If :ref:`environment-modules or dotkit <InstallEnvironmentModules>` is
+installed and available, the ``spack`` command can also load and unload
+:ref:`modules <modules>`.
 
 ^^^^^^^^^^^^^^^^^
 Clean Environment
@@ -94,12 +99,12 @@ Optional: Alternate Prefix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You may want to run Spack out of a prefix other than the git repository
-you cloned.  The ``spack bootstrap`` command provides this
+you cloned.  The ``spack clone`` command provides this
 functionality.  To install spack in a new directory, simply type:
 
 .. code-block:: console
 
-   $ spack bootstrap /my/favorite/prefix
+   $ spack clone /my/favorite/prefix
 
 This will install a new spack script in ``/my/favorite/prefix/bin``,
 which you can use just like you would the regular spack script.  Each

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -62,7 +62,7 @@ For a richer experience, use Spack's shell support:
 
 
 This automatically adds Spack to your ``PATH`` and allows the ``spack``
-command to used to execute spack :ref:`commands <shell-support>` and
+command to be used to execute spack :ref:`commands <shell-support>` and
 :ref:`useful packaging commands <packaging-shell-support>`.
 
 If :ref:`environment-modules or dotkit <InstallEnvironmentModules>` is

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -949,6 +949,19 @@ What follows are three steps describing how to install and use environment-modul
       $ module avail
 
 
+If ``tcl`` 8.0 or later is installed on  your system, you can prevent
+spack from rebuilding ``tcl`` as part of the ``environment-modules`` dependency
+stack by adding the following to your ``~/.spack/packages.yaml`` replacing
+version 8.5 with whatever version is installed on your system:
+
+   .. code-block:: yaml
+
+      packages:
+          tcl:
+              paths:
+                  tcl@8.5: /usr
+              buildable: False
+
 ^^^^^^^^^^^^^^^^^
 Package Utilities
 ^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -906,33 +906,14 @@ What follows are three steps describing how to install and use environment-modul
      Call ``spack bootstrap`` which will install ``environment-modules`` and it's 
      dependencies.
 
-   * If you wish to install ``environment-modules`` in a more manual way,
-     try the following procedure:
-
-      * Consider using system tcl (as long as your system has Tcl version 8.0 or later):
-
-         #) Identify its location using ``which tclsh``
-         #) Identify its version using ``echo 'puts $tcl_version;exit 0' | tclsh``
-         #) Add to ``~/.spack/packages.yaml`` and modify as appropriate:
-
-            .. code-block:: yaml
-
-               packages:
-                   tcl:
-                       paths:
-                           tcl@8.5: /usr
-                       buildable: False
-
-      #. Install with:
-
-         .. code-block:: console
-
-            $ spack install environment-modules
+   * Install ``environment-modules`` using ``spack install`` with
+     ``spack install environment-modules~X`` (The ``~X`` variant builds without Xorg
+     dependencies, but ``environment-modules`` works fine too.)
 
 #. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. 
 
-   * If you are using bash/zsh, Spack can currently do this for you as well.
-     After installing ``environment-modules`` using spack following the step
+   * If you are using ``bash`` or ``ksh``, Spack can currently do this for you as well.
+     After installing ``environment-modules`` following the step
      above, source Spack's shell integration script. This will automatically
      detect the lack of ``modulecmd`` and ``module``, and use the installed
      ``environment-modules`` from ``spack bootstrap`` or ``spack install``.
@@ -958,7 +939,7 @@ What follows are three steps describing how to install and use environment-modul
             echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
             cat $TMP >>.bashrc
 
-      This adds to your ``.bashrc`` (or similar) files, enabling Environment
+      This is added to your ``.bashrc`` (or similar) files, enabling Environment
       Modules when you log in.
         
 #. Test that the ``module`` command is found with:

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -210,7 +210,7 @@ Scripts to load modules recursively may be made with the command:
 
     $ spack module loads --dependencies <spec>
 
-An equivalent alternative is:
+An equivalent alternative using `process substitution <http://tldp.org/LDP/abs/html/process-sub.html>`_ is:
 
 .. code-block :: console
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -44,6 +44,10 @@ For ``csh`` and ``tcsh`` instead:
 
    $ source $SPACK_ROOT/share/spack/setup-env.csh
 
+Executing ``spack bootstrap`` will install the ``environment-modules`` package
+and ``bash`` and ``ksh`` users sourcing the appropriate setup file will have
+this package activated and the ``module`` command will be available on the
+command line.
 
 .. note::
   You can put the source line in your ``.bashrc`` or ``.cshrc`` to
@@ -54,10 +58,11 @@ For ``csh`` and ``tcsh`` instead:
 Using module files via Spack
 ----------------------------
 
-If you have shell support enabled you should be able to run either
-``module avail`` or ``use -l spack`` to see what module/dotkit files have
-been installed.  Here is sample output of those programs, showing lots
-of installed packages.
+If you have installed a supported module system either manually or through
+``spack bootstrap`` and have enabled shell support, you should be able to
+run either ``module avail`` or ``use -l spack`` to see what module/dotkit
+files have been installed.  Here is sample output of those programs,
+showing lots of installed packages.
 
 .. code-block:: console
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -44,10 +44,7 @@ For ``csh`` and ``tcsh`` instead:
 
    $ source $SPACK_ROOT/share/spack/setup-env.csh
 
-Executing ``spack bootstrap`` will install the ``environment-modules`` package
-and ``bash`` and ``ksh`` users sourcing the appropriate setup file will have
-this package activated and the ``module`` command will be available on the
-command line.
+When ``bash`` and ``ksh`` users update their environment with ``setup-env.sh``, it will check for spack-installed environment modules and add the ``module`` command to their environment; This only occurs if the module command is not already available. You can install ``environment-modules`` with ``spack bootstrap`` as described in :ref:`InstallEnvironmentModules`.
 
 .. note::
   You can put the source line in your ``.bashrc`` or ``.cshrc`` to

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -28,6 +28,8 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 
 description = "Bootstrap packages needed for spack to run smoothly"
+section = "admin"
+level = "long"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -69,28 +69,19 @@ def bootstrap(parser, args, **kwargs):
         'dirty': args.dirty
     })
 
-    # Define requirement dictionary defining specs which satisfy
-    # requirements
-    requirement_dict = {'environment-modules': ['environment-modules~X',
-                                                'environment-modules+X']}
+    # Define requirement dictionary defining general specs which need
+    # to be satisfied, and the specs to install when the general spec
+    # isn't satisfied.
+    requirement_dict = {'environment-modules': 'environment-modules~X'}
 
     for requirement in requirement_dict:
-        requirement_list = requirement_dict[requirement]
-        tty.msg("Checking whether requirements are satisfied for %s"
-                % requirement)
-        req_satisfied = False
-        for req in requirement_list:
-            spec_req = spack.Spec(req)
-            spec_req.concretize()
-            installed_specs = spack.store.db.query(spec_req)
-            if(len(installed_specs) > 0):
-                req_satisfied = True
-                tty.msg("Requirement %s is satisfied with installed "
-                        "package %s" % (requirement, installed_specs[0]))
-                break
-        if not req_satisfied:
-            # Install first item in requirement list if none is installed.
-            spec_to_install = spack.Spec(requirement_list[0])
+        installed_specs = spack.store.db.query(requirement)
+        if(len(installed_specs) > 0):
+            tty.msg("Requirement %s is satisfied with installed "
+                    "package %s" % (requirement, installed_specs[0]))
+        else:
+            # Install requirement
+            spec_to_install = spack.Spec(requirement_dict[requirement])
             spec_to_install.concretize()
             tty.msg("Installing %s to satisfy requirement for %s" %
                     (spec_to_install, requirement))

--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -33,6 +33,8 @@ from spack.util.executable import ProcessError, which
 _SPACK_UPSTREAM = 'https://github.com/llnl/spack'
 
 description = "create a new installation of spack in another prefix"
+section = "admin"
+level = "long"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -1,0 +1,105 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+
+import llnl.util.tty as tty
+from llnl.util.filesystem import join_path, mkdirp
+
+import spack
+from spack.util.executable import ProcessError, which
+
+_SPACK_UPSTREAM = 'https://github.com/llnl/spack'
+
+description = "create a new installation of spack in another prefix"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-r', '--remote', action='store', dest='remote',
+        help="name of the remote to clone from", default='origin')
+    subparser.add_argument(
+        'prefix',
+        help="names of prefix where we should install spack")
+
+
+def get_origin_info(remote):
+    git_dir = join_path(spack.prefix, '.git')
+    git = which('git', required=True)
+    try:
+        branch = git('symbolic-ref', '--short', 'HEAD', output=str)
+    except ProcessError:
+        branch = 'develop'
+        tty.warn('No branch found; using default branch: %s' % branch)
+    if remote == 'origin' and \
+       branch not in ('master', 'develop'):
+        branch = 'develop'
+        tty.warn('Unknown branch found; using default branch: %s' % branch)
+    try:
+        origin_url = git(
+            '--git-dir=%s' % git_dir,
+            'config', '--get', 'remote.%s.url' % remote,
+            output=str)
+    except ProcessError:
+        origin_url = _SPACK_UPSTREAM
+        tty.warn('No git repository found; '
+                 'using default upstream URL: %s' % origin_url)
+    return (origin_url.strip(), branch.strip())
+
+
+def clone(parser, args):
+    origin_url, branch = get_origin_info(args.remote)
+    prefix = args.prefix
+
+    tty.msg("Fetching spack from '%s': %s" % (args.remote, origin_url))
+
+    if os.path.isfile(prefix):
+        tty.die("There is already a file at %s" % prefix)
+
+    mkdirp(prefix)
+
+    if os.path.exists(join_path(prefix, '.git')):
+        tty.die("There already seems to be a git repository in %s" % prefix)
+
+    files_in_the_way = os.listdir(prefix)
+    if files_in_the_way:
+        tty.die("There are already files there! "
+                "Delete these files before boostrapping spack.",
+                *files_in_the_way)
+
+    tty.msg("Installing:",
+            "%s/bin/spack" % prefix,
+            "%s/lib/spack/..." % prefix)
+
+    os.chdir(prefix)
+    git = which('git', required=True)
+    git('init', '--shared', '-q')
+    git('remote', 'add', 'origin', origin_url)
+    git('fetch', 'origin', '%s:refs/remotes/origin/%s' % (branch, branch),
+                           '-n', '-q')
+    git('reset', '--hard', 'origin/%s' % branch, '-q')
+    git('checkout', '-B', branch, 'origin/%s' % branch, '-q')
+
+    tty.msg("Successfully created a new spack in %s" % prefix,
+            "Run %s/bin/spack to use this installation." % prefix)

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -221,7 +221,7 @@ fi;
 #
 if [ "${need_module}" = "yes" ]; then
     #check if environment-modules~X is installed
-    module_prefix="$(spack location -i "environment-modules~X" 2>&1 || :)"
+    module_prefix="$(spack location -i "environment-modules~X" 2>&1)"
     if [ $? -eq 0 ]; then
         #activate it!
         export MODULE_PREFIX=${module_prefix}

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -221,8 +221,9 @@ fi;
 #
 if [ "${need_module}" = "yes" ]; then
     #check if environment-modules~X is installed
-    module_prefix="$(spack location -i "environment-modules~X" 2>&1)"
-    if [ $? -eq 0 ]; then
+    module_prefix="$(spack location -i "environment-modules~X" 2>&1 || echo "not_installed")"
+    module_prefix=$(echo ${module_prefix} | tail -n 1)
+    if [ "${module_prefix}" != "not_installed" ]; then
         #activate it!
         export MODULE_PREFIX=${module_prefix}
         _spack_pathadd PATH "${MODULE_PREFIX}/Modules/bin"

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -27,7 +27,9 @@
 #
 # This file is part of Spack and sets up the spack environment for
 # bash and zsh.  This includes dotkit support, module support, and
-# it also puts spack in your path.  Source it like this:
+# it also puts spack in your path.  The script also checks that
+# at least module support exists, and builds and enables it if it
+# doesn't. Source it like this:
 #
 #    . /path/to/spack/share/spack/setup-env.sh
 #
@@ -169,11 +171,6 @@ function _spack_pathadd {
     fi
 }
 
-# Export spack function so it is available in subshells (only works with bash)
-if [ -n "${BASH_VERSION:-}" ]; then
-	export -f spack
-fi
-
 #
 # Figure out where this file is.  Below code needs to be portable to
 # bash and zsh.
@@ -189,19 +186,64 @@ if [ -z "$_sp_source_file" ]; then
 fi
 
 #
-# Set up modules and dotkit search paths in the user environment
+# Find root directory and add bin to path.
 #
 _sp_share_dir=$(cd "$(dirname $_sp_source_file)" && pwd)
 _sp_prefix=$(cd "$(dirname $(dirname $_sp_share_dir))" && pwd)
 _spack_pathadd PATH       "${_sp_prefix%/}/bin"
+export SPACK_ROOT=${_sp_prefix}
 
+#
+#
+# Determine which shell is being used
+#
+function _spack_determine_shell() {
+	ps -p $$ | tail -n 1 | awk '{print $4}' | xargs basename
+}
+export SPACK_SHELL=$(_spack_determine_shell)
+
+#
+# Check whether at least one of 'use' and 'module' exists
+#
+function _spack_fn_exists() {
+	type $1 2>&1 | grep -q 'shell function'
+}
+
+need_module="no"
+if [ ! $(_spack_fn_exists use) ]; then
+	if [ ! $(_spack_fn_exists module) ]; then
+		need_module="yes"
+	fi;
+fi;
+
+#
+# build and make available environment-modules
+#
+if [ "${need_module}" = "yes" ]; then
+	#check if environment-modules~X is installed
+	module_prefix=`spack location -i environment-modules~X 2>&1`
+	if [ $? -eq 0 ]; then
+		#activate it!
+		export MODULE_PREFIX=${module_prefix}
+		module() { eval `${MODULE_PREFIX}/Modules/bin/modulecmd ${SPACK_SHELL} $*`; }
+	fi;
+
+fi;
+
+#
+# Set up modules and dotkit search paths in the user environment
+#
 _sp_sys_type=$(spack-python -c 'print(spack.architecture.sys_type())')
 _sp_dotkit_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('dotkit')))")
 _sp_tcl_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('tcl')))")
 _spack_pathadd DK_NODE    "${_sp_dotkit_root%/}/$_sp_sys_type"
 _spack_pathadd MODULEPATH "${_sp_tcl_root%/}/$_sp_sys_type"
 
-#
+# Export spack function so it is available in subshells (only works with bash)
+if [ -n "${BASH_VERSION:-}" ]; then
+	export -f spack
+fi
+
 # Add programmable tab completion for Bash
 #
 if [ -n "${BASH_VERSION:-}" ]; then

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -221,7 +221,7 @@ fi;
 #
 if [ "${need_module}" = "yes" ]; then
     #check if environment-modules~X is installed
-    module_prefix=`spack location -i environment-modules~X 2>&1`
+    module_prefix="$(spack location -i "environment-modules~X" 2>&1 || :)"
     if [ $? -eq 0 ]; then
         #activate it!
         export MODULE_PREFIX=${module_prefix}

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -220,14 +220,14 @@ fi;
 # build and make available environment-modules
 #
 if [ "${need_module}" = "yes" ]; then
-	#check if environment-modules~X is installed
-	module_prefix=`spack location -i environment-modules~X 2>&1`
-	if [ $? -eq 0 ]; then
-		#activate it!
-		export MODULE_PREFIX=${module_prefix}
-		module() { eval `${MODULE_PREFIX}/Modules/bin/modulecmd ${SPACK_SHELL} $*`; }
-	fi;
-
+    #check if environment-modules~X is installed
+    module_prefix=`spack location -i environment-modules~X 2>&1`
+    if [ $? -eq 0 ]; then
+        #activate it!
+        export MODULE_PREFIX=${module_prefix}
+        _spack_pathadd PATH "${MODULE_PREFIX}/Modules/bin"
+        module() { eval `${MODULE_PREFIX}/Modules/bin/modulecmd ${SPACK_SHELL} $*`; }
+    fi;
 fi;
 
 #

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -34,6 +34,8 @@ class EnvironmentModules(Package):
     url = "http://prdownloads.sourceforge.net/modules/modules-3.2.10.tar.gz"
 
     version('3.2.10', '8b097fdcb90c514d7540bb55a3cb90fb')
+    
+    variant('X', default=True, description='Build with X functionality')
 
     # Dependencies:
     depends_on('tcl', type=('build', 'link', 'run'))
@@ -74,6 +76,9 @@ class EnvironmentModules(Package):
             '--datarootdir=' + prefix.share,
             'CPPFLAGS=' + ' '.join(cpp_flags)
         ]
+        
+        if '~X' in spec:
+            config_args = ['--without-x'] + config_args
 
         configure(*config_args)
         make()

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -34,7 +34,7 @@ class EnvironmentModules(Package):
     url = "http://prdownloads.sourceforge.net/modules/modules-3.2.10.tar.gz"
 
     version('3.2.10', '8b097fdcb90c514d7540bb55a3cb90fb')
-    
+
     variant('X', default=True, description='Build with X functionality')
 
     # Dependencies:
@@ -76,7 +76,7 @@ class EnvironmentModules(Package):
             '--datarootdir=' + prefix.share,
             'CPPFLAGS=' + ' '.join(cpp_flags)
         ]
-        
+
         if '~X' in spec:
             config_args = ['--without-x'] + config_args
 


### PR DESCRIPTION
This branch adds the ability to automatically build and enable environment-modules as part of `spack-env.sh`. The added code detects whether either dotkit or modules is available, and if neither is available, `environment-modules` is built and module function is introduced.

This change makes spack more portable as module support is automatically setup.