### PR TITLE
Fixes needed to build htop

### DIFF
--- a/var/spack/repos/builtin/packages/htop/package.py
+++ b/var/spack/repos/builtin/packages/htop/package.py
@@ -30,7 +30,17 @@ class Htop(AutotoolsPackage):
 
     homepage = "https://github.com/hishamhm/htop"
     url      = "https://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz"
+    list_url = "https://hisham.hm/htop/releases"
+    list_depth = 1
 
     version('2.0.2', '7d354d904bad591a931ad57e99fea84a')
 
     depends_on('ncurses')
+
+    def configure_args(self):
+        return ['--enable-shared']
+
+    @run_after('configure')
+    def patch_makefile(self):
+        # See https://github.com/hishamhm/htop/issues/198
+        filter_file('^(LIBS = .*)', r'\1 -ltinfo', 'Makefile')

--- a/var/spack/repos/builtin/packages/htop/package.py
+++ b/var/spack/repos/builtin/packages/htop/package.py
@@ -39,8 +39,3 @@ class Htop(AutotoolsPackage):
 
     def configure_args(self):
         return ['--enable-shared']
-
-    @run_after('configure')
-    def patch_makefile(self):
-        # See https://github.com/hishamhm/htop/issues/198
-        filter_file('^(LIBS = .*)', r'\1 -ltinfo', 'Makefile')

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -36,3 +36,4 @@ class Htslib(AutotoolsPackage):
 
     depends_on('zlib')
     depends_on('bzip2', when="@1.4:")
+    depends_on('xz')

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -67,14 +67,14 @@ class Lua(Package):
              'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
-             'MYLIBS=-lncurses',
+             'MYLIBS=-lncursesw',
              'CC=%s -std=gnu99' % spack_cc,
              target)
         make('INSTALL_TOP=%s' % prefix,
              'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
-             'MYLIBS=-lncurses',
+             'MYLIBS=-lncursesw',
              'CC=%s -std=gnu99' % spack_cc,
              'install')
 

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -57,7 +57,6 @@ class Ncurses(AutotoolsPackage):
             '--with-cxx-shared',
             '--enable-widec',
             '--enable-overwrite',
-            '--disable-lib-suffixes',
             '--without-ada',
             '--enable-pc-files',
             '--with-pkg-config-libdir={0}/lib/pkgconfig'.format(self.prefix)

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -45,4 +45,4 @@ class Readline(AutotoolsPackage):
     patch('readline-6.3-upstream_fixes-1.patch', when='@6.3')
 
     def build(self, spec, prefix):
-        make('SHLIB_LIBS=-lncurses')
+        make('SHLIB_LIBS=-lncursesw')

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -46,7 +46,7 @@ class Samtools(Package):
     def install(self, spec, prefix):
         if self.spec.version >= Version('1.3.1'):
             configure('--prefix={0}'.format(prefix), '--with-ncurses',
-                      'CURSES_LIB=-lncurses')
+                      'CURSES_LIB=-lncursesw')
             make()
             make('install')
         else:


### PR DESCRIPTION
Fixes #3593.

Without this Makefile patch, I wasn't able to build htop on CentOS 6. I ran into the same bug as reported [here](https://github.com/hishamhm/htop/issues/198).

I also noticed that even though `htop` depends on `ncurses`, it isn't linking to the Spack `ncurses` installation:
```
$ ldd -r htop 
	linux-vdso.so.1 =>  (0x00007ffe38ffb000)
	libncursesw.so.5 => /lib64/libncursesw.so.5 (0x00002aec5e5d7000)
	libm.so.6 => /lib64/libm.so.6 (0x00002aec5e805000)
	libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00002aec5ea89000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00002aec5ecab000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aec5eec1000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aec5f255000)
	/lib64/ld-linux-x86-64.so.2 (0x00002aec5e3b5000)
```
My understanding is that by default ncurses builds a `libncurses.so` library. If you add the `--enable-widec` flag, it instead builds a `libncursesw.so` library. But even though we pass that flag to configure, it doesn't seem to create the "w" versions of the library. Does anyone know why that could be the case? I sent a bug report to the ncurses developers.