### PR TITLE
Rework `spack dependents` command

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -155,9 +155,9 @@ def set_color_when(when):
 def color_when(value):
     """Context manager to temporarily use a particular color setting."""
     old_value = value
-    set_color(value)
+    set_color_when(value)
     yield
-    set_color(old_value)
+    set_color_when(old_value)
 
 
 class match_to_ansi(object):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -166,15 +166,55 @@ def gray_hash(spec, length):
     return colorize('@K{%s}' % spec.dag_hash(length))
 
 
-def display_specs(specs, **kwargs):
-    mode = kwargs.get('mode', 'short')
-    hashes = kwargs.get('long', False)
-    namespace = kwargs.get('namespace', False)
-    flags = kwargs.get('show_flags', False)
-    variants = kwargs.get('variants', False)
+def display_specs(specs, args=None, **kwargs):
+    """Display human readable specs with customizable formatting.
+
+    Prints the supplied specs to the screen, formatted according to the
+    arguments provided.
+
+    Specs are grouped by architecture and compiler, and columnized if
+    possible.  There are three possible "modes":
+
+      * ``short`` (default): short specs with name and version, columnized
+      * ``paths``: Two columns: one for specs, one for paths
+      * ``deps``: Dependency-tree style, like ``spack spec``; can get long
+
+    Options can add more information to the default display. Options can
+    be provided either as keyword arguments or as an argparse namespace.
+    Keyword arguments take precedence over settings in the argparse
+    namespace.
+
+    Args:
+        specs (list of spack.spec.Spec): the specs to display
+        args (optional argparse.Namespace): namespace containing
+            formatting arguments
+
+    Keyword Args:
+        mode (str): Either 'short', 'paths', or 'deps'
+        long (bool): Display short hashes with specs
+        very_long (bool): Display full hashes with specs (supersedes ``long``)
+        namespace (bool): Print namespaces along with names
+        show_flags (bool): Show compiler flags with specs
+        variants (bool): Show variants with specs
+
+    """
+    def get_arg(name, default=None):
+        """Prefer kwargs, then args, then default."""
+        if name in kwargs:
+            return kwargs.get(name)
+        elif args is not None:
+            return getattr(args, name, default)
+        else:
+            return default
+
+    mode      = get_arg('mode', 'short')
+    hashes    = get_arg('long', False)
+    namespace = get_arg('namespace', False)
+    flags     = get_arg('show_flags', False)
+    variants  = get_arg('variants', False)
 
     hlen = 7
-    if kwargs.get('very_long', False):
+    if get_arg('very_long', False):
         hashes = True
         hlen = None
 

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -1,0 +1,87 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import argparse
+
+import llnl.util.tty as tty
+from llnl.util.tty.colify import colify
+
+import spack
+import spack.store
+import spack.cmd
+
+description = "show dependencies of a package"
+section = "basic"
+level = "long"
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-i', '--installed', action='store_true', default=False,
+        help="List installed dependencies of an installed spec, "
+        "instead of possible dependencies of a package.")
+    subparser.add_argument(
+        '-t', '--transitive', action='store_true', default=False,
+        help="Show all transitive dependencies.")
+    subparser.add_argument(
+        'spec', nargs=argparse.REMAINDER, help="spec or package name")
+
+
+def dependencies(parser, args):
+    specs = spack.cmd.parse_specs(args.spec)
+    if len(specs) != 1:
+        tty.die("spack dependencies takes only one spec.")
+
+    if args.installed:
+        spec = spack.cmd.disambiguate_spec(specs[0])
+
+        tty.msg("Dependencies of %s" % spec.format('$_$@$%@$/', color=True))
+        deps = spack.store.db.installed_relatives(
+            spec, 'children', args.transitive)
+        if deps:
+            spack.cmd.display_specs(deps, long=True)
+        else:
+            print("No dependencies")
+
+    else:
+        spec = specs[0]
+
+        if not spec.virtual:
+            packages = [spec.package]
+        else:
+            packages = [spack.repo.get(s.name)
+                        for s in spack.repo.providers_for(spec)]
+
+        dependencies = set()
+        for pkg in packages:
+            dependencies.update(
+                set(pkg.possible_dependencies(args.transitive)))
+
+        if spec.name in dependencies:
+            dependencies.remove(spec.name)
+
+        if dependencies:
+            colify(sorted(dependencies))
+        else:
+            print("No dependencies")

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -106,7 +106,7 @@ def dependents(parser, args):
         deps = spack.store.db.installed_relatives(
             spec, 'parents', args.transitive)
         if deps:
