### PR TITLE
Add support for an older version of STAR

### DIFF
--- a/var/spack/repos/builtin/packages/star/package.py
+++ b/var/spack/repos/builtin/packages/star/package.py
@@ -31,7 +31,10 @@ class Star(Package):
     homepage = "https://github.com/alexdobin/STAR"
     url      = "https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz"
 
-    version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391')
+    version('2.5.3a', 'baf8d1b62a50482cfa13acb7652dc391',
+            url='https://github.com/alexdobin/STAR/archive/2.5.3a.tar.gz')
+    version('2.4.2a', '8b9345f2685a5ec30731e0868e86d506',
+            url='https://github.com/alexdobin/STAR/archive/STAR_2.4.2a.tar.gz')
 
     def install(self, spec, prefix):
         with working_dir('source'):


### PR DESCRIPTION
What the user wants, the user *etc*....

Add info for STAR@2.4.2a.  It's URL is different, so added a URL for it.  This broke the URL for the current version, so added a URL for it also (known bug).

*Minimally* tested on CentOS 7.