### PR TITLE
Fix bug with '# noqa' filtering

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -139,14 +139,6 @@ def filter_file(source, dest, output=False):
                 # We still want to catch trailing whitespace warnings
                 line = line.rstrip('\n')
 
-                if line == '# flake8: noqa':
-                    # Entire file is ignored
-                    break
-
-                if line.endswith('# noqa'):
-                    # Line is already ignored
-                    continue
-
                 for file_pattern, errors in exemptions.items():
                     if not file_pattern.search(source):
                         continue
@@ -154,7 +146,10 @@ def filter_file(source, dest, output=False):
                     for code, patterns in errors.items():
                         for pattern in patterns:
                             if pattern.search(line):
-                                if '# noqa: ' in line:
+                                if line.endswith('# noqa'):
+                                    # Line is already ignored
+                                    pass
+                                elif '# noqa: ' in line:
                                     line += ',{0}'.format(code)
                                 else:
                                     line += '  # noqa: {0}'.format(code)

--- a/var/spack/repos/builtin.mock/packages/flake8/package.py
+++ b/var/spack/repos/builtin.mock/packages/flake8/package.py
@@ -71,7 +71,11 @@ class Flake8(Package):
     patch('hyper-specific-patch-that-fixes-some-random-bug-that-probably-only-affects-one-user.patch', when='%gcc@3.2.2:3.2.3')
 
     def install(self, spec, prefix):
-        pass
+        # Make sure lines with '# noqa' work as expected. Don't just
+        # remove them entirely. This will mess up the indentation of
+        # the following lines.
+        if 'really-long-if-statement' != 'that-goes-over-the-line-length-limit-and-requires-noqa':  # noqa
+            pass
 
     # '@when' decorated functions are exempt from redefinition errors
     @when('@2.0')


### PR DESCRIPTION
Fixes a bug I introduced in #3932. I forgot that we aren't just filtering each line of the file, we are writing a completely new file and running flake8 on that instead. Instead of skipping the line (or the file) we need to skip modifications to the line and continue to print it. Also updated the unit tests with an example to prevent this from happening again.