### PR TITLE
Add patches to allow PGI to build Tar properly

### DIFF
--- a/var/spack/repos/builtin/packages/tar/argp-pgi.patch
+++ b/var/spack/repos/builtin/packages/tar/argp-pgi.patch
@@ -1,0 +1,25 @@
+From 8b3e22b18791f2148da46e60040fc4d9270936b5 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 14 Feb 2017 08:40:23 -0800
+Subject: argp: port to PGI 16.10
+
+* gnu/argp-pin.c (dummy): Declare as needed to make file nonempty.
+
+diff --git a/gnu/argp-pin.c b/gnu/argp-pin.c
+index 261191f..64d831d 100644
+--- a/gnu/argp-pin.c
++++ b/gnu/argp-pin.c
+@@ -24,3 +24,10 @@ char *program_invocation_short_name = 0;
+ #ifndef HAVE_PROGRAM_INVOCATION_NAME
+ char *program_invocation_name = 0;
+ #endif
++
++#if (defined HAVE_PROGRAM_INVOCATION_SHORT_NAME \
++     && defined HAVE_PROGRAM_INVOCATION_NAME)
++/* This declaration is solely to ensure that after preprocessing
++   this file is never empty.  */
++typedef int dummy;
++#endif
+-- 
+cgit v1.0-41-gc330
+

--- a/var/spack/repos/builtin/packages/tar/config-pgi.patch
+++ b/var/spack/repos/builtin/packages/tar/config-pgi.patch
@@ -1,0 +1,10 @@
+--- a/config.h.in
++++ b/config.h.in
+@@ -2182,6 +2182,7 @@
+       ? defined __GNUC_STDC_INLINE__ && __GNUC_STDC_INLINE__ \
+       : (199901L <= __STDC_VERSION__ \
+          && !defined __HP_cc \
++         && !defined __PGI \
+          && !(defined __SUNPRO_C && __STDC__))) \
+      && !defined _GL_EXTERN_INLINE_STDHEADER_BUG)
+ # define _GL_INLINE inline

--- a/var/spack/repos/builtin/packages/tar/gnutar-configure-xattrs.patch
+++ b/var/spack/repos/builtin/packages/tar/gnutar-configure-xattrs.patch
@@ -1,3 +1,7 @@
+Fixes major build errors on macOS
+
+See http://lists.gnu.org/archive/html/bug-tar/2014-08/msg00001.html
+
 diff --git a/Makefile.in b/Makefile.in
 index f9f1d1d..b403e46 100644
 --- a/Makefile.in

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -28,13 +28,15 @@ from spack import *
 class Tar(AutotoolsPackage):
     """GNU Tar provides the ability to create tar archives, as well as various
     other kinds of manipulation."""
+
     homepage = "https://www.gnu.org/software/tar/"
-    url = "https://ftp.gnu.org/gnu/tar/tar-1.28.tar.gz"
+    url = "https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz"
 
     version('1.29', 'cae466e6e58c7292355e7080248f244db3a4cf755f33f4fa25ca7f9a7ed09af0')
     version('1.28', '6ea3dbea1f2b0409b234048e021a9fd7')
 
-    # see http://lists.gnu.org/archive/html/bug-tar/2014-08/msg00001.html and
-    # https://github.com/Homebrew/homebrew-core/commit/aef9a1792de4648d0322b4b04d32287532f046bb
-    # TODO: when=sys.platform=='darwin' ?
+    patch('tar-pgi.patch',    when='@1.29')
+    patch('config-pgi.patch', when='@:1.29')
+    patch('se-selinux.patch', when='@:1.29')
+    patch('argp-pgi.patch',   when='@:1.29')
     patch('gnutar-configure-xattrs.patch', when='@1.28')

