### PR TITLE
Fix HPL build, convert to MakefilePackage

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -624,7 +624,7 @@ def find_system_libraries(args, shared=True):
 
     for library in args:
         for root in search_locations:
-            result = find_libraries(library, root, shared)
+            result = find_libraries(library, root, shared, recurse=True)
             if result:
                 libraries_found += result
                 break

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -47,6 +47,7 @@ __all__ = [
     'copy_mode',
     'filter_file',
     'find_libraries',
+    'find_system_libraries',
     'fix_darwin_install_name',
     'force_remove',
     'force_symlink',
@@ -581,6 +582,54 @@ class LibraryList(collections.Sequence):
 
     def __str__(self):
         return self.joined()
+
+
+def find_system_libraries(args, shared=True):
+    """Searches the usual system library locations for the libraries
+    specified in args.
+
+    Search order is as follows:
+
+    1. /lib64
+    2. /lib
+    3. /usr/lib64
+    4. /usr/lib
+    5. /usr/local/lib64
+    6. /usr/local/lib
+
+    :param args: Library name(s) to search for
+    :type args: str or collections.Sequence
+    :param bool shared: if True searches for shared libraries,
+
+    :returns: The libraries that have been found
+    :rtype: LibraryList
+    """
+    if isinstance(args, str):
+        args = [args]
+    elif not isinstance(args, collections.Sequence):
+        message = '{0} expects a string or sequence of strings as the '
+        message += 'first argument [got {1} instead]'
+        message = message.format(find_system_libraries.__name__, type(args))
+        raise TypeError(message)
+
+    libraries_found = []
+    search_locations = [
+        '/lib64',
+        '/lib',
+        '/usr/lib64',
+        '/usr/lib',
+        '/usr/local/lib64',
+        '/usr/local/lib',
+    ]
+
+    for library in args:
+        for root in search_locations:
+            result = find_libraries(library, root, shared)
+            if result:
+                libraries_found += result
+                break
+
+    return libraries_found
 
 
 def find_libraries(args, root, shared=True, recurse=False):

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -78,7 +78,7 @@ class Hpl(MakefilePackage):
             'LIBdir       = $(TOPdir)/lib/$(ARCH)',
             'HPLlib       = $(LIBdir)/libhpl.a',
             # Message Passing library (MPI)
-            'MPinc        = -I{0}'.format(spec['mpi'].prefix.include),
+            'MPinc        = {0}'.format(spec['mpi'].prefix.include),
             'MPlib        = -L{0}'.format(spec['mpi'].prefix.lib),
             # Linear Algebra library (BLAS or VSIPL)
             'LAinc        = {0}'.format(spec['blas'].prefix.include),

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -27,7 +27,7 @@ import os
 import platform
 
 
-class Hpl(Package):
+class Hpl(MakefilePackage):
     """HPL is a software package that solves a (random) dense linear system
     in double precision (64 bits) arithmetic on distributed-memory computers.
     It can thus be regarded as a portable as well as freely available
@@ -45,7 +45,11 @@ class Hpl(Package):
 
     parallel = False
 
-    def configure(self, spec, arch):
+    arch = '{0}-{1}'.format(platform.system(), platform.processor())
+
+    build_targets = ['arch={0}'.format(arch)]
+
+    def edit(self, spec, prefix):
         # List of configuration options
         # Order is important
         config = []
@@ -66,7 +70,7 @@ class Hpl(Package):
             'RM           = /bin/rm -f',
             'TOUCH        = touch',
             # Platform identifier
-            'ARCH         = {0}'.format(arch),
+            'ARCH         = {0}'.format(self.arch),
             # HPL Directory Structure / HPL library
             'TOPdir       = {0}'.format(os.getcwd()),
             'INCdir       = $(TOPdir)/include',
@@ -99,21 +103,13 @@ class Hpl(Package):
         ])
 
         # Write configuration options to include file
-        with open('Make.{0}'.format(arch), 'w') as makefile:
+        with open('Make.{0}'.format(self.arch), 'w') as makefile:
             for var in config:
                 makefile.write('{0}\n'.format(var))
 
     def install(self, spec, prefix):
-        # Arch used for file naming purposes only
-        arch = '{0}-{1}'.format(platform.system(), platform.processor())
-
-        # Generate Makefile include
-        self.configure(spec, arch)
-
-        make('arch={0}'.format(arch))
-
         # Manual installation
-        install_tree(join_path('bin', arch), prefix.bin)
-        install_tree(join_path('lib', arch), prefix.lib)
-        install_tree(join_path('include', arch), prefix.include)
+        install_tree(join_path('bin', self.arch), prefix.bin)
+        install_tree(join_path('lib', self.arch), prefix.lib)
+        install_tree(join_path('include', self.arch), prefix.include)
         install_tree('man', prefix.man)

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -54,23 +54,37 @@ class IntelMkl(IntelInstaller):
 
     @property
     def blas_libs(self):
-        shared = True if '+shared' in self.spec else False
-        suffix = dso_suffix if '+shared' in self.spec else 'a'
-        mkl_integer = ['libmkl_intel_ilp64'] if '+ilp64' in self.spec else ['libmkl_intel_lp64']  # NOQA: ignore=E501
+        spec = self.spec
+        prefix = self.prefix
+        shared = '+shared' in spec
+
+        if '+ilp64' in spec:
+            mkl_integer = ['libmkl_intel_ilp64']
+        else:
+            mkl_integer = ['libmkl_intel_lp64']
+
         mkl_threading = ['libmkl_sequential']
-        if '+openmp' in self.spec:
-            mkl_threading = ['libmkl_intel_thread', 'libiomp5'] if '%intel' in self.spec else ['libmkl_gnu_thread']  # NOQA: ignore=E501
+
+        if '+openmp' in spec:
+            if '%intel' in spec:
+                mkl_threading = ['libmkl_intel_thread', 'libiomp5']
+            else:
+                mkl_threading = ['libmkl_gnu_thread']
+
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
+
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(self.prefix.lib, 'intel64'),
+            root=join_path(prefix, 'mkl', 'lib', 'intel64'),
             shared=shared
         )
-        system_libs = [
-            'libpthread.{0}'.format(suffix),
-            'libm.{0}'.format(suffix),
-            'libdl.{0}'.format(suffix)
-        ]
+
+        # Intel MKL link line advisor recommends these system libraries
+        system_libs = find_system_libraries(
+            ['libpthread', 'libm', 'libdl'],
+            shared=shared
+        )
+
         return mkl_libs + system_libs
 
     @property

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -73,9 +73,11 @@ class IntelMkl(IntelInstaller):
 
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
 
+        mkl_root = join_path(prefix.lib, 'intel64')
+
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(prefix, 'mkl', 'lib', 'intel64'),
+            root=mkl_root,
             shared=shared
         )
 
@@ -89,7 +91,7 @@ class IntelMkl(IntelInstaller):
 
     @property
     def lapack_libs(self):
-        return self.libs
+        return self.blas_libs
 
     @property
     def scalapack_libs(self):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -108,18 +108,27 @@ class IntelParallelStudio(IntelInstaller):
 
     @property
     def blas_libs(self):
-        shared = True if '+shared' in self.spec else False
-        suffix = dso_suffix if '+shared' in self.spec else 'a'
-        mkl_integer = ['libmkl_intel_ilp64'] if '+ilp64' in self.spec else ['libmkl_intel_lp64']  # NOQA: ignore=E501
+        if '+ilp64' in self.spec:
+            mkl_integer = ['libmkl_intel_ilp64']
+        else:
+            mkl_integer = ['libmkl_intel_lp64']
+
         mkl_threading = ['libmkl_sequential']
+
         if '+openmp' in self.spec:
-            mkl_threading = ['libmkl_intel_thread', 'libiomp5'] if '%intel' in self.spec else ['libmkl_gnu_thread']  # NOQA: ignore=E501
+            if '%intel' in self.spec:
+                mkl_threading = ['libmkl_intel_thread', 'libiomp5']
+            else:
+                mkl_threading = ['libmkl_gnu_thread']
+
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
+
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
             root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
-            shared=shared
+            shared='+shared' in spec
         )
+
         return mkl_libs
 
     @property

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -108,15 +108,19 @@ class IntelParallelStudio(IntelInstaller):
 
     @property
     def blas_libs(self):
-        if '+ilp64' in self.spec:
+        spec = self.spec
+        prefix = self.prefix
+        shared = '+shared' in spec
+
+        if '+ilp64' in spec:
             mkl_integer = ['libmkl_intel_ilp64']
         else:
             mkl_integer = ['libmkl_intel_lp64']
 
         mkl_threading = ['libmkl_sequential']
 
-        if '+openmp' in self.spec:
-            if '%intel' in self.spec:
+        if '+openmp' in spec:
+            if '%intel' in spec:
                 mkl_threading = ['libmkl_intel_thread', 'libiomp5']
             else:
                 mkl_threading = ['libmkl_gnu_thread']
@@ -125,11 +129,17 @@ class IntelParallelStudio(IntelInstaller):
 
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
-            shared='+shared' in self.spec
+            root=join_path(prefix, 'mkl', 'lib', 'intel64'),
+            shared=shared
         )
 
-        return mkl_libs
+        # Intel MKL link line advisor recommends these system libraries
+        system_libs = find_system_libraries(
+            ['libpthread', 'libm', 'libdl'],
+            shared=shared
+        )
+
+        return mkl_libs + system_libs
 
     @property
     def lapack_libs(self):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -126,7 +126,7 @@ class IntelParallelStudio(IntelInstaller):
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
             root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
-            shared='+shared' in spec
+            shared='+shared' in self.spec
         )
 
         return mkl_libs

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -127,9 +127,11 @@ class IntelParallelStudio(IntelInstaller):
 
         # TODO: TBB threading: ['libmkl_tbb_thread', 'libtbb', 'libstdc++']
 
+        mkl_root = join_path(prefix, 'mkl', 'lib', 'intel64')
+
         mkl_libs = find_libraries(
             mkl_integer + ['libmkl_core'] + mkl_threading,
-            root=join_path(prefix, 'mkl', 'lib', 'intel64'),
+            root=mkl_root,
             shared=shared
         )
 
@@ -143,7 +145,7 @@ class IntelParallelStudio(IntelInstaller):
 
     @property
     def lapack_libs(self):
-        return self.libs
+        return self.blas_libs
 
     @property
     def scalapack_libs(self):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -96,7 +96,7 @@ class IntelParallelStudio(IntelInstaller):
     variant('ilp64', default=False, description='64 bit integers')
     variant('openmp', default=False, description='OpenMP multithreading layer')
 
-    provides('mpi', when='@cluster:+mpi')
+    provides('mpi', when='@cluster.0:cluster.9999+mpi')
     provides('mkl', when='+mkl')
     provides('daal', when='+daal')
     provides('ipp', when='+ipp')
@@ -120,12 +120,7 @@ class IntelParallelStudio(IntelInstaller):
             root=join_path(self.prefix, 'mkl', 'lib', 'intel64'),
             shared=shared
         )
-        system_libs = [
-            'libpthread.{0}'.format(suffix),
-            'libm.{0}'.format(suffix),
-            'libdl.{0}'.format(suffix)
-        ]
-        return mkl_libs + system_libs
+        return mkl_libs
 
     @property
     def lapack_libs(self):


### PR DESCRIPTION
Fixes the build error mentioned in #3764, but doesn't fix the virtual dependency resolution problem. I still can't build `hpl` without commenting out `provides('mpi')` in `intel-parallel-studio`.