### PR TITLE
add package py-statsmodels and py-patsy

### DIFF
--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPatsy(PythonPackage):
+    """A Python package for describing statistical models and for building design matrices."""
+
+    homepage = "https://github.com/pydata/patsy"
+    url      = "https://pypi.io/packages/source/p/patsy/patsy-1.9.1.tar.gz"
+
+    version('0.4.1', '286db90a03ad04a1e9e1e418142ca613')
+
+    variant('splines', desciption="Offers spline related functions")
+    variant('tests', desciption="allows nose tests")
+
+    depends_on('py-setuptools',  type='build')
+    depends_on('py-numpy',       type=('build', 'run'))
+    depends_on('py-scipy',       type=('build', 'run'), when="+splines")
+    depends_on('py-nose',        type=('build', 'run'), when="+tests")
+    depends_on('py-six',         type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -30,9 +30,9 @@ class PyPatsy(PythonPackage):
     building design matrices."""
 
     homepage = "https://github.com/pydata/patsy"
-    url      = "https://pypi.io/packages/source/p/patsy/patsy-1.9.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/patsy/patsy-0.4.1.zip"
 
-    version('0.4.1', '286db90a03ad04a1e9e1e418142ca613')
+    version('0.4.1', '9445f29e3426d1ed30d683a1e1453f84')
 
     variant('splines', description="Offers spline related functions")
     variant('tests', description="allows nose tests")

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -26,15 +26,16 @@ from spack import *
 
 
 class PyPatsy(PythonPackage):
-    """A Python package for describing statistical models and for building design matrices."""
+    """A Python package for describing statistical models and for
+    building design matrices."""
 
     homepage = "https://github.com/pydata/patsy"
     url      = "https://pypi.io/packages/source/p/patsy/patsy-1.9.1.tar.gz"
 
     version('0.4.1', '286db90a03ad04a1e9e1e418142ca613')
 
-    variant('splines', desciption="Offers spline related functions")
-    variant('tests', desciption="allows nose tests")
+    variant('splines', description="Offers spline related functions")
+    variant('tests', description="allows nose tests")
 
     depends_on('py-setuptools',  type='build')
     depends_on('py-numpy',       type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyStatsmodels(PythonPackage):
+    """Statistical computations and models for use with SciPy"""
+
+    homepage = "http://www.statsmodels.org"
+    url      = "https://pypi.io/packages/source/s/statsmodels/statsmodels-1.9.1.tar.gz"
+
+    version('0.8.0', 'b3e5911cc9b00b71228d5d39a880bba0')
+    version('0.8.0rc1', 'da32434ebfebae2c7506e9577ac558f5')
+
+    variant('tests',    default=False, description='With nose tests')
+    variant('plotting', default=False, description='With matplotlib')
+
+    # according to http://www.statsmodels.org/dev/install.html earlier versions
+    # might work.
+    depends_on('py-setuptools',      type='build')
+    depends_on('py-numpy@1.6:',      type=('build', 'run'))
+    depends_on('py-scipy@0.11:',     type=('build', 'run'))
+    depends_on('py-pandas@0.12:',    type=('build', 'run'))
+    depends_on('py-patsy@0.2.1:',    type=('build', 'run'))
+    depends_on('py-cython@0.24:',    type=('build', 'run'))
+    depends_on('py-nose',            type='run', when='+tests')
+    depends_on('py-matplotlib@1.3:', type='run', when='+plotting')

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -32,7 +32,6 @@ class PyStatsmodels(PythonPackage):
     url      = "https://pypi.io/packages/source/s/statsmodels/statsmodels-0.8.0.tar.gz"
 
     version('0.8.0', 'b3e5911cc9b00b71228d5d39a880bba0')
-    version('0.8.0rc1', 'da32434ebfebae2c7506e9577ac558f5')
 
     variant('tests',    default=False, description='With nose tests')
     variant('plotting', default=False, description='With matplotlib')

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -29,7 +29,7 @@ class PyStatsmodels(PythonPackage):
     """Statistical computations and models for use with SciPy"""
 
     homepage = "http://www.statsmodels.org"
-    url      = "https://pypi.io/packages/source/s/statsmodels/statsmodels-1.9.1.tar.gz"
+    url      = "https://pypi.io/packages/source/s/statsmodels/statsmodels-0.8.0.tar.gz"
 
     version('0.8.0', 'b3e5911cc9b00b71228d5d39a880bba0')
     version('0.8.0rc1', 'da32434ebfebae2c7506e9577ac558f5')
@@ -39,11 +39,11 @@ class PyStatsmodels(PythonPackage):
 
     # according to http://www.statsmodels.org/dev/install.html earlier versions
     # might work.
-    depends_on('py-setuptools',      type='build')
-    depends_on('py-numpy@1.6:',      type=('build', 'run'))
-    depends_on('py-scipy@0.11:',     type=('build', 'run'))
-    depends_on('py-pandas@0.12:',    type=('build', 'run'))
-    depends_on('py-patsy@0.2.1:',    type=('build', 'run'))
-    depends_on('py-cython@0.24:',    type=('build', 'run'))
-    depends_on('py-nose',            type='run', when='+tests')
-    depends_on('py-matplotlib@1.3:', type='run', when='+plotting')
+    depends_on('py-setuptools@0.6c5:', type='build')
+    depends_on('py-numpy@1.7.0:',      type=('build', 'run'))
+    depends_on('py-scipy@0.11:',       type=('build', 'run'))
+    depends_on('py-pandas@0.12:',      type=('build', 'run'))
+    depends_on('py-patsy@0.2.1:',      type=('build', 'run'))
+    depends_on('py-cython@0.24:',      type=('build', 'run'))
+    depends_on('py-nose',              type='run', when='+tests')
+    depends_on('py-matplotlib@1.3:',   type='run', when='+plotting')


### PR DESCRIPTION
I'd like some feedback regarding the variants, is this the intended usage? It's not exactly a variant of the package but rather some functionality of the package depends on the availability of certain packages. I.e. plotting requires matplotlib but does not change the package itself.