### PR TITLE
Adding packages for Keras and Theano Deep Learning toolkits, including

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -20,4 +20,5 @@ packages:
       mpi: [openmpi, mpich]
       blas: [openblas]
       lapack: [openblas]
+      scalapack: [netlib-scalapack]
       pil: [py-pillow]

--- a/var/spack/repos/builtin/packages/libgpuarray/package.py
+++ b/var/spack/repos/builtin/packages/libgpuarray/package.py
@@ -22,37 +22,36 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install libgpuarray
+#
+# You can edit this file again by typing:
+#
+#     spack edit libgpuarray
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
 from spack import *
 
-class Jasper(AutotoolsPackage):
-    """Library for manipulating JPEG-2000 images"""
 
-    homepage = "https://www.ece.uvic.ca/~frodo/jasper/"
-    url = "https://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip"
+class Libgpuarray(CMakePackage):
+    """Make a common GPU ndarray(n dimensions array) that can be reused by all
+    projects that is as future proof as possible, while keeping it easy to use
+    for simple need/quick test."""
 
-    version('1.900.1', 'a342b2b4495b3e1394e161eb5d85d754')
+    homepage = "http://deeplearning.net/software/libgpuarray/"
+    url      = "https://github.com/Theano/libgpuarray/archive/v0.6.1.tar.gz"
 
-    variant('shared', default=True,
-            description='Builds shared versions of the libraries')
-    variant('debug', default=False,
-            description='Builds debug versions of the libraries')
+    version('0.6.1', 'cfcd1b54447f9d55b05514df62c70ae2')
+    version('0.6.0', '98a4ec1b4c8f225f0b89c18b899a000b')
 
-    depends_on('libjpeg-turbo')
+    depends_on('cuda')
+    depends_on('python')
 
-    # Fixes a bug (still in upstream as of v.1.900.1) where an assertion fails
-    # when certain JPEG-2000 files with an alpha channel are processed
-    # see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=469786
-    patch('fix_alpha_channel_assert_fail.patch')
-
-    def configure_args(self):
-        spec = self.spec
-        args = ['--mandir={0}'.format(spec.prefix.man)]
-
-        if '+shared' in spec:
-            args.append('--enable-shared')
-
-        if '+debug' not in spec:
-            args.append('--disable-debug')
-
-        return args
+    extends('python')

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -22,37 +22,31 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-
 from spack import *
 
-class Jasper(AutotoolsPackage):
-    """Library for manipulating JPEG-2000 images"""
 
-    homepage = "https://www.ece.uvic.ca/~frodo/jasper/"
-    url = "https://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip"
+class PyKeras(PythonPackage):
+    """Keras is a high-level neural networks library, written in Python and 
+    capable of running on top of either TensorFlow or Theano. It was developed
+    with a focus on enabling fast experimentation. Being able to go from idea
+    to result with the least possible delay is key to doing good research."""
 
-    version('1.900.1', 'a342b2b4495b3e1394e161eb5d85d754')
+    homepage = "http://keras.io"
+    url      = "https://github.com/fchollet/keras/archive/1.2.2.tar.gz"
 
-    variant('shared', default=True,
-            description='Builds shared versions of the libraries')
-    variant('debug', default=False,
-            description='Builds debug versions of the libraries')
+    version('1.2.2', 'ed044936528c9818e95bef4c57187725')
+    version('1.2.1', 'd565724240f11913d70efb2d169c9708')
+    version('1.2.0', '5739309012b7450b80519d8fcb9b499e')
+    version('1.1.2', '5bbf8710be7e0ca5a5c3a1623111a164')
+    version('1.1.1', '8e912a380bf563f88b7aefc0cf18f390')
+    version('1.1.0', 'f554dff743ac331fb6c4b089b6f52799')
+    version('1.0.8', '46f2b12322a62658e4ff5ddf6aef526f')
+    version('1.0.7', 'fd9080b40654c43c8a986a22d35b792f')
+    version('1.0.6', 'f48b1fd85d927d58a2d297325b9a844c')
+    version('1.0.5', 'a13eecc0cdd031ad5e764c8649e5bb65')
 
-    depends_on('libjpeg-turbo')
+    depends_on('python')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-theano',     type=('build', 'run'))
 
-    # Fixes a bug (still in upstream as of v.1.900.1) where an assertion fails
-    # when certain JPEG-2000 files with an alpha channel are processed
-    # see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=469786
-    patch('fix_alpha_channel_assert_fail.patch')
-
-    def configure_args(self):
-        spec = self.spec
-        args = ['--mandir={0}'.format(spec.prefix.man)]
-
-        if '+shared' in spec:
-            args.append('--enable-shared')
-
-        if '+debug' not in spec:
-            args.append('--disable-debug')
-
-        return args
+    extends('python')

--- a/var/spack/repos/builtin/packages/py-theano/package.py
+++ b/var/spack/repos/builtin/packages/py-theano/package.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-theano
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-theano
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class PyTheano(PythonPackage):
+    """Theano is a Python library that allows you to define, optimize,
+    and evaluate mathematical expressions involving multi-dimensional
+    arrays efficiently. Theano features: tight integration with NumPy
+    transparent use of a GPU, transparent use of a GPU, efficient
+    symbolic differentiation, speed and stability optimizations,
+    dynamic C code generation, extensive unit-testing and
+    self-verification.
+
+    Theano has been powering large-scale computationally intensive
+    scientific investigations since 2007. But it is also approachable
+    enough to be used in the classroom (University of Montreal's deep
+    learning/machine learning classes)."""
+
+    homepage = "http://deeplearning.net/software/theano/index.html"
+    url      = "https://github.com/Theano/Theano/archive/rel-0.9.0rc2.tar.gz"
+
+    version('rel-0.9.0rc2', '18109046d68f3e7f9211885a98ff6357')
+    version('rel-0.7rc2',   '8bff0d24e692fd4f0a917a6af99775c6')
+
+    variant('gpu', default=False, 
+            description='Builds with support for GPUs via CUDA and cuDNN')
+
+    depends_on('python@2.6:,3.3:')
+    depends_on('py-setuptools',   type='build')
+    depends_on('py-numpy@1.7.1:', type='run')
+    depends_on('py-scipy@0.11:',  type='run')
+
+    depends_on('blas')
+
+    depends_on('cuda', when='+gpu')
+    depends_on('libgpuarray', when='+gpu')
+
+    extends('python')


### PR DESCRIPTION
associated libgpuarray packages.

Please note that this set of packages encounters a problem once it is installed.  When I try to load it with spack activate py-keras actually generates an error related to py-theano already being activated.  It seems like the system is trying to activate theano twice and doesn't recognize that it is already active.

@tgamblin