### PR TITLE
octave: add 4.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -38,9 +38,14 @@ class Octave(AutotoolsPackage):
 
     extendable = True
 
+    version('4.2.1', '80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b')
     version('4.2.0', '443ba73782f3531c94bcf016f2f0362a58e186ddb8269af7dcce973562795567')
     version('4.0.2', 'c2a5cacc6e4c52f924739cdf22c2c687')
     version('4.0.0', 'a69f8320a4f20a8480c1b278b1adb799')
+
+    # patches
+    # see https://savannah.gnu.org/bugs/?50234
+    patch('patch_4.2.1_inline.diff', when='@4.2.1')
 
     # Variants
     variant('readline',   default=True)
@@ -77,7 +82,7 @@ class Octave(AutotoolsPackage):
     depends_on('readline',     when='+readline')
 
     # Optional dependencies
-    depends_on('arpack',       when='+arpack')
+    depends_on('arpack-ng',    when='+arpack')
     depends_on('curl',         when='+curl')
     depends_on('fftw',         when='+fftw')
     depends_on('fltk',         when='+fltk')
@@ -120,9 +125,10 @@ class Octave(AutotoolsPackage):
 
         # Optional dependencies
         if '+arpack' in spec:
+            sa = spec['arpack-ng']
             config_args.extend([
-                "--with-arpack-includedir=%s" % spec['arpack'].prefix.include,
-                "--with-arpack-libdir=%s"     % spec['arpack'].prefix.lib
+                "--with-arpack-includedir=%s" % sa.prefix.include,
+                "--with-arpack-libdir=%s"     % sa.prefix.lib
             ])
         else:
             config_args.append("--without-arpack")

--- a/var/spack/repos/builtin/packages/octave/patch_4.2.1_inline.diff
+++ b/var/spack/repos/builtin/packages/octave/patch_4.2.1_inline.diff
@@ -1,0 +1,12 @@
+diff -r 73f7ef7169ac liboctave/system/file-stat.cc
+--- a/liboctave/system/file-stat.cc	Thu Feb 23 16:08:44 2017 -0800
++++ b/liboctave/system/file-stat.cc	Fri Feb 24 11:02:36 2017 -0800
+@@ -174,7 +174,7 @@ namespace octave
+           update_internal ();
+       }
+ 
+-    inline file_stat::~file_stat () { }
++    file_stat::~file_stat () { }
+ 
+     void
+     file_stat::update_internal (bool force)


### PR DESCRIPTION
Also switch to arpack-ng, which is maintained and has bugfixes,
whereas the original arpack code is abandoned.