### PR TITLE
Reindex checks install for non-external packages

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -473,13 +473,18 @@ class Database(object):
                         layout = spack.store.layout
                         if entry.spec.external:
                             layout = None
-                        kwargs = {
-                            'spec': entry.spec,
-                            'directory_layout': layout,
-                            'explicit': entry.explicit
-                        }
-                        self._add(**kwargs)
-                        processed_specs.add(entry.spec)
+                            install_check = True
+                        else:
+                            install_check = layout.check_installed(entry.spec)
+
+                        if install_check:
+                            kwargs = {
+                                'spec': entry.spec,
+                                'directory_layout': layout,
+                                'explicit': entry.explicit
+                            }
+                            self._add(**kwargs)
+                            processed_specs.add(entry.spec)
                     except Exception as e:
                         # Something went wrong, so the spec was not restored
                         # from old data


### PR DESCRIPTION
Fixes #4026

#1167 updated Database.reindex to keep old installation records to
support external packages. However, when a user manually removes a
prefix and reindexes this kept the records so the packages were
still installed according to "spack find" etc. This adds a check
for non-external packages to ensure they are properly installed
according to the directory layout.