### PR TITLE
ISAAC: Fix CMakeLists.txt Path

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -31,7 +31,9 @@ class IsaacServer(CMakePackage):
     homepage = "http://computationalradiationphysics.github.io/isaac/"
     url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
 
-    root_cmakelists_dir = 'server'
+    @property
+    def root_cmakelists_dir(self):
+        return join_path(self.stage.source_path, 'server')
 
     version('develop', branch='dev',
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')

--- a/var/spack/repos/builtin/packages/isaac/package.py
+++ b/var/spack/repos/builtin/packages/isaac/package.py
@@ -31,7 +31,9 @@ class Isaac(CMakePackage):
     homepage = "http://computationalradiationphysics.github.io/isaac/"
     url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
 
-    root_cmakelists_dir = 'lib'
+    @property
+    def root_cmakelists_dir(self):
+        return join_path(self.stage.source_path, 'lib')
 
     version('develop', branch='dev',
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')


### PR DESCRIPTION
Somehow the path to `CMakeLists.txt` via the class property `root_cmakelists_dir` was relative but is now actually relative to `spack-build/`.

Close #4324 by providing a path relative to the source repo of the stage via a method instead of a member variable