### PR TITLE
Concretization problem breaks httpie dependency

### DIFF
--- a/var/spack/repos/builtin/packages/httpie/package.py
+++ b/var/spack/repos/builtin/packages/httpie/package.py
@@ -42,5 +42,6 @@ class Httpie(PythonPackage):
     depends_on('py-pysocks', type=('build', 'run'), when="+socks")
     # Concretization problem breaks this.  Unconditional for now...
     # https://github.com/LLNL/spack/issues/3628
-    # depends_on('py-argparse@1.2.1:', type=('build', 'run'), when='^python@:2.6,3.0:3.1')
+    # depends_on('py-argparse@1.2.1:', type=('build', 'run'), 
+    #            when='^python@:2.6,3.0:3.1')
     depends_on('py-argparse@1.2.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/httpie/package.py
+++ b/var/spack/repos/builtin/packages/httpie/package.py
@@ -40,4 +40,7 @@ class Httpie(PythonPackage):
     depends_on('py-pygments@2.1.3:', type=('build', 'run'))
     depends_on('py-requests@2.11.0:', type=('build', 'run'))
     depends_on('py-pysocks', type=('build', 'run'), when="+socks")
-    depends_on('py-argparse@1.2.1:', type=('build', 'run'), when='^python@:2.6,3.0:3.1')
+    # Concretization problem breaks this.  Unconditional for now...
+    # https://github.com/LLNL/spack/issues/3628
+    # depends_on('py-argparse@1.2.1:', type=('build', 'run'), when='^python@:2.6,3.0:3.1')
+    depends_on('py-argparse@1.2.1:', type=('build', 'run'))


### PR DESCRIPTION
Concretization problem breaks this.  Unconditional for now...

See 
https://github.com/LLNL/spack/issues/3628

Tested with python 2.7.13 and 3.6.0.