### PR TITLE
Fix metis list_url

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -38,7 +38,7 @@ class Metis(Package):
 
     homepage = "http://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
     url      = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz"
-    list_url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD"
+    list_url = "http://glaros.dtc.umn.edu/gkhome/fsroot/sw/metis/OLD"
 
     version('5.1.0', '5465e67079419a69e0116de24fce58fe')
     version('5.0.2', 'acb521a4e8c2e6dd559a7f9abd0468c5')


### PR DESCRIPTION
### Before
```
$ spack versions metis
==> Safe versions (already checksummed):
  5.1.0  5.0.2  4.0.3
==> Remote versions (not yet checksummed):
  Found no versions for metis
```
### After
```
$ spack versions metis
==> Safe versions (already checksummed):
  5.1.0  5.0.2  4.0.3
==> Remote versions (not yet checksummed):
  5.0.3  5.0.1  5.0rc3  5.0rc2  5.0rc1  5.0pre2  5.0pre1  5.0  4.0.1  3.0.6  2.0.6
```