### PR TITLE
magics fixes for versions > 2.29.x

### DIFF
--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -42,7 +42,7 @@ class Magics(Package):
 
     # The patch changes the hardcoded path to python in shebang to enable the
     # usage of the first python installation that appears in $PATH
-    patch('no_hardcoded_python.patch')
+    patch('no_hardcoded_python.patch', when='@:2.29.6')
 
     # The patch reorders includes and adds namespaces where necessary to
     # resolve ambiguity of invocations of isnan and isinf functions. The
@@ -63,7 +63,8 @@ class Magics(Package):
     depends_on('python', type='build')
     depends_on('perl', type='build')
     depends_on('perl-xml-parser', type='build')
-    depends_on('grib-api')
+    depends_on('eccodes', when='@2.30.0:')
+    depends_on('grib-api', when='@:2.29.6')
     depends_on('proj')
     depends_on('boost')
     depends_on('expat')
@@ -72,6 +73,7 @@ class Magics(Package):
     depends_on('libemos', when='+bufr')
     depends_on('qt', when='+metview+qt')
 
+    @when('@:2.29.6')
     def patch(self):
         filter_file('#!/usr/bin/perl', '#!/usr/bin/env perl',
                     'tools/xml2cc_new.pl')
@@ -83,8 +85,12 @@ class Magics(Package):
         options.append('-DENABLE_PYTHON=OFF')
         options.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
         options.append('-DPROJ4_PATH=%s' % spec['proj'].prefix)
-        options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
         options.append('-DENABLE_TESTS=OFF')
+
+        if self.version >= Version('2.30.0'):
+            options.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
+        else:
+            options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
 
         if '+bufr' in spec:
             options.append('-DENABLE_BUFR=ON')


### PR DESCRIPTION
While trying out newer versions of magics (it does not compile with GCC 7), I noticed that versions > 2.29 do not work. This PR's changes should fix that.