### PR TITLE
Hack to fix python dependency ranges

### DIFF
--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -46,7 +46,7 @@ class Cmor(AutotoolsPackage):
     depends_on('hdf5@:1.8')
 
     extends('python', when='+python')
-    depends_on('python@:2.7', when='+python')
+    depends_on('python@:2.8', when='+python')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
 
     @run_before('configure')

--- a/var/spack/repos/builtin/packages/cosmomc/package.py
+++ b/var/spack/repos/builtin/packages/cosmomc/package.py
@@ -56,7 +56,7 @@ class Cosmomc(Package):
 
     depends_on('mpi', when='+mpi')
     depends_on('planck-likelihood', when='+planck')
-    depends_on('python @2.7:2.999,3.4:')
+    depends_on('python@2.7:2.8,3.4:')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/espressopp/package.py
+++ b/var/spack/repos/builtin/packages/espressopp/package.py
@@ -48,7 +48,7 @@ class Espressopp(CMakePackage):
     depends_on("mpi")
     depends_on("boost+serialization+filesystem+system+python+mpi", when='@1.9.4:')
     extends("python")
-    depends_on("python@2:2.7.13")
+    depends_on("python@2:2.8")
     depends_on("py-mpi4py@2.0.0:", when='@1.9.4', type=('build', 'run'))
     depends_on("py-mpi4py@1.3.1:", when='@1.9.4.1:', type=('build', 'run'))
     depends_on("fftw")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -75,7 +75,7 @@ class Julia(Package):
     depends_on("git", when='@:0.4')
     depends_on("git", when='@release-0.4')
     depends_on("openssl")
-    depends_on("python @2.7:2.999")
+    depends_on("python@2.7:2.8")
 
     # Run-time dependencies:
     # depends_on("arpack")

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -47,7 +47,7 @@ class NodeJs(Package):
 
     depends_on('libtool', type='build', when=sys.platform != 'darwin')
     depends_on('pkg-config', type='build')
-    depends_on('python@2.7:2.7.999', type='build')
+    depends_on('python@2.7:2.8', type='build')
     # depends_on('bash-completion', when="+bash-completion")
     depends_on('icu4c', when='+icu4c')
     depends_on('openssl', when='+openssl')
@@ -63,10 +63,10 @@ class NodeJs(Package):
         # On OSX, the system libtool must be used
         # So, we ensure that this is the case by...
         if sys.platform == 'darwin':
