### PR TITLE
cairo: ensure that X support is disabled for variant "~X"

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -51,4 +51,6 @@ class Cairo(AutotoolsPackage):
     def configure_args(self):
         args = ["--disable-trace",  # can cause problems with libiberty
                 "--enable-tee"]
+        if self.spec.satisfies("~X"):
+            args.extend(["--disable-xlib", "--disable-xcb"])
         return args

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -51,6 +51,8 @@ class Cairo(AutotoolsPackage):
     def configure_args(self):
         args = ["--disable-trace",  # can cause problems with libiberty
                 "--enable-tee"]
-        if self.spec.satisfies("~X"):
+        if self.spec.satisfies("+X"):
+            args.extend(["--enable-xlib", "--enable-xcb"])
+        else:
             args.extend(["--disable-xlib", "--disable-xcb"])
         return args

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -51,7 +51,7 @@ class Cairo(AutotoolsPackage):
     def configure_args(self):
         args = ["--disable-trace",  # can cause problems with libiberty
                 "--enable-tee"]
-        if self.spec.satisfies("+X"):
+        if '+X' in self.spec:
             args.extend(["--enable-xlib", "--enable-xcb"])
         else:
             args.extend(["--disable-xlib", "--disable-xcb"])


### PR DESCRIPTION
The cairo `configure` script auto-detects X libraries unless told otherwise. The build step can fail when system X libraries and headers are too old for the latest cairo (as I found on SLES 11). Even if the build succeeds, it is best to avoid accidentally linking libraries that are different from those required by other spack packages.