### PR TITLE
Subversion with perl bindings

### DIFF
--- a/var/spack/repos/builtin/packages/perl-term-readkey/package.py
+++ b/var/spack/repos/builtin/packages/perl-term-readkey/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PerlTermReadkey(PerlPackage):
+    """Term::ReadKey is a compiled perl module dedicated to providing simple
+    control over terminal driver modes (cbreak, raw, cooked, etc.,) support
+    for non-blocking reads, if the architecture allows, and some generalized
+    handy functions for working with terminals. One of the main goals is to
+    have the functions as portable as possible, so you can just plug in
+    "use Term::ReadKey" on any architecture and have a good likelihood of it
+    working."""
+
+    homepage = "http://search.cpan.org/perldoc/Term::ReadKey"
+    url = "http://www.cpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.37.tar.gz"
+    list_url = "http://www.cpan.org/authors/id/J/JS/JSTOWE"
+
+    version('2.37', 'e8ea15c16333ac4f8d146d702e83cc0c')
+
+    #depends_on('')

--- a/var/spack/repos/builtin/packages/perl-term-readkey/package.py
+++ b/var/spack/repos/builtin/packages/perl-term-readkey/package.py
@@ -39,5 +39,3 @@ class PerlTermReadkey(PerlPackage):
     list_url = "http://www.cpan.org/authors/id/J/JS/JSTOWE"
 
     version('2.37', 'e8ea15c16333ac4f8d146d702e83cc0c')
-
-    #depends_on('')

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -86,7 +86,7 @@ class Subversion(Package):
             make('install-swig-pl-lib')
             with working_dir(join_path(
                     'subversion', 'bindings', 'swig', 'perl', 'native')):
-                perl = Executable(join_path(spec['perl'].prefix.bin, 'perl'))
+                perl = which('perl')
                 perl('Makefile.PL', 'INSTALL_BASE=%s' % prefix)
                 make('install')
 

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -27,17 +27,23 @@ from spack import *
 
 class Subversion(Package):
     """Apache Subversion - an open source version control system."""
-    homepage  = 'https://subversion.apache.org/'
-    url       = 'http://archive.apache.org/dist/subversion/subversion-1.8.13.tar.gz'
+    homepage = 'https://subversion.apache.org/'
+    url = 'http://archive.apache.org/dist/subversion/subversion-1.8.13.tar.gz'
 
     version('1.8.13',    '8065b3698d799507fb72dd7926ed32b6')
     version('1.9.3',     'a92bcfaec4e5038f82c74a7b5bbd2f46')
+
+    variant('perl', default=False, description='Build with Perl bindings')
 
     depends_on('apr')
     depends_on('apr-util')
     depends_on('zlib')
     depends_on('sqlite')
     depends_on('serf')
+
+    extends('perl', when='+perl')
+    depends_on('swig@1.3.24:3.0.0', when='+perl')
+    depends_on('perl-term-readkey', when='+perl')
 
     # Optional: We need swig if we want the Perl, Python or Ruby
     # bindings.
@@ -60,11 +66,29 @@ class Subversion(Package):
         options.append('--with-zlib=%s' % spec['zlib'].prefix)
         options.append('--with-sqlite=%s' % spec['sqlite'].prefix)
         options.append('--with-serf=%s' % spec['serf'].prefix)
-        # options.append('--with-swig=%s' % spec['swig'].prefix)
+
+        if spec.satisfies('^swig'):
+            options.append('--with-swig=%s' % spec['swig'].prefix)
+        if spec.satisfies('+perl'):
+            options.append(
+                'PERL=%s' % join_path(spec['perl'].prefix.bin, 'perl'))
 
         configure(*options)
         make()
+        if self.run_tests:
+            make('check')
         make('install')
+
+        if spec.satisfies('+perl'):
+            make('swig-pl')
+            if self.run_tests:
+                make('check-swig-pl')
+            make('install-swig-pl-lib')
+            with working_dir(join_path(
+                    'subversion', 'bindings', 'swig', 'perl', 'native')):
+                perl = Executable(join_path(spec['perl'].prefix.bin, 'perl'))
+                perl('Makefile.PL', 'INSTALL_BASE=%s' % prefix)
+                make('install')
 
         # python bindings
         # make('swig-py',
@@ -73,10 +97,6 @@ class Subversion(Package):
         # make('install-swig-py',
         #     'swig-pydir=/usr/lib/python2.7/site-packages/libsvn',
         #     'swig_pydir_extra=/usr/lib/python2.7/site-packages/svn')
-
-        # perl bindings
-        # make('swig-pl')
-        # make('install-swig-pl')
 
         # ruby bindings
         # make('swig-rb')


### PR DESCRIPTION
Add variant of subversion with perl bindings. This allows integration with git via "git svn". The perl Term::ReadKey module is needed for password entry when accessing some subversion repositories.