### PR TITLE
Allow users to set parallel jobs in config.yaml

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -68,12 +68,7 @@ config:
   dirty: false
 
 
-  # If set to true, `spack install` and friends will run `make` in parallel.
-  # If set to false, all builds will run in serial.
-  parallel: true
-
-
   # The default number of jobs to use when running `make` in parallel.
   # If set to 4, for example, `spack install` will run `make -j4`.
   # If not set, all available cores are used by default.
-  # jobs: 4
+  # build_jobs: 4

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -66,3 +66,14 @@ config:
   # If set to true, `spack install` and friends will NOT clean
   # potentially harmful variables from the build environment. Use wisely.
   dirty: false
+
+
+  # If set to true, `spack install` and friends will run `make` in parallel.
+  # If set to false, all builds will run in serial.
+  parallel: true
+
+
+  # The default number of jobs to use when running `make` in parallel.
+  # If set to 4, for example, `spack install` will run `make -j4`.
+  # If not set, all available cores are used by default.
+  # jobs: 4

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -99,8 +99,8 @@ See :ref:`modules` for details.
 ``build_stage``
 --------------------
 
-Spack is designed to run out of a user home directories, and on many
-systems the home directory a (slow) network filesystem.  On most systems,
+Spack is designed to run out of a user home directory, and on many
+systems the home directory is a (slow) network filesystem.  On most systems,
 building in a temporary filesystem results in faster builds than building
 in the home directory.  Usually, there is also more space available in
 the temporary location than in the home directory. So, Spack tries to
@@ -122,11 +122,11 @@ See :ref:`config-file-variables` for more on ``$tempdir`` and ``$spack``.
 
 When Spack builds a package, it creates a temporary directory within the
 ``build_stage``, and it creates a symbolic link to that directory in
-``$spack/var/spack/stage``. This is used totrack the stage.
+``$spack/var/spack/stage``. This is used to track the stage.
 
 After a package is successfully installed, Spack deletes the temporary
 directory it used to build.  Unsuccessful builds are not deleted, but you
-can manually purge them with :ref:`spack purge --stage
+can manually purge them with :ref:`spack purge ---stage
 <cmd-spack-purge>`.
 
 .. note::
@@ -142,7 +142,7 @@ can manually purge them with :ref:`spack purge --stage
 
 Location to cache downloaded tarballs and repositories.  By default these
 are stored in ``$spack/var/spack/cache``.  These are stored indefinitely
-by default. Can be purged with :ref:`spack purge --downloads
+by default. Can be purged with :ref:`spack purge ---downloads
 <cmd-spack-purge>`.
 
 --------------------
@@ -151,7 +151,7 @@ by default. Can be purged with :ref:`spack purge --downloads
 
 Temporary directory to store long-lived cache files, such as indices of
 packages available in repositories.  Defaults to ``~/.spack/cache``.  Can
-be purged with :ref:`spack purge --misc-cache <cmd-spack-purge>`.
+be purged with :ref:`spack purge ---misc-cache <cmd-spack-purge>`.
 
 --------------------
 ``verify_ssl``
@@ -180,7 +180,31 @@ the way packages build. This includes ``LD_LIBRARY_PATH``, ``CPATH``,
 ``LIBRARY_PATH``, ``DYLD_LIBRARY_PATH``, and others.
 
 By default, builds are ``clean``, but on some machines, compilers and
-other tools may need custom ``LD_LIBRARY_PATH`` setings to run.  You can
+other tools may need custom ``LD_LIBRARY_PATH`` settings to run.  You can
 set ``dirty`` to ``true`` to skip the cleaning step and make all builds
 "dirty" by default.  Be aware that this will reduce the reproducibility
 of builds.
+
+------------
+``parallel``
+------------
+
+When set to ``true``, commands that build software will run in parallel.
+For example, ``spack build`` and ``spack install`` will run commands
+like ``make`` as ``make -j<jobs>`` where jobs is the number of threads to
+use. See ``jobs`` below to change the default number of jobs.
+
+When set to ``false``, all builds will happen in serial.
+
+--------
+``jobs``
+--------
+
+When ``parallel`` is set to ``true``, Spack will build software in parallel.
+The default parallelism is equal to the number of cores on your machine.
+If you work on a shared login node or have a strict ulimit, it may be
+necessary to set the default to a lower value. By setting ``jobs`` to 4, for
+example, commands like ``spack install`` will run ``make -j4`` instead of
+hogging every core.
+
+When ``parallel`` is set to ``false``, this value is ignored.

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -126,7 +126,7 @@ When Spack builds a package, it creates a temporary directory within the
 
 After a package is successfully installed, Spack deletes the temporary
 directory it used to build.  Unsuccessful builds are not deleted, but you
-can manually purge them with :ref:`spack purge ---stage
+can manually purge them with :ref:`spack purge --stage
 <cmd-spack-purge>`.
 
 .. note::
@@ -142,7 +142,7 @@ can manually purge them with :ref:`spack purge ---stage
 
 Location to cache downloaded tarballs and repositories.  By default these
 are stored in ``$spack/var/spack/cache``.  These are stored indefinitely
-by default. Can be purged with :ref:`spack purge ---downloads
+by default. Can be purged with :ref:`spack purge --downloads
 <cmd-spack-purge>`.
 
 --------------------
@@ -151,7 +151,7 @@ by default. Can be purged with :ref:`spack purge ---downloads
 
 Temporary directory to store long-lived cache files, such as indices of
 packages available in repositories.  Defaults to ``~/.spack/cache``.  Can
