### PR TITLE
pango: depends on libxft when +X, disable libxft support when ~X

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -46,7 +46,16 @@ class Pango(AutotoolsPackage):
     depends_on("cairo")
     depends_on("cairo~X", when='~X')
     depends_on("cairo+X", when='+X')
+    depends_on("libxft", when='+X')
     depends_on("glib")
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies('+X'):
+            args.append('--with-xft')
+        else:
+            args.append('--without-xft')
+        return args
 
     def install(self, spec, prefix):
         make("install", parallel=False)


### PR DESCRIPTION
libxft is auto-detected during configure, and package may link against system libxft even when variant X is off. When variant X is on, we want to use spack's libxft to ensure consistency across platforms.