### PR TITLE
Raise errors when trying to building openblas with Intel compiler 16.

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -84,6 +84,11 @@ class Openblas(MakefilePackage):
             raise InstallError(
                 'OpenBLAS does not support OpenMP with clang!'
             )
+        # OpenBLAS (0.2.15:0.2.19) does not support Intel compiler version 16
+        if self.spec.satisfies('%intel@16'):
+            raise InstallError(
+                'OpenBLAS does not support Intel compiler version 16!'
+            )
 
     @property
     def make_defs(self):


### PR DESCRIPTION
As discussed in #3036 , openblas cannot be built against Intel compiler version 16 due to upstream issues. This commit raises errors when users trying to build openblas with Intel compiler version 16.