### PR TITLE
spack: no stacktrace if not in debug mode + fix emacs variant

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -194,6 +194,8 @@ def _main(args, unknown_args):
             return_val = command(parser, args)
     except SpackError as e:
         e.die()
+    except Exception as e:
+        tty.die(str(e))
     except KeyboardInterrupt:
         sys.stderr.write('\n')
         tty.die("Keyboard interrupt.")

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -389,9 +389,9 @@ class BoolValuedVariant(SingleValuedVariant):
             self._original_value = value
             self._value = False
         else:
-            msg = 'cannot construct a BoolValuedVariant from '
+            msg = 'cannot construct a BoolValuedVariant for "{0}" from '
             msg += 'a value that does not represent a bool'
-            raise ValueError(msg)
+            raise ValueError(msg.format(self.name))
 
     def __contains__(self, item):
         return item is self.value

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -36,8 +36,12 @@ class Emacs(AutotoolsPackage):
     version('24.5', 'd74b597503a68105e61b5b9f6d065b44')
 
     variant('X', default=False, description="Enable an X toolkit")
-    variant('toolkit', default='gtk',
-            description="Select an X toolkit (gtk, athena)")
+    variant(
+        'toolkit',
+        default='gtk',
+        values=('gtk', 'athena'),
+        description="Select an X toolkit (gtk, athena)"
+    )
 
     depends_on('ncurses')
     depends_on('libtiff', when='+X')

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -54,12 +54,9 @@ class Emacs(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = []
+
         toolkit = spec.variants['toolkit'].value
         if '+X' in spec:
-            if toolkit not in ('gtk', 'athena'):
-                raise InstallError("toolkit must be in (gtk, athena), not %s" %
-                                   toolkit)
             args = [
                 '--with-x',
                 '--with-x-toolkit={0}'.format(toolkit)


### PR DESCRIPTION
Before this PR it was failing like that:
```console
$ spack spec emacs
Input spec
--------------------------------
emacs

Normalized
--------------------------------
emacs
    ^ncurses
        ^pkg-config

Concretized
--------------------------------
Traceback (most recent call last):
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 259, in <module>
    main(sys.argv)
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 255, in main
    _main(args, unknown)
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 194, in _main
    return_val = command(parser, args)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/cmd/spec.py", line 89, in spec
    spec.concretize()
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1712, in concretize
    self._concretize_helper())
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 1565, in _concretize_helper
    spack.concretizer.concretize_variants(self)))
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/concretize.py", line 255, in concretize_variants
    spec.variants[name] = variant.make_default()
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 150, in make_default
    return self.make_variant(self.default)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 163, in make_variant
    return self.variant_cls(self.name, value)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 198, in __init__
    self.value = value
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 212, in value
    self._value_setter(value)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 394, in _value_setter
    raise ValueError(msg.format(self.name))
ValueError: cannot construct a BoolValuedVariant from a value that does not represent a bool
```
Now it would fail like this:
```console
$ spack spec emacs
Input spec
--------------------------------
emacs

Normalized
--------------------------------
emacs
    ^ncurses
        ^pkg-config

Concretized
--------------------------------
==> Error: cannot construct a BoolValuedVariant for "toolkit" from a value that does not represent a bool
```
if it wasn't fixed already:
```console
$ spack spec emacs
Input spec
--------------------------------
emacs

Normalized
--------------------------------
emacs
    ^ncurses
        ^pkg-config

Concretized
--------------------------------
emacs@25.2%gcc@4.8~X toolkit=gtk arch=linux-ubuntu14-x86_64 
    ^ncurses@6.0%gcc@4.8~symlinks arch=linux-ubuntu14-x86_64 
        ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 
```