### PR TITLE
Sphinx no longer ignores first argument

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -103,6 +103,7 @@ with open('command_index.rst', 'a') as index:
 # Without this, the API Docs will never actually update
 #
 apidoc_args = [
+    '--force',         # Older versions of Sphinx ignore the first argument
     '--force',         # Overwrite existing files
     '--no-toc',        # Don't create a table of contents file
     '--output-dir=.',  # Directory to place all output

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -103,7 +103,6 @@ with open('command_index.rst', 'a') as index:
 # Without this, the API Docs will never actually update
 #
 apidoc_args = [
-    'sphinx_apidoc',   # The first arugment is ignored
     '--force',         # Overwrite existing files
     '--no-toc',        # Don't create a table of contents file
     '--output-dir=.',  # Directory to place all output


### PR DESCRIPTION
In https://github.com/LLNL/spack/pull/3982#discussion_r113266150, I discovered that when you directly call the `sphinx.apidoc.main` method, the first argument is ignored. I reported this to the Sphinx developers and my pull request was approved and merged (https://github.com/sphinx-doc/sphinx/pull/3668).

Sphinx seems to have frequent (weekly) releases. Once the next Sphinx release comes out, all of our documentation tests will break with the following error message:
```
sphinx_apidoc is not a directory.

Configuration error:
The configuration file (or one of the modules it imports) called sys.exit()
```
The only problem with merging this is that the API docs will no longer update when new sections are added. Read the Docs seems to pin the version of Sphinx installed on the system. We have two choices here:

1. Create a `.rtd-environment.yaml` to install the latest version of Sphinx
2. Duplicate the `--force` argument so it always works with any version of Sphinx

Thoughts?