### PR TITLE
Correct installation step for mummer (and dependency)

### DIFF
--- a/var/spack/repos/builtin/packages/mummer/Makefile.patch
+++ b/var/spack/repos/builtin/packages/mummer/Makefile.patch
@@ -1,0 +1,24 @@
+--- a/Makefile	2017-05-15 17:33:05.132803923 -0700
++++ b/Makefile	2017-05-16 16:01:29.264842369 -0700
+@@ -35,6 +35,13 @@
+ TIGR_SRC_DIR  := $(TOP_DIR)/src/tigr
+ KURTZ_SRC_DIR := $(TOP_DIR)/src/kurtz
+ 
++ifndef INSTALL_TOP_DIR
++INSTALL_TOP_DIR     := $(TOP_DIR)
++endif
++INSTALL_BIN_DIR := $(INSTALL_TOP_DIR)/bin
++INSTALL_AUX_BIN_DIR := $(INSTALL_TOP_DIR)/aux_bin
++INSTALL_SCRIPT_DIR    := $(INSTALL_TOP_DIR)/scripts
++
+ CC   := $(filter /%,$(shell /bin/sh -c 'type gcc'))
+ CXX  := $(filter /%,$(shell /bin/sh -c 'type g++'))
+ SED  := $(filter /%,$(shell /bin/sh -c 'type sed'))
+@@ -52,6 +59,7 @@
+ 
+ #-- EXPORT THESE VARIABLES TO OTHER MAKEFILES
+ export BIN_DIR AUX_BIN_DIR CXX CC CFLAGS CXXFLAGS LDFLAGS
++export INSTALL_BIN_DIR INSTALL_AUX_BIN_DIR INSTALL_SCRIPT_DIR
+ 
+ 
+ 

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -34,7 +34,7 @@ class Mummer(Package):
     version('3.23', 'f2422b3d2638dba4baedb71b1acdffa2')
 
     depends_on('gnuplot')
