### PR TITLE
Update README.md and add analytics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,24 @@
 [![codecov](https://codecov.io/gh/LLNL/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/LLNL/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 
-Spack is a package management tool designed to support multiple
-versions and configurations of software on a wide variety of platforms
-and environments. It was designed for large supercomputing centers,
-where many users and application teams share common installations of
-software on clusters with exotic architectures, using libraries that
-do not have a standard ABI. Spack is non-destructive: installing a new
-version does not break existing installations, so many configurations
-can coexist on the same system.
+Spack is a multi-platform package manager that builds and installs
+multiple versions and configurations of software. It works on Linux,
+macOS, and many supercomputers. Spack is non-destructive: installing a
+new version of a package does not break existing installations, so many
+configurations of the same package can coexist.
 
-Most importantly, Spack is simple. It offers a simple spec syntax so
-that users can specify versions and configuration options
-concisely. Spack is also simple for package authors: package files are
-written in pure Python, and specs allow package authors to write a
-single build script for many different builds of the same package.
+Spack offers a simple "spec" syntax that allows users to specify versions
+and configuration options. Package files are written in pure Python, and
+specs allow package authors to write a single script for many different
+builds of the same package.  With Spack, you can build your software
+*all* the ways you want to.
 
 See the
 [Feature Overview](http://spack.readthedocs.io/en/latest/features.html)
 for examples and highlights.
 
-To install spack and install your first package, make sure you have
-Python (2 or 3).  Then:
+To install spack and your first package, make sure you have Python.
+Then:
 
     $ git clone https://github.com/llnl/spack.git
     $ cd spack/bin
@@ -37,14 +34,15 @@ Documentation
 [**Full documentation**](http://spack.readthedocs.io/) for Spack is
 the first place to look.
 
-We've also got a [**Spack 101 Tutorial**](http://spack.readthedocs.io/en/latest/tutorial_sc16.html),
-so you can learn Spack yourself, or teach users at your own site.
+Try the
+[**Spack Tutorial**](http://spack.readthedocs.io/en/latest/tutorial.html),
+to learn how to use spack, write packages, or deploy packages for users
+at your site.
 
 See also:
   * [Technical paper](http://www.computer.org/csdl/proceedings/sc/2015/3723/00/2807623.pdf) and
     [slides](https://tgamblin.github.io/files/Gamblin-Spack-SC15-Talk.pdf) on Spack's design and implementation.
   * [Short presentation](https://tgamblin.github.io/files/Gamblin-Spack-Lightning-Talk-BOF-SC15.pdf) from the *Getting Scientific Software Installed* BOF session at Supercomputing 2015.
-
 
 Get Involved!
 ------------------------
@@ -55,9 +53,8 @@ packages to bugfixes, or even new core features.
 
 ### Mailing list
 
-If you are interested in contributing to spack, the first step is to
-join the mailing list.  We're using a Google Group for this, and you
-can join it here:
+If you are interested in contributing to spack, the first step is to join
+the mailing list.  We're Google Groups for this. Join here:
 
   * [Spack Google Group](https://groups.google.com/d/forum/spack)
 
@@ -69,23 +66,22 @@ When you send your request, make ``develop`` the destination branch on the
 [Spack repository](https://github.com/LLNL/spack).
 
 Your PR must pass Spack's unit tests and documentation tests, and must be
-[PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant.
-We enforce these guidelines with [Travis CI](https://travis-ci.org/LLNL/spack).
-To run these tests locally, and for helpful tips on git, see our
+[PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant.  We enforce
+these guidelines with [Travis CI](https://travis-ci.org/LLNL/spack).  To
+run these tests locally, and for helpful tips on git, see our
 [Contribution Guide](http://spack.readthedocs.io/en/latest/contribution_guide.html).
 
-Spack uses a rough approximation of the [Git
-Flow](http://nvie.com/posts/a-successful-git-branching-model/)
+Spack uses a rough approximation of the
+[Git Flow](http://nvie.com/posts/a-successful-git-branching-model/)
 branching model.  The ``develop`` branch contains the latest
-contributions, and ``master`` is always tagged and points to the
-latest stable release.
-
+contributions, and ``master`` is always tagged and points to the latest
+stable release.
 
 Authors
 ----------------
 Many thanks go to Spack's [contributors](https://github.com/llnl/spack/graphs/contributors).
 
-Spack was originally written by Todd Gamblin, tgamblin@llnl.gov.
+Spack was created by Todd Gamblin, tgamblin@llnl.gov.
 
 ### Citing Spack
 
@@ -102,3 +98,5 @@ Spack is released under an LGPL license.  For more details see the
 LICENSE file.
 
 ``LLNL-CODE-647188``
+
+![Analytics](https://ga-beacon.appspot.com/UA-101208306-3/welcome-page?pixel)


### PR DESCRIPTION
This updates the README a bit and adds a Google Analytics beacon so that we can get a better sense of our traffic.
 
Currently, GitHub only shows the top 10 referrers (which stay pretty consistent so you don't see new stuff) and doesn't give any location information.  This along with a similar link at spack.readthedocs.io will let us add a map showing where people are using Spack.