### PR TITLE
add missing newline to easy-install.pth

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -470,7 +470,7 @@ class Python(Package):
 
         else:
             with closing(open(main_pth, 'w')) as f:
-                f.write("import sys; sys.__plen = len(sys.path)")
+                f.write("import sys; sys.__plen = len(sys.path)\n")
                 for path in paths:
                     f.write("{0}\n".format(path))
                 f.write("import sys; new = sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p = getattr(sys, '__egginsert', 0); sys.path[p:p] = new; sys.__egginsert = p + len(new)")  # noqa: E501


### PR DESCRIPTION
Fixes #3575.

I accidentally omitted a newline from the easy-install.pth header. This PR adds the newline.