### PR TITLE
swig: Switch back to a generic Package since AutoToolsPackage doesn’t…

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -25,7 +25,13 @@
 from spack import *
 
 
-class Swig(AutotoolsPackage):
+# Note: Although Swig uses autotools, its "Examples" subtree contains
+# hand-written Makefiles that cannot be re-generated automatically.
+# Running "autoreconf" creates a "configure" script that goes into an
+# endless loop for this subtree, eating up all disk space. We thus
+# need to keep this as a regular package so that Spack doesn't run
+# "autoreconf".
+class Swig(Package):
     """SWIG is an interface compiler that connects programs written in
        C and C++ with scripting languages such as Perl, Python, Ruby,
        and Tcl. It works by taking the declarations found in C/C++
@@ -38,6 +44,7 @@ class Swig(AutotoolsPackage):
     homepage = "http://www.swig.org"
     url      = "http://prdownloads.sourceforge.net/swig/swig-3.0.8.tar.gz"
 
+    version('3.0.12', '82133dfa7bba75ff9ad98a7046be687c')
     version('3.0.11', '13732eb0f1ab2123d180db8425c1edea')
     version('3.0.10', 'bb4ab8047159469add7d00910e203124')
     version('3.0.8', 'c96a1d5ecb13d38604d7e92148c73c97')
@@ -47,3 +54,8 @@ class Swig(AutotoolsPackage):
     version('1.3.40', '2df766c9e03e02811b1ab4bba1c7b9cc')
 
     depends_on('pcre')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+        make()
+        make("install")


### PR DESCRIPTION
… work

Also include new version 3.0.12.

Closes #3000.