### PR TITLE
Fix setuptools bootstrapping now that dependencies are no longer vendored

### DIFF
--- a/var/spack/repos/builtin/packages/py-appdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-appdirs/package.py
@@ -34,11 +34,11 @@ class PyAppdirs(PythonPackage):
 
     version('1.4.0', '1d17b4c9694ab84794e228f28dc3275b')
 
+    patch('setuptools-import.patch', when='@:1.4.0')
+
     # Newer versions of setuptools require appdirs. Although setuptools is an
     # optional dependency of appdirs, if it is not found, setup.py will
     # fallback on distutils.core instead. Don't add a setuptools dependency
     # or we won't be able to bootstrap setuptools.
 
     # depends_on('py-setuptools', type='build')
-
-    patch('setuptools-import.patch', when='@:1.4.0')

--- a/var/spack/repos/builtin/packages/py-appdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-appdirs/package.py
@@ -25,19 +25,20 @@
 from spack import *
 
 
-class PyPyparsing(PythonPackage):
-    """A Python Parsing Module."""
-    homepage = "https://pypi.python.org/pypi/pyparsing"
-    url      = "https://pypi.io/packages/source/p/pyparsing/pyparsing-2.0.3.tar.gz"
+class PyAppdirs(PythonPackage):
+    """A small Python module for determining appropriate platform-specific
+    dirs, e.g. a "user data dir"."""
 
-    version('2.1.10', '065908b92904e0d3634eb156f44cc80e')
-    version('2.0.3',  '0fe479be09fc2cf005f753d3acc35939')
+    homepage = "https://github.com/ActiveState/appdirs"
+    url      = "https://pypi.io/packages/source/a/appdirs/appdirs-1.4.0.tar.gz"
 
-    patch('setuptools-import.patch', when='@:2.1.10')
+    version('1.4.0', '1d17b4c9694ab84794e228f28dc3275b')
 
-    # Newer versions of setuptools require pyparsing. Although setuptools is an
-    # optional dependency of pyparsing, if it is not found, setup.py will
+    # Newer versions of setuptools require appdirs. Although setuptools is an
+    # optional dependency of appdirs, if it is not found, setup.py will
     # fallback on distutils.core instead. Don't add a setuptools dependency
     # or we won't be able to bootstrap setuptools.
 
     # depends_on('py-setuptools', type='build')
+
+    patch('setuptools-import.patch', when='@:1.4.0')

--- a/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
+++ b/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index ccd1e72..5d907aa 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2,7 +2,12 @@
+ import sys
+ import os
+ import os.path
+-from setuptools import setup
++
++try:
++    from setuptools import setup
++except ImportError:
++    from distutils.core import setup
++
+ import appdirs
+ 
+ tests_require = []

--- a/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
+++ b/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
@@ -7,12 +7,11 @@ index ccd1e72..5d907aa 100644
  import os
  import os.path
 -from setuptools import setup
-+
++# appdirs is a dependency of setuptools, so allow installing without it.
 +try:
 +    from setuptools import setup
 +except ImportError:
 +    from distutils.core import setup
-+
  import appdirs
  
  tests_require = []

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -25,18 +25,20 @@
 from spack import *
 
 
-class PyPyparsing(PythonPackage):
-    """A Python Parsing Module."""
-    homepage = "https://pypi.python.org/pypi/pyparsing"
-    url      = "https://pypi.io/packages/source/p/pyparsing/pyparsing-2.0.3.tar.gz"
+class PyPackaging(PythonPackage):
+    """Core utilities for Python packages."""
 
-    version('2.1.10', '065908b92904e0d3634eb156f44cc80e')
-    version('2.0.3',  '0fe479be09fc2cf005f753d3acc35939')
+    homepage = "https://github.com/pypa/packaging"
+    url      = "https://pypi.io/packages/source/p/packaging/packaging-16.8.tar.gz"
 
-    patch('setuptools-import.patch', when='@:2.1.10')
+    version('16.8', '53895cdca04ecff80b54128e475b5d3b')
 
-    # Newer versions of setuptools require pyparsing. Although setuptools is an
-    # optional dependency of pyparsing, if it is not found, setup.py will
+    # Not needed for the installation, but used at runtime
+    depends_on('py-six',       type='run')
+    depends_on('py-pyparsing', type='run')
+
+    # Newer versions of setuptools require packaging. Although setuptools is an
+    # optional dependency of packaging, if it is not found, setup.py will
     # fallback on distutils.core instead. Don't add a setuptools dependency
     # or we won't be able to bootstrap setuptools.
 

--- a/var/spack/repos/builtin/packages/py-pyparsing/setuptools-import.patch
+++ b/var/spack/repos/builtin/packages/py-pyparsing/setuptools-import.patch
@@ -1,11 +1,15 @@
-diff -Nuar a/setup.py b/setup.py
---- a/setup.py	2017-02-20 18:45:45.000000000 -0600
-+++ b/setup.py	2017-02-20 18:47:59.000000000 -0600
-@@ -1,13 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 82061c6..ff342af 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,7 +1,13 @@
  #!/usr/bin/env python
  
  """Setup script for the pyparsing module distribution."""
 -from setuptools import setup
