### PR TITLE
Fix mummerplot when ^perl@5.20:

### DIFF
--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -39,6 +39,17 @@ class Mummer(Package):
     patch('Makefile.patch')
     patch('scripts-Makefile.patch')
 
+    def patch(self):
+        """Fix mummerplot's use of defined on hashes (deprecated
+           since perl@5.6 made illegal in perl@5.20."""
+
+        # only fix this for versions where it is actually
+        # an error, not just deprecated.
+        if not self.spec.satisfies('^perl@5.20:'):
+            return
+
+        filter_file(r'defined \(%', '(%', 'scripts/mummerplot.pl')
+
     def install(self, spec, prefix):
         if self.run_tests:
             make('check')

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -48,7 +48,9 @@ class Mummer(Package):
         if not self.spec.satisfies('^perl@5.20:'):
             return
 
-        filter_file(r'defined \(%', '(%', 'scripts/mummerplot.pl')
+        kwargs = {'string': True}
+        filter_file('defined (%', '(%', 'scripts/mummerplot.pl',
+                    **kwargs)
 
     def install(self, spec, prefix):
         if self.run_tests:

--- a/var/spack/repos/builtin/packages/mummer/package.py
+++ b/var/spack/repos/builtin/packages/mummer/package.py
@@ -41,12 +41,7 @@ class Mummer(Package):
 
     def patch(self):
         """Fix mummerplot's use of defined on hashes (deprecated
-           since perl@5.6 made illegal in perl@5.20."""
-
-        # only fix this for versions where it is actually
-        # an error, not just deprecated.
-        if not self.spec.satisfies('^perl@5.20:'):
-            return
+           since perl@5.10, made illegal in perl@5.20."""
 
         kwargs = {'string': True}
         filter_file('defined (%', '(%', 'scripts/mummerplot.pl',


### PR DESCRIPTION
Calling defined() on a hash has been deprecated for ages.  It became an error in perl@5.20.  If we're building with a perl where it's illegal, we should fix it.