### PR TITLE
Add latest alpha release of MVAPICH2

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -30,8 +30,13 @@ class Mvapich2(Package):
     """MVAPICH2 is an MPI implementation for Infiniband networks."""
     homepage = "http://mvapich.cse.ohio-state.edu/"
     url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.2.tar.gz"
+    list_url = "http://mvapich.cse.ohio-state.edu/downloads/"
 
-    version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e')
+    # Newer alpha release
+    version('2.3a', '87c3fbf8a755b53806fa9ecb21453445')
+
+    # Prefer the latest stable release
+    version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e', preferred=True)
     version('2.1', '0095ceecb19bbb7fb262131cb9c2cdd6')
     version('2.0', '9fbb68a4111a8b6338e476dc657388b4')
     version('1.9', '5dc58ed08fd3142c260b70fe297e127c')


### PR DESCRIPTION
I remember a lot of bugs with `2.2b`, so I decided to make `2.2` the preferred version until a new stable release comes out. But users can still try out `2.2a` if they want to.

I could have also updated this package to use `AutotoolsPackage`, but it would conflict with #2386 and I don't want to screw over @alalazo 😆 