### PR TITLE
New gcc uses C++14 mode, this fixes implicit conversion

### DIFF
--- a/var/spack/repos/builtin/packages/libgtextutils/package.py
+++ b/var/spack/repos/builtin/packages/libgtextutils/package.py
@@ -31,4 +31,5 @@ class Libgtextutils(AutotoolsPackage):
     homepage = "https://github.com/agordon/libgtextutils"
     url      = "https://github.com/agordon/libgtextutils/releases/download/0.7/libgtextutils-0.7.tar.gz"
 
+    patch('text_line_reader.patch')
     version('0.7', '593c7c62e3c76ec49f5736eed4f96806')

--- a/var/spack/repos/builtin/packages/libgtextutils/text_line_reader.patch
+++ b/var/spack/repos/builtin/packages/libgtextutils/text_line_reader.patch
@@ -1,0 +1,10 @@
+--- libgtextutils/src/gtextutils/text_line_reader.cpp.orig	2017-03-09 07:49:56.358283887 -0800
++++ libgtextutils/src/gtextutils/text_line_reader.cpp	2017-03-09 07:50:24.317503887 -0800
+@@ -44,6 +44,6 @@
+ 	if (input_stream.eof())
+ 		return false;
+
+-	return input_stream ;
++	return static_cast<bool>(input_stream) ;
+ }
+


### PR DESCRIPTION
The issue is described in depth [here][desc].  C++14 no longer
allows implicit conversion from iostream classes to void*.

This patch comes directly from [libgtextutils PR #6][patch].

[desc]: http://stackoverflow.com/questions/38659115/make-fails-with-error-cannot-convert-stdistream-aka-stdbasic-istreamchar
[patch]: https://github.com/agordon/libgtextutils/pull/6