### PR TITLE
Spack has a Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/LLNL/spack.svg?branch=develop)](https://travis-ci.org/LLNL/spack)
 [![codecov](https://codecov.io/gh/LLNL/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/LLNL/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
+[![Slack](https://spackpm.herokuapp.com/badge.svg)](https://spackpm.herokuapp.com)
 
 Spack is a multi-platform package manager that builds and installs
 multiple versions and configurations of software. It works on Linux,
@@ -53,10 +54,19 @@ packages to bugfixes, or even new core features.
 
 ### Mailing list
 
-If you are interested in contributing to spack, the first step is to join
-the mailing list.  We're Google Groups for this. Join here:
+If you are interested in contributing to spack, join the mailing list.
+We're using Google Groups for this:
 
   * [Spack Google Group](https://groups.google.com/d/forum/spack)
+
+### Slack channel
+
+Spack has a Slack channel where you can chat about all things Spack:
+
+  * [Spack on Slack](https://spackpm.slack.com)
+
+[Sign up here](https://spackpm.herokuapp.com) to get an invitation mailed
+to you.
 
 ### Contributions
 


### PR DESCRIPTION
I've been hesitant to set up a chat channel for Spack simply because I worried that we wouldn't know how to deal with all the traffic.  After seeing a few other projects use Slack successfully, I'm a bit less worried, and I think this will be useful for folks who want to work together on new features or coordinate across sites on all things Spack-related.  I think it's also another way to get to know folks who are using Spack.  Also, I piped GitHub notifications over there.

So now there is Spack on Slack. (Splack!?)

I deployed a little [Heroku app](https://spackpm.herokuapp.com) (based on [rauchg/slackin](https://github.com/rauchg/slackin)) so that people can sign up automatically.  Hopefully this will be pretty easy for people to join.

I also added a badge to `README.md` that shows how many people are online.  Currently, if you click the badge, you're taken to the signup page, which has a link to sign in if you're already registered.  We could also point it directly to Slack, but then new people would have to scroll down to see how to sign up.  I suspect that most people will just keep Slack running after they sign up (since that is what I do) so I optimized for people who still need to sign up.  Thoughts?

@alalazo @adamjstewart

- [x] Set up a Slack channel for Spack at [spackpm.slack.com](https://spackpm.slack.com)
- [x] Added a badge to show who's online.
- [x] Added a section to `README.md` under "Get involved!"