### PR TITLE
ncurses: Always build tools

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -63,7 +63,6 @@ class Ncurses(AutotoolsPackage):
         ]
 
         nwide_opts = ['--without-manpages',
-                      '--without-progs',
                       '--without-tests']
 
         wide_opts = ['--enable-widec']


### PR DESCRIPTION
Otherwise, the install can fail if the system-provided `tic` binary is too old.