### PR TITLE
Allow for extensions on a per filesystem view basis

### DIFF
--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -26,6 +26,7 @@
 
 import os
 import shutil
+import filecmp
 from llnl.util.filesystem import *
 
 __all__ = ['LinkTree']
@@ -62,10 +63,16 @@ class LinkTree(object):
                 return dest
         return None
 
-    def merge(self, dest_root, **kwargs):
+    def merge(self, dest_root, link=os.symlink, **kwargs):
         """Link all files in src into dest, creating directories
-           if necessary."""
+           if necessary.
+           If ignore_conflicts is True, do not break when the target exists but
+           rather return a list of files that could not be linked.
+           Note that files blocking directories will still cause an error.
+        """
         kwargs['order'] = 'pre'
+        ignore_conflicts = kwargs.get("ignore_conflicts", False)
+        existing = []
         for src, dest in traverse_tree(self._root, dest_root, **kwargs):
             if os.path.isdir(src):
                 if not os.path.exists(dest):
@@ -81,8 +88,15 @@ class LinkTree(object):
                     touch(marker)
 
             else:
-                assert(not os.path.exists(dest))
-                os.symlink(src, dest)
+                if os.path.exists(dest):
+                    if ignore_conflicts:
+                        existing.append(src)
+                    else:
+                        raise AssertionError("File already exists: %s" % dest)
+                else:
+                    link(src, dest)
+        if ignore_conflicts:
+            return existing
 
     def unmerge(self, dest_root, **kwargs):
         """Unlink all files in dest that exist in src.
@@ -112,4 +126,8 @@ class LinkTree(object):
             elif os.path.exists(dest):
                 if not os.path.islink(dest):
                     raise ValueError("%s is not a link tree!" % dest)
-                os.remove(dest)
+                # remove if dest is a hardlink/symlink to src; this will only
+                # be false if two packages are merged into a prefix and have a
+                # conflicting file
+                if filecmp.cmp(src, dest, shallow=True):
+                    os.remove(dest)

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -50,7 +50,7 @@ def activate(parser, args):
     if not spec.package.is_extension:
         tty.die("%s is not an extension." % spec.name)
 
-    if spec.package.activated:
+    if spec.package.is_activated():
         tty.die("Package %s is already activated." % specs[0].short_spec)
 
     spec.package.do_activate()

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -59,15 +59,15 @@ def deactivate(parser, args):
     if args.all:
         if pkg.extendable:
             tty.msg("Deactivating all extensions of %s" % pkg.spec.short_spec)
-            ext_pkgs = spack.store.db.installed_extensions_for(spec)
+            ext_pkgs = spack.store.db.activated_extensions_for(spec)
 
             for ext_pkg in ext_pkgs:
                 ext_pkg.spec.normalize()
-                if ext_pkg.activated:
+                if ext_pkg.is_activated():
                     ext_pkg.do_deactivate(force=True)
 
         elif pkg.is_extension:
-            if not args.force and not spec.package.activated:
+            if not args.force and not spec.package.is_activated():
                 tty.die("%s is not activated." % pkg.spec.short_spec)
 
             tty.msg("Deactivating %s and all dependencies." %
@@ -80,7 +80,7 @@ def deactivate(parser, args):
                 espec = index[name]
                 epkg = espec.package
                 if epkg.extends(pkg.extendee_spec):
-                    if epkg.activated or args.force:
+                    if epkg.is_activated() or args.force:
 
                         epkg.do_deactivate(force=args.force)
 
@@ -94,7 +94,7 @@ def deactivate(parser, args):
             tty.die("spack deactivate requires an extension.",
                     "Did you mean 'spack deactivate --all'?")
 
-        if not args.force and not spec.package.activated:
+        if not args.force and not spec.package.is_activated():
             tty.die("Package %s is not activated." % specs[0].short_spec)
 
         spec.package.do_deactivate(force=args.force)

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -90,7 +90,7 @@ def extensions(parser, args):
     # List specs of installed extensions.
     #
     installed = [s.spec
-                 for s in spack.store.db.installed_extensions_for(spec)]
+                 for s in spack.store.db.activated_extensions_for(spec)]
 
     print
     if not installed:
@@ -100,9 +100,9 @@ def extensions(parser, args):
     spack.cmd.find.display_specs(installed, mode=args.mode)
 
     #
-    # List specs of activated extensions.
+    # List specs of (globally) activated extensions.
     #
-    activated = spack.store.layout.extension_map(spec)
+    activated = spack.store.extensions.extension_map(spec)
     print
     if not activated:
         tty.msg("None activated.")

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -29,7 +29,7 @@ Spack-installed package file hierarchies.  The union is formed from:
 
 - specs resolved from the package names given by the user (the seeds)
 
-- all depenencies of the seeds unless user specifies `--no-depenencies`
+- all dependencies of the seeds unless user specifies `--no-dependencies`
 
 - less any specs with names matching the regular expressions given by
   `--exclude`
@@ -48,30 +48,52 @@ The `view` can be built and tore down via a number of methods (the "actions"):
 The file system view concept is imspired by Nix, implemented by
 brett.viren@gmail.com ca 2016.
 
