### PR TITLE
Package: ISAAC

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class IsaacServer(CMakePackage):
+    """In Situ Animation of Accelerated Computations: Server"""
+
+    homepage = "http://computationalradiationphysics.github.io/isaac/"
+    url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
+
+    root_cmakelists_dir = 'server'
+
+    version('develop', branch='dev',
+            git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('master', branch='master',
+            git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('1.3.0', 'c8a794da9bb998ef0e75449bfece1a12')
+
+    # variant('gstreamer', default=False, description= \
+    #         'Support for RTP streams, e.g. to Twitch or Youtube')
+
+    depends_on('cmake@3.3:', type='build')
+    depends_on('isaac')
+    depends_on('libwebsockets')
+    # depends_on('gstreamer@1.0', when='+gstreamer')

--- a/var/spack/repos/builtin/packages/isaac/package.py
+++ b/var/spack/repos/builtin/packages/isaac/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Isaac(CMakePackage):
+    """In Situ Animation of Accelerated Computations: Header-Only Library"""
+
+    homepage = "http://computationalradiationphysics.github.io/isaac/"
+    url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
+
+    root_cmakelists_dir = 'lib'
+
+    version('develop', branch='dev',
+            git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('master', branch='master',
+            git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('1.3.0', 'c8a794da9bb998ef0e75449bfece1a12')
+
+    variant('cuda', default=True,
+            description='Generate CUDA kernels for Nvidia GPUs')
+    # variant('alpaka', default=False,
+    #         description='Generate kernels via Alpaka, for CPUs or GPUs')
+
+    depends_on('cmake@3.3:', type='build')
+    depends_on('libjpeg-turbo', type='link')
+    depends_on('jansson', type='link')
+    depends_on('boost@1.56:', type='link')
+    depends_on('cuda@7.0:', type='link', when='+cuda')
+    # depends_on('alpaka', when='+alpaka')
+    depends_on('icet', type='link')
+    depends_on('mpi', type='link')


### PR DESCRIPTION
Adds the [ISAAC](https://github.com/ComputationalRadiationPhysics/isaac) in situ volume rendering library. The ISAAC library can be build with render/filter kernels for Nvidia GPUs via CUDA or with a more general backend via [Alpaka](https://github.com/ComputationalRadiationPhysics/alpaka) with support for  Nvidia GPUs (via CUDA) and multicore CPUs.

Since alpaka is not yet part of spack, the second variant is still commented out.

## Packages

- `isaac`: header-only library with dependencies to other C++ libraries that is then used in simulations
- `isaac-server`: stand-alone executable that connects N simulations with M clients in a `N simulations:1 server` and `1 server:M clients` fashion

(ISAAC clients simply speak websockets/JSON and are usually [HTML/JS pages](https://github.com/ComputationalRadiationPhysics/isaac/tree/v1.2.0/client))

## Downstream Usage

[PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu/) uses ISAAC for in situ visualization.

## References

- [Repo](https://github.com/ComputationalRadiationPhysics/isaac) (LGPLv3+)
- [Documentation](http://computationalradiationphysics.github.io/isaac/)
- [Talk at GTC2016](http://on-demand.gputechconf.com/gtc/2016/video/S6294.html)