### PR TITLE
added -c11 flag for pgi compiler for TSL

### DIFF
--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -70,7 +70,9 @@ class Parmetis(Package):
             '-DGKLIB_PATH:PATH=%s/GKlib' % spec['metis'].prefix.include,
             '-DMETIS_PATH:PATH=%s' % spec['metis'].prefix,
             '-DCMAKE_C_COMPILER:STRING=%s' % spec['mpi'].mpicc,
-            '-DCMAKE_CXX_COMPILER:STRING=%s' % spec['mpi'].mpicxx
+            '-DCMAKE_CXX_COMPILER:STRING=%s' % spec['mpi'].mpicxx,
+            '-DCMAKE_C_FLAGS:STRING=%s' % (
+                '-c11' if '%pgi' in spec else ''),
         ])
 
         if '+shared' in spec:


### PR DESCRIPTION
pgi compiler does not support TSL by default, so need to add -c11 flag