### PR TITLE
libpciaccess: Convert to AutotoolsPackage, remove Darwin work-around

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -60,6 +60,7 @@ class Hwloc(AutotoolsPackage):
     depends_on('libpciaccess', when='+pci')
     depends_on('libxml2', when='+libxml2')
     depends_on('pkg-config', type='build')
+    depends_on('libpciaccess', when=(sys.platform != 'darwin'))
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/hwloc/v%s/downloads/hwloc-%s.tar.gz" % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+
 from spack import *
 import sys
 
@@ -60,7 +61,6 @@ class Hwloc(AutotoolsPackage):
     depends_on('libpciaccess', when='+pci')
     depends_on('libxml2', when='+libxml2')
     depends_on('pkg-config', type='build')
-    depends_on('libpciaccess', when=(sys.platform != 'darwin'))
 
     def url_for_version(self, version):
         return "http://www.open-mpi.org/software/hwloc/v%s/downloads/hwloc-%s.tar.gz" % (version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
+++ b/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class IntelGpuTools(AutotoolsPackage):
@@ -41,7 +42,7 @@ class IntelGpuTools(AutotoolsPackage):
     version('1.16', '3996f10fc86a28ec59e1cf7b227dad78')
 
     depends_on('libdrm@2.4.64:')
-    depends_on('libpciaccess@0.10:')
+    depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
     depends_on('cairo@1.12.0:')
     depends_on('glib')
 

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class Libdrm(Package):
@@ -37,7 +38,7 @@ class Libdrm(Package):
     version('2.4.59', '105ac7af1afcd742d402ca7b4eb168b6')
     version('2.4.33', '86e4e3debe7087d5404461e0032231c8')
 
-    depends_on('libpciaccess@0.10:')
+    depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
     depends_on('libpthread-stubs')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Libpciaccess(Package):
+class Libpciaccess(AutotoolsPackage):
     """Generic PCI access library."""
 
     homepage = "http://cgit.freedesktop.org/xorg/lib/libpciaccess/"
@@ -36,15 +36,3 @@ class Libpciaccess(Package):
     depends_on('libtool', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
-
-    def install(self, spec, prefix):
-        # libpciaccess does not support OS X
-        if spec.satisfies('platform=darwin'):
-            # create a dummy directory
-            mkdir(prefix.lib)
-            return
-
-        configure('--prefix={0}'.format(prefix))
-
-        make()
-        make('install')

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import sys
 
 
 class Mvapich2(Package):
@@ -94,7 +95,7 @@ class Mvapich2(Package):
 
     # FIXME : CUDA support is missing
     depends_on('bison')
-    depends_on('libpciaccess')
+    depends_on('libpciaccess', when=(sys.platform != 'darwin'))
 
     def url_for_version(self, version):
         base_url = "http://mvapich.cse.ohio-state.edu/download"


### PR DESCRIPTION
Other packages that depend on libpciaccess can do so via a conditional dependency (via a variant); we don’t need a dummy package for Darwin any more.