### PR TITLE
Add variant to build shared Perl lib

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -70,7 +70,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             description='Optionally install cpanm with the core packages.')
 
     variant('shared', default=True,
-            description='Build a shared libperl.so library' )
+            description='Build a shared libperl.so library')
 
     resource(
         name="cpanm",

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -69,7 +69,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     variant('cpanm', default=True,
             description='Optionally install cpanm with the core packages.')
 
-    variant('useshrplib', default=False,
+    variant('shared', default=True,
             description='Build a shared libperl.so library' )
 
     resource(

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -93,7 +93,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
-        if '+useshrplib' in spec:
+        if '+shared' in spec:
             config_args.append('-Duseshrplib')
 
         return config_args

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -93,6 +93,12 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
+        # Discussion of -fPIC for Intel at:
+        # https://github.com/LLNL/spack/pull/3081 and
+        # https://github.com/LLNL/spack/pull/4416
+        if spec.satisfies('%intel'):
+            config_args.append('-Accflags={0}'.format(self.compiler.pic_flag))
+
         if '+shared' in spec:
             config_args.append('-Duseshrplib')
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -69,6 +69,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     variant('cpanm', default=True,
             description='Optionally install cpanm with the core packages.')
 
+    variant('useshrplib', default=False,
+            description='Build a shared libperl.so library' )
+
     resource(
         name="cpanm",
         url="http://search.cpan.org/CPAN/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7042.tar.gz",
@@ -87,13 +90,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-des',
             '-Dprefix={0}'.format(prefix),
             '-Dlocincpth=' + self.spec['gdbm'].prefix.include,
-            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib
+            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
-        # Discussion of -fPIC for Intel at:
-        # https://github.com/LLNL/spack/pull/3081
-        if spec.satisfies('%intel'):
-            config_args.append('-Accflags={0}'.format(self.compiler.pic_flag))
+        if '+useshrplib' in spec:
+            config_args.append('-Duseshrplib')
 
         return config_args
 


### PR DESCRIPTION
Add a variant that enables Perl's "useshrplib" feature, which builds a shared perl library.

This addresses problems like so:

```
/usr/bin/ld: /blah/blah/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/perl-5.24.1-y43dp3p5w66v7qh5xkwgufxohyuodyew/lib/5.24.1/x86_64-linux/CORE/libperl.a(op.o): relocation R_X86_64_32S against `PL_opargs' can not be used when making a shared object; recompile with -fPIC
/blah/blah/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/perl-5.24.1-y43dp3p5w66v7qh5xkwgufxohyuodyew/lib/5.24.1/x86_64-linux/CORE/libperl.a: could not read symbols: Bad value
```

It should also address the Intel compiler issue discussed in #3081 while respecting Perl's configuration machinery.

I need this feature for another package (cctools) that's finished but blocked on this.