### PR TITLE
Add Intel Parallel Studio XE 2016u4 and 2015u6.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -45,11 +45,15 @@ class IntelParallelStudio(IntelInstaller):
     version('professional.2017.0', '34c98e3329d6ac57408b738ae1daaa01')
     version('cluster.2017.0',      '34c98e3329d6ac57408b738ae1daaa01')
     version('composer.2016.3',     '3208eeabee951fc27579177b593cefe9')
+    version('professional.2016.4', '16a641a06b156bb647c8a56e71f3bb33')
+    version('cluster.2016.4',      '16a641a06b156bb647c8a56e71f3bb33')
     version('professional.2016.3', 'eda19bb0d0d19709197ede58f13443f3')
     version('cluster.2016.3',      'eda19bb0d0d19709197ede58f13443f3')
     version('composer.2016.2',     '1133fb831312eb519f7da897fec223fa')
     version('professional.2016.2', '70be832f2d34c9bf596a5e99d5f2d832')
     version('cluster.2016.2',      '70be832f2d34c9bf596a5e99d5f2d832')
+    version('professional.2015.6', 'd460f362c30017b60f85da2e51ad25bf')
+    version('cluster.2015.6',      'd460f362c30017b60f85da2e51ad25bf')
 
     variant('rpath', default=True, description="Add rpath to .cfg files")
     variant('newdtags', default=False,


### PR DESCRIPTION
This commit adds Intel Parallel Studio XE 2016 update 4 and 2015 update 6. Since Intel provides only file size and checksum from `cksum`, I comfirmed the downloaded packages have the identical checksums then generate md5 for them.

https://software.intel.com/en-us/articles/intel-parallel-studio-xe-2016-checksums
https://software.intel.com/en-us/articles/intel-parallel-studio-xe-2016-checksums

Limitation:

* I don't have the installation package for Intel Composer XE. So this commit doesn't include it.

Needs feedbacks:

* It seem that composer in `intel-cluster-studio` package is duplicate with `intel` package. Any plan to merge them?
* The latest package of Intel Parallel Studio XE for each major release -- 2015u6, 2016u4 and 2017u1 -- can be downloaded from Intel website. But other versions cannot be found. Do you think it is a good idea to provide only the latest update above in Spack then retrieve them from Internet during installtion?

```
wget http://registrationcenter-download.intel.com/irc_nas/8470/parallel_studio_xe_2015_update6.tgz
wget http://registrationcenter-download.intel.com/akdlm/irc_nas/9781/parallel_studio_xe_2016_update4.tgz
wget http://registrationcenter-download.intel.com/akdlm/irc_nas/10973/parallel_studio_xe_2017_update1.tgz