### PR TITLE
Remove test dependencies from Python packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-brian2/package.py
+++ b/var/spack/repos/builtin/packages/py-brian2/package.py
@@ -34,7 +34,7 @@ class PyBrian2(PythonPackage):
     version('2.0.1', 'df5990e9a71f7344887bc02f54dfd0f0')
     version('2.0rc3', '3100c5e4eb9eb83a06ff0413a7d43152')
 
-    variant('docs', default=False)
+    variant('docs', default=False, description='Build the documentation')
 
     # depends on py-setuptools@6: for windows, if spack targets windows,
     # this will need to be added here
@@ -45,6 +45,6 @@ class PyBrian2(PythonPackage):
     depends_on('py-jinja2@2.7:',    type=('build', 'run'))
     depends_on('py-cpuinfo@0.1.6:', type=('build', 'run'))
 
-    # depends_on('py-nosetests@1.0:',    type=('build', 'run')) # extra test
-    depends_on('py-nosetests@1.0:', type=('build', 'run'), when='+docs')
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nosetests@1.0:', type='test')
     depends_on('py-sphinx@1.4.2:',  type=('build', 'run'), when='+docs')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -93,8 +93,9 @@ class PyMatplotlib(PythonPackage):
     depends_on('texlive', when='+latex', type='run')
 
     # Testing dependencies
-    depends_on('py-nose')  # type='test'
-    depends_on('py-mock')  # type='test'
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nose', type='test')
+    # depends_on('py-mock', type='test')
 
     # Required libraries that ship with matplotlib
     # depends_on('agg@2.4:')

--- a/var/spack/repos/builtin/packages/py-pylint/package.py
+++ b/var/spack/repos/builtin/packages/py-pylint/package.py
@@ -37,5 +37,7 @@ class PyPylint(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-astroid', type=('build', 'run'))
     depends_on('py-logilab-common', type=('build', 'run'))
-    depends_on('py-nose', type='build')
     depends_on('py-setuptools', type='build')
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nose', type='test')

--- a/var/spack/repos/builtin/packages/py-pynn/package.py
+++ b/var/spack/repos/builtin/packages/py-pynn/package.py
@@ -42,8 +42,10 @@ class PyPynn(PythonPackage):
     depends_on('python@2.6:2.8,3.3:')
     depends_on('py-jinja2@2.7:',        type=('build', 'run'))
     depends_on('py-docutils@0.10:',     type=('build', 'run'))
-    depends_on('py-mock@1.0:',          type=('build', 'run'))
     depends_on('py-numpy@1.5:',         type=('build', 'run'))
     depends_on('py-quantities@0.10:',   type=('build', 'run'))
     depends_on('py-lazyarray@0.2.9:',   type=('build', 'run'))
     depends_on('py-neo@0.3:',           type=('build', 'run'))
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-mock@1.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-qtconsole/package.py
+++ b/var/spack/repos/builtin/packages/py-qtconsole/package.py
@@ -42,4 +42,6 @@ class PyQtconsole(PythonPackage):
     depends_on('py-pygments',            type=('build', 'run'))
     depends_on('py-traitlets',           type=('build', 'run'))
     depends_on('py-sphinx@1.3:',         type=('build', 'run'), when='+docs')
-    # mock; python_version=="2.7" and extra == 'test'
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-mock', type='test', when='^python@2.7:2.8')

--- a/var/spack/repos/builtin/packages/py-theano/package.py
+++ b/var/spack/repos/builtin/packages/py-theano/package.py
@@ -34,7 +34,7 @@ class PyTheano(PythonPackage):
 
     version('0.8.2', 'f2d0dfe7df141115201077cd933b2c52')
 
-    variant('gpu', default=False, 
+    variant('gpu', default=False,
             description='Builds with support for GPUs via CUDA and cuDNN')
 
     depends_on('python@2.6:2.8,3.3:')
@@ -48,6 +48,7 @@ class PyTheano(PythonPackage):
 
     depends_on('cuda', when='+gpu')
     depends_on('libgpuarray', when='+gpu')
-    # test requirements
-    # depends_on('py-nose@1.3.0:', type=('build', 'run'))
-    # depends_on('py-nose-parameterized@0.5.0:', type=('build', 'run'))
+
+    # TODO: Add a 'test' deptype
+    # depends_on('py-nose@1.3.0:', type='test')
+    # depends_on('py-nose-parameterized@0.5.0:', type='test')


### PR DESCRIPTION
Still waiting on #1279 (ping @tgamblin @scheibelp). Until then, Spack packages shouldn't add dependencies for things that are only needed when installed with `--run-tests`. This PR comments out a few test-only dependencies I found in our Python packages.