### PR TITLE
Update googletest

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -30,7 +30,9 @@ class Googletest(Package):
     homepage = "https://github.com/google/googletest"
     url      = "https://github.com/google/googletest/tarball/release-1.7.0"
 
+    version('1.8.0', 'd2edffbe844902d942c31db70c7cfec2')
     version('1.7.0', '5eaf03ed925a47b37c8e1d559eb19bc4')
+    version('1.6.0', '90407321648ab25b067fcd798caf8c78')
 
     depends_on("cmake", type='build')
 


### PR DESCRIPTION
This adds v1.8.0 and 1.6.0 one the latest stable and the other generally available on older centos based distros