### PR TITLE
Remove all test variants

### DIFF
--- a/var/spack/repos/builtin/packages/adol-c/package.py
+++ b/var/spack/repos/builtin/packages/adol-c/package.py
@@ -44,8 +44,7 @@ class AdolC(AutotoolsPackage):
     variant('doc',      default=True,  description='Install documentation')
     variant('openmp',   default=False, description='Enable OpenMP support')
     variant('sparse',   default=False, description='Enable sparse drivers')
-    variant('tests',    default=True,
-            description='Build all included examples as a test case')
+    variant('examples', default=True,  description='Install examples')
 
     # Build dependencies
     depends_on('automake', type='build', when='@develop')
@@ -82,7 +81,7 @@ class AdolC(AutotoolsPackage):
 
         # We can simply use the bundled examples to check
         # whether Adol-C works as expected
-        if '+tests' in spec:
+        if '+examples' in spec:
             configure_args.extend([
                 '--enable-docexa',  # Documented examples
                 '--enable-addexa'  # Additional examples
@@ -110,7 +109,7 @@ class AdolC(AutotoolsPackage):
                          join_path(prefix.share, 'doc'))
 
         # Install examples to {prefix}/share
-        if '+tests' in spec:
+        if '+examples' in spec:
             install_tree(join_path('ADOL-C', 'examples'),
                          join_path(prefix.share, 'examples'))
 

--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -39,9 +39,8 @@ class GitLfs(Package):
     version('1.4.1', git=git_url, tag='v1.4.1')
     version('1.3.1', git=git_url, tag='v1.3.1')
 
-    # TODO: Implement this by following the instructions at this location:
+    # TODO: Add tests by following the instructions at this location:
     # https://github.com/github/git-lfs/blob/master/CONTRIBUTING.md#building
-    # variant('test', default=True, description='Build and run tests as part of the build.')  # NOQA: E501
 
     depends_on('go@1.5:', type='build')
     depends_on('git@1.8.2:', type='run')

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -49,8 +49,6 @@ class GoBootstrap(Package):
     version('1.4-bootstrap-20161024', '76e42c8152e8560ded880a6d1d1f53cb',
             url='https://storage.googleapis.com/golang/go1.4-bootstrap-20161024.tar.gz')
 
-    variant('test', default=True, description='Build and run tests as part of the build.')
-
     provides('golang@:1.4-bootstrap-20161024')
 
     depends_on('git', type=('build', 'link', 'run'))
@@ -75,7 +73,7 @@ class GoBootstrap(Package):
         env['CGO_ENABLED'] = '0'
         bash = which('bash')
         with working_dir('src'):
-            bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
+            bash('{0}.bash'.format('all' if self.run_tests else 'make'))
 
         try:
             os.makedirs(prefix)

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -65,7 +65,7 @@ class GoBootstrap(Package):
             r'# \1\2\3',
         )
 
-    @when('@1.5.0:')
+    @when('@1.5.0:')  # noqa: F811
     def patch(self):
         pass
 

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -62,8 +62,6 @@ class Go(Package):
     version('1.7.4', '49c1076428a5d3b5ad7ac65233fcca2f')
     version('1.6.4', 'b023240be707b34059d2c114d3465c92')
 
-    variant('test', default=True, description='Build and run tests as part of the build.')
-
     provides('golang')
 
     depends_on('git', type=('build', 'link', 'run'))
@@ -93,7 +91,7 @@ class Go(Package):
     def install(self, spec, prefix):
         bash = which('bash')
         with working_dir('src'):
-            bash('{0}.bash'.format('all' if '+test' in spec else 'make'))
+            bash('{0}.bash'.format('all' if self.run_tests else 'make'))
 
         try:
             os.makedirs(prefix)

--- a/var/spack/repos/builtin/packages/pagmo/package.py
+++ b/var/spack/repos/builtin/packages/pagmo/package.py
@@ -49,7 +49,6 @@ class Pagmo(CMakePackage):
     variant('mpi',      default=True,  description='Enable support for MPI')
     variant('nlopt',    default=False, description='Enable support for NLopt minimisers')
     variant('snopt',    default=False, description='Enable support for SNOPT minimiser')
-    variant('tests',    default=False, description='Build test set')
     variant('worhp',    default=False, description='Enable support for WORHP minimiser')
     variant('headers',  default=True,  description='Installs the header files')
     variant('blas',     default=True,  description='Enable support for BLAS')
