### PR TITLE
ipopt 3.12.7

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -40,10 +40,14 @@ class Ipopt(Package):
     version('3.12.1', 'ceaf895ce80c77778f2cab68ba9f17f3')
     version('3.12.0', 'f7dfc3aa106a6711a85214de7595e827')
 
+    variant('coinhsl', default=False,
+            description="Build with Coin Harwell Subroutine Libraries")
+
     depends_on("blas")
     depends_on("lapack")
     depends_on("pkg-config", type='build')
     depends_on("mumps+double~mpi")
+    depends_on('coinhsl', when='+coinhsl')
 
     def install(self, spec, prefix):
         # Dependency directories
@@ -70,6 +74,11 @@ class Ipopt(Package):
             "--with-lapack-incdir=%s" % lapack_dir.include,
             "--with-lapack-lib=%s" % lapack_lib
         ]
+
+        if 'coinhsl' in spec:
+            configure_args.extend([
+                '--with-hsl-lib=%s' % spec['coinhsl'].libs.ld_flags,
+                '--with-hsl-incdir=%s' % spec['coinhsl'].prefix.include])
 
         configure(*configure_args)
 

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -31,6 +31,9 @@ class Ipopt(Package):
     homepage = "https://projects.coin-or.org/Ipopt"
     url      = "http://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.4.tgz"
 
+    version('3.12.7', '2a36e4a04717a8ed7012ac7d1253ae4ffbc1a8fd')
+    version('3.12.6', 'ed4072427fab786fcf6082fe7e6f6c2ed9b5e6f8')
+    version('3.12.5', '3f63ddfff517235ead17af6cceb426ca858dda37')
     version('3.12.4', '12a8ecaff8dd90025ddea6c65b49cb03')
     version('3.12.3', 'c560cbfa9cbf62acf8b485823c255a1b')
     version('3.12.2', 'ec1e855257d7de09e122c446506fb00d')

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -42,12 +42,15 @@ class Ipopt(Package):
 
     variant('coinhsl', default=False,
             description="Build with Coin Harwell Subroutine Libraries")
+    variant('metis', default=False,
+            description="Build with METIS partitioning support")
 
     depends_on("blas")
     depends_on("lapack")
     depends_on("pkg-config", type='build')
     depends_on("mumps+double~mpi")
     depends_on('coinhsl', when='+coinhsl')
+    depends_on('metis@4.0:4.999', when='+metis')
 
     def install(self, spec, prefix):
         # Dependency directories
@@ -79,6 +82,11 @@ class Ipopt(Package):
             configure_args.extend([
                 '--with-hsl-lib=%s' % spec['coinhsl'].libs.ld_flags,
                 '--with-hsl-incdir=%s' % spec['coinhsl'].prefix.include])
+
+        if 'metis' in spec:
+            configure_args.extend([
+                '--with-metis-lib=%s' % spec['metis'].libs.ld_flags,
+                '--with-metis-incdir=%s' % spec['metis'].prefix.include])
 
         configure(*configure_args)
 


### PR DESCRIPTION
The commits for #4489 and #4482 are mingled into this commit also; need to figure out a way to separate them. Anyway, the last three commits constitute the ipopt changes, and these changes depend on merging #4482 and #4489.