### PR TITLE
Override partial installs by default - part three

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -66,6 +66,9 @@ the dependencies"""
         '--keep-stage', action='store_true', dest='keep_stage',
         help="don't remove the build stage if installation succeeds")
     subparser.add_argument(
+        '--restage', action='store_true', dest='restage',
+        help="if a partial install is detected, delete prior state")
+    subparser.add_argument(
         '-n', '--no-checksum', action='store_true', dest='no_checksum',
         help="do not check packages against checksum")
     subparser.add_argument(
@@ -307,6 +310,7 @@ def install(parser, args, **kwargs):
     kwargs.update({
         'keep_prefix': args.keep_prefix,
         'keep_stage': args.keep_stage,
+        'restage': args.restage,
         'install_deps': 'dependencies' in args.things_to_install,
         'make_jobs': args.jobs,
         'run_tests': args.run_tests,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -577,6 +577,8 @@ class Database(object):
         else:
             # The file doesn't exist, try to traverse the directory.
             # reindex() takes its own write lock, so no lock here.
+            with WriteTransaction(self.lock, timeout=_db_lock_timeout):
+                self._write(None, None, None)
             self.reindex(spack.store.layout)
 
     def _add(self, spec, directory_layout=None, explicit=False):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1188,7 +1188,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         if self.spec.external:
             return self._process_external_package(explicit)
 
-        partial = self.repair_partial(keep_prefix)
+        partial = self.repair_partial(keep_prefix, keep_stage)
 
         # Ensure package is not already installed
         layout = spack.store.layout
@@ -1348,7 +1348,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             if not keep_prefix:
                 self.remove_prefix()
 
-    def repair_partial(self, continue_with_partial=False):
+    def repair_partial(self, reuse_prefix=False, reuse_stage=False):
         """If continue_with_partial is not set, this ensures that the package
            is either fully-installed or that the prefix is removed. This
            function considers a package fully-installed if there is a DB
@@ -1367,14 +1367,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
             partial = False
             if not installed_in_db and os.path.isdir(self.prefix):
-                if not continue_with_partial:
+                if not reuse_prefix:
                     self.remove_prefix()
                 else:
                     partial = True
 
         stage_is_managed_in_spack = self.stage.path.startswith(
             spack.stage_path)
-        if (not continue_with_partial) and stage_is_managed_in_spack:
+        if (not reuse_stage) and stage_is_managed_in_spack:
             self.stage.destroy()
             self.stage.create()
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1354,7 +1354,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
            prepare for a new install attempt. Options control whether these
            files are reused (vs. destroyed). This function considers a package
            fully-installed if there is a DB entry for it (in that way, it is
-           more strict than Package.installed).
+           more strict than Package.installed). The return value is used to
+           indicate when the prefix exists but the install is not complete.
         """
         if self.spec.external:
             raise ExternalPackageError("Attempted to repair external spec %s" %

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1351,7 +1351,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
 
     def check_for_unfinished_installation(
-            self, reuse_prefix=False, restage=False):
+            self, keep_prefix=False, restage=False):
         """Check for leftover files from partially-completed prior install to
            prepare for a new install attempt. Options control whether these
            files are reused (vs. destroyed). This function considers a package
@@ -1372,7 +1372,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
             partial = False
             if not installed_in_db and os.path.isdir(self.prefix):
-                if not reuse_prefix:
+                if not keep_prefix:
                     self.remove_prefix()
                 else:
                     partial = True

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1349,7 +1349,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             if not keep_prefix:
                 self.remove_prefix()
 
