### PR TITLE
Update bazel to 0.4.5

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -32,10 +32,10 @@ class Bazel(Package):
     """Bazel is Google's own build tool"""
 
     homepage = "https://www.bazel.io"
-    url = "https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz"
+    url = "https://github.com/bazelbuild/bazel/releases/download/0.5.0/bazel-0.5.0-dist.zip"
 
-    version('0.4.4', '5e7c52b89071efc41277e2f0057d258f',
-            url="https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-dist.zip")
+    version('0.4.5', '2b737be42678900470ae9e48c975ac5b2296d9ae23c007bf118350dbe7c0552b')
+    version('0.4.4', '5e7c52b89071efc41277e2f0057d258f')
     version('0.3.1', '5c959467484a7fc7dd2e5e4a1e8e866b')
     version('0.3.0', '33a2cb457d28e1bee9282134769b9283')
     version('0.2.3', '393a491d690e43caaba88005efe6da91')
@@ -43,9 +43,17 @@ class Bazel(Package):
     version('0.2.2', '644bc4ea7f429d835e74f255dc1054e6')
 
     depends_on('jdk@8:')
+    depends_on('zip')
+
     patch('fix_env_handling.patch')
     patch('link.patch')
     patch('cc_configure.patch')
+
+    def url_for_version(self, version):
+        if version >= Version('0.4.1'):
+            return 'https://github.com/bazelbuild/bazel/releases/download/{0}/bazel-{0}-dist.zip'.format(version)
+        else:
+            return 'https://github.com/bazelbuild/bazel/archive/{0}.tar.gz'.format(version)
 
     def install(self, spec, prefix):
         bash = which('bash')


### PR DESCRIPTION
0.4.5 is required for TensorFlow. I also tried adding 0.5.0 but it did not compile (I have not investigated further).