### PR TITLE
CONFIG: update versions for paraview

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/gcc-compiler-pv501.patch
+++ b/var/spack/repos/builtin/packages/paraview/gcc-compiler-pv501.patch
@@ -1,0 +1,22 @@
+--- ParaView-5.0.1.orig/VTK/CMake/vtkCompilerExtras.cmake	2016-03-28 17:07:10.000000000 +0200
++++ ParaView-5.0.1/VTK/CMake/vtkCompilerExtras.cmake	2016-12-13 17:21:25.382720945 +0100
+@@ -32,7 +32,7 @@
+     OUTPUT_VARIABLE _gcc_version_info
+     ERROR_VARIABLE _gcc_version_info)
+
+-  string (REGEX MATCH "[345]\\.[0-9]\\.[0-9]*"
++  string (REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
+     _gcc_version "${_gcc_version_info}")
+   if(NOT _gcc_version)
+     string (REGEX REPLACE ".*\\(GCC\\).*([34]\\.[0-9]).*" "\\1.0"
+--- ParaView-5.0.1.orig/VTK/CMake/GenerateExportHeader.cmake	2016-03-28 17:07:10.000000000 +0200
++++ ParaView-5.0.1/VTK/CMake/GenerateExportHeader.cmake	2016-12-13 17:21:25.382720945 +0100
+@@ -166,7 +166,7 @@
+     execute_process(COMMAND ${CMAKE_C_COMPILER} ARGS --version
+       OUTPUT_VARIABLE _gcc_version_info
+       ERROR_VARIABLE _gcc_version_info)
+-    string(REGEX MATCH "[345]\\.[0-9]\\.[0-9]*"
++    string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
+       _gcc_version "${_gcc_version_info}")
+     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+     # patch level, handle this here:

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -25,32 +25,36 @@
 from spack import *
 
 
-class Paraview(Package):
+class Paraview(CMakePackage):
+    """ParaView is an open-source, multi-platform data analysis and
+    visualization application."""
+
     homepage = 'http://www.paraview.org'
-    url      = 'http://www.paraview.org/files/v5.0/ParaView-v'
-    _url_str = 'http://www.paraview.org/files/v%s/ParaView-v%s-source.tar.gz'
+    url      = "http://www.paraview.org/files/v5.3/ParaView-v5.3.0.tar.gz"
+    _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.gz'
 
+    version('5.3.0', '68fbbbe733aa607ec13d1db1ab5eba71')
+    version('5.2.0', '4570d1a2a183026adb65b73c7125b8b0')
+    version('5.1.2', '44fb32fc8988fcdfbc216c9e40c3e925')
+    version('5.0.1', 'fdf206113369746e2276b95b257d2c9b')
     version('4.4.0', 'fa1569857dd680ebb4d7ff89c2227378')
-    version('5.0.0', '4598f0b421460c8bbc635c9a1c3bdbee')
 
+    variant('plugins', default=True,
+            description='Install include files for plugins support')
     variant('python', default=False, description='Enable Python support')
-
-    variant('tcl', default=False, description='Enable TCL support')
-
     variant('mpi', default=True, description='Enable MPI support')
-
     variant('osmesa', default=False, description='Enable OSMesa support')
-    variant('qt', default=False, description='Enable Qt support')
-    variant('opengl2', default=False, description='Enable OpenGL2 backend')
+    variant('qt', default=False, description='Enable Qt (gui) support')
+    variant('opengl2', default=True, description='Enable OpenGL2 backend')
 
     depends_on('python@2:2.7', when='+python')
     depends_on('py-numpy', when='+python', type='run')
     depends_on('py-matplotlib', when='+python', type='run')
-    depends_on('tcl', when='+tcl')
     depends_on('mpi', when='+mpi')
     depends_on('qt@:4', when='+qt')
+    # TODO# depends_on('qt@:4', when='@:5.2.0+qt')
+    # TODO# depends_on('qt@5',  when='@5.3.0:+qt')
 
-    depends_on('cmake', type='build')
     depends_on('bzip2')
     depends_on('freetype')
     # depends_on('hdf5+mpi', when='+mpi')
@@ -65,61 +69,71 @@ class Paraview(Package):
     # depends_on('sqlite') # external version not supported
     depends_on('zlib')
 
+    patch('stl-reader-pv440.patch', when='@4.4.0')
+
+    # Broken gcc-detection - improved in 5.1.0, redundant later
+    patch('gcc-compiler-pv501.patch', when='@:5.0.1')
+
+    # Broken installation (ui_pqExportStateWizard.h) - fixed in 5.2.0
+    patch('ui_pqExportStateWizard.patch', when='@:5.1.2')
+
     def url_for_version(self, version):
         """Handle ParaView version-based custom URLs."""
-        return self._url_str % (version.up_to(2), version)
+        if version < Version('5.1.0'):
+            return self._urlfmt.format(version.up_to(2), version, '-source')
+        else:
+            return self._urlfmt.format(version.up_to(2), version, '')
 
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            def feature_to_bool(feature, on='ON', off='OFF'):
-                if feature in spec:
-                    return on
-                return off
+    def cmake_args(self):
+        """Populate cmake arguments for ParaView."""
+        spec = self.spec
 
-            def nfeature_to_bool(feature):
-                return feature_to_bool(feature, on='OFF', off='ON')
+        def variant_bool(feature, on='ON', off='OFF'):
+            """Ternary for spec variant to ON/OFF string"""
+            if feature in spec:
+                return on
+            return off
 
-            feature_args = std_cmake_args[:]
-            feature_args.append(
-                '-DPARAVIEW_BUILD_QT_GUI:BOOL=%s' % feature_to_bool('+qt'))
-            feature_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=%s' %
-                                feature_to_bool('+python'))
-            if '+python' in spec:
-                feature_args.append(
-                    '-DPYTHON_EXECUTABLE:FILEPATH=%s/bin/python'
-                    % spec['python'].prefix)
-            feature_args.append('-DPARAVIEW_USE_MPI:BOOL=%s' %
-                                feature_to_bool('+mpi'))
-            if '+mpi' in spec:
-                feature_args.append(
-                    '-DMPIEXEC:FILEPATH=%s/bin/mpiexec' % spec['mpi'].prefix)
-            feature_args.append(
-                '-DVTK_ENABLE_TCL_WRAPPING:BOOL=%s' % feature_to_bool('+tcl'))
-            feature_args.append('-DVTK_OPENGL_HAS_OSMESA:BOOL=%s' %
-                                feature_to_bool('+osmesa'))
-            feature_args.append('-DVTK_USE_X:BOOL=%s' %
-                                nfeature_to_bool('+osmesa'))
-            feature_args.append(
-                '-DVTK_RENDERING_BACKEND:STRING=%s' %
-                feature_to_bool('+opengl2', 'OpenGL2', 'OpenGL'))
+        def nvariant_bool(feature):
+            """Negated ternary for spec variant to OFF/ON string"""
+            return variant_bool(feature, on='OFF', off='ON')
 
-            feature_args.extend(std_cmake_args)
+        rendering = variant_bool('+opengl2', 'OpenGL2', 'OpenGL')
+        includes  = variant_bool('+plugins')
 
-            if 'darwin' in self.spec.architecture:
-                feature_args.append('-DVTK_USE_X:BOOL=OFF')
-                feature_args.append(
-                    '-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON')
+        cmake_args = [
+            '-DPARAVIEW_BUILD_QT_GUI:BOOL=%s' % variant_bool('+qt'),
+            '-DVTK_OPENGL_HAS_OSMESA:BOOL=%s' % variant_bool('+osmesa'),
+            '-DVTK_USE_X:BOOL=%s' % nvariant_bool('+osmesa'),
+            '-DVTK_RENDERING_BACKEND:STRING=%s' % rendering,
+            '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES:BOOL=%s' % includes,
+            '-DBUILD_TESTING:BOOL=OFF',
+            '-DVTK_USE_SYSTEM_FREETYPE:BOOL=ON',
+            '-DVTK_USE_SYSTEM_HDF5:BOOL=OFF',
+            '-DVTK_USE_SYSTEM_JPEG:BOOL=ON',
+            '-DVTK_USE_SYSTEM_LIBXML2:BOOL=ON',
+            '-DVTK_USE_SYSTEM_NETCDF:BOOL=OFF',
+            '-DVTK_USE_SYSTEM_TIFF:BOOL=ON',
+            '-DVTK_USE_SYSTEM_ZLIB:BOOL=ON',
+        ]
 
-            cmake('..',
-                  '-DCMAKE_INSTALL_PREFIX:PATH=%s' % prefix,
-                  '-DBUILD_TESTING:BOOL=OFF',
-                  '-DVTK_USE_SYSTEM_FREETYPE:BOOL=ON',
-                  '-DVTK_USE_SYSTEM_HDF5:BOOL=OFF',
-                  '-DVTK_USE_SYSTEM_JPEG:BOOL=ON',
-                  '-DVTK_USE_SYSTEM_LIBXML2:BOOL=ON',
-                  '-DVTK_USE_SYSTEM_NETCDF:BOOL=OFF',
-                  '-DVTK_USE_SYSTEM_TIFF:BOOL=ON',
-                  '-DVTK_USE_SYSTEM_ZLIB:BOOL=ON',
-                  *feature_args)
-            make()
-            make('install')
+        if '+python' in spec:
+            cmake_args.extend([
+                '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON',
+                '-DPYTHON_EXECUTABLE:FILEPATH=%s/bin/python'
+                % spec['python'].prefix
+            ])
+
+        if '+mpi' in spec:
+            cmake_args.extend([
+                '-DPARAVIEW_USE_MPI:BOOL=ON',
+                '-DMPIEXEC:FILEPATH=%s/bin/mpiexec' % spec['mpi'].prefix
+            ])
+
+        if 'darwin' in self.spec.architecture:
+            cmake_args.extend([
+                '-DVTK_USE_X:BOOL=OFF',
+                '-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON',
+            ])
+
+        return cmake_args

--- a/var/spack/repos/builtin/packages/paraview/stl-reader-pv440.patch
+++ b/var/spack/repos/builtin/packages/paraview/stl-reader-pv440.patch
@@ -1,0 +1,11 @@
+--- ParaView-4.4.0.orig/VTK/IO/Geometry/vtkSTLReader.cxx	2015-09-11 19:59:24.000000000 +0200
++++ ParaView-4.4.0/VTK/IO/Geometry/vtkSTLReader.cxx	2016-06-19 12:59:50.769770143 +0200
+@@ -448,7 +448,7 @@
+           done = done || (fscanf(fp,"%s", line)==EOF);
+           }
+         }
+-      if (!done)
++      else if (!done)
+         {
+         done = (fgets(line, 255, fp) == 0);
+         lineCount++;

--- a/var/spack/repos/builtin/packages/paraview/ui_pqExportStateWizard.patch
+++ b/var/spack/repos/builtin/packages/paraview/ui_pqExportStateWizard.patch
@@ -1,0 +1,11 @@
+--- ParaView-5.0.1.orig/Qt/Components/CMakeLists.txt	2016-03-28 17:07:03.000000000 +0200
++++ ParaView-5.0.1/Qt/Components/CMakeLists.txt	2016-12-13 17:38:42.713553032 +0100
+@@ -656,7 +656,7 @@
+ #the pqSGExportStateWizard has subclasses that directly access
+ #the UI file, and currently we don't have a clean way to break this hard
+ #dependency, so for no we install this ui file.
+-if(PARAVIEW_INSTALL_DEVELOPMENT_FILES)
++if(PARAVIEW_INSTALL_DEVELOPMENT_FILES AND PARAVIEW_ENABLE_PYTHON)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ui_pqExportStateWizard.h"
+           DESTINATION "${VTK_INSTALL_INCLUDE_DIR}")
+ endif()


### PR DESCRIPTION
- drop old TCL support from paraview build.

- add +plugins variant to have include directories installed. This is
  enabled by default since the additional diskspace for includes is
  really minimal and since this also allows re-use of the VTK libraries
  from ParaView without necessarily requiring a separate VTK
  installation.