### PR TITLE
Touch up string expansion.

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3385,7 +3385,7 @@ class NoSuchHashError(SpecError):
     def __init__(self, hash):
         super(NoSuchHashError, self).__init__(
             "No installed spec matches the hash: '%s'"
-        % hash)
+            % hash)
 
 
 class RedundantSpecError(SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3384,7 +3384,8 @@ class InvalidHashError(SpecError):
 class NoSuchHashError(SpecError):
     def __init__(self, hash):
         super(NoSuchHashError, self).__init__(
-            "No installed spec matches the hash: '%s'")
+            "No installed spec matches the hash: '%s'"
+        % hash)
 
 
 class RedundantSpecError(SpecError):


### PR DESCRIPTION
I'm chasing this:

```
$ (module purge; spack install perl %gcc/5.4.0)
==> Error: No installed spec matches the hash: '%s'
```

There's something deeper going on, but the error message isn't helpful.

After this change it tells me this:

```
$ (module purge; spack install perl %gcc/5.4.0)
==> Error: No installed spec matches the hash: '5.4.0'
```

Which is weird because `5.4.0` is not a hash...  Whatever is going on here, the error message needs to be fixed.