### PR TITLE
Depend on readline, remove hardcoded -ltermcap

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/bowtie2-2.3.1.patch
+++ b/var/spack/repos/builtin/packages/bowtie2/bowtie2-2.3.1.patch
@@ -3,7 +3,8 @@
 @@ -26,10 +26,10 @@
 
  INC =
- LIBS = -lreadline -ltermcap -lz
+-LIBS = -lreadline -ltermcap -lz
++LIBS = -lreadline -lz
 -GCC_PREFIX = $(shell dirname `which gcc`)
 +GCC_PREFIX =
  GCC_SUFFIX =

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -37,6 +37,7 @@ class Bowtie2(Package):
     version('2.2.5', '51fa97a862d248d7ee660efc1147c75f')
 
     depends_on('tbb', when='@2.3.1')
+    depends_on('readline')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -43,6 +43,9 @@ class Bowtie2(Package):
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)
 
+    # seems to have trouble with 6's -std=gnu++14
+    conflicts('%gcc@6:')
+
     def install(self, spec, prefix):
         make()
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -38,6 +38,7 @@ class Bowtie2(Package):
 
     depends_on('tbb', when='@2.3.1')
     depends_on('readline')
+    depends_on('zlib')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)


### PR DESCRIPTION
Bowtie should use Spack's readline and not explicitly depend on the
system termcap (which, on CentOS, leads to linking against the
system's tinfo library).

Addresses one of the issues in #3950 