### PR TITLE
spglib requires setuptools during runtime

### DIFF
--- a/var/spack/repos/builtin/packages/py-spglib/package.py
+++ b/var/spack/repos/builtin/packages/py-spglib/package.py
@@ -34,5 +34,7 @@ class PySpglib(PythonPackage):
 
     version('1.9.9.18', 'b8b46268d3aeada7b9b201b11882548f')
 
-    depends_on('py-setuptools@18.0:', type='build')
+    # Most Python packages only require setuptools as a build dependency.
+    # However, spglib requires setuptools during runtime as well.
+    depends_on('py-setuptools@18.0:', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))


### PR DESCRIPTION
Fixes the first bug mentioned [here](https://github.com/LLNL/spack/pull/3352#issuecomment-292314480).

@gmatteo You will have to uninstall and reinstall `py-spglib` for this change to take effect.