### PR TITLE
Add latest version of Sphinx

### DIFF
--- a/var/spack/repos/builtin/packages/py-alabaster/package.py
+++ b/var/spack/repos/builtin/packages/py-alabaster/package.py
@@ -29,10 +29,12 @@ class PyAlabaster(PythonPackage):
     """Alabaster is a visually (c)lean, responsive, configurable theme
     for the Sphinx documentation system."""
 
-    homepage = "https://pypi.python.org/pypi/alabaster"
-    url      = "https://pypi.python.org/packages/source/a/alabaster/alabaster-0.7.9.tar.gz"
+    homepage = "https://alabaster.readthedocs.io/"
+    url      = "https://pypi.io/packages/source/a/alabaster/alabaster-0.7.10.tar.gz"
 
-    version('0.7.9', 'b29646a8bbe7aa52830375b7d17b5d7a',
-            url="https://pypi.python.org/packages/71/c3/70da7d8ac18a4f4c502887bd2549e05745fa403e2cd9d06a8a9910a762bc/alabaster-0.7.9.tar.gz")
+    import_modules = ['alabaster']
+
+    version('0.7.10', '7934dccf38801faa105f6e7b4784f493')
+    version('0.7.9',  'b29646a8bbe7aa52830375b7d17b5d7a')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-babel/package.py
+++ b/var/spack/repos/builtin/packages/py-babel/package.py
@@ -31,10 +31,12 @@ class PyBabel(PythonPackage):
     emphasis on web-based applications."""
 
     homepage = "http://babel.pocoo.org/en/latest/"
-    url      = "https://pypi.python.org/packages/source/B/Babel/Babel-2.3.4.tar.gz"
+    url      = "https://pypi.io/packages/source/B/Babel/Babel-2.4.0.tar.gz"
 
-    version('2.3.4', 'afa20bc55b0e991833030129ad498f35',
-            url="https://pypi.python.org/packages/6e/96/ba2a2462ed25ca0e651fb7b66e7080f5315f91425a07ea5b34d7c870c114/Babel-2.3.4.tar.gz")
+    import_modules = ['babel', 'babel.localtime', 'babel.messages']
+
+    version('2.4.0', '90e7a0add19b2036a9b415630a0d9388')
+    version('2.3.4', 'afa20bc55b0e991833030129ad498f35')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-pytz',       type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-imagesize/package.py
+++ b/var/spack/repos/builtin/packages/py-imagesize/package.py
@@ -29,10 +29,11 @@ class PyImagesize(PythonPackage):
     """Parses image file headers and returns image size. Supports PNG, JPEG,
     JPEG2000, and GIF image file formats."""
 
-    homepage = "https://pypi.python.org/pypi/imagesize"
-    url      = "https://pypi.python.org/packages/source/i/imagesize/imagesize-0.7.1.tar.gz"
+    homepage = "https://github.com/shibukawa/imagesize_py"
+    url      = "https://pypi.io/packages/source/i/imagesize/imagesize-0.7.1.tar.gz"
 
-    version('0.7.1', '976148283286a6ba5f69b0f81aef8052',
-            url="https://pypi.python.org/packages/53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826/imagesize-0.7.1.tar.gz")
+    import_modules = ['imagesize']
+
+    version('0.7.1', '976148283286a6ba5f69b0f81aef8052')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -32,8 +32,11 @@ class PyMarkupsafe(PythonPackage):
     Mako templating engine, the Pylons web framework and many more."""
 
     homepage = "http://www.pocoo.org/projects/markupsafe/"
-    url      = "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
+    url      = "https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-1.0.tar.gz"
 
+    import_modules = ['markupsafe']
+
+    version('1.0',  '2fcedc9284d50e577b5192e8e3578355')
     version('0.23', 'f5ab3deee4c37cd6a922fb81e730da6e')
     version('0.22', 'cb3ec29fd5361add24cfd0c6e2953b3e')
     version('0.21', 'fde838d9337fa51744283f46a1db2e74')

