### PR TITLE
EasyBuild and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -33,6 +33,6 @@ class Easybuild(PythonPackage):
 
     version('3.1.2', 'c2d901c2a71f51b24890fa69c3a46383')
 
-    depends_on('py-easybuild-framework@3.1:', when='@3.1', type='run')
-    depends_on('py-easybuild-easyblocks@3.1:', when='@3.1', type='run')
-    depends_on('py-easybuild-easyconfigs@3.1:', when='@3.1', type='run')
+    depends_on('py-easybuild-framework@3.1.2', when='@3.1.2', type='run')
+    depends_on('py-easybuild-easyblocks@3.1.2', when='@3.1.2', type='run')
+    depends_on('py-easybuild-easyconfigs@3.1.2', when='@3.1.2', type='run')

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Kenneth Hoste, kenneth.hoste@gmail.com
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Easybuild(PythonPackage):
+    """
+    EasyBuild is a software build and installation framework
+    for (scientific) software on HPC systems.
+    """
+
+    homepage = 'http://hpcugent.github.io/easybuild/'
+    url      = 'https://pypi.python.org/packages/7b/74/4132806b35cb6308a8776297cfa7fec5c8cfa3bc94a8701d209ed3fdd18e/easybuild-3.1.2.tar.gz'
+
+    version('3.1.2', 'c2d901c2a71f51b24890fa69c3a46383')
+
+    depends_on('python', type='run')
+    depends_on('py-easybuild-framework', type='run')
+    depends_on('py-easybuild-easyblocks', type='run')
+    depends_on('py-easybuild-easyconfigs', type='run')

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -33,6 +33,6 @@ class Easybuild(PythonPackage):
 
     version('3.1.2', 'c2d901c2a71f51b24890fa69c3a46383')
 
