### PR TITLE
Don't eat STDOUT on successful tests.

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -102,7 +102,7 @@ def test(parser, args, unknown_args):
         # Allow keyword search without -k if no options are specified
         if (args.tests and not unknown_args and
             not any(arg.startswith('-') for arg in args.tests)):
-            return pytest.main(['-k'] + args.tests)
+            return pytest.main(['-s', '-k'] + args.tests)
 
         # Just run the pytest command
         return pytest.main(unknown_args + args.tests)


### PR DESCRIPTION
While debugging, it can be really useful to see STDOUT on unit tests.  I couldn't find any way to do so, other than hacking `test.py` (see this PR).  Is such a way provided?  If not, could one be added?