### PR TITLE
Better error message for missing modulecmd

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -126,7 +126,7 @@ def load_module(mod):
     modulecmd implementation of modules used in cray and lmod.
     """
     # Create an executable of the module command that will output python code
-    modulecmd = which('modulecmd')
+    modulecmd = which('modulecmd', required=True)
     modulecmd.add_default_arg('python')
 
     # Read the module and remove any conflicting modules


### PR DESCRIPTION
Closes #4249. I don't know of a way to allow Spack to load modules without `modulecmd`, but this PR can at least make the error message more clear.

### Before
```
==> Error: AttributeError: 'NoneType' object has no attribute 'add_default_arg'
```

### After
```
==> Error: spack requires modulecmd.  Make sure it is in your path.
```