### PR TITLE
Perl - allow package activation without PERL5LIB variable

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -93,7 +93,20 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
-        # Prepend default perl @INC path to allow package activation:
+	# Extensions are installed into their private tree via
+	# `INSTALL_BASE`/`--install_base` (see [1]) which results in a
+	# "predictable" installation tree that sadly does not match the
+	# Perl core's @INC structure.  This means that when activation
+	# merges the extension into the extendee[2], the directory tree
+	# containing the extensions is not on @INC and the extensions can
+	# not be found.
+	#
+	# This bit prepends @INC with the directory that is used when
+	# extensions are activated [3].
+	#
+	# [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
+	# [2] via the activate method in the PackageBase class
+	# [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
         config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' + join_path(
                            self.spec.prefix, 'lib', 'perl5') + '\\"')
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -90,7 +90,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-des',
             '-Dprefix={0}'.format(prefix),
             '-Dlocincpth=' + self.spec['gdbm'].prefix.include,
-            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
+            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib
         ]
 
         # Prepend default perl @INC path to allow package activation:

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -107,8 +107,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
         # [2] via the activate method in the PackageBase class
         # [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
-        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' + join_path(
-                           self.prefix.lib, 'perl5') + '\\"')
+        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"'
+                           + self.prefix.lib.perl5 + '\\"')
 
         # Discussion of -fPIC for Intel at:
         # https://github.com/LLNL/spack/pull/3081 and
@@ -156,7 +156,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         for d in dependent_spec.traverse(
                 deptype=('build', 'run'), deptype_query='run'):
             if d.package.extends(self.spec):
-                perl_lib_dirs.append(join_path(d.prefix.lib, 'perl5'))
+                perl_lib_dirs.append(d.prefix.lib.perl5)
                 perl_bin_dirs.append(d.prefix.bin)
         perl_bin_path = ':'.join(perl_bin_dirs)
         perl_lib_path = ':'.join(perl_lib_dirs)
@@ -175,7 +175,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         module.perl = Executable(join_path(self.prefix.bin, 'perl'))
 
         # Add variables for library directory
-        module.perl_lib_dir = join_path(dependent_spec.prefix.lib, 'perl5')
+        module.perl_lib_dir = dependent_spec.prefix.lib.perl5
 
         # Make the site packages directory for extensions,
         # if it does not exist already.

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -93,6 +93,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
+        # Prepend default perl @INC path to allow package activation:
+        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' + join_path(
+                           self.spec.prefix, 'lib', 'perl5') + '\\"')
+
         # Discussion of -fPIC for Intel at:
         # https://github.com/LLNL/spack/pull/3081 and
         # https://github.com/LLNL/spack/pull/4416
@@ -129,10 +133,6 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
                 perl('Makefile.PL')
                 make()
                 make('install')