@@ -60,7 +59,7 @@ class Pagmo(CMakePackage):
 
     extends('python', when='+python')
 
-    # Concretization in Python is currently broken
+    # Concretization in Spack is currently broken
     # depends_on('boost+system+serialization+thread')
     # depends_on('boost+python',    when='+python')
     # depends_on('boost+date_time', when='+gtop')
@@ -103,9 +102,9 @@ class Pagmo(CMakePackage):
             '-DENABLE_MPI={0}'.format(self.variant_to_bool('+mpi')),
             '-DENABLE_NLOPT={0}'.format(self.variant_to_bool('+nlopt')),
             '-DENABLE_SNOPT={0}'.format(self.variant_to_bool('+snopt')),
-            '-DENABLE_TESTS={0}'.format(self.variant_to_bool('+tests')),
             '-DENABLE_WORHP={0}'.format(self.variant_to_bool('+worhp')),
             '-DINSTALL_HEADERS={0}'.format(self.variant_to_bool('+headers')),
+            '-DENABLE_TESTS={0}'.format('ON' if self.run_tests else 'OFF'),
         ]
 
         if '+python' in spec:

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -50,7 +50,6 @@ class Paradiseo(Package):
     variant('edo',      default=True,
             description='Compile with (Experimental) EDO module')
 
-    # variant('tests', default=False, description='Compile with build tests')
     # variant('doc', default=False, description='Compile with documentation')
     variant('debug',    default=False,
             description='Builds a debug version of the libraries')
@@ -87,7 +86,7 @@ class Paradiseo(Package):
             '-DSMP:BOOL=%s' % ('TRUE' if '+smp' in spec else 'FALSE'),
             '-DEDO:BOOL=%s' % ('TRUE' if '+edo' in spec else 'FALSE'),
             '-DENABLE_CMAKE_TESTING:BOOL=%s' % (
-                'TRUE' if '+tests' in spec else 'FALSE'),
+                'TRUE' if self.run_tests else 'FALSE'),
             '-DENABLE_OPENMP:BOOL=%s' % (
                 'TRUE' if '+openmp' in spec else 'FALSE'),
             '-DENABLE_GNUPLOT:BOOL=%s' % (
@@ -100,6 +99,6 @@ class Paradiseo(Package):
 
             # Build, test and install
             make("VERBOSE=1")
-            if '+tests' in spec:
+            if self.run_tests:
                 make("test")
             make("install")

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -35,10 +35,11 @@ class PyPatsy(PythonPackage):
     version('0.4.1', '9445f29e3426d1ed30d683a1e1453f84')
 
     variant('splines', description="Offers spline related functions")
-    variant('tests', description="allows nose tests")
 
     depends_on('py-setuptools',  type='build')
     depends_on('py-numpy',       type=('build', 'run'))
     depends_on('py-scipy',       type=('build', 'run'), when="+splines")
-    depends_on('py-nose',        type=('build', 'run'), when="+tests")
     depends_on('py-six',         type=('build', 'run'))
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nose', type='test')

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -33,7 +33,6 @@ class PyStatsmodels(PythonPackage):
 
     version('0.8.0', 'b3e5911cc9b00b71228d5d39a880bba0')
 
-    variant('tests',    default=False, description='With nose tests')
     variant('plotting', default=False, description='With matplotlib')
 
     # according to http://www.statsmodels.org/dev/install.html earlier versions
@@ -44,5 +43,7 @@ class PyStatsmodels(PythonPackage):
     depends_on('py-pandas@0.12:',      type=('build', 'run'))
     depends_on('py-patsy@0.2.1:',      type=('build', 'run'))
     depends_on('py-cython@0.24:',      type=('build', 'run'))
-    depends_on('py-nose',              type='run', when='+tests')
     depends_on('py-matplotlib@1.3:',   type='run', when='+plotting')
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nose', type='test')


### PR DESCRIPTION
Fixes #3796 

We've gone over this a few times, but I'll say it again. Spack packages should not contain a `test` variant. The problem with this is that the hash/spec of an installed package should not change depending on whether or not `make check` was run. Adding a variant means that if you do something like:
```
$ spack install a+test
$ spack install b
```
you'll find `b` reinstalling `a~test`. Note that `a+test` and `a~test` _should_ be the same thing (in theory), so we don't want to reinstall it. We decided to add a `--run-tests` flag to `spack install` to control whether or not tests are run. This was decided on in #169 and implemented by @davydden in #1169. Note that we still need to add a `test` deptype, as proposed in #1279.