### PR TITLE
Remove 'release' suffix from package name

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -224,6 +224,10 @@ class UrlStripNameSuffixesTest(unittest.TestCase):
 
     # Download version
 
+    def test_release(self):
+        self.check('cbench_release_1.3.0.tar.gz', '1.3.0',
+                   'cbench')
+
     def test_snapshot(self):
         self.check('gts-snapshot-121130', '121130',
                    'gts')

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -254,6 +254,7 @@ def strip_name_suffixes(path, version):
         '[._-]std',
 
         # Download version
+        'release',
         'snapshot',
         'distrib',
 


### PR DESCRIPTION
I'm trying to add a package for cbench:
```
$ spack create https://sourceforge.net/projects/cbench/files/cbench/1.3.0/cbench_release_1.3.0.tar.gz/download
```
but Spack incorrectly parses the name as `cbench-release`. This PR fixes that.

### Before
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1473
    Names correctly parsed:    1337/1473 (90.77%)
    Versions correctly parsed: 1394/1473 (94.64%)
```
### After
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1473
    Names correctly parsed:    1337/1473 (90.77%)
    Versions correctly parsed: 1394/1473 (94.64%)
```
So no impact on any existing packages.

@alalazo This will slightly interfere with #3430. Shouldn't be hard to resolve conflicts though.