### PR TITLE
fix build of int64 PETSc and Trilinos in the deal.II DAG

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -68,6 +68,8 @@ class Dealii(CMakePackage):
             description='Compile with Python bindings')
     variant('int64',    default=False,
             description='Compile with 64 bit indices support')
+    variant('optflags', default=False,
+            description='Compile using additional optimization flags')
 
     # required dependencies, light version
     depends_on("blas")
@@ -75,6 +77,11 @@ class Dealii(CMakePackage):
     # https://github.com/dealii/dealii/issues/1591
     # Require at least 1.59
     # +python won't affect @:8.4.2
+    # FIXME: once concretizer can unite unconditional and
+    # conditional dependencies, simplify to:
+    # depends_on("boost@1.59.0+thread+system+serialization+iostreams")
+    # depends_on("boost+mpi", when='+mpi')
+    # depends_on("boost+python", when='+python')
     depends_on("boost@1.59.0:+thread+system+serialization+iostreams",
                when='@:8.4.2~mpi')
     depends_on("boost@1.59.0:+thread+system+serialization+iostreams+mpi",
@@ -103,17 +110,23 @@ class Dealii(CMakePackage):
     depends_on("graphviz",         when='+doc')
     depends_on("gsl",              when='@8.5.0:+gsl')
     depends_on("hdf5+mpi",         when='+hdf5+mpi')
-    depends_on("metis@5:",         when='+metis')
+    # FIXME: concretizer bug. The two lines mimic what comes from PETSc
+    # but we should not need it
+    depends_on("metis@5:+int64",   when='+metis+int64')
+    depends_on("metis@5:~int64",   when='+metis~int64')
     depends_on("netcdf+mpi",       when="+netcdf+mpi")
     depends_on("netcdf-cxx",       when='+netcdf+mpi')
     depends_on("oce",              when='+oce')
     depends_on("p4est",            when='+p4est+mpi')
-    depends_on("petsc+mpi",        when='@8.4.2:+petsc+mpi~int64')
+    depends_on("petsc+mpi~int64",  when='+petsc+mpi~int64')
+    depends_on("petsc+mpi+int64",  when='+petsc+mpi+int64')
+    depends_on("petsc@:3.6.4",     when='@:8.4.1+petsc+mpi')
     depends_on('python',           when='@8.5.0:+python')
-    depends_on("slepc",            when='@8.4.2:+slepc+petsc+mpi~int64')
-    depends_on("petsc@:3.6.4+mpi", when='@:8.4.1+petsc+mpi~int64')
-    depends_on("slepc@:3.6.3",     when='@:8.4.1+slepc+petsc+mpi~int64')
-    depends_on("trilinos",         when='+trilinos+mpi')
+    depends_on("slepc",            when='+slepc+petsc+mpi')
+    depends_on("slepc@:3.6.3",     when='@:8.4.1+slepc+petsc+mpi')
+    depends_on("slepc~arpack",     when='+slepc+petsc+mpi+int64')
+    depends_on("trilinos",         when='+trilinos+mpi~int64')
+    depends_on("trilinos~hypre",   when="+trilinos+mpi+int64")
 
     # check that the combination of variants makes sense
     def variants_check(self):
@@ -130,6 +143,7 @@ class Dealii(CMakePackage):
         self.variants_check()
         spec = self.spec
         options = []
+        cxx_flags = []
 
         lapack_blas = spec['lapack'].lapack_libs + spec['blas'].blas_libs
         options.extend([
@@ -150,6 +164,16 @@ class Dealii(CMakePackage):
             '-DZLIB_DIR=%s' % spec['zlib'].prefix
         ])
 
+        # Set recommended flags for maximum (matrix-free) performance, see
+        # https://groups.google.com/forum/?fromgroups#!topic/dealii/3Yjy8CBIrgU
+        if spec.satisfies('%gcc'):
+            cxx_flags.extend(['-O3', '-march=native'])
+        elif spec.satisfies('%intel'):
+            cxx_flags.extend(['-O3', '-march=native'])
+        elif spec.satisfies('%clang'):
+            cxx_flags.extend(['-O3', '-march=native', '-ffp-contract=fast'])
+
+        # Python bindings
         if spec.satisfies('@8.5.0:'):
             options.extend([
                 '-DDEAL_II_COMPONENT_PYTHON_BINDINGS=%s' %
@@ -254,6 +278,12 @@ class Dealii(CMakePackage):
         options.extend([
             '-DDEAL_II_WITH_64BIT_INDICES=%s' % ('+int64' in spec)
         ])
+
+        # collect CXX flags:
+        if len(cxx_flags) > 0 and '+optflags' in spec:
+            options.extend([
+                '-DCMAKE_CXX_FLAGS_RELEASE:STRING=%s' % (' '.join(cxx_flags))
+            ])
 
         return options
 

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -45,12 +45,15 @@ class Slepc(Package):
     depends_on('python@2.6:2.7', type='build')
     depends_on('petsc@3.7:', when='@3.7.1:')
     depends_on('petsc@3.6.3:3.6.4', when='@3.6.2:3.6.3')
-    depends_on('arpack-ng~mpi', when='+arpack^petsc~mpi')
-    depends_on('arpack-ng+mpi', when='+arpack^petsc+mpi')
+    depends_on('arpack-ng~mpi', when='+arpack^petsc~mpi~int64')
+    depends_on('arpack-ng+mpi', when='+arpack^petsc+mpi~int64')
 
     patch('install_name_371.patch', when='@3.7.1')
 
     def install(self, spec, prefix):
+        if spec.satisfies('+arpack^petsc+int64'):
+            raise RuntimeError('Arpack can not be used with 64bit integers.')
+
         # set SLEPC_DIR for installation
         # Note that one should set the current (temporary) directory instead
         # its symlink in spack/stage/ !

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -116,7 +116,8 @@ class Trilinos(CMakePackage):
     depends_on('superlu-dist@:4.3', when='@:12.6.1+superlu-dist')
     depends_on('superlu-dist', when='@12.6.2:+superlu-dist')
     depends_on('superlu+fpic@4.3', when='+superlu')
-    depends_on('hypre~internal-superlu', when='+hypre')
+    # Trilinos can not be built against 64bit int hypre
+    depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hdf5+mpi', when='+hdf5')
     depends_on('python', when='+python')
     depends_on('py-numpy', when='+python')


### PR DESCRIPTION
@Rombur ping.

test compilation of
- [x] `spack install dealii@develop~int64` on Ubuntu16+gcc5.4
- [x] `spack install dealii@develop+int64` on Ubuntu16+gcc5.4. ~~**FAILS** due to Trilinos. Will investigate...~~ (fixed).
- [x] `spack install dealii@develop~int64` on macOS + Clang8