### PR TITLE
Add pdt dependency to scorep

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -22,6 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import os
 from spack import *
 
 
@@ -45,4 +46,17 @@ class Pdt(AutotoolsPackage):
     version('3.18.1', 'e401534f5c476c3e77f05b7f73b6c4f2')
 
     def configure(self, spec, prefix):
-        configure('-prefix=%s' % prefix)
+        configure('-prefix={0}'.format(prefix))
+
+    @run_after('install')
+    def link_arch_dirs(self):
+        # Link arch-specific directories into prefix
+        for dir in os.listdir(self.prefix):
+            path = join_path(self.prefix, dir)
+            if not os.path.isdir(path) or os.path.islink(path):
+                continue
+            for d in ('bin', 'lib'):
+                src = join_path(path, d)
+                dst = join_path(self.prefix, d)
+                if os.path.isdir(src) and not os.path.exists(dst):
+                    os.symlink(join_path(dir, d), dst)

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -62,6 +62,7 @@ class Scorep(AutotoolsPackage):
 
     depends_on("mpi")
     depends_on("papi")
+    depends_on('pdt')
 
     variant('shmem', default=False, description='Enable shmem tracing')
 
@@ -79,6 +80,7 @@ class Scorep(AutotoolsPackage):
             "--with-cube=%s" % spec['cube'].prefix.bin,
             "--with-papi-header=%s" % spec['papi'].prefix.include,
             "--with-papi-lib=%s" % spec['papi'].prefix.lib,
+            "--with-pdt=%s" % spec['pdt'].prefix.bin,
             "--enable-shared",
         ]
 


### PR DESCRIPTION
scorep's configure requires a path to pdt's binaries. Since there are multiple architecture versions of them, add a variant for them.