### PR TITLE
openfst conflicts with %intel@16: and %gcc@6: .

### DIFF
--- a/var/spack/repos/builtin/packages/openfst/package.py
+++ b/var/spack/repos/builtin/packages/openfst/package.py
@@ -26,9 +26,9 @@ from spack import *
 
 
 class Openfst(AutotoolsPackage):
-    """OpenFst is a library for constructing, combining, optimizing, 
-        and searching weighted finite-state transducers (FSTs). Weighted 
-        finite-state transducers are automata where each transition has 
+    """OpenFst is a library for constructing, combining, optimizing,
+        and searching weighted finite-state transducers (FSTs). Weighted
+        finite-state transducers are automata where each transition has
         an input label, an output label, and a weight."""
 
     homepage = "http://www.openfst.org"
@@ -45,10 +45,5 @@ class Openfst(AutotoolsPackage):
     version('1.4.1',  'ca8f1730b9b9b281e515611fa9ae23c0')
     version('1.4.0',  '662367ec91084ffab48ee9b5716de39c')
 
-    @run_before('autoreconf')
-    def check_compilers(self):
-        # Fails to built openfst with %gcc@6: or %intel@16
-        if self.spec.satisfies('%intel@16:') or self.spec.satisfies('gcc@6:'):
-            raise InstallError(
-                'openfst does not support Intel compiler >= 16 and gcc >= 6 '
-            )
+    conflicts('%intel@16:')
+    conflicts('%gcc@6:')


### PR DESCRIPTION
Rewrite `installError` with `conflicts`.