### PR TITLE
Update cray compiler options

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -53,3 +53,15 @@ class Cce(Compiler):
     @classmethod
     def default_version(cls, comp):
         return get_compiler_version(comp, '-V', r'[Vv]ersion.*(\d+(\.\d+)+)')
+
+    @property
+    def openmp_flag(self):
+        return "-h omp"
+
+    @property
+    def cxx11_flag(self):
+        return "-h std=c++11"
+
+    @property
+    def pic_flag(self):
+        return "-h PIC"


### PR DESCRIPTION
Add the 'openmp_flag', 'cxx11_flag' and 'pic_flag' to the cray compiler.