### PR TITLE
Refactored RepoPath to be a proper MutableSequence

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -85,12 +85,13 @@ import spack.repository
 import spack.error
 import spack.config
 import spack.fetch_strategy
+import spack.defaults
+
 from spack.file_cache import FileCache
 from spack.abi import ABI
 from spack.concretize import DefaultConcretizer
 from spack.version import Version
 from spack.util.path import canonicalize_path
-
 
 #-----------------------------------------------------------------------------
 # Initialize various data structures & objects at the core of Spack.
@@ -101,7 +102,7 @@ spack_version = Version("0.10.0")
 
 # Set up the default packages database.
 try:
-    repo = spack.repository.RepoPath()
+    repo = spack.defaults.make_repo_path_from_config()
     sys.meta_path.append(repo)
 except spack.error.SpackError as e:
     tty.die('while initializing Spack RepoPath:', e.message)

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -638,7 +638,7 @@ def get_repository(args, name):
             if not repo:
                 tty.die("Unknown namespace: '{0}'".format(spec.namespace))
         else:
-            repo = spack.repo.first_repo()
+            repo = spack.repo[0]
 
     # Set the namespace on the spec if it's not there already
     if not spec.namespace:

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -79,7 +79,7 @@ def location(parser, args):
         print(spack.prefix)
 
     elif args.packages:
-        print(spack.repo.first_repo().root)
+        print(spack.repo[0].root)
 
     elif args.stages:
         print(spack.stage_path)

--- a/lib/spack/spack/defaults.py
+++ b/lib/spack/spack/defaults.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+"""Creates various objects that are part of Spack Core according to the
+options specified in the configuration files.
+
+This module has been created to have a single place in which we mix the
+information stemming from the yaml configuration files with the business
+logic coded in other parts of Spack's core.
+"""
+
+import llnl.util.tty as tty
+import spack.config
+import spack.repository
+
+
+def make_repo_path_from_config():
+    """Creates an instance of RepoPath reading the directories where the
+    repositories are located from Spack configuration files.
+    """
+
+    repo_dirs = spack.config.get_config('repos')
+
+    msg = '[REPOSITORY] Creating RepoPath from configuration files: {0}'
+    tty.debug(msg.format(repo_dirs))
+
+    if not repo_dirs:
+        msg = 'Spack configuration contains no package repositories.'
+        raise spack.repository.NoRepoConfiguredError(msg)
+
+    return spack.repository.RepoPath(*repo_dirs)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -320,8 +320,8 @@ def setup_main_options(args):
         debug.register_interrupt_handler()
 
     if args.mock:
-        from spack.repository import RepoPath
-        spack.repo.swap(RepoPath(spack.mock_packages_path))
+        spack.repo.clear()
+        spack.repo.append_from_path(spack.mock_packages_path)
 
     # If the user asked for it, don't check ssl certs.
     if args.insecure:

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -22,13 +22,14 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import inspect
 import os
+import os.path
 
 import spack
 import spack.error
-import spack.stage
 import spack.fetch_strategy as fs
-
+import spack.stage
 from llnl.util.filesystem import join_path
 from spack.util.executable import which
 
@@ -90,7 +91,8 @@ class FilePatch(Patch):
     def __init__(self, pkg, path_or_url, level):
         super(FilePatch, self).__init__(pkg, path_or_url, level)
 
-        pkg_dir = spack.repo.dirname_for_package_name(pkg.name)
+        m = inspect.getmodule(pkg)
+        pkg_dir = os.path.dirname(m.__file__)
         self.path = join_path(pkg_dir, path_or_url)
         if not os.path.isfile(self.path):
             raise NoSuchPatchFileError(pkg.name, self.path)

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -419,6 +419,8 @@ class RepoPath(MutableSequence):
         return self.repo_for_pkg(spec).dump_provenance(spec, path)
 
     def dirname_for_package_name(self, pkg_name):
+        # TODO: this function may return the wrong result if there's more
+        # TODO: than one repo that contains 'pkg_name'.
         return self.repo_for_pkg(pkg_name).dirname_for_package_name(pkg_name)
 
     def filename_for_package_name(self, pkg_name):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -31,6 +31,14 @@ import inspect
 import imp
 import re
 import traceback
