### PR TITLE
Make sure py-entrypoints runs its unit tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-entrypoints/package.py
+++ b/var/spack/repos/builtin/packages/py-entrypoints/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack.package import PackageBase
 
 
 class PyEntrypoints(PythonPackage):
@@ -45,3 +46,8 @@ class PyEntrypoints(PythonPackage):
     def install(self, spec, prefix):
         pip = which('pip')
         pip('install', self.stage.archive_file, '--prefix={0}'.format(prefix))
+
+    run_after('install')(PackageBase._run_default_install_time_test_callbacks)
+
+    # Check that self.prefix is there after installation
+    run_after('install')(PackageBase.sanity_check_prefix)


### PR DESCRIPTION
See https://github.com/LLNL/spack/pull/4330#issuecomment-304054274. Thanks to @lee218llnl for discovering this bug.

Unfortunately, the unit tests fail with the following error message:
```
ImportError: No module named backports
```
is there another module we are missing? Is this related to #3757?