### PR TITLE
Make perl and python variants

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -88,6 +88,10 @@ class BlastPlus(AutotoolsPackage):
             description='Build with lzo support')
     variant('pcre', default=True,
             description='Build with pcre support')
+    variant('perl', default=True,
+            description='Build with perl support')
+    variant('python', default=True,
+            description='Build with python support')
 
     depends_on('jpeg', when='+jpeg')
     depends_on('libpng', when='+png')
@@ -100,7 +104,8 @@ class BlastPlus(AutotoolsPackage):
     depends_on('lzo', when='+lzo')
     depends_on('pcre', when='+pcre')
 
-    depends_on('python')
+    depends_on('python', when='+python')
+    depends_on('perl', when='+perl')
 
     configure_directory = 'c++'
 
@@ -198,5 +203,19 @@ class BlastPlus(AutotoolsPackage):
             )
         else:
             config_args.append('--without-pcre')
+
+        if '+python' in spec:
+            config_args.append(
+                '--with-python={0}'.format(self.spec['python'].prefix)
+            )
+        else:
+            config_args.append('--without-python')
+
+        if '+perl' in spec:
+            config_args.append(
+                '--with-perl={0}'.format(self.spec['perl'].prefix)
+            )
+        else:
+            config_args.append('--without-python')
 
         return config_args


### PR DESCRIPTION
The blast+ configure script supports building
--with-{python,perl}=path and --without-{python,perl}.

This commit makes the use of those two languages configurable via
variants and adds dependencies and explicit --with-... or
--without-... flags to configure.

Python was a non-optional dependency, now it is a variant that
defaults to `True`.

Perl was not previously an explicit dependency but the configure
script was likely to discover one on your system (`/usr/bin/perl`).
It is now a variant that defaults to `True`.

I am unable to accurately determine what these flags to the configure
script enable.  My users are frustrated by the dependency on Python in
particular because it constrains the other modules that they can have
loaded for new discernible benefit.