-            spack.cmd.display_specs(deps)
+            spack.cmd.display_specs(deps, long=True)
         else:
             print("No dependents")
 

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -45,8 +45,7 @@ def setup_parser(subparser):
         '-t', '--transitive', action='store_true', default=False,
         help="Show all transitive dependents.")
     subparser.add_argument(
-        'spec', nargs=argparse.REMAINDER,
-        help="spec or package name")
+        'spec', nargs=argparse.REMAINDER, help="spec or package name")
 
 
 def inverted_dependencies():
@@ -104,7 +103,8 @@ def dependents(parser, args):
         spec = spack.cmd.disambiguate_spec(specs[0])
 
         tty.msg("Dependents of %s" % spec.cformat('$_$@$%@$/'))
-        deps = spack.store.db.installed_dependents(spec)
+        deps = spack.store.db.installed_relatives(
+            spec, 'parents', args.transitive)
         if deps:
             spack.cmd.display_specs(deps)
         else:

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -25,6 +25,7 @@
 import argparse
 
 import llnl.util.tty as tty
+from llnl.util.tty.colify import colify
 
 import spack
 import spack.store
@@ -37,19 +38,68 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-a', '--all', action='store_true', default=False,
+        help="List all potential dependents of the package instead of actual "
+        "dependents of an installed spec")
+    subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
         help="specs to list dependencies of")
