### PR TITLE
Add variant +wide for ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -38,7 +38,7 @@ class Emacs(AutotoolsPackage):
     variant('toolkit', default='gtk',
             description="Select an X toolkit (gtk, athena)")
 
-    depends_on('ncurses')
+    depends_on('ncurses~wide')
     depends_on('libtiff', when='+X')
     depends_on('libpng', when='+X')
     depends_on('libxpm', when='+X')

--- a/var/spack/repos/builtin/packages/global/package.py
+++ b/var/spack/repos/builtin/packages/global/package.py
@@ -35,7 +35,7 @@ class Global(Package):
     version('6.5', 'dfec818b4f53d91721e247cf7b218078')
 
     depends_on('exuberant-ctags', type=('build', 'run'))
-    depends_on('ncurses')
+    depends_on('ncurses~wide')
 
     def install(self, spec, prefix):
         config_args = ['--prefix={0}'.format(prefix)]

--- a/var/spack/repos/builtin/packages/libedit/package.py
+++ b/var/spack/repos/builtin/packages/libedit/package.py
@@ -39,6 +39,3 @@ class Libedit(AutotoolsPackage):
     def url_for_version(self, version):
         url = "http://thrysoee.dk/editline/libedit-{0}-{1}.tar.gz"
         return url.format(version[-1], version.up_to(-1))
-
-    def configure_args(self):
-        return ['--enable-widec']

--- a/var/spack/repos/builtin/packages/libedit/package.py
+++ b/var/spack/repos/builtin/packages/libedit/package.py
@@ -34,11 +34,11 @@ class Libedit(AutotoolsPackage):
     version('3.1-20160903', '0467d27684c453a351fbcefebbcb16a3')
     version('3.1-20150325', '43cdb5df3061d78b5e9d59109871b4f6')
 
-    depends_on('ncurses')
+    depends_on('ncurses~wide')
 
     def url_for_version(self, version):
         url = "http://thrysoee.dk/editline/libedit-{0}-{1}.tar.gz"
         return url.format(version[-1], version.up_to(-1))
 
     def configure_args(self):
-        return ['LIBS=-lncursesw']
+        return ['--enable-widec']

--- a/var/spack/repos/builtin/packages/ncdu/package.py
+++ b/var/spack/repos/builtin/packages/ncdu/package.py
@@ -45,8 +45,12 @@ class Ncdu(Package):
     depends_on("ncurses")
 
     def install(self, spec, prefix):
+        curses_lib = '--with-ncurses%s=%s' % (
+            'w' if '+wide' in spec['ncurses'] else '',
+            spec['ncurses'])
+
         configure('--prefix=%s' % prefix,
-                  '--with-ncursesw=%s' % spec['ncurses'])
+                  curses_lib)
 
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/ncdu/package.py
+++ b/var/spack/repos/builtin/packages/ncdu/package.py
@@ -46,7 +46,7 @@ class Ncdu(Package):
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix,
-                  '--with-ncurses=%s' % spec['ncurses'])
+                  '--with-ncursesw=%s' % spec['ncurses'])
 
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/ncdu/package.py
+++ b/var/spack/repos/builtin/packages/ncdu/package.py
@@ -42,15 +42,10 @@ class Ncdu(Package):
     version('1.8', '94d7a821f8a0d7ba8ef3dd926226f7d5')
     version('1.7', '172047c29d232724cc62e773e82e592a')
 
-    depends_on("ncurses")
+    depends_on('ncurses')
 
     def install(self, spec, prefix):
-        curses_lib = '--with-ncurses%s=%s' % (
-            'w' if '+wide' in spec['ncurses'] else '',
-            spec['ncurses'])
-
-        configure('--prefix=%s' % prefix,
-                  curses_lib)
+        configure('--prefix=%s' % prefix)
 
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -41,6 +41,9 @@ class Ncurses(AutotoolsPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
 
+    variant('wide', default=True,
+            description='Enable to build ncuresesw, disable to build ncurses')
+
     depends_on('pkg-config', type='build')
 
     patch('patch_gcc_5.txt', when='@6.0%gcc@5.0:')
@@ -52,7 +55,6 @@ class Ncurses(AutotoolsPackage):
             'CXXFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-shared',
             '--with-cxx-shared',
-            '--enable-widec',
             '--enable-overwrite',
             '--without-ada',
             '--enable-pc-files',
@@ -61,5 +63,8 @@ class Ncurses(AutotoolsPackage):
 
         if '+symlinks' in self.spec:
             opts.append('--enable-symlinks')
+
+        if '+wide' in self.spec:
+            opts.append('--enable-widec')
 
         return opts

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -42,7 +42,7 @@ class Ncurses(AutotoolsPackage):
             description='Enables symlinks. Needed on AFS filesystem.')
 
     variant('wide', default=True,
-            description='Enable to build ncuresesw, disable to build ncurses')
+            description='Enable to build ncursesw, disable to build ncurses')
 
     depends_on('pkg-config', type='build')
 

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -45,8 +45,10 @@ class Readline(AutotoolsPackage):
     patch('readline-6.3-upstream_fixes-1.patch', when='@6.3')
 
     def build(self, spec, prefix):
-        options = [
-            'SHLIB_LIBS=-L{0} -lncursesw'.format(spec['ncurses'].prefix.lib)
-        ]
+        if '+wide' in spec['ncurses']:
+            shlib = 'SHLIB_LIBS=-L%s -lncursesw' % spec['ncurses'].prefix.lib
+        else:
+            shlib = 'SHLIB_LIBS=-L%s -lncurses' % spec['ncurses'].prefix.lib
 
+        options = [shlib]
         make(*options)

--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -41,7 +41,7 @@ class Tmux(Package):
     version('1.9a', 'b07601711f96f1d260b390513b509a2d')
 
     depends_on('libevent')
-    depends_on('ncurses')
+    depends_on('ncurses~wide')
 
     def install(self, spec, prefix):
         pkg_config_path = ':'.join([


### PR DESCRIPTION
Several build systems do not look for ncursesw. ncurses~wide will build curses and ncurses instead.

The following packages have ncurses as an immediate dependency:
``` bash
bash cmake+ncurses cscope emacs gettext+curses global htop libedit llvm+lldb lua mariadb mosh ncdu ocaml python r readline samtools screen tmux vim hstr ncftp openssh
```

#3126 #3849
