### PR TITLE
openblas: add develop version to make it work with Kabylake CPUs

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -42,7 +42,7 @@ class Dealii(CMakePackage):
     version('8.3.0', 'fc6cdcb16309ef4bea338a4f014de6fa')
     version('8.2.1', '71c728dbec14f371297cd405776ccf08')
     version('8.1.0', 'aa8fadc2ce5eb674f44f997461bf668d')
-    version('develop', git='https://github.com/dealii/dealii.git', tag='master')
+    version('develop', git='https://github.com/dealii/dealii.git', branch='master')
 
     variant('mpi',      default=True,  description='Compile with MPI')
     variant('arpack',   default=True,

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -38,6 +38,8 @@ class Openblas(MakefilePackage):
     version('0.2.16', 'fef46ab92463bdbb1479dcec594ef6dc')
     version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
 
+    version('develop', git='https://github.com/xianyi/OpenBLAS.git', branch='develop')
+
     variant(
         'shared',
         default=True,


### PR DESCRIPTION
fixes https://github.com/LLNL/spack/issues/3189

allows users to build `develop` which detects Kabylake until the next release is out.