### PR TITLE
Fix tests on cray

### DIFF
--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -58,7 +58,7 @@ def test_dict_functions_for_architecture():
 
 def test_platform():
         output_platform_class = spack.architecture.real_platform()
-        if os.path.exists('/opt/cray/craype'):
+        if os.environ.get('CRAYPE_VERSION') is not None:
             my_platform_class = Cray()
         elif os.path.exists('/bgsys'):
             my_platform_class = Bgq()

--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -90,7 +90,8 @@ def test_flake8(parser, flake8_package):
     try:
         flake8(parser, args)
     # Get even more coverage
-        args = parser.parse_args(['--output', '--root-relative', flake8_package])
+        args = parser.parse_args(['--output', '--root-relative',
+                                 flake8_package])
         flake8(parser, args)
     except SystemExit:
         pytest.skip("no flake8 found in path")

--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -87,11 +87,7 @@ def test_flake8(parser, flake8_package):
     # Otherwise, the unit tests would fail every time
     # the flake8 tests fail
     args = parser.parse_args([flake8_package])
-    try:
-        flake8(parser, args)
+    flake8(parser, args)
     # Get even more coverage
-        args = parser.parse_args(['--output', '--root-relative',
-                                 flake8_package])
-        flake8(parser, args)
-    except SystemExit:
-        pytest.skip("no flake8 found in path")
+    args = parser.parse_args(['--output', '--root-relative', flake8_package])
+    flake8(parser, args)

--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -87,10 +87,10 @@ def test_flake8(parser, flake8_package):
     # Otherwise, the unit tests would fail every time
     # the flake8 tests fail
     args = parser.parse_args([flake8_package])
-
-    flake8(parser, args)
-
+    try:
+        flake8(parser, args)
     # Get even more coverage
-    args = parser.parse_args(['--output', '--root-relative', flake8_package])
-
-    flake8(parser, args)
+        args = parser.parse_args(['--output', '--root-relative', flake8_package])
+        flake8(parser, args)
+    except SystemExit:
+        pytest.skip("no flake8 found in path")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -474,7 +474,9 @@ def mock_svn_repository():
     url = 'file://' + str(repodir)
     # Initialize the repository
     current = repodir.chdir()
-    svnadmin('create', str(repodir))
+    #NOTE: Adding --pre-1.5-compatible works for NERSC
+    # Unknown if this is also an issue at other sites.
+    svnadmin('create', '--pre-1.5-compatible', str(repodir))
 
     # Import a structure (first commit)
     r0_file = 'r0_file'

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -474,7 +474,7 @@ def mock_svn_repository():
     url = 'file://' + str(repodir)
     # Initialize the repository
     current = repodir.chdir()
-    #NOTE: Adding --pre-1.5-compatible works for NERSC
+    # NOTE: Adding --pre-1.5-compatible works for NERSC
     # Unknown if this is also an issue at other sites.
     svnadmin('create', '--pre-1.5-compatible', str(repodir))
 


### PR DESCRIPTION
I had a couple of failing tests on our Cray machines (Edison|Cori), these changes make sure that all tests pass. Unfortunately, I am not sure whether these changes are NERSC specific. If some other Cray users had failing tests, could you check to see if they work on your systems? Thanks!

Just to summarize:  

architecture.py
  - fixed detection of Cray platforms  

cmd/flake8.py
- Hard to get flake8 in your path unless it's provided for you already. And getting it in your path would involve starting a virtualenv. 

conftest.py  
- This one might cause problems but it's the only way to use svn on our systems. If it ends up causing problems, then this will probably remain NERSC specific.
