### PR TITLE
Do not require license for new Intel libraries

### DIFF
--- a/var/spack/repos/builtin/packages/intel-daal/package.py
+++ b/var/spack/repos/builtin/packages/intel-daal/package.py
@@ -37,12 +37,14 @@ class IntelDaal(IntelInstaller):
 
     homepage = "https://software.intel.com/en-us/daal"
 
+    version('2017.2.174', 'f067d5d7b0f70914fba1f78da0361065',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11308/l_daal_2017.2.174.tgz")
     version('2017.0.098', 'b4eb234de12beff4a5cba4b81ea60673',
-            url="file://%s/l_daal_2017.0.098.tgz" % os.getcwd())
-    version('2016.2.181', 'aad2aa70e5599ebfe6f85b29d8719d46',
-            url="file://%s/l_daal_2016.2.181.tgz" % os.getcwd())
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9664/l_daal_2017.0.098.tgz")
     version('2016.3.210', 'ad747c0dd97dace4cad03cf2266cad28',
-            url="file://%s/l_daal_2016.3.210.tgz" % os.getcwd())
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9099/l_daal_2016.3.210.tgz")
+    version('2016.2.181', 'aad2aa70e5599ebfe6f85b29d8719d46',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8687/l_daal_2016.2.181.tgz")
 
     provides('daal')
 

--- a/var/spack/repos/builtin/packages/intel-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-ipp/package.py
@@ -37,10 +37,12 @@ class IntelIpp(IntelInstaller):
 
     homepage = "https://software.intel.com/en-us/intel-ipp"
 
+    version('2017.2.174', '8ad7753ee30c5176c4931070334144bc',
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11307/l_ipp_2017.2.174.tgz")
     version('2017.0.098', 'e7be757ebe351d9f9beed7efdc7b7118',
-            url="file://%s/l_ipp_2017.0.098.tgz" % os.getcwd())
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9663/l_ipp_2017.0.098.tgz")
     version('9.0.3.210', '0e1520dd3de7f811a6ef6ebc7aa429a3',
-            url="file://%s/l_ipp_9.0.3.210.tgz" % os.getcwd())
+            url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9067/l_ipp_9.0.3.210.tgz")
 
     provides('ipp')
 

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -88,6 +88,9 @@ CONTINUE_WITH_OPTIONAL_ERROR=yes
 COMPONENTS=%s
 """ % (self.intel_prefix, self.intel_prefix, self.intel_components))
 
+        # The Intel libraries are provided without requiring a license as of
+        # version 2017.2. Trying to specify the license will fail. See
+        # https://software.intel.com/en-us/articles/free-mkl
         if not (spec.satisfies("intel-mkl@2017.2:") or
                 spec.satisfies("intel-daal@2017.2:") or
                 spec.satisfies("intel-ipp@2017.2:")):

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -84,13 +84,19 @@ PSET_MODE=install
 CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes
 PSET_INSTALL_DIR=%s
 NONRPM_DB_DIR=%s
+CONTINUE_WITH_OPTIONAL_ERROR=yes
+COMPONENTS=%s
+""" % (self.intel_prefix, self.intel_prefix, self.intel_components))
+
+        if not (spec.satisfies("intel-mkl@2017.2:") or
+                spec.satisfies("intel-daal@2017.2:") or
+                spec.satisfies("intel-ipp@2017.2:")):
+            with open(silent_config_filename, 'a') as f:
+                f.write("""
 ACTIVATION_LICENSE_FILE=%s
 ACTIVATION_TYPE=license_file
 PHONEHOME_SEND_USAGE_DATA=no
-CONTINUE_WITH_OPTIONAL_ERROR=yes
-COMPONENTS=%s
-""" % (self.intel_prefix, self.intel_prefix, self.global_license_file,
-                self.intel_components))
+""" % (self.global_license_file))
 
         install_script = Executable("./install.sh")
         install_script('--silent', silent_config_filename)

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -56,12 +56,22 @@ class IntelInstaller(Package):
 
     homepage = "https://software.intel.com/en-us"
     intel_components = "ALL"
-    license_required = True
     license_comment = '#'
     license_files = ['Licenses/license.lic']
     license_vars = ['INTEL_LICENSE_FILE']
     license_url = \
         'https://software.intel.com/en-us/articles/intel-license-manager-faq'
+
+    @property
+    def license_required(self):
+        # The Intel libraries are provided without requiring a license as of
+        # version 2017.2. Trying to specify the license will fail. See
+        # https://software.intel.com/en-us/articles/free-mkl
+        if (self.spec.satisfies("intel-mkl@2017.2:") or
+            self.spec.satisfies("intel-daal@2017.2:") or
+            self.spec.satisfies("intel-ipp@2017.2:")):
+            return False
+        return True
 
     @property
     def global_license_file(self):


### PR DESCRIPTION
For #3925. The Intel libraries are now provided for free (https://software.intel.com/en-us/articles/free-mkl). Also updated ipp and daal URLs to download files instead of use local file URLs.