### PR TITLE
Package for bcl2fastq2 (updates libxslt)

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/cmake-macros.patch
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/cmake-macros.patch
@@ -1,0 +1,10 @@
+--- a/src/cmake/bcl2fastq_redist_macros.cmake        2017-05-11 15:03:27.652495488 -0700
++++ b/src/cmake/bcl2fastq_redist_macros.cmake        2017-05-11 15:06:38.326745889 -0700
+@@ -30,6 +30,7 @@
+        message(" Found: ${libname}, correct version ${version}")
+        message("   ${${libname}_UPPER}_INCLUDE_DIR = ${${${libname}_UPPER}_INCLUDE_DIR}")
+        message("   ${${libname}_UPPER}_LIBRARIES = ${${${libname}_UPPER}_LIBRARIES}")
++       set (HAVE_${${libname}_UPPER} true CACHE BOOL "package" FORCE)
+     else("${${${libname}_UPPER}_VERSION_STRING}" STREQUAL "${version}")
+        message(" Not found: ${libname}, incorrect version ( ${${${libname}_UPPER}_VERSION} )")
+        set(${${libname}_UPPER}_FOUND "FALSE")

--- a/var/spack/repos/builtin/packages/bcl2fastq2/cxxConfigure-cmake.patch
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/cxxConfigure-cmake.patch
@@ -1,0 +1,12 @@
+--- a/src/cmake/cxxConfigure.cmake	2017-05-11 16:55:14.745107845 -0700
++++ b/src/cmake/cxxConfigure.cmake	2017-05-11 17:16:39.355981745 -0700
+@@ -101,6 +101,9 @@
+ if((NOT HAVE_LIBXML2) OR (NOT HAVE_LIBXSLT))
+   find_package_version(LibXml2 ${BCL2FASTQ_LIBXML2_VERSION})
+   find_package_version(LibXslt ${BCL2FASTQ_LIBXSLT_VERSION})
++  # macro isn't ONLY for redist, see it's definition...
++  string(REGEX REPLACE "/include$" "" LIBEXSLT_HINT ${LIBXSLT_INCLUDE_DIR})
++  find_library_redist(LIBEXSLT ${LIBEXSLT_HINT} libexslt/exslt.h exslt)
+ endif((NOT HAVE_LIBXML2) OR (NOT HAVE_LIBXSLT))
+ 
+ if((NOT HAVE_LIBXML2) OR (NOT HAVE_LIBXSLT))

--- a/var/spack/repos/builtin/packages/bcl2fastq2/cxxConfigure-cmake.patch
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/cxxConfigure-cmake.patch
@@ -4,7 +4,7 @@
  if((NOT HAVE_LIBXML2) OR (NOT HAVE_LIBXSLT))
    find_package_version(LibXml2 ${BCL2FASTQ_LIBXML2_VERSION})
    find_package_version(LibXslt ${BCL2FASTQ_LIBXSLT_VERSION})
-+  # macro isn't ONLY for redist, see it's definition...
++  # macro isn't ONLY for redist, see its definition...
 +  string(REGEX REPLACE "/include$" "" LIBEXSLT_HINT ${LIBXSLT_INCLUDE_DIR})
 +  find_library_redist(LIBEXSLT ${LIBEXSLT_HINT} libexslt/exslt.h exslt)
  endif((NOT HAVE_LIBXML2) OR (NOT HAVE_LIBXSLT))

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -75,15 +75,15 @@ class Bcl2fastq2(Package):
         def wrap():
             f()                 # call the original expand_archive()
             if os.path.isdir('bcl2fastq'):
-                tty.msg("The tarball has already been unpacked.")
+                tty.msg("The tarball has already been unpacked")
             else:
-                tty.msg("Unpacking bcl2fastq2 tarball.")
+                tty.msg("Unpacking bcl2fastq2 tarball")
                 tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
                 shutil.move(join_path('spack-expanded-archive', tarball), '.')
                 os.rmdir('spack-expanded-archive')
                 tar = which('tar')
                 tar('-xf', tarball)
