### PR TITLE
Ensure Config.pm has correct setting for cc

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -31,6 +31,7 @@
 # Date: September 6, 2015
 #
 from spack import *
+import os
 
 
 class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
@@ -175,6 +176,18 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         config_dot_pm = perl('-MModule::Loaded', '-MConfig', '-e',
                              'print is_loaded(Config)', output=str)
 
-        match = 'cc *=>.*'
+        match = '^cc *=>.*'
         substitute = 'cc => \'{cc}\','.format(cc=self.compiler.cc)
         filter_file(match, substitute, config_dot_pm, **kwargs)
+
+        # And the path Config_heavy.pl
+        d = os.path.dirname(config_dot_pm)
+        config_heavy = join_path(d, 'Config_heavy.pl')
+
+        match = '^cc=.*'
+        substitute = 'cc=\'{cc}\''.format(cc=self.compiler.cc)
+        filter_file(match, substitute, config_heavy, **kwargs)
+
+        match = '^ld=.*'
+        substitute = 'ld=\'{ld}\''.format(ld=self.compiler.cc)
+        filter_file(match, substitute, config_heavy, **kwargs)

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -176,7 +176,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         config_dot_pm = perl('-MModule::Loaded', '-MConfig', '-e',
                              'print is_loaded(Config)', output=str)
 
-        match = '^cc *=>.*'
+        match = 'cc *=>.*'
         substitute = "cc => '{cc}',".format(cc=self.compiler.cc)
         filter_file(match, substitute, config_dot_pm, **kwargs)
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -177,7 +177,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                              'print is_loaded(Config)', output=str)
 
         match = '^cc *=>.*'
-        substitute = 'cc => \'{cc}\','.format(cc=self.compiler.cc)
+        substitute = "cc => '{cc}',".format(cc=self.compiler.cc)
         filter_file(match, substitute, config_dot_pm, **kwargs)
 
         # And the path Config_heavy.pl
@@ -185,9 +185,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         config_heavy = join_path(d, 'Config_heavy.pl')
 
         match = '^cc=.*'
-        substitute = 'cc=\'{cc}\''.format(cc=self.compiler.cc)
+        substitute = "cc='{cc}'".format(cc=self.compiler.cc)
         filter_file(match, substitute, config_heavy, **kwargs)
 
         match = '^ld=.*'
-        substitute = 'ld=\'{ld}\''.format(ld=self.compiler.cc)
+        substitute = "ld='{ld}'".format(ld=self.compiler.cc)
         filter_file(match, substitute, config_heavy, **kwargs)


### PR DESCRIPTION
Run a filter after install so that Config.pm records the compiler that Spack built the package with.  If this isn't done, $Config{cc} will be set to Spack's cc wrapper script.

See #4338 for additional background.

Closes #4338 