### PR TITLE
scala + spark: added legacy versions

### DIFF
--- a/var/spack/repos/builtin/packages/scala/package.py
+++ b/var/spack/repos/builtin/packages/scala/package.py
@@ -34,10 +34,13 @@ class Scala(Package):
     """
 
     homepage = "https://www.scala-lang.org/"
-    url      = "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz"
+    url = "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz"
+
+    version('2.12.1', '3eaecbce019b0fa3067503846e292b32')
+    version('2.11.11', '3f5b76001f60cbc31111ddb81de5ea07')
+    version('2.20.6', 'd79dc9fdc627b73289306bdaec81ca98')
 
     depends_on('jdk')
-    version('2.12.1', '3eaecbce019b0fa3067503846e292b32')
 
     def install(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/spark/package.py
+++ b/var/spack/repos/builtin/packages/spark/package.py
@@ -34,7 +34,7 @@ class Spark(Package):
     """
 
     homepage = "http://spark.apache.org"
-    url      = "http://archive.apache.org/dist/spark/spark-2.0.0/spark-2.0.0-bin-without-hadoop.tgz"
+    url = "http://archive.apache.org/dist/spark/spark-2.0.0/spark-2.0.0-bin-without-hadoop.tgz"
 
     variant('hadoop', default=False,
             description='Build with Hadoop')
@@ -47,6 +47,7 @@ class Spark(Package):
     version('2.0.0', '8a5307d973da6949a385aefb6ff747bb')
     version('1.6.2', '304394fbe2899211217f0cd9e9b2b5d9')
     version('1.6.1', 'fcf4961649f15af1fea78c882e65b001')
+    version('1.6.0', '2c28edc89ca0067e63e525c04f7b1d89')
 
     def install(self, spec, prefix):
 


### PR DESCRIPTION
We had a request from some of our users to install old versions of scala and spark. Thought it was worth sharing the modifications. Feel free to close if not.