### PR TITLE
petsc: fix scalapack error:

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -198,7 +198,7 @@ class Petsc(Package):
 
         # Activates library support if needed
         for library in ('metis', 'boost', 'hdf5', 'hypre', 'parmetis',
-                        'mumps', 'scalapack', 'trilinos'):
+                        'mumps', 'trilinos'):
             options.append(
                 '--with-{library}={value}'.format(
                     library=library, value=('1' if library in spec else '0'))


### PR DESCRIPTION
> Specify either "--with-scalapack-dir" or "--with-scalapack-lib --with-scalapack-include". But not both!

we do specify `scalapack-lib` in:
```
        # Help PETSc pick up Scalapack from MKL:
         if 'scalapack' in spec:
             scalapack = spec['scalapack'].libs
             options.extend([
                 '--with-scalapack-lib=%s' % scalapack.joined(),
                 '--with-scalapack=1'
             ])
         else:
             options.extend([
                 '--with-scalapack=0'
             ])
```

p.s. the bug was introduced in https://github.com/LLNL/spack/pull/3928 
