### PR TITLE
Add ncurses as zsh dependency

### DIFF
--- a/var/spack/repos/builtin/packages/zsh/package.py
+++ b/var/spack/repos/builtin/packages/zsh/package.py
@@ -37,3 +37,4 @@ class Zsh(AutotoolsPackage):
     version('5.1.1', checksum='8ba28a9ef82e40c3a271602f18343b2f')
 
     depends_on("pcre")
+    depends_on("ncurses")


### PR DESCRIPTION
zsh build will fail with 
`configure: error: "No terminal handling library was found on your system."`
if ncurses is not found.