### PR TITLE
Add package for open source Shiny Server

### DIFF
--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -39,7 +39,7 @@ class ShinyServer(Package):
     depends_on('cmake@2.8.10:')
     # depends_on('gcc@5.4.0')
     depends_on('git')
-    depends_on('r')
+    depends_on('r+X')
     depends_on('openssl')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -60,11 +60,11 @@ class ShinyServer(CMakePackage):
 
         return options
 
+    # Recompile the npm modules included in the project
     @run_after('build')
-    def build_node(self):  # or whatever you want to call it
+    def build_node(self):
         bash = which('bash')
-        mkdirp('../build')
-        # maybe add a comment/docstring explaining what this does/is for?
+        mkdirp('build')
         bash('-c', 'bin/npm --python="$PYTHON" install')
         bash('-c', 'bin/node ./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild')  # noqa: E501
 

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -35,9 +35,9 @@ class ShinyServer(Package):
 
     version('1.5.3.838', '96f20fdcdd94c9e9bb851baccb82b97f')
 
-    depends_on('python@2.7.13') # docs say: "Really.  3.x will not work"
+    # Docs say that it requires 'gcc'.
+    depends_on('python@2.9.99')  # docs say: "Really.  3.x will not work"
     depends_on('cmake@2.8.10:')
-    # depends_on('gcc@5.4.0')
     depends_on('git')
     depends_on('r+X')
     depends_on('openssl')
@@ -46,7 +46,7 @@ class ShinyServer(Package):
         with working_dir('spack-build', create=True):
             bash = which('bash')
             cmake('..',
-                  "-DPYTHON=%s" % join_path(spec['python'].prefix.bin, 
+                  "-DPYTHON=%s" % join_path(spec['python'].prefix.bin,
                                             'python'),
                   *std_cmake_args)
             make()
@@ -60,5 +60,5 @@ class ShinyServer(Package):
                              join_path(self.prefix, 'shiny-server', 'bin'))
         # shiny comes with its own pandoc; hook it up...
         run_env.prepend_path('PATH',
-                             join_path(self.prefix, 'shiny-server', 
+                             join_path(self.prefix, 'shiny-server',
                                        'ext', 'pandoc', 'static'))

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -30,12 +30,20 @@ class ShinyServer(Package):
        documents online. Take your shiny apps and share them with your
        organization or the world."""
 
+    #
+    # HEADS UP:
+    # 1. The shiny server installation step will download various node
+    #    and npm bits from the net.  They seem to have them well
+    #    constrained ("npm shrinkwrap"?), but this package is not
+    #    "air gappable".
+    # 2. Docs say that it requires 'gcc'.  depends_on() won't do the
+    #    right thing, it's Up To You.
+    #
     homepage = "https://www.rstudio.com/products/shiny/shiny-server/"
     url = "https://github.com/rstudio/shiny-server/archive/v1.5.3.838.tar.gz"
 
     version('1.5.3.838', '96f20fdcdd94c9e9bb851baccb82b97f')
 
-    # Docs say that it requires 'gcc'.
     depends_on('python@2.9.99')  # docs say: "Really.  3.x will not work"
     depends_on('cmake@2.8.10:')
     depends_on('git')

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class ShinyServer(Package):
+    """Shiny server lets you put shiny web applications and interactive
+       documents online. Take your shiny apps and share them with your
+       organization or the world."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.rstudio.com/products/shiny/shiny-server/"
+
+    version('master', git="https://github.com/rstudio/shiny-server")
+
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')
+    depends_on('python@2.7.12') # docs say: "Really.  3.x will not work"
+    depends_on('cmake@2.8.10:')
+#    depends_on('gcc')
+    #depends_on('g++')
+    depends_on('R')
+    depends_on('openssl')
+#    depends_on('libjpg')
+#    depends_on('libpng')
+
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            cmake('..',
+                  "-DPYTHON=%s" % join_path(spec['python'].prefix.bin,'python'),
+                  *std_cmake_args)
+            make()
+            make("install")

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -66,7 +66,7 @@ class ShinyServer(CMakePackage):
         mkdirp('../build')
         # maybe add a comment/docstring explaining what this does/is for?
         bash('-c', 'bin/npm --python="$PYTHON" install')
-        bash('-c', 'bin/node ./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild')  # noqab: E501
+        bash('-c', 'bin/node ./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild')  # noqa: E501
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH',


### PR DESCRIPTION
I [once threatened to package the open source Shiny Server](https://github.com/LLNL/spack/pull/3613#issuecomment-290141972).    Here we go.

I have two questions about (and as usual, any feedback is welcome):

- the instructions say it needs *gcc*.  I build and use a gcc, so I get it without depending on it.  Should I depend on it anyway?  (There's a `depends_on()` that's commented out, for now)

- what's the right spec for Python.  The docs requires "< 3".  Should I use ":2.99.999" or ....

When you build this, it goes out to the internet and drags a bunch of node/npm stuff into it's installation directory.  They have it fairly tightly controlled ("npm shrinkwrap?"), but it's still not air-gappable.

