### PR TITLE
Update version info to include v1.5.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -30,6 +30,8 @@ class PySphinx(PythonPackage):
     homepage = "http://sphinx-doc.org"
     url      = "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.3.1.tar.gz"
 
+    version('1.5.5', 'f9581b3556df9722143c47290273bcf8',
+            url='https://pypi.python.org/packages/64/78/9d63754981e97c8e7cf14500d262fc573145624d4c765d5047f58e3fdf4e/Sphinx-1.5.5.tar.gz')
     version('1.4.5', '5c2cd2dac45dfa6123d067e32a89e89a',
             url='https://pypi.python.org/packages/8b/78/eeea2b837f911cdc301f5f05163f9729a2381cadd03ccf35b25afe816c90/Sphinx-1.4.5.tar.gz')
     version('1.3.1', '8786a194acf9673464c5455b11fd4332')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -28,12 +28,10 @@ from spack import *
 class PySphinx(PythonPackage):
     """Sphinx Documentation Generator."""
     homepage = "http://sphinx-doc.org"
-    url      = "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.3.1.tar.gz"
+    url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-1.5.5.tar.gz"
 
-    version('1.5.5', 'f9581b3556df9722143c47290273bcf8',
-            url='https://pypi.python.org/packages/64/78/9d63754981e97c8e7cf14500d262fc573145624d4c765d5047f58e3fdf4e/Sphinx-1.5.5.tar.gz')
-    version('1.4.5', '5c2cd2dac45dfa6123d067e32a89e89a',
-            url='https://pypi.python.org/packages/8b/78/eeea2b837f911cdc301f5f05163f9729a2381cadd03ccf35b25afe816c90/Sphinx-1.4.5.tar.gz')
+    version('1.5.5', 'f9581b3556df9722143c47290273bcf8')
+    version('1.4.5', '5c2cd2dac45dfa6123d067e32a89e89a')
     version('1.3.1', '8786a194acf9673464c5455b11fd4332')
 
     extends('python', ignore='bin/(pybabel|pygmentize)')


### PR DESCRIPTION
I threatened to do this in #1408....

I feel a bit dissatisfied about the `url=...` in the version info that I added.  *Is there a way that I can neaten things up?*  (I'm a pypi novice).