### PR TITLE
add symlink variant (needed for AFS)

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -59,3 +59,4 @@ class Ncurses(AutotoolsPackage):
         ]
         if '+symlinks' in self.spec:
             opts += ["--enable-symlinks"]
+        return opts

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -43,7 +43,7 @@ class Ncurses(Package):
     patch('patch_gcc_5.txt', when='%gcc@5.0:')
 
     variant('symlinks', default=False,
-        description='Enables symlinks. Needed on AFS filesystem.')
+            description='Enables symlinks. Needed on AFS filesystem.')
 
     def install(self, spec, prefix):
         opts = [

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -42,6 +42,9 @@ class Ncurses(Package):
 
     patch('patch_gcc_5.txt', when='%gcc@5.0:')
 
+    variant('symlinks', default=False,
+        description='Enables symlinks. Needed on AFS filesystem.')
+
     def install(self, spec, prefix):
         opts = [
             "--prefix=%s" % prefix,
@@ -54,6 +57,8 @@ class Ncurses(Package):
             "--enable-pc-files",
             "--with-pkg-config-libdir={0}/lib/pkgconfig".format(prefix)
         ]
+        if '+symlinks' in spec:
+            opts += ["--enable-symlinks"]
         configure(*opts)
         make()
         make("install")


### PR DESCRIPTION
This PR adds a symlinks variant to ncurses. This is needed for installs on symlinked filesystems (e.g. AFS)