### PR TITLE
ncures: remove external awk

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -41,8 +41,6 @@ class Ncurses(AutotoolsPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
-    # Use mawk instead of gawk to prevent a circular dependency
-    depends_on('mawk',       type='build')
     depends_on('pkg-config', type='build')
 
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
@@ -50,7 +48,6 @@ class Ncurses(AutotoolsPackage):
 
     def configure_args(self):
         opts = [
-            'AWK=mawk',
             'CFLAGS={0}'.format(self.compiler.pic_flag),
             'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
@@ -64,5 +61,10 @@ class Ncurses(AutotoolsPackage):
 
         if '+symlinks' in self.spec:
             opts.append('--enable-symlinks')
+
+        # The CPPFLAGS setting works around this bug:
+        # <http://stackoverflow.com/questions/37475222/ncurses-6-0-compilation-error-error-expected-before-int>
+        if self.spec.satisfies('%gcc'):
+            opts.append('CPPFLAGS=-P')
 
         return opts


### PR DESCRIPTION
fixes https://github.com/LLNL/spack/pull/3782

It appears that the most statble approach overal is to rely on system provided awk,
i.e. revert #3425

p.s. I keep the summary from #3782 as Github issues may fall one day, but commit messages will be there