### PR TITLE
Add default list_url for GitLab, BitBucket, and CRAN

### DIFF
--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -72,9 +72,9 @@ def find_list_url(url):
 
     =========  =======================================================
     GitHub     https://github.com/<repo>/<name>/releases
-    GitLab     https://gitlab.*/<repo>/<name>/tags
+    GitLab     https://gitlab.\*/<repo>/<name>/tags
     BitBucket  https://bitbucket.org/<repo>/<name>/downloads/?tab=tags
-    CRAN       https://*.r-project.org/src/contrib/Archive/<name>
+    CRAN       https://\*.r-project.org/src/contrib/Archive/<name>
     =========  =======================================================
 
     Parameters:

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -63,16 +63,49 @@ from spack.version import Version
 # "path" seemed like the most generic term.
 #
 def find_list_url(url):
-    """Finds a good list URL for the supplied URL.  This depends on
-       the site.  By default, just assumes that a good list URL is the
-       dirname of an archive path.  For github URLs, this returns the
-       URL of the project's releases page.
+    """Finds a good list URL for the supplied URL.
+
+    By default, returns the dirname of the archive path.
+
+    Provides special treatment for the following websites, which have a
+    unique list URL different from the dirname of the download URL:
+
+    =========  =======================================================
+    GitHub     https://github.com/<repo>/<name>/releases
+    GitLab     https://gitlab.*/<repo>/<name>/tags
+    BitBucket  https://bitbucket.org/<repo>/<name>/downloads/?tab=tags
+    CRAN       https://*.r-project.org/src/contrib/Archive/<name>
+    =========  =======================================================
+
+    Parameters:
+        url (str): The download URL for the package
+
+    Returns:
+        str: The list URL for the package
     """
 
     url_types = [
+        # GitHub
         # e.g. https://github.com/llnl/callpath/archive/v1.0.1.tar.gz
         (r'(.*github\.com/[^/]+/[^/]+)',
-         lambda m: m.group(1) + '/releases')]
+         lambda m: m.group(1) + '/releases'),
+
+        # GitLab
+        # e.g. https://gitlab.dkrz.de/k202009/libaec/uploads/631e85bcf877c2dcaca9b2e6d6526339/libaec-1.0.0.tar.gz
+        (r'(.*gitlab[^/]+/[^/]+/[^/]+)',
+         lambda m: m.group(1) + '/tags'),
+
+        # BitBucket
+        # e.g. https://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2
+        (r'(.*bitbucket.org/[^/]+/[^/]+)',
+         lambda m: m.group(1) + '/downloads/?tab=tags'),
+
+        # CRAN
+        # e.g. https://cran.r-project.org/src/contrib/Rcpp_0.12.9.tar.gz
+        # e.g. https://cloud.r-project.org/src/contrib/rgl_0.98.1.tar.gz
+        (r'(.*\.r-project\.org/src/contrib)/([^_]+)',
+         lambda m: m.group(1) + '/Archive/' + m.group(2)),
+    ]
 
     for pattern, fun in url_types:
         match = re.search(pattern, url)

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -32,7 +32,6 @@ class Eigen(CMakePackage):
 
     homepage = 'http://eigen.tuxfamily.org/'
     url      = 'https://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2'
-    list_url = 'https://bitbucket.org/eigen/eigen/downloads/?tab=tags'
 
     version('3.3.3', 'b2ddade41040d9cf73b39b4b51e8775b')
     version('3.3.1', 'edb6799ef413b0868aace20d2403864c')

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -40,9 +40,8 @@ class HoomdBlue(CMakePackage):
     git      = "https://bitbucket.org/glotzer/hoomd-blue"
 
     # TODO: There is a bug in Spack that requires a url to be defined
-    # even if it isn't used. These URLs can hopefully be removed someday.
+    # even if it isn't used. This URL can hopefully be removed someday.
     url      = "https://bitbucket.org/glotzer/hoomd-blue/get/v2.1.6.tar.bz2"
-    list_url = "https://bitbucket.org/glotzer/hoomd-blue/downloads/?tab=tags"
 
     version('develop', git=git, submodules=True)
 

--- a/var/spack/repos/builtin/packages/perl-term-readkey/package.py
+++ b/var/spack/repos/builtin/packages/perl-term-readkey/package.py
@@ -36,6 +36,5 @@ class PerlTermReadkey(PerlPackage):
 
     homepage = "http://search.cpan.org/perldoc/Term::ReadKey"
     url = "http://www.cpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.37.tar.gz"
-    list_url = "http://www.cpan.org/authors/id/J/JS/JSTOWE"
 
     version('2.37', 'e8ea15c16333ac4f8d146d702e83cc0c')

--- a/var/spack/repos/builtin/packages/r-abind/package.py
+++ b/var/spack/repos/builtin/packages/r-abind/package.py
@@ -33,6 +33,5 @@ class RAbind(RPackage):
 
     homepage = "https://cran.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/abind_1.4-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/abind"
 
     version('1.4-3', '10fcf80c677b991bf263d38be35a1fc5')

--- a/var/spack/repos/builtin/packages/r-adabag/package.py
+++ b/var/spack/repos/builtin/packages/r-adabag/package.py
@@ -30,7 +30,6 @@ class RAdabag(RPackage):
 
     homepage = "https://cran.r-project.org/package=adabag"
     url      = "https://cran.r-project.org/src/contrib/adabag_4.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/adabag"
 
     version('4.1', '2e019f053d49f62ebb3b1697bbb50afa')
 

--- a/var/spack/repos/builtin/packages/r-ade4/package.py
+++ b/var/spack/repos/builtin/packages/r-ade4/package.py
@@ -31,7 +31,6 @@ class RAde4(RPackage):
 
     homepage = "http://pbil.univ-lyon1.fr/ADE-4"
     url      = "https://cran.r-project.org/src/contrib/ade4_1.7-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ade4"
 
     version('1.7-6', '63401ca369677538c96c3d7b75b3f4a1')
 

--- a/var/spack/repos/builtin/packages/r-adegenet/package.py
+++ b/var/spack/repos/builtin/packages/r-adegenet/package.py
@@ -38,7 +38,6 @@ class RAdegenet(RPackage):
 
     homepage = "https://github.com/thibautjombart/adegenet/wiki"
     url      = "https://cran.r-project.org/src/contrib/adegenet_2.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/adegenet"
 
     version('2.0.1', 'ecb1220ce7c9affaba2987bc7f38adda')
 

--- a/var/spack/repos/builtin/packages/r-ape/package.py
+++ b/var/spack/repos/builtin/packages/r-ape/package.py
@@ -44,7 +44,6 @@ class RApe(RPackage):
 
     homepage = "http://ape-package.ird.fr/"
     url      = "https://cran.r-project.org/src/contrib/ape_4.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ape"
 
     version('4.1', 'a9ed416d6d172d4b9682556cf692d7c2')
 

--- a/var/spack/repos/builtin/packages/r-assertthat/package.py
+++ b/var/spack/repos/builtin/packages/r-assertthat/package.py
@@ -33,6 +33,5 @@ class RAssertthat(RPackage):
 
     homepage = "https://cran.r-project.org/package=assertthat"
     url      = "https://cran.r-project.org/src/contrib/assertthat_0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/assertthat"
 
     version('0.1', '59f9d7f7c00077ea54d763b78eeb5798')

--- a/var/spack/repos/builtin/packages/r-base64enc/package.py
+++ b/var/spack/repos/builtin/packages/r-base64enc/package.py
@@ -31,6 +31,5 @@ class RBase64enc(RPackage):
 
     homepage = "http://www.rforge.net/base64enc"
     url      = "https://cran.r-project.org/src/contrib/base64enc_0.1-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/base64enc"
 
     version('0.1-3', '0f476dacdd11a3e0ad56d13f5bc2f190')

--- a/var/spack/repos/builtin/packages/r-bh/package.py
+++ b/var/spack/repos/builtin/packages/r-bh/package.py
@@ -43,6 +43,5 @@ class RBh(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/BH/index.html"
     url      = "https://cran.r-project.org/src/contrib/BH_1.60.0-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/BH"
 
     version('1.60.0-2', 'b50fdc85285da05add4e9da664a2d551')

--- a/var/spack/repos/builtin/packages/r-bitops/package.py
+++ b/var/spack/repos/builtin/packages/r-bitops/package.py
@@ -31,6 +31,5 @@ class RBitops(RPackage):
 
     homepage = "https://cran.r-project.org/package=bitops"
     url      = "https://cran.r-project.org/src/contrib/bitops_1.0-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/bitops"
 
     version('1.0-6', 'fba16485a51b1ccd354abde5816b6bdd')

--- a/var/spack/repos/builtin/packages/r-boot/package.py
+++ b/var/spack/repos/builtin/packages/r-boot/package.py
@@ -32,6 +32,5 @@ class RBoot(RPackage):
 
     homepage = "https://cran.r-project.org/package=boot"
     url      = "https://cran.r-project.org/src/contrib/boot_1.3-18.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/boot"
 
     version('1.3-18', '711dd58af14e1027eb8377d9202e9b6f')

--- a/var/spack/repos/builtin/packages/r-brew/package.py
+++ b/var/spack/repos/builtin/packages/r-brew/package.py
@@ -32,6 +32,5 @@ class RBrew(RPackage):
 
     homepage = "https://cran.r-project.org/package=brew"
     url      = "https://cran.r-project.org/src/contrib/brew_1.0-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/brew"
 
     version('1.0-6', '4aaca5e6ec145e0fc0fe6375ce1f3806')

--- a/var/spack/repos/builtin/packages/r-c50/package.py
+++ b/var/spack/repos/builtin/packages/r-c50/package.py
@@ -31,7 +31,6 @@ class RC50(RPackage):
 
     homepage = "https://cran.r-project.org/package=C50"
     url      = "https://cran.r-project.org/src/contrib/C50_0.1.0-24.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/C50"
 
     version('0.1.0-24', '42631e65c5c579532cc6edf5ea175949')
 

--- a/var/spack/repos/builtin/packages/r-c50/package.py
+++ b/var/spack/repos/builtin/packages/r-c50/package.py
@@ -34,4 +34,4 @@ class RC50(RPackage):
 
     version('0.1.0-24', '42631e65c5c579532cc6edf5ea175949')
 
-    depends_on('r-partykit', type=('build','run'))
+    depends_on('r-partykit', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-car/package.py
+++ b/var/spack/repos/builtin/packages/r-car/package.py
@@ -31,7 +31,6 @@ class RCar(RPackage):
 
     homepage = "https://r-forge.r-project.org/projects/car/"
     url      = "https://cran.r-project.org/src/contrib/car_2.1-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/car"
 
     version('2.1-4', 'a66c307e8ccf0c336ed197c0f1799565')
     version('2.1-2', '0f78ad74ef7130126d319acec23951a0')

--- a/var/spack/repos/builtin/packages/r-caret/package.py
+++ b/var/spack/repos/builtin/packages/r-caret/package.py
@@ -31,7 +31,6 @@ class RCaret(RPackage):
 
     homepage = "https://github.com/topepo/caret/"
     url      = "https://cran.r-project.org/src/contrib/caret_6.0-73.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/caret"
 
     version('6.0-73', 'ca869e3357b5358f028fb926eb62eb70')
     version('6.0-70', '202d7abb6a679af716ea69fb2573f108')

--- a/var/spack/repos/builtin/packages/r-catools/package.py
+++ b/var/spack/repos/builtin/packages/r-catools/package.py
@@ -34,7 +34,6 @@ class RCatools(RPackage):
 
     homepage = "https://cran.r-project.org/package=caTools"
     url      = "https://cran.r-project.org/src/contrib/caTools_1.17.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/caTools"
 
     version('1.17.1', '5c872bbc78b177b306f36709deb44498')
 

--- a/var/spack/repos/builtin/packages/r-catools/package.py
+++ b/var/spack/repos/builtin/packages/r-catools/package.py
@@ -37,4 +37,4 @@ class RCatools(RPackage):
 
     version('1.17.1', '5c872bbc78b177b306f36709deb44498')
 
-    depends_on('r-bitops', type=('build','run'))
+    depends_on('r-bitops', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-checkpoint/package.py
+++ b/var/spack/repos/builtin/packages/r-checkpoint/package.py
@@ -33,7 +33,6 @@ class RCheckpoint(RPackage):
 
     homepage = "https://cran.r-project.org/package=checkpoint"
     url      = "https://cran.r-project.org/src/contrib/checkpoint_0.3.18.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/checkpoint"
 
     version('0.3.18', '021d7faeb72c36167951e103b2b065ea')
     version('0.3.15', 'a4aa8320338f1434a330d984e97981ea')

--- a/var/spack/repos/builtin/packages/r-chron/package.py
+++ b/var/spack/repos/builtin/packages/r-chron/package.py
@@ -30,6 +30,5 @@ class RChron(RPackage):
 
     homepage = "https://cran.r-project.org/package=chron"
     url      = "https://cran.r-project.org/src/contrib/chron_2.3-47.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/chron"
 
     version('2.3-47', 'b8890cdc5f2337f8fd775b0becdcdd1f')

--- a/var/spack/repos/builtin/packages/r-class/package.py
+++ b/var/spack/repos/builtin/packages/r-class/package.py
@@ -31,7 +31,6 @@ class RClass(RPackage):
 
     homepage = "http://www.stats.ox.ac.uk/pub/MASS4/"
     url      = "https://cran.r-project.org/src/contrib/class_7.3-14.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/class"
 
     version('7.3-14', '6a21dd206fe4ea29c55faeb65fb2b71e')
 

--- a/var/spack/repos/builtin/packages/r-class/package.py
+++ b/var/spack/repos/builtin/packages/r-class/package.py
@@ -34,4 +34,4 @@ class RClass(RPackage):
 
     version('7.3-14', '6a21dd206fe4ea29c55faeb65fb2b71e')
 
-    depends_on('r-mass', type=('build','run'))
+    depends_on('r-mass', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-cluster/package.py
+++ b/var/spack/repos/builtin/packages/r-cluster/package.py
@@ -32,7 +32,6 @@ class RCluster(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/cluster/index.html"
     url      = "https://cran.r-project.org/src/contrib/cluster_2.0.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/cluster"
 
     version('2.0.5', '7330f209ebce960bdee1a6d6679cb85a')
     version('2.0.4', 'bb4deceaafb1c42bb1278d5d0dc11e59')

--- a/var/spack/repos/builtin/packages/r-coda/package.py
+++ b/var/spack/repos/builtin/packages/r-coda/package.py
@@ -33,7 +33,6 @@ class RCoda(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/coda/index.html"
     url      = "https://cran.r-project.org/src/contrib/coda_0.19-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/coda"
 
     version('0.19-1', '0d2aca6a5a3bdae9542708817c1ec001')
 

--- a/var/spack/repos/builtin/packages/r-codetools/package.py
+++ b/var/spack/repos/builtin/packages/r-codetools/package.py
@@ -30,7 +30,6 @@ class RCodetools(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/codetools/index.html"
     url      = "https://cran.r-project.org/src/contrib/codetools_0.2-15.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/codetools"
 
     version('0.2-15', '37419cbc3de81984cf6d9b207d4f62d4')
     version('0.2-14', '7ec41d4f8bd6ba85facc8c5e6adc1f4d')

--- a/var/spack/repos/builtin/packages/r-coin/package.py
+++ b/var/spack/repos/builtin/packages/r-coin/package.py
@@ -32,7 +32,6 @@ class RCoin(RPackage):
 
     homepage = "https://cran.r-project.org/package=coin"
     url      = "https://cran.r-project.org/src/contrib/coin_1.1-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/coin"
 
     version('1.1-3', '97d3d21f1e4a5762e36dd718dd2d0661')
 

--- a/var/spack/repos/builtin/packages/r-colorspace/package.py
+++ b/var/spack/repos/builtin/packages/r-colorspace/package.py
@@ -33,7 +33,6 @@ class RColorspace(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/colorspace/index.html"
     url      = "https://cran.r-project.org/src/contrib/colorspace_1.3-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/colorspace"
 
     version('1.3-2', '63000bab81d995ff167df76fb97b2984')
     version('1.2-6', 'a30191e9caf66f77ff4e99c062e9dce1')

--- a/var/spack/repos/builtin/packages/r-corrplot/package.py
+++ b/var/spack/repos/builtin/packages/r-corrplot/package.py
@@ -31,6 +31,5 @@ class RCorrplot(RPackage):
 
     homepage = "https://cran.r-project.org/package=corrplot"
     url      = "https://cran.r-project.org/src/contrib/corrplot_0.77.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/corrplot"
 
     version('0.77', '2a5d54fd5c65618b9afba1a32f6b4542')

--- a/var/spack/repos/builtin/packages/r-crayon/package.py
+++ b/var/spack/repos/builtin/packages/r-crayon/package.py
@@ -34,6 +34,5 @@ class RCrayon(RPackage):
 
     homepage = "https://github.com/gaborcsardi/crayon"
     url      = "https://cran.r-project.org/src/contrib/crayon_1.3.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/crayon"
 
     version('1.3.2', 'fe29c6204d2d6ff4c2f9d107a03d0cb9')

--- a/var/spack/repos/builtin/packages/r-cubature/package.py
+++ b/var/spack/repos/builtin/packages/r-cubature/package.py
@@ -30,6 +30,5 @@ class RCubature(RPackage):
 
     homepage = "https://cran.r-project.org/package=cubature"
     url      = "https://cran.r-project.org/src/contrib/cubature_1.1-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/cubature"
 
     version('1.1-2', '5617e1d82baa803a3814d92461da45c9')

--- a/var/spack/repos/builtin/packages/r-cubist/package.py
+++ b/var/spack/repos/builtin/packages/r-cubist/package.py
@@ -30,7 +30,6 @@ class RCubist(RPackage):
 
     homepage = "https://cran.r-project.org/package=Cubist"
     url      = "https://cran.r-project.org/src/contrib/Cubist_0.0.19.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Cubist"
 
     version('0.0.19', 'bf9364f655536ec03717fd2ad6223a47')
 

--- a/var/spack/repos/builtin/packages/r-curl/package.py
+++ b/var/spack/repos/builtin/packages/r-curl/package.py
@@ -38,7 +38,6 @@ class RCurl(RPackage):
 
     homepage = "https://github.com/jeroenooms/curl"
     url      = "https://cran.r-project.org/src/contrib/curl_2.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/curl"
 
     version('2.3',   '7250ee8caed98ba76906ab4d32da60f8')
     version('1.0',   '93d34926d6071e1fba7e728b482f0dd9')

--- a/var/spack/repos/builtin/packages/r-data-table/package.py
+++ b/var/spack/repos/builtin/packages/r-data-table/package.py
@@ -33,7 +33,6 @@ class RDataTable(RPackage):
 
     homepage = "https://github.com/Rdatatable/data.table/wiki"
     url      = "https://cran.r-project.org/src/contrib/data.table_1.10.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/data.table"
 
     version('1.10.0', 'f0e08dd5ba1b3f46c59dd1574fe497c1')
     version('1.9.6',  'b1c0c7cce490bdf42ab288541cc55372')

--- a/var/spack/repos/builtin/packages/r-dbi/package.py
+++ b/var/spack/repos/builtin/packages/r-dbi/package.py
@@ -32,6 +32,5 @@ class RDbi(RPackage):
 
     homepage = "https://github.com/rstats-db/DBI"
     url      = "https://cran.r-project.org/src/contrib/DBI_0.4-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/DBI"
 
     version('0.4-1', 'c7ee8f1c5037c2284e99c62698d0f087')

--- a/var/spack/repos/builtin/packages/r-deldir/package.py
+++ b/var/spack/repos/builtin/packages/r-deldir/package.py
@@ -34,7 +34,6 @@ class RDeldir(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=deldir"
     url      = "https://cran.r-project.org/src/contrib/deldir_0.1-14.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/deldir"
 
     version('0.1-14', '6a22b13d962615cd9d51b6eae403409f')
 

--- a/var/spack/repos/builtin/packages/r-dendextend/package.py
+++ b/var/spack/repos/builtin/packages/r-dendextend/package.py
@@ -30,7 +30,6 @@ class RDendextend(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=dendextend"
     url      = "https://cran.r-project.org/src/contrib/dendextend_1.5.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/dendextend"
 
     version('1.5.2', '1134869d94005727c63cf3037e2f1bbf')
 

--- a/var/spack/repos/builtin/packages/r-deoptim/package.py
+++ b/var/spack/repos/builtin/packages/r-deoptim/package.py
@@ -32,6 +32,5 @@ class RDeoptim(RPackage):
 
     homepage = "https://cran.r-project.org/package=DEoptim"
     url      = "https://cran.r-project.org/src/contrib/DEoptim_2.2-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/DEoptim"
 
     version('2.2-3', 'ed406e6790f8f1568aa9bec159f80326')

--- a/var/spack/repos/builtin/packages/r-devtools/package.py
+++ b/var/spack/repos/builtin/packages/r-devtools/package.py
@@ -30,7 +30,6 @@ class RDevtools(RPackage):
 
     homepage = "https://github.com/hadley/devtools"
     url      = "https://cran.r-project.org/src/contrib/devtools_1.12.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/devtools"
 
     version('1.12.0', '73b46c446273566e5b21c9f5f72aeca3')
     version('1.11.1', '242672ee27d24dddcbdaac88c586b6c2')

--- a/var/spack/repos/builtin/packages/r-diagrammer/package.py
+++ b/var/spack/repos/builtin/packages/r-diagrammer/package.py
@@ -30,7 +30,6 @@ class RDiagrammer(RPackage):
 
     homepage = "https://github.com/rich-iannone/DiagrammeR"
     url      = "https://cran.r-project.org/src/contrib/DiagrammeR_0.8.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/DiagrammeR"
 
     version('0.8.4', '9ee295c744f5d4ba9a84289ca7bdaf1a')
 

--- a/var/spack/repos/builtin/packages/r-dichromat/package.py
+++ b/var/spack/repos/builtin/packages/r-dichromat/package.py
@@ -31,6 +31,5 @@ class RDichromat(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/dichromat/index.html"
     url      = "https://cran.r-project.org/src/contrib/dichromat_2.0-0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/dichromat"
 
     version('2.0-0', '84e194ac95a69763d740947a7ee346a6')

--- a/var/spack/repos/builtin/packages/r-digest/package.py
+++ b/var/spack/repos/builtin/packages/r-digest/package.py
@@ -45,7 +45,6 @@ class RDigest(RPackage):
 
     homepage = "http://dirk.eddelbuettel.com/code/digest.html"
     url      = "https://cran.r-project.org/src/contrib/digest_0.6.12.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/digest"
 
     version('0.6.12', '738efd4d9a37c5a4001ae66e954ce07e')
     version('0.6.11', '52a864f55846b48b3cab0b5d0304a82a')

--- a/var/spack/repos/builtin/packages/r-diptest/package.py
+++ b/var/spack/repos/builtin/packages/r-diptest/package.py
@@ -30,6 +30,5 @@ class RDiptest(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=diptest"
     url      = "https://cran.r-project.org/src/contrib/diptest_0.75-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/diptest"
 
     version('0.75-7', '1a4a958fda763f7c99cb485dbe5954ab')

--- a/var/spack/repos/builtin/packages/r-domc/package.py
+++ b/var/spack/repos/builtin/packages/r-domc/package.py
@@ -31,7 +31,6 @@ class RDomc(RPackage):
 
     homepage = "https://cran.r-project.org/package=doMC"
     url      = "https://cran.r-project.org/src/contrib/doMC_1.3.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/doMC"
 
     version('1.3.4', 'f965b09add9056e84f99a831dc3af7d1')
 

--- a/var/spack/repos/builtin/packages/r-doparallel/package.py
+++ b/var/spack/repos/builtin/packages/r-doparallel/package.py
@@ -31,7 +31,6 @@ class RDoparallel(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/doParallel/index.html"
     url      = "https://cran.r-project.org/src/contrib/doParallel_1.0.10.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/doParallel"
 
     version('1.0.10', 'd9fbde8f315d98d055483ee3493c9b43')
 

--- a/var/spack/repos/builtin/packages/r-dplyr/package.py
+++ b/var/spack/repos/builtin/packages/r-dplyr/package.py
@@ -31,7 +31,6 @@ class RDplyr(RPackage):
 
     homepage = "https://github.com/hadley/dplyr"
     url      = "https://cran.r-project.org/src/contrib/dplyr_0.5.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/dplyr"
 
     version('0.5.0', '1fcafcacca70806eea2e6d465cdb94ef')
 

--- a/var/spack/repos/builtin/packages/r-dt/package.py
+++ b/var/spack/repos/builtin/packages/r-dt/package.py
@@ -33,7 +33,6 @@ class RDt(RPackage):
 
     homepage = "http://rstudio.github.io/DT"
     url      = "https://cran.r-project.org/src/contrib/DT_0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/DT/"
 
     version('0.1', '5c8df984921fa484784ec4b8a4fb6f3c')
 

--- a/var/spack/repos/builtin/packages/r-dygraphs/package.py
+++ b/var/spack/repos/builtin/packages/r-dygraphs/package.py
@@ -34,7 +34,6 @@ class RDygraphs(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/dygraphs/index.html"
     url      = "https://cran.r-project.org/src/contrib/dygraphs_0.9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/dygraphs"
 
     version('0.9', '7f0ce4312bcd3f0a58b8c03b2772f833')
 

--- a/var/spack/repos/builtin/packages/r-e1071/package.py
+++ b/var/spack/repos/builtin/packages/r-e1071/package.py
@@ -32,7 +32,6 @@ class RE1071(RPackage):
 
     homepage = "https://cran.r-project.org/package=e1071"
     url      = "https://cran.r-project.org/src/contrib/e1071_1.6-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/e1071"
 
     version('1.6-7', 'd109a7e3dd0c905d420e327a9a921f5a')
 

--- a/var/spack/repos/builtin/packages/r-ellipse/package.py
+++ b/var/spack/repos/builtin/packages/r-ellipse/package.py
@@ -31,7 +31,6 @@ class REllipse(RPackage):
 
     homepage = "https://cran.r-project.org/package=ellipse"
     url      = "https://cran.r-project.org/src/contrib/ellipse_0.3-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ellipse"
 
     version('0.3-8', '385f5ec5e49bcda4317ca9dffd33f771')
 

--- a/var/spack/repos/builtin/packages/r-ergm/package.py
+++ b/var/spack/repos/builtin/packages/r-ergm/package.py
@@ -32,7 +32,6 @@ class RErgm(RPackage):
 
     homepage = "http://statnet.org"
     url      = "https://cran.r-project.org/src/contrib/ergm_3.7.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ergm"
 
     version('3.7.1', '431ae430c76b2408988f469831d80126')
 

--- a/var/spack/repos/builtin/packages/r-evaluate/package.py
+++ b/var/spack/repos/builtin/packages/r-evaluate/package.py
@@ -33,7 +33,6 @@ class REvaluate(RPackage):
 
     homepage = "https://github.com/hadley/evaluate"
     url      = "https://cran.rstudio.com/src/contrib/evaluate_0.9.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/evaluate"
 
     version('0.10', 'c49326babf984a8b36e7e276da370ad2')
     version('0.9',  '877d89ce8a9ef7f403b1089ca1021775')

--- a/var/spack/repos/builtin/packages/r-expm/package.py
+++ b/var/spack/repos/builtin/packages/r-expm/package.py
@@ -31,6 +31,5 @@ class RExpm(RPackage):
 
     homepage = "http://R-Forge.R-project.org/projects/expm"
     url      = "https://cran.r-project.org/src/contrib/expm_0.999-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/expm"
 
     version('0.999-2', 'e05fa3f995754af92bd03227625da984')

--- a/var/spack/repos/builtin/packages/r-factoextra/package.py
+++ b/var/spack/repos/builtin/packages/r-factoextra/package.py
@@ -31,7 +31,6 @@ class RFactoextra(RPackage):
 
     homepage = "http://www.sthda.com/english/rpkgs/factoextra"
     url      = "https://cran.r-project.org/src/contrib/factoextra_1.0.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/factoextra"
 
     version('1.0.4', 'aa4c81ca610f17fdee0c9f3379e35429')
 

--- a/var/spack/repos/builtin/packages/r-factominer/package.py
+++ b/var/spack/repos/builtin/packages/r-factominer/package.py
@@ -30,7 +30,6 @@ class RFactominer(RPackage):
 
     homepage = "http://factominer.free.fr"
     url      = "https://cran.r-project.org/src/contrib/FactoMineR_1.35.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/FactoMineR"
 
     version('1.35', 'bef076181ce942016114dd7a6f5c2348')
 

--- a/var/spack/repos/builtin/packages/r-filehash/package.py
+++ b/var/spack/repos/builtin/packages/r-filehash/package.py
@@ -38,6 +38,5 @@ class RFilehash(RPackage):
 
     homepage = 'https://cran.r-project.org/'
     url      = "https://cran.r-project.org/src/contrib/filehash_2.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/filehash"
 
     version('2.3', '01fffafe09b148ccadc9814c103bdc2f')

--- a/var/spack/repos/builtin/packages/r-flashclust/package.py
+++ b/var/spack/repos/builtin/packages/r-flashclust/package.py
@@ -30,7 +30,6 @@ class RFlashclust(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=flashClust"
     url      = "https://cran.r-project.org/src/contrib/flashClust_1.01-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/flashClust"
 
     version('1.01-2', '23409aeeef98bf35d0b3d5dd755fdeff')
 

--- a/var/spack/repos/builtin/packages/r-flexmix/package.py
+++ b/var/spack/repos/builtin/packages/r-flexmix/package.py
@@ -30,7 +30,6 @@ class RFlexmix(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=flexmix"
     url      = "https://cran.r-project.org/src/contrib/flexmix_2.3-14.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/flexmix"
 
     version('2.3-14', '5be4f7764e6a697f4586e60c2bf6e960')
 

--- a/var/spack/repos/builtin/packages/r-foreach/package.py
+++ b/var/spack/repos/builtin/packages/r-foreach/package.py
@@ -36,7 +36,6 @@ class RForeach(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/foreach/index.html"
     url      = "https://cran.r-project.org/src/contrib/foreach_1.4.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/foreach"
 
     version('1.4.3', 'ef45768126661b259f9b8994462c49a0')
 

--- a/var/spack/repos/builtin/packages/r-foreign/package.py
+++ b/var/spack/repos/builtin/packages/r-foreign/package.py
@@ -32,6 +32,5 @@ class RForeign(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/foreign/index.html"
     url      = "https://cran.r-project.org/src/contrib/foreign_0.8-66.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/foreign"
 
     version('0.8-66', 'ff12190f4631dca31e30ca786c2c8f62')

--- a/var/spack/repos/builtin/packages/r-formatr/package.py
+++ b/var/spack/repos/builtin/packages/r-formatr/package.py
@@ -35,7 +35,6 @@ class RFormatr(RPackage):
 
     homepage = "http://yihui.name/formatR"
     url      = "https://cran.r-project.org/src/contrib/formatR_1.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/formatR"
 
     version('1.4', '98b9b64b2785b35f9df403e1aab6c73c')
 

--- a/var/spack/repos/builtin/packages/r-formula/package.py
+++ b/var/spack/repos/builtin/packages/r-formula/package.py
@@ -32,6 +32,5 @@ class RFormula(RPackage):
 
     homepage = "https://cran.r-project.org/package=Formula"
     url      = "https://cran.r-project.org/src/contrib/Formula_1.2-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Formula"
 
     version('1.2-1', '2afb31e637cecd0c1106317aca1e4849')

--- a/var/spack/repos/builtin/packages/r-fpc/package.py
+++ b/var/spack/repos/builtin/packages/r-fpc/package.py
@@ -30,7 +30,6 @@ class RFpc(RPackage):
 
     homepage = "http://www.homepages.ucl.ac.uk/~ucakche"
     url      = "https://cran.r-project.org/src/contrib/fpc_2.1-10.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/fpc"
 
     version('2.1-10', '75e5340e416cd13d7751e06f1c07866b')
 

--- a/var/spack/repos/builtin/packages/r-gdata/package.py
+++ b/var/spack/repos/builtin/packages/r-gdata/package.py
@@ -46,7 +46,6 @@ class RGdata(RPackage):
 
     homepage = "https://cran.r-project.org/package=gdata"
     url      = "https://cran.r-project.org/src/contrib/gdata_2.17.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gdata"
 
     version('2.17.0', 'c716b663b9dc16ad8cafe6acc781a75f')
 

--- a/var/spack/repos/builtin/packages/r-geosphere/package.py
+++ b/var/spack/repos/builtin/packages/r-geosphere/package.py
@@ -32,7 +32,6 @@ class RGeosphere(RPackage):
 
     homepage = "https://cran.r-project.org/package=geosphere"
     url      = "https://cran.r-project.org/src/contrib/geosphere_1.5-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/geosphere"
 
     version('1.5-5', '28efb7a8e266c7f076cdbcf642455f3e')
 

--- a/var/spack/repos/builtin/packages/r-ggmap/package.py
+++ b/var/spack/repos/builtin/packages/r-ggmap/package.py
@@ -33,7 +33,6 @@ class RGgmap(RPackage):
 
     homepage = "https://github.com/dkahle/ggmap"
     url      = "https://cran.r-project.org/src/contrib/ggmap_2.6.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggmap"
 
     version('2.6.1', '25ad414a3a1c6d59a227a9f22601211a')
 

--- a/var/spack/repos/builtin/packages/r-ggplot2/package.py
+++ b/var/spack/repos/builtin/packages/r-ggplot2/package.py
@@ -36,7 +36,6 @@ class RGgplot2(RPackage):
 
     homepage = "http://ggplot2.org/"
     url      = "https://cran.r-project.org/src/contrib/ggplot2_2.2.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggplot2"
 
     version('2.2.1', '14c5a3507bc123c6e7e9ad3bef7cee5c')
     version('2.1.0', '771928cfb97c649c720423deb3ec7fd3')

--- a/var/spack/repos/builtin/packages/r-ggpubr/package.py
+++ b/var/spack/repos/builtin/packages/r-ggpubr/package.py
@@ -30,7 +30,6 @@ class RGgpubr(RPackage):
 
     homepage = "http://www.sthda.com/english/rpkgs/ggpubr"
     url      = "https://cran.r-project.org/src/contrib/ggpubr_0.1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggpubr"
 
     version('0.1.2', '42a5749ae44121597ef511a7424429d1')
 

--- a/var/spack/repos/builtin/packages/r-ggrepel/package.py
+++ b/var/spack/repos/builtin/packages/r-ggrepel/package.py
@@ -30,7 +30,6 @@ class RGgrepel(RPackage):
 
     homepage = "http://github.com/slowkow/ggrepel"
     url      = "https://cran.r-project.org/src/contrib/ggrepel_0.6.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggrepel"
 
     version('0.6.5', '7e2732cd4840efe2dc9e4bc689cf1ee5')
 

--- a/var/spack/repos/builtin/packages/r-ggsci/package.py
+++ b/var/spack/repos/builtin/packages/r-ggsci/package.py
@@ -31,7 +31,6 @@ class RGgsci(RPackage):
 
     homepage = "https://github.com/road2stat/ggsci"
     url      = "https://cran.r-project.org/src/contrib/ggsci_2.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggsci"
 
     version('2.4', '8e5dc2fcf84352cacbb91363e26c7175')
 

--- a/var/spack/repos/builtin/packages/r-ggvis/package.py
+++ b/var/spack/repos/builtin/packages/r-ggvis/package.py
@@ -32,7 +32,6 @@ class RGgvis(RPackage):
 
     homepage = "http://ggvis.rstudio.com/"
     url      = "https://cran.r-project.org/src/contrib/ggvis_0.4.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ggvis"
 
     version('0.4.2', '039f45e5c7f1e0652779163d7d99f922')
 

--- a/var/spack/repos/builtin/packages/r-gistr/package.py
+++ b/var/spack/repos/builtin/packages/r-gistr/package.py
@@ -36,7 +36,6 @@ class RGistr(RPackage):
 
     homepage = "https://github.com/ropensci/gistr"
     url      = "https://cran.r-project.org/src/contrib/gistr_0.3.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gistr"
 
     version('0.3.6', '49d548cb3eca0e66711aece37757a2c0')
 

--- a/var/spack/repos/builtin/packages/r-git2r/package.py
+++ b/var/spack/repos/builtin/packages/r-git2r/package.py
@@ -32,7 +32,6 @@ class RGit2r(RPackage):
 
     homepage = "https://github.com/ropensci/git2r"
     url      = "https://cran.r-project.org/src/contrib/git2r_0.18.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/git2r"
 
     version('0.18.0', 'fb5741eb490c3d6e23a751a72336f24d')
     version('0.15.0', '57658b3298f9b9aadc0dd77b4ef6a1e1')

--- a/var/spack/repos/builtin/packages/r-glmnet/package.py
+++ b/var/spack/repos/builtin/packages/r-glmnet/package.py
@@ -35,7 +35,6 @@ class RGlmnet(RPackage):
 
     homepage = "http://www.jstatsoft.org/v33/i01/"
     url      = "https://cran.r-project.org/src/contrib/glmnet_2.0-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/glmnet"
 
     version('2.0-5', '049b18caa29529614cd684db3beaec2a')
 

--- a/var/spack/repos/builtin/packages/r-gmodels/package.py
+++ b/var/spack/repos/builtin/packages/r-gmodels/package.py
@@ -30,7 +30,6 @@ class RGmodels(RPackage):
 
     homepage = "http://www.sf.net/projects/r-gregmisc"
     url      = "https://cran.r-project.org/src/contrib/gmodels_2.16.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gmodels"
 
     version('2.16.2', 'f13e5feb2a8b9f0cd47fdf25ddc74228')
 

--- a/var/spack/repos/builtin/packages/r-gmp/package.py
+++ b/var/spack/repos/builtin/packages/r-gmp/package.py
@@ -32,7 +32,6 @@ class RGmp(RPackage):
 
     homepage = "http://mulcyber.toulouse.inra.fr/projects/gmp"
     url      = "https://cran.r-project.org/src/contrib/gmp_0.5-13.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gmp"
 
     version('0.5-13.1', '4a45d45e53bf7140720bd44f10b075ed')
 

--- a/var/spack/repos/builtin/packages/r-googlevis/package.py
+++ b/var/spack/repos/builtin/packages/r-googlevis/package.py
@@ -34,7 +34,6 @@ class RGooglevis(RPackage):
 
     homepage = "https://github.com/mages/googleVis#googlevis"
     url      = "https://cran.r-project.org/src/contrib/googleVis_0.6.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/googleVis"
 
     version('0.6.0', 'ec36fd2a6884ddc7baa894007d0d0468')
 

--- a/var/spack/repos/builtin/packages/r-gridbase/package.py
+++ b/var/spack/repos/builtin/packages/r-gridbase/package.py
@@ -30,6 +30,5 @@ class RGridbase(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/gridBase/index.html"
     url      = "https://cran.r-project.org/src/contrib/gridBase_0.4-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gridBase"
 
     version('0.4-7', '6d5064a85f5c966a92ee468ae44c5f1f')

--- a/var/spack/repos/builtin/packages/r-gridextra/package.py
+++ b/var/spack/repos/builtin/packages/r-gridextra/package.py
@@ -31,7 +31,6 @@ class RGridextra(RPackage):
 
     homepage = "https://github.com/baptiste/gridextra"
     url      = "https://cran.r-project.org/src/contrib/gridExtra_2.2.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gridExtra"
 
     version('2.2.1', '7076c2122d387c7ef3add69a1c4fc1b2')
 

--- a/var/spack/repos/builtin/packages/r-gtable/package.py
+++ b/var/spack/repos/builtin/packages/r-gtable/package.py
@@ -30,6 +30,5 @@ class RGtable(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/gtable/index.html"
     url      = "https://cran.r-project.org/src/contrib/gtable_0.2.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gtable"
 
     version('0.2.0', '124090ae40b2dd3170ae11180e0d4cab')

--- a/var/spack/repos/builtin/packages/r-gtools/package.py
+++ b/var/spack/repos/builtin/packages/r-gtools/package.py
@@ -49,6 +49,5 @@ class RGtools(RPackage):
 
     homepage = "https://cran.r-project.org/package=gtools"
     url      = "https://cran.r-project.org/src/contrib/gtools_3.5.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/gtools"
 
     version('3.5.0', '45f8800c0336d35046641fbacc56bdbb')

--- a/var/spack/repos/builtin/packages/r-hexbin/package.py
+++ b/var/spack/repos/builtin/packages/r-hexbin/package.py
@@ -32,7 +32,6 @@ class RHexbin(RPackage):
 
     homepage = "http://github.com/edzer/hexbin"
     url      = "https://cran.r-project.org/src/contrib/hexbin_1.27.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/hexbin"
 
     version('1.27.1', '7f380390c6511e97df10a810a3b3bb7c')
 

--- a/var/spack/repos/builtin/packages/r-highr/package.py
+++ b/var/spack/repos/builtin/packages/r-highr/package.py
@@ -33,6 +33,5 @@ class RHighr(RPackage):
 
     homepage = "https://github.com/yihui/highr"
     url      = "https://cran.r-project.org/src/contrib/highr_0.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/highr"
 
     version('0.6', 'bf47388c5f57dc61962362fb7e1d8b16')

--- a/var/spack/repos/builtin/packages/r-htmltools/package.py
+++ b/var/spack/repos/builtin/packages/r-htmltools/package.py
@@ -30,7 +30,6 @@ class RHtmltools(RPackage):
 
     homepage = "https://github.com/rstudio/htmltools"
     url      = "https://cran.r-project.org/src/contrib/htmltools_0.3.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/htmltools"
 
     version('0.3.5', '5f001aff4a39e329f7342dcec5139724')
 

--- a/var/spack/repos/builtin/packages/r-htmlwidgets/package.py
+++ b/var/spack/repos/builtin/packages/r-htmlwidgets/package.py
@@ -32,7 +32,6 @@ class RHtmlwidgets(RPackage):
 
     homepage = "https://github.com/ramnathv/htmlwidgets"
     url      = "https://cran.r-project.org/src/contrib/htmlwidgets_0.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/htmlwidgets"
 
     version('0.6', '7fa522d2eda97593978021bda9670c0e')
 

--- a/var/spack/repos/builtin/packages/r-httpuv/package.py
+++ b/var/spack/repos/builtin/packages/r-httpuv/package.py
@@ -36,7 +36,6 @@ class RHttpuv(RPackage):
 
     homepage = "https://github.com/rstudio/httpuv"
     url      = "https://cran.r-project.org/src/contrib/httpuv_1.3.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/httpuv"
 
     version('1.3.3', 'c78ae068cf59e949b9791be987bb4489')
 

--- a/var/spack/repos/builtin/packages/r-httr/package.py
+++ b/var/spack/repos/builtin/packages/r-httr/package.py
@@ -32,7 +32,6 @@ class RHttr(RPackage):
 
     homepage = "https://github.com/hadley/httr"
     url      = "https://cran.r-project.org/src/contrib/httr_1.2.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/httr"
 
     version('1.2.1', 'c469948dedac9ab3926f23cf484b33d9')
     version('1.1.0', '5ffbbc5c2529e49f00aaa521a2b35600')

--- a/var/spack/repos/builtin/packages/r-igraph/package.py
+++ b/var/spack/repos/builtin/packages/r-igraph/package.py
@@ -32,7 +32,6 @@ class RIgraph(RPackage):
 
     homepage = "http://igraph.org/"
     url      = "https://cran.r-project.org/src/contrib/igraph_1.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/igraph"
 
     version('1.0.1', 'ea33495e49adf4a331e4ba60ba559065')
 

--- a/var/spack/repos/builtin/packages/r-inline/package.py
+++ b/var/spack/repos/builtin/packages/r-inline/package.py
@@ -32,6 +32,5 @@ class RInline(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/inline/index.html"
     url      = "https://cran.r-project.org/src/contrib/inline_0.3.14.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/inline"
 
     version('0.3.14', '9fe304a6ebf0e3889c4c6a7ad1c50bca')

--- a/var/spack/repos/builtin/packages/r-ipred/package.py
+++ b/var/spack/repos/builtin/packages/r-ipred/package.py
@@ -32,7 +32,6 @@ class RIpred(RPackage):
 
     homepage = "https://cran.r-project.org/package=ipred"
     url      = "https://cran.r-project.org/src/contrib/ipred_0.9-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ipred"
 
     version('0.9-5', 'ce8768547a7aa9554ad3650b18ea3cbd')
 

--- a/var/spack/repos/builtin/packages/r-irlba/package.py
+++ b/var/spack/repos/builtin/packages/r-irlba/package.py
@@ -32,7 +32,6 @@ class RIrlba(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/irlba/index.html"
     url      = "https://cran.r-project.org/src/contrib/irlba_2.1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/irlba"
 
     version('2.1.2', '290940abf6662ed10c0c5a8db1bc6e88')
     version('2.0.0', '557674cf8b68fea5b9f231058c324d26')

--- a/var/spack/repos/builtin/packages/r-iterators/package.py
+++ b/var/spack/repos/builtin/packages/r-iterators/package.py
@@ -31,6 +31,5 @@ class RIterators(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/iterators/index.html"
     url      = "https://cran.r-project.org/src/contrib/iterators_1.0.8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/iterators"
 
     version('1.0.8', '2ded7f82cddd8174f1ec98607946c6ee')

--- a/var/spack/repos/builtin/packages/r-jpeg/package.py
+++ b/var/spack/repos/builtin/packages/r-jpeg/package.py
@@ -32,7 +32,6 @@ class RJpeg(RPackage):
 
     homepage = "http://www.rforge.net/jpeg/"
     url      = "https://cran.r-project.org/src/contrib/jpeg_0.1-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/jpeg"
 
     version('0.1-8', '696007451d14395b1ed1d0e9af667a57')
 

--- a/var/spack/repos/builtin/packages/r-jsonlite/package.py
+++ b/var/spack/repos/builtin/packages/r-jsonlite/package.py
@@ -39,7 +39,6 @@ class RJsonlite(RPackage):
 
     homepage = "https://github.com/jeroenooms/jsonlite"
     url      = "https://cran.r-project.org/src/contrib/jsonlite_1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/jsonlite"
 
     version('1.2', '80cd2678ae77254be470f5931db71c51')
     version('1.0', 'c8524e086de22ab39b8ac8000220cc87')

--- a/var/spack/repos/builtin/packages/r-kernlab/package.py
+++ b/var/spack/repos/builtin/packages/r-kernlab/package.py
@@ -33,7 +33,6 @@ class RKernlab(RPackage):
 
     homepage = "https://cran.r-project.org/package=kernlab"
     url      = "https://cran.r-project.org/src/contrib/kernlab_0.9-25.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/kernlab"
 
     version('0.9-25', '1182a2a336a79fd2cf70b4bc5a35353f')
 

--- a/var/spack/repos/builtin/packages/r-kernsmooth/package.py
+++ b/var/spack/repos/builtin/packages/r-kernsmooth/package.py
@@ -30,7 +30,6 @@ class RKernsmooth(RPackage):
 
     homepage = "https://cran.r-project.org/package=KernSmooth"
     url      = "https://cran.r-project.org/src/contrib/KernSmooth_2.23-15.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/KernSmooth"
 
     version('2.23-15', '746cdf26dec72004cf19978e87dcc982')
 

--- a/var/spack/repos/builtin/packages/r-kknn/package.py
+++ b/var/spack/repos/builtin/packages/r-kknn/package.py
@@ -31,7 +31,6 @@ class RKknn(RPackage):
 
     homepage = "https://cran.r-project.org/package=kknn"
     url      = "https://cran.r-project.org/src/contrib/kknn_1.3.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/kknn"
 
     version('1.3.1', '372cd84f618cd5005f8c4c5721755117')
 

--- a/var/spack/repos/builtin/packages/r-knitr/package.py
+++ b/var/spack/repos/builtin/packages/r-knitr/package.py
@@ -32,7 +32,6 @@ class RKnitr(RPackage):
 
     homepage = "http://yihui.name/knitr/"
     url      = "https://cran.rstudio.com/src/contrib/knitr_1.14.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/knitr"
 
     version('1.14', 'ef0fbeaa9372f99ffbc57212a7781511')
     version('0.6',  'c67d6db84cd55594a9e870c90651a3db')

--- a/var/spack/repos/builtin/packages/r-labeling/package.py
+++ b/var/spack/repos/builtin/packages/r-labeling/package.py
@@ -30,6 +30,5 @@ class RLabeling(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/labeling/index.html"
     url      = "https://cran.r-project.org/src/contrib/labeling_0.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/labeling"
 
     version('0.3', 'ccd7082ec0b211aba8a89d85176bb534')

--- a/var/spack/repos/builtin/packages/r-laplacesdemon/package.py
+++ b/var/spack/repos/builtin/packages/r-laplacesdemon/package.py
@@ -32,6 +32,5 @@ class RLaplacesdemon(RPackage):
 
     homepage = "https://github.com/LaplacesDemonR/LaplacesDemon"
     url      = "https://cran.r-project.org/src/contrib/LaplacesDemon_16.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/LaplacesDemon"
 
     version('16.0.1', '1e4dab2dd0e27251734d68b0bfdbe911')

--- a/var/spack/repos/builtin/packages/r-lattice/package.py
+++ b/var/spack/repos/builtin/packages/r-lattice/package.py
@@ -33,6 +33,5 @@ class RLattice(RPackage):
 
     homepage = "http://lattice.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/lattice_0.20-34.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lattice"
 
     version('0.20-34', 'c2a648b22d4206ae7526fb70b8e90fed')

--- a/var/spack/repos/builtin/packages/r-lava/package.py
+++ b/var/spack/repos/builtin/packages/r-lava/package.py
@@ -30,7 +30,6 @@ class RLava(RPackage):
 
     homepage = "https://cran.r-project.org/package=lava"
     url      = "https://cran.r-project.org/src/contrib/lava_1.4.7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lava"
 
     version('1.4.7', '28039248a7039ba9281d172e4dbf9543')
 

--- a/var/spack/repos/builtin/packages/r-lazyeval/package.py
+++ b/var/spack/repos/builtin/packages/r-lazyeval/package.py
@@ -32,6 +32,5 @@ class RLazyeval(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/lazyeval/index.html"
     url      = "https://cran.r-project.org/src/contrib/lazyeval_0.2.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lazyeval"
 
     version('0.2.0', 'df1daac908dcf02ae7e12f4335b1b13b')

--- a/var/spack/repos/builtin/packages/r-leaflet/package.py
+++ b/var/spack/repos/builtin/packages/r-leaflet/package.py
@@ -32,7 +32,6 @@ class RLeaflet(RPackage):
 
     homepage = "http://rstudio.github.io/leaflet/"
     url      = "https://cran.r-project.org/src/contrib/leaflet_1.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/leaflet"
 
     version('1.0.1', '7f3d8b17092604d87d4eeb579f73d5df')
 

--- a/var/spack/repos/builtin/packages/r-leaps/package.py
+++ b/var/spack/repos/builtin/packages/r-leaps/package.py
@@ -30,6 +30,5 @@ class RLeaps(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=leaps"
     url      = "https://cran.r-project.org/src/contrib/leaps_3.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/leaps"
 
     version('3.0', '30823138890680e0493d1491c8f43edc')

--- a/var/spack/repos/builtin/packages/r-learnbayes/package.py
+++ b/var/spack/repos/builtin/packages/r-learnbayes/package.py
@@ -36,6 +36,5 @@ class RLearnbayes(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=LearnBayes"
     url      = "https://cran.r-project.org/src/contrib/LearnBayes_2.15.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/LearnBayes"
 
     version('2.15', '213713664707bc79fd6d3a109555ef76')

--- a/var/spack/repos/builtin/packages/r-lme4/package.py
+++ b/var/spack/repos/builtin/packages/r-lme4/package.py
@@ -33,7 +33,6 @@ class RLme4(RPackage):
 
     homepage = "https://github.com/lme4/lme4/"
     url      = "https://cran.r-project.org/src/contrib/lme4_1.1-12.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lme4"
 
     version('1.1-12', 'da8aaebb67477ecb5631851c46207804')
 

--- a/var/spack/repos/builtin/packages/r-lmtest/package.py
+++ b/var/spack/repos/builtin/packages/r-lmtest/package.py
@@ -32,7 +32,6 @@ class RLmtest(RPackage):
 
     homepage = "https://cran.r-project.org/package=lmtest"
     url      = "https://cran.r-project.org/src/contrib/lmtest_0.9-34.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lmtest"
 
     version('0.9-34', 'fcdf7286bb5ccc2ca46be00bf25ac2fe')
 

--- a/var/spack/repos/builtin/packages/r-lpsolve/package.py
+++ b/var/spack/repos/builtin/packages/r-lpsolve/package.py
@@ -35,6 +35,5 @@ class RLpsolve(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/lpSolve/index.html"
     url      = "https://cran.r-project.org/src/contrib/lpSolve_5.6.13.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lpSolve"
 
     version('5.6.13', '8471654d9ae76e0f85ff3449433d4bc1')

--- a/var/spack/repos/builtin/packages/r-lubridate/package.py
+++ b/var/spack/repos/builtin/packages/r-lubridate/package.py
@@ -35,7 +35,6 @@ class RLubridate(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/lubridate/index.html"
     url      = "https://cran.r-project.org/src/contrib/lubridate_1.5.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lubridate"
 
     version('1.5.6', 'a5dc44817548ee219d26a10bae92e611')
 

--- a/var/spack/repos/builtin/packages/r-magic/package.py
+++ b/var/spack/repos/builtin/packages/r-magic/package.py
@@ -33,7 +33,6 @@ class RMagic(RPackage):
 
     homepage = "https://cran.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/magic_1.5-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/magic"
 
     version('1.5-6', 'a68e5ced253b2196af842e1fc84fd029')
 

--- a/var/spack/repos/builtin/packages/r-magrittr/package.py
+++ b/var/spack/repos/builtin/packages/r-magrittr/package.py
@@ -34,6 +34,5 @@ class RMagrittr(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/magrittr/index.html"
     url      = "https://cran.r-project.org/src/contrib/magrittr_1.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/magrittr"
 
     version('1.5', 'e74ab7329f2b9833f0c3c1216f86d65a')

--- a/var/spack/repos/builtin/packages/r-mapproj/package.py
+++ b/var/spack/repos/builtin/packages/r-mapproj/package.py
@@ -30,7 +30,6 @@ class RMapproj(RPackage):
 
     homepage = "https://cran.r-project.org/package=mapproj"
     url      = "https://cran.r-project.org/src/contrib/mapproj_1.2-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mapproj"
 
     version('1.2-4', '10e22bde1c790e1540672f15ddcaee71')
 

--- a/var/spack/repos/builtin/packages/r-maps/package.py
+++ b/var/spack/repos/builtin/packages/r-maps/package.py
@@ -31,6 +31,5 @@ class RMaps(RPackage):
 
     homepage = "https://cran.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/maps_3.1.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/maps"
 
     version('3.1.1', 'ff045eccb6d5a658db5a539116ddf764')

--- a/var/spack/repos/builtin/packages/r-maptools/package.py
+++ b/var/spack/repos/builtin/packages/r-maptools/package.py
@@ -34,7 +34,6 @@ class RMaptools(RPackage):
 
     homepage = "http://r-forge.r-project.org/projects/maptools/"
     url      = "https://cran.r-project.org/src/contrib/maptools_0.8-39.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/maptools"
 
     version('0.8-39', '3690d96afba8ef22c8e27ae540ffb836')
 

--- a/var/spack/repos/builtin/packages/r-markdown/package.py
+++ b/var/spack/repos/builtin/packages/r-markdown/package.py
@@ -34,7 +34,6 @@ class RMarkdown(RPackage):
 
     homepage = "https://github.com/rstudio/markdown"
     url      = "https://cran.r-project.org/src/contrib/markdown_0.7.7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/markdown"
 
     version('0.7.7', '72deca9c675c7cc9343048edbc29f7ff')
 

--- a/var/spack/repos/builtin/packages/r-mass/package.py
+++ b/var/spack/repos/builtin/packages/r-mass/package.py
@@ -31,6 +31,5 @@ class RMass(RPackage):
 
     homepage = "http://www.stats.ox.ac.uk/pub/MASS4/"
     url      = "https://cran.r-project.org/src/contrib/MASS_7.3-45.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/MASS"
 
     version('7.3-45', 'aba3d12fab30f1793bee168a1efea88b')

--- a/var/spack/repos/builtin/packages/r-matrix/package.py
+++ b/var/spack/repos/builtin/packages/r-matrix/package.py
@@ -31,7 +31,6 @@ class RMatrix(RPackage):
 
     homepage = "http://matrix.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/Matrix_1.2-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Matrix"
 
     version('1.2-8', '4a6406666bf97d3ec6b698eea5d9c0f5')
     version('1.2-6', 'f545307fb1284861e9266c4e9712c55e')

--- a/var/spack/repos/builtin/packages/r-matrixmodels/package.py
+++ b/var/spack/repos/builtin/packages/r-matrixmodels/package.py
@@ -31,7 +31,6 @@ class RMatrixmodels(RPackage):
 
     homepage = "http://matrix.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/MatrixModels_0.4-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/MatrixModels"
 
     version('0.4-1', '65b3ab56650c62bf1046a3eb1f1e19a0')
 

--- a/var/spack/repos/builtin/packages/r-mclust/package.py
+++ b/var/spack/repos/builtin/packages/r-mclust/package.py
@@ -31,7 +31,6 @@ class RMclust(RPackage):
 
     homepage = "http://www.stat.washington.edu/mclust"
     url      = "https://cran.r-project.org/src/contrib/mclust_5.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mclust"
 
     version('5.3', '74aac9fccdfc78373ce733c1a09176ef')
 

--- a/var/spack/repos/builtin/packages/r-mda/package.py
+++ b/var/spack/repos/builtin/packages/r-mda/package.py
@@ -31,7 +31,6 @@ class RMda(RPackage):
 
     homepage = "https://cran.r-project.org/package=mda"
     url      = "https://cran.r-project.org/src/contrib/mda_0.4-9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mda"
 
     version('0.4-9', '2ce1446c4a013e0ebcc1099a00269ad9')
 

--- a/var/spack/repos/builtin/packages/r-memoise/package.py
+++ b/var/spack/repos/builtin/packages/r-memoise/package.py
@@ -31,7 +31,6 @@ class RMemoise(RPackage):
 
     homepage = "https://github.com/hadley/memoise"
     url      = "https://cran.r-project.org/src/contrib/memoise_1.0.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/memoise"
 
     version('1.0.0', 'd31145292e2a88ae9a504cab1602e4ac')
 

--- a/var/spack/repos/builtin/packages/r-mgcv/package.py
+++ b/var/spack/repos/builtin/packages/r-mgcv/package.py
@@ -33,7 +33,6 @@ class RMgcv(RPackage):
 
     homepage = "https://cran.r-project.org/package=mgcv"
     url      = "https://cran.r-project.org/src/contrib/mgcv_1.8-16.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mgcv"
 
     version('1.8-16', '4c1d85e0f80b017bccb4b63395842911')
     version('1.8-13', '30607be3aaf44b13bd8c81fc32e8c984')

--- a/var/spack/repos/builtin/packages/r-mime/package.py
+++ b/var/spack/repos/builtin/packages/r-mime/package.py
@@ -31,7 +31,6 @@ class RMime(RPackage):
 
     homepage = "https://github.com/yihui/mime"
     url      = "https://cran.r-project.org/src/contrib/mime_0.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mime"
 
     version('0.5', '87e00b6d57b581465c19ae869a723c4d')
     version('0.4', '789cb33e41db2206c6fc7c3e9fbc2c02')

--- a/var/spack/repos/builtin/packages/r-minqa/package.py
+++ b/var/spack/repos/builtin/packages/r-minqa/package.py
@@ -31,7 +31,6 @@ class RMinqa(RPackage):
 
     homepage = "http://optimizer.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/minqa_1.2.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/minqa"
 
     version('1.2.4', 'bcaae4fdba60a33528f2116e2fd51105')
 

--- a/var/spack/repos/builtin/packages/r-mlbench/package.py
+++ b/var/spack/repos/builtin/packages/r-mlbench/package.py
@@ -31,7 +31,6 @@ class RMlbench(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/mlbench/index.html"
     url      = "https://cran.r-project.org/src/contrib/mlbench_2.1-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mlbench"
 
     version('2.1-1', '9f06848b8e137b8a37417c92d8e57f3b')
 

--- a/var/spack/repos/builtin/packages/r-modelmetrics/package.py
+++ b/var/spack/repos/builtin/packages/r-modelmetrics/package.py
@@ -31,7 +31,6 @@ class RModelmetrics(RPackage):
 
     homepage = "https://cran.r-project.org/package=ModelMetrics"
     url      = "https://cran.r-project.org/src/contrib/ModelMetrics_1.1.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ModelMetrics"
 
     version('1.1.0', 'd43175001f0531b8810d2802d76b7b44')
 

--- a/var/spack/repos/builtin/packages/r-modeltools/package.py
+++ b/var/spack/repos/builtin/packages/r-modeltools/package.py
@@ -30,6 +30,5 @@ class RModeltools(RPackage):
 
     homepage = "https://cran.r-project.org/package=modeltools"
     url      = "https://cran.r-project.org/src/contrib/modeltools_0.2-21.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/modeltools"
 
     version('0.2-21', '3bf56b2e7bf78981444385d87eeccdd7')

--- a/var/spack/repos/builtin/packages/r-multcomp/package.py
+++ b/var/spack/repos/builtin/packages/r-multcomp/package.py
@@ -34,7 +34,6 @@ class RMultcomp(RPackage):
 
     homepage = "http://multcomp.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/multcomp_1.4-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/multcomp"
 
     version('1.4-6', 'f1353ede2ed78b23859a7f1f1f9ebe88')
 

--- a/var/spack/repos/builtin/packages/r-munsell/package.py
+++ b/var/spack/repos/builtin/packages/r-munsell/package.py
@@ -34,7 +34,6 @@ class RMunsell(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/munsell/index.html"
     url      = "https://cran.r-project.org/src/contrib/munsell_0.4.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/munsell"
 
     version('0.4.3', 'ebd205323dc37c948f499ee08be9c476')
 

--- a/var/spack/repos/builtin/packages/r-mvtnorm/package.py
+++ b/var/spack/repos/builtin/packages/r-mvtnorm/package.py
@@ -31,6 +31,5 @@ class RMvtnorm(RPackage):
 
     homepage = "http://mvtnorm.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/mvtnorm_1.0-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/mvtnorm"
 
     version('1.0-5', '5894dd3969bbfa26f4862c45f9a48a52')

--- a/var/spack/repos/builtin/packages/r-ncdf4/package.py
+++ b/var/spack/repos/builtin/packages/r-ncdf4/package.py
@@ -43,7 +43,6 @@ class RNcdf4(RPackage):
 
     homepage = "http://cirrus.ucsd.edu/~pierce/ncdf"
     url      = "https://cran.r-project.org/src/contrib/ncdf4_1.15.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/ncdf4"
 
     version('1.15', 'cd60dadbae3be31371e1ed40ddeb420a')
 

--- a/var/spack/repos/builtin/packages/r-network/package.py
+++ b/var/spack/repos/builtin/packages/r-network/package.py
@@ -32,6 +32,5 @@ class RNetwork(RPackage):
 
     homepage = "https://statnet.org"
     url      = "https://cran.r-project.org/src/contrib/network_1.13.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/network"
 
     version('1.13.0', 'd0b967d6f1aad43b6479d72f29b705de')

--- a/var/spack/repos/builtin/packages/r-networkd3/package.py
+++ b/var/spack/repos/builtin/packages/r-networkd3/package.py
@@ -31,7 +31,6 @@ class RNetworkd3(RPackage):
 
     homepage = "http://cran.r-project.org/package=networkD3"
     url      = "https://cran.r-project.org/src/contrib/networkD3_0.2.12.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/networkD3"
 
     version('0.2.12', '356fe4be59698e6fb052644bd9659d84')
 

--- a/var/spack/repos/builtin/packages/r-nlme/package.py
+++ b/var/spack/repos/builtin/packages/r-nlme/package.py
@@ -30,7 +30,6 @@ class RNlme(RPackage):
 
     homepage = "https://cran.r-project.org/package=nlme"
     url      = "https://cran.r-project.org/src/contrib/nlme_3.1-130.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/nlme"
 
     version('3.1-130', '1935d6e308a8018ed8e45d25c8731288')
     version('3.1-128', '3d75ae7380bf123761b95a073eb55008')

--- a/var/spack/repos/builtin/packages/r-nloptr/package.py
+++ b/var/spack/repos/builtin/packages/r-nloptr/package.py
@@ -36,6 +36,5 @@ class RNloptr(RPackage):
 
     homepage = "https://cran.r-project.org/package=nloptr"
     url      = "https://cran.r-project.org/src/contrib/nloptr_1.0.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/nloptr"
 
     version('1.0.4', '9af69a613349b236fd377d0a107f484c')

--- a/var/spack/repos/builtin/packages/r-nmf/package.py
+++ b/var/spack/repos/builtin/packages/r-nmf/package.py
@@ -35,7 +35,6 @@ class RNmf(RPackage):
 
     homepage = "http://renozao.github.io/NMF"
     url      = "https://cran.r-project.org/src/contrib/NMF_0.20.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/NMF"
 
     version('0.20.6', '81df07b3bf710a611db5af24730ff3d0')
 

--- a/var/spack/repos/builtin/packages/r-nnet/package.py
+++ b/var/spack/repos/builtin/packages/r-nnet/package.py
@@ -31,6 +31,5 @@ class RNnet(RPackage):
 
     homepage = "http://www.stats.ox.ac.uk/pub/MASS4/"
     url      = "https://cran.r-project.org/src/contrib/nnet_7.3-12.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/nnet"
 
     version('7.3-12', 'dc7c6f0d0de53d8fc72b44554400a74e')

--- a/var/spack/repos/builtin/packages/r-np/package.py
+++ b/var/spack/repos/builtin/packages/r-np/package.py
@@ -36,7 +36,6 @@ class RNp(RPackage):
 
     homepage = "https://github.com/JeffreyRacine/R-Package-np/"
     url      = "https://cran.r-project.org/src/contrib/np_0.60-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/np"
 
     version('0.60-2', 'e094d52ddff7280272b41e6cb2c74389')
 

--- a/var/spack/repos/builtin/packages/r-numderiv/package.py
+++ b/var/spack/repos/builtin/packages/r-numderiv/package.py
@@ -31,7 +31,6 @@ class RNumderiv(RPackage):
 
     homepage = "https://cran.r-project.org/package=numDeriv"
     url      = "https://cran.r-project.org/src/contrib/numDeriv_2016.8-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/numDeriv"
 
     version('2016.8-1', '30e486298d5126d86560095be8e8aac1')
 

--- a/var/spack/repos/builtin/packages/r-openssl/package.py
+++ b/var/spack/repos/builtin/packages/r-openssl/package.py
@@ -39,7 +39,6 @@ class ROpenssl(RPackage):
 
     homepage = "https://github.com/jeroenooms/openssl#readme"
     url      = "https://cran.r-project.org/src/contrib/openssl_0.9.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/openssl"
 
     version('0.9.6', '7ef137929d9dd07db690d35db242ba4b')
     version('0.9.4', '82a890e71ed0e74499878bedacfb8ccb')

--- a/var/spack/repos/builtin/packages/r-packrat/package.py
+++ b/var/spack/repos/builtin/packages/r-packrat/package.py
@@ -31,7 +31,6 @@ class RPackrat(RPackage):
 
     homepage = "https://github.com/rstudio/packrat/"
     url      = "https://cran.r-project.org/src/contrib/packrat_0.4.7-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/packrat"
 
     version('0.4.8-1', '14e82feba55fcda923396282fc490038')
     version('0.4.7-1', '80c2413269b292ade163a70ba5053e84')

--- a/var/spack/repos/builtin/packages/r-pacman/package.py
+++ b/var/spack/repos/builtin/packages/r-pacman/package.py
@@ -33,7 +33,6 @@ class RPacman(RPackage):
 
     homepage = "https://cran.r-project.org/package=pacman"
     url      = "https://cran.r-project.org/src/contrib/pacman_0.4.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pacman"
 
     version('0.4.1', 'bf18fe6d1407d31e00b337d9b07fb648')
 

--- a/var/spack/repos/builtin/packages/r-party/package.py
+++ b/var/spack/repos/builtin/packages/r-party/package.py
@@ -30,7 +30,6 @@ class RParty(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/party/index.html"
     url      = "https://cran.r-project.org/src/contrib/party_1.1-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/party"
 
     version('1.1-2', '40a00336cf8418042d2ab616675c8ddf')
 

--- a/var/spack/repos/builtin/packages/r-partykit/package.py
+++ b/var/spack/repos/builtin/packages/r-partykit/package.py
@@ -38,7 +38,6 @@ class RPartykit(RPackage):
 
     homepage = "http://partykit.r-forge.r-project.org/partykit"
     url      = "https://cran.r-project.org/src/contrib/partykit_1.1-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/partykit"
 
     version('1.1-1', '8fcb31d73ec1b8cd3bcd9789639a9277')
 

--- a/var/spack/repos/builtin/packages/r-pbdzmq/package.py
+++ b/var/spack/repos/builtin/packages/r-pbdzmq/package.py
@@ -37,7 +37,6 @@ class RPbdzmq(RPackage):
 
     homepage = "http://r-pbd.org/"
     url      = "https://cran.r-project.org/src/contrib/pbdZMQ_0.2-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pbdZMQ"
 
     version('0.2-4', 'e5afb70199aa54d737ee7a0e26bde060')
 

--- a/var/spack/repos/builtin/packages/r-pbkrtest/package.py
+++ b/var/spack/repos/builtin/packages/r-pbkrtest/package.py
@@ -34,7 +34,6 @@ class RPbkrtest(RPackage):
 
     homepage = "http://people.math.aau.dk/~sorenh/software/pbkrtest/"
     url      = "https://cran.r-project.org/src/contrib/pbkrtest_0.4-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pbkrtest"
 
     version('0.4-6', '0a7d9ff83b8d131af9b2335f35781ef9')
     version('0.4-4', '5e54b1b1b35413dd1d24ef15735ec645')

--- a/var/spack/repos/builtin/packages/r-permute/package.py
+++ b/var/spack/repos/builtin/packages/r-permute/package.py
@@ -36,7 +36,6 @@ class RPermute(RPackage):
 
     homepage = "https://github.com/gavinsimpson/permute"
     url      = "https://cran.r-project.org/src/contrib/permute_0.9-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/permute"
 
     version('0.9-4', '569fc2442d72a1e3b7e2d456019674c9')
 

--- a/var/spack/repos/builtin/packages/r-pkgmaker/package.py
+++ b/var/spack/repos/builtin/packages/r-pkgmaker/package.py
@@ -36,7 +36,6 @@ class RPkgmaker(RPackage):
 
     homepage = "https://renozao.github.io/pkgmaker"
     url      = "https://cran.r-project.org/src/contrib/pkgmaker_0.22.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pkgmaker"
 
     version('0.22', '73a0c6d3e84c6dadf3de7582ef7e88a4')
 

--- a/var/spack/repos/builtin/packages/r-plotrix/package.py
+++ b/var/spack/repos/builtin/packages/r-plotrix/package.py
@@ -30,7 +30,6 @@ class RPlotrix(RPackage):
 
     homepage = "https://cran.r-project.org/package=plotrix"
     url      = "https://cran.r-project.org/src/contrib/plotrix_3.6-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/plotrix"
 
     version('3.6-4', 'efe9b9b093d8903228a9b56c46d943fa')
     version('3.6-3', '23e3e022a13a596e9b77b40afcb4a2ef')

--- a/var/spack/repos/builtin/packages/r-pls/package.py
+++ b/var/spack/repos/builtin/packages/r-pls/package.py
@@ -32,7 +32,6 @@ class RPls(RPackage):
 
     homepage = "https://cran.r-project.org/package=pls"
     url      = "https://cran.r-project.org/src/contrib/pls_2.6-0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pls"
 
     version('2.6-0', '04e02e8e46d983c5ed53c1f952b329df')
 

--- a/var/spack/repos/builtin/packages/r-plyr/package.py
+++ b/var/spack/repos/builtin/packages/r-plyr/package.py
@@ -36,7 +36,6 @@ class RPlyr(RPackage):
 
     homepage = "http://had.co.nz/plyr"
     url      = "https://cran.r-project.org/src/contrib/plyr_1.8.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/plyr"
 
     version('1.8.4', 'ef455cf7fc06e34837692156b7b2587b')
 

--- a/var/spack/repos/builtin/packages/r-png/package.py
+++ b/var/spack/repos/builtin/packages/r-png/package.py
@@ -32,7 +32,6 @@ class RPng(RPackage):
 
     homepage = "http://www.rforge.net/png/"
     url      = "https://cran.r-project.org/src/contrib/png_0.1-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/png"
 
     version('0.1-7', '1ebc8b8aa5979b12c5ec2384b30d649f')
 

--- a/var/spack/repos/builtin/packages/r-prabclus/package.py
+++ b/var/spack/repos/builtin/packages/r-prabclus/package.py
@@ -31,7 +31,6 @@ class RPrabclus(RPackage):
 
     homepage = "http://www.homepages.ucl.ac.uk/~ucakche"
     url      = "https://cran.r-project.org/src/contrib/prabclus_2.2-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/prabclus"
 
     version('2.2-6', '7f835dcc113243e1db74aad28ce93d11')
 

--- a/var/spack/repos/builtin/packages/r-prodlim/package.py
+++ b/var/spack/repos/builtin/packages/r-prodlim/package.py
@@ -32,7 +32,6 @@ class RProdlim(RPackage):
 
     homepage = "https://cran.r-project.org/package=prodlim"
     url      = "https://cran.r-project.org/src/contrib/prodlim_1.5.9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/prodlim"
 
     version('1.5.9', 'e0843053c9270e41b657a733d6675dc9')
 

--- a/var/spack/repos/builtin/packages/r-proto/package.py
+++ b/var/spack/repos/builtin/packages/r-proto/package.py
@@ -31,6 +31,5 @@ class RProto(RPackage):
 
     homepage = "http://r-proto.googlecode.com/"
     url      = "https://cran.r-project.org/src/contrib/proto_0.3-10.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/proto"
 
     version('0.3-10', 'd5523943a5be6ca2f0ab557c900f8212')

--- a/var/spack/repos/builtin/packages/r-pryr/package.py
+++ b/var/spack/repos/builtin/packages/r-pryr/package.py
@@ -32,7 +32,6 @@ class RPryr(RPackage):
 
     homepage = "https://github.com/hadley/pryr"
     url      = "https://cran.r-project.org/src/contrib/pryr_0.1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pryr"
 
     version('0.1.2', '66b597a762aa15a3b7037779522983b6')
 

--- a/var/spack/repos/builtin/packages/r-quadprog/package.py
+++ b/var/spack/repos/builtin/packages/r-quadprog/package.py
@@ -31,6 +31,5 @@ class RQuadprog(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/quadprog/index.html"
     url      = "https://cran.r-project.org/src/contrib/quadprog_1.5-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/quadprog"
 
     version('1.5-5', '8442f37afd8d0b19b12e77d63e6515ad')

--- a/var/spack/repos/builtin/packages/r-quantmod/package.py
+++ b/var/spack/repos/builtin/packages/r-quantmod/package.py
@@ -31,7 +31,6 @@ class RQuantmod(RPackage):
 
     homepage = "http://www.quantmod.com/"
     url      = "https://cran.r-project.org/src/contrib/quantmod_0.4-5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/quantmod"
 
     version('0.4-5', 'cab3c409e4de3df98a20f1ded60f3631')
 

--- a/var/spack/repos/builtin/packages/r-quantreg/package.py
+++ b/var/spack/repos/builtin/packages/r-quantreg/package.py
@@ -35,7 +35,6 @@ class RQuantreg(RPackage):
 
     homepage = "https://cran.r-project.org/package=quantreg"
     url      = "https://cran.r-project.org/src/contrib/quantreg_5.29.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/quantreg"
 
     version('5.29', '643ca728200d13f8c2e62365204e9907')
     version('5.26', '1d89ed932fb4d67ae2d5da0eb8c2989f')

--- a/var/spack/repos/builtin/packages/r-r6/package.py
+++ b/var/spack/repos/builtin/packages/r-r6/package.py
@@ -35,7 +35,6 @@ class RR6(RPackage):
 
     homepage = "https://github.com/wch/R6/"
     url      = "https://cran.r-project.org/src/contrib/R6_2.2.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/R6"
 
     version('2.2.0', '659d83b2d3f7a308a48332b4cfbdab49')
     version('2.1.2', 'b6afb9430e48707be87638675390e457')

--- a/var/spack/repos/builtin/packages/r-randomforest/package.py
+++ b/var/spack/repos/builtin/packages/r-randomforest/package.py
@@ -31,6 +31,5 @@ class RRandomforest(RPackage):
 
     homepage = "https://www.stat.berkeley.edu/~breiman/RandomForests/"
     url      = "https://cran.r-project.org/src/contrib/randomForest_4.6-12.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/randomForest"
 
     version('4.6-12', '071c03af974198e861f1475c5bab9e7a')

--- a/var/spack/repos/builtin/packages/r-raster/package.py
+++ b/var/spack/repos/builtin/packages/r-raster/package.py
@@ -32,7 +32,6 @@ class RRaster(RPackage):
 
     homepage = "http://cran.r-project.org/package=raster"
     url      = "https://cran.r-project.org/src/contrib/raster_2.5-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/raster"
 
     version('2.5-8', '2a7db931c74d50516e82d04687c0a577')
 

--- a/var/spack/repos/builtin/packages/r-rbokeh/package.py
+++ b/var/spack/repos/builtin/packages/r-rbokeh/package.py
@@ -32,7 +32,6 @@ class RRbokeh(RPackage):
 
     homepage = "https://hafen.github.io/rbokeh"
     url      = "https://cran.r-project.org/src/contrib/rbokeh_0.5.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rbokeh"
 
     version('0.5.0', '4e14778c3fbd9286460ca28c68f57d10')
 

--- a/var/spack/repos/builtin/packages/r-rcolorbrewer/package.py
+++ b/var/spack/repos/builtin/packages/r-rcolorbrewer/package.py
@@ -31,6 +31,5 @@ class RRcolorbrewer(RPackage):
 
     homepage = "http://colorbrewer2.org"
     url      = "https://cran.r-project.org/src/contrib/RColorBrewer_1.1-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RColorBrewer"
 
     version('1.1-2', '66054d83eade4dff8a43ad4732691182')

--- a/var/spack/repos/builtin/packages/r-rcpp/package.py
+++ b/var/spack/repos/builtin/packages/r-rcpp/package.py
@@ -38,7 +38,6 @@ class RRcpp(RPackage):
 
     homepage = "http://dirk.eddelbuettel.com/code/rcpp.html"
     url      = "https://cran.r-project.org/src/contrib/Rcpp_0.12.9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Rcpp"
 
     version('0.12.9', '691c49b12794507288b728ede03668a5')
     version('0.12.6', 'db4280fb0a79cd19be73a662c33b0a8b')

--- a/var/spack/repos/builtin/packages/r-rcppeigen/package.py
+++ b/var/spack/repos/builtin/packages/r-rcppeigen/package.py
@@ -42,7 +42,6 @@ class RRcppeigen(RPackage):
 
     homepage = "http://eigen.tuxfamily.org/"
     url      = "https://cran.r-project.org/src/contrib/RcppEigen_0.3.2.9.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RcppEigen"
 
     version('0.3.2.9.0', '14a7786882a5d9862d53c4b2217df318')
     version('0.3.2.8.1', '4146e06e4fdf7f4d08db7839069d479f')

--- a/var/spack/repos/builtin/packages/r-registry/package.py
+++ b/var/spack/repos/builtin/packages/r-registry/package.py
@@ -30,6 +30,5 @@ class RRegistry(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/registry/index.html"
     url      = "https://cran.r-project.org/src/contrib/registry_0.3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/registry"
 
     version('0.3', '85345b334ec81eb3da6edcbb27c5f421')

--- a/var/spack/repos/builtin/packages/r-repr/package.py
+++ b/var/spack/repos/builtin/packages/r-repr/package.py
@@ -32,6 +32,5 @@ class RRepr(RPackage):
 
     homepage = "https://github.com/IRkernel/repr"
     url      = "https://cran.r-project.org/src/contrib/repr_0.9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/repr"
 
     version('0.9', 'db5ff74893063b492f684e42283070bd')

--- a/var/spack/repos/builtin/packages/r-reshape2/package.py
+++ b/var/spack/repos/builtin/packages/r-reshape2/package.py
@@ -31,7 +31,6 @@ class RReshape2(RPackage):
 
     homepage = "https://github.com/hadley/reshape"
     url      = "https://cran.r-project.org/src/contrib/reshape2_1.4.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/reshape2"
 
     version('1.4.2', 'c851a0312191b8c5bab956445df7cf5f')
     version('1.4.1', '41e9dffdf5c6fa830321ac9c8ebffe00')

--- a/var/spack/repos/builtin/packages/r-rgl/package.py
+++ b/var/spack/repos/builtin/packages/r-rgl/package.py
@@ -36,7 +36,6 @@ class RRgl(RPackage):
     homepage = "https://r-forge.r-project.org/projects/rgl"
     url      = "https://cloud.r-project.org/src/contrib/rgl_0.98.1.tar.gz"
 
-
     version('0.98.1', 'bd69e1d33f1590feb4b6dc080b133e5b')
 
     depends_on('r@3.2:3.9')

--- a/var/spack/repos/builtin/packages/r-rgl/package.py
+++ b/var/spack/repos/builtin/packages/r-rgl/package.py
@@ -36,7 +36,6 @@ class RRgl(RPackage):
     homepage = "https://r-forge.r-project.org/projects/rgl"
     url      = "https://cloud.r-project.org/src/contrib/rgl_0.98.1.tar.gz"
 
-    list_url = 'https://cloud.r-project.org/src/contrib/Archive/rgl'
 
     version('0.98.1', 'bd69e1d33f1590feb4b6dc080b133e5b')
 

--- a/var/spack/repos/builtin/packages/r-rgooglemaps/package.py
+++ b/var/spack/repos/builtin/packages/r-rgooglemaps/package.py
@@ -33,7 +33,6 @@ class RRgooglemaps(RPackage):
 
     homepage = "https://cran.r-project.org/package=RgoogleMaps"
     url      = "https://cran.r-project.org/src/contrib/RgoogleMaps_1.2.0.7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RgoogleMaps"
 
     version('1.2.0.7', '2e1df804f0331b4122d841105f0c7ea5')
 

--- a/var/spack/repos/builtin/packages/r-rinside/package.py
+++ b/var/spack/repos/builtin/packages/r-rinside/package.py
@@ -44,7 +44,6 @@ class RRinside(RPackage):
 
     homepage = "http://dirk.eddelbuettel.com/code/rinside.html"
     url      = "https://cran.r-project.org/src/contrib/RInside_0.2.13.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RInside"
 
     version('0.2.13', '2e3c35a7bd648e9bef98d0afcc02cf88')
 

--- a/var/spack/repos/builtin/packages/r-rjava/package.py
+++ b/var/spack/repos/builtin/packages/r-rjava/package.py
@@ -31,7 +31,6 @@ class RRjava(RPackage):
 
     homepage = "http://www.rforge.net/rJava/"
     url      = "https://cran.r-project.org/src/contrib/rJava_0.9-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rJava"
 
     version('0.9-8', '51ae0d690ceed056ebe7c4be71fc6c7a')
 

--- a/var/spack/repos/builtin/packages/r-rjson/package.py
+++ b/var/spack/repos/builtin/packages/r-rjson/package.py
@@ -30,6 +30,5 @@ class RRjson(RPackage):
 
     homepage = "https://cran.r-project.org/package=rjson"
     url      = "https://cran.r-project.org/src/contrib/rjson_0.2.15.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rjson"
 
     version('0.2.15', '87d0e29bc179c6aeaf312b138089f8e9')

--- a/var/spack/repos/builtin/packages/r-rjsonio/package.py
+++ b/var/spack/repos/builtin/packages/r-rjsonio/package.py
@@ -44,6 +44,5 @@ class RRjsonio(RPackage):
 
     homepage = "https://cran.r-project.org/package=RJSONIO"
     url      = "https://cran.r-project.org/src/contrib/RJSONIO_1.3-0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RJSONIO"
 
     version('1.3-0', '72c395622ba8d1435ec43849fd32c830')

--- a/var/spack/repos/builtin/packages/r-rmarkdown/package.py
+++ b/var/spack/repos/builtin/packages/r-rmarkdown/package.py
@@ -31,7 +31,6 @@ class RRmarkdown(RPackage):
 
     homepage = "http://rmarkdown.rstudio.com/"
     url      = "https://cran.r-project.org/src/contrib/rmarkdown_1.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rmarkdown"
 
     version('1.0', '264aa6a59e9680109e38df8270e14c58')
 

--- a/var/spack/repos/builtin/packages/r-rminer/package.py
+++ b/var/spack/repos/builtin/packages/r-rminer/package.py
@@ -32,7 +32,6 @@ class RRminer(RPackage):
 
     homepage = "http://www3.dsi.uminho.pt/pcortez/rminer.html"
     url      = "https://cran.r-project.org/src/contrib/rminer_1.4.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rminer"
 
     version('1.4.2', '7d5d90f4ae030cf647d67aa962412c05')
 

--- a/var/spack/repos/builtin/packages/r-rmpfr/package.py
+++ b/var/spack/repos/builtin/packages/r-rmpfr/package.py
@@ -34,7 +34,6 @@ class RRmpfr(RPackage):
 
     homepage = "http://rmpfr.r-forge.r-project.org"
     url      = "https://cran.r-project.org/src/contrib/Rmpfr_0.6-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Rmpfr"
 
     version('0.6-1', '55d4ec257bd2a9233bafee9e444d0265')
 

--- a/var/spack/repos/builtin/packages/r-rmpi/package.py
+++ b/var/spack/repos/builtin/packages/r-rmpi/package.py
@@ -31,7 +31,6 @@ class RRmpi(RPackage):
 
     homepage = "http://www.stats.uwo.ca/faculty/yu/Rmpi"
     url      = "https://cran.r-project.org/src/contrib/Rmpi_0.6-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/Rmpi"
 
     version('0.6-6', '59ae8ce62ff0ff99342d53942c745779')
 

--- a/var/spack/repos/builtin/packages/r-rmysql/package.py
+++ b/var/spack/repos/builtin/packages/r-rmysql/package.py
@@ -30,7 +30,6 @@ class RRmysql(RPackage):
 
     homepage = "https://github.com/rstats-db/rmysql"
     url      = "https://cran.r-project.org/src/contrib/RMySQL_0.10.9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RMySQL"
 
     version('0.10.9', '3628200a1864ac3005cfd55cc7cde17a')
 

--- a/var/spack/repos/builtin/packages/r-rngtools/package.py
+++ b/var/spack/repos/builtin/packages/r-rngtools/package.py
@@ -34,7 +34,6 @@ class RRngtools(RPackage):
 
     homepage = "https://renozao.github.io/rngtools"
     url      = "https://cran.r-project.org/src/contrib/rngtools_1.2.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rngtools"
 
     version('1.2.4', '715967f8b3af2848a76593a7c718c1cd')
 

--- a/var/spack/repos/builtin/packages/r-rodbc/package.py
+++ b/var/spack/repos/builtin/packages/r-rodbc/package.py
@@ -30,7 +30,6 @@ class RRodbc(RPackage):
 
     homepage = "https://cran.rstudio.com/web/packages/RODBC/"
     url      = "https://cran.rstudio.com/src/contrib/RODBC_1.3-13.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/RODBC"
 
     version('1.3-13', 'c52ef9139c2ed85adc53ad6effa7d68e')
 

--- a/var/spack/repos/builtin/packages/r-roxygen2/package.py
+++ b/var/spack/repos/builtin/packages/r-roxygen2/package.py
@@ -31,7 +31,6 @@ class RRoxygen2(RPackage):
 
     homepage = "https://github.com/klutometis/roxygen"
     url      = "https://cran.r-project.org/src/contrib/roxygen2_5.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/roxygen2"
 
     version('5.0.1', 'df5bdbc12fda372e427710ef1cd92ed7')
 

--- a/var/spack/repos/builtin/packages/r-rpart-plot/package.py
+++ b/var/spack/repos/builtin/packages/r-rpart-plot/package.py
@@ -31,7 +31,6 @@ class RRpartPlot(RPackage):
 
     homepage = "https://cran.r-project.org/package=rpart.plot"
     url      = "https://cran.r-project.org/src/contrib/rpart.plot_2.1.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rpart.plot"
 
     version('2.1.0', 'fb0f8edfe22c464683ee82aa429136f9')
 

--- a/var/spack/repos/builtin/packages/r-rpart/package.py
+++ b/var/spack/repos/builtin/packages/r-rpart/package.py
@@ -31,7 +31,6 @@ class RRpart(RPackage):
 
     homepage = "https://cran.r-project.org/package=rpart"
     url      = "https://cran.r-project.org/src/contrib/rpart_4.1-10.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rpart"
 
     version('4.1-10', '15873cded4feb3ef44d63580ba3ca46e')
 

--- a/var/spack/repos/builtin/packages/r-rpostgresql/package.py
+++ b/var/spack/repos/builtin/packages/r-rpostgresql/package.py
@@ -38,7 +38,6 @@ class RRpostgresql(RPackage):
 
     homepage = "https://code.google.com/p/rpostgresql/"
     url      = "https://cran.r-project.org/src/contrib/RPostgreSQL_0.4-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RPostgreSQL"
 
     version('0.4-1', 'e7b22e212afbb2cbb88bab937f93e55a')
 

--- a/var/spack/repos/builtin/packages/r-rsnns/package.py
+++ b/var/spack/repos/builtin/packages/r-rsnns/package.py
@@ -37,7 +37,6 @@ class RRsnns(RPackage):
 
     homepage = "http://sci2s.ugr.es/dicits/software/RSNNS"
     url      = "https://cran.r-project.org/src/contrib/RSNNS_0.4-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RSNNS"
 
     version('0.4-7', 'ade7736611c456effb5f72e0ce0a1e6f')
 

--- a/var/spack/repos/builtin/packages/r-rsqlite/package.py
+++ b/var/spack/repos/builtin/packages/r-rsqlite/package.py
@@ -32,7 +32,6 @@ class RRsqlite(RPackage):
 
     homepage = "https://github.com/rstats-db/RSQLite"
     url      = "https://cran.r-project.org/src/contrib/RSQLite_1.0.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/RSQLite"
 
     version('1.0.0', 'e6cbe2709612b687c13a10d30c7bad45')
 

--- a/var/spack/repos/builtin/packages/r-rstan/package.py
+++ b/var/spack/repos/builtin/packages/r-rstan/package.py
@@ -38,7 +38,6 @@ class RRstan(RPackage):
 
     homepage = "http://mc-stan.org/"
     url      = "https://cran.r-project.org/src/contrib/rstan_2.10.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rstan"
 
     version('2.10.1', 'f5d212f6f8551bdb91fe713d05d4052a')
 

--- a/var/spack/repos/builtin/packages/r-rstudioapi/package.py
+++ b/var/spack/repos/builtin/packages/r-rstudioapi/package.py
@@ -31,7 +31,6 @@ class RRstudioapi(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/rstudioapi/index.html"
     url      = "https://cran.r-project.org/src/contrib/rstudioapi_0.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rstudioapi"
 
     version('0.6', 'fdb13bf46aab02421557e713fceab66b')
     version('0.5', '6ce1191da74e7bcbf06b61339486b3ba')

--- a/var/spack/repos/builtin/packages/r-rzmq/package.py
+++ b/var/spack/repos/builtin/packages/r-rzmq/package.py
@@ -31,7 +31,6 @@ class RRzmq(RPackage):
 
     homepage = "http://github.com/armstrtw/rzmq"
     url      = "https://cran.r-project.org/src/contrib/rzmq_0.7.7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rzmq"
 
     version('0.7.7', '8ba18fd1c222d1eb25bb622ccd2897e0')
 

--- a/var/spack/repos/builtin/packages/r-sandwich/package.py
+++ b/var/spack/repos/builtin/packages/r-sandwich/package.py
@@ -31,7 +31,6 @@ class RSandwich(RPackage):
 
     homepage = "https://cran.r-project.org/package=sandwich"
     url      = "https://cran.r-project.org/src/contrib/sandwich_2.3-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/sandwich"
 
     version('2.3-4', 'a621dbd8a57b6e1e036496642aadc2e5')
 

--- a/var/spack/repos/builtin/packages/r-scales/package.py
+++ b/var/spack/repos/builtin/packages/r-scales/package.py
@@ -31,7 +31,6 @@ class RScales(RPackage):
 
     homepage = "https://github.com/hadley/scales"
     url      = "https://cran.r-project.org/src/contrib/scales_0.4.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/scales"
 
     version('0.4.1', '3fb2218866a7fe4c1f6e66790876f85a')
     version('0.4.0', '7b5602d9c55595901192248bca25c099')

--- a/var/spack/repos/builtin/packages/r-scatterplot3d/package.py
+++ b/var/spack/repos/builtin/packages/r-scatterplot3d/package.py
@@ -30,7 +30,6 @@ class RScatterplot3d(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=scatterplot3d"
     url      = "https://cran.r-project.org/src/contrib/scatterplot3d_0.3-40.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/scatterplot3d"
 
     version('0.3-40', '67b9ab6131d244d7fc1db39dcc911dfe')
 

--- a/var/spack/repos/builtin/packages/r-segmented/package.py
+++ b/var/spack/repos/builtin/packages/r-segmented/package.py
@@ -32,6 +32,5 @@ class RSegmented(RPackage):
 
     homepage = "https://CRAN.R-project.org/package=segmented"
     url      = "https://cran.r-project.org/src/contrib/segmented_0.5-1.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/segmented"
 
     version('0.5-1.4', 'f9d76ea9e22ef5f40aa126b697351cae')

--- a/var/spack/repos/builtin/packages/r-seqinr/package.py
+++ b/var/spack/repos/builtin/packages/r-seqinr/package.py
@@ -32,7 +32,6 @@ class RSeqinr(RPackage):
 
     homepage = "http://seqinr.r-forge.r-project.org"
     url      = "https://cran.r-project.org/src/contrib/seqinr_3.3-6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/seqinr"
 
     version('3.3-6', '73023d627e72021b723245665e1ad055')
 

--- a/var/spack/repos/builtin/packages/r-shiny/package.py
+++ b/var/spack/repos/builtin/packages/r-shiny/package.py
@@ -33,7 +33,6 @@ class RShiny(RPackage):
 
     homepage = "http://shiny.rstudio.com/"
     url      = "https://cran.r-project.org/src/contrib/shiny_0.13.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/shiny"
 
     version('0.13.2', 'cb5bff7a28ad59ec2883cd0912ca9611')
 

--- a/var/spack/repos/builtin/packages/r-snow/package.py
+++ b/var/spack/repos/builtin/packages/r-snow/package.py
@@ -30,7 +30,6 @@ class RSnow(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/snow/index.html"
     url      = "https://cran.r-project.org/src/contrib/snow_0.4-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/snow"
 
     version('0.4-2', 'afc7b0dfd4518aedb6fc81712fd2ac70')
 

--- a/var/spack/repos/builtin/packages/r-sp/package.py
+++ b/var/spack/repos/builtin/packages/r-sp/package.py
@@ -33,7 +33,6 @@ class RSp(RPackage):
 
     homepage = "https://github.com/edzer/sp/"
     url      = "https://cran.r-project.org/src/contrib/sp_1.2-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/sp"
 
     version('1.2-3', 'f0e24d993dec128642ee66b6b47b10c1')
 

--- a/var/spack/repos/builtin/packages/r-sparsem/package.py
+++ b/var/spack/repos/builtin/packages/r-sparsem/package.py
@@ -32,7 +32,6 @@ class RSparsem(RPackage):
 
     homepage = "http://www.econ.uiuc.edu/~roger/research/sparse/sparse.html"
     url      = "https://cran.r-project.org/src/contrib/SparseM_1.74.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/SparseM"
 
     version('1.74', 'a16c9b7db172dfd2b7b6508c48e81a5d')
     version('1.7',  '7b5b0ab166a0929ef6dcfe1d97643601')

--- a/var/spack/repos/builtin/packages/r-spdep/package.py
+++ b/var/spack/repos/builtin/packages/r-spdep/package.py
@@ -43,7 +43,6 @@ class RSpdep(RPackage):
 
     homepage = "https://r-forge.r-project.org/projects/spdep"
     url      = "https://cran.r-project.org/src/contrib/spdep_0.6-13.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/spdep"
 
     version('0.6-13', 'bfc68b3016b4894b152ecec4b86f85d1')
 

--- a/var/spack/repos/builtin/packages/r-stanheaders/package.py
+++ b/var/spack/repos/builtin/packages/r-stanheaders/package.py
@@ -44,6 +44,5 @@ class RStanheaders(RPackage):
 
     homepage = "http://mc-stan.org/"
     url      = "https://cran.r-project.org/src/contrib/StanHeaders_2.10.0-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/StanHeaders"
 
     version('2.10.0-2', '9d09b1e9278f08768f7a988ad9082d57')

--- a/var/spack/repos/builtin/packages/r-statnet-common/package.py
+++ b/var/spack/repos/builtin/packages/r-statnet-common/package.py
@@ -31,6 +31,5 @@ class RStatnetCommon(RPackage):
 
     homepage = "http://www.statnet.org"
     url      = "https://cran.r-project.org/src/contrib/statnet.common_3.3.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/statnet.common"
 
     version('3.3.0', '36bc11098dcd3652a4beb05c156ad6c8')

--- a/var/spack/repos/builtin/packages/r-stringi/package.py
+++ b/var/spack/repos/builtin/packages/r-stringi/package.py
@@ -38,7 +38,6 @@ class RStringi(RPackage):
 
     homepage = "http://www.gagolewski.com/software/stringi/"
     url      = "https://cran.r-project.org/src/contrib/stringi_1.1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/stringi"
 
     version('1.1.2', '0ec2faa62643e1900734c0eaf5096648')
     version('1.1.1', '32b919ee3fa8474530c4942962a6d8d9')

--- a/var/spack/repos/builtin/packages/r-stringr/package.py
+++ b/var/spack/repos/builtin/packages/r-stringr/package.py
@@ -34,7 +34,6 @@ class RStringr(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/stringr/index.html"
     url      = "https://cran.r-project.org/src/contrib/stringr_1.1.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/stringr"
 
     version('1.1.0', '47973a33944c6d5db9524b1e835b8a5d')
     version('1.0.0', '5ca977c90351f78b1b888b379114a7b4')

--- a/var/spack/repos/builtin/packages/r-strucchange/package.py
+++ b/var/spack/repos/builtin/packages/r-strucchange/package.py
@@ -31,7 +31,6 @@ class RStrucchange(RPackage):
 
     homepage = "https://cran.r-project.org/package=strucchange"
     url      = "https://cran.r-project.org/src/contrib/strucchange_1.5-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/strucchange"
 
     version('1.5-1', 'fc751fc011df9c8df82d577298cb8395')
 

--- a/var/spack/repos/builtin/packages/r-survey/package.py
+++ b/var/spack/repos/builtin/packages/r-survey/package.py
@@ -36,6 +36,5 @@ class RSurvey(RPackage):
 
     homepage = "http://r-survey.r-forge.r-project.org/survey/"
     url      = "https://cran.r-project.org/src/contrib/survey_3.30-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/survey"
 
     version('3.30-3', 'c70cdae9cb43d35abddd11173d64cad0')

--- a/var/spack/repos/builtin/packages/r-survival/package.py
+++ b/var/spack/repos/builtin/packages/r-survival/package.py
@@ -32,7 +32,6 @@ class RSurvival(RPackage):
 
     homepage = "https://cran.r-project.org/package=survival"
     url      = "https://cran.r-project.org/src/contrib/survival_2.40-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/survival"
 
     version('2.40-1', 'a2474b656cd723791268e3114481b8a7')
     version('2.39-5', 'a3cc6b5762e8c5c0bb9e64a276710be2')

--- a/var/spack/repos/builtin/packages/r-tarifx/package.py
+++ b/var/spack/repos/builtin/packages/r-tarifx/package.py
@@ -30,7 +30,6 @@ class RTarifx(RPackage):
 
     homepage = "https://cran.r-project.org/package=taRifx"
     url      = "https://cran.r-project.org/src/contrib/taRifx_1.0.6.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/taRifx"
 
     version('1.0.6', '7e782e04bd69d929b29f91553382e6a2')
 

--- a/var/spack/repos/builtin/packages/r-testit/package.py
+++ b/var/spack/repos/builtin/packages/r-testit/package.py
@@ -32,6 +32,5 @@ class RTestit(RPackage):
 
     homepage = "https://github.com/yihui/testit"
     url      = "https://cran.r-project.org/src/contrib/testit_0.5.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/testit"
 
     version('0.5', 'f206d3cbdc5174e353d2d05ba6a12e59')

--- a/var/spack/repos/builtin/packages/r-testthat/package.py
+++ b/var/spack/repos/builtin/packages/r-testthat/package.py
@@ -31,7 +31,6 @@ class RTestthat(RPackage):
 
     homepage = "https://github.com/hadley/testthat"
     url      = "https://cran.r-project.org/src/contrib/testthat_1.0.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/testthat"
 
     version('1.0.2', '6c6a90c8db860292df5784a70e07b8dc')
 

--- a/var/spack/repos/builtin/packages/r-th-data/package.py
+++ b/var/spack/repos/builtin/packages/r-th-data/package.py
@@ -30,7 +30,6 @@ class RThData(RPackage):
 
     homepage = "https://cran.r-project.org/package=TH.data"
     url      = "https://cran.r-project.org/src/contrib/TH.data_1.0-8.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/TH.data"
 
     version('1.0-8', '2cc20acc8b470dff1202749b4bea55c4')
     version('1.0-7', '3e8b6b1a4699544f175215aed7039a94')

--- a/var/spack/repos/builtin/packages/r-threejs/package.py
+++ b/var/spack/repos/builtin/packages/r-threejs/package.py
@@ -31,7 +31,6 @@ class RThreejs(RPackage):
 
     homepage = "http://bwlewis.github.io/rthreejs"
     url      = "https://cran.r-project.org/src/contrib/threejs_0.2.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/threejs"
 
     version('0.2.2', '35c179b10813c5e4bd3e7827fae6627b')
 

--- a/var/spack/repos/builtin/packages/r-tibble/package.py
+++ b/var/spack/repos/builtin/packages/r-tibble/package.py
@@ -31,7 +31,6 @@ class RTibble(RPackage):
 
     homepage = "https://github.com/hadley/tibble"
     url      = "https://cran.r-project.org/src/contrib/tibble_1.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/tibble"
 
     version('1.2', 'bdbc3d67aa16860741add6d6ec20ea13')
     version('1.1', '2fe9f806109d0b7fadafb1ffafea4cb8')

--- a/var/spack/repos/builtin/packages/r-tidyr/package.py
+++ b/var/spack/repos/builtin/packages/r-tidyr/package.py
@@ -32,7 +32,6 @@ class RTidyr(RPackage):
 
     homepage = "https://github.com/hadley/tidyr"
     url      = "https://cran.r-project.org/src/contrib/tidyr_0.5.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/tidyr"
 
     version('0.5.1', '3cadc869510c054ed93d374ab44120bd')
 

--- a/var/spack/repos/builtin/packages/r-trimcluster/package.py
+++ b/var/spack/repos/builtin/packages/r-trimcluster/package.py
@@ -30,7 +30,6 @@ class RTrimcluster(RPackage):
 
     homepage = "http://www.homepages.ucl.ac.uk/~ucakche"
     url      = "https://cran.r-project.org/src/contrib/trimcluster_0.1-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/trimcluster"
 
     version('0.1-2', '7617920e224bd18f5b87db38a3116ec2')
 

--- a/var/spack/repos/builtin/packages/r-trust/package.py
+++ b/var/spack/repos/builtin/packages/r-trust/package.py
@@ -31,6 +31,5 @@ class RTrust(RPackage):
 
     homepage = "http://www.stat.umn.edu/geyer/trust"
     url      = "https://cran.r-project.org/src/contrib/trust_0.1-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/trust"
 
     version('0.1-7', '7e218b3a6b33bd77bd7e86dc6360418d')

--- a/var/spack/repos/builtin/packages/r-ttr/package.py
+++ b/var/spack/repos/builtin/packages/r-ttr/package.py
@@ -30,7 +30,6 @@ class RTtr(RPackage):
 
     homepage = "https://github.com/joshuaulrich/TTR"
     url      = "https://cran.r-project.org/src/contrib/TTR_0.23-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/TTR"
 
     version('0.23-1', '35f693ac0d97e8ec742ebea2da222986')
 

--- a/var/spack/repos/builtin/packages/r-uuid/package.py
+++ b/var/spack/repos/builtin/packages/r-uuid/package.py
@@ -32,6 +32,5 @@ class RUuid(RPackage):
 
     homepage = "http://www.rforge.net/uuid"
     url      = "https://cran.rstudio.com/src/contrib/uuid_0.1-2.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/uuid"
 
     version('0.1-2', 'f97d000c0b16bca455fb5bf2cd668ddf')

--- a/var/spack/repos/builtin/packages/r-vcd/package.py
+++ b/var/spack/repos/builtin/packages/r-vcd/package.py
@@ -35,7 +35,6 @@ class RVcd(RPackage):
 
     homepage = "https://cran.r-project.org/package=vcd"
     url      = "https://cran.r-project.org/src/contrib/vcd_1.4-1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/vcd"
 
     version('1.4-1', '7db150a77f173f85b69a1f86f73f8f02')
 

--- a/var/spack/repos/builtin/packages/r-vegan/package.py
+++ b/var/spack/repos/builtin/packages/r-vegan/package.py
@@ -31,7 +31,6 @@ class RVegan(RPackage):
 
     homepage = "https://github.com/vegandevs/vegan"
     url      = "https://cran.r-project.org/src/contrib/vegan_2.4-3.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/vegan"
 
     version('2.4-3', 'db17d4c4b9a4d421246abd5b36b00fec')
 

--- a/var/spack/repos/builtin/packages/r-viridis/package.py
+++ b/var/spack/repos/builtin/packages/r-viridis/package.py
@@ -30,7 +30,6 @@ class RViridis(RPackage):
 
     homepage = "https://github.com/sjmgarnier/viridis"
     url      = "https://cran.r-project.org/src/contrib/viridis_0.4.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/viridis"
 
     version('0.4.0', 'f874384cbedf459f6c309ddb40b354ea')
 

--- a/var/spack/repos/builtin/packages/r-viridislite/package.py
+++ b/var/spack/repos/builtin/packages/r-viridislite/package.py
@@ -30,7 +30,6 @@ class RViridislite(RPackage):
 
     homepage = "https://github.com/sjmgarnier/viridisLite"
     url      = "https://cran.r-project.org/src/contrib/viridisLite_0.2.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/viridisLite"
 
     version('0.2.0', '04a04415cf651a2b5f964b261896c0fb')
 

--- a/var/spack/repos/builtin/packages/r-visnetwork/package.py
+++ b/var/spack/repos/builtin/packages/r-visnetwork/package.py
@@ -31,7 +31,6 @@ class RVisnetwork(RPackage):
 
     homepage = "https://github.com/datastorm-open/visNetwork"
     url      = "https://cran.r-project.org/src/contrib/visNetwork_1.0.1.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/visNetwork"
 
     version('1.0.1', 'dfc9664a5165134d8dbdcd949ad73cf7')
 

--- a/var/spack/repos/builtin/packages/r-whisker/package.py
+++ b/var/spack/repos/builtin/packages/r-whisker/package.py
@@ -31,6 +31,5 @@ class RWhisker(RPackage):
 
     homepage = "http://github.com/edwindj/whisker"
     url      = "https://cran.r-project.org/src/contrib/whisker_0.3-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/whisker"
 
     version('0.3-2', 'c4b9bf9a22e69ce003fe68663ab5e8e6')

--- a/var/spack/repos/builtin/packages/r-withr/package.py
+++ b/var/spack/repos/builtin/packages/r-withr/package.py
@@ -33,7 +33,6 @@ class RWithr(RPackage):
 
     homepage = "http://github.com/jimhester/withr"
     url      = "https://cran.r-project.org/src/contrib/withr_1.0.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/withr"
 
     version('1.0.2', 'ca52b729af9bbaa14fc8b7bafe38663c')
     version('1.0.1', 'ac38af2c6f74027c9592dd8f0acb7598')

--- a/var/spack/repos/builtin/packages/r-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/r-xgboost/package.py
@@ -38,7 +38,6 @@ class RXgboost(RPackage):
 
     homepage = "https://github.com/dmlc/xgboost"
     url      = "https://cran.r-project.org/src/contrib/xgboost_0.6-4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/xgboost"
 
     version('0.6-4', '86e517e3ce39f8a01de796920f6b425e')
     version('0.4-4', 'c24d3076058101a71de4b8af8806697c')

--- a/var/spack/repos/builtin/packages/r-xlconnect/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnect/package.py
@@ -31,7 +31,6 @@ class RXlconnect(RPackage):
 
     homepage = "http://miraisolutions.wordpress.com/"
     url      = "https://cran.r-project.org/src/contrib/XLConnect_0.2-11.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnect"
 
     version('0.2-12', '3340d05d259f0a41262eab4ed32617ad')
     version('0.2-11', '9d1769a103cda05665df399cc335017d')

--- a/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlconnectjars/package.py
@@ -30,7 +30,6 @@ class RXlconnectjars(RPackage):
 
     homepage = "http://miraisolutions.wordpress.com/"
     url      = "https://cran.r-project.org/src/contrib/XLConnectJars_0.2-9.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/XLConnectJars"
 
     version('0.2-12', '6984e5140cd1c887c017ef6f88cbba81')
     version('0.2-9', 'e6d6b1acfede26acaa616ee421bd30fb')

--- a/var/spack/repos/builtin/packages/r-xlsx/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsx/package.py
@@ -31,7 +31,6 @@ class RXlsx(RPackage):
 
     homepage = "http://code.google.com/p/rexcel/"
     url      = "https://cran.rstudio.com/src/contrib/xlsx_0.5.7.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/xlsx"
 
     version('0.5.7', '36b1b16f29c54b6089b1dae923180dd5')
 

--- a/var/spack/repos/builtin/packages/r-xlsxjars/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsxjars/package.py
@@ -31,7 +31,6 @@ class RXlsxjars(RPackage):
 
     homepage = "https://cran.rstudio.com/web/packages/xlsxjars/index.html"
     url      = "https://cran.rstudio.com/src/contrib/xlsxjars_0.6.1.tar.gz"
-    list_url = "https://cran.rstudio.com/src/contrib/Archive/xlsxjars"
 
     version('0.6.1', '5a1721d5733cb42f3a29e3f353e39166')
 

--- a/var/spack/repos/builtin/packages/r-xml/package.py
+++ b/var/spack/repos/builtin/packages/r-xml/package.py
@@ -32,7 +32,6 @@ class RXml(RPackage):
 
     homepage = "http://www.omegahat.net/RSXML"
     url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/XML"
 
     version('3.98-1.5', 'd1cfcd56f7aec96a84ffca91aea507ee')
     version('3.98-1.4', '1a7f3ce6f264eeb109bfa57bedb26c14')

--- a/var/spack/repos/builtin/packages/r-xtable/package.py
+++ b/var/spack/repos/builtin/packages/r-xtable/package.py
@@ -30,6 +30,5 @@ class RXtable(RPackage):
 
     homepage = "http://xtable.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/xtable_1.8-2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/xtable"
 
     version('1.8-2', '239e4825cd046156a67efae3aac01d86')

--- a/var/spack/repos/builtin/packages/r-xts/package.py
+++ b/var/spack/repos/builtin/packages/r-xts/package.py
@@ -33,7 +33,6 @@ class RXts(RPackage):
 
     homepage = "http://r-forge.r-project.org/projects/xts/"
     url      = "https://cran.r-project.org/src/contrib/xts_0.9-7.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/xts"
 
     version('0.9-7', 'a232e94aebfa654653a7d88a0503537b')
 

--- a/var/spack/repos/builtin/packages/r-yaml/package.py
+++ b/var/spack/repos/builtin/packages/r-yaml/package.py
@@ -31,6 +31,5 @@ class RYaml(RPackage):
 
     homepage = "https://cran.r-project.org/web/packages/yaml/index.html"
     url      = "https://cran.r-project.org/src/contrib/yaml_2.1.13.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/yaml"
 
     version('2.1.13', 'f2203ea395adaff6bd09134666191d9a')

--- a/var/spack/repos/builtin/packages/r-zoo/package.py
+++ b/var/spack/repos/builtin/packages/r-zoo/package.py
@@ -34,7 +34,6 @@ class RZoo(RPackage):
 
     homepage = "http://zoo.r-forge.r-project.org/"
     url      = "https://cran.r-project.org/src/contrib/zoo_1.7-14.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/zoo"
 
     version('1.7-14', '8c577a7c1e535c899ab14177b1039c32')
     version('1.7-13', '99521dfa4c668e692720cefcc5a1bf30')

--- a/var/spack/repos/builtin/packages/spindle/package.py
+++ b/var/spack/repos/builtin/packages/spindle/package.py
@@ -33,7 +33,6 @@ class Spindle(AutotoolsPackage):
     """
     homepage = "https://computation.llnl.gov/project/spindle/"
     url      = "https://github.com/hpc/Spindle/archive/v0.8.1.tar.gz"
-    list_url = "https://github.com/hpc/Spindle/releases"
 
     version('0.8.1', 'f11793a6b9d8df2cd231fccb2857d912')
 


### PR DESCRIPTION
Every tarball downloaded from GitLab, BitBucket, and CRAN has the exact same `list_url` format. This PR adds these formats to `find_list_url` and works the same way as it did for GitHub downloads.