### PR TITLE
Adding variants for MFEM

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -144,7 +144,32 @@ class Mfem(Package):
     def install(self, spec, prefix):
         self.check_variants(spec)
 
-        options = []
+        yes_no = ('NO', 'YES')
+
+        metis_str = 'NO'
+        if '+parmetis' in spec or \
+           ('+metis' in spec and spec['metis'].satisfies('@5:')):
+            metis_str = 'YES'
+
+        threadsafe_str = 'NO'
+        if '+openmp' in spec or '+threadsafe' in spec:
+            threadsafe_str = 'YES'
+
+        options = [
+            'PREFIX=%s' % prefix,
+            'MFEM_DEBUG=%s' % yes_no['+debug' in spec],
+            'MFEM_USE_METIS_5=%s' % metis_str,
+            'MFEM_THREAD_SAFE=%s' % threadsafe_str,
+            'MFEM_USE_MPI=%s' % yes_no['+mpi' in spec],
+            'MFEM_USE_LAPACK=%s' % yes_no['+lapack' in spec],
+            'MFEM_USE_SUPERLU=%s' % yes_no['+superlu-dist' in spec],
+            'MFEM_USE_SUITESPARSE=%s' % yes_no['+suite-sparse' in spec],
+            'MFEM_USE_SUNDIALS=%s' % yes_no['+sundials' in spec],
+            'MFEM_USE_PETSC=%s' % yes_no['+petsc' in spec],
+            'MFEM_USE_MESQUITE=%s' % yes_no['+mesquite' in spec],
+            'MFEM_USE_NETCDF=%s' % yes_no['+netcdf' in spec],
+            'MFEM_USE_MPFR=%s' % yes_no['+mpfr' in spec],
+            'MFEM_USE_OPENMP=%s' % yes_no['+openmp' in spec]]
 
         if '+hypre' in spec:
             options += [
@@ -152,19 +177,12 @@ class Mfem(Package):
                 'HYPRE_OPT=-I%s' % spec['hypre'].prefix.include,
                 'HYPRE_LIB=-L%s' % spec['hypre'].prefix.lib + ' -lHYPRE']
 
-        options += ['MFEM_USE_LAPACK=%s' %
-                    ('NO', 'YES')['+lapack' in spec]]
         if '+lapack' in spec:
             lapack_lib = (spec['lapack'].libs + spec['blas'].libs).ld_flags  # NOQA: ignore=E501
             options += [
                 'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,
                 'LAPACK_LIB=%s' % lapack_lib]
 
-        metis_str = 'NO'
-        if '+parmetis' in spec or \
-           ('+metis' in spec and spec['metis'].satisfies('@5:')):
-            metis_str = 'YES'
-        options += ['MFEM_USE_METIS_5=%s' % metis_str]
         if '+parmetis' in spec:
             metis_lib = '-L%s -lparmetis -lmetis' % spec['parmetis'].prefix.lib
             options += [
@@ -178,8 +196,6 @@ class Mfem(Package):
                 'METIS_OPT=-I%s' % spec['metis'].prefix.include,
                 'METIS_LIB=%s' % metis_lib]
 
-        options += ['MFEM_USE_SUPERLU=%s' %
-                    ('NO', 'YES')['+superlu-dist' in spec]]
         if '+superlu-dist' in spec:
             superlu_lib = '-L%s' % spec['superlu-dist'].prefix.lib
             superlu_lib += ' -lsuperlu_dist'
@@ -188,8 +204,6 @@ class Mfem(Package):
                 'SUPERLU_OPT=-I%s' % spec['superlu-dist'].prefix.include,
                 'SUPERLU_LIB=%s' % superlu_lib]
 
-        options += ['MFEM_USE_SUITESPARSE=%s' %
-                    ('NO', 'YES')['+suite-sparse' in spec]]
         if '+suite-sparse' in spec:
             ssp = spec['suite-sparse'].prefix
             ss_lib = '-L%s' % ssp.lib
@@ -206,8 +220,6 @@ class Mfem(Package):
                 'SUITESPARSE_OPT=-I%s' % ssp.include,
                 'SUITESPARSE_LIB=%s' % ss_lib]
 
