### PR TITLE
Add GCC 7

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/darwin/gcc-6.1.0-jit.patch
+++ b/var/spack/repos/builtin/packages/gcc/darwin/gcc-6.1.0-jit.patch
@@ -1,0 +1,21 @@
+# Fix for libgccjit.so linkage on Darwin
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+# https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225625332
+# https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225626490
+
+# Stolen from Homebrew:
+# https://raw.githubusercontent.com/Homebrew/formula-patches/e9e0ee09389a54cc4c8fe1c24ebca3cd765ed0ba/gcc/6.1.0-jit.patch
+diff --git a/gcc/jit/Make-lang.in b/gcc/jit/Make-lang.in
+index 44d0750..4df2a9c 100644
+--- a/gcc/jit/Make-lang.in
++++ b/gcc/jit/Make-lang.in
+@@ -85,8 +85,7 @@ $(LIBGCCJIT_FILENAME): $(jit_OBJS) \
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)

--- a/var/spack/repos/builtin/packages/gcc/darwin/gcc-7.1.0-headerpad.patch
+++ b/var/spack/repos/builtin/packages/gcc/darwin/gcc-7.1.0-headerpad.patch
@@ -1,0 +1,19 @@
+# Use -headerpad_max_install_names in the build,
+# otherwise lto1 load commands cannot be edited on El Capitan
+
+# Stolen from Homebrew:
+# https://raw.githubusercontent.com/Homebrew/formula-patches/32cf103/gcc/7.1.0-headerpad.patch
+
+diff --git a/config/mh-darwin b/config/mh-darwin
+index 148b730..c2318b5 100644
+--- a/config/mh-darwin
++++ b/config/mh-darwin
+@@ -16,7 +16,7 @@ DARWIN_GCC_MDYNAMIC_NO_PIC := \
+ DARWIN_NO_PIE := `case ${host} in *-*-darwin[1][1-9]*) echo -Wl,-no_pie ;; esac;`
+ 
+ BOOT_CFLAGS += $(DARWIN_MDYNAMIC_NO_PIC)
+-BOOT_LDFLAGS += $(DARWIN_NO_PIE)
++BOOT_LDFLAGS += $(DARWIN_NO_PIE) -Wl,-headerpad_max_install_names
+ 
+ # Similarly, for cross-compilation.
+ STAGE1_CFLAGS += $(DARWIN_MDYNAMIC_NO_PIC)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -142,10 +142,12 @@ class Gcc(AutotoolsPackage):
     # See https://gcc.gnu.org/gcc-5/changes.html
     conflicts('languages=jit', when='@:4')
 
-    patch('darwin/gcc-7.1.0-headerpad.patch', when='@7.1.0 platform=darwin')
-    patch('darwin/gcc-6.1.0-jit.patch', when='@6.1.0 platform=darwin')
-    patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3 platform=darwin')
-    patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3 platform=darwin')
+    if sys.platform == 'darwin':
+        patch('darwin/gcc-7.1.0-headerpad.patch', when='@5:')
+        patch('darwin/gcc-6.1.0-jit.patch', when='@5:')
+        patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3')
+        patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3')
+
     patch('piclibs.patch', when='+piclibs')
     patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from llnl.util import tty
 
 from contextlib import closing
 from glob import glob
@@ -215,8 +216,8 @@ class Gcc(AutotoolsPackage):
 
     @property
     def spec_dir(self):
-        # e.g. lib64/gcc/x86_64-unknown-linux-gnu/4.9.2
-        spec_dir = glob("%s/lib64/gcc/*/*" % self.prefix)
+        # e.g. lib/gcc/x86_64-unknown-linux-gnu/4.9.2
+        spec_dir = glob('{0}/gcc/*/*'.format(self.prefix.lib))
         return spec_dir[0] if spec_dir else None
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -57,6 +57,9 @@ class Gcc(AutotoolsPackage):
     version('4.6.4', 'b407a3d1480c11667f293bfb1f17d1a4')
     version('4.5.4', '27e459c2566b8209ab064570e1b378f7')
 
