### PR TITLE
Set default module type based on modules.yaml

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -79,8 +79,10 @@ _arguments['constraint'] = Args(
     help='constraint to select a subset of installed packages')
 
 _arguments['module_type'] = Args(
-    '-m', '--module-type', help='type of module files',
-    default='tcl', choices=spack.modules.module_types)
+    '-m', '--module-type',
+    choices=spack.modules.module_types.keys(),
+    default=spack.modules.module_types.keys()[0],
+    help='type of module files [default: %(default)s]')
 
 _arguments['yes_to_all'] = Args(
     '-y', '--yes-to-all', action='store_true', dest='yes_to_all',


### PR DESCRIPTION
Closes #2910.

Previously, `spack module` would default to `tcl`. If you added a `modules.yaml` like:
```yaml
modules:
  enable::
    - lmod
```
`spack module refresh` would crash. Now, `spack module` defaults to whatever is in your `modules.yaml`.

If you have multiple modules enabled, it uses the first. This defaults to `tcl` on my computer, but since it's a dict, it might be sorted differently for other users. Perhaps we should set the default `modules.yaml` to enable just `tcl` instead of `tcl` + `dotkit`?

Personally, I would like `spack module` to default to all enabled modules, not just the first one. But I'm not sure if that makes sense for all of the `spack module` subcommands. Thoughts? We could allow multiple module types for these commands.