### PR TITLE
cp2k: added missing macros to the makefile

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -93,6 +93,8 @@ class Cp2k(Package):
             cppflags = [
                 '-D__FFTW3',
                 '-D__LIBINT',
+                '-D__LIBINT_MAX_AM=6',
+                '-D__LIBDERIV_MAX_AM1=5',
                 spec['fftw'].headers.cpp_flags
             ]
 


### PR DESCRIPTION
This fixes a run-time failure for certain types of calculations using `libint`. According to [this](https://github.com/misteliy/cp2k/blob/master/tools/hfx_tools/libint_tools/README_LIBINT) page:

- If you want to use basis functions with higher angular momenta, you have to provide this information to the configure script of `libint`. We pass `--with-libint-max-am=5 --with-libderiv-max-am1=4`.

- This information is encoded in a macro defined in two headers within `libint`

- You have to specify again the same info in cp2k, but the two numbers must be incremented by 1 for whatever reason. If you fail doing that everything will compile and link. Failure is at run-time...

Side rant: technically, using macros that start with a double underscore puts the application in the UB realm. See [latest draft of C99 standard](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) section 7.1.3.