### PR TITLE
Add package for aspell and ass't dictionaries

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -170,6 +170,7 @@ __all__ = []
 
 from spack.package import Package, run_before, run_after, on_package_attributes
 from spack.build_systems.makefile import MakefilePackage
+from spack.build_systems.aspell_dict import AspellDictPackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.qmake import QMakePackage
@@ -185,6 +186,7 @@ __all__ += [
     'on_package_attributes',
     'Package',
     'MakefilePackage',
+    'AspellDictPackage',
     'AutotoolsPackage',
     'CMakePackage',
     'QMakePackage',

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -33,8 +33,10 @@ from spack.util.executable import which
 #
 # Aspell dictionaries install their bits into their prefix.lib
 # and when activated they'll get symlinked into the appropriate aspell's
-# dict dir (see aspell's {de,}activate methods.
+# dict dir (see aspell's {de,}activate methods).
 #
+# They aren't really an Autotools package, but it's close enough
+# that this works if we override configure().
 class AspellDictPackage(AutotoolsPackage):
     """Specialized class for builing aspell dictionairies."""
 

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -74,10 +74,9 @@ class Aspell(AutotoolsPackage):
         for d in self.dicts:
             if '+{0}'.format(d['name']) in self.spec:
                 with working_dir(d['package']):
-                    bash = which('bash')
-                    make = which('make')
+                    sh = which('sh')
                     aspell = join_path(prefix.bin, "aspell")
                     prezip = join_path(prefix.bin, "prezip")
-                    bash('./configure', '--vars', "ASPELL={0}".format(aspell),
-                         "PREZIP={0}".format(prezip))
+                    sh('./configure', '--vars', "ASPELL={0}".format(aspell),
+                        "PREZIP={0}".format(prezip))
                     make('install')

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -28,6 +28,7 @@ import spack.store
 from spack.package import ExtensionConflictError
 
 
+# See also: AspellDictPakcage
 class Aspell(AutotoolsPackage):
     """GNU Aspell is a Free and Open Source spell checker designed to
     eventually replace Ispell."""

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -24,7 +24,7 @@
 ##############################################################################
 from spack import *
 import re
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 
 class Aspell(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -28,7 +28,7 @@ import spack.store
 from spack.package import ExtensionConflictError
 
 
-# See also: AspellDictPakcage
+# See also: AspellDictPackage
 class Aspell(AutotoolsPackage):
     """GNU Aspell is a Free and Open Source spell checker designed to
     eventually replace Ispell."""

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -38,14 +38,14 @@ class Aspell(AutotoolsPackage):
 
     # additional dictionaries here: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
     dicts = [
-        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
-          'md5': "a6e002076574de9dc4915967032a1dab",
+        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
+         'md5': "a6e002076574de9dc4915967032a1dab",
         },
-        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
-          'md5': '8406336a89c64e47e96f4153d0af70c4',
+        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
+         'md5': '8406336a89c64e47e96f4153d0af70c4',
         },
-        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
-          'md5': '5950c5c8a36fc93d4d7616591bace6a6',
+        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
+         'md5': '5950c5c8a36fc93d4d7616591bace6a6',
         },
     ]
     for d in dicts:
@@ -74,10 +74,10 @@ class Aspell(AutotoolsPackage):
         for d in self.dicts:
             if '+{0}'.format(d['name']) in self.spec:
                 with working_dir(d['package']):
-                    bash=which('bash')
-                    make=which('make')
-                    aspell=join_path(prefix.bin, "aspell")
-                    prezip=join_path(prefix.bin, "prezip")
+                    bash = which('bash')
+                    make = which('make')
+                    aspell = join_path(prefix.bin, "aspell")
+                    prezip = join_path(prefix.bin, "prezip")
                     bash('./configure', '--vars', "ASPELL={0}".format(aspell),
                          "PREZIP={0}".format(prezip))
                     make('install')

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -28,7 +28,7 @@ from six.moves.urllib.parse import urlparse
 
 
 class Aspell(AutotoolsPackage):