+    # Builds all default languages by default.
+    # Ada, Go, Jit, and Objective-C++ are not default languages.
+    # In that respect, the name 'all' is rather misleading.
     variant('languages',
             default='all',
             values=('all', 'ada', 'brig', 'c', 'c++', 'fortran',

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -31,14 +31,15 @@ from os.path import isfile
 
 
 class Gcc(AutotoolsPackage):
-    """The GNU Compiler Collection includes front ends for C, C++,
-       Objective-C, Fortran, and Java."""
-    homepage = "https://gcc.gnu.org"
+    """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
+    Fortran, Ada, and Go, as well as libraries for these languages."""
 
-    url = "http://ftp.gnu.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2"
+    homepage = 'https://gcc.gnu.org'
+    url      = 'http://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
 
+    version('7.1.0', '6bf56a2bca9dac9dbbf8e8d1036964a8')
     version('6.3.0', '677a7623c7ef6ab99881bc4e048debb6')
     version('6.2.0', '9768625159663b300ae4de2f4745fcc4')
     version('6.1.0', '8fb6cb98b8459f5863328380fbf06bd1')
@@ -63,16 +64,17 @@ class Gcc(AutotoolsPackage):
             default=False,
             description="Build PIC versions of libgfortran.a and libstdc++.a")
 
-    depends_on("mpfr")
-    depends_on("gmp")
-    depends_on("mpc", when='@4.5:')
-    depends_on("isl", when='@5.0:')
-    depends_on("binutils~libiberty", when='+binutils')
-    depends_on("zip", type='build')
+    # https://gcc.gnu.org/install/prerequisites.html
+    depends_on('gmp@4.3.2:')
+    depends_on('mpfr@2.4.2:')
+    depends_on('mpc@0.8.1:', when='@4.5:')
+    depends_on('isl@0.15:', when='@5.0:')
+    depends_on('binutils~libiberty', when='+binutils')
+    depends_on('zip', type='build')
 
     # TODO: integrate these libraries.
-    # depends_on("ppl")
-    # depends_on("cloog")
+    # depends_on('ppl')
+    # depends_on('cloog')
 
     # TODO: Add a 'test' deptype
     # https://github.com/LLNL/spack/issues/1279
@@ -95,7 +97,14 @@ class Gcc(AutotoolsPackage):
         spec = self.spec
         prefix = self.spec.prefix
 
-        enabled_languages = set(('c', 'c++', 'fortran', 'java', 'objc'))
+        # TODO: Add support for ada, brig, jit, lto, obj-c++
+        enabled_languages = set(('c', 'c++', 'fortran', 'objc'))
+
+        # The GCC Java frontend and associated libjava runtime library
+        # have been removed from GCC as of GCC 7.
+        # See https://gcc.gnu.org/gcc-7/changes.html
+        if self.version < Version('7'):
+            enabled_languages.add('java')
 
         if spec.satisfies("@4.7.1:") and sys.platform != 'darwin' and \
            not (spec.satisfies('@:4.9.3') and 'ppc64le' in spec.architecture):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -163,7 +163,8 @@ class Gcc(AutotoolsPackage):
         options = [
             '--libdir={0}'.format(prefix.lib64),
             '--disable-multilib',
-            '--enable-languages={0}'.format(spec.variants['languages'].value),
+            '--enable-languages={0}'.format(
+                ','.join(spec.variants['languages'].value)),
             '--with-mpfr={0}'.format(spec['mpfr'].prefix),
             '--with-gmp={0}'.format(spec['gmp'].prefix),
             '--enable-lto',

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -94,10 +94,6 @@ class Gcc(AutotoolsPackage):
     # depends_on('autogen@5.5.4:', type='test')
     # depends_on('guile@1.4.1:', type='test')
 
-    if sys.platform == 'darwin':
-        patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3')
-        patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3')
-
     # See https://golang.org/doc/install/gccgo#Releases
     provides('golang',        when='languages=go @4.6:')
     provides('golang@:1',     when='languages=go @4.7.1:')
@@ -108,6 +104,10 @@ class Gcc(AutotoolsPackage):
     provides('golang@:1.6.1', when='languages=go @6:')
     provides('golang@:1.8',   when='languages=go @7:')
 
+    patch('darwin/gcc-7.1.0-headerpad.patch', when='@7.1.0 platform=darwin')
+    patch('darwin/gcc-6.1.0-jit.patch', when='@6.1.0 platform=darwin')
+    patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3 platform=darwin')
+    patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3 platform=darwin')
     patch('piclibs.patch', when='+piclibs')
     patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -119,6 +119,9 @@ class Gcc(AutotoolsPackage):
     # See https://gcc.gnu.org/gcc-7/changes.html
     conflicts('languages=brig', when='@:6')
 
+    # BRIG does not seem to be supported on macOS
+    conflicts('languages=brig', when='platform=darwin')
+
     # GCC 4.8 added a 'c' language. I'm sure C was always built,
     # but this is the first version that accepts 'c' as a valid language.
     conflicts('languages=c', when='@:4.7')
@@ -126,6 +129,9 @@ class Gcc(AutotoolsPackage):
     # GCC 4.6 added support for the Go programming language.
     # See https://gcc.gnu.org/gcc-4.6/changes.html
     conflicts('languages=go', when='@:4.5')
+
+    # Go is not supported on macOS
+    conflicts('languages=go', when='platform=darwin')
 
     # The GCC Java frontend and associated libjava runtime library
     # have been removed from GCC as of GCC 7.

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -79,7 +79,7 @@ class Gcc(AutotoolsPackage):
     depends_on('mpc@0.8.1:', when='@4.5:')
     depends_on('isl@0.15:', when='@5.0:')
     depends_on('binutils~libiberty', when='+binutils')
-    depends_on('zip', type='build')
+    depends_on('zip', type='build', when='languages=java')
 
     # TODO: integrate these libraries.
     # depends_on('gnat', when='languages=ada')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -107,57 +107,40 @@ class Gcc(AutotoolsPackage):
     # provides('golang@:1.6.1', when='languages=go @6:')
     # provides('golang@:1.8',   when='languages=go @7:')
 
+    # For a list of valid languages for a specific release,
+    # run the following command in the GCC source directory:
+    #    $ grep ^language= gcc/*/config-lang.in
+    # See https://gcc.gnu.org/install/configure.html
+
+    # Support for processing BRIG 1.0 files was added in GCC 7
+    # BRIG is a binary format for HSAIL:
+    # (Heterogeneous System Architecture Intermediate Language).
+    # See https://gcc.gnu.org/gcc-7/changes.html
+    conflicts('languages=brig', when='@:6')
+
+    # GCC 4.8 added a 'c' language. I'm sure C was always built,
+    # but this is the first version that accepts 'c' as a valid language.
+    conflicts('languages=c', when='@:4.7')
+
+    # GCC 4.6 added support for the Go programming language.
+    # See https://gcc.gnu.org/gcc-4.6/changes.html
+    conflicts('languages=go', when='@:4.5')
+
+    # The GCC Java frontend and associated libjava runtime library
+    # have been removed from GCC as of GCC 7.
+    # See https://gcc.gnu.org/gcc-7/changes.html
+    conflicts('languages=java', when='@7:')
+
+    # GCC 5 added the ability to build GCC as a Just-In-Time compiler.
+    # See https://gcc.gnu.org/gcc-5/changes.html
+    conflicts('languages=jit', when='@:4')
+
     patch('darwin/gcc-7.1.0-headerpad.patch', when='@7.1.0 platform=darwin')
     patch('darwin/gcc-6.1.0-jit.patch', when='@6.1.0 platform=darwin')
     patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3 platform=darwin')
     patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3 platform=darwin')
     patch('piclibs.patch', when='+piclibs')
     patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
-
-    @run_before('autoreconf')
-    def check_languages(self):
-        """Makes sure all requested languages are valid for a
-        specific version of GCC.
-
-        For a list of valid languages for a specific release,
-        run the following command in the GCC source directory:
-
-        .. code-block:: console
-
-           $ grep ^language= gcc/*/config-lang.in
-
-        See https://gcc.gnu.org/install/configure.html
-        """
-        spec = self.spec
-        version = self.version
-
-        # Support for processing BRIG 1.0 files was added in GCC 7
-        # BRIG is a binary format for HSAIL:
-        # (Heterogeneous System Architecture Intermediate Language).
-        # See https://gcc.gnu.org/gcc-7/changes.html
-        if version < Version('7') and 'languages=brig' in spec:
-            raise InstallError('BRIG is not available before GCC 7')
-
-        # GCC 4.8 added a 'c' language. I'm sure C was always built,
-        # but this is the first version that accepts 'c' as a valid language.
-        if version < Version('4.8') and 'languages=c' in spec:
-            raise InstallError('C is not a valid language before GCC 4.8')
-
-        # GCC 4.6 added support for the Go programming language.
-        # See https://gcc.gnu.org/gcc-4.6/changes.html
-        if version < Version('4.6') and 'languages=go' in spec:
-            raise InstallError('Go is not available before GCC 4.6')
-
-        # The GCC Java frontend and associated libjava runtime library
-        # have been removed from GCC as of GCC 7.
-        # See https://gcc.gnu.org/gcc-7/changes.html
-        if version >= Version('7') and 'languages=java' in spec:
-            raise InstallError('Java is no longer available as of GCC 7')
-
-        # GCC 5 added the ability to build GCC as a Just-In-Time compiler.
-        # See https://gcc.gnu.org/gcc-5/changes.html
-        if version < Version('5') and 'languages=jit' in spec:
-            raise InstallError('JIT is not available before GCC 5')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -57,12 +57,18 @@ class Gcc(AutotoolsPackage):
     version('4.6.4', 'b407a3d1480c11667f293bfb1f17d1a4')
     version('4.5.4', '27e459c2566b8209ab064570e1b378f7')
 
+    variant('languages',
+            default='all',
+            values=('all', 'ada', 'brig', 'c', 'c++', 'fortran',
+                    'go', 'java', 'jit', 'lto', 'objc', 'obj-c++'),
+            multi=True,
+            description='Compilers and runtime libraries to build')
     variant('binutils',
             default=sys.platform != 'darwin',
-            description="Build via binutils")
+            description='Build via binutils')
     variant('piclibs',
             default=False,
-            description="Build PIC versions of libgfortran.a and libstdc++.a")
+            description='Build PIC versions of libgfortran.a and libstdc++.a')
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
@@ -73,6 +79,7 @@ class Gcc(AutotoolsPackage):
     depends_on('zip', type='build')
 
     # TODO: integrate these libraries.
