### PR TITLE
Add cuda support for gromacs.

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -51,14 +51,14 @@ class Gromacs(CMakePackage):
         'double', default=False,
         description='Produces a double precision version of the executables')
     variant('plumed', default=False, description='Enable PLUMED support')
+    variant('cuda', default=False, description='Enable CUDA support')
 
     depends_on('mpi', when='+mpi')
     depends_on('plumed+mpi', when='+plumed+mpi')
     depends_on('plumed~mpi', when='+plumed~mpi')
     depends_on('fftw')
     depends_on('cmake@2.8.8:', type='build')
-
-    # TODO : add GPU support
+    depends_on('cuda', when='+cuda')
 
     def patch(self):
         if '+plumed' in self.spec:
@@ -81,5 +81,10 @@ class Gromacs(CMakePackage):
             options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
         else:
             options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
+
+        if '+cuda' in self.spec:
+            options.append('-DGMX_GPU:BOOL=ON')
+            options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
+                           self.spec['cuda'].prefix)
 
         return options


### PR DESCRIPTION
Build successfully with `spack install gromacs+mpi+cuda %gcc@5 ^openmpi ^cuda@8`. The latest cuda8 doesn't support `gcc@6` yet.