### PR TITLE
ISAAC Server: Less Strict Deps

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -45,6 +45,8 @@ class IsaacServer(CMakePackage):
     #         'Support for RTP streams, e.g. to Twitch or Youtube')
 
     depends_on('cmake@3.3:', type='build')
-    depends_on('isaac')
-    depends_on('libwebsockets')
+    depends_on('libjpeg-turbo', type='link')
+    depends_on('jansson', type='link')
+    depends_on('boost@1.56:', type='link')
+    depends_on('libwebsockets', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')


### PR DESCRIPTION
I just realized that the dependencies of the server packages were overly strict (#3733) and pulled in too many dependencies (e.g. CUDA).

This fixes it.