### PR TITLE
Add packages libbson and libmongoc

### DIFF
--- a/var/spack/repos/builtin/packages/libbson/package.py
+++ b/var/spack/repos/builtin/packages/libbson/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libbson(AutotoolsPackage):
+    """libbson is a library providing useful routines related to building,
+    parsing, and iterating BSON documents."""
+
+    homepage = "https://github.com/mongodb/libbson"
+    url      = "https://github.com/mongodb/libbson/releases/download/1.6.1/libbson-1.6.1.tar.gz"
+
+    version('1.6.1', '4d6779451bc5764a7d4982c01e7bd8c2')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+    depends_on('m4', type='build')
+
+    # 1.6.1 tarball is broken
+    force_autoreconf = True

--- a/var/spack/repos/builtin/packages/libmongoc/package.py
+++ b/var/spack/repos/builtin/packages/libmongoc/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libmongoc(AutotoolsPackage):
+    """libmongoc is a client library written in C for MongoDB."""
+
+    homepage = "https://github.com/mongodb/mongo-c-driver"
+    url      = "https://github.com/mongodb/mongo-c-driver/releases/download/1.6.1/mongo-c-driver-1.6.1.tar.gz"
+
+    version('1.6.1', '826946de9a15f7f453aefecdc76b1c0d')
+
+    depends_on('libbson')
+
+    def configure_args(self):
+        args = [
+            '--disable-automatic-init-and-cleanup',
+            '--with-libbson=system'
+        ]
+        return args


### PR DESCRIPTION
I went for libmongoc instead of mongo-c-driver for consistency and because this is the library's actual name.