### PR TITLE
Rename libson-c to json-c, add new version

### DIFF
--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -44,7 +44,7 @@ class Flux(AutotoolsPackage):
     depends_on("hwloc")
     depends_on("lua@5.1:5.1.99")
     depends_on("munge")
-    depends_on("libjson-c")
+    depends_on("json-c")
     depends_on("libxslt")
     depends_on("python")
     depends_on("py-cffi", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/json-c/package.py
+++ b/var/spack/repos/builtin/packages/json-c/package.py
@@ -25,11 +25,12 @@
 from spack import *
 
 
-class LibjsonC(AutotoolsPackage):
-    """ A JSON implementation in C """
+class JsonC(AutotoolsPackage):
+    """A JSON implementation in C."""
     homepage = "https://github.com/json-c/json-c/wiki"
-    url      = "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz"
+    url      = "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz"
+
+    version('0.12.1', '55f7853f7d8cf664554ce3fa71bf1c7d')
+    version('0.11',   'aa02367d2f7a830bf1e3376f77881e98')
 
     parallel = False
-
-    version('0.11', 'aa02367d2f7a830bf1e3376f77881e98')

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -35,6 +35,6 @@ class Libhio(AutotoolsPackage):
 
     version('1.3.0.1', 'c073541de8dd70aeb8878bd00d6d877f')
 
-    depends_on("libjson-c")
+    depends_on("json-c")
     depends_on("bzip2")
     depends_on("pkg-config", type="build")


### PR DESCRIPTION
Fixes #3774. The previous release came with a tarball that was already configured. It wasn't possible to install the package without running `make distclean` first. The latest release doesn't suffer from this problem.

I decided to rename the `libjson-c` package to `json-c`. That's what the developers seem to call it.