### PR TITLE
[Hotfix] fftw: Add 3.3.6-pl2, remove 3.3.6-pl1.

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -36,7 +36,7 @@ class Fftw(AutotoolsPackage):
     homepage = "http://www.fftw.org"
     url      = "http://www.fftw.org/fftw-3.3.4.tar.gz"
 
-    version('3.3.6-pl1', '682a0e78d6966ca37c7446d4ab4cc2a1')
+    version('3.3.6-pl2', '927e481edbb32575397eb3d62535a856')
     version('3.3.5', '6cc08a3b9c7ee06fdd5b9eb02e06f569')
     version('3.3.4', '2edab8c06b24feeb3b82bbb3ebf3e7b3')
     version('2.1.5', '8d16a84f3ca02a785ef9eb36249ba433')


### PR DESCRIPTION
According to FFTW's release notes http://www.fftw.org/release-notes.html , versions `3.3.6` and `3.3.6-p1` have been withdrawn. This commit replaces `3.3.6-pl1` with `3.3.6-p2` releases on Mar 25, 2017.

```
FFTW 3.3.6-pl2
Mar 25th, 2017
Bugfix: MPI Fortran-03 headers were missing in FFTW 3.3.6-pl1.

FFTW 3.3.6-pl1 (withdrawn)
Jan 16th, 2017
Bugfix: FFTW 3.3.6 had the wrong libtool version number, and generated shared libraries of the form libfftw3.so.2.6.6 instead of libfftw3.so.3.*.

FFTW 3.3.6 (withdrawn)
Jan 15th, 2017
The fftw_make_planner_thread_safe() API introduced in 3.3.5 didn't work, and this 3.3.6 fixes it. Sorry about that.
Compilation fixes for IBM XLC.
Compilation fixes for threads on Windows.
fix SIMD autodetection on amd64 when (_MSC_VER > 1500)
```