### PR TITLE
magics: use spack perl instead of system perl

### DIFF
--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class Magics(Package):
@@ -73,10 +74,9 @@ class Magics(Package):
     depends_on('libemos', when='+bufr')
     depends_on('qt', when='+metview+qt')
 
-    @when('@:2.29.6')
     def patch(self):
-        filter_file('#!/usr/bin/perl', '#!/usr/bin/env perl',
-                    'tools/xml2cc_new.pl')
+        for plfile in glob.glob('*/*.pl'):
+            filter_file('#!/usr/bin/perl', '#!/usr/bin/env perl', plfile)
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
Many perl scripts in the magics source distribution invoke the system perl via `#!/usr/bin/perl`. However, the system perl may not include the package XML::Parser, as I found on one of the systems I use. Patching the files to invoke perl via `#!/usr/bin/env perl` fixes the problem. This patch can be safely applied to all versions of magics.