### PR TITLE
subversion: fix dependency on swig

### DIFF
--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -67,9 +67,9 @@ class Subversion(Package):
         options.append('--with-sqlite=%s' % spec['sqlite'].prefix)
         options.append('--with-serf=%s' % spec['serf'].prefix)
 
-        if spec.satisfies('^swig'):
+        if 'swig' in spec:
             options.append('--with-swig=%s' % spec['swig'].prefix)
-        if spec.satisfies('+perl'):
+        if 'perl' in spec:
             options.append(
                 'PERL=%s' % join_path(spec['perl'].prefix.bin, 'perl'))
 


### PR DESCRIPTION
I found a problem when installing subversion without the variant `+perl`. For some reason, the expression `spec.satisfies('^swig')` in the subversion package.py evaluates to True even when swig is not in the spec. This causes an error when `spec['swig'].prefix` is evaluated. Replacing the expression by `'swig' in spec` worked as expected, so I also replaced a similar expression involving perl.