### PR TITLE
Ensure sbin is prepended to PATH in modulefiles

### DIFF
--- a/var/spack/repos/builtin/packages/nginx/package.py
+++ b/var/spack/repos/builtin/packages/nginx/package.py
@@ -42,3 +42,7 @@ class Nginx(AutotoolsPackage):
     def configure_args(self):
         args = ['--with-http_ssl_module']
         return args
+
+    def setup_environment(self, spack_env, run_env):
+        """Prepend the sbin directory to PATH."""
+        run_env.prepend_path('PATH', join_path(self.prefix, 'sbin'))


### PR DESCRIPTION
The `nginx` executable ends up in the `.../sbin` directory.   Ensure that it's set up in modulefiles.

I was surprised that this is necessary.   Did I miss something?