### PR TITLE
Add packages for clustalw and clustalo (and argtable)

### DIFF
--- a/var/spack/repos/builtin/packages/argtable/package.py
+++ b/var/spack/repos/builtin/packages/argtable/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Argtable(AutotoolsPackage):
+    """Argtable is an ANSI C library for parsing GNU style command line
+       options with a minimum of fuss.
+    """
+
+    homepage = "http://argtable.sourceforge.net/"
+    url      = "https://sourceforge.net/projects/argtable/files/argtable/argtable-2.13/argtable2-13.tar.gz/download"
+
+    version('2-13', '156773989d0d6406cea36526d3926668')

--- a/var/spack/repos/builtin/packages/clustalo/package.py
+++ b/var/spack/repos/builtin/packages/clustalo/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Clustalo(AutotoolsPackage):
+    """Clustal Omega: the last alignment program you'll ever need."""
+
+    homepage = "http://www.clustal.org/omega/"
+    url      = "http://www.clustal.org/omega/clustal-omega-1.2.4.tar.gz"
+
+    version('1.2.4', '6c0459f4c463a30e942ce7e0efc91422')
+
+    depends_on('argtable')

--- a/var/spack/repos/builtin/packages/clustalw/package.py
+++ b/var/spack/repos/builtin/packages/clustalw/package.py
@@ -1,0 +1,35 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Clustalw(AutotoolsPackage):
+    """Multiple alignment of nucleic acid and protein sequences."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "http://www.clustal.org/clustal2/"
+    url      = "http://www.clustal.org/download/2.1/clustalw-2.1.tar.gz"
+
+    version('2.1', '144df8440a0ae083d5167616c8ceeb41')

--- a/var/spack/repos/builtin/packages/clustalw/package.py
+++ b/var/spack/repos/builtin/packages/clustalw/package.py
@@ -28,7 +28,6 @@ from spack import *
 class Clustalw(AutotoolsPackage):
     """Multiple alignment of nucleic acid and protein sequences."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "http://www.clustal.org/clustal2/"
     url      = "http://www.clustal.org/download/2.1/clustalw-2.1.tar.gz"
 


### PR DESCRIPTION
Add packages for the classic multiple alignment package, `clustalw` and its younger sibling, `clustalo`.

`clustalo` needed the `argtable` package (command line arg parsing).

Lightly tested on CentOS 7.