### PR TITLE
Fixing graphviz issue when calling spec

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -90,6 +90,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('python@2:2.8', when='+python')
 
     def configure_args(self):
+        spec = self.spec
         options = []
 
         # These language bindings have been tested, we know they work.


### PR DESCRIPTION
Currently `graphviz` fails after #1089 because `spec` is not declared:

```
==> Error: NameError: global name 'spec' is not defined
/my/path/spack/var/spack/repos/builtin/packages/graphviz/package.py:106, in configure_args:
     92       def configure_args(self):
     93           options = []
     94   
     95           # These language bindings have been tested, we know they work.
     96           tested_bindings = ('+java', '+perl')
     97   
     98           # These language bindings have not yet been tested.  They
     99           # likely need additional dependencies to get working.
     100          untested_bindings = (
     101              '+swig', '+sharp', '+go', '+guile', '+io',
     102              '+lua', '+ocaml', '+php',
     103              '+python', '+r', '+ruby', '+tcl')
     104  
     105          for var in untested_bindings:
  >> 106              if var in spec:
     107                  raise SpackException(
```