### PR TITLE
gmp: switch to download directly from GNU

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -30,7 +30,7 @@ class Gmp(AutotoolsPackage):
     on signed integers, rational numbers, and floating-point numbers."""
 
     homepage = "https://gmplib.org"
-    url = "https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2"
+    url      = "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
 
     version('6.1.2',  '8ddbb26dc3bd4e2302984debba1406a5')
     version('6.1.1',  '4c175f86e11eb32d8bf9872ca3a8e11d')


### PR DESCRIPTION
The GMP website has been down for at least a couple days now. Switching to the GNU server as it's more reliable. Checksums are the same.