### PR TITLE
Fix spack info bug for Python 3

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -25,7 +25,7 @@
 from __future__ import print_function
 
 import textwrap
-import itertools
+from six.moves import zip_longest
 from llnl.util.tty.colify import *
 import spack
 import spack.fetch_strategy as fs
@@ -119,7 +119,7 @@ class VariantFormatter(object):
                     v.description,
                     width=self.column_widths[2]
                 )
-                for t in itertools.izip_longest(
+                for t in zip_longest(
                         name, allowed, description, fillvalue=''
                 ):
                     yield "    " + self.fmt % t


### PR DESCRIPTION
Closes #4390.

`itertools.izip_longest` was renamed to `itertools.zip_longest` in Python 3 (see https://pythonhosted.org/six/#module-six.moves). This causes `spack info` to crash in Python 3:
```
$ python3 $(which spack) info hdf
Package:    hdf
Homepage:   https://www.hdfgroup.org/products/hdf4/

Safe versions:  
    4.2.12    https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.12/src/hdf-4.2.12.tar.gz
    4.2.11    https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.11/src/hdf-4.2.11.tar.gz

Variants:
    Name [Default]    Allowed values    Description

==> Error: module 'itertools' has no attribute 'izip_longest'
```
This PR uses the `six` compatibility library to solve the problem.

@krafczyk 