### PR TITLE
Bugfix: allow deactivating installs that don't have packages anymore.

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -619,13 +619,12 @@ class Database(object):
         Return the specs of all packages that extend
         the given spec
         """
-        for s in self.query():
+        for spec in self.query():
             try:
-                if s.package.extends(extendee_spec):
-                    yield s.package
-            except spack.repository.UnknownPackageError:
+                spack.store.layout.check_activated(extendee_spec, spec)
+                yield spec.package
+            except spack.directory_layout.NoSuchExtensionError:
                 continue
-            # skips unknown packages
             # TODO: conditional way to do this instead of catching exceptions
 
     def query(self, query_spec=any, known=any, installed=True, explicit=any):


### PR DESCRIPTION
- deactivate -a wouldn't work if the installation's package was no longer available.

- Fix installed_extensions_for so that it doesn't need to look at the package.py file.