### PR TITLE
Bug/cctools syscall

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -51,7 +51,7 @@ class Cctools(AutotoolsPackage):
     # This is a belt and suspenders solution to the problem.
     def patch(self):
         before = '#if defined(__linux__) && defined(SYS_memfd_create)'
-        after = '#if defined(__linux__) && defined(SYS_memfd_create) && defined(__NR_memfd_create)'
+        after = '#if defined(__linux__) && defined(SYS_memfd_create) && defined(__NR_memfd_create)'  # noqa: E501
         f = 'dttools/src/memfdexe.c'
         kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
         filter_file(before, after, f, **kwargs)

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -44,6 +44,18 @@ class Cctools(AutotoolsPackage):
     # depends_on('xrootd')
     depends_on('zlib')
 
+    # Generally SYS_foo is defined to __NR_foo (sys/syscall.h) which
+    # is then defined to a syscall number (asm/unistd_64.h).  Certain
+    # CentOS systems have SYS_memfd_create defined to
+    # __NR_memfd_create but are missing the second definition.
+    # This is a belt and suspenders solution to the problem.
+    def patch(self):
+        before = '#if defined(__linux__) && defined(SYS_memfd_create)'
+        after = '#if defined(__linux__) && defined(SYS_memfd_create) && defined(__NR_memfd_create)'
+        f = 'dttools/src/memfdexe.c'
+        kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
+        filter_file(before, after, f, **kwargs)
+
     def configure_args(self):
         args = []
         # disable these bits


### PR DESCRIPTION
Generally SYS_foo is defined to __NR_foo (in sys/syscall.h) which is then defined to a syscall number (in asm/unistd_64.h).  

Certain CentOS systems (combinations of rpms?  a particular release?  sysadmin error?) have SYS_memfd_create defined to __NR_memfd_create but are missing the second definition.

This is a belt and suspenders solution to the problem.

See [this post][syscall] for a nice general description of how these parts fit together.

[syscall]: https://www.uninformativ.de/blog/postings/2017-02-11/0/POSTING-en.html