### PR TITLE
Add environment variables to directory substitution

### DIFF
--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -14,8 +14,6 @@ see the default settings by looking at
 These settings can be overridden in ``etc/spack/config.yaml`` or
 ``~/.spack/config.yaml``.  See :ref:`configuration-scopes` for details.
 
-.. _config-file-variables:
-
 --------------------
 ``install_tree``
 --------------------

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -16,25 +16,6 @@ These settings can be overridden in ``etc/spack/config.yaml`` or
 
 .. _config-file-variables:
 
-------------------------------
-Config file variables
-------------------------------
-
-You may notice some variables prefixed with ``$`` in the settings above.
-Spack understands several variables that can be used in values of
-configuration parameters.  They are:
-
-  * ``$spack``: path to the prefix of this spack installation
-  * ``$tempdir``: default system temporary directory (as specified in
-    Python's `tempfile.tempdir
-    <https://docs.python.org/2/library/tempfile.html#tempfile.tempdir>`_
-    variable.
-  * ``$user``: name of the current user
-
-Note that, as with shell variables, you can write these as ``$varname``
-or with braces to distinguish the variable from surrounding characters:
-``${varname}``.
-
 --------------------
 ``install_tree``
 --------------------

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -261,3 +261,52 @@ The merged configuration would look like this:
        - /lustre-scratch/$user
        - ~/mystage
    $ _
+
+------------------------------
+Config file variables
+------------------------------
+
+Spack understands several variables which can be used in config file paths
+where ever they appear. There are three sets of these variables, Special 
+variables, environment variables, and user path variables. Special variables
+and environment variables both are indicated by prefixing the variable name with
+``$``. User path variables are indicated at the start of the path with ``~`` or
+``~user``. A configuration path is modified first to add in any special
+variables, then user variables, then environment variables. Let's discuss each
+in turn.
+
+^^^^^^^^^^^^^^^^^
+Special Variables
+^^^^^^^^^^^^^^^^^
+
+Spack understands several special variables. These are:
+
+  * ``$spack``: path to the prefix of this spack installation
+  * ``$tempdir``: default system temporary directory (as specified in
+    Python's `tempfile.tempdir
+    <https://docs.python.org/2/library/tempfile.html#tempfile.tempdir>`_
+    variable.
+  * ``$user``: name of the current user
+
+Note that, as with shell variables, you can write these as ``$varname``
+or with braces to distinguish the variable from surrounding characters:
+``${varname}``. Their names are also case insensitive meaning that ``$SPACK``
+works just as well as ``$spack``. These special variables are also
+substituted first, so any environment variables with the same name will not
+be used.
+
+^^^^^^^^^^^^^^
+User Variables
+^^^^^^^^^^^^^^
+
+Spack also uses the ``os.path.expanduser`` function on the path to expand
+any user tilde paths such as ``~`` or ``~user``. These tilde paths must appear
+at the beginning of the path or ``os.path.expanduser`` will not properly
+expand them.
+
+^^^^^^^^^^^^^^^^^^^^^
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+Spack then uses ``os.path.expandvars`` to expand any remaining environment
+variables.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -262,22 +262,22 @@ The merged configuration would look like this:
        - ~/mystage
    $ _
 
+.. _config-file-variables:
+
 ------------------------------
 Config file variables
 ------------------------------
 
 Spack understands several variables which can be used in config file paths
-where ever they appear. There are three sets of these variables, Special 
-variables, environment variables, and user path variables. Special variables
-and environment variables both are indicated by prefixing the variable name with
-``$``. User path variables are indicated at the start of the path with ``~`` or
-``~user``. A configuration path is modified first to add in any special
-variables, then user variables, then environment variables. Let's discuss each
-in turn.
+where ever they appear. There are three sets of these variables, Spack specific 
+variables, environment variables, and user path variables. Spack specific
+variables and environment variables both are indicated by prefixing the variable
+name with ``$``. User path variables are indicated at the start of the path with
+``~`` or ``~user``. Let's discuss each in turn.
 
-^^^^^^^^^^^^^^^^^
-Special Variables
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
+Spack Specific Variables
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Spack understands several special variables. These are:
 
@@ -295,6 +295,13 @@ works just as well as ``$spack``. These special variables are also
 substituted first, so any environment variables with the same name will not
 be used.
 
+^^^^^^^^^^^^^^^^^^^^^
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+Spack then uses ``os.path.expandvars`` to expand any remaining environment
+variables.
+
 ^^^^^^^^^^^^^^
 User Variables
 ^^^^^^^^^^^^^^
@@ -303,10 +310,3 @@ Spack also uses the ``os.path.expanduser`` function on the path to expand
 any user tilde paths such as ``~`` or ``~user``. These tilde paths must appear
 at the beginning of the path or ``os.path.expanduser`` will not properly
 expand them.
-
-^^^^^^^^^^^^^^^^^^^^^
-Environment Variables
-^^^^^^^^^^^^^^^^^^^^^
-
-Spack then uses ``os.path.expandvars`` to expand any remaining environment
-variables.

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -65,8 +65,10 @@ def substitute_config_variables(path):
 
 
 def canonicalize_path(path):
-    """Substitute config vars, expand user home, take abspath."""
+    """Substitute config vars, expand environment vars,
+       expand user home, take abspath."""
     path = substitute_config_variables(path)
+    path = os.path.expandvars(path)
     path = os.path.expanduser(path)
     path = os.path.abspath(path)
     return path


### PR DESCRIPTION
This will be useful for users wishing to install an external package in their home directory or an external repo in their home directory. They can then specify the location of these items using $home.