### PR TITLE
Add missing dependencies to gawk

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -20,4 +20,5 @@ packages:
       mpi: [openmpi, mpich]
       blas: [openblas]
       lapack: [openblas]
+      awk: [gawk]
       pil: [py-pillow]

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -49,3 +49,5 @@ class Gawk(AutotoolsPackage):
     depends_on('readline')
     depends_on('mpfr')
     depends_on('gmp')
+
+    build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -43,3 +43,9 @@ class Gawk(AutotoolsPackage):
     url      = "http://ftp.gnu.org/gnu/gawk/gawk-4.1.4.tar.xz"
 
     version('4.1.4', '4e7dbc81163e60fd4f0b52496e7542c9')
+
+    depends_on('gettext')
+    depends_on('libsigsegv')
+    depends_on('readline')
+    depends_on('mpfr')
+    depends_on('gmp')

--- a/var/spack/repos/builtin/packages/mawk/package.py
+++ b/var/spack/repos/builtin/packages/mawk/package.py
@@ -25,31 +25,12 @@
 from spack import *
 
 
-class Gawk(AutotoolsPackage):
-    """If you are like many computer users, you would frequently like to make
-       changes in various text files wherever certain patterns appear, or
-       extract data from parts of certain lines while discarding the
-       rest. To write a program to do this in a language such as C or
-       Pascal is a time-consuming inconvenience that may take many lines
-       of code. The job is easy with awk, especially the GNU
-       implementation: gawk.
+class Mawk(AutotoolsPackage):
+    """mawk is an interpreter for the AWK Programming Language."""
 
-       The awk utility interprets a special-purpose programming language
-       that makes it possible to handle simple data-reformatting jobs
-       with just a few lines of code.
-    """
+    homepage = "http://invisible-island.net/mawk/mawk.html"
+    url      = "ftp://invisible-island.net/mawk/mawk-1.3.4.tgz"
 
-    homepage = "https://www.gnu.org/software/gawk/"
-    url      = "http://ftp.gnu.org/gnu/gawk/gawk-4.1.4.tar.xz"
-
-    version('4.1.4', '4e7dbc81163e60fd4f0b52496e7542c9')
-
-    depends_on('gettext')
-    depends_on('libsigsegv')
-    depends_on('readline')
-    depends_on('mpfr')
-    depends_on('gmp')
+    version('1.3.4', 'b1d27324ae80302452d0fa0c98447b65')
 
     provides('awk')
-
-    build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -44,8 +44,13 @@ class Ncurses(AutotoolsPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
+    # Use mawk instead of gawk to prevent a circular dependency
+    depends_on('mawk',       type='build')
+    depends_on('pkg-config', type='build')
+
     def configure_args(self):
         opts = [
+            'AWK=mawk',
             'CFLAGS={0}'.format(self.compiler.pic_flag),
             'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
@@ -60,10 +65,5 @@ class Ncurses(AutotoolsPackage):
 
         if '+symlinks' in self.spec:
             opts.append('--enable-symlinks')
-
-        # The CPPFLAGS setting works around this bug:
-        # <http://stackoverflow.com/questions/37475222/ncurses-6-0-compilation-error-error-expected-before-int>
-        if self.spec.satisfies('%gcc'):
-            opts.append('CPPFLAGS=-P')
 
         return opts

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -38,15 +38,15 @@ class Ncurses(AutotoolsPackage):
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')
     version('5.9', '8cb9c412e5f2d96bc6f459aa8c6282a1')
 
-    patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
-    patch('sed_pgi.patch',   when='@:6.0')
-
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
     # Use mawk instead of gawk to prevent a circular dependency
     depends_on('mawk',       type='build')
     depends_on('pkg-config', type='build')
+
+    patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
+    patch('sed_pgi.patch',   when='@:6.0')
 
     def configure_args(self):
         opts = [

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -41,14 +41,11 @@ class Ncurses(AutotoolsPackage):
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
     patch('sed_pgi.patch',   when='@:6.0')
 
-    depends_on("gawk", type='build')
-
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
     def configure_args(self):
         opts = [
-            'AWK=gawk',
             'CFLAGS={0}'.format(self.compiler.pic_flag),
             'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
@@ -63,5 +60,10 @@ class Ncurses(AutotoolsPackage):
 
         if '+symlinks' in self.spec:
             opts.append('--enable-symlinks')
+
+        # The CPPFLAGS setting works around this bug:
+        # <http://stackoverflow.com/questions/37475222/ncurses-6-0-compilation-error-error-expected-before-int>
+        if self.spec.satisfies('%gcc'):
+            opts.append('CPPFLAGS=-P')
 
         return opts


### PR DESCRIPTION
The Spack gawk build was linking to system libraries for all of these packages.

@eschnett I had to revert your #3425 because it resulted in a circular dependency. How do you feel about that?