-        options += ['MFEM_USE_SUNDIALS=%s' %
-                    ('NO', 'YES')['+sundials' in spec]]
         if '+sundials' in spec:
             sundials_libs = (
                 '-lsundials_arkode -lsundials_cvode'
@@ -221,7 +233,6 @@ class Mfem(Package):
                 'SUNDIALS_LIB=-L%s %s' % (spec['sundials'].prefix.lib,
                                           sundials_libs)]
 
-        options += ['MFEM_USE_PETSC=%s' % ('NO', 'YES')['+petsc' in spec]]
         if '+petsc' in spec:
             f = open('%s/lib/pkgconfig/PETSc.pc' % spec['petsc'].prefix, 'r')
             for line in f:
@@ -235,15 +246,12 @@ class Mfem(Package):
                 'PETSC_OPT=%s' % petsc_opts,
                 'PETSC_LIB=%s' % petsc_libs]
 
-        options += ['MFEM_USE_MESQUITE=%s' %
-                    ('NO', 'YES')['+mesquite' in spec]]
         if '+mesquite' in spec:
             options += [
                 'MESQUITE_DIR=%s' % spec['mesquite'].prefix,
                 'MESQUITE_OPT=-I%s' % spec['mesquite'].prefix.include,
                 'MESQUITE_LIB=-L%s -lmesquite' % spec['mesquite'].prefix.lib]
 
-        options += ['MFEM_USE_NETCDF=%s' % ('NO', 'YES')['+netcdf' in spec]]
         if '+netcdf' in spec:
             np = spec['netcdf'].prefix
             zp = spec['zlib'].prefix
@@ -258,24 +266,11 @@ class Mfem(Package):
                 'NETCDF_OPT=-I%s' % np.include,
                 'NETCDF_LIB=%s' % nlib]
 
-        options += ['MFEM_USE_MPFR=%s' % ('NO', 'YES')['+mpfr' in spec]]
         if '+mpfr' in spec:
             options += ['MPFR_LIB=-L%s -lmpfr' % spec['mpfr'].prefix.lib]
 
-        threadsafe_str = 'NO'
-        if '+openmp' in spec or '+theadsafe' in spec:
-            threadsafe_str = 'YES'
-        options += ['MFEM_THREAD_SAFE=%s' % threadsafe_str]
-
-        options += ['MFEM_USE_OPENMP=%s' % ('NO', 'YES')['+openmp' in spec]]
         if '+openmp' in spec:
             options += ['OPENMP_OPT = %s' % self.compiler.openmp_flag]
-
-        options += ['MFEM_USE_MPI=%s' % ('NO', 'YES')['+mpi' in spec]]
-
-        options += ['MFEM_DEBUG=%s' % ('NO', 'YES')['+debug' in spec]]
-
-        options += ['PREFIX=%s' % prefix]
 
         make('config', *options)
         make('all')

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import re
 
 
 class Mfem(Package):
@@ -62,36 +63,57 @@ class Mfem(Package):
             '841ea5cf58de6fae4de0f553b0e01ebaab9cd9c67fa821e8a715666ecf18fc57',
             url='http://goo.gl/xrScXn', extension='.tar.gz')
 
-    variant('metis', default=False, description='Activate support for metis')
-    variant('hypre', default=False, description='Activate support for hypre')
-    variant('suite-sparse', default=False,
-            description='Activate support for SuiteSparse')
-    variant('mpi', default=True, description='Activate support for MPI')
+    variant('mpi', default=True,
+        description='Enable MPI parallel features')
+    variant('metis', default=False,
+        description='Required for MPI parallel features')
+    variant('hypre', default=False,
+        description='Required for MPI parallel features')
+    variant('openmp', default=False,
+        description='Enable OpenMP parallel features')
+    variant('threadsafe', default=False,
+        description=('Enable thread safe features.'
+            ' Required for OpenMP.'
+            ' May cause minor performance issues.'))
     variant('superlu-dist', default=False,
-            description='Activate support for SuperLU_Dist')
-    variant('lapack', default=False, description='Activate support for LAPACK')
-    variant('debug', default=False, description='Build debug version')
-    variant('netcdf', default=False, description='Activate NetCDF support')
+        description='Enable parallel, sparse direct solvers')
+    variant('suite-sparse', default=False,
+        description='Enable serial, sparse direct solvers')
+    variant('petsc', default=False,
+        description='Enable PETSc solvers, preconditioners, etc..')
+    variant('sundials', default=False,
+        description='Enable Sundials time integrators')
+    variant('mesquite', default=False,
+        description='Enable MESQUITE mesh quality features')
+    variant('mpfr', default=False,
+        description='Enable multi-precision floating point features')
+    variant('lapack', default=False,
+        description='Use external blas/lapack routines')
+    variant('debug', default=False,
+        description='Build debug instead of optimized version')
+    variant('netcdf', default=False,
+        description='Enable Cubit/Genesis reader')
 
     depends_on('blas', when='+lapack')
