### PR TITLE
Fix ncl's flex dependency

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -60,7 +60,9 @@ class Ncl(Package):
 
     # Extra dependencies that may be missing from build system:
     depends_on('bison', type='build')
-    depends_on('flex+lex')
+    # Should use flex+lex as soon as it is available:
+    # https://github.com/LLNL/spack/pull/3894
+    depends_on('flex')
     depends_on('libiconv')
 
     # Also, the manual says that ncl requires zlib, but that comes as a


### PR DESCRIPTION
flex's lex variant is not yet available, see #3894.

(Just a quick fix to allow ncl to build again.)