### PR TITLE
added STAR aligner package

### DIFF
--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -33,12 +33,12 @@ class Star(Package):
     url      = "https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz"
 
     version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
-    
+
     def install(self, spec, prefix):
         source_directory = join_path(self.stage.source_path, 'source')
 
         with working_dir(source_directory):
             make('STAR', 'STARlong')
-            make('install','STAR', 'STARlong') 
+            make('install', 'STAR', 'STARlong')
             shutil.move("../bin/STAR", prefix)
             shutil.move("../bin/STARlong", prefix)

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import shutil
+
+
+class Star(Package):
+    """STAR is an ultrafast universal RNA-seq aligner."""
+
+    homepage = "https://github.com/alexdobin/STAR"
+    url      = "https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz"
+
+    version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
+    
+    def install(self, spec, prefix):
+        source_directory = join_path(self.stage.source_path, 'source')
+
+        with working_dir(source_directory):
+            make('STAR', 'STARlong')
+            make('install','STAR', 'STARlong') 
+            shutil.move("../bin/STAR", prefix)
+            shutil.move("../bin/STARlong", prefix)

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -34,6 +34,9 @@ class Star(Package):
 
     version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
 
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('PATH', join_path(self.prefix))
+
     def install(self, spec, prefix):
         source_directory = join_path(self.stage.source_path, 'source')
 

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import shutil
 
 
 class Star(Package):
@@ -35,13 +34,13 @@ class Star(Package):
     version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', join_path(self.prefix))
+        run_env.prepend_path('PATH', join_path(self.prefix.bin))
 
     def install(self, spec, prefix):
-        source_directory = join_path(self.stage.source_path, 'source')
+        join_path(self.stage.source_path, 'source')
 
-        with working_dir(source_directory):
+        with working_dir('source'):
             make('STAR', 'STARlong')
-            make('install', 'STAR', 'STARlong')
-            shutil.move("../bin/STAR", prefix)
-            shutil.move("../bin/STARlong", prefix)
+            mkdirp(prefix.bin)
+            install('STAR', prefix.bin)
+            install('STARlong', prefix.bin)

--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -33,12 +33,7 @@ class Star(Package):
 
     version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', join_path(self.prefix.bin))
-
     def install(self, spec, prefix):
-        join_path(self.stage.source_path, 'source')
-
         with working_dir('source'):
             make('STAR', 'STARlong')
             mkdirp(prefix.bin)


### PR DESCRIPTION
OK this compiles but does not install properly.

The `make install` phase simply moves the compiled binaries to `../bin `directory under the staging directory.  I cannot discern from the developer's [docs](https://github.com/alexdobin/STAR/blob/master/README.md) how I can pass Spack prefix to `make install`.

To get around that I added:

```
shutil.move("../bin/STAR", prefix)
shutil.move("../bin/STARlong",  prefix)

```

Which puts the binaries into the prefix

```
user@node103[~/repos/spack]$ spack find -p star
==> 1 installed packages.
-- linux-rhel6-x86_64 / gcc@6.3.0 -------------------------------
    star@2.5.3a  /pbtech_mounts/homes027/user/repos/spack/opt/spack/linux-rhel6-x86_64/gcc-6.3.0/star-2.5.3a-pptd3lygyhgy3p5qgmzkmkgw4taq7mkq
user@node103[~/repos/spack]$ ls -ltr /pbtech_mounts/homes027/user/repos/spack/opt/spack/linux-rhel6-x86_64/gcc-6.3.0/star-2.5.3a-pptd3lygyhgy3p5qgmzkmkgw4taq7mkq
total 3.7M
-rwxr-xr-x 1 user physbio 1.9M May 26 15:00 STARlong
-rwxr-xr-x 1 user physbio 1.9M May 26 15:00 STAR
```
Though `spack load` does not add that to `$PATH`.  I read the docs on `Package()` class though I must have missed a step.  Can you point me in the right direction as I am hoping it's some trivial thing.
