### PR TITLE
Fix for llvm 4.0.0 on centos

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -389,7 +389,8 @@ class Llvm(Package):
                 raise SpackException(
                     'The lldb variant requires the `+clang` variant')
 
-        if spec.satisfies('@4.0.0:'):
+        platform = self.spec.architecture.platform
+        if spec.satisfies('@4.0.0:') and platform == 'linux':
             cmake_args.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
 
         with working_dir('spack-build', create=True):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -389,6 +389,9 @@ class Llvm(Package):
                 raise SpackException(
                     'The lldb variant requires the `+clang` variant')
 
+        if spec.satisfies('@4.0.0:'):
+            cmake_args.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
+
         with working_dir('spack-build', create=True):
             cmake(*cmake_args)
             make()

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -389,8 +389,7 @@ class Llvm(Package):
                 raise SpackException(
                     'The lldb variant requires the `+clang` variant')
 
-        platform = self.spec.architecture.platform
-        if spec.satisfies('@4.0.0:') and platform == 'linux':
+        if spec.satisfies('@4.0.0:') and spec.satisfies('platform=linux'):
             cmake_args.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
 
         with working_dir('spack-build', create=True):


### PR DESCRIPTION
This addresses https://github.com/LLNL/spack/issues/3791

This change may impact macos, I have not tested on macos at all to verify this. However it does let me install the package on centos. This change was made according to http://lists.llvm.org/pipermail/llvm-dev/2014-February/070232.html