### PR TITLE
Package for mono

### DIFF
--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -1,0 +1,65 @@
+###############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mono(AutotoolsPackage):
+    """Mono is a software platform designed to allow developers to easily
+       create cross platform applications. It is an open source
+       implementation of Microsoft's .NET Framework based on the ECMA
+       standards for C# and the Common Language Runtime.
+    """
+
+    homepage = "http://www.mono-project.com/"
+    url      = "https://download.mono-project.com/sources/mono/mono-5.0.1.1.tar.bz2"
+
+    # /usr/share/.mono/keypairs needs to exist or be able to be
+    # created, e.g. https://github.com/gentoo/dotnet/issues/6
+    variant('patch-folder-path', default=False,
+            description='Point SpecialFolder.CommonApplicationData folder '
+            'into Spack installation instead of /usr/share')
+
+    # Spack's openssl interacts badly with mono's vendored
+    # "boringssl", don't drag it in w/ cmake
+    depends_on('cmake~openssl', type=('build'))
+    depends_on('libiconv')
+    depends_on('perl', type=('build'))
+
+    version('5.0.1.1', '17692c7a797f95ee6f9a0987fda3d486')
+    version('4.8.0.524', 'baeed5b8139a85ad7e291d402a4bcccb')
+
+    def patch(self):
+        if '+patch-folder-path' in self.spec:
+            before ='return "/usr/share";'
+            after ='return "{0}";'.format(self.prefix.share)
+            f = 'mcs/class/corlib/System/Environment.cs'
+            kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
+            filter_file(before, after, f, **kwargs)
+
+    def configure_args(self):
+        args = []
+        li = self.spec['libiconv'].prefix
+        args.append('--with-libiconv-prefix={p}'.format(p=li))
+        return args

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -52,8 +52,8 @@ class Mono(AutotoolsPackage):
 
     def patch(self):
         if '+patch-folder-path' in self.spec:
-            before ='return "/usr/share";'
-            after ='return "{0}";'.format(self.prefix.share)
+            before = 'return "/usr/share";'
+            after = 'return "{0}";'.format(self.prefix.share)
             f = 'mcs/class/corlib/System/Environment.cs'
             kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
             filter_file(before, after, f, **kwargs)


### PR DESCRIPTION
Mono's vendor'ed boringssl interacts badly with openssl, so you need to use `cmake~openssl`.

Left to its own devices, it wants to refer to things in `/usr/share/.mono`.  Applications seem to try to write there but it's not usually writable by non-root users.  If you install this as-is, you'll need to create the directory and arrange for it to be writable as necessary.  This package includes a variant to redirect those paths to `prefix.share`, which is more likely to be writable by the Spack installer.

This package works for my non-trivial test cases, but there's a lot of ground to cover.

I do not have a use case, so at the moment I have no plans for including the graphics library (GDI).