+
+
+def inverted_dag():
+    """Returns inverted package DAG as adjacency lists."""
+    dag = {}
+    for pkg in spack.repo.all_packages():
+        dag.setdefault(pkg.name, set())
+        for dep in pkg.dependencies:
+            deps = [dep]
+
+            # expand virtuals if necessary
+            if spack.repo.is_virtual(dep):
+                deps = [s.name for s in spack.repo.providers_for(dep)]
+
+            for d in deps:
+                dag.setdefault(d, set()).add(pkg.name)
+    return dag
+
+
+def all_dependents(name, inverted_dag, dependents=None):
+    if dependents is None:
+        dependents = set()
+
+    if name in dependents:
+        return set()
+    dependents.add(name)
+
+    direct = inverted_dag[name]
+    for dname in direct:
+        all_dependents(dname, inverted_dag, dependents)
+    dependents.update(direct)
+    return dependents
 
 
 def dependents(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
         tty.die("spack dependents takes only one spec.")
-    spec = spack.cmd.disambiguate_spec(specs[0])
 
-    tty.msg("Dependents of %s" % spec.cformat('$_$@$%@$/'))
-    deps = spack.store.db.installed_dependents(spec)
-    if deps:
-        spack.cmd.display_specs(deps)
+    if args.all:
+        spec = specs[0]
+        idag = inverted_dag()
+
+        dependents = all_dependents(spec.name, idag)
+        dependents.remove(spec.name)
+        if dependents:
+            colify(sorted(dependents))
+        else:
+            print("No dependents")
+
     else:
-        print("No dependents")
+        spec = spack.cmd.disambiguate_spec(specs[0])
+
+        tty.msg("Dependents of %s" % spec.cformat('$_$@$%@$/'))
+        deps = spack.store.db.installed_dependents(spec)
+        if deps:
+            spack.cmd.display_specs(deps)
+        else:
+            print("No dependents")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -128,10 +128,4 @@ def find(parser, args):
     if sys.stdout.isatty():
         tty.msg("%d installed packages." % len(query_specs))
 
-    display_specs(query_specs,
-                  mode=args.mode,
-                  long=args.long,
-                  very_long=args.very_long,
-                  show_flags=args.show_flags,
-                  namespace=args.namespace,
-                  variants=args.variants)
+    display_specs(query_specs, args)

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -90,7 +90,8 @@ def graph(parser, args):
     deptype = alldeps
     if args.deptype:
         deptype = tuple(args.deptype.split(','))
-        validate_deptype(deptype)
+        if deptype == ('all',):
+            deptype = 'all'
         deptype = canonical_deptype(deptype)
 
     if args.dot:  # Dot graph only if asked for.

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -128,8 +128,8 @@ def installed_dependents(specs):
     """
     dependents = {}
     for item in specs:
-        lst = [x for x in spack.store.db.installed_dependents(item)
-               if x not in specs]
+        installed = spack.store.db.installed_relatives(item, 'parents', True)
+        lst = [x for x in installed if x not in specs]
         if lst:
             lst = list(set(lst))
             dependents[item] = lst
@@ -157,7 +157,9 @@ def do_uninstall(specs, force):
     # Sort packages to be uninstalled by the number of installed dependents
     # This ensures we do things in the right order
     def num_installed_deps(pkg):
-        return len(spack.store.db.installed_dependents(pkg.spec))
+        dependents = spack.store.db.installed_relatives(
+            pkg.spec, 'parents', True)
+        return len(dependents)
 
     packages.sort(key=num_installed_deps)
     for item in packages:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -711,11 +711,16 @@ class Database(object):
             return self._remove(spec)
 
     @_autospec
-    def installed_dependents(self, spec):
+    def installed_dependents(self, spec, transitive=True):
         """List the installed specs that depend on this one."""
         dependents = set()
         for spec in self.query(spec):
-            for dependent in spec.traverse(direction='parents', root=False):
+            if transitive:
+                to_add = spec.traverse(direction='parents', root=False)
+            else:
+                to_add = spec.dependents()
+
+            for dependent in to_add:
                 dependents.add(dependent)
         return dependents
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -711,18 +711,34 @@ class Database(object):
             return self._remove(spec)
 
     @_autospec
-    def installed_dependents(self, spec, transitive=True):
-        """List the installed specs that depend on this one."""
-        dependents = set()
+    def installed_relatives(self, spec, direction='children', transitive=True):
+        """Return installed specs related to this one."""
+        if direction not in ('parents', 'children'):
+            raise ValueError("Invalid direction: %s" % direction)
+
+        relatives = set()
         for spec in self.query(spec):
             if transitive:
-                to_add = spec.traverse(direction='parents', root=False)
-            else:
+                to_add = spec.traverse(direction=direction, root=False)
+            elif direction == 'parents':
                 to_add = spec.dependents()
+            else:  # direction == 'children'
+                to_add = spec.dependencies()
 
-            for dependent in to_add:
-                dependents.add(dependent)
-        return dependents
+            for relative in to_add:
+                hash_key = relative.dag_hash()
+                if hash_key not in self._data:
+                    reltype = ('Dependent' if direction == 'parents'
+                               else 'Dependency')
+                    tty.warn("Inconsistent state! %s %s of %s not in DB"
+                             % (reltype, hash_key, spec.dag_hash()))
+                    continue
+
+                if not self._data[hash_key].installed:
+                    continue
+
+                relatives.add(relative)
+        return relatives
 
     @_autospec
     def installed_extensions_for(self, extendee_spec):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -241,8 +241,7 @@ def _depends_on(pkg, spec, when=None, type=None):
         #               but is most backwards-compatible.
         type = ('build', 'link')
 
-    if isinstance(type, str):
-        type = spack.spec.special_types.get(type, (type,))
+    type = spack.spec.canonical_deptype(type)
 
     for deptype in type:
         if deptype not in spack.spec.alldeps:

--- a/lib/spack/spack/hooks/case_consistency.py
+++ b/lib/spack/spack/hooks/case_consistency.py
@@ -39,7 +39,11 @@ def pre_run():
     if platform.system() != "Darwin":
         return
 
-    git_case_consistency_check(spack.repo.get_repo('builtin').packages_path)
+    try:
+        repo = spack.repo.get_repo('builtin')
+        git_case_consistency_check(repo.packages_path)
+    except spack.repository.UnknownNamespaceError:
+        pass
 
 
 def git_case_consistency_check(path):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -377,11 +377,14 @@ class SpackCommand(object):
         self.command = spack.cmd.get_command(command)
         self.fail_on_error = fail_on_error
 
-    def __call__(self, *argv):
+    def __call__(self, *argv, **kwargs):
         """Invoke this SpackCommand.
 
         Args:
             argv (list of str): command line arguments.
+
+        Keyword Args:
+            color (optional bool): force-disable or force-enable color
 
         Returns:
             (str, str): output and error as a strings

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1582,7 +1582,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                 raise InstallError(str(spec) + " is not installed.")
 
         if not force:
-            dependents = spack.store.db.installed_dependents(spec)
+            dependents = spack.store.db.installed_relatives(
+                spec, 'parents', True)
             if dependents:
                 raise PackageStillNeededError(spec, dependents)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -594,26 +594,31 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         self.extra_args = {}
 
-    def possible_dependencies(self, visited=None):
-        """Return set of possible transitive dependencies of this package."""
+    def possible_dependencies(self, transitive=True, visited=None):
+        """Return set of possible transitive dependencies of this package.
+
+        Args:
+            transitive (bool): include all transitive dependencies if True,
+                only direct dependencies if False.
+        """
         if visited is None:
             visited = set()
 
         visited.add(self.name)
         for name in self.dependencies:
-            if name in visited:
-                continue
-
             spec = spack.spec.Spec(name)
+
             if not spec.virtual:
-                pkg = spack.repo.get(name)
-                for name in pkg.possible_dependencies(visited):
-                    visited.add(name)
+                visited.add(name)
+                if transitive:
+                    pkg = spack.repo.get(name)
+                    pkg.possible_dependencies(transitive, visited)
             else:
                 for provider in spack.repo.providers_for(spec):
-                    pkg = spack.repo.get(provider.name)
-                    for name in pkg.possible_dependencies(visited):
-                        visited.add(name)
+                    visited.add(provider.name)
+                    if transitive:
+                        pkg = spack.repo.get(provider.name)
+                        pkg.possible_dependencies(transitive, visited)
 
         return visited
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -601,10 +601,19 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
         visited.add(self.name)
         for name in self.dependencies:
-            if name not in visited and not spack.spec.Spec(name).virtual:
+            if name in visited:
+                continue
+
+            spec = spack.spec.Spec(name)
+            if not spec.virtual:
                 pkg = spack.repo.get(name)
                 for name in pkg.possible_dependencies(visited):
                     visited.add(name)
+            else:
+                for provider in spack.repo.providers_for(spec):
+                    pkg = spack.repo.get(provider.name)
+                    for name in pkg.possible_dependencies(visited):
+                        visited.add(name)
 
         return visited
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2706,11 +2706,8 @@ class Spec(object):
         named_str = fmt = ''
 
         def write(s, c):
-            if color:
-                f = color_formats[c] + cescape(s) + '@.'
-                cwrite(f, stream=out, color=color)
-            else:
-                out.write(s)
+            f = color_formats[c] + cescape(s) + '@.'
+            cwrite(f, stream=out, color=color)
 
         iterator = enumerate(format_string)
         for i, c in iterator:
@@ -2802,7 +2799,7 @@ class Spec(object):
                         write(fmt % str(self.variants), '+')
                 elif named_str == 'ARCHITECTURE':
                     if self.architecture and str(self.architecture):
-                        write(fmt % str(self.architecture), ' arch=')
+                        write(fmt % str(self.architecture), '=')
                 elif named_str == 'SHA1':
                     if self.dependencies:
                         out.write(fmt % str(self.dag_hash(7)))

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -1,0 +1,77 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import re
+
+from llnl.util.tty.color import color_when
+
+import spack
+from spack.main import SpackCommand
+
+dependencies = SpackCommand('dependencies')
+
+mpis = ['mpich', 'mpich2', 'multi-provider-mpi', 'zmpi']
+mpi_deps = ['fake']
+
+
+def test_immediate_dependencies(builtin_mock):
+    out, err = dependencies('mpileaks')
+    actual = set(re.split(r'\s+', out.strip()))
+    expected = set(['callpath'] + mpis)
+    assert expected == actual
+
+
+def test_transitive_dependencies(builtin_mock):
+    out, err = dependencies('--transitive', 'mpileaks')
+    actual = set(re.split(r'\s+', out.strip()))
+    expected = set(
+        ['callpath', 'dyninst', 'libdwarf', 'libelf'] + mpis + mpi_deps)
+    assert expected == actual
+
+
+def test_immediate_installed_dependencies(builtin_mock, database):
+    with color_when(False):
+        out, err = dependencies('--installed', 'mpileaks^mpich')
+
+    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
+    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+
+    expected = set([spack.store.db.query_one(s).dag_hash(7)
+                    for s in ['mpich', 'callpath^mpich']])
+
+    assert expected == hashes
+
+
+def test_transitive_installed_dependencies(builtin_mock, database):
+    with color_when(False):
+        out, err = dependencies('--installed', '--transitive', 'mpileaks^zmpi')
+
+    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
+    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+
+    expected = set([spack.store.db.query_one(s).dag_hash(7)
+                    for s in ['zmpi', 'callpath^zmpi', 'fake',
+                              'dyninst', 'libdwarf', 'libelf']])
+
+    assert expected == hashes

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -1,0 +1,74 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import re
+
+from llnl.util.tty.color import color_when
+
+import spack
+from spack.main import SpackCommand
+
+dependents = SpackCommand('dependents')
+
+
+def test_immediate_dependents(builtin_mock):
+    out, err = dependents('libelf')
+    actual = set(re.split(r'\s+', out.strip()))
+    assert actual == set(['dyninst', 'libdwarf'])
+
+
+def test_transitive_dependents(builtin_mock):
+    out, err = dependents('--transitive', 'libelf')
+    actual = set(re.split(r'\s+', out.strip()))
+    assert actual == set(
+        ['callpath', 'dyninst', 'libdwarf', 'mpileaks', 'multivalue_variant'])
+
+
+def test_immediate_installed_dependents(builtin_mock, database):
+    with color_when(False):
+        out, err = dependents('--installed', 'libelf')
+
+    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
+    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+
+    expected = set([spack.store.db.query_one(s).dag_hash(7)
+                    for s in ['dyninst', 'libdwarf']])
+
+    libelf = spack.store.db.query_one('libelf')
+    expected = set([d.dag_hash(7) for d in libelf.dependents()])
+
+    assert expected == hashes
+
+
+def test_transitive_installed_dependents(builtin_mock, database):
+    with color_when(False):
+        out, err = dependents('--installed', '--transitive', 'fake')
+
+    lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
+    hashes = set([re.split(r'\s+', l)[0] for l in lines])
+
+    expected = set([spack.store.db.query_one(s).dag_hash(7)
+                    for s in ['zmpi', 'callpath^zmpi', 'mpileaks^zmpi']])
+
+    assert expected == hashes

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -30,7 +30,7 @@ import spack
 import spack.architecture
 import spack.package
 
-from spack.spec import Spec
+from spack.spec import Spec, canonical_deptype, alldeps
 
 
 def check_links(spec_to_check):
@@ -737,3 +737,54 @@ class TestSpecDag(object):
 
         with pytest.raises(AttributeError):
             q.libs
+
+    def test_canonical_deptype(self):
+        # special values
+        assert canonical_deptype(all) == alldeps
+        assert canonical_deptype('all') == alldeps
+        assert canonical_deptype(None) == alldeps
+
+        # everything in alldeps is canonical
+        for v in alldeps:
+            assert canonical_deptype(v) == (v,)
+
+        # tuples
+        assert canonical_deptype(('build',)) == ('build',)
+        assert canonical_deptype(
+            ('build', 'link', 'run')) == ('build', 'link', 'run')
+        assert canonical_deptype(
+            ('build', 'link')) == ('build', 'link')
+        assert canonical_deptype(
+            ('build', 'run')) == ('build', 'run')
+
+        # lists
+        assert canonical_deptype(
+            ['build', 'link', 'run']) == ('build', 'link', 'run')
+        assert canonical_deptype(
+            ['build', 'link']) == ('build', 'link')
+        assert canonical_deptype(
+            ['build', 'run']) == ('build', 'run')
+
+        # sorting
+        assert canonical_deptype(
+            ('run', 'build', 'link')) == ('build', 'link', 'run')
+        assert canonical_deptype(
+            ('run', 'link', 'build')) == ('build', 'link', 'run')
+        assert canonical_deptype(
+            ('run', 'link')) == ('link', 'run')
+        assert canonical_deptype(
+            ('link', 'build')) == ('build', 'link')
+
+        # can't put 'all' in tuple or list
+        with pytest.raises(ValueError):
+            canonical_deptype(['all'])
+        with pytest.raises(ValueError):
+            canonical_deptype(('all',))
+
+        # invalid values
+        with pytest.raises(ValueError):
+            canonical_deptype('foo')
+        with pytest.raises(ValueError):
+            canonical_deptype(('foo', 'bar'))
+        with pytest.raises(ValueError):
+            canonical_deptype(('foo',))

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -107,10 +107,6 @@ def coerced(method):
     return coercing_method
 
 
-def _numeric_lt(self0, other):
-    """Compares two versions, knowing they're both numeric"""
-
-
 class Version(object):
     """Class to represent versions"""
 


### PR DESCRIPTION
Resolves #4414.
Resolves #4334.

`spack dependents` now shows *possible* dependencies for a package by default, and you can display dependents for an installed spec with `spack dependents --installed`.  By default it shows direct dependents; you can show all transitive dependents with `--transitive`.

Note that previously the command only operated on installed specs, and it only showed all transitive dependencies.  The default behavior now is to show possible direct dependencies for packages.

TODO: 
- [x] Show possible dependents instead of installed dependents
- [x] `--installed` argument
- [x] `--transitive` argument
- [ ] add analogous `spack dependencies` command

Two things that I'll hold off on but might be interesting to think about:

1. Only show dependencies through certain dependency types.  Really requires a little path expression language.  e.g., only show transitive run dependencies of direct build dependencies might be something like `spack dependents --type 'br*'`.
1. Take partial specs and show only things that could possibly depend on *those*.  e.g. if you write `spack dependents foo@1.6` and `bar` can only ever depend on `foo@:1.5`, then `bar` shouldn't show up in the output.  This requires a fancier solver so I'll hold off on it.

@samfux84 @adamjstewart @markcmiller86 