### PR TITLE
Encode to utf-8 if using old Python

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -24,6 +24,7 @@
 ##############################################################################
 import re
 import shlex
+import sys
 import itertools
 from six import string_types
 
@@ -79,7 +80,6 @@ class Lexer(object):
         if self.mode == 1:
             scanner = self.scanner1
             mode_switches = self.mode_switches_10
-
         tokens, remainder = scanner.scan(word)
         remainder_used = 0
 
@@ -161,7 +161,10 @@ class Parser(object):
 
     def setup(self, text):
         if isinstance(text, string_types):
-            text = shlex.split(text)
+            if sys.version_info >= (2, 7, 9):
+                text = shlex.split(text)
+            else:
+                text = shlex.split(text.encode('utf-8'))
         self.text = text
         self.push_tokens(self.lexer.lex(text))
 

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -80,6 +80,7 @@ class Lexer(object):
         if self.mode == 1:
             scanner = self.scanner1
             mode_switches = self.mode_switches_10
+
         tokens, remainder = scanner.scan(word)
         remainder_used = 0
 


### PR DESCRIPTION
Addresses #4339 
According to this SO thread:
https://stackoverflow.com/questions/14218992/shlex-split-still-not-supporting-unicode

shlex does not support unicode (at least older versions don't) which
causes some parsing errors for compiler specs. Newer versions don't seem
to have this problem. This checks for python version. I arbitrarily set
it to Python 2.7.9 and above to just run shlex.split normally.