### PR TITLE
fetch: do full clone of git submodules (fix #3956)

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -686,20 +686,11 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         # Init submodules if the user asked for them.
         if self.submodules:
-            # only git 1.8.4 and later have --depth option
-            if self.git_version < ver('1.8.4'):
-                if spack.debug:
-                    self.git('submodule', 'update', '--init', '--recursive')
-                else:
-                    self.git('submodule', '--quiet', 'update', '--init',
-                             '--recursive')
+            if spack.debug:
+                self.git('submodule', 'update', '--init', '--recursive')
             else:
-                if spack.debug:
-                    self.git('submodule', 'update', '--init', '--recursive',
-                             '--depth=1')
-                else:
-                    self.git('submodule', '--quiet', 'update', '--init',
-                             '--recursive', '--depth=1')
+                self.git('submodule', '--quiet', 'update', '--init',
+                         '--recursive')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')


### PR DESCRIPTION
The required hash of a submodule might point to the
non-HEAD commit of the current main branch and hence
would lead to a "no such remote ref" at checkout in
a shallow submodule.