### PR TITLE
Add latest version of eigen

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -25,14 +25,16 @@
 from spack import *
 
 
-class Eigen(Package):
+class Eigen(CMakePackage):
     """Eigen is a C++ template library for linear algebra matrices,
     vectors, numerical solvers, and related algorithms.
     """
 
     homepage = 'http://eigen.tuxfamily.org/'
-    url = 'https://bitbucket.org/eigen/eigen/get/3.2.7.tar.bz2'
+    url      = 'https://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2'
+    list_url = 'https://bitbucket.org/eigen/eigen/downloads/?tab=tags'
 
+    version('3.3.3', 'b2ddade41040d9cf73b39b4b51e8775b')
     version('3.3.1', 'edb6799ef413b0868aace20d2403864c')
     version('3.2.10', 'a85bb68c82988648c3d53ba9768d7dcbcfe105f8')
     version('3.2.9', '59ab81212f8eb2534b1545a9b42c38bf618a0d71')
@@ -51,26 +53,15 @@ class Eigen(Package):
             description='Enables support for multi-precisions FP via mpfr')
 
     # TODO : dependency on googlehash, superlu, adolc missing
-    depends_on('cmake', type='build')
     depends_on('metis@5:', when='+metis')
     depends_on('scotch', when='+scotch')
     depends_on('fftw', when='+fftw')
     depends_on('suite-sparse', when='+suitesparse')
-    depends_on('mpfr@2.3.0:', when="+mpfr")
-    depends_on('gmp', when="+mpfr")
+    depends_on('mpfr@2.3.0:', when='+mpfr')
+    depends_on('gmp', when='+mpfr')
 
-    def install(self, spec, prefix):
-
-        options = []
-        options.extend(std_cmake_args)
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+    def build_type(self):
+        if '+debug' in self.spec:
+            return 'Debug'
+        else:
+            return 'Release'


### PR DESCRIPTION
- [x] Add eigen 3.3.3
- [x] Convert to `CMakePackage`
- [x] Add `list_url`

### Before
```
$ spack versions eigen
==> Safe versions (already checksummed):
  3.3.1  3.2.10  3.2.9  3.2.8  3.2.7
==> Remote versions (not yet checksummed):
  Found no versions for eigen
```

### After
```
$ spack versions eigen
==> Safe versions (already checksummed):
  3.3.3  3.3.1  3.2.10  3.2.9  3.2.8  3.2.7
==> Remote versions (not yet checksummed):
  3.3.2       3.2.4      3.1.3         3.0.7    3.0-beta4  2.0.12  2.0.3      2.0-beta2
  3.3.0       3.2.3      3.1.2         3.0.6    3.0-beta3  2.0.11  2.0.2      2.0-beta1
  3.3-rc2     3.2.2      3.1.1         3.0.5    3.0-beta2  2.0.10  2.0.1
  3.3-rc1     3.2.1      3.1.0-rc2     3.0.4    3.0-beta1  2.0.9   2.0.0
  3.3-beta2   3.2.0      3.1.0-rc1     3.0.3    2.0.17     2.0.8   2.0-rc1
  3.3-beta1   3.2-rc2    3.1.0-beta1   3.0.2    2.0.16     2.0.7   2.0-beta6
  3.3-alpha1  3.2-rc1    3.1.0-alpha2  3.0.1    2.0.15     2.0.6   2.0-beta5
  3.2.6       3.2-beta1  3.1.0-alpha1  3.0.0    2.0.14     2.0.5   2.0-beta4
  3.2.5       3.1.4      3.1.0         3.0-rc1  2.0.13     2.0.4   2.0-beta3
```