### PR TITLE
go: add support for v1.8

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -56,6 +56,7 @@ class Go(Package):
 
     extendable = True
 
+    version('1.8',   '7743960c968760437b6e39093cfe6f67')
     version('1.7.5', '506de2d870409e9003e1440bcfeb3a65')
     version('1.7.4', '49c1076428a5d3b5ad7ac65233fcca2f')
     version('1.6.4', 'b023240be707b34059d2c114d3465c92')


### PR DESCRIPTION
Built and minimally tested on CentOS 7.