### PR TITLE
Fix zoltan installation issue on bg-q #3193

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -92,6 +92,9 @@ class Zoltan(Package):
 
             mpi_libs = self.get_mpi_libs()
 
+            # NOTE: Some external mpi installations may have empty lib
+            # directory (e.g. bg-q). In this case we need to explicitly
+            # pass empty library name.
             if mpi_libs:
                 mpi_libs = ' -l'.join(mpi_libs)
                 config_args.append('--with-mpi-libs=-l{0}'.format(mpi_libs))

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -88,9 +88,15 @@ class Zoltan(Package):
             config_args.append('CXX={0}'.format(spec['mpi'].mpicxx))
             config_args.append('FC={0}'.format(spec['mpi'].mpifc))
 
-            mpi_libs = ' -l'.join(self.get_mpi_libs())
             config_args.append('--with-mpi={0}'.format(spec['mpi'].prefix))
-            config_args.append('--with-mpi-libs=-l{0}'.format(mpi_libs))
+
+            mpi_libs = self.get_mpi_libs()
+
+            if mpi_libs:
+                mpi_libs = ' -l'.join(mpi_libs)
+                config_args.append('--with-mpi-libs=-l{0}'.format(mpi_libs))
+            else:
+                config_args.append('--with-mpi-libs= ')
 
         # NOTE: Early versions of Zoltan come packaged with a few embedded
         # library packages (e.g. ParMETIS, Scotch), which messes with Spack's


### PR DESCRIPTION
We use pre-installed IBM mpi packages on `bg-q` which typically looks like : 
```
    mpich:
        paths:
            mpich@3.2%xl@12.1 arch=bgq-cnk-ppc64: /bgsys/drivers/ppcfloor/comm/xl
            mpich@3.2%gcc@4.4.7 arch=bgq-cnk-ppc64: /bgsys/drivers/ppcfloor/comm/gcc
```

Now if we look at those paths : 

```
○ → tree /bgsys/drivers/ppcfloor/comm/xl
/bgsys/drivers/ppcfloor/comm/xl
├── bin -> /bgsys/drivers/V1R2M4/ppc64/comm/bin/xl
├── DEPRECATED
├── include -> /bgsys/drivers/V1R2M4/ppc64/comm/include
└── lib
```

So `lib` is empty and hence there was error #3193. 

Actually, there are mpi libraries installed but they are convoluted with gcc as well as xlc (for multiple versions) : 

```
○ → ll /bgsys/drivers/V1R2M4/ppc64/comm/lib/
total 655696
drwxr-xr-x  2 root root    12288 Nov 16 14:13 .
drwxr-xr-x 14 root root     4096 Nov 16 14:13 ..
-rw-r--r--  1 root root   885268 Nov  4 15:55 libmpichcxx-gcc.a
-rwxr-xr-x  1 root root     1207 Nov  4 15:55 libmpichcxx-gcc.la
-rw-r--r--  1 root root   885276 Nov  4 15:56 libmpichcxx-gcc.legacy.a
-rwxr-xr-x  1 root root     1256 Nov  4 15:56 libmpichcxx-gcc.legacy.la
lrwxrwxrwx  1 root root       31 Nov 16 14:13 libmpichcxx-gcc.legacy.so -> libmpichcxx-gcc.legacy.so.8.0.1
lrwxrwxrwx  1 root root       31 Nov 16 14:13 libmpichcxx-gcc.legacy.so.8 -> libmpichcxx-gcc.legacy.so.8.0.1
-rwxr-xr-x  1 root root   516172 Nov  4 15:56 libmpichcxx-gcc.legacy.so.8.0.1
lrwxrwxrwx  1 root root       24 Nov 16 14:13 libmpichcxx-gcc.so -> libmpichcxx-gcc.so.8.0.1
lrwxrwxrwx  1 root root       24 Nov 16 14:13 libmpichcxx-gcc.so.8 -> libmpichcxx-gcc.so.8.0.1
-rwxr-xr-x  1 root root   516164 Nov  4 15:55 libmpichcxx-gcc.so.8.0.1
-rw-r--r--  1 root root   671492 Nov  4 16:57 libmpichcxx-xl.a
-rwxr-xr-x  1 root root     1116 Nov  4 16:57 libmpichcxx-xl.la
-rw-r--r--  1 root root   671492 Nov  4 16:55 libmpichcxx-xl.legacy.a
-rwxr-xr-x  1 root root     1165 Nov  4 16:55 libmpichcxx-xl.legacy.la
-rw-r--r--  1 root root   671508 Nov  4 16:59 libmpichcxx-xl.legacy.ndebug.a
-rwxr-xr-x  1 root root     1214 Nov  4 16:59 libmpichcxx-xl.legacy.ndebug.la
lrwxrwxrwx  1 root root       37 Nov 16 14:13 libmpichcxx-xl.legacy.ndebug.so -> libmpichcxx-xl.legacy.ndebug.so.8.0.1
lrwxrwxrwx  1 root root       37 Nov 16 14:13 libmpichcxx-xl.legacy.ndebug.so.8 -> libmpichcxx-xl.legacy.ndebug.so.8.0.1
-rwxr-xr-x  1 root root   632324 Nov  4 16:59 libmpichcxx-xl.legacy.ndebug.so.8.0.1
lrwxrwxrwx  1 root root       30 Nov 16 14:13 libmpichcxx-xl.legacy.so -> libmpichcxx-xl.legacy.so.8.0.1
lrwxrwxrwx  1 root root       30 Nov 16 14:13 libmpichcxx-xl.legacy.so.8 -> libmpichcxx-xl.legacy.so.8.0.1
-rwxr-xr-x  1 root root   632308 Nov  4 16:55 libmpichcxx-xl.legacy.so.8.0.1
-rw-r--r--  1 root root   671492 Nov  4 17:00 libmpichcxx-xl.ndebug.a
-rwxr-xr-x  1 root root     1165 Nov  4 17:00 libmpichcxx-xl.ndebug.la
............another 50 such things...
```

It's sufficient to just pass empty library name for zoltan if there is nothing inside `lib` directory.