### PR TITLE
Add Napoleon extension to support Google docstrings

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -134,6 +134,7 @@ todo_include_todos = True
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.graphviz',
+              'sphinx.ext.napoleon',
               'sphinx.ext.todo',
               'sphinxcontrib.programoutput']
 


### PR DESCRIPTION
With this change, Spack's documentation now supports both Google and Numpy-style docstrings. The Napoleon extension for Sphinx acts as a preprocessor, converting Google/Numpy docstrings to classic rST docstrings. It's a little slower because of this, but it makes docstring documentation much more readable. See http://www.sphinx-doc.org/en/stable/ext/napoleon.html for details.

From now on, we should encourage users to write docstrings in Google-style. If someone wants to be a hero and convert all existing docstrings to Google-style, be my guest.