### PR TITLE
Fix deptype of various dependencies on Python packages

### DIFF
--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -35,17 +35,17 @@ class Caffe(CMakePackage):
 
     version('rc5', '692bd3580b7576485cde6b1e03eb5a6d')
 
-    variant('gpu', default=False, 
+    variant('gpu', default=False,
             description='Builds with support for GPUs via CUDA and cuDNN')
-    variant('opencv', default=True, 
+    variant('opencv', default=True,
             description='Build with OpenCV support')
-    variant('leveldb', default=True, 
+    variant('leveldb', default=True,
             description="Build with levelDB")
-    variant('lmdb', default=True, 
+    variant('lmdb', default=True,
             description="Build with lmdb")
-    variant('python', default=False, 
+    variant('python', default=False,
             description='Build python wrapper and caffe python layer')
-    variant('matlab', default=False, 
+    variant('matlab', default=False,
             description='Build Matlab wrapper')
 
     depends_on('boost')
@@ -62,7 +62,7 @@ class Caffe(CMakePackage):
     depends_on('leveldb', when='+leveldb')
     depends_on('lmdb', when='+lmdb')
     depends_on('python@2.7:', when='+python')
-    depends_on('py-numpy@1.7:', when='+python')
+    depends_on('py-numpy@1.7:', when='+python', type=('build', 'run'))
     depends_on('matlab', when='+matlab')
 
     extends('python', when='+python')

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -62,8 +62,8 @@ class Cantera(Package):
     depends_on('py-cython', when='+python', type=('build', 'run'))
     depends_on('py-3to2',   when='+python', type=('build', 'run'))
     # TODO: these "when" specs don't actually work
-    # depends_on('py-unittest2',     when='+python^python@2.6')
-    # depends_on('py-unittest2py3k', when='+python^python@3.1')
+    # depends_on('py-unittest2',     when='+python^python@2.6', type=('build', 'run'))  # noqa
+    # depends_on('py-unittest2py3k', when='+python^python@3.1', type=('build', 'run'))  # noqa
 
     # Matlab toolbox dependencies
     # TODO: add Matlab package

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -88,7 +88,7 @@ class Conduit(Package):
     extends("python", when="+python")
     # TODO: blas and lapack are disabled due to build
     # issues Cyrus experienced on OSX 10.11.6
-    depends_on("py-numpy~blas~lapack", when="+python")
+    depends_on("py-numpy~blas~lapack", when="+python", type=('build', 'run'))
 
     #######################
     # I/O Packages
@@ -113,7 +113,7 @@ class Conduit(Package):
     #######################
     # Documentation related
     #######################
-    depends_on("py-sphinx", when="+python+doc")
+    depends_on("py-sphinx", when="+python+doc", type='build')
     depends_on("doxygen", when="+doc")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/dia/package.py
+++ b/var/spack/repos/builtin/packages/dia/package.py
@@ -35,12 +35,14 @@ class Dia(Package):
     depends_on('intltool', type='build')
     depends_on('gtkplus@2.6.0:')
     depends_on('cairo')
-    # depends_on('libart') # optional dependency, not yet supported by spack.
     depends_on('libpng')
     depends_on('libxslt')
     depends_on('python')
     depends_on('swig')
-    # depends_on('py-gtk') # optional dependency, not yet supported by spack.
+
+    # TODO: Optional dependencies, not yet supported by Spack
+    # depends_on('libart')
+    # depends_on('py-gtk', type=('build', 'run'))
 
     def url_for_version(self, version):
         """Handle Dia's version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -47,7 +47,7 @@ class Flux(AutotoolsPackage):
     depends_on("libjson-c")
     depends_on("libxslt")
     depends_on("python")
-    depends_on("py-cffi")
+    depends_on("py-cffi", type=('build', 'run'))
     depends_on("jansson")
 
     depends_on("asciidoc", type='build', when="+docs")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -77,7 +77,7 @@ class Llvm(Package):
 
     # Universal dependency
     depends_on('python@2.7:2.8')  # Seems not to support python 3.X.Y
-    depends_on('py-lit')
+    depends_on('py-lit', type=('build', 'run'))
 
     # lldb dependencies
     depends_on('ncurses', when='+lldb')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -36,7 +36,7 @@ class Mesa(AutotoolsPackage):
 
     # General dependencies
     depends_on('python@2.6.4:')
-    depends_on('py-mako@0.3.4:')
+    depends_on('py-mako@0.3.4:', type=('build', 'run'))
     depends_on('flex@2.5.35:', type='build')
     depends_on('bison@2.4.1:', type='build')
 

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -45,7 +45,7 @@ class PyH5py(PythonPackage):
     depends_on('hdf5@1.8.4:')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')
-    depends_on('py-mpi4py', when='+mpi')
+    depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 
     # Build and runtime dependencies
     depends_on('py-numpy@1.6.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -42,8 +42,8 @@ class PyIpython(PythonPackage):
 
     # These dependencies breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
-    # depends_on('py-backports-shutil-get-terminal-size', when="^python@:3.2.999")  # noqa
-    # depends_on('py-pathlib2', when="^python@:3.3.999")
+    # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2.999")  # noqa
+    # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3.999")
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
     depends_on('py-pathlib2',                   type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-lazyarray/package.py
+++ b/var/spack/repos/builtin/packages/py-lazyarray/package.py
@@ -34,5 +34,5 @@ class PyLazyarray(PythonPackage):
 
     version('0.2.8', '8e0072f0892b9fc0516e7048f96e9d74')
 
-    depends_on('py-numpy@1.3:')
-    depends_on('py-numpy@1.5:', when='^python@3:')
+    depends_on('py-numpy@1.3:', type=('build', 'run'))
+    depends_on('py-numpy@1.5:', type=('build', 'run'), when='^python@3:')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -82,7 +82,7 @@ class PyMatplotlib(PythonPackage):
     # --------- Optional dependencies
     depends_on('pkg-config', type='build')    # why not...
     depends_on('pil', when='+image', type=('build', 'run'))
-    depends_on('py-ipython', when='+ipython')
+    depends_on('py-ipython', when='+ipython', type=('build', 'run'))
     depends_on('ghostscript', when='+latex', type='run')
     depends_on('texlive', when='+latex', type='run')
 

--- a/var/spack/repos/builtin/packages/py-pygobject/package.py
+++ b/var/spack/repos/builtin/packages/py-pygobject/package.py
@@ -40,7 +40,7 @@ class PyPygobject(AutotoolsPackage):
 
     depends_on("libffi")
     depends_on('glib')
-    depends_on('py-py2cairo')
+    depends_on('py-py2cairo', type=('build', 'run'))
     depends_on('gobject-introspection')
 
     patch('pygobject-2.28.6-introspection-1.patch', when='@2.28.3:2.28.6')

--- a/var/spack/repos/builtin/packages/py-pygtk/package.py
+++ b/var/spack/repos/builtin/packages/py-pygtk/package.py
@@ -39,8 +39,8 @@ class PyPygtk(AutotoolsPackage):
     depends_on('glib')
     # for GTK 3.X use pygobject 3.X instead of pygtk
     depends_on('gtkplus+X@2.24:2.99')
-    depends_on('py-pygobject@2.28:2.99')
-    depends_on('py-py2cairo')
+    depends_on('py-pygobject@2.28:2.99', type=('build', 'run'))
+    depends_on('py-py2cairo', type=('build', 'run'))
 
     def install(self, spec, prefix):
         make('install', parallel=False)

--- a/var/spack/repos/builtin/packages/py-scientificpython/package.py
+++ b/var/spack/repos/builtin/packages/py-scientificpython/package.py
@@ -35,4 +35,4 @@ class PyScientificpython(PythonPackage):
     url      = "https://sourcesup.renater.fr/frs/download.php/file/4411/ScientificPython-2.8.1.tar.gz"
     version('2.8.1', '73ee0df19c7b58cdf2954261f0763c77')
 
-    depends_on('py-numpy')
+    depends_on('py-numpy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-singledispatch/package.py
+++ b/var/spack/repos/builtin/packages/py-singledispatch/package.py
@@ -34,7 +34,7 @@ class PySingledispatch(PythonPackage):
     version('3.4.0.3', 'af2fc6a3d6cc5a02d0bf54d909785fcb')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-six')
+    depends_on('py-six', type=('build', 'run'))
 
     # This dependency breaks concretization
     # See https://github.com/LLNL/spack/issues/2793

--- a/var/spack/repos/builtin/packages/py-symengine/package.py
+++ b/var/spack/repos/builtin/packages/py-symengine/package.py
@@ -37,7 +37,7 @@ class PySymengine(PythonPackage):
     # Build dependencies
     depends_on('python@2.7:2.8,3.3:')
     depends_on('py-setuptools',     type='build')
-    depends_on('py-cython@0.19.1:')
+    depends_on('py-cython@0.19.1:', type='build')
     depends_on('cmake@2.8.7:',      type='build')
     depends_on('symengine@0.2.0:')
 

--- a/var/spack/repos/builtin/packages/py-sympy/package.py
+++ b/var/spack/repos/builtin/packages/py-sympy/package.py
@@ -33,4 +33,4 @@ class PySympy(PythonPackage):
     version('0.7.6', '3d04753974306d8a13830008e17babca')
     version('1.0', '43e797de799f00f9e8fd2307dba9fab1')
 
-    depends_on('py-mpmath', when='@1.0:')
+    depends_on('py-mpmath', when='@1.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-unittest2/package.py
+++ b/var/spack/repos/builtin/packages/py-unittest2/package.py
@@ -35,4 +35,4 @@ class PyUnittest2(PythonPackage):
     version('1.1.0', 'f72dae5d44f091df36b6b513305ea000')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-enum34', when='^python@:3.3')
+    depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/stat/package.py
+++ b/var/spack/repos/builtin/packages/stat/package.py
@@ -53,7 +53,7 @@ class Stat(Package):
     depends_on('launchmon')
     depends_on('mrnet')
     depends_on('python')
-    depends_on('py-pygtk')
+    depends_on('py-pygtk', type=('build', 'run'))
     depends_on('swig')
     depends_on('mpi', when='+examples')
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -120,7 +120,7 @@ class Trilinos(CMakePackage):
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hdf5+mpi', when='+hdf5')
     depends_on('python', when='+python')
-    depends_on('py-numpy', when='+python')
+    depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('swig', when='+python')
 
     patch('umfpack_from_suitesparse.patch', when='@:12.8.1')


### PR DESCRIPTION
After looking at #3485, I found several other packages that depend on Python package but don't declare the deptype properly.