### PR TITLE
fix mfem build for ppc with gcc

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/mfem_ppc_build.patch
+++ b/var/spack/repos/builtin/packages/mfem/mfem_ppc_build.patch
@@ -1,0 +1,10 @@
+--- mfem/miniapps/performance/makefile	2017-06-07 13:51:29.366596901 -0700
++++ mfem/miniapps/performance/makefile.new	2017-06-07 13:51:57.087104178 -0700
+@@ -26,7 +26,6 @@
+ # Compiler specific optimizations.
+ # For best performance, GCC 5 (or newer) is recommended.
+ ifneq (,$(findstring $(MFEM_CXX),g++ mpicxx))
+-   MFEM_CXXFLAGS += -march=native
+    # MFEM_CXXFLAGS += -std=c++03
+    MFEM_CXXFLAGS += -std=c++11
+    MFEM_CXXFLAGS += -pedantic -Wall

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -96,6 +96,8 @@ class Mfem(Package):
     depends_on('zlib', when='@3.2: +netcdf')
     depends_on('hdf5', when='@3.2: +netcdf')
 
+    patch('mfem_ppc_build.patch', when='@3.2:3.3 arch=ppc64le')
+
     def check_variants(self, spec):
         if '+mpi' in spec and ('+hypre' not in spec or '+metis' not in spec):
             raise InstallError('mfem+mpi must be built with +hypre ' +


### PR DESCRIPTION
added a patch to remove unsupported -march=native gcc compiler option when mfem is built on ppc64le.