### PR TITLE
Add latest version of JDK

### DIFF
--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -49,16 +49,6 @@ def test_get_all_mock_packages():
     spack.repo.swap(db)
 
 
-def test_url_versions():
-    """Check URLs for regular packages, if they are explicitly defined."""
-    for pkg in spack.repo.all_packages():
-        for v, vattrs in pkg.versions.items():
-            if 'url' in vattrs:
-                # If there is a url for the version check it.
-                v_url = pkg.url_for_version(v)
-                assert vattrs['url'] == v_url
-
-
 def test_all_versions_are_lowercase():
     """Spack package names must be lowercase, and use `-` instead of `_`."""
     errors = []

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -45,19 +45,20 @@ class Jdk(Package):
         '-H',  # specify required License Agreement cookie
         'Cookie: oraclelicense=accept-securebackup-cookie']
 
-    version('8u92', '65a1cc17ea362453a6e0eb4f13be76e4',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.tar.gz",
-            curl_options=curl_options)
-    version('8u73', '1b0120970aa8bc182606a16bf848a686',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-x64.tar.gz",
-            curl_options=curl_options)
-    version('8u66', '88f31f3d642c3287134297b8c10e61bf',
-            url="http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz",
-            curl_options=curl_options)
+    version('8u131-b11', '81ee08846975d4b8d46acf3b6eddf103', curl_options=curl_options)
+    version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', curl_options=curl_options)
+    version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', curl_options=curl_options)
+    version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', curl_options=curl_options)
     # The 7u80 tarball is not readily available from Oracle.  If you have
     # the tarball, add it to your mirror as mirror/jdk/jdk-7u80.tar.gz and
     # away you go.
-    version('7u80', '6152f8a7561acf795ca4701daa10a965')
+    version('7u80-b0', '6152f8a7561acf795ca4701daa10a965')
+
+    def url_for_version(self, version):
+        url = "http://download.oracle.com/otn-pub/java/jdk/{0}/jdk-{1}-linux-x64.tar.gz"
+        version = str(version)
+        minor_version = version[:version.index('-')]
+        return url.format(version, minor_version)
 
     def install(self, spec, prefix):
         distutils.dir_util.copy_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -45,7 +45,11 @@ class Jdk(Package):
         '-H',  # specify required License Agreement cookie
         'Cookie: oraclelicense=accept-securebackup-cookie']
 
-    version('8u131-b11', '81ee08846975d4b8d46acf3b6eddf103', curl_options=curl_options)
+    # For instructions on how to find the magic URL, see:
+    # https://gist.github.com/P7h/9741922
+    # https://linuxconfig.org/how-to-install-java-se-development-kit-on-debian-linux
+    version('8u131-b11', '75b2cb2249710d822a60f83e28860053', curl_options=curl_options,
+            url='http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz')
     version('8u92-b14',  '65a1cc17ea362453a6e0eb4f13be76e4', curl_options=curl_options)
     version('8u73-b02',  '1b0120970aa8bc182606a16bf848a686', curl_options=curl_options)
     version('8u66-b17',  '88f31f3d642c3287134297b8c10e61bf', curl_options=curl_options)


### PR DESCRIPTION
Closes #2284, although I'm still thinking about the best way to name versions of this package.

Unfortunately, this package cannot be downloaded as @hartzell noticed in #4313. The URL is correct, and can be fetched using `wget`, but it doesn't work with `curl` anymore. @tgamblin any ideas?