### PR TITLE
BundlePackage

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -160,6 +160,7 @@ from spack.package import Package, run_before, run_after, on_package_attributes
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.bundle import BundlePackage
 from spack.build_systems.python import PythonPackage
 from spack.build_systems.r import RPackage
 
@@ -169,6 +170,7 @@ __all__ += [
     'on_package_attributes',
     'Package',
     'CMakePackage',
+    'BundlePackage',
     'AutotoolsPackage',
     'MakefilePackage',
     'PythonPackage',

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -873,6 +873,7 @@ def args_are_for(args, fetcher):
 def for_package_version(pkg, version):
     """Determine a fetch strategy based on the arguments supplied to
        version() in the package description."""
+
     # If it's not a known version, extrapolate one.
     if version not in pkg.versions:
         url = pkg.url_for_version(version)
@@ -990,3 +991,26 @@ class NoStageError(FetchError):
         super(NoStageError, self).__init__(
             "Must call FetchStrategy.set_stage() before calling %s" %
             method.__name__)
+
+
+
+
+class BundleFetchStrategy(FetchStrategy):
+
+    # Subclasses need to implement these methods
+    def fetch(self):
+        return True
+
+    def check(self):
+        return True
+
+    def expand(self):
+        return True
+
+    def reset(self):
+        return True
+
+    cachable = False
+
+    def __str__(self):  # Should be human readable URL.
+        return "<none>"

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -552,16 +552,7 @@ class PackageBase(object):
         self._fetcher = None
         self.url = getattr(self.__class__, 'url', None)
 
-        # Fix up self.url if this package fetches with a URLFetchStrategy.
-        # This makes self.url behave sanely.
-        if self.spec.versions.concrete:
-            # TODO: this is a really roundabout way of determining the type
-            # TODO: of fetch to do. figure out a more sane fetch
-            # TODO: strategy/package init order (right now it's conflated with
-            # TODO: stage, package, and the tests make assumptions)
-            f = fs.for_package_version(self, self.version)
-            if isinstance(f, fs.URLFetchStrategy):
-                self.url = self.url_for_version(self.spec.version)
+        self._fixup_url()
 
         # Set a default list URL (place to find available versions)
         if not hasattr(self, 'list_url'):
@@ -594,6 +585,19 @@ class PackageBase(object):
             spack.repo.get(self.extendee_spec)._check_extendable()
 
         self.extra_args = {}
+
+    def _fixup_url(self):
+        # Fix up self.url if this package fetches with a URLFetchStrategy.
+        # This makes self.url behave sanely.
+        if self.spec.versions.concrete:
+            # TODO: this is a really roundabout way of determining the type
+            # TODO: of fetch to do. figure out a more sane fetch
+            # TODO: strategy/package init order (right now it's conflated with
+            # TODO: stage, package, and the tests make assumptions)
+            f = fs.for_package_version(self, self.version)
+            if isinstance(f, fs.URLFetchStrategy):
+                self.url = self.url_for_version(self.spec.version)
+
 
     def possible_dependencies(self, visited=None):
         """Return set of possible transitive dependencies of this package."""

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -658,6 +658,50 @@ class DIYStage(object):
         tty.msg("Sources for DIY stages are not cached")
 
 
+class BundleStage(object):
+    """Dummy stage for BundlePackage instances, which don't have a
+    tarball."""
+
+
+    def __init__(self):
+        self.archive_file = None
+        self.path = None
+        self.source_path = None
+
+    def chdir(self):
+        pass
+
+    # BundleStage does nothing as context managers.
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def chdir_to_source(self):
+        self.chdir()
+
+    def fetch(self, *args, **kwargs):
+        tty.msg("No need to fetch for BundleStage.")
+
+    def check(self):
+        tty.msg("No checksum needed for BundleStage.")
+
+    def expand_archive(self):
+        tty.msg("Using source directory: %s" % self.source_path)
+
+    def restage(self):
+        tty.die("Cannot restage BundleStage.")
+
+    def destroy(self):
+        # No need to destroy BundleStage
+        pass
+
+    def cache_local(self):
+        tty.msg("Sources for BundleStage are not cached")
+
+
+
 def _get_mirrors():
     """Get mirrors from spack configuration."""
     config = spack.config.get_config('mirrors')


### PR DESCRIPTION
This provides an implementation for "clean" Bundle packages --- i.e. packages that don't install anything, but whose purpose is to depend on other packages.  See example below.

Addresses #1926 #2049
```
from spack import *

class ProjNcurses(BundlePackage):
    """Sample Bundle"""

    version('1.0')

    depends_on('ncurses', type='run')
```

@tgamblin @becker33 
Notes from past conversation:

> I would really like to have a MetaPackage class for this, which you could just extend, and Spack would know it's not real.

I don't like the name `MetaPackage`, it sounds too much like "meta class," which is not a class.  I think `BundlePackage` is less confusing.

> 1. Are you doing this because spack doesn't have something like [`bundler`](http://bundler.io) or [`brew bundle`](https://github.com/Homebrew/homebrew-bundle)?  Would you like something like that?  It's something I've been thinking a lot about implementing recently, as our code teams need it for building _their_ dependencies. The `Gemfile` and `Gemfile.lock`  concepts map nicely onto Spack's abstract and concrete packages (though in both cases Spack can be more specific than `gem`).  This would be a larger feature than what you're describing, but I think it's something spack needs to adequately encapsulate build environments.
> 2. Or, is this more like `X11`, where it's a bunch of packages that people will probably depend on together as _part_ of a larger system?

I would say some of both.  This also addresses the issues in #3131.  Although I've used Spack configuration scopes and `packages.yaml` to good effect, I'm coming to believe that users aren't warming up to this way of working.  I realized that we could get the same thing with packages, thereby foisting fewer abstractions on our users.  (There are some subtle differences in semantics of putting version, variant, etc. directives in `packages.yaml` vs. a Bundle Package.  That discussion should happen in Spack Environments WG).

How would I re-do #3049 with this PR in place... suppose you have A->B, and you want A and B's `+debug` flag to be configured together.  You can make a `BundlePackage` we will call `proj-A`, something like this:
```
class ProjA(BundlePackage):
    variant('debug', default=False)
    depends_on('A')
    depends_on('A+debug', when='+debug')
    depends_on('B')
    depends_on('B+debug', when='+debug')
```

This approach is quite flexible.  It can set multiple forwarded variants, create its own project-level variants to control constellations of variants in the DAG, choose which packages get the `+debug` (or whatever), etc.  The examples I work with are significantly more complex than this one; I will try to see how they turn out using this approach to project management.

If we decide to adopt this approach (part of a larger discussion on Spack Environments), then we will be better able to ask users to remove variant forwarding, site-specific stuff, etc. from their main packages -- and put it in project-level packages like the one above.  The hope is that users will be more willing to do this than the current state of affairs, where there seems to be resistance to putting stuff in `packages.yaml`.

