### PR TITLE
System config

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -95,7 +95,7 @@ by settings in ``system``, ``system/bgq``, ``site``, ``site/bgq``,
 1. ``defaults``
 2. ``defaults/<platform>``
 3. ``system``
-4. ``system/<platform>
+4. ``system/<platform>``
 5. ``site``
 6. ``site/<platform>``
 7. ``user``

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -47,25 +47,25 @@ Configuration Scopes
 Spack pulls configuration data from files in several directories. There
 are four configuration scopes.  From lowest to highest:
 
-1. **defaults**: Stored in ``$(prefix)/etc/spack/defaults/``. These are
+#. **defaults**: Stored in ``$(prefix)/etc/spack/defaults/``. These are
    the "factory" settings. Users should generally not modify the settings
    here, but should override them in other configuration scopes. The
    defaults here will change from version to version of Spack.
 
-2. **system**: Stored in ``/etc/spack``. These are settings for this
+#. **system**: Stored in ``/etc/spack``. These are settings for this
    machine, or for all machines on which this file system is
    mounted. The site scope can be used for settings idiosyncratic to a
    particular machine, such as the locations of compilers or external
    packages. These settings are presumably controlled by someone with
    root access on the machine.
 
-2. **site**: Stored in ``$(prefix)/etc/spack/``.  Settings here affect
+#. **site**: Stored in ``$(prefix)/etc/spack/``.  Settings here affect
    only *this instance* of Spack, and they override defaults.  The site
    scope can can be used for per-project settings (one spack instance per
    project) or for site-wide settings on a multi-user machine (e.g., for
    a common spack instance).
 
-3. **user**: Stored in the home directory: ``~/.spack/``. These settings
+#. **user**: Stored in the home directory: ``~/.spack/``. These settings
    affect all instances of Spack and take the highest precedence.
 
 Each configuration directory may contain several configuration files,

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -45,12 +45,19 @@ Configuration Scopes
 -------------------------
 
 Spack pulls configuration data from files in several directories. There
-are three configuration scopes.  From lowest to highest:
+are four configuration scopes.  From lowest to highest:
 
 1. **defaults**: Stored in ``$(prefix)/etc/spack/defaults/``. These are
    the "factory" settings. Users should generally not modify the settings
    here, but should override them in other configuration scopes. The
    defaults here will change from version to version of Spack.
+
+2. **system**: Stored in ``/etc/spack``. These are settings for this
+   machine, or for all machines on which this file system is
+   mounted. The site scope can be used for settings idiosyncratic to a
+   particular machine, such as the locations of compilers or external
+   packages. These settings are presumably controlled by someone with
+   root access on the machine.
 
 2. **site**: Stored in ``$(prefix)/etc/spack/``.  Settings here affect
    only *this instance* of Spack, and they override defaults.  The site
@@ -78,22 +85,25 @@ Platform-specific scopes
 -------------------------
 
 For each scope above, there can *also* be platform-specific settings.
-For example, on Blue Gene/Q machines, Spack needs to know the location of
-cross-compilers for the compute nodes.  This configuration is in
-``etc/spack/defaults/bgq/compilers.yaml``.  It will take precedence over
-settings in the ``defaults`` scope, but can still be overridden by
-settings in ``site``, ``site/bgq``, ``user``, or ``user/bgq``. So, the
-full scope precedence is:
+For example, on Blue Gene/Q machines, Spack needs to know the location
+of cross-compilers for the compute nodes.  This configuration is in
+``etc/spack/defaults/bgq/compilers.yaml``.  It will take precedence
+over settings in the ``defaults`` scope, but can still be overridden
+by settings in ``system``, ``system/bgq``, ``site``, ``site/bgq``,
+``user``, or ``user/bgq``. So, the full scope precedence is:
 
 1. ``defaults``
 2. ``defaults/<platform>``
-3. ``site``
-4. ``site/<platform>``
-5. ``user``
-6. ``user/<platform>``
+3. ``system``
+4. ``system/<platform>
+5. ``site``
+6. ``site/<platform>``
+7. ``user``
+8. ``user/<platform>``
 
 You can get the name to use for ``<platform>`` by running ``spack arch
