### PR TITLE
Fix autotools issues

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -41,6 +41,10 @@ class Libtool(AutotoolsPackage):
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))
 
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.append_path('ACLOCAL_PATH',
+                              join_path(self.prefix.share, 'aclocal'))
+
     def setup_dependent_package(self, module, dependent_spec):
         # Automake is very likely to be a build dependency,
         # so we add the tools it provides to the dependent module

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -51,6 +51,8 @@ class PkgConfig(AutotoolsPackage):
         files."""
         spack_env.append_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
         spack_env.append_path('PKG_CONFIG_PATH', '/usr/local/lib64/pkgconfig')
+        spack_env.append_path('ACLOCAL_PATH',
+                              join_path(self.prefix.share, 'aclocal'))
 
     def configure_args(self):
         config_args = ['--enable-shared']


### PR DESCRIPTION
Add ACLOCAL_PATH to libtool and pkg-config. Without this, aclocal can not find the .m4 files.

This should fix #4409.