### PR TITLE
Fix malformed py-appdirs patch

### DIFF
--- a/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
+++ b/var/spack/repos/builtin/packages/py-appdirs/setuptools-import.patch
@@ -2,7 +2,7 @@ diff --git a/setup.py b/setup.py
 index ccd1e72..5d907aa 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -2,7 +2,12 @@
+@@ -2,7 +2,11 @@
  import sys
  import os
  import os.path
@@ -13,5 +13,5 @@ index ccd1e72..5d907aa 100644
 +except ImportError:
 +    from distutils.core import setup
  import appdirs
- 
+
  tests_require = []


### PR DESCRIPTION
@adamjstewart  Trying to install py-appdirs I got this error:

```
Staging archive: /my/path/spack/var/spack/stage/py-appdirs-1.4.0-433emafxqyoxypkym3dehssde6vfep56/appdirs-1.4.0.tar.gz
/usr/bin/patch: **** malformed patch at line 17:
```

The patch seems to have the meta-information numbers wrong.
After the change it works for me.