### PR TITLE
Add -F option to find method

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -211,6 +211,7 @@ def display_specs(specs, args=None, **kwargs):
     hashes    = get_arg('long', False)
     namespace = get_arg('namespace', False)
     flags     = get_arg('show_flags', False)
+    full_compiler = get_arg('show_full_compiler', False)
     variants  = get_arg('variants', False)
 
     hlen = 7
@@ -219,7 +220,13 @@ def display_specs(specs, args=None, **kwargs):
         hlen = None
 
     nfmt = '.' if namespace else '_'
-    ffmt = '$%+' if flags else ''
+    ffmt = ''
+    if full_compiler or flags:
+        ffmt += '$%'
+        if full_compiler:
+            ffmt += '@'
+        if flags:
+            ffmt += '+'
     vfmt = '$+' if variants else ''
     format_string = '$%s$@%s%s' % (nfmt, ffmt, vfmt)
 
@@ -259,7 +266,7 @@ def display_specs(specs, args=None, **kwargs):
 
         elif mode == 'short':
             # Print columns of output if not printing flags
-            if not flags:
+            if not flags and not full_compiler:
 
                 def fmt(s):
                     string = ""

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -225,8 +225,7 @@ def display_specs(specs, args=None, **kwargs):
         ffmt += '$%'
         if full_compiler:
             ffmt += '@'
-        if flags:
-            ffmt += '+'
+        ffmt += '+'
     vfmt = '$+' if variants else ''
     format_string = '$%s$@%s%s' % (nfmt, ffmt, vfmt)
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -60,7 +60,7 @@ def setup_parser(subparser):
                            action='store_true',
                            dest='show_flags',
                            help='show spec compiler flags')
-    subparser.add_argument('--show-compiler-version',
+    subparser.add_argument('--show-full-compiler',
                            action='store_true',
                            dest='show_full_compiler',
                            help='show full compiler specs')

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -60,6 +60,10 @@ def setup_parser(subparser):
                            action='store_true',
                            dest='show_flags',
                            help='show spec compiler flags')
+    subparser.add_argument('-F', '--show-full-compiler',
+                           action='store_true',
+                           dest='show_full_compiler',
+                           help='show full compiler specs')
     implicit_explicit = subparser.add_mutually_exclusive_group()
     implicit_explicit.add_argument(
         '-e', '--explicit',

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -60,7 +60,7 @@ def setup_parser(subparser):
                            action='store_true',
                            dest='show_flags',
                            help='show spec compiler flags')
-    subparser.add_argument('-F', '--show-full-compiler',
+    subparser.add_argument('--show-compiler-version',
                            action='store_true',
                            dest='show_full_compiler',
                            help='show full compiler specs')

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -363,7 +363,7 @@ function _spack_find {
     if $list_options
     then
         compgen -W "-h --help -s --short -p --paths -d --deps -l --long
-                    -L --very-long -f --show-flags -F --show-full-compiler
+                    -L --very-long -f --show-flags --show-full-compiler
                     -e --explicit -E --implicit -u --unknown -m --missing
                     -v --variants -M --only-missing -N --namespace" -- "$cur"
     else

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -363,9 +363,9 @@ function _spack_find {
     if $list_options
     then
         compgen -W "-h --help -s --short -p --paths -d --deps -l --long
-                    -L --very-long -f --show-flags -e --explicit
-                    -E --implicit -u --unknown -m --missing -v --variants
-                    -M --only-missing -N --namespace" -- "$cur"
+                    -L --very-long -f --show-flags -F --show-full-compiler
+                    -e --explicit -E --implicit -u --unknown -m --missing
+                    -v --variants -M --only-missing -N --namespace" -- "$cur"
     else
         compgen -W "$(_installed_packages)" -- "$cur"
     fi


### PR DESCRIPTION
Occationally, a package can be built with different compilers for
some components. In these situations, it helps to be able to see
the full compiler version information. -F has been added to find
to accomplish this task.