### PR TITLE
Fix spec['python'].home

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -531,6 +531,8 @@ class Python(AutotoolsPackage):
         module.site_packages_dir = join_path(dependent_spec.prefix,
                                              self.site_packages_dir)
 
+        self.spec.home = self.home
+
         # Make the site packages directory for extensions
         if dependent_spec.package.is_extension:
             mkdirp(module.site_packages_dir)


### PR DESCRIPTION
Fixes #4226.

@tgamblin @alalazo I'm still not sure if this hack was the right way to do things. Personally I'd rather override `spec['python'].prefix` but it appears that it is immutable.

@samfux84