### PR TITLE
Fix building shared libraries for gmp

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -38,7 +38,14 @@ class Gmp(AutotoolsPackage):
     version('6.0.0a', 'b7ff2d88cae7f8085bd5006096eed470')
     version('6.0.0',  '6ef5869ae735db9995619135bd856b84')
 
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
     depends_on('m4', type='build')
+
+    # gmp's configure script seems to be broken; it sometimes misdetects
+    # shared library support. Regenerating it fixes the issue.
+    force_autoreconf = True
 
     def configure_args(self):
         args = ['--enable-cxx']


### PR DESCRIPTION
If specific compiler flags are set, gmp will not build a shared library, causing failures further down the line.

Specifically, we have set `cflags`, `cppflags`, `ldflags` etc. to `-mtune=native -march=native`. This causes gmp's `configure` script to misdetect shared library support, which causes the mpfr build to fail.