### PR TITLE
Use six.moves.input instead of raw_input

### DIFF
--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -30,6 +30,7 @@ import termios
 import struct
 import traceback
 from six import StringIO
+from six.moves import input
 
 from llnl.util.tty.color import *
 
@@ -164,7 +165,7 @@ def get_number(prompt, **kwargs):
     number = None
     while number is None:
         msg(prompt, newline=False)
-        ans = raw_input()
+        ans = input()
         if ans == str(abort):
             return None
 
@@ -197,7 +198,7 @@ def get_yes_or_no(prompt, **kwargs):
     result = None
     while result is None:
         msg(prompt, newline=False)
-        ans = raw_input().lower()
+        ans = input().lower()
         if not ans:
             result = default_value
             if result is None:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1187,7 +1187,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             # otherwise it should not have passed us the copy of the stream.
             # Thus, we are free to work with the the copy (input_stream)
             # however we want. For example, we might want to call functions
-            # (e.g. raw_input()) that implicitly read from whatever stream is
+            # (e.g. input()) that implicitly read from whatever stream is
             # assigned to sys.stdin. Since we want them to work with the
             # original input stream, we are making the following assignment:
             sys.stdin = input_stream


### PR DESCRIPTION
Fixes #3960.

@junghans Thanks for being our Python 3 guinea pig, even if it isn't by choice 😆 