### PR TITLE
Removed tip suggesting the use of 2 Spack instances

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -315,19 +315,6 @@ by adding the following to your ``packages.yaml`` file:
        compiler: [gcc@4.9.3]
 
 
-.. tip::
-
-    If you are building your own compiler, some users prefer to have a
-    Spack instance just for that.  For example, create a new Spack in
-    ``~/spack-tools`` and then run ``~/spack-tools/bin/spack install
-    gcc@4.9.3``.  Once the compiler is built, don't build anything
-    more in that Spack instance; instead, create a new "real" Spack
-    instance, configure Spack to use the compiler you've just built,
-    and then build your application software in the new Spack
-    instance.  Following this tip makes it easy to delete all your
-    Spack packages *except* the compiler.
-
-
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Compilers Requiring Modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR removes a tip in the documentation that is in my opinion controversial. As it is just my opinion though, feel free to close this without mercy if the majority thinks differently.