### PR TITLE
parallel-netcdf: use spack_cc for sequential code instead of system gcc

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -53,6 +53,7 @@ class ParallelNetcdf(AutotoolsPackage):
         spec = self.spec
 
         args = ['--with-mpi={0}'.format(spec['mpi'].prefix)]
+        args.append('SEQ_CC=%s' % spack_cc)
 
         if '+fpic' in spec:
             args.extend(['CFLAGS=-fPIC', 'CXXFLAGS=-fPIC', 'FFLAGS=-fPIC'])


### PR DESCRIPTION
Parallel-NetCDF uses /usr/bin/gcc to compile some sequential code. This breaks the build when the system gcc is old (RHEL6) or not present.
This PR sets Parallel-NetCDF's compiler for sequential code to spack_cc. Works on intel@16.0.4.