### PR TITLE
Fix for `find --explicit` #3374

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -64,7 +64,7 @@ class ConstraintAction(argparse.Action):
 
         # return everything for an empty query.
         if not qspecs:
-            return spack.store.db.query()
+            return spack.store.db.query(**kwargs)
 
         # Return only matching stuff otherwise.
         specs = set()


### PR DESCRIPTION
This fixes the problem described in #3374, which describes `spack find` ignoring the explicit/implicit flags.

I believe that this was broken in #2626.

This restores the behavior of implicit/explicit for me.

I believe that it does not screw anything else up, but ....