-    """GNU Aspell is a Free and Open Source spell checker designed to 
+    """GNU Aspell is a Free and Open Source spell checker designed to
     eventually replace Ispell."""
 
     homepage = "http://aspell.net/"
@@ -36,32 +36,30 @@ class Aspell(AutotoolsPackage):
 
     version('0.60.6.1', 'e66a9c9af6a60dc46134fdacf6ce97d7')
 
-    # additional dictionaries here: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
-    dicts = [
-        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
-         'md5': "a6e002076574de9dc4915967032a1dab",
-        },
-        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
-         'md5': '8406336a89c64e47e96f4153d0af70c4',
-        },
-        {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
-         'md5': '5950c5c8a36fc93d4d7616591bace6a6',
-        },
-    ]
-    for d in dicts:
-        o = urlparse(d['url'])
-        p = o.path.split('/')
-        d['name'] = p[4]
-        d['package'] = re.sub(r'\.tar.bz2', '', p[5])
+    @staticmethod
+    def list_resources():
+        # additional dictionaries here: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
+        dicts = [
+            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
+             'md5': "a6e002076574de9dc4915967032a1dab",
+            },
+            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
+             'md5': '8406336a89c64e47e96f4153d0af70c4',
+            },
+            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
+             'md5': '5950c5c8a36fc93d4d7616591bace6a6',
+            },
+        ]
+        for d in dicts:
+            p = urlparse(d['url']).path.split('/')
+            name = p[4]
+            package = re.sub('\.tar.bz2', '', p[5])
+            yield d['url'], d['md5'], name, package
 
-        variant(d['name'], default=False, description=d['package'])
-        resource(
-            name=d['name'],
-            url=d['url'],
-            md5=d['md5'],
-            placement=d['package'],
-            when='+{0}'.format(d['name']),
-        )
+    for dict_url,md5,name,package in list_resources.__func__():
+        variant(name, default=False, description=package)
+        resource(name=name, url=dict_url, md5=md5, placement=package,
+                 when='+{0}'.format(name))
 
     # When installing dictionaries, prezip needs to be able to find
     # prezip-bin.
@@ -71,9 +69,9 @@ class Aspell(AutotoolsPackage):
     @run_after('install')
     def install_dictionaries(self):
         prefix = self.prefix
-        for d in self.dicts:
-            if '+{0}'.format(d['name']) in self.spec:
-                with working_dir(d['package']):
+        for dict_url, md5, name, package in self.list_resources():
+            if '+{0}'.format(name) in self.spec:
+                with working_dir(package):
                     sh = which('sh')
                     aspell = join_path(prefix.bin, "aspell")
                     prezip = join_path(prefix.bin, "prezip")

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -52,7 +52,7 @@ class Aspell(AutotoolsPackage):
         o = urlparse(d['url'])
         p = o.path.split('/')
         d['name'] = p[4]
-        d['package'] = re.sub(r'\.tar.gz', '', p[5])
+        d['package'] = re.sub(r'\.tar.bz2', '', p[5])
 
         variant(d['name'], default=False, description=d['package'])
         resource(

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -23,8 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import re
-from six.moves.urllib.parse import urlparse
+from llnl.util.link_tree import LinkTree
+import spack.store
+from spack.package import ExtensionConflictError
 
 
 class Aspell(AutotoolsPackage):
@@ -34,47 +35,38 @@ class Aspell(AutotoolsPackage):
     homepage = "http://aspell.net/"
     url      = "https://ftpmirror.gnu.org/aspell/aspell-0.60.6.1.tar.gz"
 
+    extendable = True           # support activating dictionaries
+
     version('0.60.6.1', 'e66a9c9af6a60dc46134fdacf6ce97d7')
 
-    @staticmethod
-    def list_resources():
-        # additional dictionaries here: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
-        dicts = [
-            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
-             'md5': "a6e002076574de9dc4915967032a1dab",
-            },
-            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
-             'md5': '8406336a89c64e47e96f4153d0af70c4',
-            },
-            {'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
-             'md5': '5950c5c8a36fc93d4d7616591bace6a6',
-            },
-        ]
-        for d in dicts:
-            p = urlparse(d['url']).path.split('/')
-            name = p[4]
-            package = re.sub('\.tar.bz2', '', p[5])
-            yield d['url'], d['md5'], name, package
+    # The dictionaries install all their bits into their prefix.lib dir,
+    # we want to link them into aspell's dict-dir.
+    # These are identical to what's in spack/package.py except
+    # for using:
+    #   - extension.prefix.lib instead of extension.prefix in LinkTree()
+    #   - dest_dir instead of self.prefix in tree.(find_conflict|merge)()
+    def activate(self, extension, **kwargs):
+        aspell = which(self.prefix.bin.aspell)
+        dest_dir = aspell('dump', 'config', 'dict-dir', output=str).strip()
+        tree = LinkTree(extension.prefix.lib)
 
-    for dict_url,md5,name,package in list_resources.__func__():
-        variant(name, default=False, description=package)
-        resource(name=name, url=dict_url, md5=md5, placement=package,
-                 when='+{0}'.format(name))
+        def ignore(filename):
+            return (filename in spack.store.layout.hidden_file_paths or
+                    kwargs.get('ignore', lambda f: False)(filename))
 
-    # When installing dictionaries, prezip needs to be able to find
-    # prezip-bin.
-    def setup_environment(self, spack_env, run_env):
-        spack_env.prepend_path('PATH', self.prefix.bin)
+        conflict = tree.find_conflict(dest_dir, ignore=ignore)
+        if conflict:
+            raise ExtensionConflictError(conflict)
 
-    @run_after('install')
-    def install_dictionaries(self):
-        prefix = self.prefix
-        for dict_url, md5, name, package in self.list_resources():
-            if '+{0}'.format(name) in self.spec:
-                with working_dir(package):
-                    sh = which('sh')
-                    aspell = join_path(prefix.bin, "aspell")
-                    prezip = join_path(prefix.bin, "prezip")
-                    sh('./configure', '--vars', "ASPELL={0}".format(aspell),
-                        "PREZIP={0}".format(prezip))
-                    make('install')
+        tree.merge(dest_dir, ignore=ignore)
+
+    def deactivate(self, extension, **kwargs):
+        aspell = which(self.prefix.bin.aspell)
+        dest_dir = aspell('dump', 'config', 'dict-dir', output=str).strip()
+
+        def ignore(filename):
+            return (filename in spack.store.layout.hidden_file_paths or
+                    kwargs.get('ignore', lambda f: False)(filename))
+
+        tree = LinkTree(extension.prefix.lib)
+        tree.unmerge(dest_dir, ignore=ignore)

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -1,0 +1,83 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import re
+from urlparse import urlparse
+
+
+class Aspell(AutotoolsPackage):
+    """GNU Aspell is a Free and Open Source spell checker designed to 
+    eventually replace Ispell."""
+
+    homepage = "http://aspell.net/"
+    url      = "https://ftpmirror.gnu.org/aspell/aspell-0.60.6.1.tar.gz"
+
+    version('0.60.6.1', 'e66a9c9af6a60dc46134fdacf6ce97d7')
+
+    # additional dictionaries here: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
+    dicts = [
+        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2',
+          'md5': "a6e002076574de9dc4915967032a1dab",
+        },
+        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2',
+          'md5': '8406336a89c64e47e96f4153d0af70c4',
+        },
+        { 'url': 'ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2',
+          'md5': '5950c5c8a36fc93d4d7616591bace6a6',
+        },
+    ]
+    for d in dicts:
+        o = urlparse(d['url'])
+        p = o.path.split('/')
+        d['name'] = p[4]
+        d['package'] = re.sub(r'\.tar.gz', '', p[5])
+
+        variant(d['name'], default=False, description=d['package'])
+        resource(
+            name=d['name'],
+            url=d['url'],
+            md5=d['md5'],
+            placement=d['package'],
+            when='+{0}'.format(d['name']),
+        )
+
+    # When installing dictionaries, prezip needs to be able to find
+    # prezip-bin.
+    def setup_environment(self, spack_env, run_env):
+        spack_env.prepend_path('PATH', self.prefix.bin)
+
+    @run_after('install')
+    def install_dictionaries(self):
+        prefix = self.prefix
+        for d in self.dicts:
+            if '+{0}'.format(d['name']) in self.spec:
+                with working_dir(d['package']):
+                    bash=which('bash')
+                    make=which('make')
+                    aspell=join_path(prefix.bin, "aspell")
+                    prezip=join_path(prefix.bin, "prezip")
+                    bash('./configure', '--vars', "ASPELL={0}".format(aspell),
+                         "PREZIP={0}".format(prezip))
+                    make('install')

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -27,26 +27,10 @@ from spack import *
 
 # This isn't really an Autotools package, but it's close enough
 # that this works if we override configure().
-class Aspell6De(AutotoolsPackage):
+class Aspell6De(AspellDictPackage):
     """German (de) dictionary for aspell."""
-
-    extends('aspell')
 
     homepage = "http://aspell.net/"
     url      = "ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
 
     version('6-de-20030222-1', '5950c5c8a36fc93d4d7616591bace6a6')
-
-    def patch(self):
-        filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
-        filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
-
-    def configure(self, spec, prefix):
-        aspell = spec['aspell'].prefix.bin.aspell
-        prezip = spec['aspell'].prefix.bin.prezip
-        destdir = prefix
-
-        sh = which('sh')
-        sh('./configure', '--vars', "ASPELL={0}".format(aspell),
-           "PREZIP={0}".format(prezip),
-           "DESTDIR={0}".format(destdir))

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -25,8 +25,6 @@
 from spack import *
 
 
-# This isn't really an Autotools package, but it's close enough
-# that this works if we override configure().
 class Aspell6De(AspellDictPackage):
     """German (de) dictionary for aspell."""
 

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+# This isn't really an Autotools package, but it's close enough
+# that this works if we override configure().
+class Aspell6De(AutotoolsPackage):
+    """German (de) dictionary for aspell."""
+
+    extends('aspell')
+
+    homepage = "http://aspell.net/"
+    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20030222-1.tar.bz2"
+
+    version('6-de-20030222-1', '5950c5c8a36fc93d4d7616591bace6a6')
+
+    def patch(self):
+        filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
+        filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
+
+    def configure(self, spec, prefix):
+        aspell = spec['aspell'].prefix.bin.aspell
+        prezip = spec['aspell'].prefix.bin.prezip
+        destdir = prefix
+
+        sh = which('sh')
+        sh('./configure', '--vars', "ASPELL={0}".format(aspell),
+           "PREZIP={0}".format(prezip),
+           "DESTDIR={0}".format(destdir))

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+# This isn't really an Autotools package, but it's close enough
+# that this works if we override configure().
+class Aspell6En(AutotoolsPackage):
+    """English (en) dictionary for aspell."""
+
+    extends('aspell')
+
+    homepage = "http://aspell.net/"
+    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
+
+    version('2017.01.22-0', 'a6e002076574de9dc4915967032a1dab')
+
+    def patch(self):
+        filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
+        filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
+
+    def configure(self, spec, prefix):
+        aspell = spec['aspell'].prefix.bin.aspell
+        prezip = spec['aspell'].prefix.bin.prezip
+        destdir = prefix
+
+        sh = which('sh')
+        sh('./configure', '--vars', "ASPELL={0}".format(aspell),
+           "PREZIP={0}".format(prezip),
+           "DESTDIR={0}".format(destdir))

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+# This isn't really an Autotools package, but it's close enough
+# that this works if we override configure().
+class Aspell6Es(AutotoolsPackage):
+    """Spanish (es) dictionary for aspell."""
+
+    extends('aspell')
+
+    homepage = "http://aspell.net/"
+    url      = "ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+
+    version('1.11-2', '8406336a89c64e47e96f4153d0af70c4')
+
+    def patch(self):
+        filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
+        filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
+
+    def configure(self, spec, prefix):
+        aspell = spec['aspell'].prefix.bin.aspell
+        prezip = spec['aspell'].prefix.bin.prezip
+        destdir = prefix
+
+        sh = which('sh')
+        sh('./configure', '--vars', "ASPELL={0}".format(aspell),
+           "PREZIP={0}".format(prezip),
+           "DESTDIR={0}".format(destdir))

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -25,8 +25,6 @@
 from spack import *
 
 
-# This isn't really an Autotools package, but it's close enough
-# that this works if we override configure().
 class Aspell6Es(AspellDictPackage):
     """Spanish (es) dictionary for aspell."""
 

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -27,26 +27,10 @@ from spack import *
 
 # This isn't really an Autotools package, but it's close enough
 # that this works if we override configure().
-class Aspell6Es(AutotoolsPackage):
+class Aspell6Es(AspellDictPackage):
     """Spanish (es) dictionary for aspell."""
-
-    extends('aspell')
 
     homepage = "http://aspell.net/"
     url      = "ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
 
     version('1.11-2', '8406336a89c64e47e96f4153d0af70c4')
-
-    def patch(self):
-        filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
-        filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
-
-    def configure(self, spec, prefix):
-        aspell = spec['aspell'].prefix.bin.aspell
-        prezip = spec['aspell'].prefix.bin.prezip
-        destdir = prefix
-
-        sh = which('sh')
-        sh('./configure', '--vars', "ASPELL={0}".format(aspell),
-           "PREZIP={0}".format(prezip),
-           "DESTDIR={0}".format(destdir))

--- a/var/spack/repos/builtin/packages/aspell6-es/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-es/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.


### PR DESCRIPTION
[edit: added question about python 3 and urlparse and then touched it up]

Add a package definition for aspell.

Add a handful of dictionaries to convince myself that the support for a bunch of dictionaries works.

I'd appreciate a bit of feedback on the dictionary handling.  In particular:

1. I feel dirty after modifying the dict array in place.  My functional training voice wants me to map across it and make a richer data structure that gets used in the other bits.  What's the pythonic thing?

2. What to do about dictionaries?  Homebrew seems to have just [grabbed them all].  Do we want to do that?  If not, I've taken care of mine.  Should I leave "yours" up to "you" (for various definitions of "not me")?
  
    If we grab them all, it'd be nice to automate the generation of the md5's.  Someone stop me before I start writing go (or perl)...

3. These dictionaries seem to be for a particular set of versions.  Is my package future-proof enough for when they release a new set?

4. Looks like the url parsing bit is python version dependent.

    ~Do I need to do something like line 28 of `lib/spack/spack/cmd/md5.py`:~

    I stole this from `.../cmd/md5.py` and it made Travis happy.  Should I do something different?

    ```python
    from six.moves.urllib.parse import urlparse
    ```