+
+# MutableSequence can be found in the collections module in python 2
+# and in collections.abc in python 3
+try:
+    from collections import MutableSequence
+except ImportError:
+    from collections.abc import MutableSequence
+
 from bisect import bisect_left
 from types import ModuleType
 
@@ -95,12 +103,16 @@ class SpackNamespace(ModuleType):
         return getattr(self, name)
 
 
-class RepoPath(object):
+class RepoPath(MutableSequence):
     """A RepoPath is a list of repos that function as one.
 
     It functions exactly like a Repo, but it operates on the
     combined results of the Repos in its list instead of on a
     single package repository.
+
+    It also behaves like a list of Repo instances, except for the
+    __contains__ semantics that is used to check if a particular package
+    is present.
     """
 
     def __init__(self, *repo_dirs):
@@ -118,9 +130,9 @@ class RepoPath(object):
 
         # Add each repo to this path.
         for root in repo_dirs:
-            self.add_repo_from_path(root)
+            self.append_from_path(root)
 
-    def add_repo_from_path(self, root):
+    def append_from_path(self, root):
         """Append a repository to the list of managed ones. Takes a path
         as argument.
 
@@ -129,12 +141,112 @@ class RepoPath(object):
         """
         try:
             repo = Repo(root, self.super_namespace)
-            self.put_last(repo)
+            self.append(repo)
         except RepoError as e:
-            tty.warn("Failed to initialize repository at '%s'." % root,
-                     e.message,
-                     "To remove the bad repository, run this command:",
-                     "    spack repo rm %s" % root)
+            msg = "Failed to initialize repository at '{0}'  ".format(root)
+            msg += '[' + e.message + ']\n\n'
+            msg += '  To remove the bad repository, run this command:\n\n'
+            msg += '  $ spack repo rm {0}\n'.format(root)
+            e.message = msg
+            raise
+
+    def __eq__(self, other):
+        # Exit early if other is of another type of if
+        # the lists of repos are of different lengths
+
+        if not isinstance(other, RepoPath):
+            return False
+
+        if len(self.repos) != len(other.repos):
+            return False
+
+        # Two RepoPath instances are considered equal if the list of Repo
+        # they contain points to the same repositories in the same order.
+
+        for r1, r2 in zip(self.repos, other.repos):
+            if r1.root != r2.root:
+                return False
+
+        # TODO: it would me more defensive to also check the by_path
+        # TODO: and the by_namespace caches
+
+        return True
+
+    def __getitem__(self, item):
+        # Behave like a list if 'item' is a slice, i.e.
+        # copy RepoPath with just the elements in the slice
+
+        if isinstance(item, slice):
+            sl = self.repos[item]
+            args = [x.root for x in sl]
+            return RepoPath(*args)
+
+        # Else return the element requested
+
+        return self.repos[item]
+
+    def __setitem__(self, key, value):
+        if isinstance(key, slice):
+
+            # Remove entries from index caches
+            repos_to_be_substituted = self.repos[key]
+            for r in repos_to_be_substituted:
+                self._remove_from_index_caches(r)
+
+            # Add the new entries to the indx caches
+            for r in value:
+                self._add_to_index_caches(r)
+
+            # Add the new values
+            self.repos[key] = value.repos
+
+        else:
+
+            # Get the repo associated with the key
+            repo = self.repos[key]
+
+            # Remove the current repository from caches
+            self._remove_from_index_caches(repo)
+
+            # Add the new value
+            self._add_to_index_caches(value)
+            self.repos[key] = value
+
+    def _remove_from_index_caches(self, repo):
+        """Removes the repository from the 'by_path' and 'by_namespace'
+        caches.
+
+        Args:
+            repo: repository to be removed from caches
+        """
+        # We need to get 'repo.root' and remove it from 'by_path'
+        root_key = repo.root
+        del self.by_path[root_key]
+
+        # Same for 'repo.namespace' and 'by_namespace'
+        namespace_key = repo.full_namespace
+        del self.by_namespace[namespace_key]
+
+    def __delitem__(self, key):
+
+        # Delete entries from index caches
+        if isinstance(key, slice):
+            repos_to_be_deleted = self.repos[key]
+            for r in repos_to_be_deleted:
+                self._remove_from_index_caches(r)
+        else:
+            repo = self[key]
+            self._remove_from_index_caches(repo)
+
+        # Delete them also from the list of repos
+        del self.repos[key]
+
+    def __len__(self):
+        return len(self.repos)
+
+    def insert(self, index, value):
+        self._add_to_index_caches(value)
+        self.repos.insert(index, value)
 
     def swap(self, other):
         """Convenience function to make swapping repositories easier.
@@ -153,12 +265,11 @@ class RepoPath(object):
             setattr(self, attr, getattr(other, attr))
             setattr(other, attr, tmp)
 
-    def _add(self, repo):
+    def _add_to_index_caches(self, repo):
         """Add a repository to the namespace and path indexes.
 
         Checks for duplicates -- two repos can't have the same root
         directory, and they provide have the same namespace.
