### PR TITLE
Adding new package: py-py4j

### DIFF
--- a/var/spack/repos/builtin/packages/py-py4j/package.py
+++ b/var/spack/repos/builtin/packages/py-py4j/package.py
@@ -34,3 +34,5 @@ class PyPy4j(PythonPackage):
 
     version('0.10.4', 'de1ce072fb8d5bff8aba537b1700ace4')
     version('0.10.3', '6c86aebb4f1cdd4bf192b16c8a8fe8e4')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-py4j/package.py
+++ b/var/spack/repos/builtin/packages/py-py4j/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPy4j(PythonPackage):
+    """Enables Python programs to dynamically access arbitrary Java
+    objects."""
+
+    homepage = "https://www.py4j.org/"
+    url = "https://pypi.io/packages/source/p/py4j/py4j-0.10.4.tar.gz"
+
+    version('0.10.4', 'de1ce072fb8d5bff8aba537b1700ace4')
+    version('0.10.3', '6c86aebb4f1cdd4bf192b16c8a8fe8e4')


### PR DESCRIPTION
Enables Python programs to dynamically access arbitrary Java objects.