### PR TITLE
enable cuda support for suite-sparse

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -37,8 +37,8 @@ class SuiteSparse(Package):
     version('4.5.3', '8ec57324585df3c6483ad7f556afccbd')
     version('4.5.1', 'f0ea9aad8d2d1ffec66a5b6bfeff5319')
 
-    variant('tbb', default=False, description='Build with Intel TBB')
-    variant('pic', default=True, description='Build position independent code (required to link with shared libraries)')
+    variant('tbb',  default=False, description='Build with Intel TBB')
+    variant('pic',  default=True,  description='Build position independent code (required to link with shared libraries)')
     variant('cuda', default=False, description='Build with CUDA')
 
     depends_on('blas')
@@ -68,11 +68,14 @@ class SuiteSparse(Package):
             'CC=%s' % self.compiler.cc,
             'CXX=%s' % self.compiler.cxx,
             'F77=%s' % self.compiler.f77,
-            # CUDA=no does NOT disable cuda, it only disables internal search for CUDA_PATH.
-            # If in addition the latter is empty, then CUDA is completely disabled.
-            # See [SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk] for more.
+            # CUDA=no does NOT disable cuda, it only disables internal search
+            # for CUDA_PATH. If in addition the latter is empty, then CUDA is
+            # completely disabled. See
+            # [SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk] for more.
             'CUDA=no',
-            'CUDA_PATH={0}'.format(spec['cuda'].prefix if '+cuda' in spec else '')
+            'CUDA_PATH={0}'.format(
+                spec['cuda'].prefix if '+cuda' in spec else ''
+            )
         ])
 
         if '+pic' in spec:

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -72,7 +72,7 @@ class SuiteSparse(Package):
             # If in addition the latter is empty, then CUDA is completely disabled.
             # See [SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk] for more.
             'CUDA=no',
-            'CUDA_PATH={}'.format(spec['cuda'].prefix if '+cuda' in spec else '')
+            'CUDA_PATH={0}'.format(spec['cuda'].prefix if '+cuda' in spec else '')
         ])
 
         if '+pic' in spec:

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -68,19 +68,12 @@ class SuiteSparse(Package):
             'CC=%s' % self.compiler.cc,
             'CXX=%s' % self.compiler.cxx,
             'F77=%s' % self.compiler.f77,
-            # They "autodetect" CUDA before CUDA_PATH is checked
-            # setting CUDA=no disables them using `which nvcc`,
-            # so that we can use our spack managed cuda path.  If
-            # +cuda we set CUDA_PATH, and the other CUDA specific
-            # libraries are setup by suite-sparse.  See the file
-            # SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk
-            'CUDA=no'
+            # CUDA=no does NOT disable cuda, it only disables internal search for CUDA_PATH.
+            # If in addition the latter is empty, then CUDA is completely disabled.
+            # See [SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk] for more.
+            'CUDA=no',
+            'CUDA_PATH={}'.format(spec['cuda'].prefix if '+cuda' in spec else '')
         ])
-
-        if '+cuda' in spec:
-            make_args.extend([
-                'CUDA_PATH=%s' % spec['cuda'].prefix
-            ])
 
         if '+pic' in spec:
             make_args.extend([

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -77,7 +77,7 @@ class SuiteSparse(Package):
             'CUDA=no'
         ])
 
-        if spec.satisfies('+cuda'):
+        if '+cuda' in spec:
             make_args.extend([
                 'CUDA_PATH=%s' % spec['cuda'].prefix
             ])


### PR DESCRIPTION
**NEEDS FACT CHECKING**.  For convenience, the relevant section of the `SuiteSparse_config.mk` file is

```
    #---------------------------------------------------------------------------
    # NVIDIA CUDA configuration for CHOLMOD and SPQR
    #---------------------------------------------------------------------------

    # CUDA is detected automatically, and used if found.  To disable CUDA,
    # use CUDA=no

    ifneq ($(CUDA),no)
        CUDA_PATH = $(shell which nvcc 2>/dev/null | sed "s/\/bin\/nvcc//")
    endif

    ifeq ($(wildcard $(CUDA_PATH)),)
        # CUDA is not present
        CUDA_PATH     =
        GPU_BLAS_PATH =
        GPU_CONFIG    =
        CUDART_LIB    =
        CUBLAS_LIB    =
        CUDA_INC_PATH =
        CUDA_INC      =
        NVCC          = echo
        NVCCFLAGS     =
    else
        # with CUDA for CHOLMOD and SPQR
        GPU_BLAS_PATH = $(CUDA_PATH)
        # GPU_CONFIG must include -DGPU_BLAS to compile SuiteSparse for the
        # GPU.  You can add additional GPU-related flags to it as well.
        # with 4 cores (default):
        GPU_CONFIG    = -DGPU_BLAS
        # For example, to compile CHOLMOD for 10 CPU cores when using the GPU:
        # GPU_CONFIG  = -DGPU_BLAS -DCHOLMOD_OMP_NUM_THREADS=10
        CUDART_LIB    = $(CUDA_PATH)/lib64/libcudart.so
        CUBLAS_LIB    = $(CUDA_PATH)/lib64/libcublas.so
        CUDA_INC_PATH = $(CUDA_PATH)/include/
        CUDA_INC      = -I$(CUDA_INC_PATH)
        NVCC          = $(CUDA_PATH)/bin/nvcc
        NVCCFLAGS     = -Xcompiler -fPIC -O3 \
                            -gencode=arch=compute_30,code=sm_30 \
                            -gencode=arch=compute_35,code=sm_35 \
                            -gencode=arch=compute_50,code=sm_50 \
                            -gencode=arch=compute_50,code=compute_50
    endif
```

Basically, I'm sure the original author put this part I deleted in there since `cuda` hasn't been in `spack` for very long.  Since `cuda` is available now, though, this seems to be the correct way to do it -- hack around them doing `which nvcc` and then set `CUDA_PATH` based off what `spack` does.

1. I can only confirm that the libraries (e.g. `libSuiteSparse_GPURuntime.so`) are able to be built (when `+cuda`).
    - `ls -al | wc -l` was my fact checker, `42` for `~cuda` and `48` for `+cuda`.
2. I tried like heck to get their coverage tests `make cov` to work, but similar to the `patch` being applied to the file, I would have had to go through and find all of the places where instead of `LAPACK ?= thing` they do `LAPACK = thing`...and I don't feel like doing that.
3. I have no idea how to write any code using this library or its CUDA capabilities, and a brief scan of the internet makes me think it would be a lot better if somebody who actually knows what to do tested this rather than somebody (me) who has no idea whether the code they're writing is correct and the library build failed, or vice versa.

Basically, the fact that the libraries build lead me to believe it is working as expected, but this should definitely have some testing done by others before blindly merging -- `suite-sparse` is a core package and this is going to change the hashes (added a variant)...