### PR TITLE
Adding new package: py-pathos (and dependencies)

### DIFF
--- a/var/spack/repos/builtin/packages/py-dill/package.py
+++ b/var/spack/repos/builtin/packages/py-dill/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyDill(PythonPackage):
+    """Serialize all of python """
+
+    homepage = "https://github.com/uqfoundation/dill"
+    url      = "https://pypi.io/packages/source/d/dill/dill-0.2.6.zip"
+
+    version('0.2.6', 'f8b98b15223d23431024349f2102b4f9')
+    version('0.2.5', 'c9eecc32351f4934e2e67740a40397f6')
+    version('0.2.4', '5d10cd1cafea38a45bcd4542f2ca3adc')
+    version('0.2.3', '0b6c4f55da320893991cc32628a6e9be')
+    version('0.2.2', 'a282b81a6d289f91218bba8d07f49bd8')
+    version('0.2.1', 'b2354a5717da6228acae33cb13bc407b')
+    version('0.2', '759002d9b71605cde2a7a052dad96b5d')
+
+    depends_on('python@2.5:2.999,3.1:')
+
+    depends_on('py-setuptools@0.6:', type='build')

--- a/var/spack/repos/builtin/packages/py-multiprocess/package.py
+++ b/var/spack/repos/builtin/packages/py-multiprocess/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyMultiprocess(PythonPackage):
+    """Better multiprocessing and multithreading in Python"""
+
+    homepage = "https://github.com/uqfoundation/multiprocess"
+    url = "https://pypi.io/packages/source/m/multiprocess/multiprocess-0.70.5.zip"
+
+    version('0.70.5', 'bfe394368b1d98192f1f62cc0060be20')
+    version('0.70.4', '443336d84c574106da6c67d4574b7614')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-dill', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-multiprocess/package.py
+++ b/var/spack/repos/builtin/packages/py-multiprocess/package.py
@@ -34,5 +34,7 @@ class PyMultiprocess(PythonPackage):
     version('0.70.5', 'bfe394368b1d98192f1f62cc0060be20')
     version('0.70.4', '443336d84c574106da6c67d4574b7614')
 
-    depends_on('py-setuptools', type='build')
-    depends_on('py-dill', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.1:')
+
+    depends_on('py-setuptools@0.6:', type='build')
+    depends_on('py-dill@0.2.6:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pathos/package.py
+++ b/var/spack/repos/builtin/packages/py-pathos/package.py
@@ -33,8 +33,10 @@ class PyPathos(PythonPackage):
 
     version('0.2.0', '7a840ce6c3a67d71e6ad7339034ec53e')
 
+    depends_on('python@2.6:2.8,3.1:')
+
     depends_on('py-setuptools@0.6:', type='build')
-    depends_on('py-multiprocess@0.70.5:', type=('build', 'run'))
-    depends_on('py-pox@0.2.3:', type=('build', 'run'))
-    depends_on('py-ppft@1.6.4.7.1:', type=('build', 'run'))
-    depends_on('py-dill@0.2.6:', type=('build', 'run'))
+    depends_on('py-multiprocess@0.70.4:', type=('build', 'run'))
+    depends_on('py-pox@0.2.2:', type=('build', 'run'))
+    depends_on('py-ppft@1.6.4.5:', type=('build', 'run'))
+    depends_on('py-dill@0.2.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pathos/package.py
+++ b/var/spack/repos/builtin/packages/py-pathos/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPathos(PythonPackage):
+    """Parallel graph management and execution in heterogeneous computing """
+
+    homepage = "https://github.com/uqfoundation/pathos"
+    url      = "https://pypi.io/packages/source/p/pathos/pathos-0.2.0.zip"
+
+    version('0.2.0', '7a840ce6c3a67d71e6ad7339034ec53e')
+
+    depends_on('py-setuptools@0.6:', type='build')
+    depends_on('py-multiprocess@0.70.5:', type=('build', 'run'))
+    depends_on('py-pox@0.2.3:', type=('build', 'run'))
+    depends_on('py-ppft@1.6.4.7.1:', type=('build', 'run'))
+    depends_on('py-dill@0.2.6:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pox/package.py
+++ b/var/spack/repos/builtin/packages/py-pox/package.py
@@ -35,4 +35,6 @@ class PyPox(PythonPackage):
     version('0.2.2', 'e1e2ce99a63d7226ea3c1a2ce389610d')
     version('0.2.1', '517dc13c2bc2429d36a0c636f3ce42db')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('python@2.5:2.8,3.1:')
+
+    depends_on('py-setuptools@0.6:', type='build')

--- a/var/spack/repos/builtin/packages/py-pox/package.py
+++ b/var/spack/repos/builtin/packages/py-pox/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPox(PythonPackage):
+    """Utilities for filesystem exploration and automated builds."""
+
+    homepage = "https://github.com/uqfoundation/pox"
+    url      = "https://pypi.io/packages/source/p/pox/pox-0.2.3.zip"
+
+    version('0.2.3', 'fcdfd9a9ab0f72367258b675554f6a83')
+    version('0.2.2', 'e1e2ce99a63d7226ea3c1a2ce389610d')
+    version('0.2.1', '517dc13c2bc2429d36a0c636f3ce42db')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-ppft/package.py
+++ b/var/spack/repos/builtin/packages/py-ppft/package.py
@@ -35,6 +35,8 @@ class PyPpft(PythonPackage):
     version('1.6.4.6',   'e533432bfba4b5a523a07d58011df209')
     version('1.6.4.5',   'd2b1f9f07eae22b31bfe90f544dd3044')
 
+    depends_on('python@2.5:2.8,3.1:')
+
     depends_on('py-setuptools@0.6:', type='build')
     depends_on('py-six@1.7.3:', type=('build', 'run'))
     depends_on('py-dill@0.2.6:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ppft/package.py
+++ b/var/spack/repos/builtin/packages/py-ppft/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPpft(PythonPackage):
+    """Distributed and parallel python """
+
+    homepage = "https://github.com/uqfoundation/ppft"
+    url      = "https://pypi.org/packages/source/p/ppft/ppft-1.6.4.7.1.zip"
+
+    version('1.6.4.7.1',  '2b196a03bfbc102773f849c6b21e617b')
+    version('1.6.4.6',   'e533432bfba4b5a523a07d58011df209')
+    version('1.6.4.5',   'd2b1f9f07eae22b31bfe90f544dd3044')
+
+    depends_on('py-setuptools@0.6:', type='build')
+    depends_on('py-six@1.7.3:', type=('build', 'run'))
+    depends_on('py-dill@0.2.6:', type=('build', 'run'))


### PR DESCRIPTION
Parallel graph management and execution in heterogeneous computing.

This PR includes:
- py-pox
- py-multiprocess
- py-ppft
- py-dill

```
o  py-pathos
|\
| |\
| | |\
| | | |\
| | | | |\
| | o | | |  py-ppft
| |/| | | | 
|/|/| | | | 
| | |\ \ \ \
| | | | |_|/
| | | |/| | 
| | | | o |  py-pox
| |_|_|/| | 
|/| |_|/ /
| |/| | | 
| | | | o  py-multiprocess
| |_|_|/| 
|/| |_|/| 
| |/| |/
| | | o  py-dill
| |_|/| 
|/| |/
| |/| 
| o |  py-setuptools
...
```