### PR TITLE
pip requires setuptools during runtime

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -34,4 +34,7 @@ class PyPip(PythonPackage):
     version('9.0.1', '35f01da33009719497f01a4ba69d63c9')
 
     depends_on('python@2.6:2.7,3.3:')
-    depends_on('py-setuptools', type='build')
+
+    # Most Python packages only require setuptools as a build dependency.
+    # However, pip requires setuptools during runtime as well.
+    depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Without this:
```
$ pip
Traceback (most recent call last):
File "/soft/spack-0.10.0/opt/spack/linux-centos6-x86_64/gcc-6.1.0/py-pip-9.0.1-bjebrwejnyuvod27zcxrvdkttueuqeci/bin/pip", line 7, in <module>
from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```