### PR TITLE
Fixes patch paths for earlier boost versions

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -131,7 +131,6 @@ class Boost(Package):
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
-    # patch('python_jam.patch', when='^python@3:')
     patch('python_jam.patch', when='@1.56.0: ^python@3:')
     patch('python_jam_pre156.patch', when='@:1.55.0 ^python@3:')
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -131,7 +131,9 @@ class Boost(Package):
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
-    patch('python_jam.patch', when='^python@3:')
+    # patch('python_jam.patch', when='^python@3:')
+    patch('python_jam.patch', when='@1.56.0: ^python@3:')
+    patch('python_jam_pre156.patch', when='@:1.55.0 ^python@3:')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/10125
     patch('boost_10125.patch', when='@1.55.0%gcc@5.0:5.9')

--- a/var/spack/repos/builtin/packages/boost/python_jam_pre156.patch
+++ b/var/spack/repos/builtin/packages/boost/python_jam_pre156.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/build/v2/tools/python.jam b/tools/build/v2/tools/python.jam
+index 90377ea..123f66a 100644
+--- a/tools/build/v2/tools/python.jam
++++ b/tools/build/v2/tools/python.jam
+@@ -493,6 +493,10 @@ local rule probe ( python-cmd )
+                 sys.$(s) = [ SUBST $(output) \\<$(s)=([^$(nl)]+) $1 ] ;
+             }
+         }
++         # Try to get python abiflags
++        full-cmd = $(python-cmd)" -c \"from sys import abiflags; print(abiflags, end='')\"" ;
++
++        sys.abiflags = [ SHELL $(full-cmd) ] ;
+         return $(output) ;
+     }
+ }
+@@ -502,7 +506,7 @@ local rule probe ( python-cmd )
+ # have a value based on the information given.
+ #
+ local rule compute-default-paths ( target-os : version ? : prefix ? :
+-    exec-prefix ? )
++    exec-prefix ? : abiflags ? )
+ {
+     exec-prefix ?= $(prefix) ;
+ 
+@@ -539,7 +543,7 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
+     }
+     else
+     {
+-        includes ?= $(prefix)/include/python$(version) ;
++        includes ?= $(prefix)/include/python$(version)$(abiflags) ;
+ 
+         local lib = $(exec-prefix)/lib ;
+         libraries ?= $(lib)/python$(version)/config $(lib) ;
+@@ -783,7 +787,7 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
+                     exec-prefix = $(sys.exec_prefix) ;
+ 
+                     compute-default-paths $(target-os) : $(sys.version) :
+-                        $(sys.prefix) : $(sys.exec_prefix) ;
++                        $(sys.prefix) : $(sys.exec_prefix) : $(sys.abiflags) ;
+ 
+                     version = $(sys.version) ;
+                     interpreter-cmd ?= $(cmd) ;


### PR DESCRIPTION
The directory structure of boost changed at version 1.56.0, so the patch
being used for python support did not work on earlier versions. This
adds another patch that matches earlier versions.

Fixes #3711 