### PR TITLE
Fix r package, tk no longer has an X variant

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -75,8 +75,6 @@ class R(AutotoolsPackage):
     depends_on('freetype')
     depends_on('tcl')
     depends_on('tk')
-    depends_on('tk+X', when='+X')
-    depends_on('tk~X', when='~X')
     depends_on('libx11', when='+X')
     depends_on('libxt', when='+X')
     depends_on('curl')


### PR DESCRIPTION
Tk recently lost its X variant (it now always uses X).

That broke r, this commit fixes it.

Tested on CentOS 7.