### PR TITLE
Add __format__ support to version for fancy formatting.

### DIFF
--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -226,6 +226,9 @@ class Version(object):
     def __str__(self):
         return self.string
 
+    def __format__(self, format_spec):
+        return self.string.format(format_spec)
+
     @property
     def concrete(self):
         return self


### PR DESCRIPTION
Fixes #3979.

- add Version.__format__ to support new-style formatting.
- Python3 doesn't handle this well -- it delegates to
  object.__format__(), which raises an error for fancy format strings.
- not sure why it doesn't call str(self).__format__ instead, but that's
  hwo things are.

@junghans: This fixes the first issue from #3979, but I can't reproduce the second.  Do you see the second issue on current develop?

@adamjstewart: something to watch out for with fancier use of `format()` on objects without `__format__`.  I'm not sure I understand why they chose to delegate the call this way in Python3, but they did.