### PR TITLE
gitignore everything in /etc/spack except /etc/spack/defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 *~
 .DS_Store
 .idea
-/etc/spack/licenses
-/etc/spack/*.yaml
+# Ignore everything in /etc/spack except /etc/spack/defaults
+/etc/spack/**
+!/etc/spack/defaults
 /etc/spackconfig
 /share/spack/dotkit
 /share/spack/modules

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 .DS_Store
 .idea
 # Ignore everything in /etc/spack except /etc/spack/defaults
-/etc/spack/**
+/etc/spack/*
 !/etc/spack/defaults
 /etc/spackconfig
 /share/spack/dotkit


### PR DESCRIPTION
Closes #4457 

Previously, files like `.gitignore`, `linux/compilers.yaml`, and `install.sh` would be tracked if they reside in `/etc/spack`. Now, everything in `/etc/spack` is ignored except for `/etc/spack/defaults`. This lets users put whatever configuration-related files they want in `/etc/spack` and track it with git. Tested with git 1.7.1 (the default on CentOS 6) and 2.5.0 (Spack installed) but would appreciate more testing.

Thanks to @svenevs for the solution!