### PR TITLE
Fix from_sourcing_files(): decode json input as utf-8

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -310,8 +310,10 @@ class EnvironmentModifications(object):
             raise RuntimeError('sourcing files returned a non-zero exit code')
         output = ''.join([line for line in proc.stdout])
         # Construct a dictionary with all the variables in the new environment
-        after_source_env = dict(json.loads(output))
-        this_environment = dict(os.environ)
+        after_source_env = dict(
+            (k, v.decode('utf8')) for k, v in json.loads(output).items())
+        this_environment = dict(
+            (k, v.decode('utf8')) for k, v in os.environ.items())
 
         # Filter variables that are not related to sourcing a file
         to_be_filtered = 'SHLVL', '_', 'PWD', 'OLDPWD'


### PR DESCRIPTION
Try to fix `develop` failure from #3413.

Guessing that this is an issue with the fact that `json`'s default encoding is `utf-8`, and maybe there are UTF8 chars in Travis's environment.  We'll see if this fixes things.