### PR TITLE
random123: put uniform.hpp in right subfolder

### DIFF
--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -42,4 +42,4 @@ class Random123(Package):
         install_tree('include', prefix.include)
         install('./LICENSE', "%s" % prefix)
         # used by some packages, e.g. quinoa
-        install('examples/uniform.hpp', prefix.include)
+        install('examples/uniform.hpp', join_path(prefix.include, 'Random123'))


### PR DESCRIPTION
Fix up for #3856.

Part of quinoacomputing/quinoa#129.

Needed for #3852.