### PR TITLE
Replacing failing git clone by valid url

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -35,14 +35,12 @@ class Elfutils(AutotoolsPackage):
 
     homepage = "https://fedorahosted.org/elfutils/"
 
-    depends_on('libtool', type='build')
-
-    url      = "https://sourceware.org/elfutils/ftp/0.163/elfutils-0.163.tar.bz2"
+    url      = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
     list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 2
 
-    version('0.163','77ce87f259987d2e54e4d87b86cbee41')
     version('0.168','52adfa40758d0d39e5d5c57689bf38d6')
+    version('0.163','77ce87f259987d2e54e4d87b86cbee41')
 
     provides('elf@1')
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -39,8 +39,8 @@ class Elfutils(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
 
-    url      = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
-    version('0.168','52adfa40758d0d39e5d5c57689bf38d6')
+    url      = "https://sourceware.org/elfutils/ftp/0.163/elfutils-0.163.tar.bz2"
+    version('0.163','77ce87f259987d2e54e4d87b86cbee41')
 
     provides('elf@1')
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -38,7 +38,7 @@ class Elfutils(AutotoolsPackage):
     depends_on('libtool', type='build')
 
     url      = "https://sourceware.org/elfutils/ftp/0.163/elfutils-0.163.tar.bz2"
-    lsit_url = "https://sourceware.org/elfutils/ftp"
+    list_url = "https://sourceware.org/elfutils/ftp"
     list_depth = 2
 
     version('0.163','77ce87f259987d2e54e4d87b86cbee41')

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -39,9 +39,8 @@ class Elfutils(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
 
-    version('0.163',
-            git='git://git.fedorahosted.org/git/elfutils.git',
-            tag='elfutils-0.163')
+    url      = "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
+    version('0.168','52adfa40758d0d39e5d5c57689bf38d6')
 
     provides('elf@1')
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -36,11 +36,13 @@ class Elfutils(AutotoolsPackage):
     homepage = "https://fedorahosted.org/elfutils/"
 
     depends_on('libtool', type='build')
-    depends_on('automake', type='build')
-    depends_on('autoconf', type='build')
 
     url      = "https://sourceware.org/elfutils/ftp/0.163/elfutils-0.163.tar.bz2"
+    lsit_url = "https://sourceware.org/elfutils/ftp"
+    list_depth = 2
+
     version('0.163','77ce87f259987d2e54e4d87b86cbee41')
+    version('0.168','52adfa40758d0d39e5d5c57689bf38d6')
 
     provides('elf@1')
 


### PR DESCRIPTION
Following @adamjstewart indications, I've replaced the failing git clone byt the url that he suggested.