### PR TITLE
gnuplot: fixed broken package and add variants

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -64,6 +64,8 @@ class Gnuplot(AutotoolsPackage):
     # required dependencies
     depends_on('readline')
     depends_on('pkg-config', type='build')
+    depends_on('libxpm')
+    depends_on('libiconv')
 
     # optional dependencies:
     depends_on('libcerf', when='+libcerf')

--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -22,13 +22,11 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
-
 import os
 
 
-class Gnuplot(Package):
+class Gnuplot(AutotoolsPackage):
     """Gnuplot is a portable command-line driven graphing utility for Linux,
        OS/2, MS Windows, OSX, VMS, and many other platforms. The source
        code is copyrighted but freely distributed (i.e., you don't have
@@ -43,24 +41,97 @@ class Gnuplot(Package):
     homepage = "http://www.gnuplot.info"
     url      = "http://downloads.sourceforge.net/project/gnuplot/gnuplot/5.0.1/gnuplot-5.0.1.tar.gz"
 
+    # There is a conflict in term.h between gnuplot and ncurses, which is a
+    # dependency of readline. Fix it with a small patch
+    patch('term_include.patch')
+
+    version('5.0.5', 'c5e96fca73afbee4f57cbc1bfce6b3b8')
     version('5.0.1', '79b4f9e203728f76b60b28bcd402d3c7')
 
+    variant('wx',      default=False,
+            description='Activates wxWidgets terminal')
+    variant('gd',      default=True,
+            description='Activates gd based terminal')
+    variant('cairo',   default=True,
+            description='Activates cairo based terminal')
+    variant('X',       default=False,
+            description='Build with X11')
+    variant('libcerf', default=True,
+            description='Build with libcerf support')
+    variant('pbm',     default=False,
+            description='Enable PBM (Portable Bit Map) and other older bitmap terminals')  # NOQA: ignore=E501
+
+    # required dependencies
     depends_on('readline')
-    depends_on('libcerf')
-    depends_on('libgd')
-    depends_on('cairo')
-    depends_on('pango')
+    depends_on('pkg-config', type='build')
+
+    # optional dependencies:
+    depends_on('libcerf', when='+libcerf')
+    depends_on('libgd', when='+gd')
+    depends_on('cairo@1.2:', when='+cairo')
     depends_on('wx', when='+wx')
+    depends_on('pango@1.10:', when='+wx')
+    depends_on('pango@1.10:', when='+cairo')
 
-    variant('wx', default=False, description='Activates wxWidgets terminal')
+    def configure_args(self):
+        # see https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnuplot.rb
+        # and https://github.com/macports/macports-ports/blob/master/math/gnuplot/Portfile
+        spec = self.spec
+        options = [
+            '--disable-dependency-tracking',
+            '--disable-silent-rules',
+            # Per upstream: "--with-tutorial is horribly out of date."
+            '--without-tutorial',
+            '--with-readline=%s' % spec['readline'].prefix
+        ]
 
-    def install(self, spec, prefix):
-        # It seems there's an open bug for wxWidgets support
-        # See : http://sourceforge.net/p/gnuplot/bugs/1694/
-        os.environ['TERMLIBS'] = '-lX11'
+        if '+pbm' in spec:
+            options.append('--with-bitmap-terminals')
+        else:
+            options.append('--without-bitmap-terminals')
 
-        options = ['--prefix=%s' % prefix]
+        if '+X' in spec:
+            # It seems there's an open bug for wxWidgets support
+            # See : http://sourceforge.net/p/gnuplot/bugs/1694/
+            os.environ['TERMLIBS'] = '-lX11'
+            options.append('--with-x')
+        else:
+            options.append('--without-x')
 
-        configure(*options)
-        make()
-        make("install")
+        if '+wx' in spec:
+            options.append('--with-wx=%s' % spec['wx'].prefix)
+        else:
+            options.append('--disable-wxwidgets')
+
+        if '+gd' in spec:
+            options.append('--with-gd=%s' % spec['libgd'].prefix)
+        else:
+            options.append('--without-gd')
+
+        if '+cairo' in spec:
+            options.append('--with-cairo')
+        else:
+            options.append('--without-cairo')
+
+        if '+libcerf' in spec:
+            options.append('--with-libcerf')
+        else:
+            options.append('--without-libcerf')
+
+        # TODO: Enable pdflib-based pdf terminal
+        # '--with-pdf=%s' % spec['pdflib-lite'].prefix  (or pdflib)
+        options.append('--without-pdf')
+
+        # TODO: Enable qt terminal qt@5.7
+        options.append('--with-qt=no')
+
+        # TODO: Enable lua-based terminals
+        options.append('--without-lua')
+
+        # TODO: --with-latex
+        options.append('--without-latex')
+
+        # TODO: --with-aquaterm  depends_on('aquaterm')
+        options.append('--without-aquaterm')
+
+        return options

--- a/var/spack/repos/builtin/packages/gnuplot/term_include.patch
+++ b/var/spack/repos/builtin/packages/gnuplot/term_include.patch
@@ -1,0 +1,11 @@
+--- a/docs/doc2x.h      2017-03-10 13:55:51.719850190 -0500
++++ b/docs/doc2x.h      2017-03-10 13:56:17.569826925 -0500
+@@ -69,7 +69,7 @@
+ # ifdef ALL_TERM_DOC
+ #  include "allterm.h"
+ # else
+-#  include "term.h"
++#  include "src/term.h"
+ # endif
+     NULL
+ };

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -36,6 +36,8 @@ class Gtkplus(AutotoolsPackage):
 
     variant('X', default=False, description="Enable an X toolkit")
 
+    depends_on('pkg-config', type='build')
+
     depends_on("atk")
     depends_on("gdk-pixbuf")
     depends_on("glib")

--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -23,9 +23,10 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
-class Wx(Package):
+class Wx(AutotoolsPackage):
     """wxWidgets is a C++ library that lets developers create
        applications for Windows, Mac OS X, Linux and other platforms
        with a single code base. It has popular language bindings for
