### PR TITLE
Prevent users from building Score-P on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -65,6 +65,10 @@ class Scorep(AutotoolsPackage):
 
     variant('shmem', default=False, description='Enable shmem tracing')
 
+    # Score-P requires a case-sensitive file system, and therefore
+    # does not work on macOS
+    conflicts('platform=darwin')
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -67,6 +67,7 @@ class Scorep(AutotoolsPackage):
 
     # Score-P requires a case-sensitive file system, and therefore
     # does not work on macOS
+    # https://github.com/LLNL/spack/issues/1609
     conflicts('platform=darwin')
 
     def configure_args(self):


### PR DESCRIPTION
Closes #1609.

@alalazo Can we add an optional `msg` argument to the `conflicts` directive to print a custom message?
```
==> Error: Conflicts in concretized spec "scorep@3.0%gcc@6.2.1~shmem arch=linux-fedora25-x86_64"
```
isn't very informative...