### PR TITLE
Silo: support newer versions of HDF5

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -41,9 +41,10 @@ class Silo(Package):
     variant('silex', default=False,
             description='Builds Silex, a GUI for viewing Silo files')
 
-    # silo uses the obsolete function H5Pset_fapl_mpiposix:
-    depends_on("hdf5 @:1.8.12")
+    depends_on('hdf5')
     depends_on('qt', when='+silex')
+
+    patch('remove-mpiposix.patch', when='@4.8:4.10.2')
 
     def install(self, spec, prefix):
         config_args = [

--- a/var/spack/repos/builtin/packages/silo/remove-mpiposix.patch
+++ b/var/spack/repos/builtin/packages/silo/remove-mpiposix.patch
@@ -1,0 +1,40 @@
+Index: silo-llnl-4.9.1/src/hdf5_drv/silo_hdf5.c
+===================================================================
+--- silo-llnl-4.9.1.orig/src/hdf5_drv/silo_hdf5.c
++++ silo-llnl-4.9.1/src/hdf5_drv/silo_hdf5.c
+@@ -4717,16 +4717,7 @@ db_hdf5_process_file_options(opts_set_id
+ 
+         /* default HDF5 mpi drivers */
+         case DB_FILE_OPTS_H5_DEFAULT_MPIP:
+-        {
+-#ifdef H5_HAVE_PARALLEL
+-            h5status |= H5Pset_fapl_mpiposix(retval, MPI_COMM_SELF, TRUE);
+-#else
+-            H5Pclose(retval);
+-            return db_perror("HDF5 MPI VFD", E_NOTENABLEDINBUILD, me);
+-#endif
+-            break;
+-        }
+-
++        /* FALLTHROUGH */
+         case DB_FILE_OPTS_H5_DEFAULT_MPIO:
+         {
+ #ifdef H5_HAVE_PARALLEL
+@@ -4963,15 +4954,8 @@ db_hdf5_process_file_options(opts_set_id
+                     if (p = DBGetOption(opts, DBOPT_H5_MPIP_NO_GPFS_HINTS))
+                         use_gpfs_hints = FALSE;
+ 
+-                    if (vfd == DB_H5VFD_MPIO)
+-                    {
+-                        h5status |= H5Pset_fapl_mpio(retval, mpi_comm, mpi_info);
+-                        if (created_info) MPI_Info_free(&mpi_info);
+-                    }
+-                    else
+-                    {
+-                        h5status |= H5Pset_fapl_mpiposix(retval, mpi_comm, use_gpfs_hints);
+-                    }
++                    h5status |= H5Pset_fapl_mpio(retval, mpi_comm, mpi_info);
++                    if (created_info) MPI_Info_free(&mpi_info);
+ #else 
+                     H5Pclose(retval);
+                     return db_perror("HDF5 MPI VFD", E_NOTENABLEDINBUILD, me);


### PR DESCRIPTION
Silo currently depends on hdf5@:1.8.12 because it's HDF5's last version with MPI-POSIX IO support.
This PR patches Silo forcing it to use MPI-IO so it compiles on newer versions of HDF5.

The patch has been pulled from Debian and it works on all versions of Silo in Spack.