### PR TITLE
Make distro more robust to unreadable files

### DIFF
--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -993,13 +993,16 @@ class LinuxDistribution(object):
                     continue
                 match = _DISTRO_RELEASE_BASENAME_PATTERN.match(basename)
                 if match:
-                    filepath = os.path.join(_UNIXCONFDIR, basename)
-                    distro_info = self._parse_distro_release_file(filepath)
-                    if 'name' in distro_info:
-                        # The name is always present if the pattern matches
-                        self.distro_release_file = filepath
-                        distro_info['id'] = match.group(1)
-                        return distro_info
+                    try:
+                        filepath = os.path.join(_UNIXCONFDIR, basename)
+                        distro_info = self._parse_distro_release_file(filepath)
+                        if 'name' in distro_info:
+                            # The name is always present if the pattern matches
+                            self.distro_release_file = filepath
+                            distro_info['id'] = match.group(1)
+                            return distro_info
+                    except IOError:
+                        continue
             return {}
 
     def _parse_distro_release_file(self, filepath):

--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -1002,6 +1002,8 @@ class LinuxDistribution(object):
                             distro_info['id'] = match.group(1)
                             return distro_info
                     except IOError:
+                        # We found a file we do not have permission to read
+                        # Continue checking candidate files for distro file.
                         continue
             return {}
 


### PR DESCRIPTION
Added in response to an issue on LLNL machines.  Our admins add a `/etc/blueos-release` file for internal use, next to `/etc/redhat-release`.  Unfortunately they make it unreadable, and `distro` chokes.  It's harmless if unreadable.

We will try to upstream this to py-distro.