### PR TITLE
Fix boost@:1.56.0%gcc@:5

### DIFF
--- a/var/spack/repos/builtin/packages/boost/call_once_variadic.patch
+++ b/var/spack/repos/builtin/packages/boost/call_once_variadic.patch
@@ -1,0 +1,57 @@
+diff --git a/boost/thread/pthread/once.hpp b/boost/thread/pthread/once.hpp
+index ccfb051..0bef038 100644
+--- a/boost/thread/pthread/once.hpp
++++ b/boost/thread/pthread/once.hpp
+@@ -42,7 +42,7 @@ namespace boost
+   }
+ 
+ #ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+     template<typename Function, class ...ArgTypes>
+     inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+ #else
+@@ -65,7 +65,7 @@ namespace boost
+   private:
+       volatile thread_detail::uintmax_atomic_t epoch;
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+       template<typename Function, class ...ArgTypes>
+       friend void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args);
+ #else
+@@ -118,7 +118,7 @@ namespace boost
+     // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2444.html
+ 
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ 
+ 
+   template<typename Function, class ...ArgTypes>
+diff --git a/boost/thread/pthread/once_atomic.hpp b/boost/thread/pthread/once_atomic.hpp
+index 9e2f876..923f07b 100644
+--- a/boost/thread/pthread/once_atomic.hpp
++++ b/boost/thread/pthread/once_atomic.hpp
+@@ -115,7 +115,7 @@ namespace boost
+ #endif
+ 
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ 
+   template<typename Function, class ...ArgTypes>
+   inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(ArgTypes)... args)
+diff --git a/boost/thread/win32/once.hpp b/boost/thread/win32/once.hpp
+index cafcfd4..9b37b31 100644
+--- a/boost/thread/win32/once.hpp
++++ b/boost/thread/win32/once.hpp
+@@ -227,7 +227,7 @@ namespace boost
+         }
+     }
+ 
+-#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
++#if !defined BOOST_NO_CXX11_VARIADIC_TEMPLATES && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+ //#if defined(BOOST_THREAD_RVALUE_REFERENCES_DONT_MATCH_FUNTION_PTR)
+     inline void call_once(once_flag& flag, void (*f)())
+     {

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -148,6 +148,8 @@ class Boost(Package):
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl_r')
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl')
 
+    patch('call_once_variadic.patch', when='@:1.56.0%gcc@5:')
+
     def url_for_version(self, version):
         url = "http://downloads.sourceforge.net/project/boost/boost/{0}/boost_{1}.tar.bz2"
         return url.format(version.dotted, version.underscored)


### PR DESCRIPTION
[edit to correct compiler for boost@1.64.0]

I need boost@1.54.0 for bcl2fastq2.  I tested bcl2fastq2 using the system compiler (gcc@4.8.5).  My full build uses a spack-build gcc@5.4.0.

boost@1.54.0 won't build with that compiler.

I found the answer [here](https://github.com/hashdist/hashstack/issues/802) with the details in [this upstream/boost ticket](https://svn.boost.org/trac/boost/ticket/10125).

I've confirmed that these combo's build:

boost version| compiler
------------ | ------------------
boost@1.54.0 | gcc@4.8.5 (system)
boost@1.54.0 | gcc@5.4.0 (Spack)
boost@1.64.0 | gcc@5.4.0 (Spack)