### PR TITLE
Fix magics

### DIFF
--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -60,6 +60,8 @@ class Magics(Package):
     # Currently python is only necessary to run
     # building preprocessing scripts.
     depends_on('python', type='build')
+    depends_on('perl', type='build')
+    depends_on('perl-xml-parser', type='build')
     depends_on('grib-api')
     depends_on('proj')
     depends_on('boost')
@@ -68,6 +70,10 @@ class Magics(Package):
     depends_on('netcdf-cxx', when='+netcdf')
     depends_on('libemos', when='+bufr')
     depends_on('qt', when='+metview+qt')
+
+    def patch(self):
+        filter_file('#!/usr/bin/perl', '#!/usr/bin/env perl',
+                    'tools/xml2cc_new.pl')
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
- magics requires perl and perl-xml-parser.
- xml2cc_new.pl uses /usr/bin/perl by default.