### PR TITLE
Override partial installs by default

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -73,7 +73,7 @@ the dependencies"""
         '--fake', action='store_true', dest='fake',
         help="fake install. just remove prefix and create a fake file")
     subparser.add_argument(
-        '--force', '-f', action='store_true', dest='force',
+        '--force', action='store_true', dest='force',
         help='Install again even if package is already installed.')
 
     cd_group = subparser.add_mutually_exclusive_group()

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -72,6 +72,9 @@ the dependencies"""
     subparser.add_argument(
         '--fake', action='store_true', dest='fake',
         help="fake install. just remove prefix and create a fake file")
+    subparser.add_argument(
+        '--force', '-f', action='store_true', dest='force',
+        help='Install again even if package is already installed.')
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -319,6 +322,12 @@ def install(parser, args, **kwargs):
         tty.error('The `spack install` command requires a spec to install.')
 
     for spec in specs:
+        if args.force:
+            for s in spec.traverse():
+                if s.package.installed:
+                    tty.msg("Clearing %s for new installation" % s.name)
+                    s.package.do_uninstall(force=True)
+
         # Check if we were asked to produce some log for dashboards
         if args.log_format is not None:
             # Compute the filename for logging

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -271,7 +271,7 @@ class YamlDirectoryLayout(DirectoryLayout):
             return None
         elif not self.completed_install(spec):
             raise InconsistentInstallDirectoryError(
-                'This prefix {} contains a partial install'.format(path))
+                'The prefix %s contains a partial install' % path)
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -246,7 +246,7 @@ class YamlDirectoryLayout(DirectoryLayout):
                          'complete')
 
     def mark_complete(self, spec):
-        with open(self._completion_marker_file(spec), 'wa'):
+        with open(self._completion_marker_file(spec), 'w'):
             pass
 
     def completed_install(self, spec):

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -265,26 +265,34 @@ class YamlDirectoryLayout(DirectoryLayout):
     def check_installed(self, spec):
         _check_concrete(spec)
         path = self.path_for_spec(spec)
-        spec_file_path = self.spec_file_path(spec)
 
         if not os.path.isdir(path):
             return None
+        elif not self.completed_install(spec):
+            raise InconsistentInstallDirectoryError(
+                'The prefix %s contains a partial install' % path)
+
+        self.check_metadata_consistency(spec)
+        return path
+
+    def check_metadata_consistency(self, spec):
+        spec_file_path = self.spec_file_path(spec)
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(
                 'Install prefix exists but contains no spec.yaml:',
-                "  " + path)
+                "  " + spec.prefix)
 
         installed_spec = self.read_spec(spec_file_path)
         if installed_spec == spec:
-            return path
+            return
 
         # DAG hashes currently do not include build dependencies.
         #
         # TODO: remove this when we do better concretization and don't
         # ignore build-only deps in hashes.
         elif installed_spec == spec.copy(deps=('link', 'run')):
-            return path
+            return
 
         if spec.dag_hash() == installed_spec.dag_hash():
             raise SpecHashCollisionError(spec, installed_spec)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -241,6 +241,17 @@ class YamlDirectoryLayout(DirectoryLayout):
         return join_path(self.path_for_spec(spec), self.metadata_dir,
                          self.packages_dir)
 
+    def _completion_marker_file(self, spec):
+        return join_path(self.path_for_spec(spec), self.metadata_dir,
+                         'complete')
+
+    def mark_complete(self, spec):
+        with open(self._completion_marker_file(spec), 'wa'):
+            pass
+
+    def completed_install(self, spec):
+        return os.path.exists(self._completion_marker_file(spec))
+
     def create_install_directory(self, spec):
         _check_concrete(spec)
 
@@ -258,6 +269,9 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         if not os.path.isdir(path):
             return None
+        elif not self.completed_install(spec):
+            raise InconsistentInstallDirectoryError(
+                'This prefix {} contains a partial install'.format(path))
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -269,9 +269,6 @@ class YamlDirectoryLayout(DirectoryLayout):
 
         if not os.path.isdir(path):
             return None
