### PR TITLE
Fix tab completion of directories and filenames

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -136,8 +136,6 @@ function _spack_bootstrap {
     if $list_options
     then
         compgen -W "-h --help -r --remote" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -192,8 +190,6 @@ function _spack_compiler_add {
     if $list_options
     then
         compgen -W "-h --help --scope" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -375,8 +371,6 @@ function _spack_flake8 {
     then
         compgen -W "-h --help -k --keep-temp -o --output
                     -r --root-relative -U --no-untracked" -- "$cur"
-    else
-        compgen -o filenames -- "$cur"
     fi
 }
 
@@ -452,8 +446,6 @@ function _spack_md5 {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o filenames -- "$cur"
     fi
 }
 
@@ -470,8 +462,6 @@ function _spack_mirror_add {
     if $list_options
     then
         compgen -W "-h --help --scope" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -613,8 +603,6 @@ function _spack_python {
     if $list_options
     then
         compgen -W "-h --help -c" -- "$cur"
-    else
-        compgen -o filenames -- "$cur"
     fi
 }
 
@@ -635,8 +623,6 @@ function _spack_repo_add {
     if $list_options
     then
         compgen -W "-h --help --scope" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -644,8 +630,6 @@ function _spack_repo_create {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -813,8 +797,6 @@ function _spack_view_hardlink {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -822,8 +804,6 @@ function _spack_view_remove {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -841,8 +821,6 @@ function _spack_view_statlink {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -855,8 +833,6 @@ function _spack_view_symlink {
     if $list_options
     then
         compgen -W "-h --help" -- "$cur"
-    else
-        compgen -o dirnames -- "$cur"
     fi
 }
 
@@ -894,18 +870,18 @@ function _tests {
 # Testing functions
 
 function _test_vars {
-    echo "-----------------------------------------------------"            >> temp
-    echo "Full line:                '$COMP_LINE'"                           >> temp
-    echo                                                                    >> temp
+    echo "-----------------------------------------------------"             >> temp
+    echo "Full line:                '$COMP_LINE'"                            >> temp
+    echo                                                                     >> temp
     echo "Word list w/ flags:       $(_pretty_print COMP_WORDS[@])"          >> temp
-    echo "# words w/ flags:         '${#COMP_WORDS[@]}'"                    >> temp
-    echo "Cursor index w/ flags:    '$COMP_CWORD'"                          >> temp
-    echo                                                                    >> temp
+    echo "# words w/ flags:         '${#COMP_WORDS[@]}'"                     >> temp
+    echo "Cursor index w/ flags:    '$COMP_CWORD'"                           >> temp
+    echo                                                                     >> temp
     echo "Word list w/out flags:    $(_pretty_print COMP_WORDS_NO_FLAGS[@])" >> temp
-    echo "# words w/out flags:      '${#COMP_WORDS_NO_FLAGS[@]}'"           >> temp
-    echo "Cursor index w/out flags: '$COMP_CWORD_NO_FLAGS'"                 >> temp
-    echo                                                                    >> temp
-    echo "Subfunction:              '$subfunction'"                         >> temp
+    echo "# words w/out flags:      '${#COMP_WORDS_NO_FLAGS[@]}'"            >> temp
+    echo "Cursor index w/out flags: '$COMP_CWORD_NO_FLAGS'"                  >> temp
+    echo                                                                     >> temp
+    echo "Subfunction:              '$subfunction'"                          >> temp
     if $list_options
     then
         echo "List options:             'True'"  >> temp
@@ -929,4 +905,4 @@ function _pretty_print {
     done
 }
 
-complete -F _bash_completion_spack spack
+complete -o default -F _bash_completion_spack spack


### PR DESCRIPTION
`compgen` does not work the way I expected. `compgen -o filenames` doesn't list any results. If I use `compgen -o filenames -A file` or `compgen -o default`, it will list results, but directories will not have a `/` appended. The only way to get this working is to use `complete -o default`. This has the unfortunate side-effect of adding directories/filenames as possible values any time there are no other possible results, but I don't see a better way around this.

P.S. I just noticed that `spack install []` will list all packages, but `spack install gcc []` will list no results (will now list filenames/directories). I wonder if I can fix this (in another PR).