### PR TITLE
Adding new packages: py-argparse and py-importlib

### DIFF
--- a/var/spack/repos/builtin/packages/py-argparse/package.py
+++ b/var/spack/repos/builtin/packages/py-argparse/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyArgparse(PythonPackage):
+    """Python command-line parsing library."""
+
+    homepage = "https://github.com/ThomasWaldmann/argparse/"
+    url      = "https://pypi.io/packages/source/a/argparse/argparse-1.4.0.tar.gz"
+
+    version('1.4.0', '08062d2ceb6596fcbc5a7e725b53746f')
+
+    depends_on('python@2.3:')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-importlib/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib/package.py
@@ -1,0 +1,34 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyImportlib(PythonPackage):
+    """Packaging for importlib from Python 2.7"""
+
+    homepage = "https://github.com/brettcannon/importlib"
+    url      = "https://pypi.io/packages/source/i/importlib/importlib-1.0.4.zip"
+
+    version('1.0.4', '5f9a0803bca7ba95f670d1464984296f')


### PR DESCRIPTION
@becker33 @adamjstewart These are the packages mentioned in #3401, dependencies of `py-future` when using `python@2.6`.