### PR TITLE
Fix build, add version info for 1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/mosh/package.py
+++ b/var/spack/repos/builtin/packages/mosh/package.py
@@ -35,6 +35,7 @@ class Mosh(AutotoolsPackage):
     homepage = "https://mosh.org/"
     url      = "https://mosh.org/mosh-1.2.6.tar.gz"
 
+    version('1.3.0', 'd961276995936953bf2d5a794068b076')
     version('1.2.6', 'bb4e24795bb135a754558176a981ee9e')
 
     depends_on('protobuf')
@@ -43,3 +44,5 @@ class Mosh(AutotoolsPackage):
     depends_on('openssl')
 
     depends_on('perl', type='run')
+
+    build_directory = 'spack-build'


### PR DESCRIPTION
See issue #3771.

Update the package recipe w.r.t. AutotoolsPackage changes,
now builds "out of source".

Update the package with version info for 1.3.0.

> Mosh 1.3.0 released, with John Hood as release lead. The release includes broader platform compatibility, robustness improvements, better testing, and fixes for excess CPU consumption in some cases. We have switched to semver.org-style versioning and will increment the minor version number whenever we add new functionality. (In our previous practice, this release would probably have been called “1.2.7.”)

Tested on CentOS 7.