### PR TITLE
Add master as install option for yaml-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -32,6 +32,7 @@ class YamlCpp(CMakePackage):
     url      = "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz"
 
     version('0.5.3', '4e47733d98266e46a1a73ae0a72954eb')
+    version('develop', git='https://github.com/jbeder/yaml-cpp', branch='master')
 
     variant('shared', default=True,
             description='Enable build of shared libraries')


### PR DESCRIPTION
Being able to get master adds a few bug fixes and improvements over the 0.5.3 release that are useful.