### PR TITLE
udunits2: Add build dependency on texinfo

### DIFF
--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -44,6 +44,7 @@ class Udunits2(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('pkg-config', type='build')
+    depends_on('texinfo', type='build')
 
     def autoreconf(self, spec, prefix):
         # Work around autogen.sh oddities


### PR DESCRIPTION
udunits2 needs texinfo during build. If it is not installed globally, the build will fail currently.