### PR TITLE
Add ffmpeg package.

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Ffmpeg(AutotoolsPackage):
+    """FFmpeg is a complete, cross-platform solution to record,
+    convert and stream audio and video."""
+
+    homepage = "https://ffmpeg.org"
+    url      = "http://ffmpeg.org/releases/ffmpeg-3.2.4.tar.bz2"
+
+    version('3.2.4',   'd3ebaacfa36c6e8145373785824265b4')
+
+    variant('shared', default=True,
+            description='build shared libraries')
+
+    def configure_args(self):
+        spec = self.spec
+        config_args = ['--enable-pic']
+       
+        if '+shared' in spec:
+            config_args.append('--enable-shared') 
+           
+        return config_args


### PR DESCRIPTION
FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. I add a draft pacakge for it. This package has only three variants: `shared`, `pic` and `static`. The real variants in ffmpeg (`configure -h`) is much longer. 

It has been built successfully against `%gcc@6` and `%intel@2017`. I think it is ready to merge and can be further improved by future RPs.