### PR TITLE
Add latest version of pkg-config

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -25,40 +25,40 @@
 from spack import *
 
 
-class PkgConfig(Package):
+class PkgConfig(AutotoolsPackage):
     """pkg-config is a helper tool used when compiling applications
     and libraries"""
 
     homepage = "http://www.freedesktop.org/wiki/Software/pkg-config/"
-    url = "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
+    url = "http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
 
+    version('0.29.2', 'f6e931e319531b736fadc017f470e68a')
     version('0.29.1', 'f739a28cae4e0ca291f82d1d41ef107d')
     version('0.28',   'aa3c86e67551adc3ac865160e34a2a0d')
 
-    parallel = False
     variant('internal_glib', default=True,
             description='Builds with internal glib')
 
     # The following patch is needed for gcc-6.1
-    patch('g_date_strftime.patch')
+    patch('g_date_strftime.patch', when='@:0.29.1')
 
-    @when("platform=cray")
-    def setup_dependent_environment(self, spack_env, run_env, dep_spec):
+    parallel = False
+
+    @when('platform=cray')
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         """spack built pkg-config on cray's requires adding /usr/local/
         and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
         files."""
-        spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/lib64/pkgconfig")
-        spack_env.prepend_path("PKG_CONFIG_PATH", "/usr/local/lib64/pkgconfig")
+        spack_env.prepend_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
+        spack_env.prepend_path('PKG_CONFIG_PATH', '/usr/local/lib64/pkgconfig')
 
-    def install(self, spec, prefix):
-        args = ["--prefix={0}".format(prefix),
-                "--enable-shared"]
-        if "+internal_glib" in spec:
+    def configure_args(self):
+        config_args = ['--enable-shared']
+
+        if '+internal_glib' in self.spec:
             # There's a bootstrapping problem here;
             # glib uses pkg-config as well, so break
             # the cycle by using the internal glib.
-            args.append("--with-internal-glib")
-        configure(*args)
+            config_args.append('--with-internal-glib')
 
-        make()
-        make("install")
+        return config_args


### PR DESCRIPTION
Also converts the package to `AutotoolsPackage`. All tests passed for me with GCC 6.3.0 on CentOS 7.