### PR TITLE
Add --configure-args/vars support to RPackage

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -30,7 +30,9 @@ from spack.package import PackageBase, run_after
 
 
 class RPackage(PackageBase):
-    """Specialized class for packages that are built using R
+    """Specialized class for packages that are built using R. For more
+    information on the R build system, see:
+    https://stat.ethz.ch/R-manual/R-devel/library/utils/html/INSTALL.html
 
     This class provides a single phase that can be overridden:
 
@@ -49,12 +51,37 @@ class RPackage(PackageBase):
 
     depends_on('r', type=('build', 'run'))
 
+    def configure_args(self, spec, prefix):
+        """Arguments to pass to install via ``--configure-args``."""
+        return []
+
+    def configure_vars(self, spec, prefix):
+        """Arguments to pass to install via ``--configure-vars``."""
+        return []
+
     def install(self, spec, prefix):
         """Installs an R package."""
-        inspect.getmodule(self).R(
-            'CMD', 'INSTALL',
+
+        config_args = self.configure_args(spec, prefix)
+        config_vars = self.configure_vars(spec, prefix)
+
+        args = [
+            'CMD',
+            'INSTALL'
+        ]
+
+        if config_args:
+            args.append('--configure-args={0}'.format(' '.join(config_args)))
+
+        if config_vars:
+            args.append('--configure-vars={0}'.format(' '.join(config_vars)))
+
+        args.extend([
             '--library={0}'.format(self.module.r_lib_dir),
-            self.stage.source_path)
+            self.stage.source_path
+        ])
+
+        inspect.getmodule(self).R(*args)
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -30,8 +30,9 @@ from spack.package import PackageBase, run_after
 
 
 class RPackage(PackageBase):
-    """Specialized class for packages that are built using R. For more
-    information on the R build system, see:
+    """Specialized class for packages that are built using R.
+
+    For more information on the R build system, see:
     https://stat.ethz.ch/R-manual/R-devel/library/utils/html/INSTALL.html
 
     This class provides a single phase that can be overridden:

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -265,7 +265,11 @@ class RPackageTemplate(PackageTemplate):
     # depends_on('r-foo', type=('build', 'run'))"""
 
     body = """\
-    # FIXME: Override install() if necessary."""
+    def configure_args(self, spec, prefix):
+        # FIXME: Add arguments to pass to install via --configure-args
+        # FIXME: If not needed delete this function
+        args = []
+        return args"""
 
     def __init__(self, name, *args):
         # If the user provided `--name r-rcpp`, don't rename it r-r-rcpp


### PR DESCRIPTION
@tmerrick1 @HenrikBengtsson @glennpj @JavierCVilla 

This PR adds support for passing arbitrary arguments to the `INSTALL` method for `RPackage` via `--configure-args` and `--configure-vars`. Out of the 198 R packages in Spack, this is the first one that has even a slightly different install method (pretty impressive actually). This is a continuation of #4286.