### PR TITLE
ncurses: build "normal" libs, not just "wide-char" libs, for ncurses 6

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -62,7 +62,8 @@ class Ncurses(AutotoolsPackage):
             '--with-pkg-config-libdir={0}/lib/pkgconfig'.format(self.prefix)
         ]
 
-        nwide_opts = ['--without-manpages',
+        nwide_opts = ['--disable-widec',
+                      '--without-manpages',
                       '--without-tests']
 
         wide_opts = ['--enable-widec']


### PR DESCRIPTION
`ncurses@6.0` builds wide-character libraries by default, whereas `ncurses@5.9` needed a `configure` option to do so. This means `libncurses.so` and friends were not being built by `ncurses@6.0`. Various packages (e.g. `llvm`) depend on `libncurses.so` and do not yet recognise the wide-character library `libncursesw.so`.