### PR TITLE
Magics with eccodes variant

### DIFF
--- a/var/spack/repos/builtin/packages/magics/no_hardcoded_python.patch
+++ b/var/spack/repos/builtin/packages/magics/no_hardcoded_python.patch
@@ -1,5 +1,0 @@
---- a/tools/xml2mv.py	2016-06-27 17:49:27.000000000 +0200
-+++ a/tools/xml2mv.py	2016-09-13 16:25:17.246960456 +0200
-@@ -1 +1 @@
--#!/usr/bin/python
-+#!/usr/bin/env python

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -55,6 +55,7 @@ class Magics(Package):
     variant('cairo', default=True, description='Enable cairo support[png/jpeg]')
     variant('metview', default=False, description='Enable metview support')
     variant('qt', default=False, description='Enable metview support with qt')
+    variant('eccodes', default=False, description='Use eccodes instead of grib-api')
 
     depends_on('cmake', type='build')
     depends_on('pkg-config', type='build')
@@ -64,8 +65,8 @@ class Magics(Package):
     depends_on('python', type='build')
     depends_on('perl', type='build')
     depends_on('perl-xml-parser', type='build')
-    depends_on('eccodes', when='@2.30.0:')
-    depends_on('grib-api', when='@:2.29.6')
+    depends_on('eccodes', when='+eccodes')
+    depends_on('grib-api', when='~eccodes')
     depends_on('proj')
     depends_on('boost')
     depends_on('expat')
@@ -73,6 +74,8 @@ class Magics(Package):
     depends_on('netcdf-cxx', when='+netcdf')
     depends_on('libemos', when='+bufr')
     depends_on('qt', when='+metview+qt')
+
+    conflicts('+eccodes', when='@:2.29.0')
 
     def patch(self):
         for plfile in glob.glob('*/*.pl'):
@@ -86,11 +89,6 @@ class Magics(Package):
         options.append('-DBOOST_ROOT=%s' % spec['boost'].prefix)
         options.append('-DPROJ4_PATH=%s' % spec['proj'].prefix)
         options.append('-DENABLE_TESTS=OFF')
-
-        if self.version >= Version('2.30.0'):
-            options.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
-        else:
-            options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
 
         if '+bufr' in spec:
             options.append('-DENABLE_BUFR=ON')
@@ -118,6 +116,13 @@ class Magics(Package):
                 options.append('-DENABLE_METVIEW_NO_QT=ON')
         else:
             options.append('-DENABLE_METVIEW=OFF')
+
+        if '+eccodes' in spec:
+            options.append('-DENABLE_ECCODES=ON')
+            options.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
+        else:
+            options.append('-DENABLE_ECCODES=OFF')
+            options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
 
         if (self.compiler.f77 is None) or (self.compiler.fc is None):
             options.append('-DENABLE_FORTRAN=OFF')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -41,10 +41,6 @@ class Magics(Package):
     version('2.29.4', '91c561f413316fb665b3bb563f3878d1')
     version('2.29.0', 'db20a4d3c51a2da5657c31ae3de59709', preferred=True)
 
-    # The patch changes the hardcoded path to python in shebang to enable the
-    # usage of the first python installation that appears in $PATH
-    patch('no_hardcoded_python.patch', when='@:2.29.6')
-
     # The patch reorders includes and adds namespaces where necessary to
     # resolve ambiguity of invocations of isnan and isinf functions. The
     # patch is not needed since the version 2.29.1
@@ -77,9 +73,12 @@ class Magics(Package):
 
     conflicts('+eccodes', when='@:2.29.0')
 
+    # Replace system python and perl by spack versions:
     def patch(self):
         for plfile in glob.glob('*/*.pl'):
             filter_file('#!/usr/bin/perl', '#!/usr/bin/env perl', plfile)
+        for pyfile in glob.glob('*/*.py'):
+            filter_file('#!/usr/bin/python', '#!/usr/bin/env python', pyfile)
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
Recent versions of magics allow grib support to be provided by either eccodes or grib-api. Some applications may require one or the other, so we provide an eccodes variant of magics. This is more flexible than hard-coding a choice based on the magics version number.

We also ensure that recent versions of magics can be patched to avoid an in-built dependency on the system python.