### PR TITLE
Restore perl-5.22.2 for backward compat.

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -47,6 +47,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # Maintenance releases (recommended)
     version('5.24.1', '765ef511b5b87a164e2531403ee16b3c', preferred=True)
     version('5.22.3', 'aa4f236dc2fc6f88b871436b8d0fda95')
+    
+    # Misc releases that people need
+    version('5.22.2', '5767e2a10dd62a46d7b57f74a90d952b')
 
     # End of life releases
     version('5.20.3', 'd647d0ea5a7a8194c34759ab9f2610cd')


### PR DESCRIPTION
Hey, I was using that! :)

Turns out that we really want 5.22.2 for backward compatibility.
