### PR TITLE
Add latest version of cURL

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -25,14 +25,15 @@
 from spack import *
 
 
-class Curl(Package):
+class Curl(AutotoolsPackage):
     """cURL is an open source command line tool and library for
     transferring data with URL syntax"""
 
     homepage = "http://curl.haxx.se"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://curl.haxx.se/download/curl-7.46.0.tar.bz2"
+    url      = "http://curl.haxx.se/download/curl-7.53.1.tar.bz2"
 
+    version('7.53.1', 'fb1f03a142236840c1a77c035fa4c542')
     version('7.52.1', 'dd014df06ff1d12e173de86873f9f77a')
     version('7.50.3', 'bd177fd6deecce00cfa7b5916d831c5e')
     version('7.50.2', '6e161179f7af4b9f8b6ea21420132719')
@@ -45,13 +46,13 @@ class Curl(Package):
     version('7.43.0', '11bddbb452a8b766b932f859aaeeed39')
     version('7.42.1', '296945012ce647b94083ed427c1877a8')
 
-    depends_on("openssl")
-    depends_on("zlib")
+    depends_on('openssl')
+    depends_on('zlib')
 
-    def install(self, spec, prefix):
-        configure('--prefix=%s' % prefix,
-                  '--with-zlib=%s' % spec['zlib'].prefix,
-                  '--with-ssl=%s' % spec['openssl'].prefix)
+    def configure_args(self):
+        spec = self.spec
 
-        make()
-        make("install")
+        return [
+            '--with-zlib={0}'.format(spec['zlib'].prefix),
+            '--with-ssl={0}'.format(spec['openssl'].prefix),
+        ]


### PR DESCRIPTION
Fixes #2411. Also converted to `AutotoolsPackage`.

Tested on Fedora 25 with GCC 6.2.1. All tests passed with flying colors.