### PR TITLE
Revert "db and concretization of packages modified after installation: fixes #2911"

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -340,7 +340,6 @@ class Database(object):
         # cached prematurely.
         for hash_key, rec in data.items():
             rec.spec._mark_concrete()
-            rec.spec.package.spec._mark_concrete()
 
         self._data = data
 


### PR DESCRIPTION
Reverts LLNL/spack#2920

Reverting this while I implement a better fix.  This fix doesn't work when reading in `spec`s for which there is no longer a package available.

Per #2920, the module logic should be aware of packages that don't exist, and spec copying logic should preserve concreteness so we don't have to do this fix.  I think the latter is what caused the initial bug.