-            process_pipe = subprocess.Popen(["which", "libtool"], 
+            process_pipe = subprocess.Popen(["which", "libtool"],
                                             stdout=subprocess.PIPE)
             result_which = process_pipe.communicate()[0]
-            process_pipe = subprocess.Popen(["whereis", "libtool"], 
+            process_pipe = subprocess.Popen(["whereis", "libtool"],
                                             stdout=subprocess.PIPE)
             result_whereis = process_pipe.communicate()[0]
             assert result_which == result_whereis, (

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -47,7 +47,7 @@ class Paraview(CMakePackage):
     variant('qt', default=False, description='Enable Qt (gui) support')
     variant('opengl2', default=True, description='Enable OpenGL2 backend')
 
-    depends_on('python@2:2.7', when='+python')
+    depends_on('python@2:2.8', when='+python')
     depends_on('py-numpy', when='+python', type='run')
     depends_on('py-matplotlib', when='+python', type='run')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -92,7 +92,7 @@ class Petsc(Package):
     depends_on('mpi', when='+mpi')
 
     # Build dependencies
-    depends_on('python @2.6:2.7', type='build')
+    depends_on('python@2.6:2.8', type='build')
 
     # Other dependencies
     depends_on('boost', when='@:3.5+boost')

--- a/var/spack/repos/builtin/packages/py-autopep8/package.py
+++ b/var/spack/repos/builtin/packages/py-autopep8/package.py
@@ -36,7 +36,7 @@ class PyAutopep8(PythonPackage):
     version('1.2.2', '3d97f9c89d14a0975bffd32a2c61c36c')
 
     extends('python', ignore='bin/pep8')
-    depends_on('python@2.6:2.7,3.2:')
+    depends_on('python@2.6:2.8,3.2:')
 
     depends_on('py-pycodestyle@1.5.7:1.7.0', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
+++ b/var/spack/repos/builtin/packages/py-backports-shutil-get-terminal-size/package.py
@@ -37,4 +37,4 @@ class PyBackportsShutilGetTerminalSize(PythonPackage):
     # newer setuptools version mess with "namespace" packages in an
     # incompatible way cf. https://github.com/pypa/setuptools/issues/900
     depends_on('py-setuptools@:30.999.999', type='build')
-    depends_on('python@:3.2.999')
+    depends_on('python@:3.2')

--- a/var/spack/repos/builtin/packages/py-bleach/package.py
+++ b/var/spack/repos/builtin/packages/py-bleach/package.py
@@ -33,7 +33,7 @@ class PyBleach(PythonPackage):
 
     version('1.5.0', 'b663300efdf421b3b727b19d7be9c7e7')
 
-    depends_on('python@2.6:2.7,3.2:3.5')
+    depends_on('python@2.6:2.8,3.2:3.5')
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-html5lib@0.999,0.999999:0.9999999', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-configparser/package.py
+++ b/var/spack/repos/builtin/packages/py-configparser/package.py
@@ -35,7 +35,7 @@ class PyConfigparser(PythonPackage):
     version('3.5.0', 'cfdd915a5b7a6c09917a64a573140538',
             url="https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/configparser-3.5.0.tar.gz")
 
-    depends_on('python@2.6:2.7,3.4:')
+    depends_on('python@2.6:2.8,3.4:')
 
     # This dependency breaks concretization
     # See https://github.com/LLNL/spack/issues/2793

--- a/var/spack/repos/builtin/packages/py-dill/package.py
+++ b/var/spack/repos/builtin/packages/py-dill/package.py
@@ -39,6 +39,6 @@ class PyDill(PythonPackage):
     version('0.2.1', 'b2354a5717da6228acae33cb13bc407b')
     version('0.2', '759002d9b71605cde2a7a052dad96b5d')
 
-    depends_on('python@2.5:2.999,3.1:')
+    depends_on('python@2.5:2.8,3.1:')
 
     depends_on('py-setuptools@0.6:', type='build')

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -33,7 +33,7 @@ class PyEasybuildFramework(PythonPackage):
 
     version('3.1.2', '283bc5f6bdcb90016b32986d52fd04a8')
 
-    depends_on('python@2.6:2.9', type='run')
+    depends_on('python@2.6:2.8', type='run')
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-vsc-base@2.5.4:', when='@2.9:', type='run')
     depends_on('py-vsc-install', type='run')  # only required for tests (python -O -m test.framework.suite)

--- a/var/spack/repos/builtin/packages/py-enum34/package.py
+++ b/var/spack/repos/builtin/packages/py-enum34/package.py
@@ -37,5 +37,5 @@ class PyEnum34(PythonPackage):
 
     # This dependency breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
-    # depends_on('py-ordereddict', when='^python@:2.6.999', type=('build', 'run'))  # noqa
+    # depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-flake8/package.py
+++ b/var/spack/repos/builtin/packages/py-flake8/package.py
@@ -59,8 +59,8 @@ class PyFlake8(PythonPackage):
 
     # These dependencies breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
-    # depends_on('py-configparser', when='^python@:3.3.999', type=('build', 'run'))  # noqa
-    # depends_on('py-enum34', when='^python@:3.1.999', type=('build', 'run'))
+    # depends_on('py-configparser', when='^python@:3.3', type=('build', 'run'))
+    # depends_on('py-enum34', when='^python@:3.1', type=('build', 'run'))
     depends_on('py-configparser', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -33,5 +33,5 @@ class PyHtml5lib(PythonPackage):
 
     version('0.9999999', 'ef43cb05e9e799f25d65d1135838a96f')
 
-    depends_on('python@2.6:2.7,3.2:3.4')
+    depends_on('python@2.6:2.8,3.2:3.4')
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipdb/package.py
+++ b/var/spack/repos/builtin/packages/py-ipdb/package.py
@@ -39,7 +39,7 @@ class PyIpdb(PythonPackage):
     # this the original packager does not know what they are. See the 3rd party
     # section on ipdb's GitHub:
     #     https://github.com/gotcha/ipdb#third-party-support
-    depends_on('python@2.6:2.7,3.2:')
+    depends_on('python@2.6:2.8,3.2:')
 
     # Dependencies gathered from:
     #     https://github.com/gotcha/ipdb/blob/master/setup.py

--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -42,7 +42,7 @@ class PyIpykernel(PythonPackage):
     version('4.1.1', '51376850c46fb006e1f8d1cd353507c5')
     version('4.1.0', '638a43e4f8a15872f749090c3f0827b6')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-traitlets@4.1.0:', type=('build', 'run'))
     depends_on('py-tornado@4.0:', type=('build', 'run'))
     depends_on('py-ipython@4.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython-genutils/package.py
@@ -33,4 +33,4 @@ class PyIpythonGenutils(PythonPackage):
 
     version('0.1.0', '9a8afbe0978adbcbfcb3b35b2d015a56')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -41,8 +41,8 @@ class PyIpython(PythonPackage):
 
     # These dependencies breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
-    # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2.999")  # noqa
-    # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3.999")
+    # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
+    # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
     depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
     depends_on('py-pathlib2',                   type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-ipywidgets/package.py
+++ b/var/spack/repos/builtin/packages/py-ipywidgets/package.py
@@ -33,7 +33,7 @@ class PyIpywidgets(PythonPackage):
 
     version('5.2.2', '112f3daa4aa0f42f8dda831cea3649c8')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-ipython@4.0.0:', type=('build', 'run'))
     depends_on('py-ipykernel@4.2.2:', type=('build', 'run'))
     depends_on('py-traitlets@4.2.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupyter-client/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-client/package.py
@@ -40,7 +40,7 @@ class PyJupyterClient(PythonPackage):
     version('4.1.0', 'cf42048b889c8434fbb5813a9eec1d34')
     version('4.0.0', '00fa63c67cb3adf359d09dc4d803aff5')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-traitlets', type=('build', 'run'))
     depends_on('py-jupyter-core', type=('build', 'run'))
     depends_on('py-zmq@13:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupyter-console/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-console/package.py
@@ -37,7 +37,7 @@ class PyJupyterConsole(PythonPackage):
     version('4.0.3', '0e928ea261e7f8154698cf69ed4f2459')
     version('4.0.2', 'f2e174938c91136549b908bd39fa5d59')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-jupyter-client', type=('build', 'run'))
     depends_on('py-ipython', type=('build', 'run'))
     depends_on('py-ipykernel', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupyter-core/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-core/package.py
@@ -42,5 +42,5 @@ class PyJupyterCore(PythonPackage):
     version('4.0.1', 'f849136b2badaaba2a8a3b397bf04639')
     version('4.0',   'b6b37cb4f40bd0fcd20433cb2cc7a4c1')
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-traitlets', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupyter-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-notebook/package.py
@@ -44,7 +44,7 @@ class PyJupyterNotebook(PythonPackage):
 
     variant('terminal', default=False, description="Enable terminal functionality")
 
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('npm', type='build')
     depends_on('node-js', type=('build', 'run'))
     depends_on('py-jinja2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -37,7 +37,7 @@ class PyNbconvert(PythonPackage):
     version('4.0.0', '9661620b1e10a7b46f314588d2d0932f')
 
     depends_on('py-pycurl', type='build')
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-mistune', type=('build', 'run'))
     depends_on('py-jinja2', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pathlib2/package.py
+++ b/var/spack/repos/builtin/packages/py-pathlib2/package.py
@@ -34,4 +34,4 @@ class PyPathlib2(PythonPackage):
     version('2.1.0', '38e4f58b4d69dfcb9edb49a54a8b28d2')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@:3.3.999')
+    depends_on('python@:3.3')

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -33,7 +33,7 @@ class PyPip(PythonPackage):
 
     version('9.0.1', '35f01da33009719497f01a4ba69d63c9')
 
-    depends_on('python@2.6:2.7,3.3:')
+    depends_on('python@2.6:2.8,3.3:')
 
     # Most Python packages only require setuptools as a build dependency.
     # However, pip requires setuptools during runtime as well.

--- a/var/spack/repos/builtin/packages/py-readme-renderer/package.py
+++ b/var/spack/repos/builtin/packages/py-readme-renderer/package.py
@@ -34,7 +34,7 @@ class PyReadmeRenderer(PythonPackage):
 
     version('16.0', '70321cea986956bcf2deef9981569f39')
 
-    depends_on('python@2.6:2.7,3.2:3.3')
+    depends_on('python@2.6:2.8,3.2:3.3')
     depends_on('py-setuptools', type='build')
     depends_on('py-bleach', type=('build', 'run'))
     depends_on('py-docutils@0.13.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-restview/package.py
+++ b/var/spack/repos/builtin/packages/py-restview/package.py
@@ -33,8 +33,8 @@ class PyRestview(PythonPackage):
 
     version('2.6.1', 'ac8b70e15b8f1732d1733d674813666b')
 
+    depends_on('python@2.7:2.8,3.3:3.5')
     depends_on('py-setuptools', type='build')
-    depends_on('python@2.7.0:2.7.999,3.3:3.5')
     depends_on('py-docutils@0.13.1:', type=('build', 'run'))
     depends_on('py-readme-renderer', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -36,7 +36,7 @@ class PyScikitLearn(PythonPackage):
     version('0.16.1', '363ddda501e3b6b61726aa40b8dbdb7e')
     version('0.17.1', 'a2f8b877e6d99b1ed737144f5a478dfc')
 
-    depends_on('python@2.6:2.7,3.3:')
+    depends_on('python@2.6:2.8,3.3:')
     depends_on('py-setuptools',   type='build')
     depends_on('py-numpy@1.6.1:', type=('build', 'run'))
     depends_on('py-scipy@0.9:',   type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -47,9 +47,7 @@ class PySetuptools(PythonPackage):
     version('16.0',   '0ace0b96233516fc5f7c857d086aa3ad')
     version('11.3.1', '01f69212e019a2420c1693fb43593930')
 
-    # FIXME: when we use 2.6:2.7, spack spec llvm tries to install non-existing
-    # python@2.7 instead of python@2.7.13
-    depends_on('python@2.6:2.7.99,3.3:')
+    depends_on('python@2.6:2.8,3.3:')
 
     # Previously, setuptools vendored all of its dependencies to allow
     # easy bootstrapping. As of version 34.0.0, this is no longer done

--- a/var/spack/repos/builtin/packages/py-singledispatch/package.py
+++ b/var/spack/repos/builtin/packages/py-singledispatch/package.py
@@ -38,4 +38,4 @@ class PySingledispatch(PythonPackage):
 
     # This dependency breaks concretization
     # See https://github.com/LLNL/spack/issues/2793
-    # depends_on('py-ordereddict', when="^python@:2.6.999", type=('build', 'run'))  # noqa
+    # depends_on('py-ordereddict', when="^python@:2.6", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-symfit/package.py
+++ b/var/spack/repos/builtin/packages/py-symfit/package.py
@@ -38,4 +38,4 @@ class PySymfit(PythonPackage):
     depends_on('py-numpy',            type='run')
     depends_on('py-scipy',            type='run')
     depends_on('py-sympy',            type='run')
-    depends_on('py-funcsigs',         type='run', when='^python@:2.7.999')
+    depends_on('py-funcsigs',         type='run', when='^python@:2.8')

--- a/var/spack/repos/builtin/packages/py-tappy/package.py
+++ b/var/spack/repos/builtin/packages/py-tappy/package.py
@@ -35,7 +35,7 @@ class PyTappy(PythonPackage):
 
     extends('python', ignore='bin/nosetests|bin/pygmentize')
 
-    depends_on('python@2.6:2.7,3.2:3.4')
+    depends_on('python@2.6:2.8,3.2:3.4')
     depends_on('py-nose', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-widgetsnbextension/package.py
+++ b/var/spack/repos/builtin/packages/py-widgetsnbextension/package.py
@@ -34,5 +34,5 @@ class PyWidgetsnbextension(PythonPackage):
     version('1.2.6', '0aa4e152c9ba2d704389dc2453f448c7')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@2.7:2.7.999,3.3:')
+    depends_on('python@2.7:2.8,3.3:')
     depends_on('py-jupyter-notebook@4.2.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xmlrunner/package.py
+++ b/var/spack/repos/builtin/packages/py-xmlrunner/package.py
@@ -34,4 +34,4 @@ class PyXmlrunner(PythonPackage):
     version('1.7.7', '7b0b152ed2d278516aedbc0cac22dfb3')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-unittest2', type=('build', 'run'), when='^python@:2.7')
+    depends_on('py-unittest2', type=('build', 'run'), when='^python@:2.8')

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -69,7 +69,7 @@ class PyYt(PythonPackage):
     depends_on("py-setuptools", type=('build', 'run'))
     depends_on("py-sympy", type=('build', 'run'))
     depends_on("rockstar@yt", type=('build', 'run'), when="+rockstar")
-    depends_on("python @2.7:2.999,3.4:")
+    depends_on("python@2.7:2.8,3.4:")
 
     @run_before('install')
     def prep_yt(self):

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -44,7 +44,7 @@ class ShinyServer(CMakePackage):
 
     version('1.5.3.838', '96f20fdcdd94c9e9bb851baccb82b97f')
 
-    depends_on('python@:2.9.99')  # docs say: "Really.  3.x will not work"
+    depends_on('python@:2.8')  # docs say: "Really.  3.x will not work"
     depends_on('cmake@2.8.10:')
     depends_on('git')
     depends_on('r+X')

--- a/var/spack/repos/builtin/packages/simulationio/package.py
+++ b/var/spack/repos/builtin/packages/simulationio/package.py
@@ -45,7 +45,7 @@ class Simulationio(CMakePackage):
     depends_on('julia', when='+julia', type=('build', 'run'))
     depends_on('py-h5py', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python', type=('build', 'run'))
-    depends_on('python@2.7.0:2.999.999', when='+python', type=('build', 'run'))
+    depends_on('python@2.7:2.8', when='+python', type=('build', 'run'))
     depends_on('swig', type='build')
 
     extends('python')

--- a/var/spack/repos/builtin/packages/simulationio/package.py
+++ b/var/spack/repos/builtin/packages/simulationio/package.py
@@ -29,7 +29,7 @@ from spack import *
 class Simulationio(CMakePackage):
     """SimulationIO: Efficient and convenient I/O for large PDE simulations"""
     homepage = "https://github.com/eschnett/SimulationIO"
-    url= "https://github.com/eschnett/SimulationIO/archive/version/0.1.0.tar.gz"
+    url      = "https://github.com/eschnett/SimulationIO/archive/version/0.1.0.tar.gz"
 
     version('1.0.0', '5cbf1d0084eb436d861ffcdd297eaa08')
     version('0.1.0', '00f7dabc08ed1ab77858785ce0809f50')

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -42,7 +42,7 @@ class Slepc(Package):
     variant('arpack', default=True, description='Enables Arpack wrappers')
 
     # NOTE: make sure PETSc and SLEPc use the same python.
-    depends_on('python@2.6:2.7', type='build')
+    depends_on('python@2.6:2.8', type='build')
     depends_on('petsc@3.7:', when='@3.7.1:')
     depends_on('petsc@3.6.3:3.6.4', when='@3.6.2:3.6.3')
     depends_on('arpack-ng~mpi', when='+arpack^petsc~mpi~int64')


### PR DESCRIPTION
@svenevs Can you see if this fixes the bug you uncovered in https://github.com/LLNL/spack/pull/2548#issuecomment-296227466?

@tgamblin I know I've seen this bug before but I haven't quite put my finger on it yet. It seems like if one package says:
```python
depends_on('python@:2.7.999')
```
and another says:
```python
depends_on('python@2.7:')
```
for some reason, concretization dies. Hopefully this will be fixed in the new concretizer.