### PR TITLE
vim wasn't linking against ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -90,6 +90,8 @@ class Vim(AutotoolsPackage):
 
         configure_args = ["--enable-fail-if-missing"]
 
+        configure_args.append("--with-tlib=ncursesw")
+
         configure_args.append("--with-features=" + feature_set)
 
         if '+python' in spec:


### PR DESCRIPTION
Vim's configure was searching for ncurses instead of ncursesw.  Closes #3829.

Before:

```
$ which vim
/blah/spack/v0.0.5/opt/spack/linux-centos7-x86_64/gcc-5.4.0/vim-8.0.0454-zngph6kn2ucnfgrcc3x2sl235q7pjdyn/bin/vim
$ ldd $(!!)
ldd $(which vim)
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	libm.so.6 => /lib64/libm.so.6 (0x00002aaaaaac1000)
	libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00002aaaaadc3000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00002aaaaafee000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab213000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab417000)
	libpcre.so.1 => /blah/spack/v0.0.5/opt/spack/linux-centos7-x86_64/gcc-5.4.0/pcre-8.40-rnjaow53pneyrqyvxsifkdkpsvt25b3f/lib/libpcre.so.1 (0x00002aaaab7da000)
	liblzma.so.5 => /blah/spack/v0.0.5/opt/spack/linux-centos7-x86_64/gcc-5.4.0/xz-5.2.3-ehlxwhosxgdfbduwx3nk5zzxmo4qhmaq/lib/liblzma.so.5 (0x00002aaaaba1e000)
	/lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaabc45000)
```

After:

```
$ ldd /blah/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/vim-8.0.0503-55us7ijakx452ll3suegl6ocx7nzcmfi/bin/vim
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	libm.so.6 => /lib64/libm.so.6 (0x00002aaaaaabe000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00002aaaaadc1000)
	libncursesw.so.6 => /blah/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/ncurses-6.0-75hnzrecoib5eqdvfchl6n2jgcxc6dgo/lib/libncursesw.so.6 (0x00002aaaaafe6000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab25b000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab460000)
	libpcre.so.1 => /lib64/libpcre.so.1 (0x00002aaaab822000)
	liblzma.so.5 => /lib64/liblzma.so.5 (0x00002aaaaba83000)
	/lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaabca9000)
$
```