### PR TITLE
Readline package: Add ncurses library directory to link line.

### DIFF
--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -45,4 +45,8 @@ class Readline(AutotoolsPackage):
     patch('readline-6.3-upstream_fixes-1.patch', when='@6.3')
 
     def build(self, spec, prefix):
-        make('SHLIB_LIBS=-lncursesw')
+        options = [
+            'SHLIB_LIBS=-L{0} -lncursesw'.format(spec['ncurses'].prefix.lib)
+        ]
+
+        make(*options)


### PR DESCRIPTION
Resolves a issue with finding the ncurses library on MacOS:

```sh
config.status: executing default commands
==> 'make' '-j8' 'SHLIB_LIBS=-lncursesw'
test -d shlib || mkdir shlib
( cd shlib ; /Library/Developer/CommandLineTools/usr/bin/make - --jobserver-fds=6,21 -j all )
rm -f libreadline.7.0.dylib
rm -f libhistory.7.0.dylib
<path>/spack/lib/spack/env/clang/clang -dynamiclib -dynamic -undefined dynamic_lookup  -dynamiclib -install_name <path>/spack/opt/spack/darwin-elcapitan-x86_64/clang-8.0.0-apple/readline-7.0-mvh3ubvrbid3gdjzs4od5gch72rcxius/lib/`echo libreadline.7.0.dylib | sed "s:\..*::"`.7.dylib -current_version 7.0 -compatibility_version 7 -v -o libreadline.7.0.dylib readline.so vi_mode.so funmap.so keymaps.so parens.so search.so rltty.so complete.so bind.so isearch.so display.so signals.so util.so kill.so undo.so macro.so input.so callback.so terminal.so text.so nls.so misc.so history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so tilde.so colors.so parse-colors.so xmalloc.so xfree.so compat.so -lncursesw
<path>/spack/lib/spack/env/clang/clang -dynamiclib -dynamic -undefined dynamic_lookup  -dynamiclib -install_name <path>/spack/opt/spack/darwin-elcapitan-x86_64/clang-8.0.0-apple/readline-7.0-mvh3ubvrbid3gdjzs4od5gch72rcxius/lib/`echo libhistory.7.0.dylib | sed "s:\..*::"`.7.dylib -current_version 7.0 -compatibility_version 7 -v -o libhistory.7.0.dylib history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so xmalloc.so xfree.so -lncursesw
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
 "/Library/Developer/CommandLineTools/usr/bin/ld" -demangle -dynamic -dylib -dylib_compatibility_version 7 -dylib_current_version 7.0 -arch x86_64 -dylib_install_name <path>/spack/opt/spack/darwin-elcapitan-x86_64/clang-8.0.0-apple/readline-7.0-mvh3ubvrbid3gdjzs4od5gch72rcxius/lib/libhistory.7.dylib -dynamic -macosx_version_min 10.11.0 -undefined dynamic_lookup -undefined dynamic_lookup -o libhistory.7.0.dylib history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so xmalloc.so xfree.so -lncursesw -lSystem /Library/Developer/CommandLineTools/usr/bin/../lib/clang/8.0.0/lib/darwin/libclang_rt.osx.a
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
 "/Library/Developer/CommandLineTools/usr/bin/ld" -demangle -dynamic -dylib -dylib_compatibility_version 7 -dylib_current_version 7.0 -arch x86_64 -dylib_install_name <path>/spack/opt/spack/darwin-elcapitan-x86_64/clang-8.0.0-apple/readline-7.0-mvh3ubvrbid3gdjzs4od5gch72rcxius/lib/libreadline.7.dylib -dynamic -macosx_version_min 10.11.0 -undefined dynamic_lookup -undefined dynamic_lookup -o libreadline.7.0.dylib readline.so vi_mode.so funmap.so keymaps.so parens.so search.so rltty.so complete.so bind.so isearch.so display.so signals.so util.so kill.so undo.so macro.so input.so callback.so terminal.so text.so nls.so misc.so history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so tilde.so colors.so parse-colors.so xmalloc.so xfree.so compat.so -lncursesw -lSystem /Library/Developer/CommandLineTools/usr/bin/../lib/clang/8.0.0/lib/darwin/libclang_rt.osx.a
ld: library not found for -lncursesw
```