### PR TITLE
Flann package

### DIFF
--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -27,8 +27,7 @@ from spack import *
 
 
 class Flann(CMakePackage):
-    """
-    FLANN is a library for performing fast approximate nearest neighbor
+    """FLANN is a library for performing fast approximate nearest neighbor
     searches in high dimensional spaces. It contains a collection of
     algorithms we found to work best for nearest neighbor search and a system
     for automatically choosing the best algorithm and optimum parameters

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -50,9 +50,7 @@ class Flann(CMakePackage):
     # Language bindings
     variant("python",   default=False,
             description="Build the Python bindings. "
-                        "Module: pyflann. "
-                        "Python2 verified. "
-                        "Python3 claimed, not attainable.")
+                        "Module: pyflann.")
     variant("matlab",   default=False, description="Build the Matlab bindings.")
     # default to true for C because it's a C++ library, nothing extra needed
     variant("c",        default=True,  description="Build the C bindings.")
@@ -90,7 +88,7 @@ class Flann(CMakePackage):
     def patch(self):
         # Fix up the python setup.py call inside the install(CODE
         filter_file("setup.py install",
-                    '--no-user-cfg setup.py install --prefix=\\"{0}\\"'.format(
+                    'setup.py --no-user-cfg install --prefix=\\"{0}\\"'.format(
                         self.prefix
                     ),
                     "src/python/CMakeLists.txt")
@@ -103,13 +101,13 @@ class Flann(CMakePackage):
                     "# install( FILES",
                     "src/python/CMakeLists.txt", string=True)
 
-    # Tests: require hdf5 and gtest, don't know what to do so ignore...
+    # TODO: revisit after https://github.com/LLNL/spack/issues/1279
+    # depends_on('hdf5', type='test')
+    # depends_on('gtest', type='test')
 
     def cmake_args(self):
         spec = self.spec
         args = []
-        # Default is RelWithDebugInfo
-        args.append("-DCMAKE_BUILD_TYPE:STRING=Release")
 
         # Language bindings. Many default to true in CMakeLists, bypass all
         c_bind = "ON" if "+c" in spec else "OFF"

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -36,11 +36,6 @@ class Flann(CMakePackage):
 
     FLANN is written in C++ and contains bindings for the following languages:
     C, MATLAB and Python.
