### PR TITLE
Cppcheck

### DIFF
--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -23,6 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
+import shutil
 
 
 class Cppcheck(Package):
@@ -35,7 +37,8 @@ class Cppcheck(Package):
 
     def install(self, spec, prefix):
         # cppcheck does not have a configure script
-        make()
+        make("CFGDIR=%s" % os.path.join(prefix, 'cfg'))
         # manually install the final cppcheck binary
         mkdirp(prefix.bin)
         install('cppcheck', prefix.bin)
+        shutil.copytree('cfg', os.path.join(prefix, 'cfg'))

--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -30,6 +30,7 @@ class Cppcheck(Package):
     homepage = "http://cppcheck.sourceforge.net/"
     url      = "http://downloads.sourceforge.net/project/cppcheck/cppcheck/1.68/cppcheck-1.68.tar.bz2"
 
+    version('1.72', '2bd36f91ae0191ef5273bb7f6dc0d72e')
     version('1.68', 'c015195f5d61a542f350269030150708')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
- Adds version 1.72
- Installs cfg files without which cppcheck does not work. Users can provides these files individually, but some standard files exist and should be made available.