### PR TITLE
Disable parallel builds for bamutil

### DIFF
--- a/var/spack/repos/builtin/packages/bamutil/package.py
+++ b/var/spack/repos/builtin/packages/bamutil/package.py
@@ -40,6 +40,8 @@ class Bamutil(MakefilePackage):
     # https://github.com/statgen/libStatGen/issues/9
     patch('libstatgen-issue-9.patch', when='@1.0.13:')
 
+    parallel = False
+
     @property
     def install_targets(self):
         return ['install', 'INSTALLDIR={0}'.format(self.prefix.bin)]


### PR DESCRIPTION
I've had non-repeatable failures in my CI runs on all three of my clusters at the bamutil's step.  In each case there are .o or .so files that are corrupt or truncated.

I suspect that the homebrewed bamutil Makefile scheme doesn't actually support parallel builds.