### PR TITLE
Update adios to 1.11.1

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -34,10 +34,11 @@ class Adios(Package):
     """
 
     homepage = "http://www.olcf.ornl.gov/center-projects/adios/"
-    url      = "https://github.com/ornladios/ADIOS/archive/v1.10.0.tar.gz"
+    url      = "https://github.com/ornladios/ADIOS/archive/v1.11.1.tar.gz"
 
     version('develop', git='https://github.com/ornladios/ADIOS.git',
             branch='master')
+    version('1.11.1', '5639bfc235e50bf17ba9dafb14ea4185')
     version('1.10.0', 'eff450a4c0130479417cfd63186957f3')
     version('1.9.0', '310ff02388bbaa2b1c1710ee970b5678')
 
@@ -51,8 +52,9 @@ class Adios(Package):
     variant('infiniband', default=False, description='Enable infiniband support')
 
     # transforms
-    variant('zlib', default=True, description='Enable szip transform support')
+    variant('zlib', default=True, description='Enable zlib transform support')
     variant('szip', default=False, description='Enable szip transform support')
+    variant('zfp', default=False, description='Enable ZFP transform support')
     # transports and serial file converters
     variant('hdf5', default=False, description='Enable parallel HDF5 transport and serial bp2h5 converter')
 
@@ -71,9 +73,13 @@ class Adios(Package):
     # optional transformations
     depends_on('zlib', when='+zlib')
     depends_on('szip', when='+szip')
+    depends_on('zfp', when='+zfp')
     # optional transports & file converters
     depends_on('hdf5@1.8:+mpi', when='+hdf5')
 
+    # ADIOS uses the absolute Python path, which is too long and results in
+    # "bad interpreter" errors
+    patch('python.patch')
     # Fix ADIOS <=1.10.0 compile error on HDF5 1.10+
     #   https://github.com/ornladios/ADIOS/commit/3b21a8a41509
     #   https://github.com/LLNL/spack/issues/1683
@@ -119,6 +125,8 @@ class Adios(Package):
             extra_args.append('--with-zlib=%s' % spec['zlib'].prefix)
         if '+szip' in spec:
             extra_args.append('--with-szip=%s' % spec['szip'].prefix)
+        if '+zfp' in spec:
+            extra_args.append('--with-zfp=%s' % spec['zfp'].prefix)
         if '+hdf5' in spec:
             extra_args.append('--with-phdf5=%s' % spec['hdf5'].prefix)
 

--- a/var/spack/repos/builtin/packages/adios/python.patch
+++ b/var/spack/repos/builtin/packages/adios/python.patch
@@ -1,0 +1,10 @@
+diff --git a/utils/gpp/gpp.py.in b/utils/gpp/gpp.py.in
+index cbb0d88..6977a55 100755
+--- a/utils/gpp/gpp.py.in
++++ b/utils/gpp/gpp.py.in
+@@ -1,4 +1,4 @@
+-#!@PYTHON_EXECUTABLE@
++#!/usr/bin/env python
+ 
+ import sys
+ import os


### PR DESCRIPTION
Add a zfp variant and a patch that resets the interpreter for gpp.py.

The patch is required because otherwise the interpreter is longer than some magic limit and causes "bad interpreter" errors when trying to run `gpp.py`.