### PR TITLE
openblas: Fix build on aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -24,13 +24,14 @@
 ##############################################################################
 from spack import *
 from spack.package_test import *
+import spack.architecture
 import os
 
 
 class Openblas(MakefilePackage):
     """OpenBLAS: An optimized BLAS library"""
     homepage = 'http://www.openblas.net'
-    url = 'http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz'
+    url = 'http://github.com/xianyi/OpenBLAS/archive/v0.2.19.tar.gz'
 
     version('0.2.19', '28c998054fd377279741c6f0b9ea7941')
     version('0.2.18', '805e7f660877d588ea7e3792cda2ee65')
@@ -97,6 +98,12 @@ class Openblas(MakefilePackage):
             'FC={0}'.format(spack_f77),
             'MAKE_NO_J=1'
         ]
+        # invoke make with the correct TARGET for aarch64
+        if 'aarch64' in spack.architecture.sys_type():
+            make_defs += [
+                'TARGET=PILEDRIVER',
+                'TARGET=ARMV8'
+            ]
         if self.spec.satisfies('%gcc@:4.8.4'):
             make_defs += ['NO_AVX2=1']
         if '~shared' in self.spec:


### PR DESCRIPTION
- invoke make with the correct TARGET for aarch64
- force PILERDRIVER as openblas cannot correctly detect CPU on aarch64
- update url to more recent version