### PR TITLE
BarrierTimeoutError must derive from Exception

### DIFF
--- a/lib/spack/spack/util/multiproc.py
+++ b/lib/spack/spack/util/multiproc.py
@@ -92,5 +92,5 @@ class Barrier:
         self.turnstile2.release()
 
 
-class BarrierTimeoutError:
+class BarrierTimeoutError(Exception):
     pass


### PR DESCRIPTION
Seen in https://travis-ci.org/LLNL/spack/builds/229484526, very likely due to a problem in the Travis builder.