### PR TITLE
fix annoying 'fatal: Not a git repository' error message produced by 'spack list' when Spack is not run from a Git repository

### DIFF
--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -73,13 +73,16 @@ def setup_parser(subparser):
         help="revision to compare to rev1 (default is HEAD)")
 
 
-def get_git():
+def get_git(fatal=True):
     # cd to spack prefix to do git operations
     os.chdir(spack.prefix)
 
     # If this is a non-git version of spack, give up.
     if not os.path.isdir('.git'):
-        tty.die("No git repo in %s. Can't use 'spack pkg'" % spack.prefix)
+        if fatal:
+            tty.die("No git repo in %s. Can't use 'spack pkg'" % spack.prefix)
+        else:
+            return None
 
     return which("git", required=True)
 

--- a/lib/spack/spack/hooks/case_consistency.py
+++ b/lib/spack/spack/hooks/case_consistency.py
@@ -31,6 +31,7 @@ import platform
 from llnl.util.filesystem import *
 
 import spack
+from spack.cmd.pkg import get_git
 from spack.util.executable import *
 
 
@@ -61,8 +62,8 @@ def git_case_consistency_check(path):
     """
     with working_dir(path):
         # Don't bother fixing case if Spack isn't in a git repository
-        git = which('git')
-        if not git:
+        git = get_git(fatal=False)
+        if git is None:
             return
 
         try:


### PR DESCRIPTION
When `spack list` (and maybe also other Spack commands) is run from a Spack installation that is not a Git repository, an annoying `fatal: Not a git repository` is printed:

```
$ spack list
fatal: Not a git repository (or any of the parent directories): .git
==> 1114 packages.
...
```

This occurs both with the latest Spack v0.10.0 release and well as current `develop`.

The problem seems to be that the check done in `git_case_consistency_check` is incorrect. It checks whether the `git` command is available, rather than checking whether Spack is being run from a Git repository.

There is a `get_git` command available in `spack.cmd.pkg` that does the correct check, but it's currently failing hard when Spack is not being run from a Git repository.
So, I've relaxed it to optionally just return `None` rather than the path to the `git` command (or whatever it is that `which` returns, doesn't matter).