### PR TITLE
Extendable Perl

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2043,6 +2043,10 @@ The classes that are currently provided by Spack are:
     |  :py:class:`.PythonPackage`        | Specialized class for            |
     |                                    | :py:class:`.Python` extensions   |
     +------------------------------------+----------------------------------+
+    |  :py:class:`.PerlPackage`          | Specialized class for            |
+    |                                    | :py:class:`.Perl` extensions     |
+    +------------------------------------+----------------------------------+
+
 
 
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -162,6 +162,7 @@ from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.python import PythonPackage
 from spack.build_systems.r import RPackage
+from spack.build_systems.perl import PerlPackage
 
 __all__ += [
     'run_before',
@@ -172,7 +173,8 @@ __all__ += [
     'AutotoolsPackage',
     'MakefilePackage',
     'PythonPackage',
-    'RPackage'
+    'RPackage',
+    'PerlPackage'
 ]
 
 from spack.version import Version, ver

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -49,7 +49,8 @@ class AutotoolsPackage(PackageBase):
         4. :py:meth:`~.AutotoolsPackage.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override the helper method :py:meth:`.configure_args`.
+    necessary will be to override the helper method
+    :py:meth:`~.AutotoolsPackage.configure_args`.
     For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
@@ -234,7 +235,7 @@ class AutotoolsPackage(PackageBase):
         appropriately, otherwise raises an error.
 
         :raises RuntimeError: if a configure script is not found in
-            :py:meth:`~.configure_directory`
+            :py:meth:`~AutotoolsPackage.configure_directory`
         """
         # Check if a configure script is there. If not raise a RuntimeError.
         if not os.path.exists(self.configure_abs_path):
@@ -255,7 +256,8 @@ class AutotoolsPackage(PackageBase):
         return []
 
     def configure(self, spec, prefix):
-        """Runs configure with the arguments specified in :py:meth:`.configure_args`
+        """Runs configure with the arguments specified in
+        :py:meth:`~.AutotoolsPackage.configure_args`
         and an appropriately set prefix.
         """
         options = ['--prefix={0}'.format(prefix)] + self.configure_args()

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -29,46 +29,89 @@ from spack.directives import extends
 from spack.package import PackageBase, run_after, InstallError
 from spack.util.executable import Executable
 
-import os
-
 
 class PerlPackage(PackageBase):
     """Specialized class for packages that are built using Perl
 
-    This class provides a single phase that can be overridden:
+    This class provides three phases that can be overridden:
 
-        1. :py:meth:`~.PerlPackage.install`
+        1. :py:meth:`~.PerlPackage.configure`
+        2. :py:meth:`~.PerlPackage.build`
+        3. :py:meth:`~.PerlPackage.install`
 
-    It has sensible defaults, and for many packages the only thing
-    necessary will be to add dependencies
+    They all have sensible defaults. Some packages may also need to override:
+
+        +-----------------------------------------+--------------------------+
+        | **Method**                              | **Purpose**              |
+        +=========================================+==========================+
+        | :py:attr:`~.PerlPackage.build_method    | Perl build method:       |
+        |                                         | 'Makefile.PL' (default)  |
+        |                                         | or 'Build.PL'            |
+        +-----------------------------------------+--------------------------+
+        | :py:meth:`~.PerlPackage.configure_args` | List of arguments for    |
+        |                                         | Makefile.PL or Build.PL  |
+        |                                         | (excluding prefix)       |
+        +-----------------------------------------+--------------------------+
     """
-    phases = ['install']
+    #: Phases of a Perl package
+    phases = ['configure', 'build', 'install']
 
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'PerlPackage'
 
+    #: This attribute is used to select the perl build method.
+    #: Supported types are 'Makefile.PL' and 'Build.PL'.
+    build_method = 'Makefile.PL'
+
     extends('perl')
 
-    def install(self, spec, prefix):
-        """Installs a Perl package."""
-        perlx = inspect.getmodule(self).perl
-        if os.path.isfile('Makefile.PL'):
+    def configure_args(self):
+        """Produces a list containing the arguments that must be passed to
+        the configure method. The installation prefix is always prepended.
+
+        :return: list of arguments for Makefile.PL or Build.PL
+        """
+        return []
+
+    def configure(self, spec, prefix):
+        """Runs Makefile.PL or Build.PL with the arguments specified in
+        :py:meth:`.configure_args` and an appropriate installation prefix.
+        """
+        if self.build_method == 'Makefile.PL':
+            options = ['Makefile.PL', 'INSTALL_BASE={0}'.format(prefix)]
+        elif self.build_method == 'Build.PL':
+            options = ['Build.PL', '--install_base', prefix]
+        else:
+            raise InstallError('Unknown build_method for perl package')
+        options += self.configure_args()
+        inspect.getmodule(self).perl(*options)
+
+    def build(self, spec, prefix):
+        """Builds a Perl package."""
+        if self.build_method == 'Makefile.PL':
             makex = inspect.getmodule(self).make
-            perlx('Makefile.PL', 'INSTALL_BASE=%s' % self.prefix)
             makex()
             if self.run_tests:
                 makex('test')
-            makex('install')
-        elif os.path.isfile('Build.PL'):
-            perlx('Build.PL', '--install_base', '%s' % self.prefix)
+        elif self.build_method == 'Build.PL':
             Buildx = Executable('./Build')
             Buildx()
             if self.run_tests:
                 Buildx('test')
+        else:
+            raise InstallError('Unknown build_method for perl package')
+
+    def install(self, spec, prefix):
+        """Installs a Perl package."""
+        if self.build_method == 'Makefile.PL':
+            makex = inspect.getmodule(self).make
+            makex('install')
+        elif self.build_method == 'Build.PL':
+            Buildx = Executable('./Build')
             Buildx('install')
         else:
-            raise InstallError('Unknown install method for perl package')
+            raise InstallError('Unknown build_method for perl package')
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -1,0 +1,74 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import inspect
+
+from spack.directives import extends
+from spack.package import PackageBase, run_after, InstallError
+from spack.util.executable import Executable
+
+import os
+
+
+class PerlPackage(PackageBase):
+    """Specialized class for packages that are built using Perl
+
+    This class provides a single phase that can be overridden:
+
+        1. :py:meth:`~.PerlPackage.install`
+
+    It has sensible defaults, and for many packages the only thing
+    necessary will be to add dependencies
+    """
+    phases = ['install']
+
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
+    build_system_class = 'PerlPackage'
+
+    extends('perl')
+
+    def install(self, spec, prefix):
+        """Installs a Perl package."""
+        perlx = inspect.getmodule(self).perl
+        if os.path.isfile('Makefile.PL'):
+            makex = inspect.getmodule(self).make
+            perlx('Makefile.PL', 'INSTALL_BASE=%s' % self.prefix)
+            makex()
+            if self.run_tests:
+                makex('test')
+            makex('install')
+        elif os.path.isfile('Build.PL'):
+            perlx('Build.PL', '--install_base', '%s' % self.prefix)
+            Buildx = Executable('./Build')
+            Buildx()
+            if self.run_tests:
+                Buildx('test')
+            Buildx('install')
+        else:
+            raise InstallError('Unknown install method for perl package')
+
+    # Check that self.prefix is there after installation
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -47,10 +47,10 @@ class PerlPackage(PackageBase):
         (2) Build.PL.
 
     Some packages may need to override
-        :py:meth:`~.PerlPackage.configure_args`,
-    which produces a list of arguments for the configure method.
-    Arguments should exclude the installation base directory or prefix,
-    because these are defined by the configure method.
+    :py:meth:`~.PerlPackage.configure_args`,
+    which produces a list of arguments for
+    :py:meth:`~.PerlPackage.configure`.
+    Arguments should not include the installation base directory.
     """
     #: Phases of a Perl package
     phases = ['configure', 'build', 'install']
@@ -66,15 +66,17 @@ class PerlPackage(PackageBase):
 
     def configure_args(self):
         """Produces a list containing the arguments that must be passed to
-        the configure method. The installation prefix is always prepended.
+        :py:meth:`~.PerlPackage.configure`. Arguments should not include
+        the installation base directory, which is prepended automatically.
 
         :return: list of arguments for Makefile.PL or Build.PL
         """
         return []
 
     def configure(self, spec, prefix):
-        """Runs Makefile.PL or Build.PL with the arguments specified in
-        :py:meth:`.configure_args` and an appropriate installation prefix.
+        """Runs Makefile.PL or Build.PL with arguments consisting of
+        an appropriate installation base directory followed by the
+        list returned by :py:meth:`~.PerlPackage.configure_args`.
 
         :raise RuntimeError: if neither Makefile.PL or Build.PL exist
         """

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -24,12 +24,12 @@
 ##############################################################################
 
 import inspect
-
-from spack.directives import extends
-from spack.package import PackageBase, run_after, InstallError
-from spack.util.executable import Executable
-
 import os
+
+from llnl.util.filesystem import join_path
+from spack.directives import extends
+from spack.package import PackageBase, run_after
+from spack.util.executable import Executable
 
 
 class PerlPackage(PackageBase):
@@ -75,6 +75,8 @@ class PerlPackage(PackageBase):
     def configure(self, spec, prefix):
         """Runs Makefile.PL or Build.PL with the arguments specified in
         :py:meth:`.configure_args` and an appropriate installation prefix.
+
+        :raise RuntimeError: if neither Makefile.PL or Build.PL exist
         """
         if os.path.isfile('Makefile.PL'):
             self.build_method = 'Makefile.PL'
@@ -84,7 +86,7 @@ class PerlPackage(PackageBase):
             self.build_executable = Executable( 
                 join_path(self.stage.source_path, 'Build'))
         else:
-            raise InstallError('Unknown build_method for perl package')
+            raise RuntimeError('Unknown build_method for perl package')
 
         if self.build_method == 'Makefile.PL':
             options = ['Makefile.PL', 'INSTALL_BASE={0}'.format(prefix)]

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -81,7 +81,7 @@ class PerlPackage(PackageBase):
         if os.path.isfile('Makefile.PL'):
             self.build_method = 'Makefile.PL'
             self.build_executable = inspect.getmodule(self).make
-        elif os.path.isfile('Makefile.PL'):
+        elif os.path.isfile('Build.PL'):
             self.build_method = 'Build.PL'
             self.build_executable = Executable( 
                 join_path(self.stage.source_path, 'Build'))

--- a/lib/spack/spack/cmd/build.py
+++ b/lib/spack/spack/cmd/build.py
@@ -31,7 +31,8 @@ description = 'stops at build stage when installing a package, if possible'
 build_system_to_phase = {
     CMakePackage: 'build',
     AutotoolsPackage: 'build',
-    PythonPackage: 'build'
+    PythonPackage: 'build',
+    PerlPackage: 'build'
 }
 
 

--- a/lib/spack/spack/cmd/configure.py
+++ b/lib/spack/spack/cmd/configure.py
@@ -36,7 +36,8 @@ description = 'stops at configuration stage when installing a package, if possib
 
 build_system_to_phase = {
     CMakePackage: 'cmake',
-    AutotoolsPackage: 'configure'
+    AutotoolsPackage: 'configure',
+    PerlPackage: 'configure'
 }
 
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -268,6 +268,27 @@ class RPackageTemplate(PackageTemplate):
         super(RPackageTemplate, self).__init__(name, *args)
 
 
+class PerlPackageTemplate(PackageTemplate):
+    """Provides appropriate overrides for Perl extensions"""
+    base_class_name = 'PerlPackage'
+
+    dependencies = """\
+    # FIXME: Add dependencies if required.
+    # depends_on('perl-foo', type=('build', 'run'))"""
+
+    body = """\
+    # FIXME: Override install() if necessary."""
+
+    def __init__(self, name, *args):
+        # If the user provided `--name perl-cpp`, don't rename it perl-perl-cpp
+        if not name.startswith('perl-'):
+            # Make it more obvious that we are renaming the package
+            tty.msg("Changing package name from {0} to perl-{0}".format(name))
+            name = 'perl-{0}'.format(name)
+
+        super(PerlPackageTemplate, self).__init__(name, *args)
+
+
 class OctavePackageTemplate(PackageTemplate):
     """Provides appropriate overrides for octave packages"""
 
@@ -305,6 +326,7 @@ templates = {
     'bazel':      BazelPackageTemplate,
     'python':     PythonPackageTemplate,
     'r':          RPackageTemplate,
+    'perl':       PerlPackageTemplate,
     'octave':     OctavePackageTemplate,
     'generic':    PackageTemplate
 }

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -385,7 +385,9 @@ class BuildSystemGuesser:
             (r'/SConstruct$',        'scons'),
             (r'/setup.py$',          'python'),
             (r'/NAMESPACE$',         'r'),
-            (r'/WORKSPACE$',         'bazel')
+            (r'/WORKSPACE$',         'bazel'),
+            (r'/Makefile.PL$',       'perl'),
+            (r'/Build.PL$',          'perl')
         ]
 
         # Peek inside the compressed file.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -268,8 +268,9 @@ class RPackageTemplate(PackageTemplate):
         super(RPackageTemplate, self).__init__(name, *args)
 
 
