### PR TITLE
Add a new version for bamtools 2.4.1.

### DIFF
--- a/var/spack/repos/builtin/packages/bamtools/package.py
+++ b/var/spack/repos/builtin/packages/bamtools/package.py
@@ -31,6 +31,7 @@ class Bamtools(Package):
     homepage = "https://github.com/pezmaster31/bamtools"
     url      = "https://github.com/pezmaster31/bamtools/archive/v2.4.0.tar.gz"
 
+    version('2.4.1', '41cadf513f2744256851accac2bc7baa')
     version('2.4.0', '6139d00c1b1fe88fe15d094d8a74d8b9')
     version('2.3.0', 'd327df4ba037d6eb8beef65d7da75ebc')
     version('2.2.3', '6eccd3e45e4ba12a68daa3298998e76d')


### PR DESCRIPTION
Add a new version, 2.4.1, for bamtools. This version can be built against GCC 6.