+    depends_on('blas', when='+suite-sparse')
     depends_on('lapack', when='+lapack')
+    depends_on('lapack', when='+suite-sparse')
 
     depends_on('mpi', when='+mpi')
     depends_on('metis', when='+mpi')
+    depends_on('metis@4:', when='+metis')
+    depends_on('metis@5:', when='+suite-sparse ^suite-sparse@4.5:')
     depends_on('hypre', when='+mpi')
-
     depends_on('hypre', when='+hypre')
 
-    depends_on('metis@4:', when='+metis')
-
+    depends_on('sundials', when='+sundials')
+    depends_on('mesquite', when='+mesquite')
     depends_on('suite-sparse', when='+suite-sparse')
-    depends_on('blas', when='+suite-sparse')
-    depends_on('lapack', when='+suite-sparse')
-    depends_on('metis@5:', when='+suite-sparse ^suite-sparse@4.5:')
-    depends_on('cmake', when='^metis@5:', type='build')
-
     depends_on('superlu-dist', when='@3.2: +superlu-dist')
+    depends_on('petsc', when='+petsc')
 
+    depends_on('mpfr', when='+mpfr')
+    depends_on('cmake', when='^metis@5:', type='build')
     depends_on('netcdf', when='@3.2: +netcdf')
     depends_on('zlib', when='@3.2: +netcdf')
     depends_on('hdf5', when='@3.2: +netcdf')
@@ -122,73 +144,106 @@ class Mfem(Package):
     def install(self, spec, prefix):
         self.check_variants(spec)
 
-        options = ['PREFIX=%s' % prefix]
-
-        if '+lapack' in spec:
-            lapack_lib = (spec['lapack'].libs + spec['blas'].libs).ld_flags  # NOQA: ignore=E501
-            options.extend([
-                'MFEM_USE_LAPACK=YES',
-                'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,
-                'LAPACK_LIB=%s' % lapack_lib])
+        options = []
 
         if '+hypre' in spec:
-            options.extend([
+            options += [
                 'HYPRE_DIR=%s' % spec['hypre'].prefix,
                 'HYPRE_OPT=-I%s' % spec['hypre'].prefix.include,
-                'HYPRE_LIB=-L%s' % spec['hypre'].prefix.lib +
-                ' -lHYPRE'])
+                'HYPRE_LIB=-L%s' % spec['hypre'].prefix.lib + ' -lHYPRE']
 
-        if 'parmetis' in spec:
+        options += ['MFEM_USE_LAPACK=%s' %
+                    ('NO', 'YES')['+lapack' in spec]]
+        if '+lapack' in spec:
+            lapack_lib = (spec['lapack'].libs + spec['blas'].libs).ld_flags  # NOQA: ignore=E501
+            options += [
+                'LAPACK_OPT=-I%s' % spec['lapack'].prefix.include,
+                'LAPACK_LIB=%s' % lapack_lib]
+
+        metis_str = 'NO'
+        if '+parmetis' in spec or \
+           ('+metis' in spec and spec['metis'].satisfies('@5:')):
+            metis_str = 'YES'
+        options += ['MFEM_USE_METIS_5=%s' % metis_str]
+        if '+parmetis' in spec:
             metis_lib = '-L%s -lparmetis -lmetis' % spec['parmetis'].prefix.lib