-class PerlPackageTemplate(PackageTemplate):
-    """Provides appropriate overrides for Perl extensions"""
+class PerlmakePackageTemplate(PackageTemplate):
+    """Provides appropriate overrides for Perl extensions
+    that come with a Makefile.PL"""
     base_class_name = 'PerlPackage'
 
     dependencies = """\
@@ -292,7 +293,18 @@ class PerlPackageTemplate(PackageTemplate):
             tty.msg("Changing package name from {0} to perl-{0}".format(name))
             name = 'perl-{0}'.format(name)
 
-        super(PerlPackageTemplate, self).__init__(name, *args)
+        super(PerlmakePackageTemplate, self).__init__(name, *args)
+
+
+class PerlbuildPackageTemplate(PerlmakePackageTemplate):
+    """Provides appropriate overrides for Perl extensions
+    that come with a Build.PL instead of a Makefile.PL"""
+    dependencies = """\
+    depends_on('perl-module-build', type='build')
+
+    # FIXME: Add additional dependencies if required:
+    # depends_on('perl-foo')
+    # depends_on('barbaz', type=('build', 'link', 'run'))"""
 
 
 class OctavePackageTemplate(PackageTemplate):
@@ -332,7 +344,8 @@ templates = {
     'bazel':      BazelPackageTemplate,
     'python':     PythonPackageTemplate,
     'r':          RPackageTemplate,
-    'perl':       PerlPackageTemplate,
+    'perlmake':   PerlmakePackageTemplate,
+    'perlbuild':  PerlbuildPackageTemplate,
     'octave':     OctavePackageTemplate,
     'generic':    PackageTemplate
 }
