### PR TITLE
Fix missing gcc dependency on zip

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -83,6 +83,7 @@ class Gcc(AutotoolsPackage):
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
+    depends_on('zip', type='build', when='@:6 languages=all')
 
     # TODO: integrate these libraries.
     # depends_on('ppl')


### PR DESCRIPTION
For @:6, java is included in languages=all and requires zip.

I guess the other `when='languages=xxx'` dependencies might also be problematic depending on what is included in `languages=all`.