### PR TITLE
Add link to spack view docs in command index

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -476,10 +476,11 @@ if the view is built with hardlinks.
 
 .. FIXME: reference the relocation work of Hegner and Gartung (PR #1013)
 
+.. _cmd-spack-view:
 
-""""""""""""""""""""""
-Using Filesystem Views
-""""""""""""""""""""""
+""""""""""""""
+``spack view``
+""""""""""""""
 
 A filesystem view is created, and packages are linked in, by the ``spack
 view`` command's ``symlink`` and ``hardlink`` sub-commands.  The


### PR DESCRIPTION
This PR adds a link to the documentation on `spack view` from the [Command Index](http://spack.readthedocs.io/en/latest/command_index.html). @samfux84 had trouble finding this documentation (see https://github.com/LLNL/spack/issues/4080#issuecomment-298632647) but this should help.