### PR TITLE
ncl: capture more dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -58,6 +58,11 @@ class Ncl(Package):
     depends_on('netcdf')
     depends_on('cairo')
 
+    # Extra dependencies that may be missing from build system:
+    depends_on('bison', type='build')
+    depends_on('flex', type='build')
+    depends_on('libiconv')
+
     # Also, the manual says that ncl requires zlib, but that comes as a
     # mandatory dependency of libpng, which is a mandatory dependency of cairo.
 

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -60,7 +60,7 @@ class Ncl(Package):
 
     # Extra dependencies that may be missing from build system:
     depends_on('bison', type='build')
-    depends_on('flex')
+    depends_on('flex+lex')
     depends_on('libiconv')
 
     # Also, the manual says that ncl requires zlib, but that comes as a

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -80,6 +80,7 @@ class Ncl(Package):
     # szip support. We introduce this restriction with the following dependency
     # statement.
     depends_on('hdf5+szip')
+    depends_on('szip')
 
     # In Spack, we also do not have an option to compile netcdf without DAP
     # support, so we will tell the ncl configuration script that we have it.

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -60,7 +60,7 @@ class Ncl(Package):
 
     # Extra dependencies that may be missing from build system:
     depends_on('bison', type='build')
-    depends_on('flex', type='build')
+    depends_on('flex')
     depends_on('libiconv')
 
     # Also, the manual says that ncl requires zlib, but that comes as a


### PR DESCRIPTION
Some of the extra dependencies were identified from build instructions. Others were discovered when the build failed on platforms with minimal system packages.