### PR TITLE
hpx5: Convert to AutotoolsPackage, several updates

### DIFF
--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -70,14 +70,12 @@ class Hpx5(AutotoolsPackage):
     depends_on("opencl", when='+opencl')
     depends_on("pkg-config", type='build')
 
-    @property
-    def configure_directory(self):
-        return join_path(self.stage.source_path, "hpx")
+    configure_directory = "hpx"
+    build_directory = "spack-build"
 
     def configure_args(self):
         spec = self.spec
         args = [
-            '--prefix=%s' % self.prefix,
             '--enable-agas',          # make this a variant?
             '--enable-jemalloc',      # make this a variant?
             '--enable-percolation',   # make this a variant?
@@ -89,6 +87,8 @@ class Hpx5(AutotoolsPackage):
 
         if '+cuda' in spec:
             args += ['--enable-cuda']
+        else:
+            args += ['--disable-cuda']
 
         if '+cxx11' in spec:
             args += ['--enable-hpx++']
@@ -108,6 +108,8 @@ class Hpx5(AutotoolsPackage):
                 args += ['--with-mpi=mvapich2-cxx']
             else:
                 args += ['--with-mpi=system']
+        else:
+            args += ['--disable-mpi']
 
         # METIS does not support pkg-config; HPX will pick it up automatically
         # if '+metis' in spec:
@@ -119,6 +121,8 @@ class Hpx5(AutotoolsPackage):
                 args += ['--with-opencl=pocl']
             else:
                 args += ['--with-opencl=system']
+        else:
+            args += ['--disable-opencl']
 
         if '+photon' in spec:
             args += ['--enable-photon']

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -50,6 +50,7 @@ class Hpx5(AutotoolsPackage):
     variant('cuda', default=False, description='Enable CUDA support')
     variant('cxx11', default=False, description='Enable C++11 hpx++ interface')
     variant('debug', default=False, description='Build debug version of HPX-5')
+    variant('instrumentation', default=False, description='Enable instrumentation (may affect performance)')
     variant('metis', default=False, description='Enable METIS support')
     variant('mpi', default=False, description='Enable MPI support')
     variant('opencl', default=False, description='Enable OpenCL support')
@@ -64,10 +65,12 @@ class Hpx5(AutotoolsPackage):
     depends_on("libffi")
     depends_on("libtool", type='build')
     # depends_on("lz4")   # hpx5 always builds its own lz4
+    depends_on("m4", type='build')
     depends_on("metis", when='+metis')
     depends_on("mpi", when='+mpi')
     depends_on("mpi", when='+photon')
     depends_on("opencl", when='+opencl')
+    # depends_on("papi")
     depends_on("pkg-config", type='build')
 
     configure_directory = "hpx"
@@ -82,7 +85,8 @@ class Hpx5(AutotoolsPackage):
             # '--enable-rebalancing',   # this seems broken
             '--with-hwloc=hwloc',
             '--with-jemalloc=jemalloc',
-            '--with-libffi=libffi',
+            '--with-libffi=system',   # doesn't take a packge name as argument
+            # '--with-papi=papi',   # currently disabled in HPX
         ]
 
         if '+cuda' in spec:
@@ -95,6 +99,9 @@ class Hpx5(AutotoolsPackage):
 
         if '+debug' in spec:
             args += ['--enable-debug']
+
+        if '+instrumentation' in spec:
+            args += ['--enable-instrumentation']
 
         if '+mpi' in spec or '+photon' in spec:
             # photon requires mpi

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -22,11 +22,12 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 from spack import *
 import os
 
 
