### PR TITLE
add CUDA_HOME arg to nccl makefile

### DIFF
--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -37,5 +37,9 @@ class Nccl(MakefilePackage):
     depends_on('cuda')
 
     @property
+    def build_targets(self):
+        return ['CUDA_HOME={0}'.format(self.spec['cuda'].prefix)]
+
+    @property
     def install_targets(self):
         return ['PREFIX={0}'.format(self.prefix), 'install']


### PR DESCRIPTION
Without this, the package defaults to a cuda install in /opt rather than the spack specified one.