### PR TITLE
Add a new package for ExtUtils::MakeMaker

### DIFF
--- a/var/spack/repos/builtin/packages/perl-extutils-makemaker/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-makemaker/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PerlExtutilsMakemaker(PerlPackage):
+    """ExtUtils::MakeMaker - Create a module Makefile. This utility is designed
+    to write a Makefile for an extension module from a Makefile.PL. It is based
+    on the Makefile.SH model provided by Andy Dougherty and the perl5-porters.
+    """
+    homepage = "https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker"
+    url      = "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.24.tar.gz"
+
+    version('7.24', '15c67ba2ea2c9e20a3d976b738adb113')
+
+    depends_on('perl@5.6.0:', type=('build', 'run'))


### PR DESCRIPTION
I don't actually need this package anymore, but I figured I might as well add it since it works.

For a while now I've been using an external installation for Perl. Mostly because I can't install Perl with Intel, not because it takes a while to build. But when I tried building Git, it failed because it was missing ExtUtils::MakeMaker. I did some more debugging and found that I couldn't install any of the other Perl packages with my system Perl either. It turns out that I had `perl` installed but not `perl-devel`, which provides things like ExtUtils. Long story short, just let Spack build everything, external packages aren't reliable.