### PR TITLE
Fix ABI detection issues with macOS gcc

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -49,14 +49,15 @@ _version_cache = {}
 
 
 def get_compiler_version(compiler_path, version_arg, regex='(.*)'):
-    if compiler_path not in _version_cache:
+    key = (compiler_path, version_arg, regex)
+    if key not in _version_cache:
         compiler = Executable(compiler_path)
         output = compiler(version_arg, output=str, error=str)
 
         match = re.search(regex, output)
-        _version_cache[compiler_path] = match.group(1) if match else 'unknown'
+        _version_cache[key] = match.group(1) if match else 'unknown'
 
-    return _version_cache[compiler_path]
+    return _version_cache[key]
 
 
 def dumpversion(compiler_path):

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -88,6 +88,16 @@ class Gcc(Compiler):
         return "-fPIC"
 
     @classmethod
+    def default_version(cls, cc):
+        # Skip any gcc versions that are actually clang, like Apple's gcc.
+        # Returning "unknown" makes them not detected by default.
+        # Users can add these manually to compilers.yaml at their own risk.
+        if spack.compilers.clang.Clang.default_version(cc) != 'unknown':
+            return 'unknown'
+
+        return super(Gcc, cls).default_version(cc)
+
+    @classmethod
     def fc_version(cls, fc):
         return get_compiler_version(
             fc, '-dumpversion',

--- a/lib/spack/spack/test/cmd/test_compiler_cmd.py
+++ b/lib/spack/spack/test/cmd/test_compiler_cmd.py
@@ -89,6 +89,4 @@ class TestCompilerCommand(object):
         # Ensure new compiler is in there
         new_compilers = set(spack.compilers.all_compiler_specs())
         new_compiler = new_compilers - old_compilers
-        assert new_compiler
-        assert sum(1 for c in new_compiler if
-                   c.version == Version(test_version)) > 0
+        assert any(c.version == Version(test_version) for c in new_compiler)


### PR DESCRIPTION
Fixes #3529.

- gcc on macOS says it's version 4.2.1, but it's really clang, and it's
  actually the *same* clang as the system clang.

- It also doesn't respond with a full path when called with
  --print-file-name=libstdc++.dylib, which is expected from gcc in abi.py.
  Instead, it gives a relative path and _gcc_compiler_compare doesn't
  understand what to do with it.  This results in errors like:

  ```
  lib/spack/spack/abi.py, line 71, in _gcc_get_libstdcxx_version
      libpath = os.readlink(output.strip())
  OSError: [Errno 2] No such file or directory: 'libstdc++.dylib'
  ```

- This commit does two things:

  1. Ignore any gcc that's actually clang in abi.py.  We can probably do
     better than this, but it's not clear there is a need to, since we
     should handle the compiler as clang, not gcc.

  2. Don't auto-detect any "gcc" that is actually clang anymore.  Ignore
     it and expect people to use clang (which is the default macOS
     compiler anyway).

Note that this means we won't see `gcc@4.2.1` by default on Mac OS X anymore.  Only the corresponding `clang`.  I think it was confusing anyway, and users can still add fake gccs to their compilers.yaml if they want, but I think we should discourage it.
