### PR TITLE
harfbuzz: add latest version (1.4.6)

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -30,6 +30,7 @@ class Harfbuzz(AutotoolsPackage):
     homepage = "http://www.freedesktop.org/wiki/Software/HarfBuzz/"
     url      = "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.37.tar.bz2"
 
+    version('1.4.6', '21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293')
     version('0.9.37', 'bfe733250e34629a188d82e3b971bc1e')
 
     depends_on("pkg-config", type="build")


### PR DESCRIPTION
`harfbuzz@1:` is required by qt to avoid using internal harfbuzz