-
         """
         if repo.root in self.by_path:
             raise DuplicateRepoError("Duplicate repository: '%s'" % repo.root)
@@ -172,21 +283,6 @@ class RepoPath(object):
         # Add repo to the pkg indexes
         self.by_namespace[repo.full_namespace] = repo
         self.by_path[repo.root] = repo
-
-    def put_first(self, repo):
-        """Add repo first in the search path."""
-        self._add(repo)
-        self.repos.insert(0, repo)
-
-    def put_last(self, repo):
-        """Add repo last in the search path."""
-        self._add(repo)
-        self.repos.append(repo)
-
-    def remove(self, repo):
-        """Remove a repo from the search path."""
-        if repo in self.repos:
-            self.repos.remove(repo)
 
     def get_repo(self, namespace, default=NOT_PROVIDED):
         """Get a repository by namespace.
@@ -319,7 +415,8 @@ class RepoPath(object):
 
            Raises UnknownPackageError if not found.
         """
-        # FIXME: the keyword new is never used
+        # FIXME: the keyword new is never used here, but seems to be
+        # FIXME: art of the required interface
         return self.repo_for_pkg(spec).get(spec)
 
     def get_pkg_class(self, pkg_name):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -193,7 +193,7 @@ class RepoPath(MutableSequence):
             for r in repos_to_be_substituted:
                 self._remove_from_index_caches(r)
 
-            # Add the new entries to the indx caches
+            # Add the new entries to the index caches
             for r in value:
                 self._add_to_index_caches(r)
 
@@ -307,10 +307,6 @@ class RepoPath(MutableSequence):
             return default
         return self.by_namespace[fullspace]
 
-    def first_repo(self):
-        """Get the first repo in precedence order."""
-        return self.repos[0] if self.repos else None
-
     def all_package_names(self):
         """Return all unique package names in all repositories."""
         if self._all_package_names is None:
@@ -407,7 +403,7 @@ class RepoPath(MutableSequence):
         # If the package isn't in any repo, return the one with
         # highest precedence.  This is for commands like `spack edit`
         # that can operate on packages that don't exist yet.
-        return self.first_repo()
+        return self[0]
 
     @_autospec
     def get(self, spec, new=False):

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -150,6 +150,13 @@ class RepoPath(MutableSequence):
             e.message = msg
             raise
 
+    def clear(self):
+        self.repos = []
+        self.by_namespace = NamespaceTrie()
+        self.by_path = {}
+        self._all_package_names = None
+        self._provider_index = None
+
     def __eq__(self, other):
         # Exit early if other is of another type of if
         # the lists of repos are of different lengths
@@ -247,23 +254,6 @@ class RepoPath(MutableSequence):
     def insert(self, index, value):
         self._add_to_index_caches(value)
         self.repos.insert(index, value)
-
-    def swap(self, other):
-        """Convenience function to make swapping repositories easier.
-
-        This is currently used by mock tests.
-        TODO: Maybe there is a cleaner way.
-
-        """
-        attrs = ['repos',
-                 'by_namespace',
-                 'by_path',
-                 '_all_package_names',
-                 '_provider_index']
-        for attr in attrs:
-            tmp = getattr(self, attr)
-            setattr(self, attr, getattr(other, attr))
-            setattr(other, attr, tmp)
 
     def _add_to_index_caches(self, repo):
         """Add a repository to the namespace and path indexes.

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -27,7 +27,6 @@
 import re
 
 import spack
