### PR TITLE
Quick fix for #3153

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -224,6 +224,9 @@ def set_compiler_environment_variables(pkg, env):
     env.set('SPACK_COMPILER_SPEC', str(pkg.spec.compiler))
 
     for mod in compiler.modules:
+        # Fixes issue https://github.com/LLNL/spack/issues/3153
+        if os.environ.get("CRAY_CPU_TARGET") == "mic-knl":
+            load_module("cce")
         load_module(mod)
 
     compiler.setup_custom_environment(pkg, env)


### PR DESCRIPTION
@becker33 and I found that we could possibly bypass this error message:
craype-mic-knl requires cce/8.4 or later, intel/14.0 or later, or gcc/5.1 or later

however useful information about modules gets passed to stderr (why? I don't know!), so it's tricky to bypass.

loading cce has shown to do the trick but I'm unsure as what loading this module will do to the build environment.

I'm opening the discussion to other Cray users to find a suitable solution. 