### PR TITLE
Add list_url for packages from http://ab-initio.mit.edu/

### DIFF
--- a/var/spack/repos/builtin/packages/harminv/package.py
+++ b/var/spack/repos/builtin/packages/harminv/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Harminv(Package):
+class Harminv(AutotoolsPackage):
     """Harminv is a free program (and accompanying library) to solve the
     problem of harmonic inversion - given a discrete-time, finite-length
     signal that consists of a sum of finitely-many sinusoids (possibly
@@ -34,21 +34,18 @@ class Harminv(Package):
 
     homepage = "http://ab-initio.mit.edu/wiki/index.php/Harminv"
     url      = "http://ab-initio.mit.edu/harminv/harminv-1.4.tar.gz"
+    list_url = "http://ab-initio.mit.edu/harminv/old"
 
     version('1.4', 'b95e24a9bc7e07d3d2202d1605e9e86f')
 
     depends_on('blas')
     depends_on('lapack')
 
-    def install(self, spec, prefix):
-        config_args = [
-            '--prefix={0}'.format(prefix),
+    def configure_args(self):
+        spec = self.spec
+
+        return [
+            '--enable-shared',
             '--with-blas={0}'.format(spec['blas'].prefix.lib),
             '--with-lapack={0}'.format(spec['lapack'].prefix.lib),
-            '--enable-shared'
         ]
-
-        configure(*config_args)
-
-        make()
-        make('install')

--- a/var/spack/repos/builtin/packages/libctl/package.py
+++ b/var/spack/repos/builtin/packages/libctl/package.py
@@ -25,24 +25,25 @@
 from spack import *
 
 
-class Libctl(Package):
+class Libctl(AutotoolsPackage):
     """libctl is a free Guile-based library implementing flexible
     control files for scientific simulations."""
 
     homepage = "http://ab-initio.mit.edu/wiki/index.php/Libctl"
     url      = "http://ab-initio.mit.edu/libctl/libctl-3.2.2.tar.gz"
+    list_url = "http://ab-initio.mit.edu/libctl/old"
 
     version('3.2.2', '5fd7634dc9ae8e7fa70a68473b9cbb68')
 
     depends_on('guile')
 
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix),
-                  '--enable-shared',
-                  'GUILE={0}'.format(join_path(
-                      spec['guile'].prefix.bin, 'guile')),
-                  'GUILE_CONFIG={0}'.format(join_path(
-                      spec['guile'].prefix.bin, 'guile-config')))
+    def configure_args(self):
+        spec = self.spec
 
-        make()
-        make('install')
+        return [
+            '--enable-shared',
+            'GUILE={0}'.format(join_path(
+                spec['guile'].prefix.bin, 'guile')),
+            'GUILE_CONFIG={0}'.format(join_path(
+                spec['guile'].prefix.bin, 'guile-config')),
+        ]

--- a/var/spack/repos/builtin/packages/meep/package.py
+++ b/var/spack/repos/builtin/packages/meep/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Meep(Package):
+class Meep(AutotoolsPackage):
     """Meep (or MEEP) is a free finite-difference time-domain (FDTD) simulation
     software package developed at MIT to model electromagnetic systems."""
 
@@ -56,16 +56,10 @@ class Meep(Package):
     depends_on('hdf5+mpi',    when='+hdf5+mpi')
     depends_on('gsl',         when='+gsl')
 
-    def url_for_version(self, version):
-        base_url = "http://ab-initio.mit.edu/meep"
-        if version > Version('1.1.1'):
-            return "{0}/meep-{1}.tar.gz".format(base_url, version)
-        else:
-            return "{0}/old/meep-{1}.tar.gz".format(base_url, version)
+    def configure_args(self):
+        spec = self.spec
 
-    def install(self, spec, prefix):
         config_args = [
-            '--prefix={0}'.format(prefix),
             '--enable-shared'
         ]
 
@@ -97,15 +91,14 @@ class Meep(Package):
         else:
             config_args.append('--without-hdf5')
 
-        configure(*config_args)
+        return config_args
 
-        make()
+    def check(self):
+        spec = self.spec
 
         # aniso_disp test fails unless installed with harminv
         # near2far test fails unless installed with gsl
-        if self.run_tests and '+harminv' in spec and '+gsl' in spec:
+        if '+harminv' in spec and '+gsl' in spec:
             # Most tests fail when run in parallel
             # 2D_convergence tests still fails to converge for unknown reasons
             make('check', parallel=False)
-
-        make('install')


### PR DESCRIPTION
I discovered a "secret" `list_url` shared by all software from [this research group](http://ab-initio.mit.edu/) and I couldn't help but share it.

Also converts these packages to `AutotoolsPackage`.