### PR TITLE
Download udunits from FTP server

### DIFF
--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -29,37 +29,10 @@ class Udunits2(AutotoolsPackage):
     """Automated units conversion"""
 
     homepage = "http://www.unidata.ucar.edu/software/udunits"
-    url      = "https://github.com/Unidata/UDUNITS-2/archive/v2.2.23.tar.gz"
+    url      = "ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.24.tar.gz"
 
-    # When adding new versions, check whether they are listed at
-    # ftp://ftp.unidata.ucar.edu/pub/udunits first. Git tags may change
-    # for unreleased versions.
-    version('2.2.24', '316911493e3b5c28ff7019223b4e27ea')
-    version('2.2.23', '0c0d9b1ebd7ad066233bedf40e66f1ba')
-    version('2.2.21', '167738b3ec886da1b92239de9cbbbc39')
+    version('2.2.24', '898b90dc1890f172c493406d0f26f531')
+    version('2.2.23', '9f66006accecd621a4c3eda4ba9fa7c9')
+    version('2.2.21', '1585a5efb2c40c00601abab036a81299')
 
     depends_on('expat')
-
-    depends_on('bison', type='build')
-    depends_on('flex',  type='build')
-    depends_on('libtool', type='build')
-    depends_on('automake', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('pkg-config', type='build')
-    depends_on('texinfo', type='build')
-
-    def autoreconf(self, spec, prefix):
-        # Work around autogen.sh oddities
-        # bash = which("bash")
-        # bash("./autogen.sh")
-        mkdirp("config")
-        autoreconf = which("autoreconf")
-        autoreconf("--install", "--verbose", "--force",
-                   "-I", "config",
-                   "-I", join_path(spec['pkg-config'].prefix,
-                                   "share", "aclocal"),
-                   "-I", join_path(spec['automake'].prefix,
-                                   "share", "aclocal"),
-                   "-I", join_path(spec['libtool'].prefix,
-                                   "share", "aclocal"),
-                   )


### PR DESCRIPTION
See #3809 for discussion.

The developer of UDUNITS asked us to download directly from the official FTP release server. One benefit of this over the GitHub releases is that the tarball includes the configure script, so we don't need to generate our own. This significantly reduces the complexity (and the number of dependencies) of this package.

@semmerson While we have you here, do you prefer the package to be named `udunits2` or just `udunits`?