### PR TITLE
Document known issue with R concretization

### DIFF
--- a/lib/spack/docs/known_issues.rst
+++ b/lib/spack/docs/known_issues.rst
@@ -37,6 +37,46 @@ A workaround is to explicitly activate the variant related to the dependency:
 See https://github.com/LLNL/spack/issues/397 for further details.
 
 
+---------------------------------------------------
+Variants are not properly forwarded to dependencies
+---------------------------------------------------
+
+**Status:** Expected to be fixed in the next release
+
+Sometimes, a variant of a package can also affect how its dependencies are
+built. For example, in order to build MPI support for a package, it may
+require that its dependencies are also built with MPI support. In the
+``package.py``, this looks like:
+
+.. code-block:: python
+
+   depends_on('hdf5~mpi', when='~mpi')
+   depends_on('hdf5+mpi', when='+mpi')
+
+Spack handles this situation properly for *immediate* dependencies, and
+builds ``hdf5`` with the same variant you used for the package that
+depends on it. However, for *indirect* dependencies (dependencies of
+dependencies), Spack does not backtrack up the DAG far enough to handle
+this. Users commonly run into this situation when trying to build R with
+X11 support:
+
+.. code-block:: console
+
+   $ spack install r+X
+   ...
+   ==> Error: Invalid spec: 'cairo@1.14.8%gcc@6.2.1+X arch=linux-fedora25-x86_64 ^bzip2@1.0.6%gcc@6.2.1+shared arch=linux-fedora25-x86_64 ^font-util@1.3.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^fontconfig@2.12.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^freetype@2.7.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^gettext@0.19.8.1%gcc@6.2.1+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-fedora25-x86_64 ^glib@2.53.1%gcc@6.2.1~libmount arch=linux-fedora25-x86_64 ^inputproto@2.3.2%gcc@6.2.1 arch=linux-fedora25-x86_64 ^kbproto@1.0.7%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libffi@3.2.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libpng@1.6.29%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libpthread-stubs@0.4%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libx11@1.6.5%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libxau@1.0.8%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libxcb@1.12%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libxdmcp@1.1.2%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libxext@1.3.3%gcc@6.2.1 arch=linux-fedora25-x86_64 ^libxml2@2.9.4%gcc@6.2.1~python arch=linux-fedora25-x86_64 ^libxrender@0.9.10%gcc@6.2.1 arch=linux-fedora25-x86_64 ^ncurses@6.0%gcc@6.2.1~symlinks arch=linux-fedora25-x86_64 ^openssl@1.0.2k%gcc@6.2.1 arch=linux-fedora25-x86_64 ^pcre@8.40%gcc@6.2.1+utf arch=linux-fedora25-x86_64 ^pixman@0.34.0%gcc@6.2.1 arch=linux-fedora25-x86_64 ^pkg-config@0.29.2%gcc@6.2.1+internal_glib arch=linux-fedora25-x86_64 ^python@2.7.13%gcc@6.2.1+shared~tk~ucs4 arch=linux-fedora25-x86_64 ^readline@7.0%gcc@6.2.1 arch=linux-fedora25-x86_64 ^renderproto@0.11.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^sqlite@3.18.0%gcc@6.2.1 arch=linux-fedora25-x86_64 ^tar^util-macros@1.19.1%gcc@6.2.1 arch=linux-fedora25-x86_64 ^xcb-proto@1.12%gcc@6.2.1 arch=linux-fedora25-x86_64 ^xextproto@7.3.0%gcc@6.2.1 arch=linux-fedora25-x86_64 ^xproto@7.0.31%gcc@6.2.1 arch=linux-fedora25-x86_64 ^xtrans@1.3.5%gcc@6.2.1 arch=linux-fedora25-x86_64 ^xz@5.2.3%gcc@6.2.1 arch=linux-fedora25-x86_64 ^zlib@1.2.11%gcc@6.2.1+pic+shared arch=linux-fedora25-x86_64'.
+   Package cairo requires variant ~X, but spec asked for +X
+
+A workaround is to explicitly activate the variants of dependencies as well:
+
+.. code-block:: console
+
+   $ spack install r+X ^cairo+X ^pango+X
+
+See https://github.com/LLNL/spack/issues/267 and
+https://github.com/LLNL/spack/issues/2546 for further details.
+
+
 ---------------------------------
 ``spack extensions`` doesn't work
 ---------------------------------

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -74,6 +74,8 @@ class R(AutotoolsPackage):
     depends_on('cairo+X', when='+X')
     depends_on('cairo~X', when='~X')
     depends_on('pango')
+    depends_on('pango+X', when='+X')
+    depends_on('pango~X', when='~X')
     depends_on('freetype')
     depends_on('tcl')
     depends_on('tk')


### PR DESCRIPTION
This is a fairly common issue that I think is worth documenting: See #267, #1909, #2053, #2070, #2546, #2590, #4312, etc.

I think the change I made to the R package actually prevents this problem? (although the variant resolution mechanism is still broken). But all of the following commands work for me now:
```
$ spack spec r
$ spack spec r+X
$ spack spec r~X
```
@hartzell @samfux84 can you test this?

@tgamblin can you confirm that my diagnosis of the problem is accurate?