-class Hpx5(Package):
+class Hpx5(AutotoolsPackage):
     """The HPX-5 Runtime System. HPX-5 (High Performance ParalleX) is an
     open source, portable, performance-oriented runtime developed at
     CREST (Indiana University). HPX-5 provides a distributed
@@ -39,6 +40,7 @@ class Hpx5(Package):
     homepage = "http://hpx.crest.iu.edu"
     url      = "http://hpx.crest.iu.edu/release/hpx-3.1.0.tar.gz"
 
+    version('4.0.0', 'b40dc03449ae1039cbb48ee149952b22')
     version('3.1.0', '9e90b8ac46788c009079632828c77628')
     version('2.0.0', '3d2ff3aab6c46481f9ec65c5b2bfe7a6')
     version('1.3.0', '2260ecc7f850e71a4d365a43017d8cee')
@@ -46,33 +48,83 @@ class Hpx5(Package):
     version('1.1.0', '646afb460ecb7e0eea713a634933ce4f')
     version('1.0.0', '8020822adf6090bd59ed7fe465f6c6cb')
 
+    variant('cuda', default=False, description='Enable CUDA support')
+    variant('cxx11', default=False, description='Enable C++11 hpx++ interface')
     variant('debug', default=False, description='Build debug version of HPX-5')
-    variant('photon', default=False, description='Enable Photon support')
+    variant('metis', default=False, description='Enable METIS support')
     variant('mpi', default=False, description='Enable MPI support')
+    variant('opencl', default=False, description='Enable OpenCL support')
+    variant('photon', default=False, description='Enable Photon support')
+    variant('pic', default=True, description='Produce position-independent code')
 
+    depends_on("autoconf", type='build')
+    depends_on("automake", type='build')
+    depends_on("cuda", when='+cuda')
+    depends_on("hwloc")
+    depends_on("jemalloc")
+    depends_on("libffi")
+    depends_on("libtool", type='build')
+    # depends_on("lz4")   # hpx5 always builds its own lz4
+    depends_on("metis", when='+metis')
     depends_on("mpi", when='+mpi')
     depends_on("mpi", when='+photon')
+    depends_on("opencl", when='+opencl')
+    depends_on("pkg-config", type='build')
 
-    def install(self, spec, prefix):
-        extra_args = []
+    @property
+    def configure_directory(self):
+        return join_path(self.stage.source_path, "hpx")
+
+    def configure_args(self):
+        spec = self.spec
+        args = [
+            '--prefix=%s' % self.prefix,
+            '--enable-agas',          # make this a variant?
+            '--enable-jemalloc',      # make this a variant?
+            '--enable-percolation',   # make this a variant?
+            # '--enable-rebalancing',   # this seems broken
+            '--with-hwloc=hwloc',
+            '--with-jemalloc=jemalloc',
+            '--with-libffi=libffi',
+        ]
+
+        if '+cuda' in spec:
+            args += ['--enable-cuda']
+
+        if '+cxx11' in spec:
+            args += ['--enable-hpx++']
+
         if '+debug' in spec:
-            extra_args.extend([
-                '--enable-debug',
-                'CFLAGS=-g -O0'
-            ])
-        else:
-            extra_args.append('CFLAGS=-O3')
+            args += ['--enable-debug']
 
-        if '+mpi' in spec:
-            extra_args.append('--enable-mpi')
+        if '+mpi' in spec or '+photon' in spec:
+            # photon requires mpi
+            args += ['--enable-mpi']
+            # Choose pkg-config name for MPI library
+            if '^openmpi' in spec:
+                args += ['--with-mpi=ompi-cxx']
+            elif '^mpich' in spec:
+                args += ['--with-mpi=mpich']
+            elif '^mvapich2' in spec:
+                args += ['--with-mpi=mvapich2-cxx']
+            else:
+                args += ['--with-mpi=system']
+
+        # METIS does not support pkg-config; HPX will pick it up automatically
+        # if '+metis' in spec:
+        #     args += ['--with-metis=???']
+
+        if '+opencl' in spec:
+            args += ['--enable-opencl']
+            if '^pocl' in spec:
+                args += ['--with-opencl=pocl']
+            else:
+                args += ['--with-opencl=system']
 
         if '+photon' in spec:
-            extra_args.extend([
-                '--enable-mpi',
-                '--enable-photon'
-            ])
+            args += ['--enable-photon']
 
-        os.chdir("./hpx/")
-        configure('--prefix=%s' % prefix, *extra_args)
-        make()
-        make("install")
+        if '+pic' in spec:
+            args += ['--with-pic']
+
+        return args

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 
 from spack import *
-import os
 
 
 class Hpx5(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -59,8 +59,9 @@ class Hpx5(AutotoolsPackage):
 
     depends_on("autoconf", type='build')
     depends_on("automake", type='build')
-    depends_on("cuda", when='+cuda')
     depends_on("hwloc")
+    depends_on("hwloc +cuda", when='+cuda')
+    # Note: We could disable CUDA support via "hwloc ~cuda"
     depends_on("jemalloc")
     depends_on("libffi")
     depends_on("libtool", type='build')
@@ -89,11 +90,6 @@ class Hpx5(AutotoolsPackage):
             # '--with-papi=papi',   # currently disabled in HPX
         ]
 
-        if '+cuda' in spec:
-            args += ['--enable-cuda']
-        else:
-            args += ['--disable-cuda']
-
         if '+cxx11' in spec:
             args += ['--enable-hpx++']
 
@@ -115,8 +111,6 @@ class Hpx5(AutotoolsPackage):
                 args += ['--with-mpi=mvapich2-cxx']
             else:
                 args += ['--with-mpi=system']
-        else:
-            args += ['--disable-mpi']
 
         # METIS does not support pkg-config; HPX will pick it up automatically
         # if '+metis' in spec:
@@ -128,8 +122,6 @@ class Hpx5(AutotoolsPackage):
                 args += ['--with-opencl=pocl']
             else:
                 args += ['--with-opencl=system']
-        else:
-            args += ['--disable-opencl']
 
         if '+photon' in spec:
             args += ['--enable-photon']

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -63,7 +63,7 @@ class Hpx5(AutotoolsPackage):
     depends_on("hwloc +cuda", when='+cuda')
     # Note: We could disable CUDA support via "hwloc ~cuda"
     depends_on("jemalloc")
-    depends_on("libffi")
+    # depends_on("libffi")
     depends_on("libtool", type='build')
     # depends_on("lz4")   # hpx5 always builds its own lz4
     depends_on("m4", type='build')
@@ -86,7 +86,9 @@ class Hpx5(AutotoolsPackage):
             # '--enable-rebalancing',   # this seems broken
             '--with-hwloc=hwloc',
             '--with-jemalloc=jemalloc',
-            '--with-libffi=system',   # doesn't take a packge name as argument
+            # Spack's libffi installs its headers strangely,
+            # leading to problems
+            '--with-libffi=contrib',
             # '--with-papi=papi',   # currently disabled in HPX
         ]
 


### PR DESCRIPTION
- convert to AutotoolsPackage
- add several variants
- add several dependencies
- add new version 4.0.0
- don’t set compiler flags explicitly