+    # depends_on('gnat', when='languages=ada')
     # depends_on('ppl')
     # depends_on('cloog')
 
@@ -93,22 +100,60 @@ class Gcc(AutotoolsPackage):
     patch('piclibs.patch', when='+piclibs')
     patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
 
-    def configure_args(self):
-        spec = self.spec
-        prefix = self.spec.prefix
+    @run_before('autoreconf')
+    def check_languages(self):
+        """Makes sure all requested languages are valid for a
+        specific version of GCC.
 
-        # TODO: Add support for ada, brig, jit, lto, obj-c++
-        enabled_languages = set(('c', 'c++', 'fortran', 'objc'))
+        For a list of valid languages for a specific release,
+        run the following command in the GCC source directory:
+
+        .. code-block:: console
+
+           $ grep ^language= gcc/*/config-lang.in
+
+        See https://gcc.gnu.org/install/configure.html
+        """
+        spec = self.spec
+        version = self.version
+
+        # Ada is not currently supported as it requires
+        # an existing Ada compiler to build.
+        if 'languages=ada' in spec:
+            raise InstallError('Ada requires GNAT to install')
+
+        # Support for processing BRIG 1.0 files was added in GCC 7
+        # BRIG is a binary format for HSAIL:
+        # (Heterogeneous System Architecture Intermediate Language).
+        # See https://gcc.gnu.org/gcc-7/changes.html
+        if version < Version('7') and 'languages=brig' in spec:
+            raise InstallError('BRIG is not available before GCC 7')
+
+        # GCC 4.8 added a 'c' language. I'm sure C was always built,
+        # but this is the first version that accepts 'c' as a valid language.
+        if version < Version('4.8') and 'languages=c' in spec:
+            raise InstallError('C is not a valid language before GCC 4.8')
+
+        # GCC 4.6 added support for the Go programming language.
+        # See https://gcc.gnu.org/gcc-4.6/changes.html
+        # See https://golang.org/doc/install/gccgo#Releases
+        if version < Version('4.6') and 'languages=go' in spec:
+            raise InstallError('Go is not available before GCC 4.6')
 
         # The GCC Java frontend and associated libjava runtime library
         # have been removed from GCC as of GCC 7.
         # See https://gcc.gnu.org/gcc-7/changes.html
