### PR TITLE
travis: fixes failure on six

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ before_install:
 # Install various dependencies
 install:
   - pip install --upgrade pip
+  - pip install --upgrade six
   - pip install --upgrade setuptools
   - pip install --upgrade codecov
   - pip install --upgrade flake8


### PR DESCRIPTION
We are [experiencing errors on Travis](https://travis-ci.org/LLNL/spack/builds/238234076) due to dependencies:
```console
...
 Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-F5vHeJ/configparser/setup.py", line 63, in <module>
      'Topic :: Software Development :: Libraries :: Python Modules',
    File "/opt/python/2.7.9/lib/python2.7/distutils/core.py", line 151, in setup
      dist.run_commands()
    File "/opt/python/2.7.9/lib/python2.7/distutils/dist.py", line 953, in run_commands
      self.run_command(cmd)
    File "/opt/python/2.7.9/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 211, in run
      self.run_command('install')
    File "/opt/python/2.7.9/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/opt/python/2.7.9/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
      return orig.install.run(self)
    File "/opt/python/2.7.9/lib/python2.7/distutils/command/install.py", line 575, in run
      self.run_command(cmd_name)
    File "/opt/python/2.7.9/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/opt/python/2.7.9/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/setuptools/command/install_scripts.py", line 17, in run
      import setuptools.command.easy_install as ei
    File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 49, in <module>
      from setuptools.py27compat import rmtree_safe
    File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/setuptools/py27compat.py", line 7, in <module>
      import six
  ImportError: No module named six
```

I hope this will fix things.