### PR TITLE
abinit: fix compilation on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -62,6 +62,9 @@ class Abinit(Package):
     # TODO: To be tested.
     # It was working before the last `git pull` but now all tests crash.
     # For the time being, the default is netcdf3 and the internal fallbacks
+    # FIXME: rename (trio?) and use multivalued variants to cover
+    # --with-trio-flavor={netcdf, none, netcdf+etsf_io, netcdf-fallback}
+    # add etsf_io package.
     variant('hdf5', default=False,
             description='Enables HDF5+Netcdf4 with MPI. WARNING: experimental')
 

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -63,8 +63,9 @@ class Abinit(Package):
     # It was working before the last `git pull` but now all tests crash.
     # For the time being, the default is netcdf3 and the internal fallbacks
     # FIXME: rename (trio?) and use multivalued variants to cover
-    # --with-trio-flavor={netcdf, none, netcdf+etsf_io, netcdf-fallback}
-    # add etsf_io package.
+    # --with-trio-flavor={netcdf, none}
+    # Note that Abinit@8: does not support etsf_io anymore because it is not
+    # compatible with HDF5 and MPI-IO
     variant('hdf5', default=False,
             description='Enables HDF5+Netcdf4 with MPI. WARNING: experimental')
 
@@ -158,6 +159,8 @@ class Abinit(Package):
         # Netcdf4/HDF5
         if "+hdf5" in spec:
             oapp("--with-trio-flavor=netcdf")
+            # Since version 8, Abinit started to use netcdf4 + hdf5 and we have
+            # to link with -lhdf5_hl -lhdf5
             hdf_libs = "-L%s -lhdf5_hl -lhdf5" % spec["hdf5"].prefix.lib
             options.extend([
                 "--with-netcdf-incs=-I%s" % (

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -25,7 +25,6 @@
 #
 # Author: Matteo Giantomassi <matteo.giantomassiNOSPAM AT uclouvain.be>
 # Date: October 11, 2016
-import sys
 from spack import *
 
 
@@ -164,12 +163,9 @@ class Abinit(Package):
                     spec["netcdf-fortran"].prefix.lib, hdf_libs),
             ])
         else:
-            if sys.platform == 'darwin':
-                # internal netcdf does not comile on macOS (Sierra)
-                oapp("--with-trio-flavor=none")
-            else:
-                # Use internal fallbacks (netcdf3)
-                oapp("--with-trio-flavor=netcdf-fallback")
+            # In Spack we do our best to avoid building any internally provided
+            # dependencies, such as netcdf3 in this case.
+            oapp("--with-trio-flavor=none")
 
         configure(*options)
         make()

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -25,7 +25,7 @@
 #
 # Author: Matteo Giantomassi <matteo.giantomassiNOSPAM AT uclouvain.be>
 # Date: October 11, 2016
-
+import sys
 from spack import *
 
 
@@ -164,8 +164,12 @@ class Abinit(Package):
                     spec["netcdf-fortran"].prefix.lib, hdf_libs),
             ])
         else:
-            # Use internal fallbacks (netcdf3)
-            oapp("--with-trio-flavor=netcdf-fallback")
+            if sys.platform == 'darwin':
+                # internal netcdf does not comile on macOS (Sierra)
+                oapp("--with-trio-flavor=none")
+            else:
+                # Use internal fallbacks (netcdf3)
+                oapp("--with-trio-flavor=netcdf-fallback")
 
         configure(*options)
         make()


### PR DESCRIPTION
subj.

OT: 
@gmatteo I presume you added `hdf5` as a dependency to `abinit` to make sure you have `hdf5+mpi` in DAG? However i was not sure why extra linking flags `-lhdf5_hl -lhdf5` are needed, neither [Macports](https://trac.macports.org/browser/trunk/dports/science/abinit/Portfile) nor [Homebrew](https://github.com/Homebrew/homebrew-science/blob/master/abinit.rb) add anything `hdf5`-related while building `abinit`.