### PR TITLE
Openmpi cuda support

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -38,6 +38,8 @@ class Cuda(Package):
 
     homepage = "http://www.nvidia.com/object/cuda_home_new.html"
 
+    version('8.0.61', '33e1bd980e91af4e55f3ef835c103f9b', expand=False,
+            url="https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_375.26_linux-run")
     version('8.0.44', '6dca912f9b7e2b7569b0074a41713640', expand=False,
             url="https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers/cuda_8.0.44_linux-run")
     version('7.5.18', '4b3bcecf0dfc35928a0898793cf3e4c6', expand=False,

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -258,8 +258,10 @@ class Openmpi(AutotoolsPackage):
         # CUDA support
         if spec.satisfies('@1.6:'):
             if '+cuda' in spec:
-                config_args.append('--with-cuda={0}'.format(spec['cuda'].prefix))
-                config_args.append('--with-cuda-libdir={0}'.format(spec['cuda'].libs.directories))
+                config_args.append('--with-cuda={0}'.format(
+                    spec['cuda'].prefix))
+                config_args.append('--with-cuda-libdir={0}'.format(
+                    spec['cuda'].libs.directories))
             else:
                 config_args.append('--without-cuda')
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -257,10 +257,10 @@ class Openmpi(AutotoolsPackage):
 
         # CUDA support
         if spec.satisfies('@1.6:'):
-	    if '+cuda' in spec:
+            if '+cuda' in spec:
                 config_args.append('--with-cuda={0}'.format(spec['cuda'].prefix))
-                config_args.append('--with-cuda-libdir={0}/lib64'.format(spec['cuda'].prefix))
-	    else:
+                config_args.append('--with-cuda-libdir={0}'.format(spec['cuda'].libs.directories))
+            else:
                 config_args.append('--without-cuda')
 
         return config_args

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -105,14 +105,14 @@ class Openmpi(AutotoolsPackage):
     variant('vt', default=True, description='Build VampirTrace support')
     variant('thread_multiple', default=False,
             description='Enable MPI_THREAD_MULTIPLE support')
-
-    # TODO: support for CUDA is missing
+    variant('cuda', default=False, description='Enable CUDA support')
 
     provides('mpi@:2.2', when='@1.6.5')
     provides('mpi@:3.0', when='@1.7.5:')
     provides('mpi@:3.1', when='@2.0.0:')
 
     depends_on('hwloc')
+    depends_on('hwloc +cuda', when='+cuda')
     depends_on('jdk', when='+java')
     depends_on('sqlite', when='+sqlite3')
 
@@ -254,6 +254,14 @@ class Openmpi(AutotoolsPackage):
                 config_args.append('--enable-mpi-thread-multiple')
             else:
                 config_args.append('--disable-mpi-thread-multiple')
+
+        # CUDA support
+        if spec.satisfies('@1.6:'):
+	    if '+cuda' in spec:
+                config_args.append('--with-cuda={0}'.format(spec['cuda'].prefix))
+                config_args.append('--with-cuda-libdir={0}/lib64'.format(spec['cuda'].prefix))
+	    else:
+                config_args.append('--without-cuda')
 
         return config_args
 


### PR DESCRIPTION
This PR updates the cuda package with the latest stable version of cuda (needed for the new 1080ti) and enables cuda support in openmpi.