### PR TITLE
WIP: Make Paraview work

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -33,8 +33,8 @@ class Mesa(AutotoolsPackage):
     url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
 
     version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
-    version('10.2.4', '11d3542da1b703618634be840a87b0b2',
-        url="ftp://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2")
+    #version('10.2.4', '11d3542da1b703618634be840a87b0b2',
+    #    url="ftp://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2")
 
     # General dependencies
     depends_on('autoconf', type='build')
@@ -65,7 +65,7 @@ class Mesa(AutotoolsPackage):
 
 
     def configure_args(self):
-        make('autoreconf -fi')
+        #make('autoreconf -fi')
         return ['--enable-osmesa', '--disable-dri', '--disable-egl',
                 '--enable-xlib-glx', '--disable-gallium-llvm',
                 '--with-dri-drivers=', '--with-gallium-drivers=']

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -30,11 +30,11 @@ class Mesa(AutotoolsPackage):
     specification - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    #url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2"
+    url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
 
     version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
-    version('10.2.4', '11d3542da1b703618634be840a87b0b2')
+    version('10.2.4', '11d3542da1b703618634be840a87b0b2',
+        url="ftp://ftp.freedesktop.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2")
 
     # General dependencies
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -37,6 +37,10 @@ class Mesa(AutotoolsPackage):
     version('10.2.4', '11d3542da1b703618634be840a87b0b2')
 
     # General dependencies
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
     depends_on('python@2.6.4:')
     depends_on('py-mako@0.3.4:')
     depends_on('flex@2.5.35:', type='build')
@@ -59,7 +63,9 @@ class Mesa(AutotoolsPackage):
     depends_on('presentproto@1.0:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
 
+
     def configure_args(self):
+        make('autoreconf -fi')
         return ['--enable-osmesa', '--disable-dri', '--disable-egl',
                 '--enable-xlib-glx', '--disable-gallium-llvm',
                 '--with-dri-drivers=', '--with-gallium-drivers=']

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -34,7 +34,7 @@ class Mesa(AutotoolsPackage):
 
     version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
     version('10.2.4', '11d3542da1b703618634be840a87b0b2',
-        url="ftp://ftp.freedesktop.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2")
+        url="ftp://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2")
 
     # General dependencies
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -30,9 +30,11 @@ class Mesa(AutotoolsPackage):
     specification - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
+    #url      = "http://ftp.iij.ad.jp/pub/X11/x.org/pub/mesa/12.0.3/mesa-12.0.3.tar.gz"
+    url      = "ftp://ftp.freedesktop.org/pub/mesa/older-versions/10.x/10.2.4/MesaLib-10.2.4.tar.bz2"
 
     version('12.0.3', '60c5f9897ddc38b46f8144c7366e84ad')
+    version('10.2.4', '11d3542da1b703618634be840a87b0b2')
 
     # General dependencies
     depends_on('python@2.6.4:')
@@ -56,6 +58,11 @@ class Mesa(AutotoolsPackage):
     depends_on('dri3proto@1.0:', type='build')
     depends_on('presentproto@1.0:', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
+
+    def configure_args(self):
+        return ['--enable-osmesa', '--disable-dri', '--disable-egl',
+                '--enable-xlib-glx', '--disable-gallium-llvm',
+                '--with-dri-drivers=', '--with-gallium-drivers=']
 
     # TODO: Add package for systemd, provides libudev
     # Using the system package manager to install systemd didn't work for me

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -51,6 +51,7 @@ class Paraview(Package):
     depends_on('qt@:4', when='+qt')
 
     depends_on('cmake', type='build')
+    depends_on('mesa')
     depends_on('bzip2')
     depends_on('freetype')
     # depends_on('hdf5+mpi', when='+mpi')


### PR DESCRIPTION
I use a stock Ubuntu 16.04. Paraview fails to build due to a missing opengl library. In Hashdist I build Paraview with os mesa, then things work. The +osmesa flag to paraview fails (missing osmesa library).

So I first concentrate on the mesa library. Below I made the modifications to build it just like in Hashdist (as the default spack version fails to build due to `configure: error: libudev-dev or sysfs required for building DRI`). I build it with `spack install mesa@10.2.4 %gcc@5.4.0`. 

It fails with:
```
==> 'make' '-j32' 'autoreconf -fi'
make: *** No rule to make target 'autoreconf -fi'.  Stop.
```
But I have to call autoreconf, otherwise (if I comment the line that calls autoreconf), i.e.:
```diff
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -65,7 +65,7 @@ class Mesa(AutotoolsPackage):
 
 
     def configure_args(self):
-        make('autoreconf -fi')
+        #make('autoreconf -fi')
         return ['--enable-osmesa', '--disable-dri', '--disable-egl',
                 '--enable-xlib-glx', '--disable-gallium-llvm',
                 '--with-dri-drivers=', '--with-gallium-drivers=']
```
the configure phase succeeds, but the make phase fails with:
```
==> 'make' '-j32'
CDPATH="${ZSH_VERSION+.}:" && cd /home/certik/repos/spack/var/spack/stage/mesa-10.2.4-gqowes7nvl5cnpgvpakilmzrcktjvnhs/Mesa-10.2.4 && /bin/bash /tmp/certik/spack-stage/spack-stage-_yG_LZ/Mesa-10.2.4/bin/missing aclocal-1.14 -I m4
/tmp/certik/spack-stage/spack-stage-_yG_LZ/Mesa-10.2.4/bin/missing: line 81: aclocal-1.14: command not found
WARNING: 'aclocal-1.14' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
Makefile:557: recipe for target '/home/certik/repos/spack/var/spack/stage/mesa-10.2.4-gqowes7nvl5cnpgvpakilmzrcktjvnhs/Mesa-10.2.4/aclocal.m4' failed
make: *** [/home/certik/repos/spack/var/spack/stage/mesa-10.2.4-gqowes7nvl5cnpgvpakilmzrcktjvnhs/Mesa-10.2.4/aclocal.m4] Error 127
```


I don't know what else to do. I tried to also debug it by doing:
```
$ spack cd mesa@10.2.4 %gcc@5.4.0
~/.../mesa-10.2.4-gqowes7nvl5cnpgvpakilmzrcktjvnhs/Mesa-10.2.4$ spack env mesa@10.2.4 %gcc@5.4.0
Traceback (most recent call last):
  File "/home/certik/repos/spack/bin/spack", line 212, in <module>
    main(sys.argv)
  File "/home/certik/repos/spack/bin/spack", line 208, in main
    _main(args, unknown)
  File "/home/certik/repos/spack/bin/spack", line 174, in _main
    return_val = command(parser, args)
  File "/home/certik/repos/spack/lib/spack/spack/cmd/env.py", line 62, in env
    build_env.setup_package(spec.package)
  File "/home/certik/repos/spack/lib/spack/spack/build_environment.py", line 513, in setup_package
    dpkg.setup_dependent_environment(spack_env, run_env, spec)
  File "/home/certik/repos/spack/var/spack/repos/builtin/packages/python/package.py", line 358, in setup_dependent_environment
    raise RuntimeError('Cannot locate python executable')
RuntimeError: Cannot locate python executable
```

So that seems like another, unrelated bug, so I reported it as #3319. But it prevents me from debugging it that way.