### PR TITLE
Update ECWMF packages: grib-api, libemos and magics

### DIFF
--- a/var/spack/repos/builtin/packages/grib-api/package.py
+++ b/var/spack/repos/builtin/packages/grib-api/package.py
@@ -33,6 +33,7 @@ class GribApi(Package):
     homepage = "https://software.ecmwf.int/wiki/display/GRIB/Home"
     url      = "https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.17.0-Source.tar.gz"
 
+    version('1.21.0', 'eb64c5eb72e6e90841237cba9d644016')
     version('1.17.0', 'bca7114d2c3100501a08190a146818d2')
     version('1.16.0', '8c7fdee03344e4379d400ae20976a460')
 

--- a/var/spack/repos/builtin/packages/libemos/package.py
+++ b/var/spack/repos/builtin/packages/libemos/package.py
@@ -35,7 +35,8 @@ class Libemos(Package):
     version('4.4.7', '395dcf21cf06872f772fb6b73d8e67b9')
     version('4.4.2', 'f15a9aff0f40861f3f046c9088197376')
 
-    variant('eccodes', default=False)
+    variant('eccodes', default=False,
+            description="Use eccodes instead of grib-api for GRIB decoding")
 
     depends_on('cmake', type='build')
     depends_on('eccodes', when='+eccodes')

--- a/var/spack/repos/builtin/packages/libemos/package.py
+++ b/var/spack/repos/builtin/packages/libemos/package.py
@@ -32,16 +32,26 @@ class Libemos(Package):
     homepage = "https://software.ecmwf.int/wiki/display/EMOS/Emoslib"
     url      = "https://software.ecmwf.int/wiki/download/attachments/3473472/libemos-4.4.2-Source.tar.gz"
 
+    version('4.4.7', '395dcf21cf06872f772fb6b73d8e67b9')
     version('4.4.2', 'f15a9aff0f40861f3f046c9088197376')
 
+    variant('eccodes', default=False)
+
     depends_on('cmake', type='build')
-    depends_on('grib-api')
+    depends_on('eccodes', when='+eccodes')
+    depends_on('grib-api', when='~eccodes')
+    depends_on('fftw+float+double')
 
     def install(self, spec, prefix):
         options = []
         options.extend(std_cmake_args)
 
-        options.append('-DGRIB_API_PATH=%s' % spec['grib_api'].prefix)
+        if spec.satisfies('+eccodes'):
+            options.append('-DENABLE_ECCODES=ON')
+            options.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
+        else:
+            options.append('-DENABLE_ECCODES=OFF')
+            options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
 
         # To support long pathnames that spack generates
         options.append('-DCMAKE_Fortran_FLAGS=-ffree-line-length-none')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -36,6 +36,7 @@ class Magics(Package):
     # Maintainers of Magics do not keep tarballs of minor releases. Once the
     # next minor released is published the previous one becomes unavailable.
     # That is why the preferred version is the latest stable one.
+    version('2.32.0', 'e17956fffce9ea826cf994f8d275e0f5')
     version('2.29.4', '91c561f413316fb665b3bb563f3878d1')
     version('2.29.0', 'db20a4d3c51a2da5657c31ae3de59709', preferred=True)
 


### PR DESCRIPTION
Also capture dependencies of libemos in more detail. In particular, libemos@4.4.7 failed to build without fftw. Variant "libemos+eccodes" depends on #3900.