--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyPygments(PythonPackage):
     """Pygments is a syntax highlighting package written in Python."""
 
-    homepage = "https://pypi.python.org/pypi/pygments"
+    homepage = "http://pygments.org/"
     url      = "https://pypi.io/packages/source/P/Pygments/Pygments-2.2.0.tar.gz"
 
     import_modules = [

--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -27,7 +27,7 @@ from spack import *
 
 class PyPyparsing(PythonPackage):
     """A Python Parsing Module."""
-    homepage = "https://pypi.python.org/pypi/pyparsing"
+    homepage = "http://pyparsing.wikispaces.com/"
     url      = "https://pypi.io/packages/source/p/pyparsing/pyparsing-2.2.0.tar.gz"
 
     import_modules = ['pyparsing']

--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -28,9 +28,13 @@ from spack import *
 class PyPytz(PythonPackage):
     """World timezone definitions, modern and historical."""
 
-    homepage = "https://pypi.python.org/pypi/pytz"
+    homepage = "http://pythonhosted.org/pytz"
     url      = "https://pypi.io/packages/source/p/pytz/pytz-2016.10.tar.gz"
 
+    import_modules = ['pytz']
+
+    version('2017.2',   'f89bde8a811c8a1a5bac17eaaa94383c',
+            url="https://pypi.io/packages/source/p/pytz/pytz-2017.2.zip")
     version('2016.10',  'cc9f16ba436efabdcef3c4d32ae4919c')
     version('2016.6.1', 'b6c28a3b968bc1d8badfb61b93874e03')
     version('2014.10',  'eb1cb941a20c5b751352c52486aa1dd7')

--- a/var/spack/repos/builtin/packages/py-requests/package.py
+++ b/var/spack/repos/builtin/packages/py-requests/package.py
@@ -29,17 +29,27 @@ class PyRequests(PythonPackage):
     """Python HTTP for Humans."""
 
     homepage = "http://python-requests.org"
-    url = "https://pypi.io/packages/source/r/requests/requests-2.13.0.tar.gz"
+    url = "https://pypi.io/packages/source/r/requests/requests-2.14.2.tar.gz"
 
+    import_modules = [
+        'requests', 'requests.packages', 'requests.packages.chardet',
+        'requests.packages.urllib3', 'requests.packages.idna',
+        'requests.packages.chardet.cli', 'requests.packages.urllib3.util',
+        'requests.packages.urllib3.packages',
+        'requests.packages.urllib3.contrib',
+        'requests.packages.urllib3.packages.ssl_match_hostname',
+        'requests.packages.urllib3.packages.backports',
+        'requests.packages.urllib3.contrib._securetransport'
+    ]
+
+    version('2.14.2', '4c3c169ed67466088a2a6947784fe444')
     version('2.13.0', '921ec6b48f2ddafc8bb6160957baf444')
     version('2.11.1', 'ad5f9c47b5c5dfdb28363ad7546b0763')
 
-    depends_on('py-setuptools',              type='build')
-    # from setup.py:
-    # test_requirements = ['pytest>=2.8.0', 'pytest-httpbin'==0.0.7,
-    #                      'pytest-cov', 'pytest-mock']
-    # needs #1279 and #2869
-    # depends_on('py-pytest@2.8.7:',           type=('build', 'run'))
-    # depends_on('py-pytest-cov@2.2.1:',       type=('build', 'run'))
-    # depends_on('py-pytest-httpbin@0.2.0:',   type=('build', 'run'))
-    # depends_on('py-pytest-mock@0.11.0:',     type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-pytest@2.8.0:',        type='test')
+    # depends_on('py-pytest-cov',           type='test')
+    # depends_on('py-pytest-httpbin@0.0.7', type='test')
+    # depends_on('py-pytest-mock',          type='test')

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -34,6 +34,8 @@ class PySetuptools(PythonPackage):
 
     import_modules = ['pkg_resources', 'setuptools', 'setuptools.command']
 
+    version('35.0.2', 'c368b4970d3ad3eab5afe4ef4dbe2437',
+            url="https://pypi.io/packages/source/s/setuptools/setuptools-35.0.2.zip")
     version('34.4.1', '5f9b07aeaafd29eac2548fc0b89a4934',
             url="https://pypi.io/packages/source/s/setuptools/setuptools-34.4.1.zip")
     version('34.2.0', '41b630da4ea6cfa5894d9eb3142922be',
@@ -55,11 +57,3 @@ class PySetuptools(PythonPackage):
     depends_on('py-packaging@16.8:', when='@34.0.0:', type=('build', 'run'))
     depends_on('py-six@1.6.0:',      when='@34.0.0:', type=('build', 'run'))
     depends_on('py-appdirs@1.4.0:',  when='@34.0.0:', type=('build', 'run'))
-
-    # Tests require:
-    # TODO: Add a 'test' deptype
-    # FIXME: All of these depend on setuptools, creating a dependency loop
-    # FIXME: Is there any way around this problem?
-    # depends_on('py-pytest-flake8', type='test')
-    # depends_on('pytest@2.8:', type='test')
-    # depends_on('py-mock', when='^python@:3.2', type='test')

--- a/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
+++ b/var/spack/repos/builtin/packages/py-snowballstemmer/package.py
@@ -29,7 +29,9 @@ class PySnowballstemmer(PythonPackage):
     """This package provides 16 stemmer algorithms (15 + Poerter
     English stemmer) generated from Snowball algorithms."""
 
-    homepage = "https://pypi.python.org/pypi/snowballstemmer"
-    url      = "https://pypi.python.org/packages/source/s/snowballstemmer/snowballstemmer-1.2.1.tar.gz"
+    homepage = "https://github.com/shibukawa/snowball_py"
+    url      = "https://pypi.io/packages/source/s/snowballstemmer/snowballstemmer-1.2.1.tar.gz"
+
+    import_modules = ['snowballstemmer']
 
     version('1.2.1', '643b019667a708a922172e33a99bf2fa')

--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -28,10 +28,12 @@ from spack import *
 class PySphinxRtdTheme(PythonPackage):
     """ReadTheDocs.org theme for Sphinx."""
 
-    homepage = "https://pypi.python.org/pypi/sphinx_rtd_theme"
-    url      = "https://pypi.python.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.10a0.tar.gz"
+    homepage = "https://github.com/rtfd/sphinx_rtd_theme/"
+    url      = "https://pypi.io/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.10a0.tar.gz"
 
-    version('0.1.10a0', '83bd95cae55aa8b773a8cc3a41094282',
-            url="https://pypi.python.org/packages/da/6b/1b75f13d8aa3333f19c6cdf1f0bc9f52ea739cae464fbee050307c121857/sphinx_rtd_theme-0.1.10a0.tar.gz")
+    import_modules = ['sphinx_rtd_theme']
+
+    version('0.2.5b1',  '0923473a43bd2527f32151f195f2a521')
+    version('0.1.10a0', '83bd95cae55aa8b773a8cc3a41094282')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -28,24 +28,39 @@ from spack import *
 class PySphinx(PythonPackage):
     """Sphinx Documentation Generator."""
     homepage = "http://sphinx-doc.org"
-    url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-1.5.5.tar.gz"
+    url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-1.6.1.tar.gz"
 
+    import_modules = ['sphinx', 'sphinx.testing', 'sphinx.ext', 'sphinx.pycode', 'sphinx.search', 'sphinx.transforms', 'sphinx.builders', 'sphinx.directives', 'sphinx.util', 'sphinx.environment', 'sphinx.writers', 'sphinx.domains', 'sphinx.locale', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'sphinx.pycode.pgen2', 'sphinx.transforms.post_transforms', 'sphinx.util.stemmer', 'sphinx.environment.collectors', 'sphinx.environment.adapters']
+
+    version('1.6.1', '26cb1cdca7aa4afc8c925d926b6268e7')
     version('1.5.5', 'f9581b3556df9722143c47290273bcf8')
     version('1.4.5', '5c2cd2dac45dfa6123d067e32a89e89a')
     version('1.3.1', '8786a194acf9673464c5455b11fd4332')
 
     extends('python', ignore='bin/(pybabel|pygmentize)')
 
+    # Sphinx requires at least Python 2.7 or 3.4 to run
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-sphinx requires py-setuptools during runtime as well.
-    depends_on('py-setuptools',              type=('build', 'run'))
+    depends_on('py-setuptools',               type=('build', 'run'))
 
-    depends_on('py-six@1.4:',                type=('build', 'run'))
-    depends_on('py-jinja2@2.3:',             type=('build', 'run'))
-    depends_on('py-pygments@2.0:',           type=('build', 'run'))
-    depends_on('py-docutils@0.11:',          type=('build', 'run'))
-    depends_on('py-snowballstemmer@1.1:',    type=('build', 'run'))
-    depends_on('py-babel@1.3:',              type=('build', 'run'))  # not 2.0
-    depends_on('py-alabaster@0.7:',          type=('build', 'run'))
-    depends_on('py-imagesize', when='@1.4:', type=('build', 'run'))
-    depends_on('py-sphinx-rtd-theme@0.1:',   type=('build', 'run'))  # optional as of 1.4
+    depends_on('py-six@1.5:',                 type=('build', 'run'))
+    depends_on('py-jinja2@2.3:',              type=('build', 'run'))
+    depends_on('py-pygments@2.0:',            type=('build', 'run'))
+    depends_on('py-docutils@0.11:',           type=('build', 'run'))
+    depends_on('py-snowballstemmer@1.1:',     type=('build', 'run'))
+    depends_on('py-babel@1.3:',               type=('build', 'run'))  # not 2.0
+    depends_on('py-alabaster@0.7.0:0.7.999',  type=('build', 'run'))
+    depends_on('py-imagesize', when='@1.4:',  type=('build', 'run'))
+    depends_on('py-requests@2.0.0:',          type=('build', 'run'))
+    depends_on('py-typing',                   type=('build', 'run'))
+    depends_on('py-sphinxcontrib-websupport', type=('build', 'run'))
+    depends_on('py-sphinx-rtd-theme@0.1:',    type=('build', 'run'))  # optional as of 1.4
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-pytest',     type='test')
+    # depends_on('py-mock',       type='test')
+    # depends_on('py-simplejson', type='test')
+    # depends_on('py-html5lib',   type='test')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -30,7 +30,15 @@ class PySphinx(PythonPackage):
     homepage = "http://sphinx-doc.org"
     url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-1.6.1.tar.gz"
 
-    import_modules = ['sphinx', 'sphinx.testing', 'sphinx.ext', 'sphinx.pycode', 'sphinx.search', 'sphinx.transforms', 'sphinx.builders', 'sphinx.directives', 'sphinx.util', 'sphinx.environment', 'sphinx.writers', 'sphinx.domains', 'sphinx.locale', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'sphinx.pycode.pgen2', 'sphinx.transforms.post_transforms', 'sphinx.util.stemmer', 'sphinx.environment.collectors', 'sphinx.environment.adapters']
+    import_modules = [
+        'sphinx', 'sphinx.testing', 'sphinx.ext', 'sphinx.pycode',
+        'sphinx.search', 'sphinx.transforms', 'sphinx.builders',
+        'sphinx.directives', 'sphinx.util', 'sphinx.environment',
+        'sphinx.writers', 'sphinx.domains', 'sphinx.locale',
+        'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'sphinx.pycode.pgen2',
+        'sphinx.transforms.post_transforms', 'sphinx.util.stemmer',
+        'sphinx.environment.collectors', 'sphinx.environment.adapters'
+    ]
 
     version('1.6.1', '26cb1cdca7aa4afc8c925d926b6268e7')
     version('1.5.5', 'f9581b3556df9722143c47290273bcf8')

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-websupport/package.py
@@ -25,23 +25,23 @@
 from spack import *
 
 
-class PyJinja2(PythonPackage):
-    """Jinja2 is a template engine written in pure Python. It provides
-    a Django inspired non-XML syntax but supports inline expressions
-    and an optional sandboxed environment."""
+class PySphinxcontribWebsupport(PythonPackage):
+    """sphinxcontrib-webuspport provides a Python API to easily integrate
+    Sphinx documentation into your Web application."""
 
-    homepage = "http://jinja.pocoo.org/"
-    url      = "https://pypi.io/packages/source/J/Jinja2/Jinja2-2.9.6.tar.gz"
+    homepage = "http://sphinx-doc.org/"
+    url      = "https://pypi.io/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-1.0.1.tar.gz"
 
-    import_modules = ['jinja2']
+    # FIXME: These import tests don't work for some reason
+    # import_modules = [
+    #     'sphinxcontrib', 'sphinxcontrib.websupport',
+    #     'sphinxcontrib.websupport.storage', 'sphinxcontrib.websupport.search'
+    # ]
 
-    version('2.9.6', '6411537324b4dba0956aaa8109f3c77b')
-    version('2.8',   'edb51693fe22c53cee5403775c71a99e')
-    version('2.7.3', 'b9dffd2f3b43d673802fe857c8445b1a')
-    version('2.7.2', 'df1581455564e97010e38bc792012aa5')
-    version('2.7.1', '282aed153e69f970d6e76f78ed9d027a')
-    version('2.7',   'c2fb12cbbb523c57d3d15bfe4dc0e8fe')
+    version('1.0.1', '84df26463b1ba65b07f926dbe2055665')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-markupsafe', type=('build', 'run'))
-    depends_on('py-babel@0.8:', type=('build', 'run'))  # optional, required for i18n
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-pytest', type='test')
+    # depends_on('py-mock',   type='test')

--- a/var/spack/repos/builtin/packages/py-typing/package.py
+++ b/var/spack/repos/builtin/packages/py-typing/package.py
@@ -25,23 +25,16 @@
 from spack import *
 
 
-class PyJinja2(PythonPackage):
-    """Jinja2 is a template engine written in pure Python. It provides
-    a Django inspired non-XML syntax but supports inline expressions
-    and an optional sandboxed environment."""
+class PyTyping(PythonPackage):
+    """This is a backport of the standard library typing module to Python
+    versions older than 3.6."""
 
-    homepage = "http://jinja.pocoo.org/"
-    url      = "https://pypi.io/packages/source/J/Jinja2/Jinja2-2.9.6.tar.gz"
+    homepage = "https://docs.python.org/3/library/typing.html"
+    url      = "https://pypi.io/packages/source/t/typing/typing-3.6.1.tar.gz"
 
-    import_modules = ['jinja2']
+    import_modules = ['typing']
 
-    version('2.9.6', '6411537324b4dba0956aaa8109f3c77b')
-    version('2.8',   'edb51693fe22c53cee5403775c71a99e')
-    version('2.7.3', 'b9dffd2f3b43d673802fe857c8445b1a')
-    version('2.7.2', 'df1581455564e97010e38bc792012aa5')
-    version('2.7.1', '282aed153e69f970d6e76f78ed9d027a')
-    version('2.7',   'c2fb12cbbb523c57d3d15bfe4dc0e8fe')
+    version('3.6.1', '3fec97415bae6f742fb3c3013dedeb89')
 
-    depends_on('py-setuptools', type='build')
-    depends_on('py-markupsafe', type=('build', 'run'))
-    depends_on('py-babel@0.8:', type=('build', 'run'))  # optional, required for i18n
+    # You need Python 2.7 or 3.3+ to install the typing package
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))


### PR DESCRIPTION
Adds the latest version of Sphinx and all of its dependencies.

Notable changes in this Sphinx release: a couple new dependencies, dropped support for Python 2.6.

All packages pass their unit tests, install, and activate properly.