### PR TITLE
Fix ncview with netcdf+mpi

### DIFF
--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -36,3 +36,13 @@ class Ncview(AutotoolsPackage):
     depends_on('udunits2')
     depends_on('libpng')
     depends_on('libxaw')
+
+    def configure_args(self):
+        spec = self.spec
+
+        config_args = []
+
+        if spec.satisfies('^netcdf+mpi'):
+            config_args.append('CC={0}'.format(spec['mpi'].mpicc))
+
+        return config_args


### PR DESCRIPTION
ncview has to be compiled using the same compiler as netcdf.

Not sure if this is the best approach but I wanted to avoid introducing a variant.