--- a/var/spack/repos/builtin/packages/tar/se-selinux.patch
+++ b/var/spack/repos/builtin/packages/tar/se-selinux.patch
@@ -1,0 +1,66 @@
+From e041ac5f63e23b20c322f2777d6330074c8a7215 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 14 Feb 2017 08:46:05 -0800
+Subject: selinux-h: port to PGI 16.10
+
+* gnu/se-selinux.in.h: Don't assume that include_next skips over
+duplicate -I DIR options.
+
+diff --git a/gnu/se-selinux.in.h b/gnu/se-selinux.in.h
+index cd19951..1cf7c00 100644
+--- a/gnu/se-selinux.in.h
++++ b/gnu/se-selinux.in.h
+@@ -14,26 +14,25 @@
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+ 
+-#ifndef _@GUARD_PREFIX@_SELINUX_SELINUX_H
+-# define _@GUARD_PREFIX@_SELINUX_SELINUX_H
+-
+-# if __GNUC__ >= 3
++#if __GNUC__ >= 3
+ @PRAGMA_SYSTEM_HEADER@
+-# endif
++#endif
+ @PRAGMA_COLUMNS@
+ 
+-# if HAVE_SELINUX_SELINUX_H
++#if HAVE_SELINUX_SELINUX_H
+ 
+ #@INCLUDE_NEXT@ @NEXT_SELINUX_SELINUX_H@
+ 
+-# else
++#else
++# if !defined _@GUARD_PREFIX@_SELINUX_SELINUX_H
++#  define _@GUARD_PREFIX@_SELINUX_SELINUX_H
+ 
+ #  include <sys/types.h>
+ #  include <errno.h>
+ 
+-#ifndef _GL_INLINE_HEADER_BEGIN
+- #error "Please include config.h first."
+-#endif
++#  ifndef _GL_INLINE_HEADER_BEGIN
++    #error "Please include config.h first."
++#  endif
+ _GL_INLINE_HEADER_BEGIN
+ #  ifndef SE_SELINUX_INLINE
+ #   define SE_SELINUX_INLINE _GL_INLINE
+@@ -114,10 +113,10 @@ matchpathcon_init_prefix (char const *path _GL_UNUSED_PARAMETER,
+ #   define GNULIB_defined_security_types 1
+ #  endif
+ 
+-#ifndef _GL_INLINE_HEADER_BEGIN
+- #error "Please include config.h first."
+-#endif
++#  ifndef _GL_INLINE_HEADER_BEGIN
++    #error "Please include config.h first."
++#  endif
+ _GL_INLINE_HEADER_BEGIN
+ 
+ # endif
+-#endif /* _@GUARD_PREFIX@_SELINUX_SELINUX_H */
++#endif
+-- 
+cgit v1.0-41-gc330
+

--- a/var/spack/repos/builtin/packages/tar/tar-pgi.patch
+++ b/var/spack/repos/builtin/packages/tar/tar-pgi.patch
@@ -1,0 +1,66 @@
+From 2be02a7c9afa5b4f01261e5b66c64217f7f3c29a Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 14 Feb 2017 08:55:05 -0800
+Subject: Fix incompatibility with PGI 16.10
+
+* src/tar.c (options): Fix incompatibility with the C standard,
+which says that arguments to macro calls cannot contain # directives.
+
+diff --git a/src/tar.c b/src/tar.c
+index fd29cd3..ea68c82 100644
+--- a/src/tar.c
++++ b/src/tar.c
+@@ -548,11 +548,11 @@ static struct argp_option options[] = {
+    N_("cancel the effect of --delay-directory-restore option"), GRID+1 },
+   {"sort", SORT_OPTION, N_("ORDER"), 0,
+ #if D_INO_IN_DIRENT
+-   N_("directory sorting order: none (default), name or inode"
++   N_("directory sorting order: none (default), name or inode")
+ #else
+-   N_("directory sorting order: none (default) or name"
++   N_("directory sorting order: none (default) or name")
+ #endif
+-     ), GRID+1 },
++     , GRID+1 },
+ #undef GRID
+ 
+ #define GRID 55
+@@ -1758,7 +1758,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
+     case GROUP_MAP_OPTION:
+       group_map_read (arg);
+       break;
+-      
++
+     case MODE_OPTION:
+       mode_option = mode_compile (arg);
+       if (!mode_option)
+@@ -1829,7 +1829,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
+     case OWNER_MAP_OPTION:
+       owner_map_read (arg);
+       break;
+-      
++
+     case QUOTE_CHARS_OPTION:
+       for (;*arg; arg++)
+ 	set_char_quoting (NULL, *arg, 1);
+@@ -2123,7 +2123,7 @@ find_argp_option (struct argp *ap, int key)
+ {
+   struct argp_option const *p = NULL;
+   struct argp_child const *child;
+-  
++
+   p = find_argp_option_key (ap->options, key);
+   if (!p && ap->children)
+     {
+@@ -2136,7 +2136,7 @@ find_argp_option (struct argp *ap, int key)
+     }
+   return p;
+ }
+-  
++
+ static const char *tar_authors[] = {
+   "John Gilmore",
+   "Jay Fenlason",
+-- 
+cgit v1.0-41-gc330
+


### PR DESCRIPTION
Adds several patches necessary to build Tar with PGI 16.10. With these patches in place, `make check` passes with flying colors for me on CentOS 6.8.

If `config-pgi.patch` looks familiar, that's because it's the same patch from #3044 and #501. `config.in.h`, `gnu/se-selinux.in.h`, and `gnu/argp-pin.c` all come from Gnulib, the GNU Portability Library. Gnulib is not distributed in releases; it is intended to be copied into the tarball for a package. Unfortunately, this means that I'll have to add similar patches for other packages as well. Luckily, Gnulib is being patched permanently each time, so we shouldn't expect these bugs in newer releases.