### PR TITLE
Fix readline support in `spack python`

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -360,6 +360,47 @@ Developer commands
 ``spack test``
 ^^^^^^^^^^^^^^
 
+.. _cmd-spack-python:
+
+^^^^^^^^^^^^^^^^
+``spack python``
+^^^^^^^^^^^^^^^^
+
+``spack python`` is a command that lets you import and debug things as if
+you were in a Spack interactive shell. Without any arguments, it is similar
+to a normal interactive Python shell, except you can import spack and any
+other Spack modules:
+
+.. code-block:: console
+
+   $ spack python
+   Spack version 0.10.0
+   Python 2.7.13, Linux x86_64
+   >>> from spack.version import Version
+   >>> a = Version('1.2.3')
+   >>> b = Version('1_2_3')
+   >>> a == b
+   True
+   >>> c = Version('1.2.3b')
+   >>> c > a
+   True
+   >>>
+
+You can also run a single command:
+
+.. code-block:: console
+
+   $ spack python -c 'import distro; distro.linux_distribution()'
+   ('Fedora', '25', 'Workstation Edition')
+
+or a file:
+
+.. code-block:: console
+
+   $ spack python ~/test_fetching.py
+
+just like you would with the normal ``python`` command.
+
 .. _cmd-spack-url:
 
 ^^^^^^^^^^^^^

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -62,6 +62,9 @@ def python(parser, args):
         with open(python_args[0]) as file:
             console.runsource(file.read(), python_args[0], 'exec')
     else:
+        # Provides readline support, allowing user to use arrow keys
+        console.push('import readline')
+
         console.interact("Spack version %s\nPython %s, %s %s"""
                          % (spack.spack_version, platform.python_version(),
                             platform.system(), platform.machine()))

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import argparse
+import pytest
+
+from spack.cmd.python import *
+
+
+@pytest.fixture(scope='module')
+def parser():
+    """Returns the parser for the ``python`` command"""
+    parser = argparse.ArgumentParser()
+    setup_parser(parser)
+    return parser
+
+
+def test_python(parser):
+    args = parser.parse_args([
+        '-c', 'import spack; print(spack.spack_version)'
+    ])
+    python(parser, args)


### PR DESCRIPTION
Fixes #3128.

`spack python` is a command that lets you import and debug things as if you were in a Spack interactive shell. Without any arguments, it is similar to a normal interactive Python shell, except you can `import spack` and any other Spack modules.

Solution came from http://stackoverflow.com/questions/36676629.