### PR TITLE
Moab 5.0 , cgm 16.0, and meshkit 1.5

### DIFF
--- a/var/spack/repos/builtin/packages/cgm/package.py
+++ b/var/spack/repos/builtin/packages/cgm/package.py
@@ -39,6 +39,8 @@ class Cgm(AutotoolsPackage):
 
     variant("mpi", default=True, description='enable mpi support')
     variant("oce", default=False, description='enable oce geometry kernel')
+    variant("debug", default=False, description='enable debug symbols')
+    variant("shared", default=False, description='enable shared builds')
 
     depends_on('mpi', when='+mpi')
     depends_on('oce+X11', when='+oce')
@@ -60,5 +62,11 @@ class Cgm(AutotoolsPackage):
             args.append("--with-occ={0}".format(spec['oce'].prefix))
         else:
             args.append("--without-occ")
+
+        if '+debug' in spec:
+            args.append("--enable-debug")
+
+        if '+shared' in spec:
+            args.append("--enable-shared")
 
         return args

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -41,12 +41,30 @@ class Meshkit(AutotoolsPackage):
     version('1.3-nightly', 'f56129ce1f3beae83a4038b47ae6b2c2')
     version('1.3',         '19bf51f56392f28d70e581fd4c2f51c8')
 
+    variant("mpi", default=True, description='enable mpi support')
+    variant("debug", default=False, description='enable debug symbols')
+    variant("shared", default=False, description='enable shared builds')
+    
+    depends_on('mpi', when='+mpi')
     depends_on('cgm')
     depends_on('moab')
 
     def configure_args(self):
         args = [ 
-             "--with-igeom={0}".format(spec['cgm'].prefix),
-             "--with-imesh={0}".format(spec['moab'].prefix)
+            "--with-igeom={0}".format(spec['cgm'].prefix),
+            "--with-imesh={0}".format(spec['moab'].prefix)
         ]
+        if '+mpi' in spec:
+            args.extend([
+                "--with-mpi",
+                "CC={0}".format(spec['mpi'].mpicc),
+                "CXX={0}".format(spec['mpi'].mpicxx),
+                "FC={0}".format(spec['mpi'].mpifc)
+            ])
+
+        if '+debug' in spec:
+            args.append("--enable-debug")
+        if '+shared' in spec:
+            args.append("--enable-shared")
+
         return args

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -28,7 +28,7 @@ from spack import *
 
 class Meshkit(AutotoolsPackage):
     """MeshKit is an open-source library of mesh generation functionality.
-       Its design philosophy is two-fold: it provides a collection of 
+       Its design philosophy is two-fold: it provides a collection of
        meshing algorithms for use in real meshing problems, along with
        other tools commonly needed to support mesh generation"""
 
@@ -38,10 +38,10 @@ class Meshkit(AutotoolsPackage):
     version('1.5.0',       '90b52416598ef65525ce4457a50ffe68')
 
     variant("mpi", default=True, description='enable mpi support')
-    variant("netgen", default=False, description = 'enable netgen support')
+    variant("netgen", default=False, description='enable netgen support')
     variant("debug", default=False, description='enable debug symbols')
     variant("shared", default=False, description='enable shared builds')
-    
+
     depends_on('mpi', when='+mpi')
     depends_on('netgen', when='+netgen')
     depends_on('cgm')
@@ -49,7 +49,7 @@ class Meshkit(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = [ 
+        args = [
             "--with-igeom={0}".format(spec['cgm'].prefix),
             "--with-imesh={0}".format(spec['moab'].prefix)
         ]
@@ -61,7 +61,7 @@ class Meshkit(AutotoolsPackage):
                 "FC={0}".format(spec['mpi'].mpifc)
             ])
         if '+netgen' in spec:
-            args.append("--with-netgen={0}".format(spec['netgen'].prefix ))
+            args.append("--with-netgen={0}".format(spec['netgen'].prefix))
 
         if '+debug' in spec:
             args.append("--enable-debug")

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -47,7 +47,7 @@ class Meshkit(AutotoolsPackage):
     
     depends_on('mpi', when='+mpi')
     depends_on('cgm')
