### PR TITLE
Add latest version of GNU Guile

### DIFF
--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -25,13 +25,15 @@
 from spack import *
 
 
-class Guile(Package):
+class Guile(AutotoolsPackage):
     """Guile is the GNU Ubiquitous Intelligent Language for Extensions,
     the official extension language for the GNU operating system."""
 
     homepage = "https://www.gnu.org/software/guile/"
-    url      = "https://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz"
+    url      = "https://ftp.gnu.org/gnu/guile/guile-2.2.0.tar.gz"
 
+    version('2.2.0',  '0d5de8075b965f9ee5ea04399b60a3f9')
+    version('2.0.14', '333b6eec83e779935a45c818f712484e')
     version('2.0.11', 'e532c68c6f17822561e3001136635ddd')
 
     variant('readline', default=True, description='Use the readline library')
@@ -45,9 +47,12 @@ class Guile(Package):
     depends_on('readline', when='+readline')
     depends_on('pkg-config', type='build')
 
-    def install(self, spec, prefix):
+    build_directory = 'spack-build'
+
+    def configure_args(self):
+        spec = self.spec
+
         config_args = [
-            '--prefix={0}'.format(prefix),
             '--with-libunistring-prefix={0}'.format(
                 spec['libunistring'].prefix),
             '--with-libltdl-prefix={0}'.format(spec['libtool'].prefix),
@@ -61,8 +66,4 @@ class Guile(Package):
         else:
             config_args.append('--without-libreadline-prefix')
 
-        configure(*config_args)
-
-        make()
-        make('check')
-        make('install')
+        return config_args


### PR DESCRIPTION
Also converts to `AutotoolsPackage`.

I actually ran into a bug with the `guile` build system. It only searches for libraries in `lib`, not `lib64`. I tried using my system `libtool` installation, but it wouldn't pick up `libltdl` because it was installed in `/usr/lib64`. I submitted a bug report. This shouldn't affect the Spack package, as our `libtool` installs its libraries into `<prefix>/lib`.