-
     def check_for_unfinished_installation(
             self, keep_prefix=False, restage=False):
         """Check for leftover files from partially-completed prior install to

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1188,8 +1188,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         if self.spec.external:
             return self._process_external_package(explicit)
 
-        reuse_stage = not kwargs.get('restage', False)
-        partial = self.repair_partial(keep_prefix, reuse_stage)
+        restage = kwargs.get('restage', False)
+        partial = self.check_for_unfinished_installation(keep_prefix, restage)
 
         # Ensure package is not already installed
         layout = spack.store.layout
@@ -1349,8 +1349,10 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             if not keep_prefix:
                 self.remove_prefix()
 
-    def repair_partial(self, reuse_prefix=False, reuse_stage=True):
-        """Remove leftover files from partially-completed prior install to
+
+    def check_for_unfinished_installation(
+            self, reuse_prefix=False, restage=False):
+        """Check for leftover files from partially-completed prior install to
            prepare for a new install attempt. Options control whether these
            files are reused (vs. destroyed). This function considers a package
            fully-installed if there is a DB entry for it (in that way, it is
@@ -1377,7 +1379,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         stage_is_managed_in_spack = self.stage.path.startswith(
             spack.stage_path)
-        if (not reuse_stage) and stage_is_managed_in_spack:
+        if restage and stage_is_managed_in_spack:
             self.stage.destroy()
             self.stage.create()
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -115,7 +115,7 @@ class MockStage(object):
 
 
 @pytest.mark.usefixtures('install_mockery')
-def test_partial_install(mock_archive):
+def test_partial_install_delete_prefix_and_stage(mock_archive):
     spec = Spec('canfail')
     spec.concretize()
     pkg = spack.repo.get(spec)
@@ -159,7 +159,7 @@ def test_partial_install_keep_prefix(mock_archive):
         # error
         spack.package.Package.remove_prefix = mock_remove_prefix
         with pytest.raises(spack.build_environment.ChildError):
-            pkg.do_install(keep_prefix=True, keep_stage=True)
+            pkg.do_install(keep_prefix=True)
         assert os.path.exists(pkg.prefix)
         setattr(pkg, 'succeed', True)
         pkg.stage = MockStage(pkg.stage)
@@ -183,12 +183,11 @@ def test_second_install_no_overwrite_first(mock_archive):
     fake_fetchify(mock_archive.url, pkg)
     remove_prefix = spack.package.Package.remove_prefix
     try:
-        # If remove_prefix is called at any point in this test, that is an
-        # error
         spack.package.Package.remove_prefix = mock_remove_prefix
         setattr(pkg, 'succeed', True)
         pkg.do_install()
         assert pkg.installed
+        # If Package.install is called after this point, it will fail
         delattr(pkg, 'succeed')
         pkg.do_install()
     finally:

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -128,6 +128,7 @@ def test_partial_install_keep_prefix(mock_archive):
     spec = Spec('canfail')
     spec.concretize()
     pkg = spack.repo.get(spec)
+    # Normally the stage should start unset, but other tests set it
     pkg._stage = None
     fake_fetchify(mock_archive.url, pkg)
     remove_prefix = spack.package.Package.remove_prefix
@@ -136,10 +137,10 @@ def test_partial_install_keep_prefix(mock_archive):
         # error
         spack.package.Package.remove_prefix = mock_remove_prefix
         with pytest.raises(spack.build_environment.ChildError):
-            pkg.do_install(keep_prefix=True)
+            pkg.do_install(keep_prefix=True, keep_stage=True)
         assert os.path.exists(pkg.prefix)
         setattr(pkg, 'succeed', True)
-        pkg.do_install(keep_prefix=True)
+        pkg.do_install(keep_prefix=True, keep_stage=True)
         assert pkg.installed
     finally:
         spack.package.Package.remove_prefix = remove_prefix
@@ -154,7 +155,6 @@ def test_second_install_no_overwrite_first(mock_archive):
     spec = Spec('canfail')
     spec.concretize()
     pkg = spack.repo.get(spec)
-    pkg._stage = None
     fake_fetchify(mock_archive.url, pkg)
     remove_prefix = spack.package.Package.remove_prefix
     try:

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -132,7 +132,7 @@ def test_partial_install(mock_archive):
         spack.package.Package.remove_prefix = rm_prefix_checker.remove_prefix
         setattr(pkg, 'succeed', True)
         pkg.stage = MockStage(pkg.stage)
-        pkg.do_install()
+        pkg.do_install(restage=True)
         assert rm_prefix_checker.removed
         assert pkg.stage.test_destroyed
         assert pkg.installed
@@ -163,7 +163,7 @@ def test_partial_install_keep_prefix(mock_archive):
         assert os.path.exists(pkg.prefix)
         setattr(pkg, 'succeed', True)
         pkg.stage = MockStage(pkg.stage)
-        pkg.do_install(keep_prefix=True, keep_stage=True)
+        pkg.do_install(keep_prefix=True)
         assert pkg.installed
         assert not pkg.stage.test_destroyed
     finally:

--- a/var/spack/repos/builtin.mock/packages/canfail/package.py
+++ b/var/spack/repos/builtin.mock/packages/canfail/package.py
@@ -35,7 +35,9 @@ class Canfail(Package):
 
     def install(self, spec, prefix):
         try:
-            getattr(self, 'succeed')
+            succeed = getattr(self, 'succeed')
+            if not succeed:
+                raise InstallError("'succeed' was false")
             touch(join_path(prefix, 'an_installation_file'))
         except AttributeError:
             raise InstallError("'succeed' attribute was not set")

--- a/var/spack/repos/builtin.mock/packages/canfail/package.py
+++ b/var/spack/repos/builtin.mock/packages/canfail/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Canfail(Package):
+    """Package which fails install unless a special attribute is set"""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    def install(self, spec, prefix):
+        try:
+            getattr(self, 'succeed')
+            touch(join_path(prefix, 'an_installation_file'))
+        except AttributeError:
+            raise InstallError("'succeed' attribute was not set")


### PR DESCRIPTION
Fixes #2794
Fixes #2634

This is intended to be a simpler approach with (most of) the same benefits as https://github.com/LLNL/spack/pull/3929. Compared to that PR, this PR has the disadvantage that reindex will mistakenly add partially-installed packages.

During install, remove prior unfinished installs

If a user performs an installation which fails, in some cases the
install prefix is still present, and the stage path may also be
present. With this commit, unless the user specifies
'--keep-prefix', installs are guaranteed to begin with a clean
slate. The database is used to decide whether an install finished,
since a database record is not added until the end of the install
process.