### PR TITLE
New Packages: gearshifft, clFFT

### DIFF
--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Clfft(CMakePackage):
+    """a software library containing FFT functions written in OpenCL"""
+
+    homepage = "https://github.com/clMathLibraries/clFFT"
+    url      = "https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz"
+
+    @property
+    def root_cmakelists_dir(self):
+        return join_path(self.stage.source_path, 'src')
+
+    version('2.12.2', '9104d85f9f2f3c58dd8efc0e4b06496f')
+
+    variant('client', default=True,
+            description='build client and callback client')
+
+    depends_on('opencl@1.2:')
+    depends_on('boost@1.33.0:', when='+client')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DBUILD_CLIENT:BOOL={0}'.format((
+                'ON' if '+client' in spec else 'OFF')),
+            '-DBUILD_CALLBACK_CLIENT:BOOL={0}'.format((
+                'ON' if '+client' in spec else 'OFF'))
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -35,8 +35,8 @@ class Gearshifft(CMakePackage):
 
     variant('cufft', default=True,
             description='Compile gearshifft_cufft')
-    variant('clfft', default=True,
-            description='Compile gearshifft_clfft')
+    # variant('clfft', default=True,
+    #         description='Compile gearshifft_clfft')
     variant('fftw', default=True,
             description='Compile gearshifft_fftw')
     variant('openmp', default=True,
@@ -48,8 +48,8 @@ class Gearshifft(CMakePackage):
     depends_on('cmake@2.8.0:', type='build')
     depends_on('boost@1.56.0:')
     depends_on('cuda@8.0:', when='+cufft')
-    depends_on('opencl@1.2:', when='+clfft')
-    depends_on('clfft@2.12.0:', when='+clfft')
+    # depends_on('opencl@1.2:', when='+clfft')
+    # depends_on('clfft@2.12.0:', when='+clfft')
     depends_on('fftw@3.3.4:~mpi~openmp', when='+fftw~openmp')
     depends_on('fftw@3.3.4:~mpi+openmp', when='+fftw+openmp')
 
@@ -58,7 +58,8 @@ class Gearshifft(CMakePackage):
 
         args = [
             '-DGEARSHIFFT_HCFFT:BOOL=OFF',
-            '-DGEARSHIFFT_FFTW_PTHREADS:BOOL=ON'
+            '-DGEARSHIFFT_FFTW_PTHREADS:BOOL=ON',
+            '-DGEARSHIFFT_CLFFT:BOOL=OFF'
         ]
         args.extend([
             '-DGEARSHIFFT_FFTW:BOOL={0}'.format((
@@ -66,8 +67,8 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_FFTW_OPENMP:BOOL={0}'.format((
                 'ON' if '+openmp' in spec else 'OFF')),
             '-DGEARSHIFFT_CUFFT:BOOL={0}'.format((
-                'ON' if '+cufft' in spec else 'OFF')),
-            '-DGEARSHIFFT_CLFFT:BOOL={0}'.format((
-                'ON' if '+clfft' in spec else 'OFF'))
+                'ON' if '+cufft' in spec else 'OFF'))
+            # '-DGEARSHIFFT_CLFFT:BOOL={0}'.format((
+            #     'ON' if '+clfft' in spec else 'OFF'))
         ])
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -1,0 +1,73 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Gearshifft(CMakePackage):
+    """Benchmark Suite for Heterogenuous FFT Implementations"""
+
+    homepage = "https://github.com/mpicbg-scicomp/gearshifft"
+    url      = "https://github.com/mpicbg-scicomp/gearshifft/archive/v0.2.0.tar.gz"
+
+    version('0.2.1-lw', 'c3208b767b24255b488a83e5d9e517ea')
+
+    variant('cufft', default=True,
+            description='Compile gearshifft_cufft')
+    variant('clfft', default=True,
+            description='Compile gearshifft_clfft')
+    variant('fftw', default=True,
+            description='Compile gearshifft_fftw')
+    variant('openmp', default=True,
+            description='use OpenMP parallel fftw libraries')
+    # variant('hcfft', default=True,
+    #         description='Not implemented yet')
+
+    # depends_on C++14 compiler, e.g. GCC 5.0+
+    depends_on('cmake@2.8.0:', type='build')
+    depends_on('boost@1.56.0:')
+    depends_on('cuda@8.0:', when='+cufft')
+    depends_on('opencl@1.2:', when='+clfft')
+    depends_on('clfft@2.12.0:', when='+clfft')
+    depends_on('fftw@3.3.4:~mpi~openmp', when='+fftw~openmp')
+    depends_on('fftw@3.3.4:~mpi+openmp', when='+fftw+openmp')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            '-DGEARSHIFFT_HCFFT:BOOL=OFF',
+            '-DGEARSHIFFT_FFTW_PTHREADS:BOOL=ON'
+        ]
+        args.extend([
+            '-DGEARSHIFFT_FFTW:BOOL={0}'.format((
+                'ON' if '+fftw' in spec else 'OFF')),
+            '-DGEARSHIFFT_FFTW_OPENMP:BOOL={0}'.format((
+                'ON' if '+openmp' in spec else 'OFF')),
+            '-DGEARSHIFFT_CUFFT:BOOL={0}'.format((
+                'ON' if '+cufft' in spec else 'OFF')),
+            '-DGEARSHIFFT_CLFFT:BOOL={0}'.format((
+                'ON' if '+clfft' in spec else 'OFF'))
+        ])
+        return args


### PR DESCRIPTION
Adds a [gearshifft](https://github.com/mpicbg-scicomp/gearshifft) package, a benchmark suite for heterogeneous implementations of FFTs.

Adds [clFFT](https://github.com/clMathLibraries/clFFT), a software library containing FFT functions written in OpenCL.