### PR TITLE
Fix simul by diabling inline and replacing mpicc command.

### DIFF
--- a/var/spack/repos/builtin/packages/simul/package.py
+++ b/var/spack/repos/builtin/packages/simul/package.py
@@ -40,6 +40,8 @@ class Simul(Package):
     depends_on('mpi')
 
     def install(self, spec, prefix):
+        filter_file('mpicc',  '$(MPICC)',  'Makefile', string=True)
+        filter_file('inline void',  'void',  'simul.c', string=True)
         make('simul')
         mkdirp(prefix.bin)
         install('simul', prefix.bin)


### PR DESCRIPTION
This commit fixes simul's bulding issue in GCC. I am sorry that I hadn't tested simul against GCC before it was merged in #3300 . Changes include:

1. Replacing `mpicc` with `$(MPICC)` in `Makefile`.
2. Replacing `inline void` with `void` in `simul.c`.

Tests of `spack` and `flake8` pass and simul has been successfully built with openmpi and gcc.

[`simul.c`](https://github.com/LLNL/simul/blob/master/simul.c#L52) uses the following macros to determine whether `inline` keyword should be enabled:

```
#ifdef __GNUC__
   /* "inline" is a keyword in GNU C */
#elif __STDC_VERSION__ >= 199901L
   /* "inline" is a keyword in C99 and later versions */
#else
#  define inline /* "inline" not available */
#endif
```

Functions `begin` and `end` are declared as `inline void`. I have no idea why GCC fails to link those  inline `begin` and `end` functions. In contrast, Intel compiler works well with `inline void`.