### PR TITLE
Update tinyxml

### DIFF
--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -33,7 +33,7 @@ class Tinyxml(CMakePackage):
     homepage = "http://grinninglizard.com/tinyxml/"
     url = "https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
 
-    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764', url=url)
+    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764')
 
     def patch(self):
         copyfile(join_path(os.path.dirname(__file__),

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from shutil import copyfile
 import os.path
 
 
@@ -30,9 +31,9 @@ class Tinyxml(CMakePackage):
     """Simple, small, efficient, C++ XML parser"""
 
     homepage = "http://grinninglizard.com/tinyxml/"
-    url = "https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
+    url = "https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
 
-    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764')
+    version('2.6.2', 'cba3f50dd657cb1434674a03b21394df9913d764', url=url)
 
     def patch(self):
         copyfile(join_path(os.path.dirname(__file__),


### PR DESCRIPTION
* url seems to have changed
* spack replaces "_2_6_2" with "_2.6.2" unless the url is explicitly
given
* copyfile is no longuer available by default