@@ -41,18 +42,24 @@ class Wx(Package):
     version('3.0.2', '6461eab4428c0a8b9e41781b8787510484dea800')
     version('3.0.1', '73e58521d6871c9f4d1e7974c6e3a81629fddcf8')
 
+    version('develop', git='https://github.com/wxWidgets/wxWidgets.git', branch='master')
+
     depends_on('gtkplus')
 
-    def make_wx(self):
-        make()
+    parallel = False
 
-    @when('@:3.0.2')
-    def make_wx(self):
-        make(parallel=False)
+    def configure_args(self):
+        spec = self.spec
+        options = [
+            '--enable-unicode',
+            '--disable-precomp-headers'
+        ]
 
-    def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix, "--enable-unicode",
-                  "--disable-precomp-headers")
+        # see http://trac.wxwidgets.org/ticket/17639
+        if spec.satisfies('@:3.1.0') and sys.platform == 'darwin':
+            options.extend([
+                '--disable-qtkit',
+                '--disable-mediactrl'
+            ])
 
-        self.make_wx()
-        make("install")
+        return options

--- a/var/spack/repos/builtin/packages/wx/package.py
+++ b/var/spack/repos/builtin/packages/wx/package.py
@@ -46,7 +46,9 @@ class Wx(AutotoolsPackage):
 
     depends_on('gtkplus')
 
-    parallel = False
+    @when('@:3.0.2')
+    def build(self, spec, prefix):
+        make(parallel=False)
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
there is an issue with `ncurses` (or `gnuplot`?) that neeeds to be fixed:
```
In file included from $SPACK_ROOT/darwin-sierra-x86_64/clang-8.0.0-apple/ncurses-6.0-f5ft4ie4brbq44gkyjhr7r42xnfjkhgt/include/term.h:86:
In file included from /usr/include/termios.h:27:
/usr/include/sys/termios.h:263:1: error: expected expression
typedef unsigned long   tcflag_t;
^
```
~~but at least `spack install gnuplot~x11~gd~cairo` works now on macOS.~~
Same happens on Ubuntu16.04.2 with gcc5.4.0.

p.s. looking at how [homebrew builds ncurses](https://github.com/Homebrew/homebrew-dupes/blob/master/ncurses.rb) or [macports](https://github.com/macports/macports-ports/blob/master/devel/ncurses/Portfile), i don't see anything special. Moreover, current args in `ncurses` in Spack are almost identical to those in macports.