### PR TITLE
Find more versions from GitHub

### DIFF
--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -71,7 +71,7 @@ def find_list_url(url):
 
     url_types = [
         # e.g. https://github.com/llnl/callpath/archive/v1.0.1.tar.gz
-        (r'(.*github\.com/[^/]+/[^/]+)/archive/',
+        (r'(.*github\.com/[^/]+/[^/]+)',
          lambda m: m.group(1) + '/releases')]
 
     for pattern, fun in url_types:


### PR DESCRIPTION
This PR allows us to find significantly more versions of software available on GitHub. The way that it works is essentially by adding the `releases` page of a GitHub repository as an additional `list_url`. Previously, we would only do this when the URL pointed to the archive page, but there are plenty of other URLs that we can pick up as well. For example:
```
https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9.18/ghostscript-9.18.tar.gz
```
Previously, `spack versions` picked up no versions. Now, it picks up several versions. For a full list of packages that this likely affects, run:
```
$ spack url list | grep github | grep -v archive
```
@mjwoods This is the idea I mentioned.