### PR TITLE
ncurses package builds ncurses and ncursesw

### DIFF
--- a/var/spack/repos/builtin/packages/atop/package.py
+++ b/var/spack/repos/builtin/packages/atop/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Atop(Package):
     """Atop is an ASCII full-screen performance monitor for Linux"""
     homepage = "http://www.atoptool.nl/index.php"
-    url = "http://www.atoptool.nl/download/atop-2.2-3.tar.gz"
+    url      = "http://www.atoptool.nl/download/atop-2.2-3.tar.gz"
 
     version('2.2-3', '034dc1544f2ec4e4d2c739d320dc326d')
 

--- a/var/spack/repos/builtin/packages/atop/package.py
+++ b/var/spack/repos/builtin/packages/atop/package.py
@@ -28,9 +28,12 @@ from spack import *
 class Atop(Package):
     """Atop is an ASCII full-screen performance monitor for Linux"""
     homepage = "http://www.atoptool.nl/index.php"
-    url      = "http://www.atoptool.nl/download/atop-2.2-3.tar.gz"
+    url = "http://www.atoptool.nl/download/atop-2.2-3.tar.gz"
 
     version('2.2-3', '034dc1544f2ec4e4d2c739d320dc326d')
+
+    depends_on('zlib')
+    depends_on('ncurses')
 
     def install(self, spec, prefix):
         make()

--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -26,12 +26,14 @@ from spack import *
 
 
 class Fish(AutotoolsPackage):
-    """fish is a smart and user-friendly command line shell for OS X, Linux, and
-    the rest of the family.
+    """fish is a smart and user-friendly command line shell for OS X, Linux,
+    and the rest of the family.
     """
 
     homepage = "http://fishshell.com/"
-    url      = "http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz"
+    url = "http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz"
     list_url = "http://fishshell.com/"
+
+    depends_on('ncurses')
 
     version('2.2.0', 'a76339fd14ce2ec229283c53e805faac48c3e99d9e3ede9d82c0554acfc7b77a')

--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -26,12 +26,12 @@ from spack import *
 
 
 class Fish(AutotoolsPackage):
-    """fish is a smart and user-friendly command line shell for OS X, Linux,
-    and the rest of the family.
+    """fish is a smart and user-friendly command line shell for OS X, Linux, and
+    the rest of the family.
     """
 
     homepage = "http://fishshell.com/"
-    url = "http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz"
+    url      = "http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz"
     list_url = "http://fishshell.com/"
 
     depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/hstr/package.py
