### PR TITLE
Add cub-1.4.1 required by cntk.

### DIFF
--- a/var/spack/repos/builtin/packages/cub/package.py
+++ b/var/spack/repos/builtin/packages/cub/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from distutils.dir_util import copy_tree
 
 
 class Cub(Package):
@@ -34,6 +33,8 @@ class Cub(Package):
     url      = "https://github.com/NVlabs/cub/archive/1.6.4.zip"
 
     version('1.6.4', '924fc12c0efb17264c3ad2d611ed1c51')
+    version('1.4.1', '74a36eb84e5b5f0bf54aa3df39f660b2')
 
     def install(self, spec, prefix):
-        copy_tree('cub', prefix.include)
+        mkdirp(prefix.include)
+        install_tree('cub', join_path(prefix.include, 'cub'))


### PR DESCRIPTION
This commit:

1. preserves the include path `cub/cub.h` as they are in the tar file.
2. Add version 1.4.1 required by CNTK.

By far only the CNTK package depends on cub, I've updated CNTK in #3578 to adapt these changes. 