### PR TITLE
Be sure to upgrade pip so that our python packages can install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ before_install:
 
 # Install various dependencies
 install:
+  - pip install --upgrade pip      # make sure we're using a recent pip
   - pip install --upgrade codecov
   - pip install --upgrade flake8
   - pip install --upgrade sphinx


### PR DESCRIPTION
- latest requests release requires a really new pip version.
- Travis OS images come with an old version of pip.
- Upgrade pip to fix.