### PR TITLE
Coverage for multiple Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_script:
 script: share/spack/qa/run-$TEST_SUITE-tests
 
 after_success:
-  - if [[ $TEST_SUITE == unit && $TRAVIS_PYTHON_VERSION == 2.7 && $TRAVIS_OS_NAME == "linux" ]]; then codecov --env PY_VERSION; fi
+  - codecov --env PY_VERSION
 
 #=============================================================================
 # Notifications

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -42,7 +42,9 @@ spack compilers
 spack config get compilers
 
 # Run unit tests with code coverage
-if [[ "$TRAVIS_PYTHON_VERSION" == 2.7 ]]; then
+py_ver=$(python -c 'import platform; print(platform.python_version())')
+if [[ "$py_ver" == 2.7* || "$py_ver" == 3.6* ]];
+then
     coverage run bin/spack install -v libdwarf
     coverage run bin/spack test "$@" && coverage combine
 else


### PR DESCRIPTION
Trying to update the test scripts to get more coverage data.

Codecov aggregates results from the different Travis build jobs, so this submits coverage results from the Mac and Linux 2.7 builds, as well as the Linux 3.6 build.