### PR TITLE
Dont auto-init compiler conf for 'compiler find'

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -95,8 +95,8 @@ def compiler_find(args):
     new_compilers = []
     for c in compilers:
         arch_spec = ArchSpec(None, c.operating_system, c.target)
-        same_specs = spack.compilers.compilers_for_spec(c.spec,
-                                                        arch_spec)
+        same_specs = spack.compilers.compilers_for_spec(
+            c.spec, arch_spec, init_config=False)
 
         if not same_specs:
             new_compilers.append(c)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -200,10 +200,11 @@ def supported(compiler_spec):
 
 
 @_auto_compiler_spec
-def find(compiler_spec, scope=None):
+def find(compiler_spec, scope=None, init_config=True):
     """Return specs of available compilers that match the supplied
        compiler spec.  Return an empty list if nothing found."""
-    return [c for c in all_compiler_specs(scope) if c.satisfies(compiler_spec)]
+    return [c for c in all_compiler_specs(scope, init_config)
+            if c.satisfies(compiler_spec)]
 
 
 def all_compilers(scope=None):
@@ -217,16 +218,16 @@ def all_compilers(scope=None):
 
 @_auto_compiler_spec
 def compilers_for_spec(compiler_spec, arch_spec=None, scope=None,
-                       use_cache=True):
+                       use_cache=True, init_config=True):
     """This gets all compilers that satisfy the supplied CompilerSpec.
        Returns an empty list if none are found.
     """
     if use_cache:
-        config = all_compilers_config(scope)
+        config = all_compilers_config(scope, init_config)
     else:
-        config = get_compiler_config(scope)
+        config = get_compiler_config(scope, init_config)
 
-    matches = set(find(compiler_spec, scope))
+    matches = set(find(compiler_spec, scope, init_config))
     compilers = []
     for cspec in matches:
         compilers.extend(get_compilers(cspec, config, arch_spec))


### PR DESCRIPTION
Fixes #3428

Users can run 'spack compiler find' to automatically initialize their
compilers.yaml configuration file. It also turns out that Spack will
implicitly initialize the compilers configuration file as part of
detecting compilers if none are found (so if a user were to attempt to
concretize a spec without running 'spack compiler find' it would not
fail). However, in this case Spack was overlooking its own implicit
initialization of the config files and would report that no new
compilers were found. This commit removes implicit initialization when
the user calls 'spack compiler find'.

This did not surface until #2999 because the 'spack compiler' command
defaulted to using a scope 'user/platform' that was not accounted for
in get_compiler_config (where the implicit initialization logic
predates the addition of this new scope); #2999 removed the scope
specification when checking through config files, leading to the
implicit initialization.