### PR TITLE
Patch openblas Makefile only when version >= 0.2.16.

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -50,7 +50,7 @@ class Openblas(MakefilePackage):
     provides('blas')
     provides('lapack')
 
-    patch('make.patch')
+    patch('make.patch', when='@0.2.16:')
     #  This patch is in a pull request to OpenBLAS that has not been handled
     #  https://github.com/xianyi/OpenBLAS/pull/915
     patch('openblas_icc.patch', when='%intel')


### PR DESCRIPTION
As discussed in #3036 , `make.patch` doesn't fit openblas version 0.2.15. Thus patching should b elimited to version >= 0.2.16 only.