-    depends_on('moab')
+    depends_on('moab+irel+fbigeom')
 
     def configure_args(self):
         args = [ 

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -50,6 +50,7 @@ class Meshkit(AutotoolsPackage):
     depends_on('moab+irel+fbigeom')
 
     def configure_args(self):
+        spec = self.spec
         args = [ 
             "--with-igeom={0}".format(spec['cgm'].prefix),
             "--with-imesh={0}".format(spec['moab'].prefix)

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+from spack import *
+
+
+class Meshkit(AutotoolsPackage):
+    """MeshKit is an open-source library of mesh generation functionality.
+       Its design philosophy is two-fold: it provides a collection of 
+       meshing algorithms for use in real meshing problems, along with
+       other tools commonly needed to support mesh generation"""
+
+    homepage = "http://sigma.mcs.anl.gov/meshkit-library"
+    url = "http://ftp.mcs.anl.gov/pub/fathom/meshkit-1.5.0.tar.gz"
+
+    version('1.5.0',       '90b52416598ef65525ce4457a50ffe68')
+    version('1.4.1',       'a8cee0babf32be0f3964a5a2a99f7e5b')
+    version('1.4.0',       '5d7799ee528045b20e78e5c900006e92')
+    version('1.3-nightly', 'f56129ce1f3beae83a4038b47ae6b2c2')
+    version('1.3',         '19bf51f56392f28d70e581fd4c2f51c8')
+
+    depends_on('cgm')
+    depends_on('moab')
+
+    def configure_args(self):
+        args = [ 
+             "--with-igeom={0}".format(spec['cgm'].prefix),
+             "--with-imesh={0}".format(spec['moab'].prefix)
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -36,16 +36,14 @@ class Meshkit(AutotoolsPackage):
     url = "http://ftp.mcs.anl.gov/pub/fathom/meshkit-1.5.0.tar.gz"
 
     version('1.5.0',       '90b52416598ef65525ce4457a50ffe68')
-    version('1.4.1',       'a8cee0babf32be0f3964a5a2a99f7e5b')
-    version('1.4.0',       '5d7799ee528045b20e78e5c900006e92')
-    version('1.3-nightly', 'f56129ce1f3beae83a4038b47ae6b2c2')
-    version('1.3',         '19bf51f56392f28d70e581fd4c2f51c8')
 
     variant("mpi", default=True, description='enable mpi support')
+    variant("netgen", default=False, description = 'enable netgen support')
     variant("debug", default=False, description='enable debug symbols')
     variant("shared", default=False, description='enable shared builds')
     
     depends_on('mpi', when='+mpi')
+    depends_on('netgen', when='+netgen')
     depends_on('cgm')
     depends_on('moab+irel+fbigeom')
 
@@ -62,10 +60,17 @@ class Meshkit(AutotoolsPackage):
                 "CXX={0}".format(spec['mpi'].mpicxx),
                 "FC={0}".format(spec['mpi'].mpifc)
             ])
+        if '+netgen' in spec:
+            args.append("--with-netgen={0}".format(spec['netgen'].prefix ))
 
         if '+debug' in spec:
             args.append("--enable-debug")
+        else:
+            args.append("--disable-debug")
+
         if '+shared' in spec:
             args.append("--enable-shared")
+        else:
+            args.append("--disable-shared")
 
         return args

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -83,7 +83,8 @@ class Moab(AutotoolsPackage):
     depends_on('cgm', when='+cgm')
     depends_on('metis', when='+metis')
     depends_on('parmetis', when='+parmetis')
-    depends_on('zoltan', when='+zoltan')
+    # FIXME it seems that zoltan needs to be built without fortran
+    depends_on('zoltan~fortran', when='+zoltan')
 
     def configure_args(self):
         spec = self.spec
@@ -129,8 +130,15 @@ class Moab(AutotoolsPackage):
             options.append('--with-zoltan=%s' % spec['zoltan'].prefix)
         if '+debug' in spec:
             options.append('--enable-debug')
+        # FIXME it seems that with cgm and shared, we have a link 
+        #   issue 
         if '+shared' in spec:
             options.append('--enable-shared')
         if '~fortran' in spec:
             options.append('--disable-fortran')
         return options
+
+    # Run the install phase with -j 1.  There seems to be a problem with
+    # parallel installations of examples
+    def install(self, spec, prefix):
+        make('install', parallel=False)

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -39,8 +39,6 @@ class Moab(AutotoolsPackage):
     url      = "http://ftp.mcs.anl.gov/pub/fathom/moab-5.0.0.tar.gz"
 
     version('5.0.0', '1840ca02366f4d3237d44af63e239e3b')
-    version('4.9.2-RC1', '012c2c29e2c504c5c39131a0a10adc50')
-    version('4.9.2-RC0', '8581acec855308b34144c66e1163ad8e')
     version('4.9.2', '540931a604c180bbd3c1bb3ee8c51dd0')
     version('4.9.1', '19cc2189fa266181ad9109b18d0b2ab8')
     version('4.9.0', '40695d0a159040683cfa05586ad4a7c2')
@@ -67,6 +65,10 @@ class Moab(AutotoolsPackage):
     variant('shared', default=False,
             description='Enables the build of shared libraries')
     variant('fortran', default=True, description='Enable Fortran support')
+
+    conflicts('+irel', when='~cgm')
+    conflicts('+pnetcdf', when='~mpi')
+    conflicts('+parmetis', when='~mpi')
 
     # There are many possible variants for MOAB. Here are examples for
     # two of them:
@@ -125,9 +127,6 @@ class Moab(AutotoolsPackage):
             options.append('--with-cgm=%s' % spec['cgm'].prefix)
             if '+irel' in spec:
                 options.append('--enable-irel')
-        else:
-            if '+irel' in spec:
-                raise InstallError("configure with cgm if you need irel")
         if '+fbigeom' in spec:
             options.append('--enable-fbigeom')    
         if '+coupler' in spec:

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -36,7 +36,7 @@ class Moab(AutotoolsPackage):
     versatile enough to support individual entity access."""
 
     homepage = "https://bitbucket.org/fathomteam/moab"
-    url      = "http://ftp.mcs.anl.gov/pub/fathom/moab-5.0.0.tar.gz"
+    url = "http://ftp.mcs.anl.gov/pub/fathom/moab-5.0.0.tar.gz"
 
     version('5.0.0', '1840ca02366f4d3237d44af63e239e3b')
     version('4.9.2', '540931a604c180bbd3c1bb3ee8c51dd0')
@@ -104,31 +104,32 @@ class Moab(AutotoolsPackage):
             '--disable-refiner',
             '--disable-h5mtools',
             '--disable-mbcslam',
-            '--with-pic', 
+            '--with-pic',
             '--without-vtk'
             ]
         if '+mpi' in spec:
-            options.extend ([ 
+            options.extend([
                 '--with-mpi=%s' % spec['mpi'].prefix,
                 'CXX=%s' % spec['mpi'].mpicxx,
                 'CC=%s' % spec['mpi'].mpicc,
                 'FC=%s' % spec['mpi'].mpifc
                 ])
             if '+parmetis' in spec:
-                 options.append('--with-parmetis=%s' % spec['parmetis'].prefix)
-                
+                options.append('--with-parmetis=%s' % spec['parmetis'].prefix)
+
         if '+hdf5' in spec:
             options.append('--with-hdf5=%s' % spec['hdf5'].prefix)
         if '+netcdf' in spec:
             options.append('--with-netcdf=%s' % spec['netcdf'].prefix)
         if '+pnetcdf' in spec:
-            options.append('--with-pnetcdf=%s' % spec['parallel-netcdf'].prefix)
+            options.append('--with-pnetcdf=%s'
+                           % spec['parallel-netcdf'].prefix)
         if '+cgm' in spec:
             options.append('--with-cgm=%s' % spec['cgm'].prefix)
             if '+irel' in spec:
                 options.append('--enable-irel')
         if '+fbigeom' in spec:
-            options.append('--enable-fbigeom')    
+            options.append('--enable-fbigeom')
         if '+coupler' in spec:
             options.append('--enable-mbcoupler')
         if '+metis' in spec:
@@ -140,7 +141,7 @@ class Moab(AutotoolsPackage):
 
         if '+debug' in spec:
             options.append('--enable-debug')
-        # FIXME it seems that with cgm and shared, we have a link 
+        # FIXME it seems that with cgm and shared, we have a link
         #   issue  in tools/geometry
         if '+shared' in spec:
             options.append('--enable-shared')

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -46,6 +46,11 @@ class Moab(Package):
     variant('shared', default=True,
             description='Enables the build of shared libraries')
     variant('fortran', default=True, description='Enable Fortran support')
+    variant('pnetcdf', default=False, description='Enable pnetcdf support')
+    variant('zoltan', default=False, description='Enable zoltan support')
+    variant('cgm', default=False, description='Enable common geometric module')
+    variant('metis', default=True, description='Enable metis link')
+    variant('parmetis', default=True, description='Enable parmetis link')
 
     # There are many possible variants for MOAB. Here are examples for
     # two of them:
@@ -58,29 +63,22 @@ class Moab(Package):
     depends_on('mpi')
     depends_on('hdf5+mpi')
     depends_on('netcdf', when='+netcdf')
-    depends_on('netcdf+mpi', when='+netcdf')
     depends_on('metis')
     depends_on('parmetis')
-    depends_on('zoltan')
-    depends_on('zoltan~fortran', when='~fortran')
+    depends_on('zoltan', when='+zoltan')
 
     def install(self, spec, prefix):
 
         options = [
             '--prefix=%s' % prefix,
             '--enable-optimize',
-            '--disable-tools',
-            '--disable-mbconvert',
             '--disable-hexmodops',
             '--disable-vtkMOABReader',
-            '--disable-mbsize',
             '--disable-mbskin',
             '--disable-mbtagprop',
             '--disable-mbmem',
             '--disable-spheredecomp',
             '--disable-mbsurfplot',
-            '--disable-mbpart',
-            '--disable-dagmc',
             '--disable-gsets',
             '--disable-mbmerge',
             '--disable-mbdepth',
@@ -89,15 +87,10 @@ class Moab(Package):
             '--disable-refiner',
             '--disable-h5mtools',
             '--disable-mbcslam',
-            '--disable-mbquality',
-            '--disable-ahf',
-            '--disable-mbumr',
-            '--disable-imesh',
             '--with-pic',
             '--with-mpi=%s' % spec['mpi'].prefix,
             '--with-hdf5=%s' % spec['hdf5'].prefix,
             '--with-parmetis=%s' % spec['parmetis'].prefix,
-            '--with-zoltan=%s' % spec['zoltan'].prefix,
             '--without-vtk',
             'CXX=%s' % spec['mpi'].mpicxx,
             'CC=%s' % spec['mpi'].mpicc,
@@ -109,6 +102,8 @@ class Moab(Package):
             options.append('--enable-shared')
         if '+netcdf' in spec:
             options.append('--with-netcdf=%s' % spec['netcdf'].prefix)
+        if '+zoltan' in spec:
+            options.append('--with-zoltan=%s' % spec['zoltan'].prefix)
 
         configure(*options)
         make()

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -78,6 +78,7 @@ class Moab(AutotoolsPackage):
 
     depends_on('mpi', when='+mpi')
     depends_on('hdf5', when='+hdf5')
+    depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('netcdf', when='+netcdf')
     depends_on('parallel-netcdf', when='+pnetcdf')
     depends_on('cgm', when='+cgm')

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -123,16 +123,26 @@ class Moab(AutotoolsPackage):
             options.append('--with-pnetcdf=%s' % spec['parallel-netcdf'].prefix)
         if '+cgm' in spec:
             options.append('--with-cgm=%s' % spec['cgm'].prefix)
+            if '+irel' in spec:
+                options.append('--enable-irel')
+        else:
+            if '+irel' in spec:
+                raise InstallError("configure with cgm if you need irel")
+        if '+fbigeom' in spec:
+            options.append('--enable-fbigeom')    
+        if '+coupler' in spec:
+            options.append('--enable-mbcoupler')
         if '+metis' in spec:
             options.append('--with-metis=%s' % spec['metis'].prefix)
         if '+parmetis' in spec:
             options.append('--with-parmetis=%s' % spec['parmetis'].prefix)
         if '+zoltan' in spec:
             options.append('--with-zoltan=%s' % spec['zoltan'].prefix)
+
         if '+debug' in spec:
             options.append('--enable-debug')
         # FIXME it seems that with cgm and shared, we have a link 
-        #   issue 
+        #   issue  in tools/geometry
         if '+shared' in spec:
             options.append('--enable-shared')
         if '~fortran' in spec:

--- a/var/spack/repos/builtin/packages/netgen/package.py
+++ b/var/spack/repos/builtin/packages/netgen/package.py
@@ -24,17 +24,18 @@
 ##############################################################################
 from spack import *
 
+
 class Netgen(AutotoolsPackage):
-    """NETGEN is an automatic 3d tetrahedral mesh generator. It accepts 
-       input from constructive solid geometry (CSG) or boundary 
-       representation (BRep) from STL file format. The connection to 
+    """NETGEN is an automatic 3d tetrahedral mesh generator. It accepts
+       input from constructive solid geometry (CSG) or boundary
+       representation (BRep) from STL file format. The connection to
        a geometry kernel allows the handling of IGES and STEP files.
-       NETGEN contains modules for mesh optimization and hierarchical 
+       NETGEN contains modules for mesh optimization and hierarchical
        mesh refinement. """
 
     # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://ngsolve.org/"
-    url      = "https://gigenet.dl.sourceforge.net/project/netgen-mesher/netgen-mesher/5.3/netgen-5.3.1.tar.gz"
+    url = "https://gigenet.dl.sourceforge.net/project/netgen-mesher/netgen-mesher/5.3/netgen-5.3.1.tar.gz"
 
     version('5.3.1', 'afd5a9b0b1296c242a9c554f06af6510')
 
@@ -42,11 +43,11 @@ class Netgen(AutotoolsPackage):
     variant("oce", default=False, description='enable oce geometry kernel')
     variant("nogui", default=True, description='disable gui')
     variant("metis", default=False, description='use metis for partitioning')
-    
+
     depends_on('mpi', when='+mpi')
     depends_on('oce+X11', when='+oce')
     depends_on('metis', when='+metis')
-    
+
     def configure_args(self):
         spec = self.spec
         args = []
@@ -59,15 +60,14 @@ class Netgen(AutotoolsPackage):
         if '+oce' in spec:
             args.append("--with-occ={0}".format(spec['oce'].prefix))
         #  FIXME
-        # due to a bug in netgen config, when --without-occ is specified 
-        #   or --with-occ=no, OCC flags is turned true, and build fails 
-        #   later; so do not specify anything like that  
+        # due to a bug in netgen config, when --without-occ is specified
+        #   or --with-occ=no, OCC flags is turned true, and build fails
+        #   later; so do not specify anything like that
         #else:
         #    args.append("--without-occ")
 
         if '+nogui' in spec:
             args.append("--disable-gui")
-        
         if '+metis' in spec:
             args.append('--with-metis=%s' % spec['metis'].prefix)
 

--- a/var/spack/repos/builtin/packages/netgen/package.py
+++ b/var/spack/repos/builtin/packages/netgen/package.py
@@ -1,0 +1,74 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+class Netgen(AutotoolsPackage):
+    """NETGEN is an automatic 3d tetrahedral mesh generator. It accepts 
+       input from constructive solid geometry (CSG) or boundary 
+       representation (BRep) from STL file format. The connection to 
+       a geometry kernel allows the handling of IGES and STEP files.
+       NETGEN contains modules for mesh optimization and hierarchical 
+       mesh refinement. """
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://ngsolve.org/"
+    url      = "https://gigenet.dl.sourceforge.net/project/netgen-mesher/netgen-mesher/5.3/netgen-5.3.1.tar.gz"
+
+    version('5.3.1', 'afd5a9b0b1296c242a9c554f06af6510')
+
+    variant("mpi", default=True, description='enable mpi support')
+    variant("oce", default=False, description='enable oce geometry kernel')
+    variant("nogui", default=True, description='disable gui')
+    variant("metis", default=False, description='use metis for partitioning')
+    
+    depends_on('mpi', when='+mpi')
+    depends_on('oce+X11', when='+oce')
+    depends_on('metis', when='+metis')
+    
+    def configure_args(self):
+        spec = self.spec
+        args = []
+        if '+mpi' in spec:
+            args.extend([
+                "CC={0}".format(spec['mpi'].mpicc),
+                "CXX={0}".format(spec['mpi'].mpicxx)
+            ])
+
+        if '+oce' in spec:
+            args.append("--with-occ={0}".format(spec['oce'].prefix))
+        #  FIXME
+        # due to a bug in netgen config, when --without-occ is specified 
+        #   or --with-occ=no, OCC flags is turned true, and build fails 
+        #   later; so do not specify anything like that  
+        #else:
+        #    args.append("--without-occ")
+
+        if '+nogui' in spec:
+            args.append("--disable-gui")
+        
+        if '+metis' in spec:
+            args.append('--with-metis=%s' % spec['metis'].prefix)
+
+        return args


### PR DESCRIPTION
modify moab to allow more tools, and linking with cgm
add more variants for moab 
still to do in moab:
  enable pymoab
  enable tempest (new package)

package meshkit with minimal configuration; more work for netgen link 

it depends on moab and cgm; 
moab has to be built with irel, and cgm
cgm dependency can be derived from moab 

