### PR TITLE
Fix scotch build on bg-q 

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -144,6 +144,9 @@ class Scotch(Package):
             ldflags.append('-L%s -lz' % (self.spec['zlib'].prefix.lib))
 
         cflags.append('-DCOMMON_PTHREAD')
+
+        # NOTE: bg-q platform needs -lpthread (and not -pthread)
+        # otherwise we get illegal instruction error during runtime
         if self.spec.satisfies('platform=darwin'):
             cflags.append('-DCOMMON_PTHREAD_BARRIER')
             ldflags.append('-lm -pthread')

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -56,6 +56,10 @@ class Scotch(Package):
     depends_on('mpi', when='+mpi')
     depends_on('zlib', when='+compression')
 
+    # NOTE: In cross-compiling environment parallel build
+    # produces weired linker errors.
+    parallel = False
+
     # NOTE: Versions of Scotch up to version 6.0.0 don't include support for
     # building with 'esmumps' in their default packages.  In order to enable
     # support for this feature, we must grab the 'esmumps' enabled archives
@@ -143,6 +147,8 @@ class Scotch(Package):
         if self.spec.satisfies('platform=darwin'):
             cflags.append('-DCOMMON_PTHREAD_BARRIER')
             ldflags.append('-lm -pthread')
+        elif self.spec.satisfies('platform=bgq'):
+            ldflags.append('-lm -lrt -lpthread')
         else:
             ldflags.append('-lm -lrt -pthread')
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -57,7 +57,7 @@ class Scotch(Package):
     depends_on('zlib', when='+compression')
 
     # NOTE: In cross-compiling environment parallel build
-    # produces weired linker errors.
+    # produces weird linker errors.
     parallel = False
 
     # NOTE: Versions of Scotch up to version 6.0.0 don't include support for


### PR DESCRIPTION
Fix #3190 :  

- disable parallel build as it produces weird linker errors in cross compiling environment (also scotch_6.0.3/INSTALL.txt just specify `make` command and doesn't say if parallel build is supported or not)
 - update ldflags for bg-q as per Makefile provided Makefile.inc.ppca2_ibm_bgq

