### PR TITLE
Tighten up graphviz package (explicitly disable unused languages, etc...)

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.error import SpackError
 import sys
 import shutil
 
@@ -108,7 +107,7 @@ class Graphviz(AutotoolsPackage):
 
         for var in untested_bindings:
             if var in spec:
-                raise SpackError(
+                raise InstallError(
                     "The variant {0} for language bindings has not been "
                     "tested.  It might or might not work.  To try it "
                     "out, run `spack edit graphviz`, and then move '{0}' "

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -87,7 +87,7 @@ class Graphviz(AutotoolsPackage):
         '+lua', '+ocaml', '+php',
         '+python', '+r', '+ruby', '+tcl')
 
-    for b in tested_bindings+untested_bindings:
+    for b in tested_bindings + untested_bindings:
         depends_on('swig', when='%s' % b)
 
     depends_on('ghostscript')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+from spack.error import SpackError
 import sys
 import shutil
 
@@ -34,11 +35,14 @@ class Graphviz(AutotoolsPackage):
 
     version('2.38.0', '5b6a829b2ac94efcd5fa3c223ed6d3ae')
 
+    # Swig can be enabled on it's own, though it doesn't do much.  It
+    # will also be enabled if any of the languages are enabled.
+    variant('swig', default=False,
+            description='Enable swig language binding tools'
+            ' (not yet functional)')
+
     # We try to leave language bindings enabled if they don't cause
     # build issues or add dependencies.
-    variant('swig', default=False,
-            description='Enable for optional swig language bindings'
-            ' (not yet functional)')
     variant('sharp', default=False,
             description='Enable for optional sharp language bindings'
             ' (not yet functional)')
@@ -99,13 +103,13 @@ class Graphviz(AutotoolsPackage):
         # These language bindings have not yet been tested.  They
         # likely need additional dependencies to get working.
         untested_bindings = (
-            '+swig', '+sharp', '+go', '+guile', '+io',
+            '+sharp', '+go', '+guile', '+io',
             '+lua', '+ocaml', '+php',
             '+python', '+r', '+ruby', '+tcl')
 
         for var in untested_bindings:
             if var in spec:
-                raise SpackException(
+                raise SpackError(
                     "The variant {0} for language bindings has not been "
                     "tested.  It might or might not work.  To try it "
                     "out, run `spack edit graphviz`, and then move '{0}' "
@@ -113,11 +117,23 @@ class Graphviz(AutotoolsPackage):
                     "`tested_bindings` list.  Be prepared to add "
                     "required dependencies.  "
                     "Please then submit a pull request to "
-                    "http://github.com/llnl/spack")
+                    "http://github.com/llnl/spack".format(var))
+
+        need_swig = True if ("+swig" in spec) else False
 
         for var in tested_bindings:
+            if (var in spec):
+                need_swig = True
             enable = 'enable' if (var in spec) else 'disable'
             options.append('--%s-%s' % (enable, var[1:]))
+
+        for var in untested_bindings:
+            options.append('--disable-%s' % var[1:])
+
+        if need_swig:
+            options.append('--enable-swig=yes')
+        else:
+            options.append('--enable-swig=no')
 
         # On OSX fix the compiler error:
         # In file included from tkStubLib.c:15:

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -38,8 +38,7 @@ class Graphviz(AutotoolsPackage):
     # Swig can be enabled on it's own, though it doesn't do much.  It
     # will also be enabled if any of the languages are enabled.
     variant('swig', default=False,
-            description='Enable swig language binding tools'
-            ' (not yet functional)')
+            description='Enable swig language binding tools')
 
     # We try to leave language bindings enabled if they don't cause
     # build issues or add dependencies.

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -119,12 +119,12 @@ class Graphviz(AutotoolsPackage):
             options.append('--disable-%s' % var[1:])
 
         for var in self.tested_bindings:
-            if (var in spec):
+            if var in spec:
                 need_swig = True
-                enable = 'enable'
+                enable = 'yes'
             else:
-                enable = 'disable'
-            options.append('--%s-%s' % (enable, var[1:]))
+                enable = 'no'
+            options.append('--enable-%s=%s' % (var[1:], enable))
 
         if need_swig:
             options.append('--enable-swig=yes')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -77,7 +77,7 @@ class Graphviz(AutotoolsPackage):
     parallel = False
 
     # These language bindings have been tested, we know they work.
-    tested_bindings = ('+java')
+    tested_bindings = ('+java', )
 
     # These language bindings have not yet been tested.  They
     # likely need additional dependencies to get working.

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -121,10 +121,9 @@ class Graphviz(AutotoolsPackage):
         for var in self.tested_bindings:
             if var in spec:
                 need_swig = True
-                enable = 'yes'
+                options.append('--enable-{0}'.format(var[1:]))
             else:
-                enable = 'no'
-            options.append('--enable-%s=%s' % (var[1:], enable))
+                options.append('--disable-{0}'.format(var[1:]))
 
         if need_swig:
             options.append('--enable-swig=yes')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -77,11 +77,12 @@ class Graphviz(AutotoolsPackage):
     parallel = False
 
     # These language bindings have been tested, we know they work.
-    tested_bindings = ('+java', '+perl')
+    tested_bindings = ('+java')
 
     # These language bindings have not yet been tested.  They
     # likely need additional dependencies to get working.
     untested_bindings = (
+        '+perl',
         '+sharp', '+go', '+guile', '+io',
         '+lua', '+ocaml', '+php',
         '+python', '+r', '+ruby', '+tcl')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -123,7 +123,9 @@ class Graphviz(AutotoolsPackage):
         for var in tested_bindings:
             if (var in spec):
                 need_swig = True
-            enable = 'enable' if (var in spec) else 'disable'
+                enable = 'enable'
+            else:
+                enable = 'disable'
             options.append('--%s-%s' % (enable, var[1:]))
 
         for var in untested_bindings:

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -88,7 +88,7 @@ class Graphviz(AutotoolsPackage):
         '+python', '+r', '+ruby', '+tcl')
 
     for b in tested_bindings + untested_bindings:
-        depends_on('swig', when='%s' % b)
+        depends_on('swig', when=b)
 
     depends_on('ghostscript')
     depends_on('freetype')


### PR DESCRIPTION
The fun started when configure discovered a broken/partial installation of `swig` in `/usr/local`, then auto-discovered my system's python and ruby packages.

- SpackException doesn't seem to exist.  Convert it to ~a SpackError~ an InstallError  and call `.format(...)` on the error string to fill in the placeholder.

- Pull swig out of the list of languages.  It's something that can be asked for explicitly and that is needed if *any* of the langagues are enabled.  It's disabled by default.

- Explicitly disable the languages that are in "untested_bindings" list lest the configure script pick up things from the system.