### PR TITLE
Prevent spack test flake8 from making changes

### DIFF
--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -54,12 +54,12 @@ def flake8_package():
     package = FileFilter(filename)
 
     # Make the change
-    package.filter('unmodified', 'modified')
+    package.filter("state = 'unmodified'", "state = 'modified'", string=True)
 
     yield filename
 
     # Undo the change
-    package.filter('modified', 'unmodified')
+    package.filter("state = 'modified'", "state = 'unmodified'", string=True)
 
 
 def test_changed_files(parser, flake8_package):


### PR DESCRIPTION
Fixes another bug I introduced in #3932. I'm toggling a variable to repeatably modify a mock package. Unfortunately, I wasn't specific enough and I ended up modifying a comment instead. This causes `spack test flake8` to leave behind a modified file. Made the search/replace more specific.

@alalazo @tgamblin This explains the accidental changes to the mock package.