### PR TITLE
Close #4388 libaio fetch

### DIFF
--- a/var/spack/repos/builtin/packages/libaio/package.py
+++ b/var/spack/repos/builtin/packages/libaio/package.py
@@ -28,10 +28,10 @@ from spack import *
 class Libaio(Package):
     """This is the linux native Asynchronous I/O interface library."""
 
-    homepage = "https://git.fedorahosted.org/cgit/libaio.git"
-    url      = "https://git.fedorahosted.org/cgit/libaio.git/snapshot/libaio-0.3.110-1.tar.gz"
+    homepage = "http://lse.sourceforge.net/io/aio.html"
+    url      = "https://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.110.orig.tar.gz"
 
-    version('0.3.110-1', 'eb6b1b435afadb5b80c5dd80984249f6')
+    version('0.3.110', '2a35602e43778383e2f4907a4ca39ab8')
 
     def install(self, spec, prefix):
         # libaio is not supported on OS X


### PR DESCRIPTION
Currently, a new mainline repo of libaio is not known. Close #4388 by fetching libaio via the debian mirrors, [the same way as archlinux builds it](https://git.archlinux.org/svntogit/packages.git/commit/trunk/PKGBUILD?h=packages/libaio&id=a8ec32dd3988668809e6c6affe678db04db3fc76) (from original, unmodified sources)

Fixes also one of #3851