### PR TITLE
Add package kaldi.

### DIFF
--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -1,0 +1,107 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from distutils.dir_util import copy_tree
+from os.path import join
+from fnmatch import fnmatch
+import os
+
+
+class Kaldi(Package):    # Does not use Autotools
+    """Kaldi is a toolkit for speech recognition written
+    in C++ and licensed under the Apache License v2.0.
+    Kaldi is intended for use by speech recognition researchers."""
+
+    homepage = "https://github.com/kaldi-asr/kaldi"
+    url      = "https://github.com/kaldi-asr/kaldi/archive/master.zip"
+
+    version('master', git='https://github.com/kaldi-asr/kaldi.git')
+
+    variant('shared', default=True,
+            description='build shared libraries')
+    variant('double', default=False,
+            description='build with double precision floats')
+    variant('cuda', default=False,
+            description='build with CUDA')
+
+    depends_on('blas')
+    depends_on('speex')
+    depends_on('openfst@1.6:')
+    depends_on('cuda', when='+cuda')
+    depends_on('sph2pipe', type='run')
+    depends_on('sctk', type='run')
+
+    def install(self, spec, prefix):
+        configure_args = [
+            '--threaded-math',
+            '--speex-root=' + spec['speex'].prefix,
+            '--fst-root=' + spec['openfst'].prefix,
+            '--fst-version=' + str(spec['openfst'].version)
+        ]
+
+        if '~shared' in spec:
+            configure_args.append('--static')
+        else:
+            configure_args.append('--shared')
+
+        if '^openblas' in spec:
+            configure_args.append('--mathlib=OPENBLAS')
+            configure_args.append('--openblas-root=' + spec['blas'].prefix)
+            if '+openmp' in spec['blas'].variants:
+                configure_args.append('--threaded-math')
+        elif '^atlas' in spec:
+            configure_args.append('--mathlib=ATLAS')
+            configure_args.append('--atlas-root=' + spec['blas'].prefix)
+            if '+pthread' in spec['blas'].variants:
+                configure_args.append('--threaded-atlas')
+        elif '^intel-parallel-studio' in spec or '^intel-mkl' in spec:
+            configure_args.append('--mathlib=MKL')
+            configure_args.append('--mkl-root=' + spec['blas'].prefix)
+            if '+openmp' in spec['blas'].variants:
+                configure_args.append('--mkl-threading=iomp')
+
+        if '+cuda' in spec:
+            configure_args.append('--use-cuda=yes')
+            configure_args.append('--cudatk-dir=' + spec['cuda'].prefix)
+
+        with working_dir("src"):
+            configure(*configure_args)
+            make()
+
+            mkdirp(prefix.bin)
+            for root, dirs, files in os.walk('bin'):
+                for name in files:
+                    if os.access(join(root, name), os.X_OK):
+                        install(join(root, name), prefix.bin)
+
+            mkdir(prefix.lib)
+            copy_tree('lib', prefix.lib)
+
+            for root, dirs, files in os.walk('.'):
+                for name in files:
+                    if fnmatch(name, '*.h'):
+                        mkdirp(join(prefix.include, root.strip("./")))
+                        install(join(root, name),
+                                join(prefix.include, root.strip("./")))

--- a/var/spack/repos/builtin/packages/speex/package.py
+++ b/var/spack/repos/builtin/packages/speex/package.py
@@ -1,0 +1,35 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Speex(AutotoolsPackage):
+    """Speex is an Open Source/Free Software patent-free 
+    audio compression format designed for speech."""
+
+    homepage = "https://speex.org"
+    url      = "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
+
+    version('1.2.0', '8ab7bb2589110dfaf0ed7fa7757dc49c')

--- a/var/spack/repos/builtin/packages/sph2pipe/cmake.patch
+++ b/var/spack/repos/builtin/packages/sph2pipe/cmake.patch
@@ -1,0 +1,10 @@
+diff -ruN sph2pipe_v2.5.ori/CMakeLists.txt sph2pipe_v2.5/CMakeLists.txt
+--- sph2pipe_v2.5.ori/CMakeLists.txt    1970-01-01 08:00:00.000000000 +0800
++++ sph2pipe_v2.5/CMakeLists.txt        2017-03-27 17:33:27.000000000 +0800
+@@ -0,0 +1,6 @@
++PROJECT (SPH2PIPE)
++SET(SRC_LIST file_headers.c shorten_x.c sph2pipe.c)
++ADD_EXECUTABLE(sph2pipe ${SRC_LIST})
++TARGET_LINK_LIBRARIES(sph2pipe m)
++INSTALL(TARGETS sph2pipe
++       RUNTIME DESTINATION bin)

--- a/var/spack/repos/builtin/packages/sph2pipe/package.py
+++ b/var/spack/repos/builtin/packages/sph2pipe/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Sph2pipe(CMakePackage):
+    """Sph2pipe is a portable tool for
+    converting SPHERE files to other formats."""
+
+    homepage = "https://www.ldc.upenn.edu/language-resources/tools/sphere-conversion-tools"
+    url      = "https://www.ldc.upenn.edu/sites/www.ldc.upenn.edu/files/ctools/sph2pipe_v2.5.tar.gz"
+
+    version('2.5', '771d9143e9aec0a22c6a14e138974be2')
+
+    patch('cmake.patch')


### PR DESCRIPTION
#Kaldi is a toolkit for speech recognition written in C++ and licensed under the Apache License v2.0. Kaldi is intended for use by speech recognition researchers. It has quite a number of dependency packages. This PR hosts a board for watching progress on building Kaldi.

The following list may keep increasing as I build kaldi.

- [x] sctk (#3325 merged)
- [x] openfst (#3324 merged)
- [x] sph2pipe
- [x] speedx
- [x] kaldi CPU version
- [x] kaldi GPU verison

- [x] Add `# Does not use Aututools` to kaldi
- [x] Refine the BLAS configuration (check `petsc` and `trillioins`) 
- [x] Substitute `find` with `os.walk()`.
- [x] Substitute `rsync` with `os.walk()`.
- [x] Patch `sph2pipe` with a CMake file.