### PR TITLE
If bash is version 3, don't add bash completions..

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -203,7 +203,7 @@ _spack_pathadd MODULEPATH "${_sp_tcl_root%/}/$_sp_sys_type"
 # Add programmable tab completion for Bash
 #
 if [ -n "${BASH_VERSION:-}" ]; then
-    if [ $(echo ${BASH_VERSION:-} | cut -c 1) -gt 3 ]; then
+    if [ "${BASH_VERSION::1}" -gt 3 ]; then
         source $_sp_share_dir/spack-completion.bash
     fi;
 fi

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -203,5 +203,7 @@ _spack_pathadd MODULEPATH "${_sp_tcl_root%/}/$_sp_sys_type"
 # Add programmable tab completion for Bash
 #
 if [ -n "${BASH_VERSION:-}" ]; then
-    source $_sp_share_dir/spack-completion.bash
+    if [ $(echo ${BASH_VERSION:-} | cut -c 1) -gt 3 ]; then
+        source $_sp_share_dir/spack-completion.bash
+    fi;
 fi


### PR DESCRIPTION
I've found that old versions bash (3) cannot complete the setup-env.sh script failing on the bash completions. This patch checks whether bash is a new enough version for the completions.