-from spack.repository import RepoPath
 
 
 def check_db():
@@ -43,10 +42,18 @@ def test_get_all_packages():
 
 def test_get_all_mock_packages():
     """Get the mock packages once each too."""
-    db = RepoPath(spack.mock_packages_path)
-    spack.repo.swap(db)
+
+    # Plugin the mock repository
+    cache = spack.repo[:]
+    spack.repo.clear()
+    spack.repo.append_from_path(spack.mock_packages_path)
+
     check_db()
-    spack.repo.swap(db)
+
+    # Restore the real one
+    spack.repo.clear()
+    for x in cache:
+        spack.repo.append(x)
 
 
 def test_all_versions_are_lowercase():

--- a/lib/spack/spack/test/repository.py
+++ b/lib/spack/spack/test/repository.py
@@ -1,0 +1,121 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import spack
+import spack.repository
+import pytest
+
+
+@pytest.fixture()
+def mock_repository():
+    return spack.repository.RepoPath('$spack/var/spack/repos/builtin.mock')
+
+
+class TestRepoPath(object):
+
+    def test_error_during_construction(self):
+
+        # If the repository has no repo.yaml, raise BadRepoError
+        with pytest.raises(spack.repository.BadRepoError):
+            spack.repository.RepoPath('/foo/bar')
+
+    def test_magic_methods(self, mock_repository):
+
+        # We constructed a RepoPath with only one item in it,
+        # pointing to the mock repository we use for tests
+        assert len(mock_repository) == 1
+
+        # Get a single item
+        a = mock_repository[0]
+        assert isinstance(a, spack.repository.Repo)
+
+        # Get a Slice
+        b = mock_repository[:]
+        assert isinstance(b, spack.repository.RepoPath)
+        assert b == mock_repository
+
+        b.append_from_path('$spack/var/spack/repos/builtin')
+        assert len(b) == 2
+
+        c = b[:]
+        assert c == b
+        assert c != mock_repository
+
+        c = b[:1]
+        assert c != b
+        assert c == mock_repository
+
+        # Set an item passing from the mock repository
+        # to the builtin one
+        c = mock_repository[:]
+        c[0] = spack.repository.Repo('$spack/var/spack/repos/builtin')
+
+        d = b[1:]
+        assert c == d
+
+        # Set a slice to a RepoPath
+        a = spack.repository.RepoPath()
+
+        assert len(a) == 0
+
+        # Check that we can go out of bounds as in built-in lists
+        a[0:6] = spack.repository.RepoPath(
+            '$spack/var/spack/repos/builtin',
+            '$spack/var/spack/repos/builtin.mock'
+        )
+
+        assert len(a) == 2
+
+        # Delete a slice of items, check that we treat nicely
+        # requests that go out of bounds
+        del a[1:100]
+        assert len(a) == 1
+
+        del a[0:]
+        assert len(a) == 0
+
+        # Delete an single item
+        b = mock_repository[:]
+        b.append_from_path('$spack/var/spack/repos/builtin')
+        expected = spack.repository.RepoPath('$spack/var/spack/repos/builtin')
+        del b[0]
+
+        assert b == expected
+
+        # Check that the '__contains__' semantic is correctly used to check
+        # if a package can be found in a repository
+        assert 'a' in mock_repository
+        assert 'boost' in mock_repository
+
+        # Check that instead the iteration semantic steps through
+        # the repositories
+        b = mock_repository[:]
+        b.append_from_path('$spack/var/spack/repos/builtin')
+        counter = 0
+
+        for _ in b:
+            counter += 1
+
+        assert counter == 2


### PR DESCRIPTION
I spent the last couple of days studying the code that implements repositories (and I have to say it has been quite instructive to see how it blends into the python "import" protocol). While I was at it I thought it could have been a good exercise to refactor some parts to be more "pythonic"  hence this PR.

The modifications here involve just `RepoPath`, as I would like to keep the PR as focused as possible. If there's agreement on the type of changes I will start having a look at `Repo` and `NamespaceTrie` in other PRs (in case they need any change).

Let me know if you agree with these kind of PRs or if you can figure out further tests besides the ones implemented.

Fixes #4236 
Fixes #5002