### PR TITLE
Fix url parse offset for SourceForge downloads

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -160,6 +160,8 @@ def test_url_strip_name_suffixes(url, version, expected):
     ('sionlib', 30, '1.7.1', 59, 'http://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.1'),
     # Regex in name
     ('voro++', 40, '0.4.6', 47, 'http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz'),
+    # SourceForge download
+    ('glew', 55, '2.0.0', 60, 'https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download'),
 ])
 def test_url_parse_offset(name, noffset, ver, voffset, path):
     """Tests that the name, version and offsets are computed correctly.

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -301,7 +301,8 @@ def split_url_extension(path):
     prefix, ext, suffix = path, '', ''
 
     # Strip off sourceforge download suffix.
-    match = re.search(r'((?:sourceforge\.net|sf\.net)/.*)(/download)$', path)
+    # e.g. https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
+    match = re.search(r'(.*(?:sourceforge\.net|sf\.net)/.*)(/download)$', path)
     if match:
         prefix, suffix = match.groups()
 


### PR DESCRIPTION
Fixes #4413 

### Before
```
$ spack url parse https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
==> Parsing URL: https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download

==> Matched version regex  0: r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
==> Matched  name   regex  7: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
                                                   ---- ~~~~~
    name:    glew
    version: 2.0.0

==> Substituting version 9.9.9b:
    https://sourceforge.net/projects/glew/files/glew/9.9.9b/glew-9.9.9b.tgz/download
                                                    ---- ~~~~~~
```
### After
```
$ spack url parse https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
==> Parsing URL: https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download

==> Matched version regex  0: r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
==> Matched  name   regex  7: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
                                                           ---- ~~~~~
    name:    glew
    version: 2.0.0

==> Substituting version 9.9.9b:
    https://sourceforge.net/projects/glew/files/glew/9.9.9b/glew-9.9.9b.tgz/download
                                                            ---- ~~~~~~
```