### PR TITLE
Dont propagate flags between different compilers

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -377,41 +377,26 @@ class DefaultConcretizer(object):
             # running.
             return True
 
+        compiler_match = lambda other: (
+            spec.compiler == other.compiler and
+            spec.architecture == other.architecture)
+
         ret = False
         for flag in spack.spec.FlagMap.valid_compiler_flags():
+            if flag not in spec.compiler_flags:
+                spec.compiler_flags[flag] = list()
             try:
                 nearest = next(p for p in spec.traverse(direction='parents')
-                               if ((p.compiler == spec.compiler and
-                                    p is not spec) and
+                               if (compiler_match(p) and
+                                   (p is not spec) and
                                    flag in p.compiler_flags))
-                if flag not in spec.compiler_flags or \
-                        not (sorted(spec.compiler_flags[flag]) >=
-                             sorted(nearest.compiler_flags[flag])):
-                    if flag in spec.compiler_flags:
-                        spec.compiler_flags[flag] = list(
-                            set(spec.compiler_flags[flag]) |
-                            set(nearest.compiler_flags[flag]))
-                    else:
-                        spec.compiler_flags[
-                            flag] = nearest.compiler_flags[flag]
+                nearest_flags = set(nearest.compiler_flags.get(flag, []))
+                flags = set(spec.compiler_flags.get(flag, []))
+                if (nearest_flags - flags):
+                    spec.compiler_flags[flag] = list(nearest_flags | flags)
                     ret = True
-
             except StopIteration:
-                if (flag in spec.root.compiler_flags and
-                    ((flag not in spec.compiler_flags) or
-                     sorted(spec.compiler_flags[flag]) !=
-                     sorted(spec.root.compiler_flags[flag]))):
-                    if flag in spec.compiler_flags:
-                        spec.compiler_flags[flag] = list(
-                            set(spec.compiler_flags[flag]) |
-                            set(spec.root.compiler_flags[flag]))
-                    else:
-                        spec.compiler_flags[
-                            flag] = spec.root.compiler_flags[flag]
-                    ret = True
-                else:
-                    if flag not in spec.compiler_flags:
-                        spec.compiler_flags[flag] = []
+                pass
 
         # Include the compiler flag defaults from the config files
         # This ensures that spack will detect conflicts that stem from a change
@@ -419,19 +404,13 @@ class DefaultConcretizer(object):
         compiler = spack.compilers.compiler_for_spec(
             spec.compiler, spec.architecture)
         for flag in compiler.flags:
-            if flag not in spec.compiler_flags:
-                spec.compiler_flags[flag] = compiler.flags[flag]
-                if compiler.flags[flag] != []:
-                    ret = True
-            else:
-                if ((sorted(spec.compiler_flags[flag]) !=
-                     sorted(compiler.flags[flag])) and
-                    (not set(spec.compiler_flags[flag]) >=
-                     set(compiler.flags[flag]))):
-                    ret = True
-                    spec.compiler_flags[flag] = list(
-                        set(spec.compiler_flags[flag]) |
-                        set(compiler.flags[flag]))
+            config_flags = set(compiler.flags.get(flag, []))
+            flags = set(spec.compiler_flags.get(flag, []))
+            if (config_flags - flags):
+                spec.compiler_flags[flag] = list(config_flags | flags)
+                ret = True
+            elif flag not in spec.compiler_flags:
+                spec.compiler_flags[flag] = list()
 
         return ret
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -406,11 +406,9 @@ class DefaultConcretizer(object):
         for flag in compiler.flags:
             config_flags = set(compiler.flags.get(flag, []))
             flags = set(spec.compiler_flags.get(flag, []))
+            spec.compiler_flags[flag] = list(config_flags | flags)
             if (config_flags - flags):
-                spec.compiler_flags[flag] = list(config_flags | flags)
                 ret = True
-            elif flag not in spec.compiler_flags:
-                spec.compiler_flags[flag] = list()
 
         return ret
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -175,6 +175,16 @@ class TestConcretize(object):
         assert Spec('builtin.mock.multi-provider-mpi@1.10.0') in providers
         assert Spec('builtin.mock.multi-provider-mpi@1.8.8') in providers
 
+    def test_different_compilers_get_different_flags(self):
+        client = Spec('cmake-client %gcc@4.7.2 platform=test os=fe target=fe' +
+                      ' ^cmake %clang@3.5 platform=test os=fe target=fe')
+        client.concretize()
+        cmake = client['cmake']
+        assert set(client.compiler_flags['cflags']) == set(['-O0'])
+        assert set(cmake.compiler_flags['cflags']) == set(['-O3'])
+        assert set(client.compiler_flags['fflags']) == set(['-O0'])
+        assert not set(cmake.compiler_flags['fflags'])
+
     def concretize_multi_provider(self):
         s = Spec('mpileaks ^multi-provider-mpi@3.0')
         s.concretize()


### PR DESCRIPTION
Fixes #2786

Previously when a spec had no parents with an equivalent compiler, Spack would default to adding the compiler flags associated with the root of the DAG. This eliminates that default.

This also fixes an infinite recursion issue when a child spec has compiler flags that the root spec does not. This was triggered by the following in concretize.py:

```
if (flag in spec.root.compiler_flags and
    ((flag not in spec.compiler_flags) or
     sorted(spec.compiler_flags[flag]) !=
     sorted(spec.root.compiler_flags[flag]))):
```

If ```spec.compiler_flags[flag]``` had a flag that the root did not, this continually evaluated as true without changing the root.