### PR TITLE
new package virtualgl

### DIFF
--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -34,5 +34,6 @@ class MesaGlu(AutotoolsPackage):
 
     version('9.0.0', 'bbc57d4fe3bd3fb095bdbef6fcb977c4')
 
-    variant('mesa', default=True,  description='Depends on mesa')
+    variant('mesa', default=True,
+       description='Usually depends on mesa, disable for accelerated OpenGL')
     depends_on('mesa', when='+mesa')

--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -26,13 +26,23 @@
 from spack import *
 
 
-class MesaGlu(AutotoolsPackage):
-    """This package provides the Mesa OpenGL Utility library."""
+class Virtualgl(CMakePackage):
+    """VirtualGL redirects 3D commands from a Unix/Linux OpenGL application
+       onto a server-side GPU and converts the rendered 3D images into a video
+       stream with which remote clients can interact to view and control the
+       3D application in real time."""
 
-    homepage = "https://www.mesa3d.org"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.0.tar.gz"
+    homepage = "http://www.virtualgl.org/Main/HomePage"
+    url      = "http://downloads.sourceforge.net/project/virtualgl/2.5.2/VirtualGL-2.5.2.tar.gz"
 
-    version('9.0.0', 'bbc57d4fe3bd3fb095bdbef6fcb977c4')
+    version('2.5.2', '1a9f404f4a35afa9f56381cb33ed210c')
 
-    variant('mesa', default=True,  description='Depends on mesa')
-    depends_on('mesa', when='+mesa')
+    depends_on("libjpeg-turbo")
+    depends_on("mesa-glu~mesa")
+
+    def cmake_args(self):
+        # FIXME: Add arguments other than
+        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -38,11 +38,6 @@ class Virtualgl(CMakePackage):
     version('2.5.2', '1a9f404f4a35afa9f56381cb33ed210c')
 
     depends_on("libjpeg-turbo")
+    # virtualgl require OpenGL but also glu, on systems without development,
+    # use mesa-glu, but we do not want Mesa OpenGL sw emulation
     depends_on("mesa-glu~mesa")
-
-    def cmake_args(self):
-        # FIXME: Add arguments other than
-        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
-        # FIXME: If not needed delete this function
-        args = []
-        return args


### PR DESCRIPTION
virtualgl depends on mesa-glu but NOT on mesa, so added a variant to mesa-glu called mesa that defaults to true as it was before