### PR TITLE
cuda_memtest: Package of CRP

### DIFF
--- a/var/spack/repos/builtin/packages/cuda-memtest/package.py
+++ b/var/spack/repos/builtin/packages/cuda-memtest/package.py
@@ -1,0 +1,45 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class CudaMemtest(CMakePackage):
+    """Maintained and updated fork of cuda_memtest.
+
+    original homepage: http://sourceforge.net/projects/cudagpumemtest .
+
+    This software tests GPU memory for hardware errors and soft errors
+    using CUDA or OpenCL.
+    """
+
+    homepage = "https://github.com/ComputationalRadiationPhysics/cuda_memtest"
+    url      = "https://github.com/ComputationalRadiationPhysics/cuda_memtest.git"
+
+    version('master', branch='dev',
+            git='https://github.com/ComputationalRadiationPhysics/cuda_memtest.git')
+
+    depends_on('cmake@2.8.5:', type='build')
+    # depends_on('nvml', when='+nvml')
+    depends_on('cuda@5.0:')


### PR DESCRIPTION
This adds a maintained version of the (since 2012) stalled original project. Creates a binary to run on a GPU node just like other (CPU) memtests.

https://github.com/ComputationalRadiationPhysics/cuda_memtest

~~Nvidia's [NVML](https://developer.nvidia.com/nvidia-management-library-nvml) (via the [GPU deployment kit](https://developer.nvidia.com/gpu-deployment-kit)) could also be added, providing serial number output of failing GPUs for multi-GPU nodes.~~ Part of the CUDA toolkit since CUDA 8.