### PR TITLE
Fix tab completion after change to uninstall flag

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -718,7 +718,7 @@ function _spack_test {
 function _spack_uninstall {
     if $list_options
     then
-        compgen -W "-h --help -f --force -a --all -d --dependents
+        compgen -W "-h --help -f --force -a --all -R --dependents
                     -y --yes-to-all" -- "$cur"
     else
         compgen -W "$(_installed_packages)" -- "$cur"


### PR DESCRIPTION
#1917 changed an option flag for `spack uninstall`. This PR updates our Bash tab-completion to reflect this.