### PR TITLE
Mark 1.64.0 unstable until +mpi+python fixed.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -42,8 +42,15 @@ class Boost(Package):
     list_url = "http://sourceforge.net/projects/boost/files/boost/"
     list_depth = 1
 
+    # NOTE: 1.64.0 seems fine for *most* applications, but if you need
+    #       +python and +mpi, there seem to be errors with out-of-date
+    #       API calls from mpi/python.
+    #       See: https://github.com/LLNL/spack/issues/3963
     version('1.64.0', '93eecce2abed9d2442c9676914709349')
-    version('1.63.0', '1c837ecd990bb022d07e7aab32b09847')
+
+    # Set previous release to preferred for now, can be removed
+    # once boost+python+mpi is fixed.
+    version('1.63.0', '1c837ecd990bb022d07e7aab32b09847', preferred=True)
     version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')
     version('1.61.0', '6095876341956f65f9d35939ccea1a9f')
     version('1.60.0', '65a840e1a0b13a558ff19eeb2c4f0cbe')


### PR DESCRIPTION
This is a continuation of #3964. @svenevs @alalazo @davydden 

>  If anything, maybe one of you just issue the PR so it gets in there

Done. We'll see if this PR fairs any better. Interestingly, I'm already seeing weird differences. Normally, when I push a PR to my repo, if I go to https://github.com/LLNL/spack or https://github.com/ajstewart/spack, GitHub will ask if I want to open a new PR. This time, it didn't. I had to go to my branches and manually create a PR. Maybe it's the commit message or branch name?