### PR TITLE
metis: bugfix: make shared library build portable

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -135,7 +135,8 @@ class Metis(Package):
 
         # Set up and run tests on installation
         ccompile('-I%s' % prefix.include, '-L%s' % prefix.lib,
-                 '-Wl,-rpath=%s' % (prefix.lib if '+shared' in spec else ''),
+                 self.compiler.cc_rpath_arg +
+                 '%s' % (prefix.lib if '+shared' in spec else ''),
                  join_path('Programs', 'io.o'), join_path('Test', 'mtest.c'),
                  '-o', '%s/mtest' % prefix.bin, '-lmetis', '-lm')
 


### PR DESCRIPTION
Fixes #4488. When compiling metis as a shared library, the package
used the syntax `-rpath=`, followed by a path. This syntax is
non-portable, so replace it using Spack's compiler rpath argument
property.