### PR TITLE
Don't print successfully uninstalled twice

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1548,7 +1548,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             msg = 'Deleting DB entry [{0}]'
             tty.debug(msg.format(spec.short_spec))
             spack.store.db.remove(spec)
-        tty.msg("Successfully uninstalled %s" % spec.short_spec)
 
         if pkg is not None:
             spack.hooks.post_uninstall(spec)


### PR DESCRIPTION
This fixes part of the problem mentioned in #3690, the fact that "Successfully uninstalled" prints twice for the same hash:
```
$ spack uninstall automake
==> The following packages will be uninstalled:

-- linux-fedora25-x86_64 / gcc@6.2.1 ----------------------------
zwtptzu automake@1.15%gcc

==> Do you want to proceed? [y/N] y
==> Successfully uninstalled automake@1.15%gcc@6.2.1 arch=linux-fedora25-x86_64 /zwtptzu
==> Successfully uninstalled automake@1.15%gcc@6.2.1 arch=linux-fedora25-x86_64 /zwtptzu
```
@alalazo This looks like a bad rebase from #1167. Can you check to see if any of your changes caused the rest of #3690?