### PR TITLE
Add package for cctools

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import llnl.util.tty as tty
+
 
 class Cctools(AutotoolsPackage):
     """The Cooperative Computing Tools (cctools) enable large scale

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -37,7 +37,7 @@ class Cctools(AutotoolsPackage):
     version('6.1.1', '9b43cdb3aceebddc1608c77184590619')
 
     depends_on('openssl')
-    depends_on('perl+useshrplib', type=('build','run'))
+    depends_on('perl+shared', type=('build','run'))
     depends_on('python@:3', type=('build','run'))
     depends_on('readline')
     depends_on('swig')

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -37,8 +37,8 @@ class Cctools(AutotoolsPackage):
     version('6.1.1', '9b43cdb3aceebddc1608c77184590619')
 
     depends_on('openssl')
-    depends_on('perl+shared', type=('build','run'))
-    depends_on('python@:3', type=('build','run'))
+    depends_on('perl+shared', type=('build', 'run'))
+    depends_on('python@:3', type=('build', 'run'))
     depends_on('readline')
     depends_on('swig')
     # depends_on('xrootd')

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import llnl.util.tty as tty
+
+class Cctools(AutotoolsPackage):
+    """The Cooperative Computing Tools (cctools) enable large scale
+       distributed computations to harness hundreds to thousands of
+       machines from clusters, clouds, and grids.
+    """
+
+    homepage = "https://github.com/cooperative-computing-lab/cctools"
+    url      = "https://github.com/cooperative-computing-lab/cctools/archive/release/6.1.1.tar.gz"
+
+    version('6.1.1', '9b43cdb3aceebddc1608c77184590619')
+
+    depends_on('openssl')
+    depends_on('perl+useshrplib', type=('build','run'))
+    depends_on('python@:3', type=('build','run'))
+    depends_on('readline')
+    depends_on('swig')
+    # depends_on('xrootd')
+    depends_on('zlib')
+
+    def configure_args(self):
+        args = []
+        # disable these bits
+        for p in ['mysql', 'python3', 'xrootd']:
+            args.append('--with-{0}-path=no'.format(p))
+        # point these bits at the Spack installations
+        for p in ['openssl', 'perl', 'python', 'readline', 'swig', 'zlib']:
+            args.append('--with-{0}-path={1}'.format(p, self.spec[p].prefix))
+        return args


### PR DESCRIPTION
Add a package for cctools.

Requires the recently submitted (#4416) "useshrplib" support in Perl (or some other mechanism to enable -fPIC for perl).