### PR TITLE
Improve qt

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -62,6 +62,8 @@ class Qt(Package):
             description="Build with D-Bus support.")
     variant('phonon',     default=False,
             description="Build with phonon support.")
+    variant('opengl',     default=True,
+            description="Build with OpenGL support.")
 
     patch('qt3krell.patch', when='@3.3.8b+krellpatch')
 
@@ -90,6 +92,8 @@ class Qt(Package):
     depends_on("libmng")
     depends_on("jpeg")
     depends_on("icu4c")
+    depends_on("fontconfig")
+    depends_on("freetype")
     # FIXME:
     # depends_on("freetype", when='@5.8:') and '-system-freetype'
     # -system-harfbuzz
@@ -101,12 +105,12 @@ class Qt(Package):
     # OpenGL hardware acceleration
     depends_on("mesa", when='@4:+mesa')
     depends_on("libxcb", when=sys.platform != 'darwin')
+    depends_on("libx11", when=sys.platform != 'darwin')
 
     # Webkit
     depends_on("flex", when='+webkit', type='build')
     depends_on("bison", when='+webkit', type='build')
     depends_on("gperf", when='+webkit')
-    depends_on("fontconfig", when='+webkit')
 
     # Multimedia
     # depends_on("gstreamer", when='+multimedia')
@@ -148,6 +152,7 @@ class Qt(Package):
         return url
 
     def setup_environment(self, spack_env, run_env):
+        spack_env.set('MAKEFLAGS', '-j{0}'.format(make_jobs))
         run_env.set('QTDIR', self.prefix)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
@@ -189,12 +194,15 @@ class Qt(Package):
             '-prefix', self.prefix,
             '-v',
             '-opensource',
-            '-opengl',
+            '-{0}opengl'.format('' if '+opengl' in self.spec else 'no-'),
             '-release',
             '-shared',
             '-confirm-license',
             '-openssl-linked',
             '-optimized-qmake',
+            '-fontconfig',
+            '-system-freetype',
+            '-I{0}/freetype2'.format(self.spec['freetype'].prefix.include),
             '-no-pch'
         ]
 


### PR DESCRIPTION
- Introduce an opengl variant that is enabled by default. Disabling it allows building qt for X forwarding etc.
- Depend on fontconfig and freetype to make use of system fonts. Otherwise qt can not find any fonts.
- libx11 is required when libxcb is used.
- Set MAKEFLAGS to parallelize qmake compilation.
- Skip script component to make qt compile due to pcre problems (#1517).

(Skipping script can probably be dropped when #4270 is merged.)