### PR TITLE
Ior package: fix build issues

### DIFF
--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -40,7 +40,7 @@ class Ior(Package):
 
     depends_on('mpi')
     depends_on('hdf5+mpi',   when='+hdf5')
-    depends_on('netcdf+mpi', when='+ncmpi')
+    depends_on('parallel-netcdf', when='+ncmpi')
 
     def install(self, spec, prefix):
         os.system('./bootstrap')
@@ -52,6 +52,7 @@ class Ior(Package):
 
         if '+hdf5' in spec:
             config_args.append('--with-hdf5')
+            config_args.append('CFLAGS=-D H5_USE_16_API')
         else:
             config_args.append('--without-hdf5')
 


### PR DESCRIPTION
This commit tries to address build issues reported in issue #3268.
In particular, makes cleaner the dependency on parallel-netcdf
when +ncmpi variant is requested and adds CFLAGS=-D H5_USE_16_API
to handle the fact that Ior uses old 1.6 style APIs when +hdf5 is
requested.
These changes make Ior build fine and create modules for HDF5 versions
1.8.x and 1.10.0.
Even though build is successful the modules haven't been tested in a
run.