### PR TITLE
cp2k: fixed compilation issues for intel stack

### DIFF
--- a/lib/spack/spack/file_cache.py
+++ b/lib/spack/spack/file_cache.py
@@ -149,7 +149,7 @@ class FileCache(object):
                 if value:
                     # remove tmp on exception & raise it
                     shutil.rmtree(cm.tmp_filename, True)
-                    raise value
+
                 else:
                     os.rename(cm.tmp_filename, cm.orig_filename)
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -50,7 +50,7 @@ class Cp2k(Package):
     depends_on('fftw')
     depends_on('libint@:1.2', when='@3.0,4.1')
 
-    depends_on('mpi', when='+mpi')
+    depends_on('mpi@2:', when='+mpi')
     depends_on('scalapack', when='+mpi')
     depends_on('plumed+shared+mpi', when='+plumed+mpi')
     depends_on('plumed+shared~mpi', when='+plumed~mpi')
@@ -80,32 +80,56 @@ class Cp2k(Package):
             optflags = {
                 'gcc': ['-O2',
                         '-ffast-math',
-                        '-ffree-form',
-                        '-ffree-line-length-none',
                         '-ftree-vectorize',
                         '-funroll-loops',
                         '-mtune=native'],
                 'intel': ['-O2',
                           '-pc64',
-                          '-unroll',
-                          '-heap-arrays 64']
+                          '-unroll']
             }
+
+            dflags = ['-DNDEBUG']
+
             cppflags = [
                 '-D__FFTW3',
                 '-D__LIBINT',
                 spec['fftw'].headers.cpp_flags
             ]
+
+            if '^mpi@3:' in spec:
+                cppflags.append('-D__MPI_VERSION=3')
+            elif '^mpi@2:' in spec:
+                cppflags.append('-D__MPI_VERSION=2')
+
+            if '^intel-mkl' in spec:
+                cppflags.append('-D__FFTSG')
+
+            cflags = copy.deepcopy(optflags[self.spec.compiler.name])
+            cxxflags = copy.deepcopy(optflags[self.spec.compiler.name])
             fcflags = copy.deepcopy(optflags[self.spec.compiler.name])
-            fcflags.append(spec['fftw'].headers.cpp_flags)
+            fcflags.extend([
+                '-ffree-form',
+                '-ffree-line-length-none',
+                spec['fftw'].headers.cpp_flags
+            ])
+
+            if '%intel' in spec:
+                cflags.append('-fp-model precise')
+                cxxflags.append('-fp-model precise')
+                fcflags.extend(['-fp-model source', '-heap-arrays 64'])
+
             fftw = find_libraries('libfftw3', root=spec['fftw'].prefix.lib)
             ldflags = [fftw.search_flags]
+
             if 'superlu-dist@4.3' in spec:
                 ldflags = ['-Wl,--allow-multiple-definition'] + ldflags
+
             libs = [
                 join_path(spec['libint'].prefix.lib, 'libint.so'),
                 join_path(spec['libint'].prefix.lib, 'libderiv.so'),
                 join_path(spec['libint'].prefix.lib, 'libr12.so')
             ]
+
             if '+plumed' in self.spec:
                 # Include Plumed.inc in the Makefile
                 mkf.write('include {0}\n'.format(
@@ -116,6 +140,7 @@ class Cp2k(Package):
                               'Plumed.inc')
                 ))
                 # Add required macro
