### PR TITLE
Add Blast+ package.

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/blast-make-fix2.5.0.diff
+++ b/var/spack/repos/builtin/packages/blast-plus/blast-make-fix2.5.0.diff
@@ -1,0 +1,22 @@
+--- ncbi-blast-2.5.0+-src/c++/src/build-system/Makefile.in.top	2014-11-12 17:41:55.000000000 +0100
++++ MakeFile	2016-12-19 18:00:58.000000000 +0100
+@@ -1,4 +1,4 @@
+-# $Id: Makefile.in.top 451817 2014-11-12 16:41:55Z ucko $
++# $Id$
+ # Top-level meta-makefile that simplifies building even further.
+
+ # include @builddir@/Makefile.mk
+@@ -49,9 +49,10 @@
+ 	    for x in *.a; do \
+ 	        $(LN_S) "$$x" "`$(BASENAME) \"$$x\" .a`-static.a"; \
+ 	    done
+-	cd $(includedir0) && find * -name CVS -prune -o -print |\
+-            cpio -pd $(pincludedir)
+-	$(INSTALL) -m 644 $(incdir)/* $(pincludedir)
++	for d in $(includedir0) $(incdir); do \
++	    cd $$d && find . -name .svn prune -o -print | \
++                cpio -pd $(pincludedir) ; \
++	done
+ ## set up appropriate build and status directories somewhere under $(libdir)?
+
+ install-gbench:

--- a/var/spack/repos/builtin/packages/blast-plus/blast-make-fix2.5.0.diff
+++ b/var/spack/repos/builtin/packages/blast-plus/blast-make-fix2.5.0.diff
@@ -13,10 +13,10 @@
 -	cd $(includedir0) && find * -name CVS -prune -o -print |\
 -            cpio -pd $(pincludedir)
 -	$(INSTALL) -m 644 $(incdir)/* $(pincludedir)
-+	for d in $(includedir0) $(incdir); do \
-+	    cd $$d && find . -name .svn prune -o -print | \
-+                cpio -pd $(pincludedir) ; \
-+	done
++	#for d in $(includedir0) $(incdir); do \
++	#    cd $$d && find * -name .svn prune -o -print | \
++	#         cpio -pd $(pincludedir) ; \
++	#done
  ## set up appropriate build and status directories somewhere under $(libdir)?
 
  install-gbench:

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -1,0 +1,130 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+# This is a based largely on the Homebrew science formula:
+# https://github.com/Homebrew/homebrew-science/blob/master/blast.rb
+class BlastPlus(AutotoolsPackage):
+    """Basic Local Alignment Search Tool."""
+
+
+    homepage = "http://blast.ncbi.nlm.nih.gov/"
+    url      = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-src.tar.gz"
+
+    def url_for_version(self, version):
+        url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{0}/ncbi-blast-{0}+-src.tar.gz"
+        return url.format(version)
+
+    version('2.6.0', 'c8ce8055b10c4d774d995f88c7cc6225')
+
+    # homebrew sez: Fixed upstream in future version > 2.6
+    patch('blast-make-fix2.5.0.diff', when="@:2.6.0")
+
+    # No...
+    # depends_on :mysql => :optional
+
+    variant('static', default=False,
+            description='Build with static linkage')
+    variant('jpeg', default=True,
+            description='Build with jpeg support')
+    variant('png', default=True,
+            description='Build with png support')
+    variant('freetype', default=True,
+            description='Build with freetype support')
+    # variant('hdf5', default=True,
+    #        description='Build with hdf5 support')
+    variant('lzo', default=True,
+            description='Build with lzo support')
+    variant('pcre', default=True,
+            description='Build with pcre support')
+
+    depends_on('jpeg', when='+jpeg')
+    depends_on('libpng', when='+png')
+    depends_on('freetype', when='+freetype')
+    # depends_on('hdf5', when='+hdf5')
+    depends_on('lzo', when='+lzo')
+    depends_on('pcre', when='+pcre')
+
+    depends_on('python')
+
+    configure_directory ='c++'
+
+    def configure_args(self):
+        spec   = self.spec
+        prefix = self.prefix
+
+        config_args = [
+            '--prefix={0}'.format(prefix),
+            #--libdir=#{libexec},
+            '--without-debug',
+            '--with-mt',
+            '--without-boost',
+        ]
+
+        if '+static' in spec:
+            config_args.append('--with-static')
+            # FIXME
+            # args << "--with-static-exe" unless OS.linux?
+            # args << "--with-dll" if build.with? "dll"
+        else:
+            config_args.extend([
+                '--with-dll',
+                '--without-static',
+                '--without-static-exe'
+            ])
+
+        if '+jpeg' in spec:
+            config_args.append('--with-jpeg')
+        else:
+            config_args.append('--without-jpeg')
+
+        if '+png' in spec:
+            config_args.append('--with-png')
+        else:
+            config_args.append('--without-png')
+
+        if '+freetype' in spec:
+            config_args.append('--with-freetype')
+        else:
+            config_args.append('--without-freetype')
+
+        config_args.append('--without-hdf5')
+        # if '+hdf5' in spec:
+        #     # FIXME
+        #     config_args.append('--with-hdf5={0}'.format(self.spec['hdf5'].prefix))
+        # else:
+        #     config_args.append('--without-hdf5')
+
+        if '+lzo' in spec:
+            config_args.append('--with-lzo')
+        else:
+            config_args.append('--without-lzo')
+
+        if '+pcre' in spec:
+            config_args.append('--with-pcre')
+        else:
+            config_args.append('--without-pcre')
+
+        return config_args

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -29,8 +29,8 @@
 # There s one tricky bit to be resolved:
 #
 # - HDF5 builds explode, blast's configure script tries to run a program that
-#   uses a variable called 'HOST' but some other bit defines a macro called HOST
-#   that's defined to a string.  Hilarity ensues.
+#   uses a variable called 'HOST' but some other bit defines a macro called
+#   HOST that's defined to a string.  Hilarity ensues.
 #
 #
 from spack import *
@@ -73,9 +73,9 @@ class BlastPlus(AutotoolsPackage):
     # variant('hdf5', default=True,
     #        description='Build with hdf5 support')
     variant('gnutls', default=True,
-           description='Build with gnutls support')
+            description='Build with gnutls support')
     variant('openssl', default=True,
-           description='Build with openssl support')
+            description='Build with openssl support')
     variant('zlib', default=True,
             description='Build with zlib support')
     variant('bzip2', default=True,
@@ -126,54 +126,74 @@ class BlastPlus(AutotoolsPackage):
             ])
 
         if '+jpeg' in spec:
-            config_args.append('--with-jpeg={0}'.format(self.spec['jpeg'].prefix))
+            config_args.append(
+                '--with-jpeg={0}'.format(self.spec['jpeg'].prefix)
+            )
         else:
             config_args.append('--without-jpeg')
 
         if '+png' in spec:
-            config_args.append('--with-png={0}'.format(self.spec['libpng'].prefix))
+            config_args.append(
+                '--with-png={0}'.format(self.spec['libpng'].prefix)
+            )
         else:
             config_args.append('--without-png')
 
         if '+freetype' in spec:
-            config_args.append('--with-freetype={0}'.format(self.spec['freetype'].prefix))
+            config_args.append(
+                '--with-freetype={0}'.format(self.spec['freetype'].prefix)
+            )
         else:
             config_args.append('--without-freetype')
 
         config_args.append('--without-hdf5')
         # if '+hdf5' in spec:
         #     # FIXME
-        #     config_args.append('--with-hdf5={0}'.format(self.spec['hdf5'].prefix))
+        #     config_args.append(
+        #         '--with-hdf5={0}'.format(self.spec['hdf5'].prefix)
+        #     )
         # else:
         #     config_args.append('--without-hdf5')
 
         if '+zlib' in spec:
-            config_args.append('--with-z={0}'.format(self.spec['zlib'].prefix))
+            config_args.append(
+                '--with-z={0}'.format(self.spec['zlib'].prefix)
+            )
         else:
             config_args.append('--without-z')
 
         if '+bzip2' in spec:
-            config_args.append('--with-bz2={0}'.format(self.spec['bzip2'].prefix))
+            config_args.append(
+                '--with-bz2={0}'.format(self.spec['bzip2'].prefix)
+            )
         else:
             config_args.append('--without-bz2')
 
         if '+lzo' in spec:
-            config_args.append('--with-lzo={0}'.format(self.spec['lzo'].prefix))
+            config_args.append(
+                '--with-lzo={0}'.format(self.spec['lzo'].prefix)
+            )
         else:
             config_args.append('--without-lzo')
 
         if '+gnutls' in spec:
-            config_args.append('--with-gnutls={0}'.format(self.spec['gnutls'].prefix))
+            config_args.append(
+                '--with-gnutls={0}'.format(self.spec['gnutls'].prefix)
+            )
         else:
             config_args.append('--without-gnutls')
 
         if '+openssl' in spec:
-            config_args.append('--with-openssl={0}'.format(self.spec['openssl'].prefix))
+            config_args.append(
+                '--with-openssl={0}'.format(self.spec['openssl'].prefix)
+            )
         else:
             config_args.append('--without-openssl')
 
         if '+pcre' in spec:
-            config_args.append('--with-pcre={0}'.format(self.spec['pcre'].prefix))
+            config_args.append(
+                '--with-pcre={0}'.format(self.spec['pcre'].prefix)
+            )
         else:
             config_args.append('--without-pcre')
 

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -60,8 +60,7 @@ class BlastPlus(AutotoolsPackage):
     # to just comment out the block.
     patch('blast-make-fix2.5.0.diff', when="@2.5.0:2.6.0")
 
-    # See https://github.com/Homebrew/homebrew-science/\
-    # issues/2337#issuecomment-170011511
+    # See https://github.com/Homebrew/homebrew-science/issues/2337#issuecomment-170011511
     @when('@:2.2.31')
     def patch(self):
         filter_file("2.95* | 2.96* | 3.* | 4.* )",

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -22,10 +22,13 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from spack import *
-
+#
 # This is a based largely on the Homebrew science formula:
 # https://github.com/Homebrew/homebrew-science/blob/master/blast.rb
+#
+from spack import *
+
+
 class BlastPlus(AutotoolsPackage):
     """Basic Local Alignment Search Tool."""
 
@@ -69,7 +72,7 @@ class BlastPlus(AutotoolsPackage):
 
     depends_on('python')
 
-    configure_directory ='c++'
+    configure_directory = 'c++'
 
     def configure_args(self):
         spec   = self.spec
@@ -77,7 +80,6 @@ class BlastPlus(AutotoolsPackage):
 
         config_args = [
             '--prefix={0}'.format(prefix),
-            #--libdir=#{libexec},
             '--without-debug',
             '--with-mt',
             '--without-boost',

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -47,7 +47,8 @@ class BlastPlus(AutotoolsPackage):
         url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{0}/ncbi-blast-{0}+-src.tar.gz"
         return url.format(version)
 
-    version('2.6.0', 'c8ce8055b10c4d774d995f88c7cc6225')
+    version('2.6.0',  'c8ce8055b10c4d774d995f88c7cc6225')
+    version('2.2.30', 'f8e9a5eb368173142fe6867208b73715')
 
     # homebrew sez: Fixed upstream in future version > 2.6
     # But this bug sez that it will be fixed in 2.6
@@ -57,7 +58,16 @@ class BlastPlus(AutotoolsPackage):
     # On the other hand, the `find` command is broken and there
     # aren't any .svn dirs in the tree, so I've updated their patch
     # to just comment out the block.
-    patch('blast-make-fix2.5.0.diff', when="@:2.6.0")
+    patch('blast-make-fix2.5.0.diff', when="@2.5.0:2.6.0")
+
+    # See https://github.com/Homebrew/homebrew-science/\
+    # issues/2337#issuecomment-170011511
+    @when('@:2.2.31')
+    def patch(self):
+        filter_file("2.95* | 2.96* | 3.* | 4.* )",
+                    "2.95* | 2.96* | 3.* | 4.* | 5.* )",
+                    "c++/src/build-system/configure",
+                    string=True)
 
     # No...
     # depends_on :mysql => :optional

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -111,10 +111,8 @@ class BlastPlus(AutotoolsPackage):
 
     def configure_args(self):
         spec   = self.spec
-        prefix = self.prefix
 
         config_args = [
-            '--prefix={0}'.format(prefix),
             '--with-bin-release',
             '--without-debug',
             '--with-mt',


### PR DESCRIPTION
Add Blast+ package.

Adds support for NCBI's blast+@2.6.0.  I'll be adding a few historical versions in the near future.

This should be ready to go, in spite of the comments below.  It builds and runs as is, I'd like to get some real-users miles on it.

It's a fairly direct transliteration of the [Homebrew Science recipe][hbs].

~I've applied the patch that homebrew uses, but as-I-found-it it didn't work.  Line 17 was `... find * ...` and I rewrote it to `... find . ...`.  I can't find any CVS or .svn dirs anywhere in the tree, so it probably doesn't matter but it was generating an error (which was ignored, but...) at the tail end of the build.~  Edit: I've updated the patch to comment out the block.  It doesn't appear to be relevant (no .svn dirs to be found...) and it wasn't running successfully as written.

I skipped the mysql support (for now?).

There is a problem with HDF5 support.  Blast's configure script test program defines a macro 'HOST' to a string value and one of the HDF5 bits has an variable named 'HOST'.  Fun things happen.   I've disabled support for now.

I've run very basic tests.  I'll get this out to my users and ensure that it works and fine tune the options and etc....

[hbs]: https://github.com/Homebrew/homebrew-science/blob/master/blast.rb