### PR TITLE
Ensure that tests are optional

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -110,7 +110,8 @@ class Atlas(Package):
                     make('shared_all')
 
             make("install")
-            self.install_test()
+            if self.run_tests:
+                self.install_test()
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/cosmomc/package.py
+++ b/var/spack/repos/builtin/packages/cosmomc/package.py
@@ -108,7 +108,7 @@ class Cosmomc(Package):
         else:
             wantmpi = 'BUILD=NOMPI'
             mpif90 = 'MPIF90C='
-        
+
         # Choose BLAS and LAPACK
         lapack = ("LAPACKL=%s" %
                   (spec['lapack'].libs + spec['blas'].libs).ld_flags)
@@ -158,8 +158,8 @@ class Cosmomc(Package):
             for filename in fnmatch.filter(filenames, '*~'):
                 os.remove(os.path.join(dirpath, filename))
 
-    @on_package_attributes(run_tests=True)
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         prefix = self.prefix
         spec = self.spec

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -138,7 +138,8 @@ class Fftw(AutotoolsPackage):
             with working_dir('quad'):
                 make()
 
-    def check(self, spec, prefix):
+    def check(self):
+        spec = self.spec
         if '+double' in spec:
             with working_dir('double'):
                 make("check")

--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -111,7 +111,8 @@ class Hdf5Blosc(Package):
                         "-L%s" % spec["hdf5"].prefix.lib, "-lhdf5")
                 _install_shlib("libblosc_plugin", ".libs", prefix.lib)
 
-        self.check_install(spec)
+        if self.run_tests:
+            self.check_install(spec)
 
     def check_install(self, spec):
         "Build and run a small program to test the installed HDF5 Blosc plugin"

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -79,11 +79,11 @@ class Hdf5(AutotoolsPackage):
     @property
     def libs(self):
         """Hdf5 can be queried for the following parameters:
-        
+
         - "hl": high-level interface
         - "cxx": C++ APIs
         - "fortran": fortran APIs
-        
+
         :return: list of matching libraries
         """
         query_parameters = self.spec.last_query.extra_parameters
@@ -228,6 +228,7 @@ class Hdf5(AutotoolsPackage):
                 'libtool')
 
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         # Build and run a small program to test the installed HDF5 library
         spec = self.spec

--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -63,7 +63,8 @@ class Nfft(AutotoolsPackage):
             with working_dir('long-double'):
                 make()
 
-    def check(self, spec, prefix):
+    def check(self):
+        spec = self.spec
         if '+double' in spec['fftw']:
             with working_dir('double'):
                 make("check")

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -123,8 +123,8 @@ class Openblas(MakefilePackage):
 
         return self.make_defs + targets
 
-    @on_package_attributes(run_tests=True)
     @run_after('build')
+    @on_package_attributes(run_tests=True)
     def check_build(self):
         make('tests', *self.make_defs)
 
@@ -136,8 +136,8 @@ class Openblas(MakefilePackage):
         ]
         return make_args + self.make_defs
 
-    @on_package_attributes(run_tests=True)
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         spec = self.spec
         # Openblas may pass its own test but still fail to compile Lapack

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -47,7 +47,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # Maintenance releases (recommended)
     version('5.24.1', '765ef511b5b87a164e2531403ee16b3c', preferred=True)
     version('5.22.3', 'aa4f236dc2fc6f88b871436b8d0fda95')
-    
+
     # Misc releases that people need
     version('5.22.2', '5767e2a10dd62a46d7b57f74a90d952b')
 
@@ -98,6 +98,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def build(self, spec, prefix):
         make()
 
+    @run_after('build')
     @on_package_attributes(run_tests=True)
     def test(self):
         make('test')

--- a/var/spack/repos/builtin/packages/pfft/package.py
+++ b/var/spack/repos/builtin/packages/pfft/package.py
@@ -67,7 +67,8 @@ class Pfft(AutotoolsPackage):
             with working_dir('long-double'):
                 make()
 
-    def check(self, spec, prefix):
+    def check(self):
+        spec = self.spec
         if '+double' in spec['fftw']:
             with working_dir('double'):
                 make("check")

--- a/var/spack/repos/builtin/packages/planck-likelihood/package.py
+++ b/var/spack/repos/builtin/packages/planck-likelihood/package.py
@@ -137,8 +137,8 @@ class PlanckLikelihood(Package):
         run_env.set('CLIK_DATA', join_path(prefix, 'share', 'clik'))
         run_env.set('CLIK_PLUGIN', 'rel2015')
 
-    @on_package_attributes(run_tests=True)
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         prefix = self.prefix
         clik_example_C = Executable(join_path(prefix.bin, 'clik_example_C'))

--- a/var/spack/repos/builtin/packages/pnfft/package.py
+++ b/var/spack/repos/builtin/packages/pnfft/package.py
@@ -64,7 +64,8 @@ class Pnfft(AutotoolsPackage):
             with working_dir('long-double'):
                 make()
 
-    def check(self, spec, prefix):
+    def check(self):
+        spec = self.spec
         if '+double' in spec['fftw']:
             with working_dir('double'):
                 make("check")

--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -95,6 +95,7 @@ class Pocl(CMakePackage):
             os.symlink("OpenCL", join_path(self.prefix.include, "CL"))
 
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         # Build and run a small program to test the installed OpenCL library
         spec = self.spec

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -78,6 +78,7 @@ class PyYt(PythonPackage):
                 rockstar_cfg.write(self.spec['rockstar'].prefix)
 
     @run_after('install')
+    @on_package_attributes(run_tests=True)
     def check_install(self):
         # The Python interpreter path can be too long for this
         # yt = Executable(join_path(prefix.bin, "yt"))


### PR DESCRIPTION
Previously, these tests were run regardless of whether or not the user specified `--run-tests`. Tests are rarely stable enough that they will pass on every operating system with every compiler for every version. This PR makes them optional.