### PR TITLE
hdf5: source directory already configured

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -157,6 +157,10 @@ class Hdf5(AutotoolsPackage):
         return ["--with-zlib=%s" % spec['zlib'].prefix] + extra_args
 
     def configure(self, spec, prefix):
+        # workaround an error:
+        # error: source directory already configured
+        make("distclean")
+
         # Run the default autotools package configure
         super(Hdf5, self).configure(spec, prefix)
 


### PR DESCRIPTION
p.s. probably something changed in Autotools package as I did not have this with 1124bdc99ee84c26201c40536d9b04dac74d7f6a

p.p.s.  the stage was clean, i was not rebuilding a failing build.