### PR TITLE
ncl: cairo and math libraries

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -56,7 +56,7 @@ class Ncl(Package):
     # Non-optional dependencies according to the manual:
     depends_on('jpeg')
     depends_on('netcdf')
-    depends_on('cairo')
+    depends_on('cairo+X')
 
     # Extra dependencies that may be missing from build system:
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -124,7 +124,7 @@ class Ncl(Package):
 
         if self.compiler.name == 'gcc':
             fc_flags.append('-fno-range-check')
-            c2f_flags.extend(['-lgfortran'])
+            c2f_flags.extend(['-lgfortran', '-lm'])
         elif self.compiler.name == 'intel':
             fc_flags.append('-fp-model precise')
             cc_flags.append('-fp-model precise')


### PR DESCRIPTION
Some minor changes were required to build the ncl package fully on RHEL6 and RHEL7. The Configure script reported an error when cairo was built without X support. The linker reported missing symbols when `-lm` was not included in the argument list. The installation succeeded despite these errors, but the installed package was only partially complete, and the `ncl` executable and other important components were excluded. The changes in this request avoid the errors and result in a complete ncl installation.