### PR TITLE
mpfr: switch to more reliable URL

### DIFF
--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -30,7 +30,7 @@ class Mpfr(AutotoolsPackage):
        floating-point computations with correct rounding."""
 
     homepage = "http://www.mpfr.org"
-    url      = "http://ftp.gnu.org/gnu/mpfr/mpfr-3.1.5.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/mpfr/mpfr-3.1.5.tar.bz2"
 
     version('3.1.5', 'b1d23a55588e3b2a13e3be66bc69fd8d')
     version('3.1.4', 'b8a2f6b0e68bef46e53da2ac439e1cf4')

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -31,13 +31,15 @@ class Mpfr(AutotoolsPackage):
 
     homepage = "http://www.mpfr.org"
     url      = "https://gforge.inria.fr/frs/download.php/latestfile/159/mpfr-3.1.2.tar.bz2"
+    list_url = "http://www.mpfr.org/mpfr-current/"
 
     version('3.1.5', 'b1d23a55588e3b2a13e3be66bc69fd8d')
     version('3.1.4', 'b8a2f6b0e68bef46e53da2ac439e1cf4')
     version('3.1.3', '5fdfa3cfa5c86514ee4a241a1affa138')
     version('3.1.2', 'ee2c3ac63bf0c2359bf08fc3ee094c19')
 
-    depends_on('gmp@4.1.0:')  # mpir is a drop-in replacement for this
+    # mpir is a drop-in replacement for gmp
+    depends_on('gmp@4.1.0:')  # 4.2.3 or higher is recommended
 
     patch('vasprintf.patch', when='@3.1.5')
     patch('strtofr.patch',   when='@3.1.5')

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -30,8 +30,7 @@ class Mpfr(AutotoolsPackage):
        floating-point computations with correct rounding."""
 
     homepage = "http://www.mpfr.org"
-    url      = "https://gforge.inria.fr/frs/download.php/latestfile/159/mpfr-3.1.2.tar.bz2"
-    list_url = "http://www.mpfr.org/mpfr-current/"
+    url      = "http://ftp.gnu.org/gnu/mpfr/mpfr-3.1.5.tar.bz2"
 
     version('3.1.5', 'b1d23a55588e3b2a13e3be66bc69fd8d')
     version('3.1.4', 'b8a2f6b0e68bef46e53da2ac439e1cf4')


### PR DESCRIPTION
Now `spack versions` will tell you whether or not a newer version exists.