+++ b/var/spack/repos/builtin/packages/hstr/package.py
@@ -40,3 +40,4 @@ class Hstr(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('ncurses@5.9')
+    depends_on('readline')

--- a/var/spack/repos/builtin/packages/hstr/package.py
+++ b/var/spack/repos/builtin/packages/hstr/package.py
@@ -31,7 +31,7 @@ class Hstr(AutotoolsPackage):
     your command history."""
 
     homepage = "https://github.com/dvorka/hstr"
-    url = "https://github.com/dvorka/hstr/archive/1.22.tar.gz"
+    url      = "https://github.com/dvorka/hstr/archive/1.22.tar.gz"
 
     version('1.22', '620dab922fadf2858938fbe36d9f99fd')
 

--- a/var/spack/repos/builtin/packages/hstr/package.py
+++ b/var/spack/repos/builtin/packages/hstr/package.py
@@ -31,7 +31,7 @@ class Hstr(AutotoolsPackage):
     your command history."""
 
     homepage = "https://github.com/dvorka/hstr"
-    url      = "https://github.com/dvorka/hstr/archive/1.22.tar.gz"
+    url = "https://github.com/dvorka/hstr/archive/1.22.tar.gz"
 
     version('1.22', '620dab922fadf2858938fbe36d9f99fd')
 

--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -28,7 +28,7 @@ from spack import *
 class Libtermkey(Package):
     """Easy keyboard entry processing for terminal programs"""
     homepage = "http://www.leonerd.org.uk/code/libtermkey/"
-    url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
+    url      = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
 
     version('0.18', '3be2e3e5a851a49cc5e8567ac108b520')
     version('0.17', '20edb99e0d95ec1690fe90e6a555ae6d')

--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -28,13 +28,16 @@ from spack import *
 class Libtermkey(Package):
     """Easy keyboard entry processing for terminal programs"""
     homepage = "http://www.leonerd.org.uk/code/libtermkey/"
-    url      = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
+    url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
 
     version('0.18', '3be2e3e5a851a49cc5e8567ac108b520')
     version('0.17', '20edb99e0d95ec1690fe90e6a555ae6d')
     version('0.16', '7a24b675aaeb142d30db28e7554987d4')
     version('0.15b', '27689756e6c86c56ae454f2ac259bc3d')
     version('0.14', 'e08ce30f440f9715c459060e0e048978')
+
+    depends_on('libtool', type='build')
+    depends_on('ncurses')
 
     def install(self, spec, prefix):
         make()

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -29,7 +29,7 @@ class Nano(AutotoolsPackage):
     """Tiny little text editor"""
 
     homepage = "http://www.nano-editor.org"
-    url = "https://www.nano-editor.org/dist/v2.6/nano-2.6.3.tar.gz"
+    url      = "https://www.nano-editor.org/dist/v2.6/nano-2.6.3.tar.gz"
 
     version('2.6.3', '1213c7f17916e65afefc95054c1f90f9')
     version('2.6.2', '58568a4b8a33841d774c25f285fc11c1')

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -29,7 +29,9 @@ class Nano(AutotoolsPackage):
     """Tiny little text editor"""
 
     homepage = "http://www.nano-editor.org"
-    url      = "https://www.nano-editor.org/dist/v2.6/nano-2.6.3.tar.gz"
+    url = "https://www.nano-editor.org/dist/v2.6/nano-2.6.3.tar.gz"
 
     version('2.6.3', '1213c7f17916e65afefc95054c1f90f9')
     version('2.6.2', '58568a4b8a33841d774c25f285fc11c1')
+
+    depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -23,6 +23,10 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from glob import glob
+from os.path import exists, join
+from os import makedirs
+from shutil import copy
 
 
 class Ncurses(AutotoolsPackage):
@@ -95,3 +99,17 @@ class Ncurses(AutotoolsPackage):
          with working_dir('build_ncursesw'):
            make('install')
 
+	 # fix for packages like hstr that use "#include <ncurses/ncurses.h>"
+	 headers = glob(join(prefix.include, '*'))
+         for p_dir in ['ncurses', 'ncursesw']:
+             path = join(prefix.include, p_dir)
+             if not exists(path):
+                 makedirs(path)
+             for header in headers:
+                 copy(header, path)
+
+    @property
+    def libs(self):
+         return find_libraries(
+             ['libncurses', 'libncursesw'], 
+             root=self.prefix.lib)

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -111,4 +111,4 @@ class Ncurses(AutotoolsPackage):
     @property
     def libs(self):
         return find_libraries(
-            ['libncurses', 'libncursesw'], root=self.prefix.lib)
+            ['libncurses', 'libncursesw'], root=self.prefix, recurse=True)

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -37,7 +37,7 @@ class Ncurses(AutotoolsPackage):
     SYSV-curses enhancements over BSD curses."""
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
-    url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
+    url = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
 
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')
     version('5.9', '8cb9c412e5f2d96bc6f459aa8c6282a1')
@@ -64,7 +64,7 @@ class Ncurses(AutotoolsPackage):
 
         nwide_opts = ['--without-manpages',
                       '--without-progs',
-                      '--without-tests' ]
+                      '--without-tests']
 
         wide_opts = ['--enable-widec']
 
@@ -76,40 +76,39 @@ class Ncurses(AutotoolsPackage):
         configure = Executable('../configure')
 
         with working_dir('build_ncurses', create=True):
-           configure(prefix, *(opts + nwide_opts))
+            configure(prefix, *(opts + nwide_opts))
 
         with working_dir('build_ncursesw', create=True):
-           configure(prefix, *(opts + wide_opts))
+            configure(prefix, *(opts + wide_opts))
 
     def build(self, spec, prefix):
-         with working_dir('build_ncurses'):
-           make()
-         with working_dir('build_ncursesw'):
-           make()
+        with working_dir('build_ncurses'):
+            make()
+        with working_dir('build_ncursesw'):
+            make()
 
     def check(self):
-         with working_dir('build_ncurses'):
-           make('check')
-         with working_dir('build_ncursesw'):
-           make('check')
+        with working_dir('build_ncurses'):
+            make('check')
+        with working_dir('build_ncursesw'):
+            make('check')
 
     def install(self, spec, prefix):
-         with working_dir('build_ncurses'):
-           make('install')
-         with working_dir('build_ncursesw'):
-           make('install')
+        with working_dir('build_ncurses'):
+            make('install')
+        with working_dir('build_ncursesw'):
+            make('install')
 
-	 # fix for packages like hstr that use "#include <ncurses/ncurses.h>"
-	 headers = glob(join(prefix.include, '*'))
-         for p_dir in ['ncurses', 'ncursesw']:
-             path = join(prefix.include, p_dir)
-             if not exists(path):
-                 makedirs(path)
-             for header in headers:
-                 copy(header, path)
+        # fix for packages like hstr that use "#include <ncurses/ncurses.h>"
+        headers = glob(join(prefix.include, '*'))
+        for p_dir in ['ncurses', 'ncursesw']:
+            path = join(prefix.include, p_dir)
+            if not exists(path):
+                makedirs(path)
+            for header in headers:
+                copy(header, path)
 
     @property
     def libs(self):
-         return find_libraries(
-             ['libncurses', 'libncursesw'], 
-             root=self.prefix.lib)
+        return find_libraries(
+            ['libncurses', 'libncursesw'], root=self.prefix.lib)

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -37,7 +37,7 @@ class Ncurses(AutotoolsPackage):
     SYSV-curses enhancements over BSD curses."""
 
     homepage = "http://invisible-island.net/ncurses/ncurses.html"
-    url = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
+    url      = "http://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz"
 
     version('6.0', 'ee13d052e1ead260d7c28071f46eefb1')
     version('5.9', '8cb9c412e5f2d96bc6f459aa8c6282a1')


### PR DESCRIPTION
This change to the ncurses package builds ncurses and ncursesw in two build directories then merges them into one installation. ncurses' headers are superseded by ncursesw's headers, which is the structure I saw in yum's ```ncurses-devel``` package. 

The yum package also keeps identical copies of the headers in include/ncurses and include/ncursesw. During testing I found hstr expected this structure and added it to the package.

@davydden How does the ```libs``` function look?

Fixes #3849