### PR TITLE
Disable parallel builds for vim

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -68,11 +68,6 @@ class Vim(AutotoolsPackage):
 
     depends_on('ncurses', when="@7.4:")
 
-    # Run the build with -j 1.  There seems to be a problem with parallel
-    # builds that results in the creation of the links (e.g. view) to the
-    # vim binary silently failing.
-    parallel = False
-
     def configure_args(self):
         spec = self.spec
         feature_set = None
@@ -134,3 +129,9 @@ class Vim(AutotoolsPackage):
             configure_args.append("--enable-cscope")
 
         return configure_args
+
+    # Run the install phase with -j 1.  There seems to be a problem with
+    # parallel builds that results in the creation of the links (e.g. view)
+    # to the vim binary silently failing.
+    def install(self, spec, prefix):
+        make('install', parallel=False)

--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -68,6 +68,11 @@ class Vim(AutotoolsPackage):
 
     depends_on('ncurses', when="@7.4:")
 
+    # Run the build with -j 1.  There seems to be a problem with parallel
+    # builds that results in the creation of the links (e.g. view) to the
+    # vim binary silently failing.
+    parallel = False
+
     def configure_args(self):
         spec = self.spec
         feature_set = None


### PR DESCRIPTION
The install step creates a bunch of links to the vim binary, e.g.
`view`.  When run with -j greater than 1 there are silent failures.

Running w/out parallelism seems to fix it.

Closes #3867 