### PR TITLE
Add patch to fix missing MODULESHOME in profile

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/0001-fix-problem-with-MODULESHOME-and-issue-271.patch
+++ b/var/spack/repos/builtin/packages/lmod/0001-fix-problem-with-MODULESHOME-and-issue-271.patch
@@ -1,0 +1,25 @@
+From 6dea3d8c6d1ec9dc279e0f1fbd9965e7cc774678 Mon Sep 17 00:00:00 2001
+From: Robert McLay <mclay@zaniahgroup.com>
+Date: Thu, 11 May 2017 12:42:08 -0500
+Subject: [PATCH] fix problem with MODULESHOME and issue #271
+
+---
+ init/profile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/init/profile.in b/init/profile.in
+index 0a7f7be..fdcbfcc 100644
+--- a/init/profile.in
++++ b/init/profile.in
+@@ -15,7 +15,7 @@ if [ -z "${USER_IS_ROOT:-}" ]; then
+     export MODULEPATH_ROOT="@modulepath_root@"
+     export MODULEPATH=$(@PKG@/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys $MODULEPATH_ROOT/Core)
+     export MODULEPATH=$(@PKG@/libexec/addto --append MODULEPATH @PKG@/modulefiles/Core)
+-    export BASH_ENV=$MODULESHOME/init/bash
++    export BASH_ENV=@PKG@/init/bash
+ 
+     #
+     # If MANPATH is empty, Lmod is adding a trailing ":" so that
+-- 
+2.9.3
+

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -36,22 +36,27 @@ class Lmod(AutotoolsPackage):
     """
 
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'
-    url = 'https://github.com/TACC/Lmod/archive/7.4.9.tar.gz'
+    url      = 'https://github.com/TACC/Lmod/archive/7.4.11.tar.gz'
 
-    version('7.4.9', 'd8ffab81ddca2491fe13e2ac0a4fd320')
-    version('7.4.8', '3b22932437cc29ce546ec887885355e7')
-    version('7.4.5', 'fc34029c60dd9782c3d011c2b93fd266')
-    version('7.4.1', '59b2558ee50877f2cf49ed37d7b09fea')
-    version('7.3',   '70180ec2ea1fae53aa83350523f6b2b3')
-    version('6.4.5', '14f6c58dbc0a5a75574d795eac2c1e3c')
-    version('6.4.1', '7978ba777c8aa41a4d8c05fec5f780f4')
-    version('6.3.7', '0fa4d5a24c41cae03776f781aa2dedc1')
-    version('6.0.1', '91abf52fe5033bd419ffe2842ebe7af9')
+    version('7.4.11', '70c55ba0ba3877b6d8df536ee7ea6d49')
+    version('7.4.10', 'a13e36d6196747fded7987ef3dcfb605')
+    version('7.4.9',  'd8ffab81ddca2491fe13e2ac0a4fd320')
+    version('7.4.8',  '3b22932437cc29ce546ec887885355e7')
+    version('7.4.5',  'fc34029c60dd9782c3d011c2b93fd266')
+    version('7.4.1',  '59b2558ee50877f2cf49ed37d7b09fea')
+    version('7.3',    '70180ec2ea1fae53aa83350523f6b2b3')
+    version('6.4.5',  '14f6c58dbc0a5a75574d795eac2c1e3c')
+    version('6.4.1',  '7978ba777c8aa41a4d8c05fec5f780f4')
+    version('6.3.7',  '0fa4d5a24c41cae03776f781aa2dedc1')
+    version('6.0.1',  '91abf52fe5033bd419ffe2842ebe7af9')
 
     depends_on('lua@5.2:')
     depends_on('lua-luaposix', type=('build', 'run'))
     depends_on('lua-luafilesystem', type=('build', 'run'))
     depends_on('tcl', type=('build', 'run'))
+
+    patch('fix_tclsh_paths.patch', when='@:6.4.3')
+    patch('0001-fix-problem-with-MODULESHOME-and-issue-271.patch', when='@7.3.28:7.4.10')
 
     parallel = False
 
@@ -60,8 +65,6 @@ class Lmod(AutotoolsPackage):
             self.stage.path, 'Lmod-{version}', 'src', '?.lua')
         spack_env.append_path('LUA_PATH', stage_lua_path.format(
             version=self.version), separator=';')
-
-    patch('fix_tclsh_paths.patch', when='@:6.4.3')
 
     def patch(self):
         """The tcl scripts should use the tclsh that was discovered


### PR DESCRIPTION
Fixed a bug I ran across in the Lmod package. Reported at https://github.com/TACC/Lmod/issues/271. Fixed in https://github.com/TACC/Lmod/commit/6dea3d8c6d1ec9dc279e0f1fbd9965e7cc774678

Also added the latest release which includes this change.