-                tty.msg("Finished unpacking bcl2fastq2 tarball.")
+                tty.msg("Finished unpacking bcl2fastq2 tarball")
         return wrap
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -1,0 +1,91 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+from spack.util.executable import which
+import shutil
+import llnl.util.tty as tty
+
+
+#class Bcl2fastq2(CMakePackage):
+class Bcl2fastq2(Package):
+    """The bcl2fastq2 Conversion Software converts base
+       call (BCL) files from a sequencing run into FASTQ
+       files."""
+
+    homepage = "https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html"
+    url      = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-18-0-12-tar.zip"
+
+    version('2-18-0-12', 'fbe06492117f65609c41be0c27e3215c')
+
+    depends_on('boost@1.54.0')
+    depends_on('cmake@2.8.9:')
+    depends_on('libxml2@2.7.8')
+    depends_on('libxslt@1.1.26~crypto')
+    depends_on('libgcrypt')
+    depends_on('zlib')
+
+    # They forgot to set the flag when they find a library that makes
+    # them happy.
+    patch('cmake-macros.patch')
+    # After finding the libxslt bits, still need to wire in the libexslt
+    # bits.
+    patch('cxxConfigure-cmake.patch')
+
+    root_cmakelists_dir = '../src'
+
+    def url_for_version(self, version):
+        url = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v{0}-tar.zip"
+        return url.format(version.dashed)
+
+    # Illumina tucks the source inside a gzipped tarball inside a zip file.
+    # The normal Spack expansion bits unzip's the zip file.
+    # This function untars the tarball after Spack's done it's bit.
+    def de_SNAFU(self, f):
+        def wrap():
+            tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
+            tty.msg("Bcl2fastq2 expand_archive hack in progress")
+            f()
+            if os.path.isdir('bcl2fastq'):
+                tty.msg("Already hacked up the bcl2fastq directory")
+            else:
+                shutil.move(join_path('spack-expanded-archive', tarball), '.')
+                os.rmdir('spack-expanded-archive')
+                tar=which('tar')
+                tar('-xf', tarball)
+            tty.msg("Bcl2fastq2 expand_archive hack finished")
+        return wrap
+
+    def do_stage(self, mirror_only=False):
+        self.stage.expand_archive = self.de_SNAFU(self.stage.expand_archive)
+        super(Bcl2fastq2, self).do_stage(mirror_only)
+
+    def install(self, spec, prefix):
+        bash=which('bash')
+        bash("src/configure", "--prefix={0}".format(prefix),
+             "--with-cmake={0}".format(join_path(spec['cmake'].prefix.bin,
+                                                 "cmake")))
+        make()
+        make("install")

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -24,7 +24,6 @@
 ##############################################################################
 from spack import *
 import os
-from spack.util.executable import which
 import shutil
 import llnl.util.tty as tty
 
@@ -82,13 +81,13 @@ class Bcl2fastq2(Package):
                 tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
                 shutil.move(join_path('spack-expanded-archive', tarball), '.')
                 os.rmdir('spack-expanded-archive')
-                tar=which('tar')
+                tar = which('tar')
                 tar('-xf', tarball)
                 tty.msg("Finished unpacking bcl2fastq2 tarball.")
         return wrap
 
     def install(self, spec, prefix):
-        bash=which('bash')
+        bash = which('bash')
         bash("src/configure", "--prefix={0}".format(prefix),
              "--with-cmake={0}".format(join_path(spec['cmake'].prefix.bin,
                                                  "cmake")))

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -50,7 +50,7 @@ class Libxslt(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if self.spec.satisfies('~crypto'):
+        if '~crypto' in self.spec:
             args.append('--without-crypto')
         else:
             args.append('--with-crypto')

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -52,4 +52,6 @@ class Libxslt(AutotoolsPackage):
         args = []
         if self.spec.satisfies('~crypto'):
             args.append('--without-crypto')
+        else:
+            args.append('--with-crypto')
         return args

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -36,10 +36,20 @@ class Libxslt(AutotoolsPackage):
     homepage = "http://www.xmlsoft.org/XSLT/index.html"
     url      = "http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz"
 
-    version('1.1.28', '9667bf6f9310b957254fdcf6596600b7')
     version('1.1.29', 'a129d3c44c022de3b9dcf6d6f288d72e')
+    version('1.1.28', '9667bf6f9310b957254fdcf6596600b7')
+    version('1.1.26', 'e61d0364a30146aaa3001296f853b2b9')
+
+    variant('crypto',  default=True,
+            description='Build libexslt with crypto support')
 
     depends_on("libxml2")
     depends_on("xz")
     depends_on("zlib")
-    depends_on("libgcrypt")
+    depends_on("libgcrypt", when="+crypto")
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies('~crypto'):
+            args.append('--without-crypto')
+        return args


### PR DESCRIPTION
This adds a package for Illumina's bcl2fastq2.  

A couple of things might stand out:

1. It looks like a CMakePackage, but it's not really.  They have a configure script and using it is a sign of wisdom.
1. It wraps the standard `self.stage.expand_archive` so that it can unpack the gzipped tarball that is inside the zip file that Illumina distributes (thanks @alalazo in #4206).
2. It pins down some very precise versions of things.  Illumina is blunt in their requirements and they actually have vendored copies of these things that their build process will use unless you make it very, very happy.  I'm open to other folk exploring the space of versions that may or may not work but this works for me.  I'm also not sure what's going to happen if/when they make a newer release available.
3. One of those requirements is for an older version of libxslt.  They build their vendor'ed copy w/out crypto support.  Our existing libxslt package builds with crypto support and I could not figure out how to convince their cmake infrastructure to link against our libgcrypt package (plus, it seems like that package doesn't build static versions).  The cleaner way forward seemed to be to add a variant for crypto support.

Other than those things, it works.