### PR TITLE
Fixes to allow Boost to build with Python 3

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -131,7 +131,7 @@ class Boost(Package):
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
-    patch('python_jam.patch')
+    patch('python_jam.patch', when='^python@3:')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
     patch('boost_10125.patch', when='@1.55.0%gcc@5.0:5.9')
@@ -156,7 +156,7 @@ class Boost(Package):
 
         toolsets = {'g++': 'gcc',
                     'icpc': 'intel',
-                    'clang++': 'clang', 
+                    'clang++': 'clang',
                     'xlc++': 'xlcpp',
                     'xlc++_r': 'xlcpp'}
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -130,6 +130,9 @@ class Boost(Package):
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11856
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
+    # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
+    patch('python_jam.patch')
+
     # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
     patch('boost_10125.patch', when='@1.55.0%gcc@5.0:5.9')
 
@@ -192,8 +195,7 @@ class Boost(Package):
         options.append("--with-libraries=%s" % ','.join(withLibs))
 
         if '+python' in spec:
-            options.append('--with-python=%s' %
-                           join_path(spec['python'].prefix.bin, 'python'))
+            options.append('--with-python=%s' % python_exe)
 
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in

--- a/var/spack/repos/builtin/packages/boost/python_jam.patch
+++ b/var/spack/repos/builtin/packages/boost/python_jam.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/build/src/tools/python.jam b/tools/build/src/tools/python.jam
+index 90377ea..123f66a 100644
+--- a/tools/build/src/tools/python.jam
++++ b/tools/build/src/tools/python.jam
+@@ -493,6 +493,10 @@ local rule probe ( python-cmd )
+                 sys.$(s) = [ SUBST $(output) \\<$(s)=([^$(nl)]+) $1 ] ;
+             }
+         }
++         # Try to get python abiflags
++        full-cmd = $(python-cmd)" -c \"from sys import abiflags; print(abiflags, end='')\"" ;
++
++        sys.abiflags = [ SHELL $(full-cmd) ] ;
+         return $(output) ;
+     }
+ }
+@@ -502,7 +506,7 @@ local rule probe ( python-cmd )
+ # have a value based on the information given.
+ #
+ local rule compute-default-paths ( target-os : version ? : prefix ? :
+-    exec-prefix ? )
++    exec-prefix ? : abiflags ? )
+ {
+     exec-prefix ?= $(prefix) ;
+ 
+@@ -539,7 +543,7 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
+     }
+     else
+     {
+-        includes ?= $(prefix)/include/python$(version) ;
++        includes ?= $(prefix)/include/python$(version)$(abiflags) ;
+ 
+         local lib = $(exec-prefix)/lib ;
+         libraries ?= $(lib)/python$(version)/config $(lib) ;
+@@ -783,7 +787,7 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
+                     exec-prefix = $(sys.exec_prefix) ;
+ 
+                     compute-default-paths $(target-os) : $(sys.version) :
+-                        $(sys.prefix) : $(sys.exec_prefix) ;
++                        $(sys.prefix) : $(sys.exec_prefix) : $(sys.abiflags) ;
+ 
+                     version = $(sys.version) ;
+                     interpreter-cmd ?= $(cmd) ;

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -387,6 +387,7 @@ class Python(Package):
             'python{0}'.format('3' if self.spec.satisfies('@3') else '')
         )
 
+        module.python_exe = python_path
         module.python = Executable(python_path)
         module.setup_py = Executable(python_path + ' setup.py --no-user-cfg')
 


### PR DESCRIPTION
Fixes #3274.

~~Needs to be tested with Python 2.~~
Tested with:
```
boost@1.63.0%intel@17.0.1+python ^python@2.7.13
boost@1.63.0%gcc@6.1.0+python ^python@3.6.0
```
Both builds succeed now!