### PR TITLE
Remove need for autoreconf in glib package

### DIFF
--- a/var/spack/repos/builtin/packages/glib/no-Werror=format-security.patch
+++ b/var/spack/repos/builtin/packages/glib/no-Werror=format-security.patch
@@ -1,16 +1,13 @@
---- a/configure.ac	2016-08-16 11:57:34.000000000 -0400
-+++ b/configure.ac	2016-08-16 11:57:36.000000000 -0400
-@@ -3357,11 +3357,11 @@
- 			      enable_compile_warnings=yes)
- AS_IF([test "x$enable_compile_warnings" = xyes], [
-   CC_CHECK_FLAGS_APPEND([GLIB_WARN_CFLAGS], [CFLAGS], [\
+--- a/configure	2017-05-12 16:03:01.000000000 -0500
++++ b/configure	2017-05-12 16:01:58.000000000 -0500
+@@ -29273,8 +29273,8 @@
+   for flag in \
     -Wall -Wstrict-prototypes -Werror=declaration-after-statement \
     -Werror=missing-prototypes -Werror=implicit-function-declaration \
 -   -Werror=pointer-arith -Werror=init-self -Werror=format-security \
--   -Werror=format=2 -Werror=missing-include-dirs])
+-   -Werror=format=2 -Werror=missing-include-dirs; do
 +   -Werror=pointer-arith -Werror=init-self \
-+   -Werror=missing-include-dirs])
- ])
- AC_SUBST(GLIB_WARN_CFLAGS)
++   -Werror=missing-include-dirs; do
  
- #
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports flag $flag in envvar CFLAGS" >&5
+ $as_echo_n "checking if $CC supports flag $flag in envvar CFLAGS... " >&6; }

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -32,18 +32,15 @@ class Glib(AutotoolsPackage):
        threads, dynamic loading and an object system."""
 
     homepage = "https://developer.gnome.org/glib/"
-    url      = "http://ftp.gnome.org/pub/gnome/sources/glib/2.42/glib-2.42.1.tar.xz"
+    url      = "https://ftp.gnome.org/pub/gnome/sources/glib/2.53/glib-2.53.1.tar.xz"
 
+    version('2.53.1', '3362ef4da713f834ea26904caf3a75f5')
     version('2.49.7', '397ead3fcf325cb921d54e2c9e7dfd7a')
     version('2.49.4', 'e2c87c03017b0cd02c4c73274b92b148')
     version('2.48.1', '67bd3b75c9f6d5587b457dc01cdcd5bb')
     version('2.42.1', '89c4119e50e767d3532158605ee9121a')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool', type='build')
-    depends_on('m4', type='build')
-    depends_on('pkg-config+internal_glib', type='build')
+    depends_on('pkg-config@0.16:+internal_glib', type='build')
     depends_on('libffi')
     depends_on('zlib')
     depends_on('gettext')
@@ -54,8 +51,6 @@ class Glib(AutotoolsPackage):
     # Clang doesn't seem to acknowledge the pragma lines to disable the -Werror
     # around a legitimate usage.
     patch('no-Werror=format-security.patch')
-
-    force_autoreconf = True
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""


### PR DESCRIPTION
The default autoreconf method wasn't working for the `glib` package. Instead of wasting time trying to get it working, I replaced the patch to `configure.ac` with one for `configure`. Now autoreconf is no longer necessary. This also removes the need for 4 of its Autotools dependencies.

This patch was added by @mathstuf in #1529 to get `glib` to build on macOS. I confirmed that with the new patch I can build `glib` on macOS with clang. Also confirmed that this patch applies for every version of `glib` in Spack.

Also added the latest version of glib.