### PR TITLE
Make emacs pkg compat with multi-valued variants

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -37,6 +37,7 @@ class Emacs(AutotoolsPackage):
 
     variant('X', default=False, description="Enable an X toolkit")
     variant('toolkit', default='gtk',
+            values=('gtk', 'athena'),
             description="Select an X toolkit (gtk, athena)")
 
     depends_on('pkg-config@0.9.0:', type='build')


### PR DESCRIPTION
Need to add acceptable values to the toolkit variant now that multi-valued variants are a thing.