### PR TITLE
fix automatic mixing of clang with gfortran 6.3.0 on macOS

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -172,7 +172,10 @@ class Clang(Compiler):
         # to clang version, but there could be multiple clang
         # versions that work for a single gcc/gfortran version
         if sys.platform == 'darwin':
-            clangversionfromgcc = {'6.2.0': '8.0.0-apple'}
+            clangversionfromgcc = {
+                '6.2.0': '8.0.0-apple',
+                '6.3.0': '8.0.0-apple'
+            }
         else:
             clangversionfromgcc = {}
         if version in clangversionfromgcc:

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -164,22 +164,10 @@ class Clang(Compiler):
 
     @classmethod
     def fc_version(cls, fc):
-        version = get_compiler_version(
-            fc, '-dumpversion',
-            # older gfortran versions don't have simple dumpversion output.
-            r'(?:GNU Fortran \(GCC\))?(\d+\.\d+(?:\.\d+)?)')
-        # This is horribly ad hoc, we need to map from gcc/gfortran version
-        # to clang version, but there could be multiple clang
-        # versions that work for a single gcc/gfortran version
+        # We could map from gcc/gfortran version to clang version, but on macOS
+        # we normally mix any version of gfortran with any version of clang.
         if sys.platform == 'darwin':
-            clangversionfromgcc = {
-                '6.2.0': '8.0.0-apple',
-                '6.3.0': '8.0.0-apple'
-            }
-        else:
-            clangversionfromgcc = {}
-        if version in clangversionfromgcc:
-            return clangversionfromgcc[version]
+            return cls.default_version('clang')
         else:
             return 'unknown'
 

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -90,5 +90,5 @@ class TestCompilerCommand(object):
         new_compilers = set(spack.compilers.all_compiler_specs())
         new_compiler = new_compilers - old_compilers
         assert new_compiler
-        c = new_compiler.pop()
-        assert c.version == Version(test_version)
+        assert sum(1 for c in new_compiler if
+                   c.version == Version(test_version)) > 0


### PR DESCRIPTION
that is still a terribly ad hoc, but at least it fixes https://github.com/LLNL/spack/issues/3426