+                dflags.extend(['-D__PLUMED2'])
                 cppflags.extend(['-D__PLUMED2'])
                 libs.extend([
                     join_path(self.spec['plumed'].prefix.lib,
@@ -130,18 +155,20 @@ class Cp2k(Package):
                 # ${CPP} <file>.F > <file>.f90
                 #
                 # and use `-fpp` instead
-                mkf.write('CPP = # {0.compiler.cc} -P\n'.format(self))
-                mkf.write('AR = xiar -r\n')
+                mkf.write('CPP = # {0.compiler.cc} -P\n\n'.format(self))
+                mkf.write('AR = xiar -r\n\n')
             else:
-                mkf.write('CPP = {0.compiler.cc} -E\n'.format(self))
-                mkf.write('AR = ar -r\n')
+                mkf.write('CPP = {0.compiler.cc} -E\n\n'.format(self))
+                mkf.write('AR = ar -r\n\n')
             fc = self.compiler.fc if '~mpi' in spec else self.spec['mpi'].mpifc
             mkf.write('FC = {0}\n'.format(fc))
             mkf.write('LD = {0}\n'.format(fc))
             # Intel
             if '%intel' in self.spec:
                 cppflags.extend([
-                    '-D__INTEL_COMPILER',
+                    '-D__INTEL',
+                    '-D__HAS_ISO_C_BINDING',
+                    '-D__USE_CP2K_TRACE',
                     '-D__MKL'
                 ])
                 fcflags.extend([
@@ -196,7 +223,7 @@ class Cp2k(Package):
                     libs.append(wannier)
 
                 libs.extend(scalapack)
-                libs.extend(self.spec['mpi'].mpicxx_shared_libs)
+                libs.extend(self.spec['mpi:cxx'].libs)
                 libs.extend(self.compiler.stdcxx_libs)
             # LAPACK / BLAS
             lapack = spec['lapack'].libs
@@ -205,11 +232,23 @@ class Cp2k(Package):
             ldflags.append((lapack + blas).search_flags)
             libs.extend([str(x) for x in (fftw, lapack, blas)])
 
+            dflags.extend(cppflags)
+            cflags.extend(cppflags)
+            cxxflags.extend(cppflags)
+            fcflags.extend(cppflags)
+
             # Write compiler flags to file
-            mkf.write('CPPFLAGS = {0}\n'.format(' '.join(cppflags)))
-            mkf.write('FCFLAGS = {0}\n'.format(' '.join(fcflags)))
-            mkf.write('LDFLAGS = {0}\n'.format(' '.join(ldflags)))
-            mkf.write('LIBS = {0}\n'.format(' '.join(libs)))
+            mkf.write('DFLAGS = {0}\n\n'.format(' '.join(dflags)))
+            mkf.write('CPPFLAGS = {0}\n\n'.format(' '.join(cppflags)))
+            mkf.write('CFLAGS = {0}\n\n'.format(' '.join(cflags)))
+            mkf.write('CXXFLAGS = {0}\n\n'.format(' '.join(cxxflags)))
+            mkf.write('FCFLAGS = {0}\n\n'.format(' '.join(fcflags)))
+            mkf.write('LDFLAGS = {0}\n\n'.format(' '.join(ldflags)))
+            if '%intel' in spec:
+                mkf.write('LDFLAGS_C = {0}\n\n'.format(
+                    ' '.join(ldflags) + ' -nofor_main')
+                )
+            mkf.write('LIBS = {0}\n\n'.format(' '.join(libs)))
 
         with working_dir('makefiles'):
             # Apparently the Makefile bases its paths on PWD

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -96,19 +96,25 @@ class IntelMkl(IntelInstaller):
     @property
     def scalapack_libs(self):
         libnames = ['libmkl_scalapack']
-        if self.spec.satisfies('^openmpi'):
+
+        # Intel MKL does not directly depend on mpi but the scalapack
+        # interface does and the corresponding  BLACS library changes
+        # depending on the MPI implementation we are using. We need then to
+        # inspect the root package which asked for Scalapack and check which
+        # MPI it depends on.
+        root = self.spec.root
+        if '^openmpi' in root:
             libnames.append('libmkl_blacs_openmpi')
-        elif self.spec.satisfies('^mpich@1'):
+        elif '^mpich@1' in root:
             libnames.append('libmkl_blacs')
-        elif self.spec.satisfies('^mpich@2:'):
+        elif '^mpich@2:' in root:
             libnames.append('libmkl_blacs_intelmpi')
-        elif self.spec.satisfies('^mvapich2'):
+        elif '^mvapich2' in root:
             libnames.append('libmkl_blacs_intelmpi')
-        elif self.spec.satisfies('^mpt'):
+        elif '^mpt' in root:
             libnames.append('libmkl_blacs_sgimpt')
-        # TODO: ^intel-parallel-studio can mean intel mpi, a compiler or a lib
-        # elif self.spec.satisfies('^intel-parallel-studio'):
-        #     libnames.append('libmkl_blacs_intelmpi')
+        elif '^intel-mpi' in root:
+            libnames.append('libmkl_blacs_intelmpi')
         else:
             raise InstallError("No MPI found for scalapack")
 

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -42,6 +42,18 @@ class IntelMpi(IntelInstaller):
 
     provides('mpi')
 
+    @property
+    def mpi_libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+        libraries = ['libmpifort', 'libmpi']
+
+        if 'cxx' in query_parameters:
+            libraries = ['libmpicxx'] + libraries
+
+        return find_libraries(
+            libraries, root=self.prefix.lib64, shared=True, recurse=True
+        )
+
     def install(self, spec, prefix):
         self.intel_prefix = prefix
         IntelInstaller.install(self, spec, prefix)


### PR DESCRIPTION
##### Modifications
 - [x] Added DFLAGS to the `make.inc` file being written. These macros are also added to the language specific variables like CFLAGS, CXXFLAGS and FCFLAGS. 
- [x] Changed `spec.satisfies('foo')` with `'foo' in spec` in `intel-mkl`, see #4135. 
- [x] Added a basic build interface to `intel-mpi`.
- [x] Don't re-raise from `__exit__` as it doesn't respect the context manager protocol.