### PR TITLE
fix easy-install.pth

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -470,19 +470,10 @@ class Python(Package):
 
         else:
             with closing(open(main_pth, 'w')) as f:
-                f.write("""
-import sys
-sys.__plen = len(sys.path)
-""")
+                f.write("import sys; sys.__plen = len(sys.path)")
                 for path in paths:
                     f.write("{0}\n".format(path))
-                f.write("""
-new = sys.path[sys.__plen:]
-del sys.path[sys.__plen:]
-p = getattr(sys, '__egginsert', 0)
-sys.path[p:p] = new
-sys.__egginsert = p + len(new)
-""")
+                f.write("import sys; new = sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p = getattr(sys, '__egginsert', 0); sys.path[p:p] = new; sys.__egginsert = p + len(new)")  # noqa: E501
 
     def activate(self, ext_pkg, **args):
         ignore = self.python_ignore(ext_pkg, args)


### PR DESCRIPTION
A user of mine noticed that Spack's Python easy-install.pth is broken. Per the specification of .pth files in https://docs.python.org/2.7/library/site.html, the header and footer of easy-install.pth should not have been broken into multiple lines, and needs to start with an "import" statement to be executed as expected.