### PR TITLE
Add version 4.0 for foam-extend.

### DIFF
--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -35,6 +35,7 @@ class FoamExtend(Package):
 
     homepage = "http://www.extend-project.de/"
 
+    version('4.0', git='http://git.code.sf.net/p/foam-extend/foam-extend-4.0')
     version('3.2', git='http://git.code.sf.net/p/foam-extend/foam-extend-3.2')
     version('3.1', git='http://git.code.sf.net/p/foam-extend/foam-extend-3.1')
     version('3.0', git='http://git.code.sf.net/p/foam-extend/foam-extend-3.0')


### PR DESCRIPTION
`foam-extend-4.0` has been built sucessfully with dependency packages introduced by `foam-extend-3.2`.