### PR TITLE
package: removed default no-op patch 

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -939,10 +939,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         self.stage.expand_archive()
         self.stage.chdir_to_source()
 
-    def patch(self):
-        """Default patch implementation is a no-op."""
-        pass
-
     def do_patch(self):
         """Calls do_stage(), then applied patches to the expanded tarball if they
            haven't been applied already."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -58,6 +58,7 @@ import spack.mirror
 import spack.repository
 import spack.url
 import spack.util.web
+import spack.multimethod
 
 from llnl.util.filesystem import *
 from llnl.util.lang import *
@@ -999,6 +1000,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 self.patch()
                 tty.msg("Ran patch() for %s" % self.name)
                 patched = True
+            except spack.multimethod.NoSuchMethodError:
+                # We are running a multimethod without a default case.
+                # If there's no default it means we don't need to patch.
+                tty.msg("No patches needed for %s" % self.name)
             except:
                 tty.msg("patch() function failed for %s" % self.name)
                 touch(bad_file)


### PR DESCRIPTION
Apparently the change was introduced in 221f17971634e43950f90333776589c4d0bf0ce3. The function doesn't seem to be needed at a first glance.