@@ -392,8 +405,8 @@ class BuildSystemGuesser:
             (r'/setup.py$',          'python'),
             (r'/NAMESPACE$',         'r'),
             (r'/WORKSPACE$',         'bazel'),
-            (r'/Makefile.PL$',       'perl'),
-            (r'/Build.PL$',          'perl')
+            (r'/Makefile.PL$',       'perlmake'),
+            (r'/Build.PL$',          'perlbuild')
         ]
 
         # Peek inside the compressed file.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -275,8 +275,7 @@ class PerlPackageTemplate(PackageTemplate):
     dependencies = """\
     # FIXME: Add dependencies if required:
     # depends_on('perl-foo')
-    # depends_on('barbaz', type=('build', 'link', 'run'))
-    """
+    # depends_on('barbaz', type=('build', 'link', 'run'))"""
 
     body = """\
     # FIXME: If non-standard arguments are used for configure step:
@@ -284,8 +283,7 @@ class PerlPackageTemplate(PackageTemplate):
     #     return ['my', 'configure', 'args']
 
     # FIXME: in unusual cases, it may be necessary to override methods for
-    #        configure(), build(), check() or install().
-    """
+    #        configure(), build(), check() or install()."""
 
     def __init__(self, name, *args):
         # If the user provided `--name perl-cpp`, don't rename it perl-perl-cpp

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -405,8 +405,8 @@ class BuildSystemGuesser:
             (r'/setup.py$',          'python'),
             (r'/NAMESPACE$',         'r'),
             (r'/WORKSPACE$',         'bazel'),
