### PR TITLE
Do not depend on py-backports for 3.3+ when >3.3.

### DIFF
--- a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
@@ -27,7 +27,21 @@ from spack import *
 
 class PyBackportsShutilGetTerminalSize(PythonPackage):
     """A backport of the get_terminal_size function
-    from Python 3.3's shutil."""
+    from Python 3.3's shutil.
+
+    .. warning::
+
+       If you depend on this package, you *must* specify ``when`` and the
+       ``python`` versions.  Example
+
+       .. code-block:: py
+
+          depends_on('py-backports-shutil-get-terminal-size',
+                     when="^python@3.2.999", type=('build', 'run'))
+
+       Otherwise, for ``python@3.3:``, the dependency cannot be met.
+       The module should not be a dependency for python 3.3+.
+    """
 
     homepage = "https://pypi.python.org/pypi/backports.shutil_get_terminal_size"
     url      = "https://pypi.io/packages/source/b/backports.shutil_get_terminal_size/backports.shutil_get_terminal_size-1.0.0.tar.gz"
@@ -37,4 +51,4 @@ class PyBackportsShutilGetTerminalSize(PythonPackage):
     # newer setuptools version mess with "namespace" packages in an
     # incompatible way cf. https://github.com/pypa/setuptools/issues/900
     depends_on('py-setuptools@:30.999.999', type='build')
-    depends_on('python@:3.2.999')
+    depends_on('python@2.6.1:3.2.999')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -44,7 +44,8 @@ class PyIpython(PythonPackage):
     # See https://github.com/LLNL/spack/issues/2793
     # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2.999")  # noqa
     # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3.999")
-    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
+    depends_on('py-backports-shutil-get-terminal-size', when="^python@3.2.999",
+                                                type=('build', 'run'))
     depends_on('py-pathlib2',                   type=('build', 'run'))
 
     depends_on('py-pygments',                   type=('build', 'run'))


### PR DESCRIPTION
Impossible dependency to meet when `python@3.6.0` for example.

Though to be honest, I feel like there is a better way to do this.  I tried to just do

```diff
diff --git a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
index 3447666..ff01086 100644
--- a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
@@ -37,4 +37,4 @@ class PyBackportsShutilGetTerminalSize(PythonPackage):
     # newer setuptools version mess with "namespace" packages in an
     # incompatible way cf. https://github.com/pypa/setuptools/issues/900
     depends_on('py-setuptools@:30.999.999', type='build')
-    depends_on('python@:3.2.999')
+    depends_on('python@2.6.1:3.2.999', when="^python@2.6.1:3.2.999")
```

But that doesn't work:

```console
$ spack spec py-ipython ^python@3.6.0
Input spec
--------------------------------
py-ipython
    ^python@3.6.0

Normalized
--------------------------------
==> Error: Invalid spec: 'python@3.6.0^bzip2^ncurses^openssl^readline^sqlite^zlib'. Package python requires version :3.3.999, but spec asked for 3.6.0
```