### PR TITLE
Features/votca

### DIFF
--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -42,7 +42,8 @@ class VotcaCsg(CMakePackage):
     variant('debug', default=False, description='Build debug version')
 
     depends_on("cmake@2.8:", type='build')
-    depends_on("votca-tools")
+    depends_on("votca-tools@1.4:1.4.999", when='@1.4:1.4.999')
+    depends_on("votca-tools@develop", when='@develop')
     depends_on("gromacs~mpi@5.1:")
 
     def build_type(self):

--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -43,7 +43,7 @@ class VotcaCsg(CMakePackage):
 
     depends_on("cmake@2.8:", type='build')
     depends_on("votca-tools")
-    depends_on("gromacs@5.1:")
+    depends_on("gromacs~mpi@5.1:")
 
     def build_type(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/votca-ctp/package.py
+++ b/var/spack/repos/builtin/packages/votca-ctp/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2017, The VOTCA Development Team (http://www.votca.org)
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class VotcaCtp(CMakePackage):
+    """Versatile Object-oriented Toolkit for Coarse-graining
+       Applications (VOTCA) is a package intended to reduce the amount of
+       routine work when doing systematic coarse-graining of various
+       systems. The core is written in C++.
+
+       This package contains the VOTCA charge transport engine.
+    """
+    homepage = "http://www.votca.org"
+    #No release yet
+    #url      = "https://github.com/votca/ctp/tarball/v1.4"
+
+    version('develop', git='https://github.com/votca/ctp', branch='master')
+
+    variant('debug', default=False, description='Build debug version')
+
+    depends_on("cmake@2.8:", type='build')
+    depends_on("votca-tools@develop", when='@develop')
+    depends_on("votca-csg@develop", when='@develop')
+    depends_on("votca-moo@develop", when='@develop')
+
+    def build_type(self):
+        spec = self.spec
+        if '+debug' in spec:
+            return 'Debug'
+        else:
+            return 'Release'

--- a/var/spack/repos/builtin/packages/votca-ctp/package.py
+++ b/var/spack/repos/builtin/packages/votca-ctp/package.py
@@ -34,8 +34,8 @@ class VotcaCtp(CMakePackage):
        This package contains the VOTCA charge transport engine.
     """
     homepage = "http://www.votca.org"
-    #No release yet
-    #url      = "https://github.com/votca/ctp/tarball/v1.4"
+    # No release yet
+    # url      = "https://github.com/votca/ctp/tarball/v1.4"
 
     version('develop', git='https://github.com/votca/ctp', branch='master')
 

--- a/var/spack/repos/builtin/packages/votca-moo/package.py
+++ b/var/spack/repos/builtin/packages/votca-moo/package.py
@@ -1,0 +1,52 @@
+#############################################################################
+# Copyright (c) 2017, The VOTCA Development Team (http://www.votca.org)
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class VotcaMoo(CMakePackage):
+    """Versatile Object-oriented Toolkit for Coarse-graining
+       Applications (VOTCA) is a package intended to reduce the amount of
+       routine work when doing systematic coarse-graining of various
+       systems. The core is written in C++.
+
+       This package contains the VOTCA molecular orbital module.
+    """
+    homepage = "http://www.votca.org"
+    # No release yet
+    # url      = "https://github.com/votca/moo/tarball/v1.4"
+
+    version('develop', git='https://github.com/votca/moo', branch='master')
+
+    variant('debug', default=False, description='Build debug version')
+
+    depends_on("cmake@2.8:", type='build')
+    depends_on("votca-tools@develop", when='@develop')
+
+    def build_type(self):
+        spec = self.spec
+        if '+debug' in spec:
+            return 'Debug'
+        else:
+            return 'Release'


### PR DESCRIPTION
A couple of changes related to VOTCA package:

- `votca-csg` needs non-mpi version of gromacs
- `@develop` versions depend on `votca-XXX@develop`
- adding 2 new modules `votca-moo` and `votca-ctp`

/cc @xiongshiyun