### PR TITLE
Adding a flag to solve 'undefined reference to libintl_dgettext' in extrae package

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -64,6 +64,7 @@ class Binutils(Package):
             '--enable-shared',
             '--enable-64-bit-bfd',
             '--enable-targets=all',
+            '--disable-nls',
             '--with-sysroot=/']
 
         if '+gold' in spec:


### PR DESCRIPTION
Related to #3213 and #3216.