### PR TITLE
py-cdat-lite: ensure that RPATH includes netcdf

### DIFF
--- a/var/spack/repos/builtin/packages/py-cdat-lite/package.py
+++ b/var/spack/repos/builtin/packages/py-cdat-lite/package.py
@@ -40,3 +40,14 @@ class PyCdatLite(PythonPackage):
     depends_on("python@2.5:2.8", type=('build', 'run'))
     depends_on("py-numpy", type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+
+    phases = ['install']
+
+    def install(self, spec, prefix):
+        """Install everything from build directory."""
+        install_args = self.install_args(spec, prefix)
+        # Combine all phases into a single setup.py command,
+        # otherwise extensions are rebuilt without rpath by install phase:
+        self.setup_py('build_ext', '--rpath=%s' % ":".join(self.rpath),
+                      'build_py', 'build_scripts',
+                      'install', *install_args)


### PR DESCRIPTION
In py-cdat-lite, the netcdf library was not being found during `import cdms2` (unless a suitable library was installed in a system directory). I now set the RPATH explicitly in the install method of the package.