### PR TITLE
Add new CMake version, 3.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -33,6 +33,7 @@ class Cmake(Package):
     list_url = 'https://cmake.org/files/'
     list_depth = 1
 
+    version('3.8.0',    'f28cba717ba38ad82a488daed8f45b5b')
     version('3.7.2',    '79bd7e65cd81ea3aa2619484ad6ff25a')
     version('3.7.1',    'd031d5a06e9f1c5367cdfc56fbd2a1c8')
     version('3.6.1',    'd6dd661380adacdb12f41b926ec99545')


### PR DESCRIPTION
This does not address the fact that spack does not build ccmake. See #3870.