+            (r'/Build.PL$',          'perlbuild'),
             (r'/Makefile.PL$',       'perlmake'),
-            (r'/Build.PL$',          'perlbuild')
         ]
 
         # Peek inside the compressed file.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -274,10 +274,21 @@ class PerlPackageTemplate(PackageTemplate):
 
     dependencies = """\
     # FIXME: Add dependencies if required.
-    # depends_on('perl-foo', type=('build', 'run'))"""
+    # depends_on('perl-foo')
+    # depends_on('barbaz', type=('build', 'link', 'run'))
+    """
 
     body = """\
-    # FIXME: Override install() if necessary."""
+    # FIXME: Select appropriate perl build method:
+    # build_method = 'Makefile.PL' # Default
+    # build_method = 'Build.PL'    # Needed by some packages
+
+    # FIXME: If non-standard arguments are used for configure step:
+    # def configure_args(self):
+    #     return ['my', 'configure', 'args']
+
+    # FIXME: in unusual cases, override configure(), build() or install()
+    """
 
     def __init__(self, name, *args):
         # If the user provided `--name perl-cpp`, don't rename it perl-perl-cpp

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -273,21 +273,18 @@ class PerlPackageTemplate(PackageTemplate):
     base_class_name = 'PerlPackage'
 
     dependencies = """\
