### PR TITLE
fetch git submodules recursively

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -854,7 +854,7 @@ Git fetching is enabled with the following parameters to ``version``:
 * ``tag``: name of a tag to fetch.
 * ``branch``: name of a branch to fetch.
 * ``commit``: SHA hash (or prefix) of a commit to fetch.
-* ``submodules``: Also fetch submodules when checking out this repository.
+* ``submodules``: Also fetch submodules recursively when checking out this repository.
 
 Only one of ``tag``, ``branch``, or ``commit`` can be used at a time.
 
@@ -917,7 +917,8 @@ Commits
 Submodules
 
   You can supply ``submodules=True`` to cause Spack to fetch submodules
-  along with the repository at fetch time.
+  recursively along with the repository at fetch time. For more information
+  about git submodules see the manpage of git: ``man git-submodule``.
 
   .. code-block:: python
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -671,10 +671,11 @@ class GitFetchStrategy(VCSFetchStrategy):
         # Init submodules if the user asked for them.
         if self.submodules:
             if spack.debug:
-                self.git('submodule', 'update', '--init', '--recursive')
+                self.git('submodule', 'update', '--init', '--recursive',
+                         '--depth=1')
             else:
                 self.git('submodule', '--quiet', 'update', '--init',
-                         '--recursive')
+                         '--recursive', '--depth=1')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -671,9 +671,10 @@ class GitFetchStrategy(VCSFetchStrategy):
         # Init submodules if the user asked for them.
         if self.submodules:
             if spack.debug:
-                self.git('submodule', 'update', '--init')
+                self.git('submodule', 'update', '--init', '--recursive')
             else:
-                self.git('submodule', '--quiet', 'update', '--init')
+                self.git('submodule', '--quiet', 'update', '--init',
+                         '--recursive')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -670,12 +670,20 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         # Init submodules if the user asked for them.
         if self.submodules:
-            if spack.debug:
-                self.git('submodule', 'update', '--init', '--recursive',
-                         '--depth=1')
+            # only git 1.8.4 and later have --depth option
+            if self.git_version < ver('1.8.4'):
+                if spack.debug:
+                    self.git('submodule', 'update', '--init', '--recursive')
+                else:
+                    self.git('submodule', '--quiet', 'update', '--init',
+                             '--recursive')
             else:
-                self.git('submodule', '--quiet', 'update', '--init',
-                         '--recursive', '--depth=1')
+                if spack.debug:
+                    self.git('submodule', 'update', '--init', '--recursive',
+                             '--depth=1')
+                else:
+                    self.git('submodule', '--quiet', 'update', '--init',
+                             '--recursive', '--depth=1')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')


### PR DESCRIPTION
Fixes #983.
Fixes #2190.

This is useful if the submodules have submodules themselves. On
the other hand doing a recursive update doesn't hurt if there
is only one level.