-    depends_on('perl')
+    depends_on('perl',type=('build', 'run)')
 
     patch('Makefile.patch')
     patch('scripts-Makefile.patch')

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -41,14 +41,14 @@ class Mummer(Package):
         make('install')
         mkdirp(prefix.bin)
 
-        bins = ["show-tiling", "show-snps", "show-coords", "show-aligns", 
-                "show-diff", "delta-filter", "combineMUMs", "mummer", 
-                "repeat-match", "annotate", "mgaps", "gaps", "dnadiff", 
-                "nucmer2xfig", "run-mummer3", "mummerplot", "promer", 
+        bins = ["show-tiling", "show-snps", "show-coords", "show-aligns",
+                "show-diff", "delta-filter", "combineMUMs", "mummer",
+                "repeat-match", "annotate", "mgaps", "gaps", "dnadiff",
+                "nucmer2xfig", "run-mummer3", "mummerplot", "promer",
                 "run-mummer1", "nucmer", "mapview", "exact-tandems"]
         aux_bins = ["aux_bin/postnuc", "aux_bin/postpro",
                     "aux_bin/prenuc", "aux_bin/prepro"]
-                  
+
         for b in bins:
             install(b, join_path(prefix.bin, b))
         for b in aux_bins:

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -34,6 +34,7 @@ class Mummer(Package):
     version('3.23', 'f2422b3d2638dba4baedb71b1acdffa2')
 
     depends_on('gnuplot')
+    depends_on('perl')
 
     patch('Makefile.patch')
     patch('scripts-Makefile.patch')

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -1,4 +1,4 @@
-u#############################################################################
+##############################################################################
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -35,11 +35,19 @@ class Mummer(Package):
 
     depends_on('gnuplot')
 
+    patch('Makefile.patch')
+    patch('scripts-Makefile.patch')
+
     def install(self, spec, prefix):
         if self.run_tests:
             make('check')
-        make('install')
-        mkdirp(prefix.bin)
+        make('INSTALL_TOP_DIR={0}'.format(prefix))
+        bd = prefix.bin
+        abd = join_path(prefix, 'aux_bin')
+        sd = join_path(prefix, 'scripts')
+        mkdirp(bd)
+        mkdirp(abd)
+        mkdirp(sd)
 
         bins = ["show-tiling", "show-snps", "show-coords", "show-aligns",
                 "show-diff", "delta-filter", "combineMUMs", "mummer",
@@ -48,8 +56,11 @@ class Mummer(Package):
                 "run-mummer1", "nucmer", "mapview", "exact-tandems"]
         aux_bins = ["aux_bin/postnuc", "aux_bin/postpro",
                     "aux_bin/prenuc", "aux_bin/prepro"]
+        scripts = ["scripts/Foundation.pm"]
 
-        for b in bins:
-            install(b, join_path(prefix.bin, b))
-        for b in aux_bins:
-            install(b, join_path(prefix.bin, b[8:]))
+        for f in bins:
+            install(f, join_path(bd, f))
+        for f in aux_bins:
+            install(f, join_path(abd, f[8:]))
+        for f in scripts:
+            install(f, join_path(sd, f[8:]))

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -1,4 +1,4 @@
-##############################################################################
+u#############################################################################
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
@@ -34,7 +34,7 @@ class Mummer(Package):
     version('3.23', 'f2422b3d2638dba4baedb71b1acdffa2')
 
     depends_on('gnuplot')
-    depends_on('perl',type=('build', 'run)')
+    depends_on('perl', type=('build', 'run'))
 
     patch('Makefile.patch')
     patch('scripts-Makefile.patch')

--- a/var/spack/repos/builtin/packages/mummer/scripts-Makefile.patch
+++ b/var/spack/repos/builtin/packages/mummer/scripts-Makefile.patch
@@ -1,0 +1,74 @@
+--- a/scripts/Makefile	2011-12-16 18:49:26.000000000 -0800
++++ b/scripts/Makefile	2017-05-16 16:05:48.697853000 -0700
+@@ -37,56 +37,56 @@
+ #-- not so PHONY rules --#
+ exact-tandems: exact-tandems.csh
+ 	$(SED)  -e 's?__CSH_PATH?$(CSH)?g' \
+-		-e 's?__BIN_DIR?$(BIN_DIR)?g' \
+-		-e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
++		-e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
++		-e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
+ 		exact-tandems.csh > $(BIN_DIR)/exact-tandems
+ 	chmod 755 $(BIN_DIR)/exact-tandems
+ 
+ mapview: mapview.pl
+ 	$(SED)  -e 's?__PERL_PATH?$(PERL)?g' \
+-		-e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
++		-e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
+                 mapview.pl > $(BIN_DIR)/mapview
+ 	chmod 755 $(BIN_DIR)/mapview
+ 
+ mummerplot: mummerplot.pl Foundation.pm
+ 	$(SED)  -e 's?__PERL_PATH?$(PERL)?g' \
+-                -e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
+-                -e 's?__BIN_DIR?$(BIN_DIR)?g' \
++                -e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
++                -e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+                 mummerplot.pl > $(BIN_DIR)/mummerplot
+ 	chmod 755 $(BIN_DIR)/mummerplot
+ 
+ dnadiff: dnadiff.pl Foundation.pm
+ 	$(SED) -e 's?__PERL_PATH?$(PERL)?g' \
+-               -e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
+-               -e 's?__BIN_DIR?$(BIN_DIR)?g' \
++               -e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
++               -e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+                  dnadiff.pl > $(BIN_DIR)/dnadiff
+ 	chmod 755 $(BIN_DIR)/dnadiff
+ 
+ nucmer: nucmer.pl Foundation.pm
+ 	$(SED)  -e 's?__PERL_PATH?$(PERL)?g' \
+-                -e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
+-                -e 's?__AUX_BIN_DIR?$(AUX_BIN_DIR)?g' \
+-                -e 's?__BIN_DIR?$(BIN_DIR)?g' \
++                -e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
++                -e 's?__AUX_BIN_DIR?$(INSTALL_AUX_BIN_DIR)?g' \
++                -e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+                  nucmer.pl > $(BIN_DIR)/nucmer
+ 	chmod 755 $(BIN_DIR)/nucmer
+ 
+ promer: promer.pl Foundation.pm
+ 	$(SED)  -e 's?__PERL_PATH?$(PERL)?g' \
+-                -e 's?__SCRIPT_DIR?$(SCRIPT_DIR)?g' \
+-                -e 's?__AUX_BIN_DIR?$(AUX_BIN_DIR)?g' \
+-                -e 's?__BIN_DIR?$(BIN_DIR)?g' \
++                -e 's?__SCRIPT_DIR?$(INSTALL_SCRIPT_DIR)?g' \
++                -e 's?__AUX_BIN_DIR?$(INSTALL_AUX_BIN_DIR)?g' \
++                -e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+                 promer.pl > $(BIN_DIR)/promer
+ 	chmod 755 $(BIN_DIR)/promer
+ 
+ run-mummer1: run-mummer1.csh
+ 	$(SED)  -e 's?__CSH_PATH?$(CSH)?g' \
+-		-e 's?__BIN_DIR?$(BIN_DIR)?g' \
++		-e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+ 		run-mummer1.csh > $(BIN_DIR)/run-mummer1
+ 	chmod 755 $(BIN_DIR)/run-mummer1
+ 
+ run-mummer3: run-mummer3.csh
+ 	$(SED)  -e 's?__CSH_PATH?$(CSH)?g' \
+-		-e 's?__BIN_DIR?$(BIN_DIR)?g' \
++		-e 's?__BIN_DIR?$(INSTALL_BIN_DIR)?g' \
+ 		run-mummer3.csh > $(BIN_DIR)/run-mummer3
+ 	chmod 755 $(BIN_DIR)/run-mummer3
+ 


### PR DESCRIPTION
1. Correct the installation step for mummer.  It has it's own handcrafted build process which is intended to build and run from the same location.  I was copying the various bits to `prefix`, but I missed a variety of hardcoded references that the build step seds into the perl scripts.

2. Speaking of perl scripts, add a dependency on our perl.