### PR TITLE
Force suite-sparse to use Spack's compiler wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -62,12 +62,11 @@ class SuiteSparse(Package):
 
         make_args = ['INSTALL=%s' % prefix]
 
-        # inject Spack compiler wrappers
         make_args.extend([
+            # By default, the Makefile uses the Intel compilers if
+            # they are found. This flag disables this behavior,
+            # forcing it to use Spack's compiler wrappers.
             'AUTOCC=no',
-            'CC=%s' % self.compiler.cc,
-            'CXX=%s' % self.compiler.cxx,
-            'F77=%s' % self.compiler.f77,
             # CUDA=no does NOT disable cuda, it only disables internal search
             # for CUDA_PATH. If in addition the latter is empty, then CUDA is
             # completely disabled. See


### PR DESCRIPTION
Fixes #4160. Closes #4161. 

@davydden The reason that the compiler wrappers weren't working for `suite-sparse` was because we weren't using the compiler wrappers! `self.compiler.cc` isn't the compiler wrapper, it's the path to the actual compiler. We already set `CC` and friends elsewhere in Spack, so removing them solves the problem.

@svenevs Can you confirm that this solves the problem you were seeing? I just built `suite-sparse+tbb` locally.