### PR TITLE
qa: adjust thresholds for acceptance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,13 +4,17 @@ coverage:
   range: 60...90
   status:
     project:
+      default: true
       llnl:
+        threshold: 0.5
         paths:
           - lib/spack/llnl
       commands:
+        threshold: 0.5
         paths:
           - lib/spack/spack/cmd
       core:
+        threshold: 0.5
         paths:
           - "!lib/spack/llnl"
           - "!lib/spack/spack/cmd"


### PR DESCRIPTION
##### Modifications
- [x] activated the default status check
- [x] added thresholds for single parts

The idea is that the project should be monotonically increasing in coverage, but a drop in e.g. command is ok if balanced by an increase in some other parts or vice-versa