-            metis_str = 'MFEM_USE_METIS_5=YES'
-            options.extend([metis_str,
-                            'METIS_DIR=%s' % spec['parmetis'].prefix,
-                            'METIS_OPT=-I%s' % spec['parmetis'].prefix.include,
-                            'METIS_LIB=%s' % metis_lib])
-        elif 'metis' in spec:
+            options += [
+                'METIS_DIR=%s' % spec['parmetis'].prefix,
+                'METIS_OPT=-I%s' % spec['parmetis'].prefix.include,
+                'METIS_LIB=%s' % metis_lib]
+        elif '+metis' in spec:
             metis_lib = '-L%s -lmetis' % spec['metis'].prefix.lib
-            if spec['metis'].satisfies('@5:'):
-                metis_str = 'MFEM_USE_METIS_5=YES'
-            else:
-                metis_str = 'MFEM_USE_METIS_5=NO'
-            options.extend([
-                metis_str,
+            options += [
                 'METIS_DIR=%s' % spec['metis'].prefix,
                 'METIS_OPT=-I%s' % spec['metis'].prefix.include,
-                'METIS_LIB=%s' % metis_lib])
+                'METIS_LIB=%s' % metis_lib]
 
-        if 'mpi' in spec:
-            options.extend(['MFEM_USE_MPI=YES'])
-
+        options += ['MFEM_USE_SUPERLU=%s' %
+                    ('NO', 'YES')['+superlu-dist' in spec]]
         if '+superlu-dist' in spec:
             superlu_lib = '-L%s' % spec['superlu-dist'].prefix.lib
             superlu_lib += ' -lsuperlu_dist'
-            sl_inc = 'SUPERLU_OPT=-I%s' % spec['superlu-dist'].prefix.include
-            options.extend(['MFEM_USE_SUPERLU=YES',
-                            'SUPERLU_DIR=%s' % spec['superlu-dist'].prefix,
-                            sl_inc,
-                            'SUPERLU_LIB=%s' % superlu_lib])
+            options += [
+                'SUPERLU_DIR=%s' % spec['superlu-dist'].prefix,
+                'SUPERLU_OPT=-I%s' % spec['superlu-dist'].prefix.include,
+                'SUPERLU_LIB=%s' % superlu_lib]
 
+        options += ['MFEM_USE_SUITESPARSE=%s' %
+                    ('NO', 'YES')['+suite-sparse' in spec]]
         if '+suite-sparse' in spec:
             ssp = spec['suite-sparse'].prefix
             ss_lib = '-L%s' % ssp.lib
-
             if '@3.2:' in spec:
                 ss_lib += ' -lklu -lbtf'
-
             ss_lib += (' -lumfpack -lcholmod -lcolamd' +
                        ' -lamd -lcamd -lccolamd -lsuitesparseconfig')
-
             no_rt = spec.satisfies('platform=darwin')
             if not no_rt:
                 ss_lib += ' -lrt'
             ss_lib += (' ' + metis_lib + ' ' + lapack_lib)
+            options += [
+                'SUITESPARSE_DIR=%s' % ssp,
+                'SUITESPARSE_OPT=-I%s' % ssp.include,
+                'SUITESPARSE_LIB=%s' % ss_lib]
 
-            options.extend(['MFEM_USE_SUITESPARSE=YES',
-                            'SUITESPARSE_DIR=%s' % ssp,
-                            'SUITESPARSE_OPT=-I%s' % ssp.include,
-                            'SUITESPARSE_LIB=%s' % ss_lib])
+        options += ['MFEM_USE_SUNDIALS=%s' %
+                    ('NO', 'YES')['+sundials' in spec]]
+        if '+sundials' in spec:
+            sundials_libs = (
+                '-lsundials_arkode -lsundials_cvode'
+                ' -lsundials_nvecserial -lsundials_kinsol')
+            if '+mpi' in spec:
+                sundials_libs += (
+                    ' -lsundials_nvecparhyp -lsundials_nvecparallel')
+            options += [
+                'SUNDIALS_DIR=%s' % spec['sundials'].prefix,
+                'SUNDIALS_OPT=-I%s' % spec['sundials'].prefix.include,
+                'SUNDIALS_LIB=-L%s %s' % (spec['sundials'].prefix.lib,
+                                          sundials_libs)]
 
