### PR TITLE
Fix vim ~gui behavior

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Vim(Package):
+class Vim(AutotoolsPackage):
     """Vim is a highly configurable text editor built to enable efficient text
     editing. It is an improved version of the vi editor distributed with most
     UNIX systems.  Vim is often called a "programmer's editor," and so useful
@@ -37,6 +37,7 @@ class Vim(Package):
     homepage = "http://www.vim.org"
     url      = "https://github.com/vim/vim/archive/v8.0.0134.tar.gz"
 
+    version('8.0.0454', '4030bf677bdfbd14efb588e4d9a24128')
     version('8.0.0134', 'c74668d25c2acc85d655430dd60886cd')
     version('7.4.2367', 'a0a7bc394f7ab1d95571fe6ab05da3ea')
 
@@ -59,12 +60,15 @@ class Vim(Package):
     variant('cscope', default=False, description="build with cscope support")
     depends_on('cscope', when='+cscope', type='run')
 
+    # TODO: Once better support for multi-valued variants is added, add
+    # support for auto/no/gtk2/gnome2/gtk3/motif/athena/neXtaw/photon/carbon
     variant('gui', default=False, description="build with gui (gvim)")
-    # virtual dependency?
+    variant('x', default=False, description="use the X Window System")
 
     depends_on('ncurses', when="@7.4:")
 
-    def install(self, spec, prefix):
+    def configure_args(self):
+        spec = self.spec
         feature_set = None
         for fs in self.feature_sets:
             if "+" + fs in spec:
@@ -110,11 +114,15 @@ class Vim(Package):
 
         if '+gui' in spec:
             configure_args.append("--enable-gui=auto")
+        else:
+            configure_args.append("--enable-gui=no")
+
+        if '+x' in spec:
+            configure_args.append("--with-x")
+        else:
+            configure_args.append("--without-x")
 
         if '+cscope' in spec:
             configure_args.append("--enable-cscope")
 
-        configure("--prefix=%s" % prefix, *configure_args)
-
-        make()
-        make("install")
+        return configure_args


### PR DESCRIPTION
Also adds the latest version and converts to `AutotoolsPackage`.

Previously, `spack install vim ~gui` would still build the GUI (`gvim`) if the X11 libraries were found on your system. Worse yet, both `gvim` and `vim` would link to these libraries. When I tried switching to a different node without the X11 libraries, `vim` didn't work at all for me.