### PR TITLE
oce changes for cgm

### DIFF
--- a/var/spack/repos/builtin/packages/cgm/package.py
+++ b/var/spack/repos/builtin/packages/cgm/package.py
@@ -37,29 +37,15 @@ class Cgm(AutotoolsPackage):
     version('13.1.0', 'a6c7b22660f164ce893fb974f9cb2028')
     version('13.1', '95f724bda04919fc76818a5b7bc0b4ed')
 
-    variant("mpi", default=False, description='enable mpi support')
+    variant("mpi", default=True, description='enable mpi support')
     variant("oce", default=False, description='enable oce geometry kernel')
 
     depends_on('mpi', when='+mpi')
     depends_on('oce+X11', when='+oce')
 
-    def url_for_version(self, version):
-        if Version('13.0') <= version <= Version('13.999'):
-            return "http://ftp.mcs.anl.gov/pub/fathom/cgm{0}.tar.gz".format(version)
-        else:
-            return "http://ftp.mcs.anl.gov/pub/fathom/cgm-{0}.tar.gz".format(version)
-
-    def patch(self):
-        if self.version < Version('14.1'):
-            filter_file('^(#include "CGMParallelConventions.h")',
-                        '//\1',
-                        'geom/parallel/CGMReadParallel.cpp')
-
     def configure_args(self):
         spec = self.spec
-
-        args = [
-        ]
+        args = []
 
         if '+mpi' in spec:
             args.extend([
@@ -67,9 +53,12 @@ class Cgm(AutotoolsPackage):
                 "CC={0}".format(spec['mpi'].mpicc),
                 "CXX={0}".format(spec['mpi'].mpicxx)
             ])
+        else:
+            args.append("--without-mpi")
 
         if '+oce' in spec:
-            args.extend([
-                "--with-occ={0}".format(spec['oce'].prefix)
-            ])
+            args.append("--with-occ={0}".format(spec['oce'].prefix))
+        else:
+            args.append("--without-occ")
+
         return args

--- a/var/spack/repos/builtin/packages/cgm/package.py
+++ b/var/spack/repos/builtin/packages/cgm/package.py
@@ -25,30 +25,51 @@
 from spack import *
 
 
-class Cgm(Package):
+class Cgm(AutotoolsPackage):
     """The Common Geometry Module, Argonne (CGMA) is a code library
        which provides geometry functionality used for mesh generation and
        other applications."""
-    homepage = "http://trac.mcs.anl.gov/projects/ITAPS/wiki/CGM"
-    url      = "http://ftp.mcs.anl.gov/pub/fathom/cgm13.1.1.tar.gz"
+    homepage = "http://sigma.mcs.anl.gov/cgm-library"         
+    url = "http://ftp.mcs.anl.gov/pub/fathom/cgm-16.0.tar.gz"
 
+    version('16.0', 'a68aa5954d82502ff75d5eb91a29a01c')
     version('13.1.1', '4e8dbc4ba8f65767b29f985f7a23b01f')
     version('13.1.0', 'a6c7b22660f164ce893fb974f9cb2028')
     version('13.1', '95f724bda04919fc76818a5b7bc0b4ed')
 
-    depends_on("mpi")
+    variant("mpi", default=False, description='enable mpi support')
+    variant("oce", default=False, description='enable oce geometry kernel')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('oce+X11', when='+oce')
+
+    def url_for_version(self, version):
+        if Version('13.0') <= version <= Version('13.999'):
+            return "http://ftp.mcs.anl.gov/pub/fathom/cgm{0}.tar.gz".format(version)
+        else:
+            return "http://ftp.mcs.anl.gov/pub/fathom/cgm-{0}.tar.gz".format(version)
 
     def patch(self):
-        filter_file('^(#include "CGMParallelConventions.h")',
-                    '//\1',
-                    'geom/parallel/CGMReadParallel.cpp')
+        if self.version < Version('14.1'):
+            filter_file('^(#include "CGMParallelConventions.h")',
+                        '//\1',
+                        'geom/parallel/CGMReadParallel.cpp')
 
-    def install(self, spec, prefix):
-        configure("--with-mpi",
-                  "--prefix=%s" % prefix,
-                  "CFLAGS=-static",
-                  "CXXFLAGS=-static",
-                  "FCFLAGS=-static")
+    def configure_args(self):
+        spec = self.spec
 
-        make()
-        make("install")
+        args = [
+        ]
+
+        if '+mpi' in spec:
+            args.extend([
+                "--with-mpi",
+                "CC={0}".format(spec['mpi'].mpicc),
+                "CXX={0}".format(spec['mpi'].mpicxx)
+            ])
+
+        if '+oce' in spec:
+            args.extend([
+                "--with-occ={0}".format(spec['oce'].prefix)
+            ])
+        return args

--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -32,7 +32,7 @@ class Oce(Package):
     Open CASCADE library.
     """
     homepage = "https://github.com/tpaviot/oce"
-    url      = "https://github.com/tpaviot/oce/archive/OCE-0.18.tar.gz"
+    url = "https://github.com/tpaviot/oce/archive/OCE-0.18.tar.gz"
 
     version('0.18.1', '2a7597f4243ee1f03245aeeb02d00956')
     version('0.18',   '226e45e77c16a4a6e127c71fefcd171410703960ae75c7ecc7eb68895446a993')
@@ -44,6 +44,8 @@ class Oce(Package):
 
     variant('tbb', default=True,
             description='Build with Intel Threading Building Blocks')
+    variant('X11', default=False,
+            description='Build with X11 enabled')
 
     depends_on('cmake@2.8:', type='build')
     depends_on('tbb', when='+tbb')
@@ -70,7 +72,8 @@ class Oce(Package):
             '-DOCE_BUILD_SHARED_LIB:BOOL=ON',
             '-DCMAKE_BUILD_TYPE:STRING=Release',
             '-DOCE_DATAEXCHANGE:BOOL=ON',
-            '-DOCE_DISABLE_X11:BOOL=ON',
+            '-DOCE_DISABLE_X11:BOOL=%s' % (
+                'OFF' if '+X11' in spec else 'ON'),
             '-DOCE_DRAW:BOOL=OFF',
             '-DOCE_MODEL:BOOL=ON',
             '-DOCE_MULTITHREAD_LIBRARY:STRING=%s' % (


### PR DESCRIPTION
cgm can be configured with oce, but oce needs
to have X11 enabled, because some libraries needed by cgm
(like TKCAF in occ/oce) gets built only if X11 is NOT disabled
so introduce a variant +X11 for oce, which is needed when
configuring cgm with oce(+X11)
Also, use AutotoolsPackage for cgm, add new released version
mpi and oce are optional