### PR TITLE
coreutils can no longer be built in source

### DIFF
--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -32,6 +32,9 @@ class Coreutils(AutotoolsPackage):
        operating system.
     """
     homepage = "http://www.gnu.org/software/coreutils/"
-    url      = "http://ftp.gnu.org/gnu/coreutils/coreutils-8.23.tar.xz"
+    url      = "http://ftp.gnu.org/gnu/coreutils/coreutils-8.26.tar.xz"
 
+    version('8.26', 'd5aa2072f662d4118b9f4c63b94601a6')
     version('8.23', 'abed135279f87ad6762ce57ff6d89c41')
+
+    build_directory = 'spack-build'


### PR DESCRIPTION
After the switch to `AutotoolsPackage`, `coreutils` can no longer be built. This is because `Package` runs `./configure` while `AutotoolsPackage` runs `/absolute/path/to/configure`. Building in a different directory solves this issue.

Also added the latest version.