### PR TITLE
add kokkos package

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -42,20 +42,20 @@ class Kokkos(Package):
     depends_on('cuda', when='+cuda')
 
     def install(self, spec, prefix):
-        generate = which(join_path(self.stage.source_path, 'generate_makefile.bash'))
+        generate = which(join_path(self.stage.source_path,
+                                   'generate_makefile.bash'))
         with working_dir('build', create=True):
-            generate_args = [
+            g_args = [
                 '--prefix=%s' % prefix,
                 '--with-hwloc=%s' % spec['hwloc'].prefix,
                 '--with-serial',
                 '--with-openmp',
             ]
             if 'qthreads' in spec:
-                generate_args.append('--with-qthreads=%s' % spec ['qthreads'].prefix)
+                g_args.append('--with-qthreads=%s' % spec['qthreads'].prefix)
             if 'cuda' in spec:
-                generate_args.append('--with-cuda=%s' % spec['cuda'].prefix)
+                g_args.append('--with-cuda=%s' % spec['cuda'].prefix)
 
-            generate(*generate_args)
+            generate(*g_args)
             make()
             make('install')
-

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -1,0 +1,61 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Kokkos(Package):
+    """Kokkos implements a programming model in C++ for writing performance
+    portable applications targeting all major HPC platforms."""
+
+    homepage = "https://github.com/kokkos/kokkos"
+    url      = "https://github.com/kokkos/kokkos/archive/2.03.00.tar.gz"
+
+    version('2.03.00', 'f205d659d4304747759fabfba32d43c3')
+
+    variant('qthreads', default=False)
+    variant('cuda', default=False)
+
+    depends_on('hwloc')
+    depends_on('qthreads', when='+qthreads')
+    depends_on('cuda', when='+cuda')
+
+    def install(self, spec, prefix):
+        generate = which(join_path(self.stage.source_path, 'generate_makefile.bash'))
+        with working_dir('build', create=True):
+            generate_args = [
+                '--prefix=%s' % prefix,
+                '--with-hwloc=%s' % spec['hwloc'].prefix,
+                '--with-serial',
+                '--with-openmp',
+            ]
+            if 'qthreads' in spec:
+                generate_args.append('--with-qthreads=%s' % spec ['qthreads'].prefix)
+            if 'cuda' in spec:
+                generate_args.append('--with-cuda=%s' % spec['cuda'].prefix)
+
+            generate(*generate_args)
+            make()
+            make('install')
+

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -34,8 +34,8 @@ class Kokkos(Package):
 
     version('2.03.00', 'f205d659d4304747759fabfba32d43c3')
 
-    variant('qthreads', default=False)
-    variant('cuda', default=False)
+    variant('qthreads', default=False, description="enable Qthreads backend")
+    variant('cuda', default=False, description="enable Cuda backend")
 
     depends_on('hwloc')
     depends_on('qthreads', when='+qthreads')


### PR DESCRIPTION
while kokkos is contained in trilinos, it is useful to also have the much more lightweight option of installing just kokkos 