### PR TITLE
Fix tab completion of Spack subcommands

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -843,7 +843,7 @@ function _spack_view_symlink {
 # Helper functions for subcommands
 
 function _subcommands {
-    spack help | grep "^    [a-z]" | awk '{print $1}'
+    spack help --all | grep "^  [a-z]" | awk '{print $1}' | grep -v spack
 }
 
 function _all_packages {


### PR DESCRIPTION
The format of `spack help` changed but we forgot to update the tab completion script.