### PR TITLE
Multiple anon fix

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2958,16 +2958,15 @@ class SpecParser(spack.parse.Parser):
                         # We're parsing an anonymous spec beginning with a
                         # key-value pair.
                         if not specs:
+                            self.push_tokens([self.previous, self.token])
+                            self.previous = None
                             specs.append(self.spec(None))
-                        self.expect(VAL)
-                        # Raise an error if the previous spec is already
-                        # concrete (assigned by hash)
-                        if specs[-1]._hash:
-                            raise RedundantSpecError(specs[-1],
-                                                     'key-value pair')
-                        specs[-1]._add_flag(
-                            self.previous.value, self.token.value)
-                        self.previous = None
+                        else:
+                            if specs[-1].concrete:
+                                # Trying to add k-v pair to spec from hash
+                                raise RedundantSpecError(specs[-1],
+                                                         'key-value pair')
+                            self.unexpected_token()
                     else:
                         # We're parsing a new spec by name
                         self.previous = None
@@ -3011,6 +3010,7 @@ class SpecParser(spack.parse.Parser):
                             raise RedundantSpecError(specs[-1],
                                                      'compiler, version, '
                                                      'or variant')
+                        print "HERE IS THE PROBLEM", specs
                         specs.append(self.spec(None))
                     else:
                         self.unexpected_token()
@@ -3085,6 +3085,7 @@ class SpecParser(spack.parse.Parser):
         added_version = False
 
         while self.next:
+            print self.next.type, self.next
             if self.accept(AT):
                 vlist = self.version_list()
                 for version in vlist:
@@ -3112,6 +3113,7 @@ class SpecParser(spack.parse.Parser):
                 else:
                     # We've found the start of a new spec. Go back to do_parse
                     # and read this token again.
+                    print "HOW DID I GET HERE", self.token
                     self.push_tokens([self.token])
                     self.previous = None
                     break
@@ -3126,6 +3128,7 @@ class SpecParser(spack.parse.Parser):
                     raise InvalidHashError(spec, hash_spec.dag_hash())
 
             else:
+                print "I got here???"
                 break
 
         # If there was no version in the spec, consier it an open range
@@ -3151,7 +3154,11 @@ class SpecParser(spack.parse.Parser):
 
         if self.accept(COLON):
             if self.accept(ID):
-                end = self.token.value
+                if self.next and self.next.type is EQ:
+                    # This is a start: range followed by a key=value pair
+                    self.push_tokens([self.token])
+                else:
+                    end = self.token.value
         elif start:
             # No colon, but there was a version.
             return Version(start)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3010,7 +3010,6 @@ class SpecParser(spack.parse.Parser):
                             raise RedundantSpecError(specs[-1],
                                                      'compiler, version, '
                                                      'or variant')
-                        print "HERE IS THE PROBLEM", specs
                         specs.append(self.spec(None))
                     else:
                         self.unexpected_token()
@@ -3085,7 +3084,6 @@ class SpecParser(spack.parse.Parser):
         added_version = False
 
         while self.next:
-            print self.next.type, self.next
             if self.accept(AT):
                 vlist = self.version_list()
                 for version in vlist:
@@ -3113,7 +3111,6 @@ class SpecParser(spack.parse.Parser):
                 else:
                     # We've found the start of a new spec. Go back to do_parse
                     # and read this token again.
-                    print "HOW DID I GET HERE", self.token
                     self.push_tokens([self.token])
                     self.previous = None
                     break
@@ -3128,7 +3125,6 @@ class SpecParser(spack.parse.Parser):
                     raise InvalidHashError(spec, hash_spec.dag_hash())
 
             else:
-                print "I got here???"
                 break
 
         # If there was no version in the spec, consier it an open range

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2966,6 +2966,14 @@ class SpecParser(spack.parse.Parser):
                                 # Trying to add k-v pair to spec from hash
                                 raise RedundantSpecError(specs[-1],
                                                          'key-value pair')
+                            # We should never end up here.
+                            # This requires starting a new spec with ID, EQ
+                            # After another spec that is not concrete
+                            # If the previous spec is not concrete, this is
+                            # handled in the spec parsing loop
+                            # If it is concrete, see the if statement above
+                            # If there is no previous spec, we don't land in
+                            # this else case.
                             self.unexpected_token()
                     else:
                         # We're parsing a new spec by name

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -140,10 +140,9 @@ class TestSpecSyntax(object):
         self.check_parse("arch=test-None-None", "platform=test")
         self.check_parse('@2.7:')
 
-    @pytest.mark.xfail()
     def test_anonymous_specs_with_multiple_parts(self):
         # Parse anonymous spec with multiple tokens
-        self.check_parse('languages=go @4.2:')
+        self.check_parse('@4.2: languages=go', 'languages=go @4.2:')
         self.check_parse('@4.2: languages=go')
 
     def test_simple_dependence(self):
@@ -551,12 +550,8 @@ class TestSpecSyntax(object):
 @pytest.mark.parametrize('spec,anon_spec,spec_name', [
     ('openmpi languages=go', 'languages=go', 'openmpi'),
     ('openmpi @4.6:', '@4.6:', 'openmpi'),
-    pytest.mark.xfail(
-        ('openmpi languages=go @4.6:', 'languages=go @4.6:', 'openmpi')
-    ),
-    pytest.mark.xfail(
-        ('openmpi @4.6: languages=go', '@4.6: languages=go', 'openmpi')
-    ),
+    ('openmpi languages=go @4.6:', 'languages=go @4.6:', 'openmpi'),
+    ('openmpi @4.6: languages=go', '@4.6: languages=go', 'openmpi'),
 ])
 def test_parse_anonymous_specs(spec, anon_spec, spec_name):
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -97,17 +97,14 @@ class Gcc(AutotoolsPackage):
     # depends_on('guile@1.4.1:', type='test')
 
     # See https://golang.org/doc/install/gccgo#Releases
-    provides('golang', when='languages=go')
-    # 'when' does not currently support multiple parts of a spec.
-    # See https://github.com/LLNL/spack/pull/4151
-    # provides('golang',        when='languages=go @4.6:')
-    # provides('golang@:1',     when='languages=go @4.7.1:')
-    # provides('golang@:1.1',   when='languages=go @4.8:')
-    # provides('golang@:1.1.2', when='languages=go @4.8.2:')
-    # provides('golang@:1.2',   when='languages=go @4.9:')
-    # provides('golang@:1.4',   when='languages=go @5:')
-    # provides('golang@:1.6.1', when='languages=go @6:')
-    # provides('golang@:1.8',   when='languages=go @7:')
+    provides('golang',        when='languages=go @4.6:')
+    provides('golang@:1',     when='languages=go @4.7.1:')
+    provides('golang@:1.1',   when='languages=go @4.8:')
+    provides('golang@:1.1.2', when='languages=go @4.8.2:')
+    provides('golang@:1.2',   when='languages=go @4.9:')
+    provides('golang@:1.4',   when='languages=go @5:')
+    provides('golang@:1.6.1', when='languages=go @6:')
+    provides('golang@:1.8',   when='languages=go @7:')
 
     # For a list of valid languages for a specific release,
     # run the following command in the GCC source directory:


### PR DESCRIPTION
Addresses issues from #4144 and #4151.

Allows anonymous specs with multiple parts.

Previously, anonymous specs that had version ranges ending in a colon followed by a key=value pair failed, as did anonymous specs with a version or other directive after a key=value pair.