### PR TITLE
Make 0.163 the preferred version of elfutils.

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -40,7 +40,7 @@ class Elfutils(AutotoolsPackage):
     list_depth = 2
 
     version('0.168','52adfa40758d0d39e5d5c57689bf38d6')
-    version('0.163','77ce87f259987d2e54e4d87b86cbee41')
+    version('0.163','77ce87f259987d2e54e4d87b86cbee41', preferred=True)
 
     provides('elf@1')
 


### PR DESCRIPTION
- later versions do not seem to work properly with `libdwarf`.

@lee218llnl: is this the right resolution?  I think we should keep the preferred version at one that works well with `libdwarf` until there is a fix for the issue described in your email:

> Elfutils 0.168 was added in [3923bdc](https://github.com/LLNL/spack/commit/3923bdca90bd60678f041d7ad6235c406dc05459#diff-432b6709875797fbdc23169be936fefe) by @kserradell (fixing #3443 by @nicksan2c). The problem appears to be due to the fact that `libdwarf` has a `libdwarfdefs.h` header that does this:
>  
> ```
> #ifndef SHF_COMPRESSED
> /*  This from ubuntu xenial. Is in top of trunk binutils
>     as of February 2016. Elf Section Flag */
> #define SHF_COMPRESSED (1 << 11)
> #endif
>  ```
>  
>  
> While elfutils does this:
>  
> ```
> #ifndef SHF_COMPRESSED
> /* Older glibc elf.h might not yet define the ELF compression types.  */
> #define SHF_COMPRESSED      (1 << 11)  /* Section with compressed data. */
>  
> /* Section compression header.  Used when SHF_COMPRESSED is set.  */
>  
> typedef struct
> {
>    Elf32_Word   ch_type;        /* Compression format.  */
>    Elf32_Word   ch_size;        /* Uncompressed data size.  */
>    Elf32_Word   ch_addralign;   /* Uncompressed data alignment.  */
> } Elf32_Chdr;
>  
> typedef struct
> {
>    Elf64_Word   ch_type;        /* Compression format.  */
>    Elf64_Word   ch_reserved;
>    Elf64_Xword  ch_size;        /* Uncompressed data size.  */
>    Elf64_Xword  ch_addralign;   /* Uncompressed data alignment.  */
> } Elf64_Chdr;
>  
> /* Legal values for ch_type (compression algorithm).  */
> #define ELFCOMPRESS_ZLIB       1          /* ZLIB/DEFLATE algorithm.  */
> #define ELFCOMPRESS_LOOS       0x60000000 /* Start of OS-specific.  */
> #define ELFCOMPRESS_HIOS       0x6fffffff /* End of OS-specific.  */
> #define ELFCOMPRESS_LOPROC     0x70000000 /* Start of processor-specific.  */
> #define ELFCOMPRESS_HIPROC     0x7fffffff /* End of processor-specific.  */
> #endif
>  ```
>  
> Thus the types do not get defined. From https://www.prevanders.net/dwarf.html I found this blurb:
>  
> “Sture Carlson reports a new problem compiling libdwarf/dwarf_elf_access.c in CentOS. CentOS-7.3 libelf.h makes an assumption of the connection between SHF_COMPRESSED and Elf32(64)_Chdr that conflicts with libdwarf coding. Moving the SHF_COMPRESSED from a libdwarf header to a C file in libdwarf source fixes the problem very simply. The libdwarf fix is now on sourceforge. (December 20, 2016)”
>  
> It doesn’t look like there is a release yet with this fix in place.