-    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')
-    depends_on('py-easybuild-easyblocks@3.1', when='@3.1', type='run')
-    depends_on('py-easybuild-easyconfigs@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-framework@3.1:', when='@3.1', type='run')
+    depends_on('py-easybuild-easyblocks@3.1:', when='@3.1', type='run')
+    depends_on('py-easybuild-easyconfigs@3.1:', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/easybuild/package.py
+++ b/var/spack/repos/builtin/packages/easybuild/package.py
@@ -24,17 +24,15 @@ from spack import *
 
 
 class Easybuild(PythonPackage):
-    """
-    EasyBuild is a software build and installation framework
+    """EasyBuild is a software build and installation framework
     for (scientific) software on HPC systems.
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.python.org/packages/7b/74/4132806b35cb6308a8776297cfa7fec5c8cfa3bc94a8701d209ed3fdd18e/easybuild-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild/easybuild-3.1.2.tar.gz'
 
     version('3.1.2', 'c2d901c2a71f51b24890fa69c3a46383')
 
-    depends_on('python', type='run')
-    depends_on('py-easybuild-framework', type='run')
-    depends_on('py-easybuild-easyblocks', type='run')
-    depends_on('py-easybuild-easyconfigs', type='run')
+    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-easyblocks@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-easyconfigs@3.1', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -24,14 +24,13 @@ from spack import *
 
 
 class PyEasybuildEasyblocks(PythonPackage):
-    """
-    Collection of easyblocks for EasyBuild, a software build and
+    """Collection of easyblocks for EasyBuild, a software build and
     installation framework for (scientific) software on HPC systems.
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.python.org/packages/d6/55/9b6634b01fbc26edb9f5af39b06acbe7ec843da438ba5ac3063937934b3e/easybuild-easyblocks-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-easyblocks/easybuild-easyblocks-3.1.2.tar.gz'
 
     version('3.1.2', 'be08da30c07e67ed3e136e8d38905fbc')
 
-    depends_on('py-easybuild-framework', type='run')
+    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Kenneth Hoste, kenneth.hoste@gmail.com
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyEasybuildEasyblocks(PythonPackage):
+    """
+    Collection of easyblocks for EasyBuild, a software build and
+    installation framework for (scientific) software on HPC systems.
+    """
+
+    homepage = 'http://hpcugent.github.io/easybuild/'
+    url      = 'https://pypi.python.org/packages/d6/55/9b6634b01fbc26edb9f5af39b06acbe7ec843da438ba5ac3063937934b3e/easybuild-easyblocks-3.1.2.tar.gz'
+
+    version('3.1.2', 'be08da30c07e67ed3e136e8d38905fbc')
+
+    depends_on('py-easybuild-framework', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyblocks/package.py
@@ -33,4 +33,4 @@ class PyEasybuildEasyblocks(PythonPackage):
 
     version('3.1.2', 'be08da30c07e67ed3e136e8d38905fbc')
 
-    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-framework@3.1:', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -33,5 +33,5 @@ class PyEasybuildEasyconfigs(PythonPackage):
 
     version('3.1.2', '13a4a97fe8a5b9a94f885661cf497d13')
 
-    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')
-    depends_on('py-easybuild-easyblocks@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-framework@3.1:', when='@3.1', type='run')
+    depends_on('py-easybuild-easyblocks@3.1:', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -24,15 +24,14 @@ from spack import *
 
 
 class PyEasybuildEasyconfigs(PythonPackage):
-    """
-    Collection of easyconfig files for EasyBuild, a software build and
+    """Collection of easyconfig files for EasyBuild, a software build and
     installation framework for (scientific) software on HPC systems.
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.python.org/packages/5a/4c/ea8faa46c7874a3d20f28e2d222a1f4a5e97a4f8052add338a785755ec89/easybuild-easyconfigs-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-easyconfigs/easybuild-easyconfigs-3.1.2.tar.gz'
 
     version('3.1.2', '13a4a97fe8a5b9a94f885661cf497d13')
 
-    depends_on('py-easybuild-framework', type='run')
-    depends_on('py-easybuild-easyblocks', type='run')
+    depends_on('py-easybuild-framework@3.1', when='@3.1', type='run')
+    depends_on('py-easybuild-easyblocks@3.1', when='@3.1', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -34,4 +34,4 @@ class PyEasybuildEasyconfigs(PythonPackage):
     version('3.1.2', '13a4a97fe8a5b9a94f885661cf497d13')
 
     depends_on('py-easybuild-framework@3.1:', when='@3.1', type='run')
-    depends_on('py-easybuild-easyblocks@3.1:', when='@3.1', type='run')
+    depends_on('py-easybuild-easyblocks@3.1.2:', when='@3.1.2', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-easyconfigs/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Kenneth Hoste, kenneth.hoste@gmail.com
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyEasybuildEasyconfigs(PythonPackage):
+    """
+    Collection of easyconfig files for EasyBuild, a software build and
+    installation framework for (scientific) software on HPC systems.
+    """
+
+    homepage = 'http://hpcugent.github.io/easybuild/'
+    url      = 'https://pypi.python.org/packages/5a/4c/ea8faa46c7874a3d20f28e2d222a1f4a5e97a4f8052add338a785755ec89/easybuild-easyconfigs-3.1.2.tar.gz'
+
+    version('3.1.2', '13a4a97fe8a5b9a94f885661cf497d13')
+
+    depends_on('py-easybuild-framework', type='run')
+    depends_on('py-easybuild-easyblocks', type='run')

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Kenneth Hoste, kenneth.hoste@gmail.com
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyEasybuildFramework(PythonPackage):
+    """
+    The core of EasyBuild, a software build and installation framework
+    for (scientific) software on HPC systems.
+    """
+
+    homepage = 'http://hpcugent.github.io/easybuild/'
+    url      = 'https://pypi.python.org/packages/fa/00/6a47862b38e6d921071d305deab4c494ae2eae58556c90c95e520fea28b9/easybuild-framework-3.1.2.tar.gz'
+
+    version('3.1.2', '283bc5f6bdcb90016b32986d52fd04a8')
+
+    depends_on('python', type='run')
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-vsc-base', type='run')
+    depends_on('py-vsc-install', type='run')  # only requires for tests (python -O -m test.framework.suite)

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -24,17 +24,16 @@ from spack import *
 
 
 class PyEasybuildFramework(PythonPackage):
-    """
-    The core of EasyBuild, a software build and installation framework
+    """The core of EasyBuild, a software build and installation framework
     for (scientific) software on HPC systems.
     """
 
     homepage = 'http://hpcugent.github.io/easybuild/'
-    url      = 'https://pypi.python.org/packages/fa/00/6a47862b38e6d921071d305deab4c494ae2eae58556c90c95e520fea28b9/easybuild-framework-3.1.2.tar.gz'
+    url      = 'https://pypi.io/packages/source/e/easybuild-framework/easybuild-framework-3.1.2.tar.gz'
 
     version('3.1.2', '283bc5f6bdcb90016b32986d52fd04a8')
 
-    depends_on('python', type='run')
+    depends_on('python@2.6:3.0', type='run')
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-vsc-base', type='run')
-    depends_on('py-vsc-install', type='run')  # only requires for tests (python -O -m test.framework.suite)
+    depends_on('py-vsc-base@2.5.4:', when='@2.9:', type='run')
+    depends_on('py-vsc-install', type='run')  # only required for tests (python -O -m test.framework.suite)

--- a/var/spack/repos/builtin/packages/py-vsc-base/package.py
+++ b/var/spack/repos/builtin/packages/py-vsc-base/package.py
@@ -1,0 +1,35 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyVscBase(PythonPackage):
+    """Common Python libraries tools created by HPC-UGent"""
+
+    homepage = 'https://github.com/hpcugent/vsc-base/'
+    url      = 'https://pypi.python.org/packages/f7/66/1ff7ecc4a93ba37e063f5bfbe395e95a547b1dec73b017c2724f4475a958/vsc-base-2.5.8.tar.gz'
+
+    version('2.5.8', '57f3f49eab7aa15a96be76e6c89a72d8')
+
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-vsc-base/package.py
+++ b/var/spack/repos/builtin/packages/py-vsc-base/package.py
@@ -28,7 +28,7 @@ class PyVscBase(PythonPackage):
     """Common Python libraries tools created by HPC-UGent"""
 
     homepage = 'https://github.com/hpcugent/vsc-base/'
-    url      = 'https://pypi.python.org/packages/f7/66/1ff7ecc4a93ba37e063f5bfbe395e95a547b1dec73b017c2724f4475a958/vsc-base-2.5.8.tar.gz'
+    url      = 'https://pypi.io/packages/source/v/vsc-base/vsc-base-2.5.8.tar.gz'
 
     version('2.5.8', '57f3f49eab7aa15a96be76e6c89a72d8')
 

--- a/var/spack/repos/builtin/packages/py-vsc-install/package.py
+++ b/var/spack/repos/builtin/packages/py-vsc-install/package.py
@@ -24,13 +24,12 @@ from spack import *
 
 
 class PyVscInstall(PythonPackage):
-    """
-    Shared setuptools functions and classes
+    """Shared setuptools functions and classes
     for Python libraries developed by HPC-UGent.
     """
 
     homepage = 'https://github.com/hpcugent/vsc-install/'
-    url      = 'https://pypi.python.org/packages/ef/c7/640c6d791ba452321c0d1371b6626486bb495e0645bb896d33c78a09f810/vsc-install-0.10.25.tar.gz'
+    url      = 'https://pypi.io/packages/source/v/vsc-install/vsc-install-0.10.25.tar.gz'
 
     version('0.10.25', 'd1b9453a75cb56dba0deb7a878047b51')
 

--- a/var/spack/repos/builtin/packages/py-vsc-install/package.py
+++ b/var/spack/repos/builtin/packages/py-vsc-install/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2017, Kenneth Hoste
+#
+# This file is part of Spack.
+# Created by Kenneth Hoste, kenneth.hoste@gmail.com
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyVscInstall(PythonPackage):
+    """
+    Shared setuptools functions and classes
+    for Python libraries developed by HPC-UGent.
+    """
+
+    homepage = 'https://github.com/hpcugent/vsc-install/'
+    url      = 'https://pypi.python.org/packages/ef/c7/640c6d791ba452321c0d1371b6626486bb495e0645bb896d33c78a09f810/vsc-install-0.10.25.tar.gz'
+
+    version('0.10.25', 'd1b9453a75cb56dba0deb7a878047b51')
+
+    depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Added packages for EasyBuild and all dependencies, i.e.:

* `vsc-install`
* `vsc-base`
* all three EasyBuild components, i.e.:
  * `easybuild-framework`
  * `easybuild-easyblocks`
  * `easybuild-easyconfigs`

A couple of open questions I have:

* there are more strict dependency requirements than what is specified now, but I'm not sure how to specify them:
   * `vsc-base` needs a particular version of `vsc-install`, but the exact requirement depends on the `vsc-base` version, how do I express that? (similar for `easybuild-framework` and `vsc-base`)
   * `easybuild-easyblocks` version `x.y.z` typically requires `easybuild-framework` version `x.y.z`, how do I express that? (similar for `easybuild-easyconfigs`)

I was a bit surprised that a simply `spack load easybuild` is not sufficient to make the EasyBuild installation done with Spack active in my environment. In particular, `python` and `python2` were still the default system Python.
This is important for EasyBuild since the main `eb` command is a bash wrapper scripts that calls out to `python` or `python2`, so there's no shebang that Spack can hijack to make sure the `python` command provided by Spack is being used.
`spack activate easybuild` didn't work either, but maybe I wasn't using it correctly...

The only way I could use the installation is using `source <(spack module loads --dependencies easybuild)`, is that what I'm supposed to do?