-    # FIXME: Add dependencies if required.
+    # FIXME: Add dependencies if required:
     # depends_on('perl-foo')
     # depends_on('barbaz', type=('build', 'link', 'run'))
     """
 
     body = """\
-    # FIXME: Select appropriate perl build method:
-    # build_method = 'Makefile.PL' # Default
-    # build_method = 'Build.PL'    # Needed by some packages
-
     # FIXME: If non-standard arguments are used for configure step:
     # def configure_args(self):
     #     return ['my', 'configure', 'args']
 
-    # FIXME: in unusual cases, override configure(), build() or install()
+    # FIXME: in unusual cases, it may be necessary to override methods for
+    #        configure(), build(), check() or install().
     """
 
     def __init__(self, name, *args):

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -38,8 +38,8 @@ import spack.stage
         ('setup.py',       'python'),
         ('NAMESPACE',      'r'),
         ('WORKSPACE',      'bazel'),
-        ('Makefile.PL',    'perl'),
-        ('Build.PL',       'perl'),
+        ('Makefile.PL',    'perlmake'),
+        ('Build.PL',       'perlbuild'),
         ('foobar',         'generic')
     ]
 )

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -38,6 +38,8 @@ import spack.stage
         ('setup.py',       'python'),
         ('NAMESPACE',      'r'),
         ('WORKSPACE',      'bazel'),
+        ('Makefile.PL',    'perl'),
+        ('Build.PL',       'perl'),
         ('foobar',         'generic')
     ]
 )

--- a/var/spack/repos/builtin/packages/perl-module-build/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+from spack import *
+
+
+class PerlModuleBuild(PerlPackage):
+    """Module::Build is a system for building, testing, and installing Perl
+modules. It is meant to be an alternative to ExtUtils::MakeMaker. Developers
+may alter the behavior of the module through subclassing in a much more
+straightforward way than with MakeMaker. It also does not require a make on
+your system - most of the Module::Build code is pure-perl and written in a
+very cross-platform way.
+"""
+
+    homepage = "http://search.cpan.org/perldoc/Module::Build"
+    url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/Module-Build-0.4220.tar.gz"
+
+    version('0.4220', '9df204e188462a4410d496f316c2c531')

--- a/var/spack/repos/builtin/packages/perl-module-build/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build/package.py
@@ -28,12 +28,12 @@ from spack import *
 
 class PerlModuleBuild(PerlPackage):
     """Module::Build is a system for building, testing, and installing Perl
-modules. It is meant to be an alternative to ExtUtils::MakeMaker. Developers
-may alter the behavior of the module through subclassing in a much more
-straightforward way than with MakeMaker. It also does not require a make on
-your system - most of the Module::Build code is pure-perl and written in a
-very cross-platform way.
-"""
+    modules. It is meant to be an alternative to ExtUtils::MakeMaker.
+    Developers may alter the behavior of the module through subclassing in a
+    much more straightforward way than with MakeMaker. It also does not
+    require a make on your system - most of the Module::Build code is
+    pure-perl and written in a very cross-platform way.
+    """
 
     homepage = "http://search.cpan.org/perldoc/Module::Build"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/Module-Build-0.4220.tar.gz"


### PR DESCRIPTION
Resolves #1817.

Issue #1817 raises a scenario where installing a package is difficult without making perl extendable. This feature is listed as being up-for-grabs.

I have added support for perl extensions, using R extensions as a guide.

Perl packages use a variety of build methods, some of which are not provided by the core perl distribution. As a test of my perl extension code, I have included an extension that provides one of the common "unofficial" build methods: perl-module-build.