-
-    NOTE: The author of the package was careful to support HDF5 without
-    parallel support, so the dependencies do not require this, but you will
-    likely want to make sure that you are giving hdf5+mpi as the dependency,
-    this is the spack default so it should be fine.
     """
 
     homepage = "http://www.cs.ubc.ca/research/flann/"
@@ -102,7 +97,7 @@ class Flann(CMakePackage):
                     "src/python/CMakeLists.txt")
         # Fix the install location so that spack activate works
         filter_file("share/flann/python",
-                    "{}".format(site_packages_dir),
+                    "{0}".format(site_packages_dir),
                     "src/python/CMakeLists.txt")
         # Hack. Don't install setup.py
         filter_file("install( FILES",
@@ -119,31 +114,31 @@ class Flann(CMakePackage):
 
         # Language bindings. Many default to true in CMakeLists, bypass all
         c_bind = "ON" if "+c" in spec else "OFF"
-        args.append("-DBUILD_C_BINDINGS:BOOL={}".format(c_bind))
+        args.append("-DBUILD_C_BINDINGS:BOOL={0}".format(c_bind))
 
         py_bind = "ON" if "+python" in spec else "OFF"
-        args.append("-DBUILD_PYTHON_BINDINGS:BOOL={}".format(py_bind))
+        args.append("-DBUILD_PYTHON_BINDINGS:BOOL={0}".format(py_bind))
 
         mat_bind = "ON" if "+matlab" in spec else "OFF"
-        args.append("-DBUILD_MATLAB_BINDINGS:BOOL={}".format(mat_bind))
+        args.append("-DBUILD_MATLAB_BINDINGS:BOOL={0}".format(mat_bind))
 
         # Extra options
         cuda_lib = "ON" if "+cuda" in spec else "OFF"
-        args.append("-DBUILD_CUDA_LIB:BOOL={}".format(cuda_lib))
+        args.append("-DBUILD_CUDA_LIB:BOOL={0}".format(cuda_lib))
 
         examples = "ON" if "+examples" in spec else "OFF"
-        args.append("-DBUILD_EXAMPLES:BOOL={}".format(examples))
+        args.append("-DBUILD_EXAMPLES:BOOL={0}".format(examples))
 
         use_openmp = "ON" if "+openmp" in spec else "OFF"
-        args.append("-DUSE_OPENMP:BOOL={}".format(use_openmp))
+        args.append("-DUSE_OPENMP:BOOL={0}".format(use_openmp))
 
         use_mpi = "ON" if "+mpi" in spec else "OFF"
-        args.append("-DUSE_MPI:BOOL={}".format(use_mpi))
+        args.append("-DUSE_MPI:BOOL={0}".format(use_mpi))
 
         # Configure the proper python executable
         if "+python" in spec:
             args.append(
-                "-DPYTHON_EXECUTABLE={}".format(spec["python"].command.path)
+                "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path)
             )
 
         return args

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -95,40 +95,39 @@ class Flann(CMakePackage):
 
     # Tests: require hdf5 and gtest, don't know what to do so ignore...
 
-    def patch(self):
-        # TODO: when #3367 is merged:
-        # filter_file(
-        #     "python2",
-        #     self.spec["python"].command.name,
-        #     "src/python/setup.py.tpl"
-        # )
-        if self.spec.satisfies("^python@3:"):
-            filter_file("python2", "python3", "src/python/setup.py.tpl")
-
     def cmake_args(self):
+        spec = self.spec
         args = []
+        # Default is RelWithDebugInfo
+        args.append("-DCMAKE_BUILD_TYPE:STRING=Release")
 
         # Language bindings. Many default to true in CMakeLists, bypass all
-        c_bind   = "ON" if self.spec.satisfies("+c")      else "OFF"
+        c_bind = "ON" if "+c" in spec else "OFF"
         args.append("-DBUILD_C_BINDINGS:BOOL={}".format(c_bind))
 
-        py_bind  = "ON" if self.spec.satisfies("+python") else "OFF"
+        py_bind = "ON" if "+python" in spec else "OFF"
         args.append("-DBUILD_PYTHON_BINDINGS:BOOL={}".format(py_bind))
 
-        mat_bind = "ON" if self.spec.satisfies("+matlab") else "OFF"
+        mat_bind = "ON" if "+matlab" in spec else "OFF"
         args.append("-DBUILD_MATLAB_BINDINGS:BOOL={}".format(mat_bind))
 
         # Extra options
-        cuda_lib   = "ON" if self.spec.satisfies("+cuda")     else "OFF"
+        cuda_lib = "ON" if "+cuda" in spec else "OFF"
         args.append("-DBUILD_CUDA_LIB:BOOL={}".format(cuda_lib))
 
-        examples   = "ON" if self.spec.satisfies("+examples") else "OFF"
+        examples = "ON" if "+examples" in spec else "OFF"
         args.append("-DBUILD_EXAMPLES:BOOL={}".format(examples))
 
-        use_openmp = "ON" if self.spec.satisfies("+openmp")   else "OFF"
+        use_openmp = "ON" if "+openmp" in spec else "OFF"
         args.append("-DUSE_OPENMP:BOOL={}".format(use_openmp))
 
-        use_mpi    = "ON" if self.spec.satisfies("+mpi")      else "OFF"
+        use_mpi = "ON" if "+mpi" in spec else "OFF"
         args.append("-DUSE_MPI:BOOL={}".format(use_mpi))
+
+        # Configure the proper python executable
+        if "+python" in spec:
+            args.append(
+                "-DPYTHON_EXECUTABLE={}".format(spec["python"].command.path)
+            )
 
         return args

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -71,7 +71,7 @@ class Flann(CMakePackage):
     # Dependencies
     extends("python",      when="+python")
     depends_on("py-numpy", when="+python", type=("build", "run"))
-    depends_on("matlab",   when="+matlab")
+    depends_on("matlab",   when="+matlab", type=("build", "run"))
     depends_on("cuda",     when="+cuda")
     depends_on("mpi",      when="+mpi")
     depends_on("hdf5",     when="+hdf5")

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -93,6 +93,13 @@ class Flann(CMakePackage):
     # Example uses hdf5.
     depends_on("hdf5", when="+examples")
 
+    def patch(self):
+        filter_file("setup.py install",
+                    'setup.py install --no-user-cfg --prefix=\\"{0}\\"'.format(
+                        self.prefix
+                     ),
+                     "src/python/CMakeLists.txt")
+
     # Tests: require hdf5 and gtest, don't know what to do so ignore...
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -90,13 +90,13 @@ class Flann(CMakePackage):
     def patch(self):
         # Fix up the python setup.py call inside the install(CODE
         filter_file("setup.py install",
-                    'setup.py install --no-user-cfg --prefix=\\"{0}\\"'.format(
+                    '--no-user-cfg setup.py install --prefix=\\"{0}\\"'.format(
                         self.prefix
                     ),
                     "src/python/CMakeLists.txt")
         # Fix the install location so that spack activate works
         filter_file("share/flann/python",
-                    "{0}".format(site_packages_dir),
+                    site_packages_dir,
                     "src/python/CMakeLists.txt")
         # Hack. Don't install setup.py
         filter_file("install( FILES",

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -22,21 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install flann
-#
-# You can edit this file again by typing:
-#
-#     spack edit flann
-#
-# See the Spack documentation for more information on packaging.
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
+
 from spack import *
 
 
@@ -69,7 +55,10 @@ class Flann(CMakePackage):
     # Options available in the CMakeLists.txt
     # Language bindings
     variant("python",   default=False,
-            description="Build the Python bindings. Module: pyflann.  Python2 only.")
+            description="Build the Python bindings. "
+                        "Module: pyflann. "
+                        "Python2 verified. "
+                        "Python3 claimed, not attainable.")
     variant("matlab",   default=False, description="Build the Matlab bindings.")
     # default to true for C because it's a C++ library, nothing extra needed
     variant("c",        default=True,  description="Build the C bindings.")
@@ -88,8 +77,8 @@ class Flann(CMakePackage):
     variant("hdf5",     default=True,  description="Enable HDF5 support.")
 
     # Dependencies
-    extends("python",      when="+python") # creates a site-packages pyflann folder
-    depends_on("py-numpy", when="+python") # imports ctypes and numpy
+    extends("python",      when="+python")
+    depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("matlab",   when="+matlab")
     depends_on("cuda",     when="+cuda")
     depends_on("mpi",      when="+mpi")
@@ -108,13 +97,18 @@ class Flann(CMakePackage):
 
     def patch(self):
         # TODO: when #3367 is merged:
-        # filter_file("python2", self.spec["python"].command.name, "src/python/setup.py.tpl")
+        # filter_file(
+        #     "python2",
+        #     self.spec["python"].command.name,
+        #     "src/python/setup.py.tpl"
+        # )
         if self.spec.satisfies("^python@3:"):
             filter_file("python2", "python3", "src/python/setup.py.tpl")
 
     def cmake_args(self):
         args = []
-        args.append("-DCMAKE_BUILD_TYPE:STRING=Release") # Default is RelWithDebugInfo
+        # Default is RelWithDebugInfo
+        args.append("-DCMAKE_BUILD_TYPE:STRING=Release")
 
         # Language bindings. Many default to true in CMakeLists, bypass all
         c_bind   = "ON" if self.spec.satisfies("+c")      else "OFF"

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -94,11 +94,20 @@ class Flann(CMakePackage):
     depends_on("hdf5", when="+examples")
 
     def patch(self):
+        # Fix up the python setup.py call inside the install(CODE
         filter_file("setup.py install",
                     'setup.py install --no-user-cfg --prefix=\\"{0}\\"'.format(
                         self.prefix
-                     ),
-                     "src/python/CMakeLists.txt")
+                    ),
+                    "src/python/CMakeLists.txt")
+        # Fix the install location so that spack activate works
+        filter_file("share/flann/python",
+                    "{}".format(site_packages_dir),
+                    "src/python/CMakeLists.txt")
+        # Hack. Don't install setup.py
+        filter_file("install( FILES",
+                    "# install( FILES",
+                    "src/python/CMakeLists.txt", string=True)
 
     # Tests: require hdf5 and gtest, don't know what to do so ignore...
 

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -1,0 +1,142 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install flann
+#
+# You can edit this file again by typing:
+#
+#     spack edit flann
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+
+
+class Flann(CMakePackage):
+    """
+    FLANN is a library for performing fast approximate nearest neighbor
+    searches in high dimensional spaces. It contains a collection of
+    algorithms we found to work best for nearest neighbor search and a system
+    for automatically choosing the best algorithm and optimum parameters
+    depending on the dataset.
+
+    FLANN is written in C++ and contains bindings for the following languages:
+    C, MATLAB and Python.
+
+    NOTE: The author of the package was careful to support HDF5 without
+    parallel support, so the dependencies do not require this, but you will
+    likely want to make sure that you are giving hdf5+mpi as the dependency,
+    this is the spack default so it should be fine.
+    """
+
+    homepage = "http://www.cs.ubc.ca/research/flann/"
+    url      = "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
+
+    version('1.9.1', '73adef1c7bf8e8b978987e7860926ea6')
+    version('1.8.5', '02a81640b1e9c11796a0413976dc11f5')
+    version('1.8.4', '774b74580e3cbc5b0d45c6ec345a64ae')
+    version('1.8.1', '1f51500e172f5e11fbda05f033858eb6')
+    version('1.8.0', '473150f592c2997e32d5ce31fd3c19a2')
+
+    # Options available in the CMakeLists.txt
+    # Language bindings
+    variant("python",   default=False,
+            description="Build the Python bindings. Module: pyflann.  Python2 only.")
+    variant("matlab",   default=False, description="Build the Matlab bindings.")
+    # default to true for C because it's a C++ library, nothing extra needed
+    variant("c",        default=True,  description="Build the C bindings.")
+
+    # Must build C bindings for Python / Matlab
+    conflicts("+python", when="~c")
+    conflicts("+matlab", when="~c")
+
+    # Additional options
+    variant("cuda",     default=False, description="Build the CUDA library.")
+    variant("examples", default=False, description="Build the examples.")
+    variant("doc",      default=False, description="Build the documentation.")
+    variant("openmp",   default=True,  description="Use OpenMP multi-threading.")
+    # mpi and hdf5 are the bread and butter of this library, use 'em
+    variant("mpi",      default=True,  description="Use MPI.")
+    variant("hdf5",     default=True,  description="Enable HDF5 support.")
+
+    # Dependencies
+    extends("python",      when="+python") # creates a site-packages pyflann folder
+    depends_on("py-numpy", when="+python") # imports ctypes and numpy
+    depends_on("matlab",   when="+matlab")
+    depends_on("cuda",     when="+cuda")
+    depends_on("mpi",      when="+mpi")
+    depends_on("hdf5",     when="+hdf5")
+    # HDF5_IS_PARALLEL actually comes from hdf5+mpi
+    # https://github.com/mariusmuja/flann/blob/06a49513138009d19a1f4e0ace67fbff13270c69/CMakeLists.txt#L108-L112
+    depends_on("boost+mpi+system+serialization+thread", when="+mpi ^hdf5+mpi")
+
+    # Doc deps
+    depends_on("latex", when="+doc")
+
+    # Example uses hdf5.
+    depends_on("hdf5", when="+examples")
+
+    # Tests: require hdf5 and gtest, don't know what to do so ignore...
+
+    def patch(self):
+        # TODO: when #3367 is merged:
+        # filter_file("python2", self.spec["python"].command.name, "src/python/setup.py.tpl")
+        if self.spec.satisfies("^python@3:"):
+            filter_file("python2", "python3", "src/python/setup.py.tpl")
+
+    def cmake_args(self):
+        args = []
+        args.append("-DCMAKE_BUILD_TYPE:STRING=Release") # Default is RelWithDebugInfo
+
+        # Language bindings. Many default to true in CMakeLists, bypass all
+        c_bind   = "ON" if self.spec.satisfies("+c")      else "OFF"
+        args.append("-DBUILD_C_BINDINGS:BOOL={}".format(c_bind))
+
+        py_bind  = "ON" if self.spec.satisfies("+python") else "OFF"
+        args.append("-DBUILD_PYTHON_BINDINGS:BOOL={}".format(py_bind))
+
+        mat_bind = "ON" if self.spec.satisfies("+matlab") else "OFF"
+        args.append("-DBUILD_MATLAB_BINDINGS:BOOL={}".format(mat_bind))
+
+        # Extra options
+        cuda_lib   = "ON" if self.spec.satisfies("+cuda")     else "OFF"
+        args.append("-DBUILD_CUDA_LIB:BOOL={}".format(cuda_lib))
+
+        examples   = "ON" if self.spec.satisfies("+examples") else "OFF"
+        args.append("-DBUILD_EXAMPLES:BOOL={}".format(examples))
+
+        use_openmp = "ON" if self.spec.satisfies("+openmp")   else "OFF"
+        args.append("-DUSE_OPENMP:BOOL={}".format(use_openmp))
+
+        use_mpi    = "ON" if self.spec.satisfies("+mpi")      else "OFF"
+        args.append("-DUSE_MPI:BOOL={}".format(use_mpi))
+
+        return args

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -107,8 +107,6 @@ class Flann(CMakePackage):
 
     def cmake_args(self):
         args = []
-        # Default is RelWithDebugInfo
-        args.append("-DCMAKE_BUILD_TYPE:STRING=Release")
 
         # Language bindings. Many default to true in CMakeLists, bypass all
         c_bind   = "ON" if self.spec.satisfies("+c")      else "OFF"


### PR DESCRIPTION
In general it seems to be working very well.  Notes:

1. `python3` is definitively broken.  They have a weird [`cmake` + `setup.py`](https://github.com/mariusmuja/flann/blob/e02f66f9663a2bdf49162a9543a459a29a9cd869/src/python/CMakeLists.txt#L7-L12) thing going on.
    - Not sure if `extends('python')` is correct.  The `site-packages` directory is always empty.
    - `python2` works. Something [about this does that](https://github.com/mariusmuja/flann/blob/77d3fbead67f2dc031ef9206cc952a9c55d9566d/src/python/pyflann/flann_ctypes.py#L149-L193)
2. Defaults are `+mpi` and `+hdf5` under the assumption that if anybody actually wants this library directly, they likely will want it for these purposes.  The tests are all using these features.
    - `+openmp` for same reasons.
3. Untested variants: `matlab`, didn't try and combine every possible variant either.
4. Not sure about the `type` for the `py-numpy` dependency.  That's only needed for when somebody uses the `python` bindings, not the library itself.
5. What is the `spack` default `cmake` build type?

    ```diff
    +        # Default is RelWithDebugInfo
    +        args.append("-DCMAKE_BUILD_TYPE:STRING=Release")
    ```