### PR TITLE
patch sqlite to work around macro definition

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -40,6 +40,12 @@ class Sqlite(AutotoolsPackage):
 
     depends_on('readline')
 
+    # On some platforms (e.g., PPC) the include chain includes termios.h which
+    # defines a macro B0. Sqlite has a shell.c source file that declares a
+    # variable named B0 and will fail to compile when the macro is found. The
+    # following patch undefines the macro in shell.c
+    patch('sqlite_b0.patch', when='@3.18.0')
+
     def get_arch(self):
         arch = architecture.Arch()
         arch.platform = architecture.platform()

--- a/var/spack/repos/builtin/packages/sqlite/sqlite_b0.patch
+++ b/var/spack/repos/builtin/packages/sqlite/sqlite_b0.patch
@@ -1,0 +1,13 @@
+--- a/shell.c	2017-05-03 10:49:13.266276246 -0700
++++ b/shell.c	2017-05-03 10:51:34.868963321 -0700
+@@ -198,6 +198,10 @@
+ #define getrusage(A,B) memset(B,0,sizeof(*B))
+ #endif
+ 
++#ifdef B0
++#undef B0
++#endif
++
+ /* Saved resource information for the beginning of an operation */
+ static struct rusage sBegin;  /* CPU time at start */
+ static sqlite3_int64 iBegin;  /* Wall-clock time at start */


### PR DESCRIPTION
On some platforms (e.g., PPC) the include chain includes termios.h which defines a macro B0. Sqlite has a shell.c source file that declares a variable named B0 and will fail to compile when the macro is found. The following patch undefines the macro in shell.c