### PR TITLE
Add latest version of OpenSSL

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -41,6 +41,7 @@ class Openssl(Package):
     # remain supported until 2019. We could thus make this version the
     # preferred version, if we find that many packages cannot handle
     # version 1.1.
+    version('1.1.0e', '51c42d152122e474754aea96f66928c6')
     version('1.1.0d', '711ce3cd5f53a99c0e12a7d5804f0f63')
     version('1.1.0c', '601e8191f72b18192a937ecf1a800f3f')
     version('1.0.2k', 'f965fc0bf01bf882b31314b61391ae65')


### PR DESCRIPTION
This release fixes **CVE-2017-3733, Severity: High**
https://www.openssl.org/news/secadv/20170216.txt

> OpenSSL 1.1.0 users should upgrade to 1.1.0e
>
> This issue does not affect OpenSSL version 1.0.2.

@tgamblin We should get this merged quickly.