### PR TITLE
Keep Curl Bootstrap Working With http://

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -30,6 +30,7 @@ class Curl(Package):
     transferring data with URL syntax"""
 
     homepage = "http://curl.haxx.se"
+    # URL must remain http:// so Spack can bootstrap curl
     url      = "http://curl.haxx.se/download/curl-7.46.0.tar.bz2"
 
     version('7.52.1', 'dd014df06ff1d12e173de86873f9f77a')

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -33,7 +33,11 @@ class Netcdf(AutotoolsPackage):
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     url      = "http://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-4.3.3.tar.gz"
 
+    # Version 4.4.1.1 is having problems in tests
+    #    https://github.com/Unidata/netcdf-c/issues/343 
     version('4.4.1.1', '503a2d6b6035d116ed53b1d80c811bda')
+    # netcdf@4.4.1 can crash on you (in real life and in tests).  See:
+    #    https://github.com/Unidata/netcdf-c/issues/282
     version('4.4.1',   '7843e35b661c99e1d49e60791d5072d8')
     version('4.4.0',   'cffda0cbd97fdb3a06e9274f7aef438e')
     version('4.3.3.1', '5c9dad3705a3408d27f696e5b31fb88c')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -33,6 +33,7 @@ class Openssl(Package):
        Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.
        It is also a general-purpose cryptography library."""
     homepage = "http://www.openssl.org"
+    # URL must remain http:// so Spack can bootstrap curl
     url      = "http://www.openssl.org/source/openssl-1.0.1h.tar.gz"
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 2

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -35,6 +35,7 @@ class Perl(Package):
     """Perl 5 is a highly capable, feature-rich programming language with over
        27 years of development."""
     homepage = "http://www.perl.org"
+    # URL must remain http:// so Spack can bootstrap curl
     url      = "http://www.cpan.org/src/5.0/perl-5.24.1.tar.gz"
 
     version('5.24.1', '765ef511b5b87a164e2531403ee16b3c')

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -30,6 +30,7 @@ class Zlib(AutotoolsPackage):
        data-compression library."""
 
     homepage = "http://zlib.net"
+    # URL must remain http:// so Spack can bootstrap curl
     url = "http://zlib.net/fossils/zlib-1.2.10.tar.gz"
 
     version('1.2.10', 'd9794246f853d15ce0fcbf79b9a3cf13')


### PR DESCRIPTION
In order to download from `https://` websites, Spack needs a working `curl`, with a new-enough OpenSSL.  That is not the case on some systems; in that case, Spack must install `curl` itself:
```
curl@7.52.1%clang@7.3.0-apple arch=darwin-elcapitan-x86_64 
    ^openssl@1.1.0d%clang@7.3.0-apple arch=darwin-elcapitan-x86_64 
        ^perl@5.24.1%clang@7.3.0-apple+cpanm arch=darwin-elcapitan-x86_64 
        ^zlib@1.2.10%clang@7.3.0-apple+pic+shared arch=darwin-elcapitan-x86_64 
```
The problem would appear if any of those packages requires SSL to download --- then, Spack would be unable to bootstrap a working `curl` if it didn't already have one.  This PR adds comments that discourage authors from changing these four packages to `https://`.
