### PR TITLE
Add old version of ROOT 5

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -44,6 +44,7 @@ class Root(CMakePackage):
     version('6.06.06', '4308449892210c8d36e36924261fea26')
     version('6.06.04', '55a2f98dd4cea79c9c4e32407c2d6d17')
     version('6.06.02', 'e9b8b86838f65b0a78d8d02c66c2ec55')
+    version('5.34.36', '6a1ad549b3b79b10bbb1f116b49067ee')
 
     if sys.platform == 'darwin':
         patch('math_uint.patch', when='@6.06.02')


### PR DESCRIPTION
Apparently ROOT 5 and 6 are pretty different and a lot of users are still using the ROOT 5 API.

Built fine for me on CentOS 6 with GCC 4.8.5. GCC 6 didn't work (although it does work for ROOT 6). Didn't even bother trying Intel as it didn't work for ROOT 6 either.