### PR TITLE
htslib depends_on version must match samtools

### DIFF
--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -38,7 +38,9 @@ class Samtools(Package):
     version('1.2', '988ec4c3058a6ceda36503eebecd4122')
 
     depends_on("ncurses")
-    depends_on("htslib", when='@1.3.1:')  # htslib became standalone
+    # htslib became standalone @1.3.1, must use corresponding version
+    depends_on("htslib@1.4",   when='@1.4')
+    depends_on("htslib@1.3.1", when='@1.3.1')
     depends_on('zlib', when='@1.2')       # needed for builtin htslib
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Empirically, the version of htslib used must match the samtools version.

I'm open to prettier ways to do this.