### PR TITLE
correct ipython dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-appnope/package.py
+++ b/var/spack/repos/builtin/packages/py-appnope/package.py
@@ -25,15 +25,10 @@
 from spack import *
 
 
-class PyJedi(PythonPackage):
-    """An autocompletion tool for Python that can be used for text editors."""
+class PyAppnope(PythonPackage):
+    """Disable App Nap on OS X 10.9"""
 
-    homepage = "https://github.com/davidhalter/jedi"
-    url      = "https://pypi.io/packages/source/j/jedi/jedi-0.9.0.tar.gz"
+    homepage = "https://github.com/minrk/appnope"
+    url      = "https://pypi.io/packages/source/a/appnope/appnope-0.1.0.tar.gz"
 
-    # unfortunately pypi.io only offers a .whl
-    version('0.10.0', '89ed853d4a283bfa0fdbcf688b4d35fe',
-                url='https://github.com/davidhalter/jedi/archive/v0.10.0.tar.gz')
-    version('0.9.0', '2fee93d273622527ef8c97ac736e92bd')
-
-    depends_on('py-setuptools', type='build')
+    version('0.1.0', '932fbaa73792c9b06754755a774dcac5')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -35,7 +35,6 @@ class PyIpython(PythonPackage):
     version('3.1.0', 'a749d90c16068687b0ec45a27e72ef8f')
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
-    depends_on('py-pygments', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
 
     # These dependencies breaks concretization
@@ -43,7 +42,14 @@ class PyIpython(PythonPackage):
     # depends_on('py-backports-shutil-get-terminal-size', when="^python@:3.2.999")  # noqa
     # depends_on('py-pathlib2', when="^python@:3.3.999")
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
-    depends_on('py-pathlib2', type=('build', 'run'))
+    depends_on('py-pathlib2',                   type=('build', 'run'))
 
-    depends_on('py-pickleshare', type=('build', 'run'))
-    depends_on('py-simplegeneric', type=('build', 'run'))
+    depends_on('py-jedi@0.10:',                 type=('build', 'run'))
+    depends_on('py-pygments',                   type=('build', 'run'))
+    depends_on('py-pickleshare',                type=('build', 'run'))
+    depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))
+    depends_on('py-prompt-toolkit@1.0.9',       type=('build', 'run'))
+    # according to setup.py, but tries to download @2.0.0, which does not exist
+    # depends_on('py-prompt-toolkit@1.04:2.0.0',  type=('build', 'run'))
+    depends_on('py-traitlets@4.2:',             type=('build', 'run'))
+    depends_on('py-decorator',                  type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 import sys
+import platform
 
 
 class PyIpython(PythonPackage):
@@ -54,4 +55,5 @@ class PyIpython(PythonPackage):
     depends_on('py-decorator',                  type=('build', 'run'))
 
     depends_on('py-appnope', type=('build', 'run'),
-                    when=sys.platform == 'darwin')
+                    when=sys.platform == 'darwin'
+                            and int(platform.mac_ver()[0].split('.')[1]) >= 9)

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -55,5 +55,5 @@ class PyIpython(PythonPackage):
     depends_on('py-decorator',                  type=('build', 'run'))
 
     depends_on('py-appnope', type=('build', 'run'),
-                    when=sys.platform == 'darwin'
-                            and int(platform.mac_ver()[0].split('.')[1]) >= 9)
+                    when=sys.platform == 'darwin' and
+                            int(platform.mac_ver()[0].split('.')[1]) >= 9)

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class PyIpython(PythonPackage):
@@ -35,7 +36,8 @@ class PyIpython(PythonPackage):
     version('3.1.0', 'a749d90c16068687b0ec45a27e72ef8f')
     version('2.3.1', '2b7085525dac11190bfb45bb8ec8dcbf')
 
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.3:')
+    depends_on('py-setuptools@18.5:', type=('build', 'run'))
 
     # These dependencies breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
@@ -44,12 +46,12 @@ class PyIpython(PythonPackage):
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
     depends_on('py-pathlib2',                   type=('build', 'run'))
 
-    depends_on('py-jedi@0.10:',                 type=('build', 'run'))
     depends_on('py-pygments',                   type=('build', 'run'))
     depends_on('py-pickleshare',                type=('build', 'run'))
     depends_on('py-simplegeneric@0.8:',         type=('build', 'run'))
-    depends_on('py-prompt-toolkit@1.0.9',       type=('build', 'run'))
-    # according to setup.py, but tries to download @2.0.0, which does not exist
-    # depends_on('py-prompt-toolkit@1.04:2.0.0',  type=('build', 'run'))
+    depends_on('py-prompt-toolkit@1.0.4:1.999', type=('build', 'run'))
     depends_on('py-traitlets@4.2:',             type=('build', 'run'))
     depends_on('py-decorator',                  type=('build', 'run'))
+
+    depends_on('py-appnope', type=('build', 'run'),
+                    when=sys.platform == 'darwin')

--- a/var/spack/repos/builtin/packages/py-jedi/package.py
+++ b/var/spack/repos/builtin/packages/py-jedi/package.py
@@ -32,5 +32,8 @@ class PyJedi(PythonPackage):
     url      = "https://pypi.io/packages/source/j/jedi/jedi-0.9.0.tar.gz"
 
     version('0.9.0', '2fee93d273622527ef8c97ac736e92bd')
+    # unfortunately pypi.io only offers a .whl
+    version('0.10.0', '89ed853d4a283bfa0fdbcf688b4d35fe',
+        url='https://github.com/davidhalter/jedi/archive/v0.10.0.tar.gz')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
* needed to introduce a github download for py-jedi

updated dependencies according to current ```setup.py```