### PR TITLE
adding H5Z-ZFP; updating zfp to use choice variant for bit stream word size

### DIFF
--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -44,20 +44,13 @@ class H5zZfp(MakefilePackage):
     @property
     def make_defs(self):
         make_defs = [
-            "CC=%s" % spack_cc,
-            "HDF5_HOME=%s" % self.spec['hdf5'].prefix,
-            "ZFP_HOME=%s" % self.spec['zfp'].prefix]
+            'PREFIX=%s' % prefix,
+            'CC=%s' % spack_cc,
+            'HDF5_HOME=%s' % self.spec['hdf5'].prefix,
+            'ZFP_HOME=%s' % self.spec['zfp'].prefix]
 
-        if '+fortran' in self.spec and not spack_fc:
-            msg = 'cannot build a Fortran variant without a Fortran compiler'
-            raise RuntimeError(msg)
-
-        if '+fortran' in self.spec:
-            make_defs += ["FC=%s" % spack_fc]
-
-        make_defs += [
-            "PREFIX=%s" % prefix,
-            "all"]
+        if '+fortran' in self.spec and spack_fc:
+            make_defs += ['FC=%s' % spack_fc]
 
         return make_defs
 

--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -1,0 +1,72 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class H5zZfp(MakefilePackage):
+    """A highly flexible floating point and integer compression plugin for the
+       HDF5 library using ZFP compression."""
+
+    homepage = "http://www.example.com"
+    url      = "https://github.com/LLNL/H5Z-ZFP"
+
+    version('develop', git='https://github.com/LLNL/H5Z-ZFP.git', tag='master')
+    version('0.7.0', git='https://github.com/LLNL/H5Z-ZFP.git', commit='58ac811')
+
+    variant('fortran', default=True, description='Enable Fortran support')
+
+    depends_on('hdf5')
+#    depends_on('zfp bsws=8')
+    depends_on('zfp')
+
+    @property
+    def make_defs(self):
+        make_defs = [
+            "CC=%s" % spack_cc,
+            "HDF5_HOME=%s" % self.spec['hdf5'].prefix,
+            "ZFP_HOME=%s" % self.spec['zfp'].prefix]
+
+        if '+fortran' in self.spec and not spack_fc:
+            msg = 'cannot build a Fortran variant without a Fortran compiler'
+            raise RuntimeError(msg)
+
+        if '+fortran' in self.spec:
+            make_defs += ["FC=%s" % spack_fc]
+
+        make_defs += [
+            "PREFIX=%s" % prefix,
+            "all"]
+
+        return make_defs
+
+    @property
+    def build_targets(self):
+        targets = ['all']
+        return self.make_defs + targets
+
+    @property
+    def install_targets(self):
+        make_args = ['install']
+        return make_args + self.make_defs

--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -29,7 +29,7 @@ class H5zZfp(MakefilePackage):
     """A highly flexible floating point and integer compression plugin for the
        HDF5 library using ZFP compression."""
 
-    homepage = "http://www.example.com"
+    homepage = "http://h5z-zfp.readthedocs.io/en/latest"
     url      = "https://github.com/LLNL/H5Z-ZFP"
 
     version('develop', git='https://github.com/LLNL/H5Z-ZFP.git', tag='master')

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -41,16 +41,20 @@ class Zfp(MakefilePackage):
     version('0.5.1', '0ed7059a9b480635e0dd33745e213d17')
     version('0.5.0', '2ab29a852e65ad85aae38925c5003654')
 
-    variant('bswtuint8', default=False,
-            description='Build with bit stream word type of uint8')
+    variant('bsws',
+        default='64',
+        values=('8', '16', '32', '64'),
+        multi=False,
+        description='Bit stream word size: use smaller for finer \
+            rate granularity. Use 8 for H5Z-ZFP filter.')
 
     def edit(self, spec, prefix):
-        if '+bswtuint8' in self.spec:
-            config_file = FileFilter('Config')
-            config_file.filter(
-                '^\s*#\s*DEFS\s*\+=\s*-DBIT_STREAM_WORD_TYPE\s*=\s*uint8',
-                'DEFS += -DBIT_STREAM_WORD_TYPE=uint8')
- 
+        config_file = FileFilter('Config')
+        config_file.filter(
+            '^\s*#\s*DEFS\s*\+=\s*-DBIT_STREAM_WORD_TYPE\s*=\s*uint8',
+            'DEFS += -DBIT_STREAM_WORD_TYPE=uint%s' %
+            spec.variants['bsws'].value)
+
     def build(self, spec, prefix):
         make("shared")
 


### PR DESCRIPTION
This adds the H5Z-ZFP filter plugin package

I adjusted zfp package variant to accept 4 choices for bsws variant controlling the bit stream word size instead of just setting uint8.

The H5Z-ZFP plugin really needs `depends_on('zfp bsws=8')` but that appears to be failing in spack internally somewhere...

```
[scratlantis:~/spack/spack] miller86% spack install h5z-zfp
==> Error: Invalid spec: 'zfp@0.5.1%clang@7.3.0-apple bsws=8 arch=darwin-elcapitan-x86_64'. Package zfp requires variant bsws=8, but spec asked for bsws=8
```

So, I will fix after I can file a bug ticket for this.