---platform``.
+--platform``. The system config scope has a ``<platform>`` section for
+sites at which ``/etc`` is mounted on multiple heterogeneous machines.
 
 -------------------------
 Scope precedence

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -64,9 +64,9 @@ mock_packages_path = join_path(repos_path, "builtin.mock")
 user_config_path = os.path.expanduser('~/.spack')
 
 prefix = spack_root
-opt_path       = join_path(prefix, "opt")
-etc_path       = join_path(prefix, "etc")
-
+opt_path        = join_path(prefix, "opt")
+etc_path        = join_path(prefix, "etc")
+system_etc_path = '/etc'
 
 # GPG paths.
 gpg_keys_path      = join_path(var_path, "gpg")

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -100,7 +100,8 @@ def get_compiler_config(scope=None, init_config=True):
             # Check the site config and update the user config if
             # nothing is configured at the site level.
             site_config = spack.config.get_config('compilers', scope='site')
-            if not site_config:
+            sys_config = spack.config.get_config('compilers', scope='system')
+            if not site_config and not sys_config:
                 init_compiler_config()
                 config = spack.config.get_config('compilers', scope=scope)
         return config

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -30,6 +30,7 @@ documentation on :ref:`configuration-scopes` for details on how Spack's
 configuration system behaves.  The scopes are:
 
   #. ``default``
+  #. ``system``
   #. ``site``
   #. ``user``
 
@@ -211,10 +212,16 @@ class ConfigScope(object):
 _platform = spack.architecture.platform().name
 
 """Default configuration scope is the lowest-level scope. These are
-   versioned with Spack and can be overridden by sites or users."""
+   versioned with Spack and can be overridden by systems, sites or users."""
 _defaults_path = os.path.join(spack.etc_path, 'spack', 'defaults')
 ConfigScope('defaults', _defaults_path)
 ConfigScope('defaults/%s' % _platform, os.path.join(_defaults_path, _platform))
+
+"""System configuration is per machine.
+   No system-level configs should be checked into spack by default"""
+_system_path = os.path.join(spack.system_etc_path, 'spack')
+ConfigScope('system', _system_path)
+ConfigScope('system/%s' % _platform, os.path.join(_system_path, _platform))
 
 """Site configuration is per spack instance, for sites or projects.
    No site-level configs should be checked into spack by default."""
@@ -226,7 +233,6 @@ ConfigScope('site/%s' % _platform, os.path.join(_site_path, _platform))
 _user_path = spack.user_config_path
 ConfigScope('user', _user_path)
 ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
-
 
 def highest_precedence_scope():
     """Get the scope with highest precedence (prefs will override others)."""
@@ -398,6 +404,7 @@ def get_config(section, scope=None):
 
     for scope in scopes:
         # read potentially cached data from the scope.
+
         data = scope.get_section(section)
 
         # Skip empty configs

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -234,6 +234,7 @@ _user_path = spack.user_config_path
 ConfigScope('user', _user_path)
 ConfigScope('user/%s' % _platform, os.path.join(_user_path, _platform))
 
+
 def highest_precedence_scope():
     """Get the scope with highest precedence (prefs will override others)."""
     return config_scopes.values()[-1]

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -173,6 +173,7 @@ def config(configuration_dir):
     real_scope = spack.config.config_scopes
     spack.config.config_scopes = ordereddict_backport.OrderedDict()
     spack.config.ConfigScope('site', str(configuration_dir.join('site')))
+    spack.config.ConfigScope('system', str(configuration_dir.join('system')))
     spack.config.ConfigScope('user', str(configuration_dir.join('user')))
     Config = collections.namedtuple('Config', ['real', 'mock'])
 


### PR DESCRIPTION
Allow sites to set a system configuration file for spack in /etc/spack.

The system config scope falls between site/instance and default in priority.

Spack will have those configurations "out of the box" on that machine.

