### PR TITLE
fix flake8 ignore syntax, otherwise will ignore all

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -127,7 +127,7 @@ def filter_file(source, dest, output=False):
                     for code, patterns in errors.items():
                         for pattern in patterns:
                             if pattern.search(line):
-                                line += ("  # NOQA: ignore=%d" % code)
+                                line += ("  # NOQA: E%d" % code)
                                 break
 
                 oline = line + '\n'


### PR DESCRIPTION
As discovered in #3648, the "# NOQA: ignore=XYZ" syntax was causing all errors to be ignored. Per http://flake8.pycqa.org/en/latest/user/ignoring-errors.html, it looks like the correct syntax is "# NOQA: EXYZ