### PR TITLE
Add paths to PKG_CONFIG_PATH to find cray .pc file

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -50,7 +50,6 @@ class PkgConfig(Package):
         spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
         spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")
 
-
     def install(self, spec, prefix):
         args = ["--prefix={0}".format(prefix),
                 "--enable-shared"]

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -42,6 +42,16 @@ class PkgConfig(Package):
     # The following patch is needed for gcc-6.1
     patch('g_date_strftime.patch')
 
+    @when("platform=cray")
+    def setup_dependent_environment(self, spack_env, run_env, dep_spec):
+        """spack built pkg-config on cray's requires adding /usr/local/
+        and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
+        files."""
+
+        spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
+        spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")
+
+
     def install(self, spec, prefix):
         args = ["--prefix={0}".format(prefix),
                 "--enable-shared"]

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -47,7 +47,6 @@ class PkgConfig(Package):
         """spack built pkg-config on cray's requires adding /usr/local/
         and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
         files."""
-
         spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
         spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")
 


### PR DESCRIPTION
Adds two paths: /usr/lib64/pkgconfig and /usr/local/lib64/pkgconfig.

cray pkg-config looks at two different paths which are not included
in PKG_CONFIG_PATH environment variable. This PR addresses #3167.