### PR TITLE
Improve output for compiler commands

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -112,6 +112,8 @@ def compiler_find(args):
         colify(reversed(sorted(c.spec for c in new_compilers)), indent=4)
     else:
         tty.msg("Found no new compilers")
+    tty.msg("Compilers are defined in the following files:")
+    colify(spack.compilers.compiler_config_files(), indent=4)
 
 
 def compiler_remove(args):

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -166,7 +166,8 @@ def compiler_list(args):
     tty.msg("Available compilers")
     index = index_by(spack.compilers.all_compilers(scope=args.scope),
                      lambda c: (c.spec.name, c.operating_system, c.target))
-    for i, (key, compilers) in enumerate(index.items()):
+    ordered_sections = sorted(index.items(), key=lambda (k, v): k)
+    for i, (key, compilers) in enumerate(ordered_sections):
         if i >= 1:
             print
         name, os, target = key

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -110,6 +110,16 @@ def get_compiler_config(scope=None, init_config=True):
         return []  # Return empty list which we will later append to.
 
 
+def compiler_config_files():
+    config_files = list()
+    for scope in spack.config.config_scopes:
+        config = spack.config.get_config('compilers', scope=scope)
+        if config:
+            config_files.append(spack.config.config_scopes[scope]
+                                .get_section_filename('compilers'))
+    return config_files
+
+
 def add_compilers_to_config(compilers, scope=None, init_config=True):
     """Add compilers to the config for the specified architecture.
 


### PR DESCRIPTION
This adds two changes:

* ```spack compiler list``` now sorts sections by compiler name, os, and target
* ```spack compiler find``` now lists all configuration files with compilers