### PR TITLE
Move doc dependencies to requirements.txt for readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
   - pip install --upgrade codecov
   - pip install --upgrade flake8
   - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade sphinx; fi
-  - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade sphinxcontrib-programoutput; fi
+  - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade -r lib/spack/docs/requirements.txt; fi
 
 before_script:
   # Need this for the git tests to succeed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,6 @@ install:
   - pip install --upgrade setuptools
   - pip install --upgrade codecov
   - pip install --upgrade flake8
-  - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade sphinx; fi
   - if [[ "$TEST_SUITE" == "doc" ]]; then pip install --upgrade -r lib/spack/docs/requirements.txt; fi
 
 before_script:

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,4 +1,5 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
+sphinx
 sphinxcontrib-programoutput

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,0 +1,4 @@
+# These dependencies should be installed using pip in order
+# to build the documentation.
+
+sphinxcontrib-programoutput


### PR DESCRIPTION
`readthedocs` builds need a `requirements.txt` to properly install `python` dependencies of docs.  This is an update to #4266.