### PR TITLE
Adding ZFP version 0.5.1 and variant for uint8 bit stream word type

### DIFF
--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -31,23 +31,44 @@ class Zfp(Package):
        target error bounds or bit rates.  Although bit-for-bit lossless
        compression is not always possible, zfp is usually accurate to
        within machine epsilon in near-lossless mode, and is often orders
-       of magnitude more accurate than other lossy compressors.
-
+       of magnitude more accurate than other lossy compressors. Versions
+       of zfp 0.5.1 or newer also support compression of integer data.
     """
 
     homepage = "http://computation.llnl.gov/projects/floating-point-compression"
-    url      = "http://computation.llnl.gov/projects/floating-point-compression/download/zfp-0.5.0.tar.gz"
+    url      = "http://computation.llnl.gov/projects/floating-point-compression/download/zfp-0.5.1.tar.gz"
+    list_url = "http://computation.llnl.gov/projects/floating-point-compression/download"
+    list_depth = 1
 
+    version('0.5.1', '0ed7059a9b480635e0dd33745e213d17')
     version('0.5.0', '2ab29a852e65ad85aae38925c5003654')
+
+    variant('bswtuint8', default=False,
+        description='Build with bit stream word type of uint8')
+
+    def edit(self, spec, prefix):
+        config_file = FileFilter('Config')
+
+        if '+bswtunit8' in self.spec:
+            config_file.filter('#DEFS += -DBIT_STREAM_WORD_TYPE=uint8)','DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
 
     def install(self, spec, prefix):
         make("shared")
+
+        zfp_incdir = 'inc'
+        if spec.satisfies('@0.5.1:'):
+            zfp_incdir = 'include'
 
         # No install provided
         mkdirp(prefix.lib)
         mkdirp(prefix.include)
         install('lib/libzfp.so', prefix.lib)
-        install('inc/zfp.h', prefix.include)
-        install('inc/types.h', prefix.include)
-        install('inc/bitstream.h', prefix.include)
-        install('inc/system.h', prefix.include)
+        install('%s/zfp.h'%zfp_incdir, prefix.include)
+        install('%s/bitstream.h'%zfp_incdir, prefix.include)
+        if spec.satisfies('@0.5.1:'):
+            mkdirp('%s/zfp'%prefix.include)
+            install('%s/zfp/system.h'%zfp_incdir, '%s/zfp'%prefix.include)
+            install('%s/zfp/types.h'%zfp_incdir, '%s/zfp'%prefix.include)
+        else:
+            install('%s/types.h'%zfp_incdir, prefix.include)
+            install('%s/system.h'%zfp_incdir, prefix.include)

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -50,22 +50,23 @@ class Zfp(MakefilePackage):
             config_file.filter(
                 '^\s*#\s*DEFS\s*\+=\s*-DBIT_STREAM_WORD_TYPE\s*=\s*uint8',
                 'DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
-
-    def install(self, spec, prefix):
+ 
+    def build(self, spec, prefix):
         make("shared")
 
-        zfp_incdir = 'include' if spec.satisfies('@0.5.1:') else 'inc'
+    def install(self, spec, prefix):
+        incdir = 'include' if spec.satisfies('@0.5.1:') else 'inc'
 
         # No install provided
         mkdirp(prefix.lib)
         mkdirp(prefix.include)
         install('lib/libzfp.so', prefix.lib)
-        install('%s/zfp.h' % zfp_incdir, prefix.include)
-        install('%s/bitstream.h' % zfp_incdir, prefix.include)
+        install('%s/zfp.h' % incdir, prefix.include)
+        install('%s/bitstream.h' % incdir, prefix.include)
         if spec.satisfies('@0.5.1:'):
             mkdirp('%s/zfp' % prefix.include)
-            install('%s/zfp/system.h' % zfp_incdir, '%s/zfp' % prefix.include)
-            install('%s/zfp/types.h' % zfp_incdir, '%s/zfp' % prefix.include)
+            install('%s/zfp/system.h' % incdir, '%s/zfp' % prefix.include)
+            install('%s/zfp/types.h' % incdir, '%s/zfp' % prefix.include)
         else:
-            install('%s/types.h' % zfp_incdir, prefix.include)
-            install('%s/system.h' % zfp_incdir, prefix.include)
+            install('%s/types.h' % incdir, prefix.include)
+            install('%s/system.h' % incdir, prefix.include)

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Zfp(Package):
+class Zfp(MakefilePackage):
     """zfp is an open source C library for compressed floating-point arrays
        that supports very high throughput read and write random acces,
        target error bounds or bit rates.  Although bit-for-bit lossless
