### PR TITLE
qt: patch JavaScriptCore to favour internal pcre headers

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -73,6 +73,9 @@ class Qt(Package):
     # https://github.com/xboxdrv/xboxdrv/issues/188
     patch('btn_trigger_happy.patch', when='@5.7.0:')
 
+    # https://github.com/LLNL/spack/issues/1517
+    patch('qt5-pcre.patch', when='@5:')
+
     patch('qt4-corewlan-new-osx.patch', when='@4')
     patch('qt4-pcre-include-conflict.patch', when='@4')
     patch('qt4-el-capitan.patch', when='@4')

--- a/var/spack/repos/builtin/packages/qt/qt5-pcre.patch
+++ b/var/spack/repos/builtin/packages/qt/qt5-pcre.patch
@@ -1,0 +1,33 @@
+--- a/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/runtime/RegExp.cpp	2016-09-17 20:55:14.000000000 +0000
++++ b/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/runtime/RegExp.cpp	2017-05-17 01:55:10.000000000 +0000
+@@ -44,7 +44,7 @@
+ #include "JIT.h"
+ #include "WRECGenerator.h"
+ #endif
+-#include <pcre/pcre.h>
++#include "../pcre/pcre.h"
+ 
+ #endif
+ 
+--- a/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/yarr/RegexJIT.cpp	2016-09-17 20:55:14.000000000 +0000
++++ b/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/yarr/RegexJIT.cpp	2017-05-17 01:55:51.000000000 +0000
+@@ -32,7 +32,7 @@
+ #include "MacroAssembler.h"
+ #include "RegexCompiler.h"
+ 
+-#include "pcre.h" // temporary, remove when fallback is removed.
++#include "../pcre/pcre.h" // temporary, remove when fallback is removed.
+ 
+ #if ENABLE(YARR_JIT)
+ 
+--- a/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/yarr/RegexJIT.h	2016-09-17 20:55:14.000000000 +0000
++++ b/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/yarr/RegexJIT.h	2017-05-17 01:55:36.000000000 +0000
+@@ -34,7 +34,7 @@
+ #include "RegexPattern.h"
+ #include <UString.h>
+ 
+-#include <pcre.h>
++#include "../pcre/pcre.h"
+ struct JSRegExp; // temporary, remove when fallback is removed.
+ 
+ #if CPU(X86) && !COMPILER(MSVC)


### PR DESCRIPTION
Building qt currently fails if spack dependencies include pcre (see #1517).

It seems that the qtscript component of qt requires heavily customised pcre functions, and these clash with other pcre headers that spack may find. A clue is given in the file `qtscript/src/3rdparty/javascriptcore/JavaScriptCore/pcre/pcre.h` in the qt source directory:

> // FIXME: This file needs to be renamed to JSRegExp.h; it's no longer PCRE.

Unfortunately, the suggested renaming has not been done in any version of `qt@5` (so far). This means it is easy for a build system to find a pcre.h in the search path and override the customised qt version.

To avoid this problem, I have patched the JavaScriptCore source files that need to include the customised pcre.h. I replace statements of the form `#include <pcre.h>` by `#include "pcre.h"`. The quoted form is interpreted by most compilers as a path relative to the file being preprocessed, and other locations will not be searched if the specified file is found.

I have successfully built `qt@5.2.1`, `qt@5.7.1` and `qt@5.8.0` with spack using the patch.