++
++# Setuptools depends on pyparsing (via packaging) as of version 34, so allow
++# installing without it to avoid bootstrap problems.
 +try:
 +    from setuptools import setup
 +except ImportError:
@@ -14,9 +18,3 @@ diff -Nuar a/setup.py b/setup.py
  import sys
  import os
  
- from pyparsing import __version__ as pyparsing_version
--    
-+
- modules = ["pyparsing",]
- 
- setup(# Distribution meta-data

--- a/var/spack/repos/builtin/packages/py-pyparsing/setuptools-import.patch
+++ b/var/spack/repos/builtin/packages/py-pyparsing/setuptools-import.patch
@@ -1,0 +1,22 @@
+diff -Nuar a/setup.py b/setup.py
+--- a/setup.py	2017-02-20 18:45:45.000000000 -0600
++++ b/setup.py	2017-02-20 18:47:59.000000000 -0600
+@@ -1,13 +1,16 @@
+ #!/usr/bin/env python
+ 
+ """Setup script for the pyparsing module distribution."""
+-from setuptools import setup
++try:
++    from setuptools import setup
++except ImportError:
++    from distutils.core import setup
+ 
+ import sys
+ import os
+ 
+ from pyparsing import __version__ as pyparsing_version
+-    
++
+ modules = ["pyparsing",]
+ 
+ setup(# Distribution meta-data

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -42,3 +42,12 @@ class PySetuptools(PythonPackage):
     version('18.1',   'f72e87f34fbf07f299f6cb46256a0b06')
     version('16.0',   '0ace0b96233516fc5f7c857d086aa3ad')
     version('11.3.1', '01f69212e019a2420c1693fb43593930')
+
+    depends_on('python@2.6:2.7,3.3:')
+
+    # Previously, setuptools vendored all of its dependencies to allow
+    # easy bootstrapping. As of version 34.0.0, this is no longer done
+    # and the dependencies need to be installed externally.
+    depends_on('py-packaging@16.8:', when='@34.0.0:', type=('build', 'run'))
+    depends_on('py-six@1.6.0:',      when='@34.0.0:', type=('build', 'run'))
+    depends_on('py-appdirs@1.4.0:',  when='@34.0.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -29,11 +29,16 @@ class PySix(PythonPackage):
     """Python 2 and 3 compatibility utilities."""
 
     homepage = "https://pypi.python.org/pypi/six"
-    url      = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    url      = "https://pypi.io/packages/source/s/six/six-1.9.0.tar.gz"
 
     version('1.10.0', '34eed507548117b2ab523ab14b2f8b55')
     version('1.9.0',  '476881ef4012262dfc8adc645ee786c4')
 
     extends('python', ignore=r'bin/pytest')
 
-    depends_on('py-setuptools', type='build')
+    # Newer versions of setuptools require six. Although setuptools is an
+    # optional dependency of six, if it is not found, setup.py will fallback
+    # on distutils.core instead. Don't add a setuptools dependency or we
+    # won't be able to bootstrap setuptools.
+
+    # depends_on('py-setuptools', type='build')


### PR DESCRIPTION
@tgamblin @svenevs This fixes the bug I introduced in #3195.

Based on the `CHANGES.rst` that comes with `setuptools`:
```
v34.0.0
-------

* #581: Instead of vendoring the growing list of
  dependencies that Setuptools requires to function,
  Setuptools now requires these dependencies just like
  any other project. Unlike other projects, however,
  Setuptools cannot rely on ``setup_requires`` to
  demand the dependencies it needs to install because
  its own machinery would be necessary to pull those
  dependencies if not present (a bootstrapping problem).
  As a result, Setuptools no longer supports self upgrade or
  installation in the general case. Instead, users are
  directed to use pip to install and upgrade using the
  ``wheel`` distributions of setuptools.

  Users are welcome to contrive other means to install
  or upgrade Setuptools using other means, such as
  pre-installing the Setuptools dependencies with pip
  or a bespoke bootstrap tool, but such usage is not
  recommended and is not supported.

  As discovered in #940, not all versions of pip will
  successfully install Setuptools from its pre-built
  wheel. If you encounter issues with "No module named
  six" or "No module named packaging", especially
  following a line "Running setup.py egg_info for package
  setuptools", then your pip is not new enough.

  There's an additional issue in pip where setuptools
  is upgraded concurrently with other source packages,
  described in pip #4253. The proposed workaround is to
  always upgrade Setuptools first prior to upgrading
  other packages that would upgrade Setuptools.
```
it looks like `setuptools` no longer supports any installation method aside from `pip`. All of its dependencies use `setuptools`, making it very difficult to build from source. I had to hack a couple packages to provide a fallback (`distutils.core`) so that they could build without setuptools. I'll see if I can get these patches merged upstream.