@@ -45,11 +45,11 @@ class Zfp(Package):
             description='Build with bit stream word type of uint8')
 
     def edit(self, spec, prefix):
-        config_file = FileFilter('Config')
-
-        if '+bswtunit8' in self.spec:
-            config_file.filter('#DEFS += -DBIT_STREAM_WORD_TYPE=uint8)',
-                               'DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
+        if '+bswtuint8' in self.spec:
+            config_file = FileFilter('Config')
+            config_file.filter(
+                '^\s*#\s*DEFS\s*\+=\s*-DBIT_STREAM_WORD_TYPE\s*=\s*uint8',
+                'DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
 
     def install(self, spec, prefix):
         make("shared")

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -37,8 +37,6 @@ class Zfp(Package):
 
     homepage = "http://computation.llnl.gov/projects/floating-point-compression"
     url      = "http://computation.llnl.gov/projects/floating-point-compression/download/zfp-0.5.1.tar.gz"
-    list_url = "http://computation.llnl.gov/projects/floating-point-compression/download"
-    list_depth = 1
 
     version('0.5.1', '0ed7059a9b480635e0dd33745e213d17')
     version('0.5.0', '2ab29a852e65ad85aae38925c5003654')
@@ -55,9 +53,7 @@ class Zfp(Package):
     def install(self, spec, prefix):
         make("shared")
 
-        zfp_incdir = 'inc'
-        if spec.satisfies('@0.5.1:'):
-            zfp_incdir = 'include'
+        zfp_incdir = 'include' if spec.satisfies('@0.5.1:') else 'inc'
 
         # No install provided
         mkdirp(prefix.lib)

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -42,13 +42,14 @@ class Zfp(Package):
     version('0.5.0', '2ab29a852e65ad85aae38925c5003654')
 
     variant('bswtuint8', default=False,
-        description='Build with bit stream word type of uint8')
+            description='Build with bit stream word type of uint8')
 
     def edit(self, spec, prefix):
         config_file = FileFilter('Config')
 
         if '+bswtunit8' in self.spec:
-            config_file.filter('#DEFS += -DBIT_STREAM_WORD_TYPE=uint8)','DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
+            config_file.filter('#DEFS += -DBIT_STREAM_WORD_TYPE=uint8)',
+                               'DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
 
     def install(self, spec, prefix):
         make("shared")
@@ -59,12 +60,12 @@ class Zfp(Package):
         mkdirp(prefix.lib)
         mkdirp(prefix.include)
         install('lib/libzfp.so', prefix.lib)
-        install('%s/zfp.h'%zfp_incdir, prefix.include)
-        install('%s/bitstream.h'%zfp_incdir, prefix.include)
+        install('%s/zfp.h' % zfp_incdir, prefix.include)
+        install('%s/bitstream.h' % zfp_incdir, prefix.include)
         if spec.satisfies('@0.5.1:'):
-            mkdirp('%s/zfp'%prefix.include)
-            install('%s/zfp/system.h'%zfp_incdir, '%s/zfp'%prefix.include)
-            install('%s/zfp/types.h'%zfp_incdir, '%s/zfp'%prefix.include)
+            mkdirp('%s/zfp' % prefix.include)
+            install('%s/zfp/system.h' % zfp_incdir, '%s/zfp' % prefix.include)
+            install('%s/zfp/types.h' % zfp_incdir, '%s/zfp' % prefix.include)
         else:
-            install('%s/types.h'%zfp_incdir, prefix.include)
-            install('%s/system.h'%zfp_incdir, prefix.include)
+            install('%s/types.h' % zfp_incdir, prefix.include)
+            install('%s/system.h' % zfp_incdir, prefix.include)


### PR DESCRIPTION
The variant is needed when building ZFP to be used for H5Z-ZFP plugin (see https://github.com/LLNL/H5Z-ZFP)

- I did not see a way to install all include files in a dir or dir-tree from within spack's install method using the install function. That seems problematic if the package doesn't define an install target yet has numerous (and possibly names changing with releases) header files to install. It'd be nicer to just be able to install **everything** under a specific dir tree.
- it is not clear in the docs whether spec.satisifies[':@0.5.1'] is strictly less than or less than or equal
- I ran into some funkyness with md5sum...I manually downloaded the zfp tarball via Safari and computed an md5 checksum using OSX md5 command. The value I got was not the same that spack computed during its download
