### PR TITLE
Fix error raised for multiple virtual packages

### DIFF
--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -43,7 +43,8 @@ def get_packages_config():
     if virtuals:
         errors = ["%s: %s" % (line_info, name) for name, line_info in virtuals]
         raise VirtualInPackagesYAMLError(
-            "packages.yaml entries cannot be virtual packages:", *errors)
+            "packages.yaml entries cannot be virtual packages:",
+            '\n'.join(errors))
 
     return config
 


### PR DESCRIPTION
Previously this was falling over when multiple virtual packages were defined in the `packages.yaml`. Now a list of virtual packages is printed. 