### PR TITLE
Fixing issue when overwriting build_args in PythonPackage

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -231,7 +231,7 @@ class PythonPackageTemplate(PackageTemplate):
     # depends_on('py-foo',        type=('build', 'run'))"""
 
     body = """\
-    def build_args(self):
+    def build_args(self, spec, prefix):
         # FIXME: Add arguments other than --prefix
         # FIXME: If not needed delete the function
         args = []


### PR DESCRIPTION
The template created with `spack create -t python` in `PythonPackage`'s contains this suggestion to overwrite the `build_args` method:

```
def build_args(self):
    ...
```

However, when overwriting this method the installation fails with this error:

```
==> Error: TypeError: build_args() takes exactly 1 argument (3 given)
/my/path/slc6/spack/lib/spack/spack/build_systems/python.py:125, in build:
     123      def build(self, spec, prefix):
     124          """Build everything needed to install."""
  >> 125          args = self.build_args(spec, prefix)
     126
     127          self.setup_py('build', *args)
```

The overwritten method by default only passes `self` as argument whereas the internal call of the method in `build` passes three arguments (`self, spec, prefix`). The user may not know this detail.