### PR TITLE
Fix tpetra-related xsdk errors

### DIFF
--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -48,9 +48,9 @@ class Xsdk(Package):
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0')
     depends_on('superlu-dist@develop', when='@develop')
 
-    depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2',
+    depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2~exodus',
                when='@xsdk-0.2.0')
-    depends_on('trilinos@develop+xsdkflags+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2',
+    depends_on('trilinos@develop+xsdkflags+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2~exodus',
                when='@develop')
 
     depends_on('petsc@xsdk-0.2.0+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps~boost',

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -48,9 +48,9 @@ class Xsdk(Package):
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0')
     depends_on('superlu-dist@develop', when='@develop')
 
-    depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra',
+    depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2',
                when='@xsdk-0.2.0')
-    depends_on('trilinos@develop+xsdkflags+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra',
+    depends_on('trilinos@develop+xsdkflags+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2',
                when='@develop')
 
     depends_on('petsc@xsdk-0.2.0+trilinos+mpi+hypre+superlu-dist+metis+hdf5~mumps~boost',


### PR DESCRIPTION
Recent changes to the trilinos package broke the xsdk build.
xSDK explicitly disables tpetra, but packages depending on it
(such as ifpack2 and amesos2) are explicitly enabled by default
in the trilinos package.  This commit explicitly disables them
within the xsdk package.py.