### PR TITLE
flex: create variant +lex that creates symlinks for lex and libl.{a,so}

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -40,7 +40,7 @@ class Flex(AutotoolsPackage):
     version('2.6.0', '760be2ee9433e822b6eb65318311c19d')
     version('2.5.39', '5865e76ac69c05699f476515592750d7')
 
-    variant('lex', default=False,
+    variant('lex', default=True,
             description="Provide symlinks for lex, libl.a and libl.so")
 
     depends_on('bison',         type='build')

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -41,7 +41,7 @@ class Flex(AutotoolsPackage):
     version('2.5.39', '5865e76ac69c05699f476515592750d7')
 
     variant('lex', default=True,
-            description="Provide symlinks for lex, libl.a and libl.so")
+            description="Provide symlinks for lex and libl")
 
     depends_on('bison',         type='build')
     depends_on('gettext@0.19:', type='build')
@@ -69,14 +69,12 @@ class Flex(AutotoolsPackage):
     @run_after('install')
     def symlink_lex(self):
         if self.spec.satisfies('+lex'):
-            with working_dir(self.prefix.bin):
-                if (os.path.isfile('flex') and not
-                   os.path.lexists('lex')):
-                    symlink('flex', 'lex')
-            with working_dir(self.prefix.lib):
-                if (os.path.isfile('libfl.a') and not
-                   os.path.lexists('libl.a')):
-                    symlink('libfl.a', 'libl.a')
-                if (os.path.isfile('libfl.so') and not
-                   os.path.lexists('libl.so')):
-                    symlink('libfl.so', 'libl.so')
+            dso = dso_suffix
+            for dir, flex, lex in \
+                    ((self.prefix.bin, 'flex', 'lex'),
+                     (self.prefix.lib, 'libfl.a', 'libl.a'),
+                     (self.prefix.lib, 'libfl.' + dso, 'libl.' + dso)):
+                with working_dir(dir):
+                    if (os.path.isfile(flex) and not
+                            os.path.lexists(lex)):
+                        symlink(flex, lex)

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import os
 
 
 class Flex(AutotoolsPackage):
@@ -38,6 +39,9 @@ class Flex(AutotoolsPackage):
     version('2.6.1', '05bcd8fb629e0ae130311e8a6106fa82')
     version('2.6.0', '760be2ee9433e822b6eb65318311c19d')
     version('2.5.39', '5865e76ac69c05699f476515592750d7')
+
+    variant('lex', default=False,
+            description="Provide symlinks for lex, libl.a and libl.so")
 
     depends_on('bison',         type='build')
     depends_on('gettext@0.19:', type='build')
@@ -61,3 +65,18 @@ class Flex(AutotoolsPackage):
             url += "/archive/flex-{0}.tar.gz".format(version.dashed)
 
         return url
+
+    @run_after('install')
+    def symlink_lex(self):
+        if self.spec.satisfies('+lex'):
+            with working_dir(self.prefix.bin):
+                if (os.path.isfile('flex') and not
+                   os.path.lexists('lex')):
+                    symlink('flex', 'lex')
+            with working_dir(self.prefix.lib):
+                if (os.path.isfile('libfl.a') and not
+                   os.path.lexists('libl.a')):
+                    symlink('libfl.a', 'libl.a')
+                if (os.path.isfile('libfl.so') and not
+                   os.path.lexists('libl.so')):
+                    symlink('libfl.so', 'libl.so')


### PR DESCRIPTION
This gives similar results to the flex and flex-devel packages on Redhat Enterprise Linux. Some packages (e.g. ncl) test for lex and libl before flex and libfl, so we end up using the system flex package unless we provide our own lex and libl.