### PR TITLE
Add list_url for bzip2

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -34,6 +34,7 @@ class Bzip2(Package):
 
     homepage = "http://www.bzip.org"
     url      = "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+    list_url = "http://www.bzip.org/downloads.html"
 
     version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b')
 


### PR DESCRIPTION
With this change, `spack versions` will tell us if there is a new version of `bzip2` available, and `spack checksum` will let us add it to the package.