### PR TITLE
Add patch to allow ncurses to be built with PGI

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -25,14 +25,12 @@
 from spack import *
 
 
-class Ncurses(Package):
+class Ncurses(AutotoolsPackage):
     """The ncurses (new curses) library is a free software emulation of
-       curses in System V Release 4.0, and more. It uses terminfo format,
-       supports pads and color and multiple highlights and forms
-       characters and function-key mapping, and has all the other
-       SYSV-curses enhancements over BSD curses.
-
-    """
+    curses in System V Release 4.0, and more. It uses terminfo format,
+    supports pads and color and multiple highlights and forms
+    characters and function-key mapping, and has all the other
+    SYSV-curses enhancements over BSD curses."""
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
     url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
@@ -40,20 +38,19 @@ class Ncurses(Package):
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')
     version('5.9', '8cb9c412e5f2d96bc6f459aa8c6282a1')
 
-    patch('patch_gcc_5.txt', when='%gcc@5.0:')
+    patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
+    patch('sed_pgi.patch',   when='@:6.0')
 
-    def install(self, spec, prefix):
-        opts = [
-            "--prefix=%s" % prefix,
-            "--with-shared",
-            "--with-cxx-shared",
-            "--enable-widec",
-            "--enable-overwrite",
-            "--disable-lib-suffixes",
-            "--without-ada",
-            "--enable-pc-files",
-            "--with-pkg-config-libdir={0}/lib/pkgconfig".format(prefix)
+    def configure_args(self):
+        return [
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
+            'CXXFLAGS={0}'.format(self.compiler.pic_flag),
+            '--with-shared',
+            '--with-cxx-shared',
+            '--enable-widec',
+            '--enable-overwrite',
+            '--disable-lib-suffixes',
+            '--without-ada',
+            '--enable-pc-files',
+            '--with-pkg-config-libdir={0}/lib/pkgconfig'.format(self.prefix)
         ]
-        configure(*opts)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/ncurses/sed_pgi.patch
+++ b/var/spack/repos/builtin/packages/ncurses/sed_pgi.patch
@@ -1,0 +1,11 @@
+--- a/ncurses/tty/MKexpanded.sh	2017-02-12 09:09:33.828954282 -0600
++++ b/ncurses/tty/MKexpanded.sh	2017-02-12 09:11:03.430673306 -0600
+@@ -125,7 +125,7 @@
+ EOF
+ 
+ $preprocessor $TMP 2>/dev/null | \
+-	sed -e '1,/^IGNORE$/d' -e 's/^@/#/' -e 's/^#if_/#if /'
++	sed -e '1,/^IGNORE$/d' -e 's/^@/#/' -e 's/^#[    ]*if_/#if /'
+ 
+ cat <<EOF
+ #else /* ! NCURSES_EXPANDED */


### PR DESCRIPTION
Without this patch, `make` crashes with:
```
PGC-S-0239-Unmatched #else (../ncurses/expanded.c: 61)
PGC-S-0240-Unmatched #endif (../ncurses/expanded.c: 63)
PGC/x86-64 Linux 16.5-0: compilation completed with severe errors
make[1]: *** [../obj_s/expanded.o] Error 2
```
This patch came from the developer, and should be included in the next release.

Even with this patch, the PGI build failed with dozens of lines like:
```
ld: ../obj_s/hardscroll.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
```
Adding `CFLAGS=-fPIC` and `CXXFLAGS=-fPIC` solved this problem.

Also converted to `AutotoolsPackage` while I was at it. Also locked down the previous patch to `@6.0` only as it wouldn't apply to `@5.9`.