-        elif not self.completed_install(spec):
-            raise InconsistentInstallDirectoryError(
-                'The prefix %s contains a partial install' % path)
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1183,7 +1183,7 @@ class PackageBase(object):
                             rec = spack.store.db.get_record(self.spec)
                             rec.explicit = True
                 except KeyError:
-                    tty.msg("Repairing db for %s" % str(self.spec))
+                    tty.msg("Repairing db for %s" % self.name)
                     spack.store.db.add(self.spec)
                     rec = spack.store.db.get_record(
                         self.spec, layout, explicit)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1351,6 +1351,12 @@ class PackageBase(object):
                     tty.msg("Repairing db for %s" % self.name)
                     spack.store.db.add(self.spec)
 
+            if continue_with_partial and not self.installed:
+                try:
+                    layout.check_metadata_consistency(self.spec)
+                except directory_layout.DirectoryLayoutError:
+                    self.remove_prefix()
+
         if not continue_with_partial:
             self.stage.destroy()
             self.stage.create()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -115,9 +115,11 @@ def test_install_succeeds_but_db_add_fails(mock_archive):
     fake_fetchify(mock_archive.url, pkg)
     remove_prefix = spack.package.Package.remove_prefix
     db_add = spack.store.db.add
+
     def mock_db_add(*args, **kwargs):
         raise MockInstallError(
             "Intentional error", "Mock db add method intentionally fails")
+
     try:
         spack.package.Package.remove_prefix = mock_remove_prefix
         spack.store.db.add = mock_db_add

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -407,7 +407,7 @@ function _spack_install {
     then
         compgen -W "-h --help --only -j --jobs --keep-prefix --keep-stage
                     -n --no-checksum -v --verbose --fake --clean --dirty
-                    --run-tests --log-format --log-file" -- "$cur"
+                    --run-tests --log-format --log-file --force" -- "$cur"
     else
         compgen -W "$(_all_packages)" -- "$cur"
     fi

--- a/var/spack/repos/builtin.mock/packages/canfail/package.py
+++ b/var/spack/repos/builtin.mock/packages/canfail/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Canfail(Package):
+    """Package which fails install unless a special attribute is set"""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    def install(self, spec, prefix):
+        try:
+            getattr(self, 'succeed')
+            touch(join_path(prefix, 'an_installation_file'))
+        except AttributeError:
+            raise InstallError()


### PR DESCRIPTION
Fixes https://github.com/LLNL/spack/issues/2634

@tgamblin we originally talked about not automatically removing the prefix if --keep-prefix is set. While working on this I also noticed that it is possible that a partially complete installation may also have left stage files and in some cases re-initiating the install will fail because of that (gmp is an example as the 'configure' step cannot be performed twice without an intervening make clean). ~~My thought there was to also remove the stage files by default unless the user has specified --keep-stage. Perhaps adding a different option would be better.~~

(EDIT 3/27) --keep-prefix now indicates that the install prefix and staging directory should be kept if present. If --keep-prefix is not set, then both of these are removed.

- [x] Test removal of stage by default
- [x] Add test to ensure that the prefix is not deleted on a new install attempt if --keep-prefix is set

Depending on how spack is terminated in the middle of building a package it may leave a partially installed package in the install prefix. Originally Spack treated the package as being installed if the prefix was present, in which case the user would have to manually remove the installation prefix before restarting an install. This adds a more-thorough check to ensure that a package is actually installed. If the installation prefix is present but Spack determines that the install did not complete, it removes the installation prefix and starts a new install. ~~If the user has enabled --keep-prefix, then Spack reverts to its old behavior.~~

EDIT 3/27: If the user has enabled --keep-prefix, then Spack will keep its stage directory if present (as it did before); in this case Spack will also keep the installation prefix and re-execute the installation commands unless there is an issue with the metadata (e.g. the spec.yaml file), in which case it will reset the installation prefix.