### PR TITLE
Modified ipopt package to support build on ppc64le

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/ipopt_ppc_build.patch
+++ b/var/spack/repos/builtin/packages/ipopt/ipopt_ppc_build.patch
@@ -1,0 +1,26 @@
+--- ipopt/config.guess	2017-06-20 14:49:19.618016003 -0700
++++ ipopt/config.guess.new	2017-06-20 14:50:35.678878802 -0700
+@@ -908,6 +908,9 @@
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++        echo powerpc64-unknown-linux-gnu
++        exit ;;
+     ppc64:Linux:*:*)
+ 	echo powerpc64-unknown-linux-gnu
+ 	exit ;;
+
+
+--- ipopt/Ipopt/config.guess	2017-06-20 14:49:19.618016003 -0700
++++ ipopt/Ipopt/config.guess.new	2017-06-20 14:50:35.678878802 -0700
+@@ -908,6 +908,9 @@
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++        echo powerpc64-unknown-linux-gnu
++        exit ;;
+     ppc64:Linux:*:*)
+ 	echo powerpc64-unknown-linux-gnu
+ 	exit ;;

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -52,6 +52,8 @@ class Ipopt(Package):
     depends_on('coinhsl', when='+coinhsl')
     depends_on('metis@4.0:4.999', when='+metis')
 
+    patch('ipopt_ppc_build.patch', when='arch=ppc64le')
+
     def install(self, spec, prefix):
         # Dependency directories
         blas_dir = spec['blas'].prefix


### PR DESCRIPTION
Added line in package.py to patch using ipopt_ppc_build.patch. The patch simply adds support in config.guess and Ipopt/config.guess to build ipopt on ppc64le.