### PR TITLE
Fixed duplicated spec: nag@6.1 line in getting started guide

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -641,6 +641,7 @@ Or it can be set permanently in your ``compilers.yaml``:
       fflags: -mismatch
     spec: nag@6.1
 
+
 ---------------
 System Packages
 ---------------


### PR DESCRIPTION
this fixes a duplicated line at the end of this section: flags:
https://spack.readthedocs.io/en/latest/getting_started.html#nag

Adding extra empty line fixed the duplication.