+        options += ['MFEM_USE_PETSC=%s' % ('NO', 'YES')['+petsc' in spec]]
+        if '+petsc' in spec:
+            f = open('%s/lib/pkgconfig/PETSc.pc' % spec['petsc'].prefix, 'r')
+            for line in f:
+                if re.search('^\s*Cflags: ', line):
+                    petsc_opts = re.sub('^\s*Cflags: (.*)', '\\1', line)
+                elif re.search('^\s*Libs.*: ', line):
+                    petsc_libs = re.sub('^\s*Libs.*: (.*)', '\\1', line)
+            f.close()
+            options += [
+                'PETSC_DIR=%s' % spec['petsc'].prefix,
+                'PETSC_OPT=%s' % petsc_opts,
+                'PETSC_LIB=%s' % petsc_libs]
+
+        options += ['MFEM_USE_MESQUITE=%s' %
+                    ('NO', 'YES')['+mesquite' in spec]]
+        if '+mesquite' in spec:
+            options += [
+                'MESQUITE_DIR=%s' % spec['mesquite'].prefix,
+                'MESQUITE_OPT=-I%s' % spec['mesquite'].prefix.include,
+                'MESQUITE_LIB=-L%s -lmesquite' % spec['mesquite'].prefix.lib]
+
+        options += ['MFEM_USE_NETCDF=%s' % ('NO', 'YES')['+netcdf' in spec]]
         if '+netcdf' in spec:
             np = spec['netcdf'].prefix
             zp = spec['zlib'].prefix
@@ -196,15 +251,31 @@ class Mfem(Package):
             nlib = '-L%s -lnetcdf ' % np.lib
             nlib += '-L%s -lhdf5_hl -lhdf5 ' % h5p.lib
             nlib += '-L%s -lz' % zp.lib
-            options.extend(['MFEM_USE_NETCDF=YES',
-                            'NETCDF_DIR=%s' % np,
-                            'HDF5_DIR=%s' % h5p,
-                            'ZLIB_DIR=%s' % zp,
-                            'NETCDF_OPT=-I%s' % np.include,
-                            'NETCDF_LIB=%s' % nlib])
+            options += [
+                'NETCDF_DIR=%s' % np,
+                'HDF5_DIR=%s' % h5p,
+                'ZLIB_DIR=%s' % zp,
+                'NETCDF_OPT=-I%s' % np.include,
+                'NETCDF_LIB=%s' % nlib]
 
-        if '+debug' in spec:
-            options.extend(['MFEM_DEBUG=YES'])
+        options += ['MFEM_USE_MPFR=%s' % ('NO', 'YES')['+mpfr' in spec]]
+        if '+mpfr' in spec:
+            options += ['MPFR_LIB=-L%s -lmpfr' % spec['mpfr'].prefix.lib]
+
+        threadsafe_str = 'NO'
+        if '+openmp' in spec or '+theadsafe' in spec:
+            threadsafe_str = 'YES'
+        options += ['MFEM_THREAD_SAFE=%s' % threadsafe_str]
+
+        options += ['MFEM_USE_OPENMP=%s' % ('NO', 'YES')['+openmp' in spec]]
+        if '+openmp' in spec:
+            options += ['OPENMP_OPT = %s' % self.compiler.openmp_flag]
+
+        options += ['MFEM_USE_MPI=%s' % ('NO', 'YES')['+mpi' in spec]]
+
+        options += ['MFEM_DEBUG=%s' % ('NO', 'YES')['+debug' in spec]]
+
+        options += ['PREFIX=%s' % prefix]
 
         make('config', *options)
         make('all')


### PR DESCRIPTION
1. I've added Sundials and PETSc variants needed for ATPESC installs. While I was at it, I also added Mesquite, OpenMP, threadsafe and mpfr.
1. I also adjusted logic of the package to NOT make assumptions about the default build variables that control various options.