### PR TITLE
qa: allow fast finish on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
 # Build matrix
 #=============================================================================
 matrix:
+  fast_finish: true
   include:
     - python: '2.6'
       os: linux


### PR DESCRIPTION
This is to avoid consuming an OSX build on a PR that will fail for sure. [Docs here](https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing).