### PR TITLE
Travis version of pip is too old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ before_install:
 # Install various dependencies
 install:
   - pip install --upgrade pip
+  - pip install --upgrade setuptools
   - pip install --upgrade codecov
   - pip install --upgrade flake8
   - pip install --upgrade sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ before_install:
 
 # Install various dependencies
 install:
+  - pip install --upgrade pip
   - pip install --upgrade codecov
   - pip install --upgrade flake8
   - pip install --upgrade sphinx


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/4469 and https://github.com/kennethreitz/requests/issues/4006 and the last 20 PRs for Spack that have failed their unit tests.

My understanding is that the Travis version of pip is a bit too old. We need to install coverage, which depends on requests, which apparently requires a newer version of pip. ~~I have no idea why things all of a sudden broke today.~~ Because `requests` pushed out a new release one hour ago: https://github.com/kennethreitz/requests/releases