### PR TITLE
Remove python dependency for libxcb and xcbproto

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -43,7 +43,8 @@ class Libxcb(AutotoolsPackage):
     depends_on('libxdmcp')
 
     depends_on('xcb-proto', type='build')
-    depends_on('python@2:2.8', type='build')
+    # TODO: uncomment once build deps can be resolved separately
+    # depends_on('python@2:2.8', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -35,6 +35,7 @@ class XcbProto(AutotoolsPackage):
     version('1.12', '5ee1ec124ea8d56bd9e83b8e9e0b84c4')
     version('1.11', 'c8c6cb72c84f58270f4db1f39607f66a')
 
-    extends('python')
+    # TODO: uncomment once build deps can be resolved separately
+    # extends('python')
 
     patch('xcb-proto-1.12-schema-1.patch', when='@1.12')


### PR DESCRIPTION
python+tk will not build because it depends (indirectly) on python~tk
via libxcb. There are efforts to allow multiple instances of a package
to concretize together but they are ongoing so in the meantime this
comments out the dependencies and adds TODOs