+All operations on views are performed via proxy objects such as
+YamlFilesystemView.
+
 '''
-# Implementation notes:
-#
-# This is implemented as a visitor pattern on the set of package specs.
-#
-# The command line ACTION maps to a visitor_*() function which takes
-# the set of package specs and any args which may be specific to the
-# ACTION.
-#
-# To add a new view:
-# 1. add a new cmd line args sub parser ACTION
-# 2. add any action-specific options/arguments, most likely a list of specs.
-# 3. add a visitor_MYACTION() function
-# 4. add any visitor_MYALIAS assignments to match any command line aliases
 
 import os
-import re
 import spack
 import spack.cmd
+import spack.store
+from spack.filesystem_view import YamlFilesystemView
 import llnl.util.tty as tty
 
 description = "produce a single-rooted directory view of packages"
 section = "environment"
 level = "short"
+
+actions_link = ["symlink", "add", "soft", "hardlink", "hard"]
+actions_remove = ["remove", "rm"]
+actions_status = ["statlink", "status", "check"]
+
+
+def relaxed_disambiguate(specs, view):
+    """
+        When dealing with querying actions (remove/status) the name of the spec
+        is sufficient even though more versions of that name might be in the
+        database.
+    """
+    name_to_spec = dict((s.name, s) for s in view.get_all_specs())
+
+    def squash(matching_specs):
+        if not matching_specs:
+            tty.die("Spec '%s' matches no installed packages." % spec)
+
+        elif len(matching_specs) == 1:
+            return matching_specs[0]
+
+        elif matching_specs[0].name in name_to_spec:
+            return name_to_spec[matching_specs[0].name]
+
+        else:
+            # we just return the first matching spec, the error about the
+            # missing spec will be printed later on
+            return matching_specs[0]
+
+    # make function always return a list to keep consistency between py2/3
+    return list(map(squash, map(spack.store.db.query, specs)))
 
 
 def setup_parser(sp):
@@ -79,227 +101,134 @@ def setup_parser(sp):
 
     sp.add_argument(
         '-v', '--verbose', action='store_true', default=False,
-        help="display verbose output")
+        help="If not verbose only warnings/errors will be printed.")
     sp.add_argument(
         '-e', '--exclude', action='append', default=[],
         help="exclude packages with names matching the given regex pattern")
     sp.add_argument(
         '-d', '--dependencies', choices=['true', 'false', 'yes', 'no'],
         default='true',
-        help="follow dependencies")
+        help="Link/remove/list dependencies.")
 
     ssp = sp.add_subparsers(metavar='ACTION', dest='action')
 
-    specs_opts = dict(metavar='spec', nargs='+',
+    specs_opts = dict(metavar='spec', action='store',
                       help="seed specs of the packages to view")
 
     # The action parameterizes the command but in keeping with Spack
     # patterns we make it a subcommand.
-    file_system_view_actions = [
-        ssp.add_parser(
+    file_system_view_actions = {
+        "symlink": ssp.add_parser(
             'symlink', aliases=['add', 'soft'],
             help='add package files to a filesystem view via symbolic links'),
-        ssp.add_parser(
+        "hardlink": ssp.add_parser(
             'hardlink', aliases=['hard'],
             help='add packages files to a filesystem via via hard links'),
-        ssp.add_parser(
+        "remove": ssp.add_parser(
             'remove', aliases=['rm'],
             help='remove packages from a filesystem view'),
-        ssp.add_parser(
+        "statlink": ssp.add_parser(
             'statlink', aliases=['status', 'check'],
             help='check status of packages in a filesystem view')
-    ]
+    }
+
     # All these options and arguments are common to every action.
-    for act in file_system_view_actions:
+    for cmd, act in file_system_view_actions.items():
         act.add_argument('path', nargs=1,
                          help="path to file system view directory")
-        act.add_argument('specs', **specs_opts)
+
+        if cmd == "remove":
+            grp = act.add_mutually_exclusive_group(required=True)
+            act.add_argument(
+                '--no-remove-dependents', action="store_true",
+                help="Do not remove dependents of specified specs.")
+
+            # with all option, spec is an optional argument
+            so = specs_opts.copy()
+            so["nargs"] = "*"
+            so["default"] = []
+            grp.add_argument('specs', **so)
+            grp.add_argument("-a", "--all", action='store_true',
+                             help="act on all specs in view")
+
+        elif cmd == "statlink":
+            so = specs_opts.copy()
+            so["nargs"] = "*"
+            act.add_argument('specs', **so)
+
+        else:
+            # without all option, spec is required
+            so = specs_opts.copy()
+            so["nargs"] = "+"
+            act.add_argument('specs', **so)
+
+    for cmd in ["symlink", "hardlink"]:
+        act = file_system_view_actions[cmd]
+        act.add_argument("-i", "--ignore-conflicts", action='store_true')
 
     return
-
-
-def assuredir(path):
-    'Assure path exists as a directory'
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-
-def relative_to(prefix, path):
-    'Return end of `path` relative to `prefix`'
-    assert 0 == path.find(prefix)
-    reldir = path[len(prefix):]
-    if reldir.startswith('/'):
-        reldir = reldir[1:]
-    return reldir
-
-
-def transform_path(spec, path, prefix=None):
-    'Return the a relative path corresponding to given path spec.prefix'
-    if os.path.isabs(path):
-        path = relative_to(spec.prefix, path)
-    subdirs = path.split(os.path.sep)
-    if subdirs[0] == '.spack':
-        lst = ['.spack', spec.name] + subdirs[1:]
-        path = os.path.join(*lst)
-    if prefix:
-        path = os.path.join(prefix, path)
-    return path
-
-
-def purge_empty_directories(path):
-    '''Ascend up from the leaves accessible from `path`
-    and remove empty directories.'''
-    for dirpath, subdirs, files in os.walk(path, topdown=False):
-        for sd in subdirs:
-            sdp = os.path.join(dirpath, sd)
-            try:
-                os.rmdir(sdp)
-            except OSError:
-                pass
-
-
-def filter_exclude(specs, exclude):
-    'Filter specs given sequence of exclude regex'
-    to_exclude = [re.compile(e) for e in exclude]
-
-    def exclude(spec):
-        for e in to_exclude:
-            if e.match(spec.name):
-                return True
-        return False
-    return [s for s in specs if not exclude(s)]
-
-
-def flatten(seeds, descend=True):
-    'Normalize and flattend seed specs and descend hiearchy'
-    flat = set()
-    for spec in seeds:
-        if not descend:
-            flat.add(spec)
-            continue
-        flat.update(spec.normalized().traverse())
-    return flat
-
-
-def check_one(spec, path, verbose=False):
-    'Check status of view in path against spec'
-    dotspack = os.path.join(path, '.spack', spec.name)
-    if os.path.exists(os.path.join(dotspack)):
-        tty.info('Package in view: "%s"' % spec.name)
-        return
-    tty.info('Package not in view: "%s"' % spec.name)
-    return
-
-
-def remove_one(spec, path, verbose=False):
-    'Remove any files found in `spec` from `path` and purge empty directories.'
-
-    if not os.path.exists(path):
-        return                  # done, short circuit
-
-    dotspack = transform_path(spec, '.spack', path)
-    if not os.path.exists(dotspack):
-        if verbose:
-            tty.info('Skipping nonexistent package: "%s"' % spec.name)
-        return
-
-    if verbose:
-        tty.info('Removing package: "%s"' % spec.name)
-    for dirpath, dirnames, filenames in os.walk(spec.prefix):
-        if not filenames:
-            continue
-        targdir = transform_path(spec, dirpath, path)
-        for fname in filenames:
-            dst = os.path.join(targdir, fname)
-            if not os.path.exists(dst):
-                continue
-            os.unlink(dst)
-
-
-def link_one(spec, path, link=os.symlink, verbose=False):
-    'Link all files in `spec` into directory `path`.'
-
-    dotspack = transform_path(spec, '.spack', path)
-    if os.path.exists(dotspack):
-        tty.warn('Skipping existing package: "%s"' % spec.name)
-        return
-
-    if verbose:
-        tty.info('Linking package: "%s"' % spec.name)
-    for dirpath, dirnames, filenames in os.walk(spec.prefix):
-        if not filenames:
-            continue        # avoid explicitly making empty dirs
-
-        targdir = transform_path(spec, dirpath, path)
-        assuredir(targdir)
-
-        for fname in filenames:
-            src = os.path.join(dirpath, fname)
-            dst = os.path.join(targdir, fname)
-            if os.path.exists(dst):
-                if '.spack' in dst.split(os.path.sep):
-                    continue    # silence these
-                tty.warn("Skipping existing file: %s" % dst)
-                continue
-            link(src, dst)
-
-
-def visitor_symlink(specs, args):
-    'Symlink all files found in specs'
-    path = args.path[0]
-    assuredir(path)
-    for spec in specs:
-        link_one(spec, path, verbose=args.verbose)
-
-
-visitor_add = visitor_symlink
-visitor_soft = visitor_symlink
-
-
-def visitor_hardlink(specs, args):
-    'Hardlink all files found in specs'
-    path = args.path[0]
-    assuredir(path)
-    for spec in specs:
-        link_one(spec, path, os.link, verbose=args.verbose)
-
-
-visitor_hard = visitor_hardlink
-
-
-def visitor_remove(specs, args):
-    'Remove all files and directories found in specs from args.path'
-    path = args.path[0]
-    for spec in specs:
-        remove_one(spec, path, verbose=args.verbose)
-    purge_empty_directories(path)
-
-
-visitor_rm = visitor_remove
-
-
-def visitor_statlink(specs, args):
-    'Give status of view in args.path relative to specs'
-    path = args.path[0]
-    for spec in specs:
-        check_one(spec, path, verbose=args.verbose)
-
-
-visitor_status = visitor_statlink
-visitor_check = visitor_statlink
 
 
 def view(parser, args):
     'Produce a view of a set of packages.'
 
-    # Process common args
-    seeds = [spack.cmd.disambiguate_spec(s) for s in args.specs]
-    specs = flatten(seeds, args.dependencies.lower() in ['yes', 'true'])
-    specs = filter_exclude(specs, args.exclude)
+    path = args.path[0]
 
-    # Execute the visitation.
-    try:
-        visitor = globals()['visitor_' + args.action]
-    except KeyError:
+    view = YamlFilesystemView(
+        path, spack.store.layout,
+        ignore_conflicts=getattr(args, "ignore_conflicts", False),
+        link=os.hardlink if args.action in ["hardlink", "hard"]
+        else os.symlink,
+        verbose=args.verbose)
+
+    # Process common args and specs
+    if getattr(args, "all", False):
+        specs = view.get_all_specs()
+        if len(specs) == 0:
+            tty.warn("Found no specs in %s" % path)
+
+    elif args.action in actions_link:
+        # only link commands need to disambiguate specs
+        specs = [spack.cmd.disambiguate_spec(s) for s in args.specs]
+
+    elif args.action in actions_status:
+        # no specs implies all
+        if len(args.specs) == 0:
+            specs = view.get_all_specs()
+        else:
+            specs = relaxed_disambiguate(args.specs, view)
+
+    else:
+        # status and remove can map the name to packages in view
+        specs = relaxed_disambiguate(args.specs, view)
+
+    activated = filter(lambda s: s.package.is_extension and
+                       s.package.is_activated(), specs)
+
+    if len(activated) > 0:
+        tty.error("Globally activated extensions cannot be used in "
+                  "conjunction with filesystem views. "
+                  "Please deactivate the following specs: ")
+        spack.cmd.display_specs(activated, flags=True, variants=True,
+                                long=args.verbose)
+        return
+
+    with_dependencies = args.dependencies.lower() in ['true', 'yes']
+
+    # Map action to corresponding functionality
+    if args.action in actions_link:
+        view.add_specs(*specs,
+                       with_dependencies=with_dependencies,
+                       exclude=args.exclude)
+
+    elif args.action in actions_remove:
+        view.remove_specs(*specs,
+                          with_dependencies=with_dependencies,
+                          exclude=args.exclude,
+                          with_dependents=not args.no_remove_dependents)
+
+    elif args.action in actions_status:
+        view.print_status(*specs, with_dependencies=with_dependencies)
+
+    else:
         tty.error('Unknown action: "%s"' % args.action)
-    visitor(specs, args)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -720,14 +720,16 @@ class Database(object):
         return dependents
 
     @_autospec
-    def installed_extensions_for(self, extendee_spec):
+    def activated_extensions_for(self, extendee_spec, extensions_layout=None):
         """
         Return the specs of all packages that extend
         the given spec
         """
+        if extensions_layout is None:
+            extensions_layout = spack.store.extensions
         for spec in self.query():
             try:
-                spack.store.layout.check_activated(extendee_spec, spec)
+                extensions_layout.check_activated(extendee_spec, spec)
                 yield spec.package
             except spack.directory_layout.NoSuchExtensionError:
                 continue

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -88,37 +88,6 @@ class DirectoryLayout(object):
         """
         raise NotImplementedError()
 
-    def extension_map(self, spec):
-        """Get a dict of currently installed extension packages for a spec.
-
-           Dict maps { name : extension_spec }
-           Modifying dict does not affect internals of this layout.
-        """
-        raise NotImplementedError()
-
-    def check_extension_conflict(self, spec, ext_spec):
-        """Ensure that ext_spec can be activated in spec.
-
-           If not, raise ExtensionAlreadyInstalledError or
-           ExtensionConflictError.
-        """
-        raise NotImplementedError()
-
-    def check_activated(self, spec, ext_spec):
-        """Ensure that ext_spec can be removed from spec.
-
-           If not, raise NoSuchExtensionError.
-        """
-        raise NotImplementedError()
-
-    def add_extension(self, spec, ext_spec):
-        """Add to the list of currently installed extensions."""
-        raise NotImplementedError()
-
-    def remove_extension(self, spec, ext_spec):
-        """Remove from the list of currently installed extensions."""
-        raise NotImplementedError()
-
     def path_for_spec(self, spec):
         """Return absolute path from the root to a directory for the spec."""
         _check_concrete(spec)
@@ -147,6 +116,55 @@ class DirectoryLayout(object):
                     return
                 os.rmdir(path)
             path = os.path.dirname(path)
+
+
+class ExtensionsLayout(object):
+    """A directory layout is used to associate unique paths with specs for
+       package extensions.
+       Keeps track of which extensions are activated for what package.
+       Depending on the use case, this can mean globally activated extensions
+       directly in the installation folder - or extensions activated in
+       filesystem views.
+    """
+    def __init__(self, root, **kwargs):
+        self.root = root
+        self.link = kwargs.get("link", os.symlink)
+
+    def add_extension(self, spec, ext_spec):
+        """Add to the list of currently installed extensions."""
+        raise NotImplementedError()
+
+    def check_activated(self, spec, ext_spec):
+        """Ensure that ext_spec can be removed from spec.
+
+           If not, raise NoSuchExtensionError.
+        """
+        raise NotImplementedError()
+
+    def check_extension_conflict(self, spec, ext_spec):
+        """Ensure that ext_spec can be activated in spec.
+
+           If not, raise ExtensionAlreadyInstalledError or
+           ExtensionConflictError.
+        """
+        raise NotImplementedError()
+
+    def extension_map(self, spec):
+        """Get a dict of currently installed extension packages for a spec.
+
+           Dict maps { name : extension_spec }
+           Modifying dict does not affect internals of this layout.
+        """
+        raise NotImplementedError()
+
+    def extendee_target_directory(self, extendee):
+        """Specify to which full path extendee should link all files
+        from extensions."""
+        raise NotImplementedError
+
+    def remove_extension(self, spec, ext_spec):
+        """Remove from the list of currently installed extensions."""
+        raise NotImplementedError()
 
 
 class YamlDirectoryLayout(DirectoryLayout):
@@ -181,9 +199,6 @@ class YamlDirectoryLayout(DirectoryLayout):
         self.build_log_name      = 'build.out'  # build log.
         self.build_env_name      = 'build.env'  # build environment
         self.packages_dir        = 'repos'      # archive of package.py files
-
-        # Cache of already written/read extension maps.
-        self._extension_maps = {}
 
     @property
     def hidden_file_paths(self):
@@ -295,31 +310,72 @@ class YamlDirectoryLayout(DirectoryLayout):
             by_hash[spec.dag_hash()] = spec
         return by_hash
 
+
+class YamlExtensionsLayout(ExtensionsLayout):
+    """Implements globally activated extensions within a YamlDirectoryLayout.
+    """
+    def __init__(self, root, layout):
+        """layout is the corresponding YamlDirectoryLayout object for which
+           we implement extensions.
+        """
+        super(YamlExtensionsLayout, self).__init__(root)
+        self.layout = layout
+        self.extension_file_name = 'extensions.yaml'
+
+        # Cache of already written/read extension maps.
+        self._extension_maps = {}
+
+    def add_extension(self, spec, ext_spec):
+        _check_concrete(spec)
+        _check_concrete(ext_spec)
+
+        # Check whether it's already installed or if it's a conflict.
+        exts = self._extension_map(spec)
+        self.check_extension_conflict(spec, ext_spec)
+
+        # do the actual adding.
+        exts[ext_spec.name] = ext_spec
+        self._write_extensions(spec, exts)
+
+    def check_extension_conflict(self, spec, ext_spec):
+        exts = self._extension_map(spec)
+        if ext_spec.name in exts:
+            installed_spec = exts[ext_spec.name]
+            if ext_spec == installed_spec:
+                raise ExtensionAlreadyInstalledError(spec, ext_spec)
+            else:
+                raise ExtensionConflictError(spec, ext_spec, installed_spec)
+
+    def check_activated(self, spec, ext_spec):
+        exts = self._extension_map(spec)
+        if (ext_spec.name not in exts) or (ext_spec != exts[ext_spec.name]):
+            raise NoSuchExtensionError(spec, ext_spec)
+
     def extension_file_path(self, spec):
         """Gets full path to an installed package's extension file"""
         _check_concrete(spec)
-        return join_path(self.metadata_path(spec), self.extension_file_name)
+        return join_path(self.layout.metadata_path(spec),
+                         self.extension_file_name)
 
-    def _write_extensions(self, spec, extensions):
-        path = self.extension_file_path(spec)
+    def extension_map(self, spec):
+        """Defensive copying version of _extension_map() for external API."""
+        _check_concrete(spec)
+        return self._extension_map(spec).copy()
 
-        # Create a temp file in the same directory as the actual file.
-        dirname, basename = os.path.split(path)
-        tmp = tempfile.NamedTemporaryFile(
-            prefix=basename, dir=dirname, delete=False)
+    def extendee_target_directory(self, extendee):
+        return extendee.prefix
 
-        # write tmp file
-        with tmp:
-            yaml.dump({
-                'extensions': [
-                    {ext.name: {
-                        'hash': ext.dag_hash(),
-                        'path': str(ext.prefix)
-                    }} for ext in sorted(extensions.values())]
-            }, tmp, default_flow_style=False)
+    def remove_extension(self, spec, ext_spec):
+        _check_concrete(spec)
+        _check_concrete(ext_spec)
 
-        # Atomic update by moving tmpfile on top of old one.
-        os.rename(tmp.name, path)
+        # Make sure it's installed before removing.
+        exts = self._extension_map(spec)
+        self.check_activated(spec, ext_spec)
+
+        # do the actual removing.
+        del exts[ext_spec.name]
+        self._write_extensions(spec, exts)
 
     def _extension_map(self, spec):
         """Get a dict<name -> spec> for all extensions currently
@@ -332,7 +388,7 @@ class YamlDirectoryLayout(DirectoryLayout):
                 self._extension_maps[spec] = {}
 
             else:
-                by_hash = self.specs_by_hash()
+                by_hash = self.layout.specs_by_hash()
                 exts = {}
                 with open(path) as ext_file:
                     yaml_file = yaml.load(ext_file)
@@ -356,48 +412,43 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         return self._extension_maps[spec]
 
-    def extension_map(self, spec):
-        """Defensive copying version of _extension_map() for external API."""
+    def _write_extensions(self, spec, extensions):
+        path = self.extension_file_path(spec)
+
+        # Create a temp file in the same directory as the actual file.
+        dirname, basename = os.path.split(path)
+        tmp = tempfile.NamedTemporaryFile(
+            prefix=basename, dir=dirname, delete=False)
+
+        # write tmp file
+        with tmp:
+            yaml.dump({
+                'extensions': [
+                    {ext.name: {
+                        'hash': ext.dag_hash(),
+                        'path': str(ext.prefix)
+                    }} for ext in sorted(extensions.values())]
+            }, tmp, default_flow_style=False)
+
+        # Atomic update by moving tmpfile on top of old one.
+        os.rename(tmp.name, path)
+
+
+class YamlViewExtensionsLayout(YamlExtensionsLayout):
+    """Governs the directory layout present when creating filesystem views in a
+    certain root folder.
+
+    Meant to replace YamlDirectoryLayout when working with filesystem views.
+    """
+
+    def extension_file_path(self, spec):
+        """Gets the full path to an installed package's extension file."""
         _check_concrete(spec)
-        return self._extension_map(spec).copy()
+        return join_path(self.root, self.layout.metadata_dir, spec.name,
+                         self.extension_file_name)
 
-    def check_extension_conflict(self, spec, ext_spec):
-        exts = self._extension_map(spec)
-        if ext_spec.name in exts:
-            installed_spec = exts[ext_spec.name]
-            if ext_spec == installed_spec:
-                raise ExtensionAlreadyInstalledError(spec, ext_spec)
-            else:
-                raise ExtensionConflictError(spec, ext_spec, installed_spec)
-
-    def check_activated(self, spec, ext_spec):
-        exts = self._extension_map(spec)
-        if (ext_spec.name not in exts) or (ext_spec != exts[ext_spec.name]):
-            raise NoSuchExtensionError(spec, ext_spec)
-
-    def add_extension(self, spec, ext_spec):
-        _check_concrete(spec)
-        _check_concrete(ext_spec)
-
-        # Check whether it's already installed or if it's a conflict.
-        exts = self._extension_map(spec)
-        self.check_extension_conflict(spec, ext_spec)
-
-        # do the actual adding.
-        exts[ext_spec.name] = ext_spec
-        self._write_extensions(spec, exts)
-
-    def remove_extension(self, spec, ext_spec):
-        _check_concrete(spec)
-        _check_concrete(ext_spec)
-
-        # Make sure it's installed before removing.
-        exts = self._extension_map(spec)
-        self.check_activated(spec, ext_spec)
-
-        # do the actual removing.
-        del exts[ext_spec.name]
-        self._write_extensions(spec, exts)
+    def extendee_target_directory(self, extendee):
+        return self.root
 
 
 class DirectoryLayoutError(SpackError):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -1,0 +1,524 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import functools as ft
+import os
+import re
+import shutil
+import sys
+
+from llnl.util.filesystem import join_path
+from llnl.util.link_tree import LinkTree
+from llnl.util import tty
+
+import spack
+import spack.spec
+import spack.store
+from spack.directory_layout import ExtensionAlreadyInstalledError
+from spack.directory_layout import YamlViewExtensionsLayout
+
+# compatability
+if sys.version_info < (3, 0):
+    from itertools import imap as map
+    from itertools import ifilter as filter
+    from itertools import izip as zip
+
+__all__ = ["FilesystemView", "YamlFilesystemView"]
+
+
+class FilesystemView(object):
+    """
+        Governs a filesystem view that is located at certain root-directory.
+
+        Packages are linked from their install directories into a common file
+        hierachy.
+
+        In distributed filesystems, loading each installed package seperately
+        can lead to slow-downs due to too many directories being traversed.
+        This can be circumvented by loading all needed modules into a common
+        directory structure.
+    """
+
+    def __init__(self, root, layout, **kwargs):
+        """
+            Initialize a filesystem view under the given `root` directory with
+            corresponding directory `layout`.
+
+            Files are linked by method `link` (os.symlink by default).
+        """
+        self.root = root
+        self.layout = layout
+
+        self.ignore_conflicts = kwargs.get("ignore_conflicts", False)
+        self.link = kwargs.get("link", os.symlink)
+        self.verbose = kwargs.get("verbose", False)
+
+    def add_specs(self, *specs, **kwargs):
+        """
+            Add given specs to view.
+
+            The supplied specs might be standalone packages or extensions of
+            other packages.
+
+            Should accept `with_dependencies` as keyword argument (default
+            True) to indicate wether or not dependencies should be activated as
+            well.
+
+            Should except an `exclude` keyword argument containing a list of
+            regexps that filter out matching spec names.
+
+            This method should make use of `activate_{extension,standalone}`.
+        """
+        raise NotImplementedError
+
+    def add_extension(self, spec):
+        """
+            Add (link) an extension in this view.
+        """
+        raise NotImplementedError
+
+    def add_standalone(self, spec):
+        """
+            Add (link) a standalone package into this view.
+        """
+        raise NotImplementedError
+
+    def check_added(self, spec):
+        """
+            Check if the given concrete spec is active in this view.
+        """
+        raise NotImplementedError
+
+    def remove_specs(self, *specs, **kwargs):
+        """
+            Removes given specs from view.
+
+            The supplied spec might be a standalone package or an extension of
+            another package.
+
+            Should accept `with_dependencies` as keyword argument (default
+            True) to indicate wether or not dependencies should be deactivated
+            as well.
+
+            Should accept `with_dependents` as keyword argument (default True)
+            to indicate wether or not dependents on the deactivated specs
+            should be removed as well.
+
+            Should except an `exclude` keyword argument containing a list of
+            regexps that filter out matching spec names.
+
+            This method should make use of `deactivate_{extension,standalone}`.
+        """
+        raise NotImplementedError
+
+    def remove_extension(self, spec):
+        """
+            Remove (unlink) an extension from this view.
+        """
+        raise NotImplementedError
+
+    def remove_standalone(self, spec):
+        """
+            Remove (unlink) a standalone package from this view.
+        """
+        raise NotImplementedError
+
+    def get_all_specs(self):
+        """
+            Get all specs currently active in this view.
+        """
+        raise NotImplementedError
+
+    def get_spec(self, spec):
+        """
+            Return the actual spec linked in this view (i.e. do not look it up
+            in the database by name).
+
+            `spec` can be a name or a spec from which the name is extracted.
+
+            As there can only be a single version active for any spec the name
+            is enough to identify the spec in the view.
+
+            If no spec is present, returns None.
+        """
+        raise NotImplementedError
+
+    def print_status(self, *specs, **kwargs):
+        """
+            Print a short summary about the given specs, detailing whether..
+                * ..they are active in the view.
+                * ..they are active but the activated version differs.
+                * ..they are not activte in the view.
+
+            Takes `with_dependencies` keyword argument so that the status of
+            dependencies is printed as well.
+        """
+        raise NotImplementedError
+
+
+class YamlFilesystemView(FilesystemView):
+    """
+        Filesystem view to work with a yaml based directory layout.
+    """
+
+    def __init__(self, root, layout, **kwargs):
+        super(YamlFilesystemView, self).__init__(root, layout, **kwargs)
+
+        self.extensions_layout = YamlViewExtensionsLayout(root, layout)
+
+        self._croot = colorize_root(self.root) + " "
+
+    def add_specs(self, *specs, **kwargs):
+        assert all((s.concrete for s in specs))
+        specs = set(specs)
+
+        if kwargs.get("with_dependencies", True):
+            specs.update(get_dependencies(specs))
+
+        if kwargs.get("exclude", None):
+            specs = set(filter_exclude(specs, kwargs["exclude"]))
+
+        conflicts = self.get_conflicts(*specs)
+
+        if conflicts:
+            for s, v in conflicts:
+                self.print_conflict(v, s)
+            return
+
+        extensions = set(filter(lambda s: s.package.is_extension, specs))
+        standalones = specs - extensions
+
+        set(map(self._check_no_ext_conflicts, extensions))
+        # fail on first error, otherwise link extensions as well
+        if all(map(self.add_standalone, standalones)):
+            all(map(self.add_extension, extensions))
+
+    def add_extension(self, spec):
+        if not spec.package.is_extension:
+            tty.error(self._croot + 'Package %s is not an extension.'
+                      % spec.name)
+            return False
+
+        try:
+            if not spec.package.is_activated(self.extensions_layout):
+                spec.package.do_activate(
+                    verbose=self.verbose,
+                    extensions_layout=self.extensions_layout)
+
+        except ExtensionAlreadyInstalledError:
+            # As we use sets in add_specs(), the order in which packages get
+            # activated is essentially random. So this spec might have already
+            # been activated as dependency of another package -> fail silently
+            pass
+
+        # make sure the meta folder is linked as well (this is not done by the
+        # extension-activation mechnism)
+        if not self.check_added(spec):
+            self.link_meta_folder(spec)
+
+        return True
+
+    def add_standalone(self, spec):
+        if spec.package.is_extension:
+            tty.error(self._croot + 'Package %s is an extension.'
+                      % spec.name)
+            return False
+
+        if self.check_added(spec):
+            tty.warn(self._croot + 'Skipping already linked package: %s'
+                     % colorize_spec(spec))
+            return True
+
+        tree = LinkTree(spec.prefix)
+
+        if not self.ignore_conflicts:
+            conflict = tree.find_conflict(self.root)
+            if conflict is not None:
+                tty.error(self._croot +
+                          "Cannot link package %s, file already exists: %s"
+                          % (spec.name, conflict))
+                return False
+
+        conflicts = tree.merge(self.root, link=self.link,
+                               ignore=ignore_metadata_dir,
+                               ignore_conflicts=self.ignore_conflicts)
+        self.link_meta_folder(spec)
+
+        if self.ignore_conflicts:
+            for c in conflicts:
+                tty.warn(self._croot + "Could not link: %s" % c)
+
+        if self.verbose:
+            tty.info(self._croot + 'Linked package: %s' % colorize_spec(spec))
+        return True
+
+    def check_added(self, spec):
+        assert spec.concrete
+        return spec == self.get_spec(spec)
+
+    def remove_specs(self, *specs, **kwargs):
+        assert all((s.concrete for s in specs))
+        with_dependents = kwargs.get("with_dependents", True)
+        with_dependencies = kwargs.get("with_dependencies", False)
+
+        specs = set(specs)
+
+        if with_dependencies:
+            specs = get_dependencies(specs)
+
+        if kwargs.get("exclude", None):
+            specs = set(filter_exclude(specs, kwargs["exclude"]))
+
+        all_specs = set(self.get_all_specs())
+
+        to_deactivate = specs
+        to_keep = all_specs - to_deactivate
+
+        dependents = find_dependents(to_keep, to_deactivate)
+
+        if with_dependents:
+            # remove all packages depending on the ones to remove
+            if len(dependents) > 0:
+                tty.warn(self._croot +
+                         "The following dependents will be removed: %s"
+                         % ", ".join((s.name for s in dependents)))
+                to_deactivate.update(dependents)
+        elif len(dependents) > 0:
+            tty.warn(self._croot +
+                     "The following packages will be unusable: %s"
+                     % ", ".join((s.name for s in dependents)))
+
+        extensions = set(filter(lambda s: s.package.is_extension,
+                         to_deactivate))
+        standalones = to_deactivate - extensions
+
+        # Please note that a traversal of the DAG in post-order and then
+        # forcibly removing each package should remove the need to specify
+        # with_dependents for deactivating extensions/allow removal without
+        # additional checks (force=True). If removal performance becomes
+        # unbearable for whatever reason, this should be the first point of
+        # attack.
+        #
+        # see: https://github.com/LLNL/spack/pull/3227#discussion_r117147475
+        remove_extension = ft.partial(self.remove_extension,
+                                      with_dependents=with_dependents)
+
+        set(map(remove_extension, extensions))
+        set(map(self.remove_standalone, standalones))
+
+        self.purge_empty_directories()
+
+    def remove_extension(self, spec, with_dependents=True):
+        """
+            Remove (unlink) an extension from this view.
+        """
+        if not self.check_added(spec):
+            tty.warn(self._croot +
+                     'Skipping package not linked in view: %s' % spec.name)
+            return
+
+        # The spec might have been deactivated as depdency of another package
+        # already
+        if spec.package.is_activated(self.extensions_layout):
+            spec.package.do_deactivate(
+                verbose=self.verbose,
+                remove_dependents=with_dependents,
+                extensions_layout=self.extensions_layout)
+        self.unlink_meta_folder(spec)
+
+    def remove_standalone(self, spec):
+        """
+            Remove (unlink) a standalone package from this view.
+        """
+        if not self.check_added(spec):
+            tty.warn(self._croot +
+                     'Skipping package not linked in view: %s' % spec.name)
+            return
+
+        tree = LinkTree(spec.prefix)
+        tree.unmerge(self.root, ignore=ignore_metadata_dir)
+        self.unlink_meta_folder(spec)
+
+        if self.verbose:
+            tty.info(self._croot + 'Removed package: %s' % colorize_spec(spec))
+
+    def get_all_specs(self):
+        dotspack = join_path(self.root, spack.store.layout.metadata_dir)
+        if os.path.exists(dotspack):
+            return list(filter(None, map(self.get_spec, os.listdir(dotspack))))
+        else:
+            return []
+
+    def get_conflicts(self, *specs):
+        """
+            Return list of tuples (<spec>, <spec in view>) where the spec
+            active in the view differs from the one to be activated.
+        """
+        in_view = map(self.get_spec, specs)
+        return [(s, v) for s, v in zip(specs, in_view)
+                if v is not None and s != v]
+
+    def get_path_meta_folder(self, spec):
+        "Get path to meta folder for either spec or spec name."
+        return join_path(self.root, spack.store.layout.metadata_dir,
+                         getattr(spec, "name", spec))
+
+    def get_spec(self, spec):
+        dotspack = self.get_path_meta_folder(spec)
+        filename = join_path(dotspack, spack.store.layout.spec_file_name)
+
+        try:
+            with open(filename, "r") as f:
+                return spack.spec.Spec.from_yaml(f)
+        except IOError:
+            return None
+
+    def link_meta_folder(self, spec):
+        src = spack.store.layout.metadata_path(spec)
+        tgt = self.get_path_meta_folder(spec)
+
+        tree = LinkTree(src)
+        # there should be no conflicts when linking the meta folder
+        tree.merge(tgt, link=self.link)
+
+    def print_conflict(self, spec_active, spec_specified, level="error"):
+        "Singular print function for spec conflicts."
+        cprint = getattr(tty, level)
+        color = sys.stdout.isatty()
+        linked    = tty.color.colorize("   (@gLinked@.)", color=color)
+        specified = tty.color.colorize("(@rSpecified@.)", color=color)
+        cprint(self._croot + "Package conflict detected:\n"
+               "%s %s\n" % (linked, colorize_spec(spec_active)) +
+               "%s %s" % (specified, colorize_spec(spec_specified)))
+
+    def print_status(self, *specs, **kwargs):
+        if kwargs.get("with_dependencies", False):
+            specs = set(get_dependencies(specs))
+
+        specs = sorted(specs, key=lambda s: s.name)
+        in_view = list(map(self.get_spec, specs))
+
+        for s, v in zip(specs, in_view):
+            if not v:
+                tty.error(self._croot +
+                          'Package not linked: %s' % s.name)
+            elif s != v:
+                self.print_conflict(v, s, level="warn")
+
+        in_view = list(filter(None, in_view))
+
+        if len(specs) > 0:
+            tty.msg("Packages linked in %s:" % self._croot[:-1])
+
+            # avoid circular dependency
+            import spack.cmd
+            spack.cmd.display_specs(in_view, flags=True, variants=True,
+                                    long=self.verbose)
+        else:
+            tty.warn(self._croot + "No packages found.")
+
+    def purge_empty_directories(self):
+        """
+            Ascend up from the leaves accessible from `path`
+            and remove empty directories.
+        """
+        for dirpath, subdirs, files in os.walk(self.root, topdown=False):
+            for sd in subdirs:
+                sdp = os.path.join(dirpath, sd)
+                try:
+                    os.rmdir(sdp)
+                except OSError:
+                    pass
+
+    def unlink_meta_folder(self, spec):
+        path = self.get_path_meta_folder(spec)
+        assert os.path.exists(path)
+        shutil.rmtree(path)
+
+    def _check_no_ext_conflicts(self, spec):
+        """
+            Check that there is no extension conflict for specs.
+        """
+        extendee = spec.package.extendee_spec
+        try:
+            self.extensions_layout.check_extension_conflict(extendee, spec)
+        except ExtensionAlreadyInstalledError:
+            # we print the warning here because later on the order in which
+            # packages get activated is not clear (set-sorting)
+            tty.warn(self._croot +
+                     'Skipping already activated package: %s' % spec.name)
+
+
+#####################
+# utility functions #
+#####################
+
+def colorize_root(root):
+    colorize = ft.partial(tty.color.colorize, color=sys.stdout.isatty())
+    pre, post = map(colorize, "@M[@. @M]@.".split())
+    return "".join([pre, root, post])
+
+
+def colorize_spec(spec):
+    "Colorize spec output if in TTY."
+    if sys.stdout.isatty():
+        return spec.cshort_spec
+    else:
+        return spec.short_spec
+
+
+def find_dependents(all_specs, providers, deptype='run'):
+    """
+        Return a set containing all those specs from all_specs that depend on
+        providers at the given dependency type.
+    """
+    dependents = set()
+    for s in all_specs:
+        for dep in s.traverse(deptype=deptype):
+            if dep in providers:
+                dependents.add(s)
+    return dependents
+
+
+def filter_exclude(specs, exclude):
+    "Filter specs given sequence of exclude regex"
+    to_exclude = [re.compile(e) for e in exclude]
+
+    def keep(spec):
+        for e in to_exclude:
+            if e.match(spec.name):
+                return False
+        return True
+    return filter(keep, specs)
+
+
+def get_dependencies(specs):
+    "Get set of dependencies (includes specs)"
+    retval = set()
+    set(map(retval.update, (set(s.traverse()) for s in specs)))
+    return retval
+
+
+def ignore_metadata_dir(f):
+    return f in spack.store.layout.hidden_file_paths

--- a/lib/spack/spack/hooks/extensions.py
+++ b/lib/spack/spack/hooks/extensions.py
@@ -29,5 +29,6 @@ def pre_uninstall(spec):
     assert spec.concrete
 
     if pkg.is_extension:
-        if pkg.activated:
+        if pkg.is_activated():
+            # deactivate globally
             pkg.do_deactivate(force=True)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -836,12 +836,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         s = self.extendee_spec
         return s and s.satisfies(spec)
 
-    @property
-    def activated(self):
+    def is_activated(self, extensions_layout=None):
+        """Return True if package is activated."""
         if not self.is_extension:
             raise ValueError(
                 "is_extension called on package that is not an extension.")
-        exts = spack.store.layout.extension_map(self.extendee_spec)
+        if extensions_layout is None:
+            extensions_layout = spack.store.extensions
+        exts = extensions_layout.extension_map(self.extendee_spec)
         return (self.name in exts) and (exts[self.name] == self.spec)
 
     def provides(self, vpkg_name):
@@ -1590,7 +1592,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             raise ActivationError("%s does not extend %s!" %
                                   (self.name, self.extendee.name))
 
-    def do_activate(self, force=False):
+    def do_activate(self, force=False, verbose=True, extensions_layout=None):
         """Called on an extension to invoke the extendee's activate method.
 
         Commands should call this routine, and should not call
@@ -1598,27 +1600,38 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """
         self._sanity_check_extension()
 
-        spack.store.layout.check_extension_conflict(
+        if extensions_layout is None:
+            extensions_layout = spack.store.extensions
+
+        extensions_layout.check_extension_conflict(
             self.extendee_spec, self.spec)
 
         # Activate any package dependencies that are also extensions.
         if not force:
             for spec in self.dependency_activations():
-                if not spec.package.activated:
-                    spec.package.do_activate(force=force)
+                if not spec.package.is_activated(
+                        extensions_layout=extensions_layout):
+                    spec.package.do_activate(
+                        force=force, verbose=verbose,
+                        extensions_layout=extensions_layout)
 
-        self.extendee_spec.package.activate(self, **self.extendee_args)
+        self.extendee_spec.package.activate(
+            self, extensions_layout=extensions_layout, **self.extendee_args)
 
-        spack.store.layout.add_extension(self.extendee_spec, self.spec)
-        tty.msg("Activated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        extensions_layout.add_extension(self.extendee_spec, self.spec)
+
+        if verbose:
+            tty.msg("Activated extension %s for %s" %
+                    (self.spec.cshort_spec, self.extendee_spec.cshort_spec))
 
     def dependency_activations(self):
         return (spec for spec in self.spec.traverse(root=False, deptype='run')
                 if spec.package.extends(self.extendee_spec))
 
     def activate(self, extension, **kwargs):
-        """Symlinks all files from the extension into extendee's install dir.
+        """Make extension package usable by linking all its files to a target
+        provided bythe directory layout (depending if the user wants to
+        activate globally or in a specified file system view).
 
         Package authors can override this method to support other
         extension mechanisms.  Spack internals (commands, hooks, etc.)
@@ -1626,54 +1639,75 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         always executed.
 
         """
+        extensions_layout = kwargs.get("extensions_layout",
+                                       spack.store.extensions)
+        target = extensions_layout.extendee_target_directory(self)
 
         def ignore(filename):
             return (filename in spack.store.layout.hidden_file_paths or
                     kwargs.get('ignore', lambda f: False)(filename))
 
         tree = LinkTree(extension.prefix)
-        conflict = tree.find_conflict(self.prefix, ignore=ignore)
+        conflict = tree.find_conflict(target, ignore=ignore)
         if conflict:
             raise ExtensionConflictError(conflict)
 
-        tree.merge(self.prefix, ignore=ignore)
+        tree.merge(target, ignore=ignore, link=extensions_layout.link)
 
     def do_deactivate(self, **kwargs):
-        """Called on the extension to invoke extendee's deactivate() method."""
+        """Called on the extension to invoke extendee's deactivate() method.
+
+        `remove_dependents=True` deactivates extensions depending on this
+        package instead of raising an error.
+        """
         self._sanity_check_extension()
         force = kwargs.get('force', False)
+        verbose = kwargs.get("verbose", True)
+        remove_dependents = kwargs.get("remove_dependents", False)
+        extensions_layout = kwargs.get("extensions_layout",
+                                       spack.store.extensions)
 
         # Allow a force deactivate to happen.  This can unlink
         # spurious files if something was corrupted.
         if not force:
-            spack.store.layout.check_activated(
+            extensions_layout.check_activated(
                 self.extendee_spec, self.spec)
 
-            activated = spack.store.layout.extension_map(
+            activated = extensions_layout.extension_map(
                 self.extendee_spec)
             for name, aspec in activated.items():
                 if aspec == self.spec:
                     continue
                 for dep in aspec.traverse(deptype='run'):
                     if self.spec == dep:
-                        msg = ("Cannot deactivate %s because %s is activated "
-                               "and depends on it.")
-                        raise ActivationError(
-                            msg % (self.spec.short_spec, aspec.short_spec))
+                        if remove_dependents:
+                            aspec.package.do_deactivate(**kwargs)
+                        else:
+                            msg = ("Cannot deactivate %s because %s is "
+                                   "activated and depends on it.")
+                            raise ActivationError(
+                                msg % (self.spec.cshort_spec,
+                                       aspec.cshort_spec))
 
-        self.extendee_spec.package.deactivate(self, **self.extendee_args)
+        self.extendee_spec.package.deactivate(
+            self,
+            extensions_layout=extensions_layout,
+            **self.extendee_args)
 
         # redundant activation check -- makes SURE the spec is not
         # still activated even if something was wrong above.
-        if self.activated:
-            spack.store.layout.remove_extension(
+        if self.is_activated(extensions_layout):
+            extensions_layout.remove_extension(
                 self.extendee_spec, self.spec)
 
-        tty.msg("Deactivated extension %s for %s" %
-                (self.spec.short_spec, self.extendee_spec.format("$_$@$+$%@")))
+        if verbose:
+            tty.msg("Deactivated extension %s for %s" %
+                    (self.spec.cshort_spec,
+                     self.extendee_spec.cshort_spec))
 
     def deactivate(self, extension, **kwargs):
-        """Unlinks all files from extension out of this package's install dir.
+        """Unlinks all files from extension out of this package's install dir
+        or the corresponding filesystem view.
 
         Package authors can override this method to support other
         extension mechanisms.  Spack internals (commands, hooks, etc.)
@@ -1681,13 +1715,16 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         always executed.
 
         """
+        extensions_layout = kwargs.get("extensions_layout",
+                                       spack.store.extensions)
+        target = extensions_layout.extendee_target_directory(self)
 
         def ignore(filename):
             return (filename in spack.store.layout.hidden_file_paths or
                     kwargs.get('ignore', lambda f: False)(filename))
 
         tree = LinkTree(extension.prefix)
-        tree.unmerge(self.prefix, ignore=ignore)
+        tree.unmerge(target, ignore=ignore)
 
     def do_restage(self):
         """Reverts expanded/checked out source to a pristine state."""

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -48,9 +48,10 @@ import spack.config
 from spack.util.path import canonicalize_path
 from spack.database import Database
 from spack.directory_layout import YamlDirectoryLayout
+from spack.directory_layout import YamlExtensionsLayout
 
 __author__ = "Benedikt Hegner (CERN)"
-__all__ = ['db', 'layout', 'root']
+__all__ = ['db', 'extensions', 'layout', 'root']
 
 #
 # Read in the config
@@ -75,3 +76,5 @@ db = Database(root)
 layout = YamlDirectoryLayout(root,
                              hash_len=config.get('install_hash_length'),
                              path_scheme=config.get('install_path_scheme'))
+
+extensions = YamlExtensionsLayout(root, layout)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -484,6 +484,10 @@ class Python(AutotoolsPackage):
     def site_packages_dir(self):
         return join_path(self.python_lib_dir, 'site-packages')
 
+    @property
+    def easy_install_file(self):
+        return join_path(self.site_packages_dir, "easy-install.pth")
+
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on."""
@@ -563,11 +567,15 @@ class Python(AutotoolsPackage):
 
         return match_predicate(ignore_arg, patterns)
 
-    def write_easy_install_pth(self, exts):
+    def write_easy_install_pth(self, exts, prefix=None):
+        if not prefix:
+            prefix = self.prefix
+
         paths = []
+        unique_paths = set()
+
         for ext in sorted(exts.values()):
-            ext_site_packages = join_path(ext.prefix, self.site_packages_dir)
-            easy_pth = join_path(ext_site_packages, "easy-install.pth")
+            easy_pth = join_path(ext.prefix, self.easy_install_file)
 
             if not os.path.isfile(easy_pth):
                 continue
@@ -585,10 +593,11 @@ class Python(AutotoolsPackage):
                             re.search(r'setuptools.*egg$', line)):
                         continue
 
-                    paths.append(line)
+                    if line not in unique_paths:
+                        unique_paths.add(line)
+                        paths.append(line)
 
-        site_packages = join_path(self.home, self.site_packages_dir)
-        main_pth = join_path(site_packages, "easy-install.pth")
+        main_pth = join_path(prefix, self.easy_install_file)
 
         if not paths:
             if os.path.isfile(main_pth):
@@ -609,18 +618,29 @@ class Python(AutotoolsPackage):
         ignore = self.python_ignore(ext_pkg, args)
         args.update(ignore=ignore)
 
+        extensions_layout = args.get("extensions_layout",
+                                     spack.store.extensions)
+
         super(Python, self).activate(ext_pkg, **args)
 
-        exts = spack.store.layout.extension_map(self.spec)
+        exts = extensions_layout.extension_map(self.spec)
         exts[ext_pkg.name] = ext_pkg.spec
-        self.write_easy_install_pth(exts)
+
+        self.write_easy_install_pth(
+            exts,
+            prefix=extensions_layout.extendee_target_directory(self))
 
     def deactivate(self, ext_pkg, **args):
         args.update(ignore=self.python_ignore(ext_pkg, args))
         super(Python, self).deactivate(ext_pkg, **args)
 
-        exts = spack.store.layout.extension_map(self.spec)
+        extensions_layout = args.get("extensions_layout",
+                                     spack.store.extensions)
+
+        exts = extensions_layout.extension_map(self.spec)
         # Make deactivate idempotent
         if ext_pkg.name in exts:
             del exts[ext_pkg.name]
-            self.write_easy_install_pth(exts)
+            self.write_easy_install_pth(
+                exts,
+                prefix=extensions_layout.extendee_target_directory(self))


### PR DESCRIPTION
Resolves #1789

In our scenario we have a a globally installed (i.e., read-only) set of
packages from which each user should then be able to add a subset to
local filesystem views. However, the current extension mechanism only
allows for one set of extensions to be activated for any given extendee.

One way to circumvent this issue is to use a module system, but this way
environment variables tend to get very long after a short while.
Furthermore, since an error is raised when two files have the same
target in the view, the user can immediately spot when multiple specs
from one package are loaded (an error that sill creeps up from time to
time).

In order to support multiple (and maybe mutually exclusive)
configurations of extensions for a given extendee, the following changes
were made. The aim is to silently activate any specified extensions when
adding them to the filesystem view; no actions from the user required.

TL;DR: Adding python packages built with py-setuptools to fileystem
views without globally activating them should "just work".

* `DirectoryLayout`/`Package`: All extension-related command accept a
`path_view` argument restricting extension operations to the given
filesystem view.

* `Package`: `{do_,}{de,}activate`-functions also accept a `path_view`
argument. If `path_view` is `not None`, the necessary extension files
are linked into the view instead of the extendee's install directory.

* `LinkTree`: `merge`-method now accepts a link argument to allow for
both symlinks and hardlinks.

* `view`: All linking operations have been refactored to use `LinkTree`s
instead of custom code.

* `view`: Check extensions prior to linking packages, activate
extensions in filesystem view afterwards.

* `view statlink`: The `--verbose` option now prints the `short_spec` of
packages linked.

* `view statlink`: `status` and `remove` now accept `--all` argument to
display the status of/remove all packages in the filesystem view.

* `view statlink`: Now uses `display_specs`-function for prettier
output.

* `view remove`: Only removes packages specified by user, packages
depending on those packages and packages that only user-specified
packages depend on.

I am currently working on some meaningful tests (I did not find any for the `view` command on its own to start from), but would appreciate some feedback in the meantime.