### PR TITLE
Remove mawk dependency from ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -41,8 +41,6 @@ class Ncurses(AutotoolsPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
-    # Use mawk instead of gawk to prevent a circular dependency
-    depends_on('mawk',       type='build')
     depends_on('pkg-config', type='build')
 
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
@@ -50,7 +48,6 @@ class Ncurses(AutotoolsPackage):
 
     def configure_args(self):
         opts = [
-            'AWK=mawk',
             'CFLAGS={0}'.format(self.compiler.pic_flag),
             'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',


### PR DESCRIPTION
Ok, long history lesson for this package:

1. @eschnett discovered that `ncurses` wouldn't build for him and added `CPPFLAGS=-p` to fix this. #3361 

2. A couple users report that this breaks the build when using the Intel compilers. @jrood-nrel changed it so that the `CPPFLAGS=-p` flag is only used when building with GCC. #3404

3. Of course, the problem is really with the system awk installation, not with the GCC compiler. @eschnett removes `CPPFLAGS=-p` and instead adds a dependency on `gawk` which seems to work. #3425 

4. I take a look at the `gawk` package and realize that it has a link dependency on `gettext` which has a link dependency on `ncurses`. In order to add the proper dependencies without creating a circular dependency, I substitute the `gawk` dependency for `mawk`, which has no dependencies. #3481 

5. Turns out `mawk` builds just fine with clang, but crashes whenever you run it. This means that you can't build `ncurses` or anything that depends on it (like `python`). #3647 

I happen to like being able to build `python` on macOS, so we need to fix this. The way I see it, we have two options:

1. Patch `ncurses` so that it can build with the weird system `awk` that @eschnett encountered.

2. Patch `mawk` so that it can be built properly with clang.

I can't reproduce the `awk` bug that @eschnett encountered, so that might be difficult. And I'm not sure how much the `mawk` devs care about macOS support. This PR removes the `mawk` dependency but doesn't really offer an alternative solution for the original problem. Anyone want to help me out here?