### PR TITLE
Fix alignment of versions and urls in spack checksum

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -78,7 +78,7 @@ def get_checksums(url_dict, name, **kwargs):
             num_ver, '' if num_ver == 1 else 's', name),
             "",
             *spack.cmd.elide_list(
-                ["{0:{1}}  {2}".format(v, max_len, url_dict[v])
+                ["{0:{1}}  {2}".format(str(v), max_len, url_dict[v])
                  for v in sorted_versions]))
     print()
 


### PR DESCRIPTION
@tgamblin This is related to #3996. It seems that the alignment of string formatting is still a bit out of place unless you cast `Version` to `str` first. If I had to guess, it would be because the length of `'1.2'` is 3 while the length of `Version('1.2')` is 2 or 1 or something like that. This occurs in both Python 2 and Python 3.

### Before:
```
$ spack checksum pax-utils
==> Found 28 versions of pax-utils:
  
  1.2.2  https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.2.tar.xz
  1.2.1  https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.1.tar.xz
  1.2  https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.tar.xz
  1.1.7  https://dev.gentoo.org/~vapier/dist/pax-utils-1.1.7.tar.xz
  1.1.6  https://dev.gentoo.org/~vapier/dist/pax-utils-1.1.6.tar.xz
```
### After:
```
$ spack checksum pax-utils
==> Found 28 versions of pax-utils:
  
  1.2.2  https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.2.tar.xz
  1.2.1  https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.1.tar.xz
  1.2    https://dev.gentoo.org/~vapier/dist/pax-utils-1.2.tar.xz
  1.1.7  https://dev.gentoo.org/~vapier/dist/pax-utils-1.1.7.tar.xz
  1.1.6  https://dev.gentoo.org/~vapier/dist/pax-utils-1.1.6.tar.xz
```