### PR TITLE
py-pillow: ensure that RPATH includes graphics libraries

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -129,4 +129,6 @@ class PyPillow(PythonPackage):
             return '--{0}-{1}'.format(able, variant)
 
         variants = ['jpeg', 'zlib', 'tiff', 'freetype', 'lcms', 'jpeg2000']
-        return list(map(variant_to_flag, variants))
+        args = list(map(variant_to_flag, variants))
+        args.extend(['--rpath=%s' % ":".join(self.rpath)])
+        return args


### PR DESCRIPTION
After installing py-pillow, the jpeg library was not detected when converting images. After setting RPATH explicitly during package installation, image conversions worked as expected.

This is the second RPATH problem I have had today with python packages. The problem could be resolved by using the spack compiler wrappers for package installation, but python is configured to use the real compilers (by the `filter_compilers` method of the `python` package). This makes it easier for users to install packages without spack, but it causes problems when installing packages with spack. Perhaps it would be better to configure python to use a generic compiler (e.g. gcc) so that the actual compiler can be specified through environment variables (set by environment modules or spack).