### PR TITLE
Fix dashes in variant parsing

### DIFF
--- a/lib/spack/spack/test/cmd/flake8.py
+++ b/lib/spack/spack/test/cmd/flake8.py
@@ -81,6 +81,7 @@ def test_changed_files(parser, flake8_package):
     sys.version_info[:2] <= (2, 6) or
     (3, 0) <= sys.version_info[:2] <= (3, 3),
     reason='flake8 no longer supports Python 2.6 or 3.3 and older')
+@pytest.mark.skipif(not which('flake8'), reason='flake8 is not installed.')
 def test_flake8(parser, flake8_package):
     # Only test the flake8_package that we modified
     # Otherwise, the unit tests would fail every time


### PR DESCRIPTION
Fixes #4491.

This bug was introduced by #3033 with the new parser that added.   Using `nargs='?'` instead of `argparse.REMAINDER` causes `argparse` to parse farther than it should and start interpreting specs as args.