### PR TITLE
Add list_url for fftw

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -35,6 +35,7 @@ class Fftw(AutotoolsPackage):
 
     homepage = "http://www.fftw.org"
     url      = "http://www.fftw.org/fftw-3.3.4.tar.gz"
+    list_url = "http://www.fftw.org/download.html"
 
     version('3.3.6-pl2', '927e481edbb32575397eb3d62535a856')
     version('3.3.5', '6cc08a3b9c7ee06fdd5b9eb02e06f569')


### PR DESCRIPTION
With this change, `spack versions` will tell us if there is a new version of `fftw` available, and `spack checksum` will let us add it to the package.