### PR TITLE
add Intel mpi package and add MPI wrappers to Intel parallel studio

### DIFF
--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -61,6 +61,7 @@ class Prefix(str):
     def __new__(cls, path):
         s = super(Prefix, cls).__new__(cls, path)
         s.bin     = join_path(s, 'bin')
+        s.bin64   = join_path(s, 'bin64')
         s.sbin    = join_path(s, 'sbin')
         s.etc     = join_path(s, 'etc')
         s.include = join_path(s, 'include')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -64,6 +64,6 @@ class IntelMpi(IntelInstaller):
             raise "No suitable bindir found"
 
         self.spec.mpicc = join_path(bindir, 'mpicc')
-        self.spec.mpicxx = join_path(bindir, 'mpic++')
+        self.spec.mpicxx = join_path(bindir, 'mpicxx')
         self.spec.mpifc = join_path(bindir, 'mpif90')
         self.spec.mpif77 = join_path(bindir, 'mpif77')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -59,7 +59,7 @@ class IntelMpi(IntelInstaller):
         elif os.path.isdir(join_path(self.prefix, 'bin64')):
             bindir = join_path(self.prefix, 'bin64')
         else:
-            raise "No suitable bindir found"
+            raise RuntimeError('No suitable bindir found')
 
         self.spec.mpicc = join_path(bindir, 'mpicc')
         self.spec.mpicxx = join_path(bindir, 'mpicxx')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -35,11 +35,11 @@ class IntelMpi(IntelInstaller):
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
-    version('2017.2', '70e54b33d940a1609ff1d35d3c56e3b3',
+    version('2017.2', '106a4b362c13ddc6978715e50f5f81c58c1a4c70cd2d20a99e94947b7e733b88',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11334/l_mpi_2017.2.174.tgz')
-    version('2017.1', '70e54b33d940a1609ff1d35d3c56e3b3',
+    version('2017.1', '8d30a63674fe05f17b0a908a9f7d54403018bfed2de03c208380b171ab99be82',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11014/l_mpi_2017.1.132.tgz')
-    version('5.1.3', '',
+    version('5.1.3', '544f4173b09609beba711fa3ba35567397ff3b8390e4f870a3307f819117dd9b',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9278/l_mpi_p_5.1.3.223.tgz')
 
     provides('mpi')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -33,11 +33,11 @@ class IntelMpi(IntelInstaller):
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
-    version('2017.2', '106a4b362c13ddc6978715e50f5f81c58c1a4c70cd2d20a99e94947b7e733b88',
+    version('2017.2', 'b6c2e62c3fb9b1558ede72ccf72cf1d6',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11334/l_mpi_2017.2.174.tgz')
-    version('2017.1', '8d30a63674fe05f17b0a908a9f7d54403018bfed2de03c208380b171ab99be82',
+    version('2017.1', 'd5e941ac2bcf7c5576f85f6bcfee4c18',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11014/l_mpi_2017.1.132.tgz')
-    version('5.1.3', '544f4173b09609beba711fa3ba35567397ff3b8390e4f870a3307f819117dd9b',
+    version('5.1.3', '4316e78533a932081b1a86368e890800',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9278/l_mpi_p_5.1.3.223.tgz')
 
     provides('mpi')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -51,6 +51,7 @@ class IntelMpi(IntelInstaller):
         spack_env.set('I_MPI_CXX', spack_cxx)
         spack_env.set('I_MPI_F77', spack_fc)
         spack_env.set('I_MPI_F90', spack_f77)
+        spack_env.set('I_MPI_FC', spack_fc)
 
     def setup_dependent_package(self, module, dep_spec):
         # Check for presence of bin64 or bin directory

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -24,10 +24,8 @@
 ##############################################################################
 from spack import *
 import os
-import re
 
-from spack.pkg.builtin.intel import IntelInstaller, filter_pick, \
-    get_all_components
+from spack.pkg.builtin.intel import IntelInstaller
 
 
 class IntelMpi(IntelInstaller):

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -46,7 +46,6 @@ class IntelMpi(IntelInstaller):
         self.intel_prefix = prefix
         IntelInstaller.install(self, spec, prefix)
 
-
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('I_MPI_CC', spack_cc)
         spack_env.set('I_MPI_CXX', spack_cxx)

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -56,8 +56,8 @@ class IntelMpi(IntelInstaller):
         # Check for presence of bin64 or bin directory
         if os.path.isdir(self.prefix.bin):
             bindir = self.prefix.bin
-        elif os.path.isdir(join_path(self.prefix, 'bin64')):
-            bindir = join_path(self.prefix, 'bin64')
+        elif os.path.isdir(self.prefix.bin64):
+            bindir = self.prefix.bin64
         else:
             raise RuntimeError('No suitable bindir found')
 

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -1,0 +1,69 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import re
+
+from spack.pkg.builtin.intel import IntelInstaller, filter_pick, \
+    get_all_components
+
+
+class IntelMpi(IntelInstaller):
+    """Intel MPI"""
+
+    homepage = "https://software.intel.com/en-us/intel-mpi-library"
+
+    version('2017.2', '70e54b33d940a1609ff1d35d3c56e3b3',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11334/l_mpi_2017.2.174.tgz')
+    version('2017.1', '70e54b33d940a1609ff1d35d3c56e3b3',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11014/l_mpi_2017.1.132.tgz')
+    version('5.1.3', '',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9278/l_mpi_p_5.1.3.223.tgz')
+
+    provides('mpi')
+
+    def install(self, spec, prefix):
+        # FIXME:
+        raise RuntimeError('Install method is not implemented yet')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('I_MPI_CC', spack_cc)
+        spack_env.set('I_MPI_CXX', spack_cxx)
+        spack_env.set('I_MPI_F77', spack_fc)
+        spack_env.set('I_MPI_F90', spack_f77)
+
+    def setup_dependent_package(self, module, dep_spec):
+        # Check for presence of bin64 or bin directory
+        if os.path.isdir(self.prefix.bin):
+            bindir = self.prefix.bin
+        elif os.path.isdir(join_path(self.prefix, 'bin64')):
+            bindir = join_path(self.prefix, 'bin64')
+        else:
+            raise "No suitable bindir found"
+
+        self.spec.mpicc = join_path(bindir, 'mpicc')
+        self.spec.mpicxx = join_path(bindir, 'mpic++')
+        self.spec.mpifc = join_path(bindir, 'mpif90')
+        self.spec.mpif77 = join_path(bindir, 'mpif77')

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -43,8 +43,9 @@ class IntelMpi(IntelInstaller):
     provides('mpi')
 
     def install(self, spec, prefix):
-        # FIXME:
-        raise RuntimeError('Install method is not implemented yet')
+        self.intel_prefix = prefix
+        IntelInstaller.install(self, spec, prefix)
+
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.set('I_MPI_CC', spack_cc)

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -387,3 +387,23 @@ class IntelParallelStudio(IntelInstaller):
             run_env.prepend_path('VTUNE_AMPLIFIER_XE_{0}_DIR'.format(
                                  major_ver),
                                  join_path(self.prefix, 'vtune_amplifier_xe'))
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.set('I_MPI_CC', spack_cc)
+        spack_env.set('I_MPI_CXX', spack_cxx)
+        spack_env.set('I_MPI_F77', spack_fc)
+        spack_env.set('I_MPI_F90', spack_f77)
+
+    def setup_dependent_package(self, module, dep_spec):
+        # Check for presence of bin64 or bin directory
+        if os.path.isdir(self.prefix.bin):
+            bindir = self.prefix.bin
+        elif os.path.isdir(self.prefix.bin64):
+            bindir = self.prefix.bin64
+        else:
+            raise RuntimeError('No suitable bindir found')
+
+        self.spec.mpicc = join_path(bindir, 'mpicc')
+        self.spec.mpicxx = join_path(bindir, 'mpic++')
+        self.spec.mpifc = join_path(bindir, 'mpif90')
+        self.spec.mpif77 = join_path(bindir, 'mpif77')

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -393,6 +393,7 @@ class IntelParallelStudio(IntelInstaller):
         spack_env.set('I_MPI_CXX', spack_cxx)
         spack_env.set('I_MPI_F77', spack_fc)
         spack_env.set('I_MPI_F90', spack_f77)
+        spack_env.set('I_MPI_FC', spack_fc)
 
     def setup_dependent_package(self, module, dep_spec):
         # Check for presence of bin64 or bin directory


### PR DESCRIPTION
as per discussion in https://groups.google.com/forum/#!topic/spack/SDR04CNRoyQ and https://groups.google.com/forum/#!topic/spack/8ep-wfq9AVw

testing 
- [x] `spack install hdf5%gcc+mpi^intel-mpi`
- [x] `spack install hdf5%intel+mpi^intel-mpi`

on CentOS 7 cluster with  (setup with `spack compiler find` after `module load intelmpi`)
```
compilers:
- compiler:
    environment: {}
    extra_rpaths: []
    flags: {}
    modules: []
    operating_system: centos7
    paths:
      cc: /usr/bin/gcc
      cxx: /usr/bin/g++
      f77: /usr/bin/gfortran
      fc: /usr/bin/gfortran
    spec: gcc@4.8.5
- compiler:
    environment: {}
    extra_rpaths: []
    flags: {}
    modules: []
    operating_system: centos7
    paths:
      cc: /apps/intel/ComposerXE2016/compilers_and_libraries_2016.3.210/linux/bin/intel64/icc
      cxx: /apps/intel/ComposerXE2016/compilers_and_libraries_2016.3.210/linux/bin/intel64/icpc
      f77: /apps/intel/ComposerXE2016/compilers_and_libraries_2016.3.210/linux/bin/intel64/ifort
      fc: /apps/intel/ComposerXE2016/compilers_and_libraries_2016.3.210/linux/bin/intel64/ifort
    spec: intel@16.0.3
    target: x86_64
```
and
```
  intel-mpi:
    version: ['5.1.3']
    paths:
      intel-mpi@5.1.3%intel@16.0.3: /apps/intel/mpi/5.1.3.210/
      intel-mpi@5.1.3%gcc@4.8.5: /apps/intel/mpi/5.1.3.210/
    buildable: False
```