### PR TITLE
Make openmpi package defn more robust

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -48,6 +48,8 @@ def _verbs_dir():
         return path
     except TypeError:
         return None
+    except ProcessError:
+        return None
 
 
 class Openmpi(AutotoolsPackage):


### PR DESCRIPTION
Make openmpi handle bad ibv_devices return statuses without bailing out completely.

See #4162 for background.