### PR TITLE
Add add'l output formats for graphviz

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -25,7 +25,6 @@
 from spack import *
 import sys
 import shutil
-import llnl.util.tty as tty
 
 
 class Graphviz(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -74,6 +74,11 @@ class Graphviz(AutotoolsPackage):
             description='Enable for optional tcl language bindings'
             ' (not yet functional)')
 
+    variant('pangocairo', default=False,
+            description='Build with pango+cairo support (more output formats)')
+    variant('libgd', default=False,
+            description='Build with libgd support (more output formats)')
+
     parallel = False
 
     # These language bindings have been tested, we know they work.
@@ -90,6 +95,9 @@ class Graphviz(AutotoolsPackage):
     for b in tested_bindings + untested_bindings:
         depends_on('swig', when=b)
 
+    depends_on('cairo~X', when='+pangocairo')
+    depends_on('pango~X', when='+pangocairo')
+    depends_on('libgd', when='+libgd')
     depends_on('ghostscript')
     depends_on('freetype')
     depends_on('expat')
@@ -129,6 +137,12 @@ class Graphviz(AutotoolsPackage):
             options.append('--enable-swig=yes')
         else:
             options.append('--enable-swig=no')
+
+        for var in ('+pangocairo', '+libgd'):
+            if var in spec:
+                options.append('--with-{0}'.format(var[1:]))
+            else:
+                options.append('--without-{0}'.format(var[1:]))
 
         # On OSX fix the compiler error:
         # In file included from tkStubLib.c:15:

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import sys
 import shutil
+import llnl.util.tty as tty
 
 
 class Graphviz(AutotoolsPackage):
@@ -95,8 +96,8 @@ class Graphviz(AutotoolsPackage):
     for b in tested_bindings + untested_bindings:
         depends_on('swig', when=b)
 
-    depends_on('cairo~X', when='+pangocairo')
-    depends_on('pango~X', when='+pangocairo')
+    depends_on('cairo', when='+pangocairo')
+    depends_on('pango', when='+pangocairo')
     depends_on('libgd', when='+libgd')
     depends_on('ghostscript')
     depends_on('freetype')
@@ -106,6 +107,14 @@ class Graphviz(AutotoolsPackage):
 
     depends_on('jdk', when='+java')
     depends_on('python@2:2.8', when='+python')
+
+    def patch(self):
+        # Fix a few variable names, gs after 9.18 renamed them
+        # See http://lists.linuxfromscratch.org/pipermail/blfs-book/2015-October/056960.html
+        if self.spec.satisfies('^ghostscript@9.18:'):
+            kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
+            filter_file(' e_', ' gs_error_', 'plugin/gs/gvloadimage_gs.c',
+                        **kwargs)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -54,5 +54,6 @@ class Libgd(AutotoolsPackage):
 
     depends_on('libiconv')
     depends_on('libpng')
+    depends_on('jpeg')
     depends_on('libtiff')
     depends_on('fontconfig')


### PR DESCRIPTION
Add support for additional output formats to graphviz, including gif, jpg, pdf, and png.

Graphviz calls its pango+cairo option *pangocairo* so I followed suit.

Libgd was missing jpeg/jpg support.  None of the other supported formats are conditionalized and there is no --with/--without support, so I followed suit.