### PR TITLE
Adjustments to get gtkplus to build

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -38,8 +38,13 @@ class Atk(AutotoolsPackage):
 
     depends_on('glib')
     depends_on('pkg-config', type='build')
+    depends_on('gobject-introspection')
+    depends_on('python')
 
     def url_for_version(self, version):
         """Handle atk's version-based custom URLs."""
         url = 'http://ftp.gnome.org/pub/gnome/sources/atk'
         return url + '/%s/atk-%s.tar.xz' % (version.up_to(2), version)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -39,7 +39,6 @@ class Atk(AutotoolsPackage):
     depends_on('glib')
     depends_on('pkg-config', type='build')
     depends_on('gobject-introspection')
-    depends_on('python')
 
     def url_for_version(self, version):
         """Handle atk's version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -46,4 +46,5 @@ class Atk(AutotoolsPackage):
         return url + '/%s/atk-%s.tar.xz' % (version.up_to(2), version)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))
+        spack_env.prepend_path("XDG_DATA_DIRS",
+                               self.prefix.share)

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -40,6 +40,7 @@ class Cairo(AutotoolsPackage):
     depends_on('libxext', when='+X')
     depends_on('libxrender', when='+X')
     depends_on('libxcb', when='+X')
+    depends_on('python', when='+X')
     depends_on("libpng")
     depends_on("glib")
     depends_on("pixman")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -40,7 +40,7 @@ class Cairo(AutotoolsPackage):
     depends_on('libxext', when='+X')
     depends_on('libxrender', when='+X')
     depends_on('libxcb', when='+X')
-    depends_on('python', when='+X')
+    depends_on('python', when='+X', type='build')
     depends_on("libpng")
     depends_on("glib")
     depends_on("pixman")

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -45,7 +45,6 @@ class GdkPixbuf(AutotoolsPackage):
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("gobject-introspection")
-    depends_on("python")
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -44,3 +44,8 @@ class GdkPixbuf(AutotoolsPackage):
     depends_on("jpeg")
     depends_on("libpng")
     depends_on("libtiff")
+    depends_on("gobject-introspection")
+    depends_on("python")
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -47,4 +47,5 @@ class GdkPixbuf(AutotoolsPackage):
     depends_on("gobject-introspection")
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))
+        spack_env.prepend_path("XDG_DATA_DIRS",
+                               self.prefix.share)

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack import spack_root
 
 
 class GobjectIntrospection(Package):
@@ -44,10 +45,35 @@ class GobjectIntrospection(Package):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
 
+    # This package creates several scripts from
+    # toosl/g-ir-tool-template.in.  In their original form these
+    # scripts end up with a sbang line like
+    #
+    # `#!/usr/bin/env /path/to/spack/python`.
+    #
+    # These scripts are generated and then used as part of the build
+    # (other packages also use the scripts after they've been
+    # installed).
+    #
+    # The path to the spack python can become too long.  Because these
+    # tools are used as part of the build, the normal hook that fixes
+    # this problem can't help us.
+    # This package fixes the problem in two steps:
+    # - it rewrites the g-ir-tool-template so that its sbang line
+    #   refers directly to spack's python (filter_file step below); and
+    # - it patches the Makefile.in so that the generated Makefile has an
+    #   extra sed expression in its TOOL_SUBSTITUTION that results in
+    #   an `#!/bin/bash /path/to/spack/bin/sbang` unconditionally being
+    #   inserted into the scripts as they're generated.
+    patch("sbang.patch")
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         # we need to filter this file to avoid an overly long hashbang line
-        filter_file('@PYTHON@', 'python',
+        filter_file('#!/usr/bin/env @PYTHON@', '#!@PYTHON@',
                     'tools/g-ir-tool-template.in')
         make()
         make("install")
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root )

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -76,4 +76,4 @@ class GobjectIntrospection(Package):
         make("install")
 
     def setup_environment(self, spack_env, run_env):
-        spack_env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root )
+        spack_env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root)

--- a/var/spack/repos/builtin/packages/gobject-introspection/sbang.patch
+++ b/var/spack/repos/builtin/packages/gobject-introspection/sbang.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in	2016-09-13 01:23:59.000000000 -0700
++++ b/Makefile.in	2017-02-22 10:26:31.824509512 -0800
+@@ -1475,7 +1475,7 @@
+ gir_DATA = $(STATIC_GIRSOURCES) $(SUBSTITUTED_GIRSOURCES) $(BUILT_GIRSOURCES)
+ typelibsdir = $(libdir)/girepository-1.0
+ typelibs_DATA = $(gir_DATA:.gir=.typelib)
+-TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,$(PYTHON),
++TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,$(PYTHON), -e "1i\#!/bin/bash $(SPACK_SBANG)"
+ g_ir_compiler_SOURCES = tools/compiler.c
+ g_ir_compiler_CPPFLAGS = -DGIREPO_DEFAULT_SEARCH_PATH="\"$(libdir)\"" \
+ 			 -I$(top_srcdir)/girepository

--- a/var/spack/repos/builtin/packages/gtkplus/no-demos.patch
+++ b/var/spack/repos/builtin/packages/gtkplus/no-demos.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in    2017-02-21 12:18:44.774922978 -0800
++++ b/Makefile.in 2017-02-21 12:18:54.465965697 -0800
+@@ -564,7 +564,7 @@
+        || { echo "Gtk+Tests:ERROR: Failed to start Xvfb environment for X11 target tests."; exit 1; } \
+        && DISPLAY=:$$XID && export DISPLAY
+
+-SRC_SUBDIRS = gdk gtk modules demos tests perf
++SRC_SUBDIRS = gdk gtk modules tests perf
+ SUBDIRS = po po-properties $(SRC_SUBDIRS) docs m4macros build
+
+ # require automake 1.4

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -45,7 +45,6 @@ class Gtkplus(AutotoolsPackage):
     depends_on("pango~X", when='~X')
     depends_on("pango+X", when='+X')
     depends_on('gobject-introspection', when='+X')
-    depends_on('python')
 
     patch('no-demos.patch')
 

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -45,6 +45,9 @@ class Gtkplus(AutotoolsPackage):
     depends_on("pango~X", when='~X')
     depends_on("pango+X", when='+X')
     depends_on('gobject-introspection', when='+X')
+    depends_on('python')
+
+    patch('no-demos.patch')
 
     def patch(self):
         # remove disable deprecated flag.

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -49,7 +49,6 @@ class Pango(AutotoolsPackage):
     depends_on("libxft", when='+X')
     depends_on("glib")
     depends_on('gobject-introspection')
-    depends_on('python')
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -62,4 +62,5 @@ class Pango(AutotoolsPackage):
         make("install", parallel=False)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))
+        spack_env.prepend_path("XDG_DATA_DIRS",
+                               self.prefix.share)

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -48,6 +48,8 @@ class Pango(AutotoolsPackage):
     depends_on("cairo+X", when='+X')
     depends_on("libxft", when='+X')
     depends_on("glib")
+    depends_on('gobject-introspection')
+    depends_on('python')
 
     def configure_args(self):
         args = []
@@ -59,3 +61,6 @@ class Pango(AutotoolsPackage):
 
     def install(self, spec, prefix):
         make("install", parallel=False)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS", join_path(self.prefix, 'share'))


### PR DESCRIPTION
This is either a WIP or a CFH (Cry For Help).

See #3149 for detailed history, but PR #3077 broke gtkplus when it introduced gobject-introspection.

I used to be able to `spack install emacs@25.1+X`.  I no longer can.  Very sad.

**Can *you* build it?**

The issue I run into is that `gtkplus+X` no longer builds and emacs@25.1+X needs it.

The changes in this branch let gtkplus+X build, but they leave a bit to be desired.

1. There's a problem with the sbang lines of some python scripts that get used as part of the build process ([details here](https://github.com/LLNL/spack/issues/3149#issuecomment-280803833)).  I've worked around them by adding python dependencies to all of the victims.

2. Several packages generate their `.gir` files in their install tree rather than a standard `/usr/share` directory.  I worked around the by adding those directories to `XDG_DATA_DIRS`, but that might not be the best fix.

3.  I can't, after an embarrassing/costly number of hours, get the demos in the gtkplus source tree to build.  I resorted to walking through the binary w/ gdb trying to figure out where it's having trouble before my timer fired and I [temporarily] gave up.

    I ended up just patching them out of the `Makefile.in`.  The `tests` target passes and I can build a mostly functional emacs with the resulting gtkplus package (icons are missing, TBD).

Misery loves company, so come join me.  Or better yet, throw me a life ring?

Thanks!

---

PR #3077 broke gtkplus by introducing gobject-introspection.

This big hack makes things work.  It has problems.

1. Rather than deal with the nasty sbang fooey in the
   g-ir-tool-template.in derived scripts, it just adds a python
   dependency to each package that runs one of the scripts.  This lets
   the `/usr/bin/env python` sbang do the right thing.

2. It stuffs a several directories on to the XDG_DATA_DIRS environment
   variable, which is used for (among other things) locating the .gir
   files.

3. It avoids building the gtkplus demos because I can't make the bit
   that calls `gdk-pixbuf-csource` work.  It doesn't think that it can
   load `.png` files and all of the google hits I found suggest a bad
   `loader.cache` file.  The file's fine and I can strace the command
   and watch it read it in...  Many, many hours wasted here.

   In spite of the demo failing, the tests pass and an emacs built
   with this lib seems to work.