-be purged with :ref:`spack purge ---misc-cache <cmd-spack-purge>`.
+be purged with :ref:`spack purge --misc-cache <cmd-spack-purge>`.
 
 --------------------
 ``verify_ssl``

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -185,26 +185,19 @@ set ``dirty`` to ``true`` to skip the cleaning step and make all builds
 "dirty" by default.  Be aware that this will reduce the reproducibility
 of builds.
 
-------------
-``parallel``
-------------
+--------------
+``build_jobs``
+--------------
 
-When set to ``true``, commands that build software will run in parallel.
-For example, ``spack build`` and ``spack install`` will run commands
-like ``make`` as ``make -j<jobs>`` where jobs is the number of threads to
-use. See ``jobs`` below to change the default number of jobs.
+Unless overridden in a package or on the command line, Spack builds all
+packages in parallel. For a build system that uses Makefiles, this means
+running ``make -j<build_jobs>``, where ``build_jobs`` is the number of
+threads to use.
 
-When set to ``false``, all builds will happen in serial.
-
---------
-``jobs``
---------
-
-When ``parallel`` is set to ``true``, Spack will build software in parallel.
 The default parallelism is equal to the number of cores on your machine.
 If you work on a shared login node or have a strict ulimit, it may be
-necessary to set the default to a lower value. By setting ``jobs`` to 4, for
-example, commands like ``spack install`` will run ``make -j4`` instead of
-hogging every core.
+necessary to set the default to a lower value. By setting ``build_jobs``
+to 4, for example, commands like ``spack install`` will run ``make -j4``
+instead of hogging every core.
 
-When ``parallel`` is set to ``false``, this value is ignored.
+To build all software in serial, set ``build_jobs`` to 1.

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -23,6 +23,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import multiprocessing
 import os
 import sys
 import tempfile
@@ -139,6 +140,15 @@ do_checksum = _config.get('checksum', True)
 # If this is True, spack will not clean the environment to remove
 # potentially harmful variables before builds.
 dirty = _config.get('dirty', False)
+
+
+# If this is True, spack will build software in parallel.
+parallel = _config.get('parallel', True)
+
+
+# The number of jobs to use when building in parallel.
+# By default, use all cores on the machine.
+jobs = _config.get('jobs', multiprocessing.cpu_count())
 
 
 #-----------------------------------------------------------------------------

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -142,13 +142,9 @@ do_checksum = _config.get('checksum', True)
 dirty = _config.get('dirty', False)
 
 
-# If this is True, spack will build software in parallel.
-parallel = _config.get('parallel', True)
-
-
 # The number of jobs to use when building in parallel.
 # By default, use all cores on the machine.
-jobs = _config.get('jobs', multiprocessing.cpu_count())
+build_jobs = _config.get('build_jobs', multiprocessing.cpu_count())
 
 
 #-----------------------------------------------------------------------------

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -354,7 +354,7 @@ def set_module_variables_for_package(pkg, module):
        This makes things easier for package writers.
     """
     # number of jobs spack will build with.
-    jobs = spack.jobs
+    jobs = spack.build_jobs
     if not pkg.parallel:
         jobs = 1
     elif pkg.make_jobs:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -354,7 +354,7 @@ def set_module_variables_for_package(pkg, module):
        This makes things easier for package writers.
     """
     # number of jobs spack will build with.
-    jobs = multiprocessing.cpu_count()
+    jobs = spack.jobs
     if not pkg.parallel:
         jobs = 1
     elif pkg.make_jobs:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -482,10 +482,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # These are default values for instance variables.
     #
     """By default we build in parallel.  Subclasses can override this."""
-    parallel = True
+    parallel = spack.parallel
 
     """# jobs to use for parallel make. If set, overrides default of ncpus."""
-    make_jobs = None
+    make_jobs = spack.jobs
 
     """By default do not run tests within package's install()"""
     run_tests = False

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -482,10 +482,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # These are default values for instance variables.
     #
     """By default we build in parallel.  Subclasses can override this."""
-    parallel = spack.parallel
+    parallel = True
 
     """# jobs to use for parallel make. If set, overrides default of ncpus."""
-    make_jobs = spack.jobs
+    make_jobs = spack.build_jobs
 
     """By default do not run tests within package's install()"""
     run_tests = False

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -63,6 +63,8 @@ schema = {
                 'verify_ssl': {'type': 'boolean'},
                 'checksum': {'type': 'boolean'},
                 'dirty': {'type': 'boolean'},
+                'parallel': {'type': 'boolean'},
+                'jobs': {'type': 'integer', 'minimum': 1},
             }
         },
     },

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -63,8 +63,7 @@ schema = {
                 'verify_ssl': {'type': 'boolean'},
                 'checksum': {'type': 'boolean'},
                 'dirty': {'type': 'boolean'},
-                'parallel': {'type': 'boolean'},
-                'jobs': {'type': 'integer', 'minimum': 1},
+                'build_jobs': {'type': 'integer', 'minimum': 1},
             }
         },
     },


### PR DESCRIPTION
Fixes #327 
Fixes #3010 
Fixes https://groups.google.com/forum/#!topic/spack/viVmaAUQCj4

By popular demand, you can now set the default level of parallelism in your `~/.spack/config.yaml` settings! By default, Spack runs all builds in parallel, using the number of available cores as the number of jobs to pass to make. With a `config.yaml` of:
```yaml
config:
  jobs: 4
```
Spack will use `make -j4` instead of hogging every core. This can still be overridden on the command line with:
```
$ spack install -j8 zlib
```
If you want to forego parallel builds altogether, you can use:
```yaml
config:
  parallel: false
```

@eschnett @HenrikBengtsson 