### PR TITLE
Convert gettext to AutotoolsPackage

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -25,8 +25,9 @@
 from spack import *
 
 
-class Gettext(Package):
+class Gettext(AutotoolsPackage):
     """GNU internationalization (i18n) and localization (l10n) library."""
+
     homepage = "https://www.gnu.org/software/gettext/"
     url      = "http://ftpmirror.gnu.org/gettext/gettext-0.19.7.tar.xz"
 
@@ -60,9 +61,10 @@ class Gettext(Package):
     depends_on('libunistring', when='+libunistring')
     # depends_on('cvs')
 
-    def install(self, spec, prefix):
+    def configure_args(self):
+        spec = self.spec
+
         config_args = [
-            '--prefix={0}'.format(prefix),
             '--disable-java',
             '--disable-csharp',
             '--with-included-glib',
@@ -97,7 +99,4 @@ class Gettext(Package):
         else:
             config_args.append('--with-included-libunistring')
 
-        configure(*config_args)
-
-        make()
-        make("install")
+        return config_args


### PR DESCRIPTION
Tests passed, yay!

I actually noticed something a little strange about the installation.
```
drwxr-sr-x 2 ajstewart lcrcsoft     512 Mar 21 14:56 gettext
-rw-r--r-- 1 ajstewart lcrcsoft   61614 Mar 21 14:56 libasprintf.a
-rwxr-xr-x 1 ajstewart lcrcsoft    1063 Mar 21 14:56 libasprintf.la
lrwxrwxrwx 1 ajstewart lcrcsoft      20 Mar 21 14:56 libasprintf.so -> libasprintf.so.0.0.0
lrwxrwxrwx 1 ajstewart lcrcsoft      20 Mar 21 14:56 libasprintf.so.0 -> libasprintf.so.0.0.0
-rwxr-xr-x 1 ajstewart lcrcsoft   43248 Mar 21 14:56 libasprintf.so.0.0.0
-rwxr-xr-x 1 ajstewart lcrcsoft 2481344 Mar 21 14:56 libgettextlib-0.19.8.1.so
-rw-r--r-- 1 ajstewart lcrcsoft 4188096 Mar 21 14:56 libgettextlib.a
-rwxr-xr-x 1 ajstewart lcrcsoft    1273 Mar 21 14:56 libgettextlib.la
lrwxrwxrwx 1 ajstewart lcrcsoft      25 Mar 21 14:56 libgettextlib.so -> libgettextlib-0.19.8.1.so
-rw-r--r-- 1 ajstewart lcrcsoft 2628714 Mar 21 14:56 libgettextpo.a
-rwxr-xr-x 1 ajstewart lcrcsoft    1219 Mar 21 14:56 libgettextpo.la
lrwxrwxrwx 1 ajstewart lcrcsoft      21 Mar 21 14:56 libgettextpo.so -> libgettextpo.so.0.5.4
lrwxrwxrwx 1 ajstewart lcrcsoft      21 Mar 21 14:56 libgettextpo.so.0 -> libgettextpo.so.0.5.4
-rwxr-xr-x 1 ajstewart lcrcsoft 1501224 Mar 21 14:56 libgettextpo.so.0.5.4
-rwxr-xr-x 1 ajstewart lcrcsoft 1372040 Mar 21 14:56 libgettextsrc-0.19.8.1.so
-rwxr-xr-x 1 ajstewart lcrcsoft    1424 Mar 21 14:56 libgettextsrc.la
lrwxrwxrwx 1 ajstewart lcrcsoft      25 Mar 21 14:56 libgettextsrc.so -> libgettextsrc-0.19.8.1.so
-rw-r--r-- 1 ajstewart lcrcsoft  378252 Mar 21 14:56 libintl.a
-rw-r--r-- 1 ajstewart lcrcsoft    1039 Mar 21 14:56 libintl.la
lrwxrwxrwx 1 ajstewart lcrcsoft      16 Mar 21 14:56 libintl.so -> libintl.so.8.1.5
lrwxrwxrwx 1 ajstewart lcrcsoft      16 Mar 21 14:56 libintl.so.8 -> libintl.so.8.1.5
-rw-r--r-- 1 ajstewart lcrcsoft  204792 Mar 21 14:56 libintl.so.8.1.5
```
All of the .so files are either symlinks or executables, but `libintl.so.8.1.5` doesn't have the executable permissions set. We've seen a few issues lately where packages weren't linking to libintl properly. Could this be the cause?