### PR TITLE
fix py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -43,7 +43,9 @@ class PySetuptools(PythonPackage):
     version('16.0',   '0ace0b96233516fc5f7c857d086aa3ad')
     version('11.3.1', '01f69212e019a2420c1693fb43593930')
 
-    depends_on('python@2.6:2.7,3.3:')
+    # FIXME: when we use 2.6:2.7, spack spec llvm tries to install non-existing
+    # python@2.7 instead of python@2.7.13
+    depends_on('python@2.6:2.7.99,3.3:')
 
     # Previously, setuptools vendored all of its dependencies to allow
     # easy bootstrapping. As of version 34.0.0, this is no longer done


### PR DESCRIPTION
@adamjstewart @alalazo @jppelteret ping.

That's a very recent thing, not sure why this happens as my understanding is that such behaviour is common for `depends_on(python@2.7)` and not for the range.