### PR TITLE
Update for paraview 5.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -33,6 +33,7 @@ class Paraview(CMakePackage):
     url      = "http://www.paraview.org/files/v5.3/ParaView-v5.3.0.tar.gz"
     _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.gz'
 
+    version('5.4.0', 'b92847605bac9036414b644f33cb7163')
     version('5.3.0', '68fbbbe733aa607ec13d1db1ab5eba71')
     version('5.2.0', '4570d1a2a183026adb65b73c7125b8b0')
     version('5.1.2', '44fb32fc8988fcdfbc216c9e40c3e925')
@@ -116,6 +117,13 @@ class Paraview(CMakePackage):
             '-DVTK_USE_SYSTEM_TIFF:BOOL=ON',
             '-DVTK_USE_SYSTEM_ZLIB:BOOL=ON',
         ]
+
+        # The assumed qt version changed to QT5 (as of paraview 5.2.1),
+        # so explicitly specify which QT major version is actually being used
+        if '+qt' in spec:
+            cmake_args.extend([
+                '-DPARAVIEW_QT_VERSION=%s' % spec['qt'].version[0],
+            ])
 
         if '+python' in spec:
             cmake_args.extend([


### PR DESCRIPTION
- paraview 5.2.1 -> 5.4.0 supports both Qt4 and Qt5, but the assumed
  default version changes between versions. So explicitly define
  which QT major version is being used.

This updates the version and one cmake parameter, but neither resolved nor provokes #4581, which looks like something more fundamental within spack.