### PR TITLE
fontconfig should depend on gperf

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -35,6 +35,7 @@ class Fontconfig(AutotoolsPackage):
     version('2.11.1', 'e75e303b4f7756c2b16203a57ac87eba')
 
     depends_on('freetype')
+    depends_on('gperf', type='build')
     depends_on('libxml2')
     depends_on('pkg-config', type='build')
     depends_on('font-util')

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -35,7 +35,7 @@ class Fontconfig(AutotoolsPackage):
     version('2.11.1', 'e75e303b4f7756c2b16203a57ac87eba')
 
     depends_on('freetype')
-    depends_on('gperf', type='build')
+    depends_on('gperf', type='build', when='@2.12.2:')
     depends_on('libxml2')
     depends_on('pkg-config', type='build')
     depends_on('font-util')


### PR DESCRIPTION
Sometime around 2.12.2 fontconfig acquired a build-time dependency on `gperf` (See comment around line 2340 of the Changelog referencing this commit, I think:59fd9960bbb58fd6257adb13ec0f918882149332).

This adds the dependency.

`gperf` is called in the `src/Makefile`, see line 907 of `src/Makefile.in`.

I've tested `2.12.3` and `2.12.1` on CentOS 7.