### PR TITLE
Fix PGI version detection: 17.4-0 -> 17.4

### DIFF
--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -77,4 +77,4 @@ class Pgi(Compiler):
         on PowerPC.
         """
         return get_compiler_version(
-            comp, '-V', r'pg[^ ]* ([0-9.-]+) [^ ]+ target on ')
+            comp, '-V', r'pg[^ ]* ([0-9.]+)-[0-9]+ [^ ]+ target on ')


### PR DESCRIPTION
I've been playing around with Spack's Lmod support and so far most things are great. One problem I discovered is a discrepancy between Spack's version detection for PGI and the versions we use for the PGI package. In the `pgi` package, we have versions like `17.4`. But when I install the compiler with Spack and add it to `compilers.yaml` with `spack compiler find`, it detects the version as `17.4-0`. This is fine, unless you use Lmod. When I run `module load pgi`, it appends the following directory to my `MODULEPATH`:
```
$SPACK_ROOT/share/spack/lmod/linux-centos7-x86_64/pgi/17.4
```
unfortunately, Spack writes module files for things built with PGI to:
```
$SPACK_ROOT/share/spack/lmod/linux-centos7-x86_64/pgi/17.4-0
```
so none of these modules appear in `module avail`.

We have 2 options to fix this:

1. Change our PGI version detection to pick up `17.4` instead of `17.4-0`
2. Change the PGI package to contain versions for `17.4-0` instead of `17.4`

I chose the former option, but if people prefer the latter I can go down that route too.