### PR TITLE
Gtkplus icons

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -48,3 +48,5 @@ class Atk(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",
                                self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS",
+                             self.prefix.share)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -49,3 +49,5 @@ class GdkPixbuf(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",
                                self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS",
+                             self.prefix.share)

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -52,3 +52,7 @@ class Gtkplus(AutotoolsPackage):
         # remove disable deprecated flag.
         filter_file(r'CFLAGS="-DGDK_PIXBUF_DISABLE_DEPRECATED $CFLAGS"',
                     '', 'configure', string=True)
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS",
+                               self.prefix.share)

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -57,3 +57,5 @@ class Gtkplus(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",
                                self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS",
+                             self.prefix.share)

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -45,6 +45,7 @@ class Gtkplus(AutotoolsPackage):
     depends_on("pango~X", when='~X')
     depends_on("pango+X", when='+X')
     depends_on('gobject-introspection', when='+X')
+    depends_on('shared-mime-info')
 
     patch('no-demos.patch')
 

--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -64,3 +64,5 @@ class Pango(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",
                                self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS",
+                             self.prefix.share)

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -43,3 +43,5 @@ class SharedMimeInfo(AutotoolsPackage):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",
                                self.prefix.share)
+        run_env.prepend_path("XDG_DATA_DIRS",
+                             self.prefix.share)

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -38,6 +38,7 @@ class SharedMimeInfo(AutotoolsPackage):
 
     depends_on('glib')
     depends_on('libxml2')
+    depends_on('intltool', type='build')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         spack_env.prepend_path("XDG_DATA_DIRS",

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -1,0 +1,44 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+from spack import *
+
+
+class SharedMimeInfo(AutotoolsPackage):
+    """Database of common MIME types."""
+
+    homepage = "https://freedesktop.org/wiki/Software/shared-mime-info"
+    url      = "http://freedesktop.org/~hadess/shared-mime-info-1.8.tar.xz"
+
+    version('1.8', 'f6dcadce764605552fc956563efa058c')
+
+    parallel = False
+
+    depends_on('glib')
+    depends_on('libxml2')
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        spack_env.prepend_path("XDG_DATA_DIRS",
+                               self.prefix.share)


### PR DESCRIPTION
When using the py-pygtk package to run a graphical application, I was receiving hundreds of warning messages about missing gtk icons, and some buttons were blank.

A set of stock icons are normally embedded in one of the gtkplus libraries by processing a directory of icon image files. The program used for the processing, `gtk-update-icon-cache`, is built as part of gtkplus. The program was running without error, but when I checked the output file, the size was much smaller than I expected, suggesting that the icons were not being included.

It turns out that `gtk-update-icon-cache` was trying to find the database of mime types, but was excluding the system database in `/usr/share/mime`. The reason was that some of the spack dependencies set the environment variable `XDG_DATA_DIRS`, which has the side-effect of disabling the default search path for gtkplus applications.

Although I could have appended `/usr/share/mime` to `XDG_DATA_DIRS`, I chose to create a new spack package (shared-mime-info) so that gtkplus could list it as a dependency.

After reinstalling gtkplus (with shared-mime-info) and py-pygtk, my graphical application worked as expected.