### PR TITLE
petsc: a workaround for macOS Clang 8.1.0 and XCode 8.3

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/macos-clang-8.1.0.diff
+++ b/var/spack/repos/builtin/packages/petsc/macos-clang-8.1.0.diff
@@ -1,0 +1,18 @@
+diff --git a/config/BuildSystem/config/libraries.py b/config/BuildSystem/config/libraries.py
+index 0af92f0..8644b55 100644
+--- a/config/BuildSystem/config/libraries.py
++++ b/config/BuildSystem/config/libraries.py
+@@ -50,12 +50,7 @@ class Configure(config.base.Configure):
+         flagName  = self.language[-1]+'SharedLinkerFlag'
+         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
+         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
+-        if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
+-          return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
+-        if flagSubst in self.argDB:
+-          return [self.argDB[flagSubst]+dirname,'-L'+dirname,'-l'+name]
+-        else:
+-          return ['-L'+dirname,' -l'+name]
++        return ['-L'+dirname,' -l'+name]
+       else:
+         return ['-l'+name]
+     if os.path.splitext(library)[1] == '.so':

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -74,6 +74,13 @@ class Petsc(Package):
     variant('int64', default=False,
             description='Compile with 64bit indices')
 
+    # temporary workaround Clang 8.1.0 with XCode 8.3 on macOS, see
+    # https://bitbucket.org/petsc/petsc/commits/4f290403fdd060d09d5cb07345cbfd52670e3cbc
+    # the patch is an adaptation of the original commit to 3.7.5
+    if sys.platform == "darwin":
+        patch('macos-clang-8.1.0.diff',
+              when='@3.7.5%clang@8.1.0:')
+
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface
     depends_on('sowing', when='@develop')


### PR DESCRIPTION
unfortunately new XCode 8.3 breaks things 😢 see http://lists.mcs.anl.gov/pipermail/petsc-users/2017-March/032049.html