-
-    def setup_environment(self, spack_env, run_env):
-        """Set PERL5LIB to support activation of Perl packages"""
-        run_env.set('PERL5LIB', join_path(self.prefix, 'lib', 'perl5'))
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         """Set PATH and PERL5LIB to include the extension and

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -93,20 +93,20 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
-	# Extensions are installed into their private tree via
-	# `INSTALL_BASE`/`--install_base` (see [1]) which results in a
-	# "predictable" installation tree that sadly does not match the
-	# Perl core's @INC structure.  This means that when activation
-	# merges the extension into the extendee[2], the directory tree
-	# containing the extensions is not on @INC and the extensions can
-	# not be found.
-	#
-	# This bit prepends @INC with the directory that is used when
-	# extensions are activated [3].
-	#
-	# [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
-	# [2] via the activate method in the PackageBase class
-	# [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
+        # Extensions are installed into their private tree via
+        # `INSTALL_BASE`/`--install_base` (see [1]) which results in a
+        # "predictable" installation tree that sadly does not match the
+        # Perl core's @INC structure.  This means that when activation
+        # merges the extension into the extendee[2], the directory tree
+        # containing the extensions is not on @INC and the extensions can
+        # not be found.
+        #
+        # This bit prepends @INC with the directory that is used when
+        # extensions are activated [3].
+        #
+        # [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
+        # [2] via the activate method in the PackageBase class
+        # [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
         config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' + join_path(
                            self.prefix.lib, 'perl5') + '\\"')
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -90,7 +90,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             '-des',
             '-Dprefix={0}'.format(prefix),
             '-Dlocincpth=' + self.spec['gdbm'].prefix.include,
-            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib
+            '-Dloclibpth=' + self.spec['gdbm'].prefix.lib,
         ]
 
         # Prepend default perl @INC path to allow package activation:

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -108,7 +108,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 	# [2] via the activate method in the PackageBase class
 	# [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
         config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' + join_path(
-                           self.spec.prefix, 'lib', 'perl5') + '\\"')
+                           self.prefix.lib, 'perl5') + '\\"')
 
         # Discussion of -fPIC for Intel at:
         # https://github.com/LLNL/spack/pull/3081 and
@@ -156,8 +156,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         for d in dependent_spec.traverse(
                 deptype=('build', 'run'), deptype_query='run'):
             if d.package.extends(self.spec):
-                perl_lib_dirs.append(join_path(d.prefix, 'lib', 'perl5'))
-                perl_bin_dirs.append(join_path(d.prefix, 'bin'))
+                perl_lib_dirs.append(join_path(d.prefix.lib, 'perl5'))
+                perl_bin_dirs.append(d.prefix.bin)
         perl_bin_path = ':'.join(perl_bin_dirs)
         perl_lib_path = ':'.join(perl_lib_dirs)
         spack_env.prepend_path('PATH', perl_bin_path)
@@ -172,10 +172,10 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         """
 
         # perl extension builds can have a global perl executable function
-        module.perl = Executable(join_path(self.spec.prefix.bin, 'perl'))
+        module.perl = Executable(join_path(self.prefix.bin, 'perl'))
 
         # Add variables for library directory
-        module.perl_lib_dir = join_path(dependent_spec.prefix, 'lib', 'perl5')
+        module.perl_lib_dir = join_path(dependent_spec.prefix.lib, 'perl5')
 
         # Make the site packages directory for extensions,
         # if it does not exist already.

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -107,8 +107,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # [1] https://metacpan.org/pod/ExtUtils::MakeMaker#INSTALL_BASE
         # [2] via the activate method in the PackageBase class
         # [3] https://metacpan.org/pod/distribution/perl/INSTALL#APPLLIB_EXP
-        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"'
-                           + self.prefix.lib.perl5 + '\\"')
+        config_args.append('-Accflags=-DAPPLLIB_EXP=\\"' +
+                           self.prefix.lib.perl5 + '\\"')
 
         # Discussion of -fPIC for Intel at:
         # https://github.com/LLNL/spack/pull/3081 and

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -172,7 +172,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         """
 
         # perl extension builds can have a global perl executable function
-        module.perl = Executable(join_path(self.prefix.bin, 'perl'))
+        module.perl = self.spec['perl'].command
 
         # Add variables for library directory
         module.perl_lib_dir = dependent_spec.prefix.lib.perl5
@@ -192,7 +192,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
 
         # Find the actual path to the installed Config.pm file.
-        perl = Executable(join_path(prefix.bin, 'perl'))
+        perl = self.spec['perl'].command
         config_dot_pm = perl('-MModule::Loaded', '-MConfig', '-e',
                              'print is_loaded(Config)', output=str)
 


### PR DESCRIPTION
Issue #4423 describes a problem where perl packages installed by spack are not found by perl after being activated.

When perl packages are installed using `Makefile.PL`, we use the configure option `INSTALL_BASE` as recommended by http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.30/lib/ExtUtils/MakeMaker.pm. Similarly, for packages installed using `Build.PL`, we use the option `--install_base`. These options provide a consistent and predictable directory structure for all packages.

When perl packages are activated by spack, the result is equivalent to setting `INSTALL_BASE` or `--install_base` to the base directory of the perl installation. But for reasons known only to perl experts, the packages are not installed in a location that perl searches by default.

As a workaround, I have modified the configure options used to install perl so that an extra directory is prepended to the package search path. With this change, packages can be used after activation without needing to define `PERL5LIB`.