### PR TITLE
Apply a patch to allow valgrind 3.12 to build on MacOS >= 10.11

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -58,6 +58,10 @@ class Valgrind(AutotoolsPackage):
     depends_on("automake", type='build', when='@develop')
     depends_on("libtool", type='build', when='@develop')
 
+    # Apply the patch suggested here:
+    # http://valgrind.10908.n7.nabble.com/Unable-to-compile-on-Mac-OS-X-10-11-td57237.html
+    patch('valgrind_3_12_0_osx.patch', when='@3.12.0 platform=darwin')
+
     def configure_args(self):
         spec = self.spec
         options = []

--- a/var/spack/repos/builtin/packages/valgrind/valgrind_3_12_0_osx.patch
+++ b/var/spack/repos/builtin/packages/valgrind/valgrind_3_12_0_osx.patch
@@ -1,0 +1,13 @@
+diff --git a/coregrind/m_main.c b/coregrind/m_main.c
+index d008ab3..42d8f30 100644
+--- a/coregrind/m_main.c
++++ b/coregrind/m_main.c
+@@ -4058,7 +4058,7 @@ UWord voucher_mach_msg_set ( UWord arg1 )
+ 
+ #endif
+ 
+-#if defined(VGO_darwin) && DARWIN_VERS == DARWIN_10_10
++#if defined(VGO_darwin)
+ 
+ /* This might also be needed for > DARWIN_10_10, but I have no way
+    to test for that.  Hence '==' rather than '>=' in the version


### PR DESCRIPTION
This patch is what is suggested as an answer to [this post](http://valgrind.10908.n7.nabble.com/Unable-to-compile-on-Mac-OS-X-10-11-td57237.html).