### PR TITLE
Fix Fetch MariaDB

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -33,8 +33,11 @@ class Mariadb(Package):
     tools make it very versatile for a wide variety of use cases."""
 
     homepage = "https://mariadb.org/about/"
-    url      = "https://downloads.mariadb.org/f/mariadb-10.1.14/source/mariadb-10.1.14.tar.gz"
+    url      = "https://downloads.mariadb.org/f/mariadb-10.1.23/source/mariadb-10.1.23.tar.gz"
 
+    version('10.1.23', '1a7392cc05c7c249acd4495022719ca8')
+    version('5.5.56', '8bc7772fea3e11b0bc1a09d2278e2e32')
+    # old versions, do not fetch under given url anymore
     version('10.1.14', '294925531e0fd2f0461e3894496a5adc')
     version('5.5.49', '67b5a499a5f158b2a586e6e3bfb4f304')
 


### PR DESCRIPTION
The two given versions of mariadb are not fetchable under the given URL, probably because older versions are purged and only kept in an archive.

~~Replace both with working, latest revisions of the release lines.~~ *Add two working, latest revisions of each release line.*