### PR TITLE
Bugfixes for compiler detection on the Cray platform.

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -254,7 +254,7 @@ class OperatingSystem(object):
 
     def find_compilers(self, *paths):
         """
-        Return a list of compilers found in the suppied paths.
+        Return a list of compilers found in the supplied paths.
         This invokes the find() method for each Compiler class,
         and appends the compilers detected to a list.
         """

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -36,7 +36,6 @@ from llnl.util.lang import index_by
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 from spack.spec import CompilerSpec, ArchSpec
-from spack.util.environment import get_path
 
 description = "manage compilers"
 section = "system"
@@ -89,8 +88,6 @@ def compiler_find(args):
 
     """
     paths = args.add_paths
-    if not paths:
-        paths = get_path('PATH')
 
     # Don't initialize compilers config via compilers.get_compiler_config.
     # Just let compiler_find do the

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -182,7 +182,7 @@ def all_compiler_specs(scope=None, init_config=True):
 
 
 def find_compilers(*paths):
-    """Return a list of compilers found in the suppied paths.
+    """Return a list of compilers found in the supplied paths.
        This invokes the find_compilers() method for each operating
        system associated with the host platform, and appends
        the compilers detected to a list.

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -52,7 +52,7 @@ class Cce(Compiler):
 
     @classmethod
     def default_version(cls, comp):
-        return get_compiler_version(comp, '-V', r'[Vv]ersion.*(\d+(\.\d+)+)')
+        return get_compiler_version(comp, '-V', r'[Vv]ersion.*?(\d+(\.\d+)+)')
 
     @property
     def openmp_flag(self):

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import os
+
+from spack.operating_systems.linux_distro import LinuxDistro
+from spack.util.module_cmd import get_module_cmd
+
+
+class CrayFrontend(LinuxDistro):
+    """Represents OS that runs on login and service nodes of the Cray platform.
+    It acts as a regular Linux without Cray-specific modules and compiler
+    wrappers."""
+
+    def find_compilers(self, *paths):
+        """Calls the overridden method but prevents it from detecting Cray
+        compiler wrappers to avoid possible false detections. The detected
+        compilers come into play only if a user decides to work with the Cray's
+        frontend OS as if it was a regular Linux environment."""
+
+        env_bu = None
+
+        # We rely on the fact that the PrgEnv-* modules set the PE_ENV
+        # environment variable.
+        if 'PE_ENV' in os.environ:
+            # Copy environment variables to restore them after the compiler
+            # detection. We expect that the only thing PrgEnv-* modules do is
+            # the environment variables modifications.
+            env_bu = os.environ.copy()
+
+            # Get the name of the module from the environment variable.
+            prg_env = 'PrgEnv-' + os.environ['PE_ENV'].lower()
+
+            # Unload the PrgEnv-* module. By doing this we intentionally
+            # provoke errors when the Cray's compiler wrappers are executed
+            # (Error: A PrgEnv-* modulefile must be loaded.) so they will not
+            # be detected as valid compilers by the overridden method. We also
+            # expect that the modules that add the actual compilers' binaries
+            # into the PATH environment variable (i.e. the following modules:
+            # 'intel', 'cce', 'gcc', etc.) will also be unloaded since they are
+            # specified as prerequisites in the PrgEnv-* modulefiles.
+            modulecmd = get_module_cmd()
+            exec (compile(
+                modulecmd('unload', prg_env, output=str, error=os.devnull),
+                '<string>', 'exec'))
+
+        # Call the overridden method.
+        clist = super(CrayFrontend, self).find_compilers(*paths)
+
+        # Restore the environment.
+        if env_bu is not None:
+            os.environ.clear()
+            os.environ.update(env_bu)
+
+        return clist

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -28,7 +28,7 @@ import llnl.util.tty as tty
 from spack import build_env_path
 from spack.util.executable import which
 from spack.architecture import Platform, Target, NoPlatformError
-from spack.operating_systems.linux_distro import LinuxDistro
+from spack.operating_systems.cray_frontend import CrayFrontend
 from spack.operating_systems.cnl import Cnl
 from llnl.util.filesystem import join_path
 from spack.util.module_cmd import get_module_cmd
@@ -88,7 +88,7 @@ class Cray(Platform):
         else:
             raise NoPlatformError()
 
-        front_distro = LinuxDistro()
+        front_distro = CrayFrontend()
         back_distro = Cnl()
 
         self.default_os = str(back_distro)


### PR DESCRIPTION
This PR offers the following:

1. Fixed regexp for cray compiler version matching (the current greedy regexp does not match the first digit of the version).
2. Dedicated class for Cray platform's frontend OS. It runs the default LinuxDistro's compiler detection algorithm but prevents it from detecting compilers that should be worked with through the module system (and are detected by the Cnl class). This also prevents false detections of cray compiler wrappers as cray compilers when the PrgEnv-intel module is loaded (the wrapper returns the Intel compiler's version string, which also satisfies the cray compiler's regexp, so we detect cray compiler with Intel's compiler version).
3. A small modification that allows OS classes to know if a set of paths they are provided with were given by a user or not (they are capable of reading the PATH environment variable by themselves anyway).
4. Typo and formatting fixes here and there.