### PR TITLE
serf: scons requires same python for build and run

### DIFF
--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -36,6 +36,7 @@ class Serf(Package):
 
     depends_on('apr')
     depends_on('apr-util')
+    depends_on('python', type='build')
     depends_on('scons', type='build')
     depends_on('expat')
     depends_on('openssl')


### PR DESCRIPTION
On a system where the native python is version 2.6, the serf package in spack fails to build. I found that adding a `depends_on('python')` to the serf package fixed the problem, because scons then uses the spack-built `python@2.7` at run-time, matching the version used during installation of scons.

I am not sure why it is necessary to add an explicit dependency on python, when scons is installed as a python package. Shouldn't all python extension packages imply a run-time dependency on python? And similarly for extensions of perl, R, etc.?