### PR TITLE
Spec.__init__: removed dead code

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -966,15 +966,12 @@ class Spec(object):
         # Spec(a, b) will copy a but just add b as a dep.
         deptypes = ()
         for dep in dep_like:
-            if isinstance(dep, Spec):
-                spec = dep
-            elif isinstance(dep, (list, tuple)):
+
+            if isinstance(dep, (list, tuple)):
                 # Literals can be deptypes -- if there are tuples in the
                 # list, they will be used as deptypes for the following Spec.
                 deptypes = tuple(dep)
                 continue
-            else:
-                spec = Spec(dep)
 
             spec = dep if isinstance(dep, Spec) else Spec(dep)
             self._add_dependency(spec, deptypes)


### PR DESCRIPTION
The conditionals are repeated in the statement before _add_dependencies