### PR TITLE
Supress output from gpg --version during tests

### DIFF
--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import argparse
-import os.path
+import os
 
 import pytest
 import spack
@@ -42,7 +42,7 @@ def testing_gpg_directory(tmpdir):
 
 def has_gnupg2():
     try:
-        gpg_util.Gpg.gpg()('--version')
+        gpg_util.Gpg.gpg()('--version', output=os.devnull)
         return True
     except Exception:
         return False


### PR DESCRIPTION
When building the documentation, I noticed that Sphinx spit out the following text:
```
gpg (GnuPG) 2.1.13 [ 83%] spack.test.cmd                                                      
libgcrypt 1.6.6
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /home/ajstewart/spack/opt/spack/gpg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
reading sources... [100%] workflows  
```
This change suppresses that output.