### PR TITLE
openblas: Run tests only when requested

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -117,6 +117,7 @@ class Openblas(MakefilePackage):
 
         return self.make_defs + targets
 
+    @on_package_attributes(run_tests=True)
     @run_after('build')
     def check_build(self):
         make('tests', *self.make_defs)
@@ -129,6 +130,7 @@ class Openblas(MakefilePackage):
         ]
         return make_args + self.make_defs
 
+    @on_package_attributes(run_tests=True)
     @run_after('install')
     def check_install(self):
         spec = self.spec


### PR DESCRIPTION
The tests fail on some systems (e.g. Comet at SDSC) that impose limits on the number of processes or threads one can run simultaneously on the head node. Thus the tests should not be run by default.