-        if self.version < Version('7'):
-            enabled_languages.add('java')
+        if version >= Version('7') and 'languages=java' in spec:
+            raise InstallError('Java is no longer available as of GCC 7')
 
-        if spec.satisfies("@4.7.1:") and sys.platform != 'darwin' and \
-           not (spec.satisfies('@:4.9.3') and 'ppc64le' in spec.architecture):
-            enabled_languages.add('go')
+        # GCC 5 added the ability to build GCC as a Just-In-Time compiler.
+        # See https://gcc.gnu.org/gcc-5/changes.html
+        if version < Version('5') and 'languages=jit' in spec:
+            raise InstallError('JIT is not available before GCC 5')
+
+    def configure_args(self):
+        spec = self.spec
+        prefix = self.spec.prefix
 
         # Fix a standard header file for OS X Yosemite that
         # is GCC incompatible by replacing non-GCC compliant macros
@@ -127,7 +172,7 @@ class Gcc(AutotoolsPackage):
         options = [
             '--libdir={0}'.format(prefix.lib64),
             '--disable-multilib',
-            '--enable-languages={0}'.format(','.join(enabled_languages)),
+            '--enable-languages={0}'.format(spec.variants['languages'].value),
             '--with-mpfr={0}'.format(spec['mpfr'].prefix),
             '--with-gmp={0}'.format(spec['gmp'].prefix),
             '--enable-lto',

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -95,14 +95,17 @@ class Gcc(AutotoolsPackage):
     # depends_on('guile@1.4.1:', type='test')
 
     # See https://golang.org/doc/install/gccgo#Releases
-    provides('golang',        when='languages=go @4.6:')
-    provides('golang@:1',     when='languages=go @4.7.1:')
-    provides('golang@:1.1',   when='languages=go @4.8:')
-    provides('golang@:1.1.2', when='languages=go @4.8.2:')
-    provides('golang@:1.2',   when='languages=go @4.9:')
-    provides('golang@:1.4',   when='languages=go @5:')
-    provides('golang@:1.6.1', when='languages=go @6:')
-    provides('golang@:1.8',   when='languages=go @7:')
+    provides('golang', when='languages=go')
+    # 'when' does not currently support multiple parts of a spec.
+    # See https://github.com/LLNL/spack/pull/4151
+    # provides('golang',        when='languages=go @4.6:')
+    # provides('golang@:1',     when='languages=go @4.7.1:')
+    # provides('golang@:1.1',   when='languages=go @4.8:')
+    # provides('golang@:1.1.2', when='languages=go @4.8.2:')
+    # provides('golang@:1.2',   when='languages=go @4.9:')
+    # provides('golang@:1.4',   when='languages=go @5:')
+    # provides('golang@:1.6.1', when='languages=go @6:')
+    # provides('golang@:1.8',   when='languages=go @7:')
 
     patch('darwin/gcc-7.1.0-headerpad.patch', when='@7.1.0 platform=darwin')
     patch('darwin/gcc-6.1.0-jit.patch', when='@6.1.0 platform=darwin')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -97,8 +97,16 @@ class Gcc(AutotoolsPackage):
     if sys.platform == 'darwin':
         patch('darwin/gcc-4.9.patch1', when='@4.9.0:4.9.3')
         patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3')
-    else:
-        provides('golang', when='@4.7.1:')
+
+    # See https://golang.org/doc/install/gccgo#Releases
+    provides('golang',        when='languages=go @4.6:')
+    provides('golang@:1',     when='languages=go @4.7.1:')
+    provides('golang@:1.1',   when='languages=go @4.8:')
+    provides('golang@:1.1.2', when='languages=go @4.8.2:')
+    provides('golang@:1.2',   when='languages=go @4.9:')
+    provides('golang@:1.4',   when='languages=go @5:')
+    provides('golang@:1.6.1', when='languages=go @6:')
+    provides('golang@:1.8',   when='languages=go @7:')
 
     patch('piclibs.patch', when='+piclibs')
     patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
@@ -139,7 +147,6 @@ class Gcc(AutotoolsPackage):
 
         # GCC 4.6 added support for the Go programming language.
         # See https://gcc.gnu.org/gcc-4.6/changes.html
-        # See https://golang.org/doc/install/gccgo#Releases
         if version < Version('4.6') and 'languages=go' in spec:
             raise InstallError('Go is not available before GCC 4.6')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -78,11 +78,11 @@ class Gcc(AutotoolsPackage):
     depends_on('mpfr@2.4.2:')
     depends_on('mpc@0.8.1:', when='@4.5:')
     depends_on('isl@0.15:', when='@5.0:')
+    depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
 
     # TODO: integrate these libraries.
-    # depends_on('gnat', when='languages=ada')
     # depends_on('ppl')
     # depends_on('cloog')
 
@@ -130,11 +130,6 @@ class Gcc(AutotoolsPackage):
         """
         spec = self.spec
         version = self.version
-
-        # Ada is not currently supported as it requires
-        # an existing Ada compiler to build.
-        if 'languages=ada' in spec:
-            raise InstallError('Ada requires GNAT to install')
 
         # Support for processing BRIG 1.0 files was added in GCC 7
         # BRIG is a binary format for HSAIL:

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -79,6 +79,7 @@ class Gcc(AutotoolsPackage):
     depends_on('mpfr@2.4.2:')
     depends_on('mpc@0.8.1:', when='@4.5:')
     depends_on('isl@0.15:', when='@5.0:')
+    depends_on('zlib', when='@6:')
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
@@ -182,6 +183,10 @@ class Gcc(AutotoolsPackage):
             '--enable-lto',
             '--with-quad'
         ]
+
+        # Use installed libz
+        if self.version >= Version('6'):
+            options.append('--with-system-zlib')
 
         # Enabling language "jit" requires --enable-host-shared.
         if 'languages=jit' in spec:

--- a/var/spack/repos/builtin/packages/gnat/package.py
+++ b/var/spack/repos/builtin/packages/gnat/package.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Gnat(MakefilePackage):
+    """The GNAT Ada compiler. Ada is a modern programming language designed
+    for large, long-lived applications - and embedded systems in particular
+    - where reliability and efficiency are essential."""
+
+    homepage = "https://libre.adacore.com/tools/gnat-gpl-edition/"
+
+    # NOTE: This is a binary installer intended to bootstrap GCC's Ada compiler
+
+    # There may actually be a way to install GNAT from source. If you go to
+    # the GNAT Download page: https://libre.adacore.com/download/
+    # select "Free Software or Academic Development", select your platform,
+    # expand GNAT Ada, and expand Sources, you'll see links to download the
+    # source code for GNAT and all of its dependencies. Most of these
+    # dependencies are already in Spack.
+
+    # This is the GPL release for Linux x86-64
+    version('2016', '9741107cca1a6a4ddb0d5e8de824a90c',
+            url="http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b")
+
+    phases = ['install']
+
+    def install(self, spec, prefix):
+        make('ins-all', 'prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/gnat/package.py
+++ b/var/spack/repos/builtin/packages/gnat/package.py
@@ -42,7 +42,7 @@ class Gnat(MakefilePackage):
     # dependencies are already in Spack.
 
     # This is the GPL release for Linux x86-64
-    version('2016', '9741107cca1a6a4ddb0d5e8de824a90c',
+    version('2016', '9741107cca1a6a4ddb0d5e8de824a90c', extension='tar.gz',
             url="http://mirrors.cdn.adacore.com/art/5739cefdc7a447658e0b016b")
 
     phases = ['install']


### PR DESCRIPTION
GCC 7 is out!

The biggest change I've noticed so far is that the Java compiler is gone. I haven't actually tried installing it yet to make sure all of our flags/hacks still work, so marking this WIP for now.

Fixes #1501. Now, Spack adds a `zip` dependency only when building `gcc languages=java`.