### PR TITLE
Don't require perl for openssl by default.

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -59,8 +59,10 @@ class Openssl(Package):
 
     depends_on('zlib')
 
-    # 'make test' requires Test::More version 0.96
-    depends_on('perl@5.14.0:', type='build')
+    # TODO: 'make test' requires Perl module Test::More version 0.96
+    # TODO: uncomment when test dependency types are supported.
+    # TODO: This is commented in the meantime to avoid dependnecy bloat.
+    # depends_on('perl@5.14.0:', type='build', when='+tests')
 
     parallel = False
 
@@ -95,6 +97,7 @@ class Openssl(Package):
         filter_file(r'-arch x86_64', '', 'Makefile')
 
         make()
-        if self.run_tests:
-            make('test')            # 'VERBOSE=1'
+        # TODO: add this back when we have a 'test' dependency type. See above.
+        # if self.run_tests:
+        #     make('test')            # 'VERBOSE=1'
         make('install')


### PR DESCRIPTION
Perl is a pretty big dependency to drag in by default, just to get OpenSSL, and it is only needed for tests.  Turning this off by default.