### PR TITLE
Allow arbitrary Prefix attributes

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2430,7 +2430,7 @@ e.g.:
 
 .. code-block:: python
 
-   configure('--prefix=' + prefix)
+   configure('--prefix={0}'.format(prefix))
 
 For the most part, prefix objects behave exactly like strings.  For
 packages that do not have their own install target, or for those that
@@ -2451,29 +2451,19 @@ yourself, e.g.:
        mkdirp(prefix.lib)
        install('libfoo.a', prefix.lib)
 
-Most of the standard UNIX directory names are attributes on the
-``prefix`` object.  Here is a full list:
 
-  =========================  ================================================
-  Prefix Attribute           Location
-  =========================  ================================================
-  ``prefix.bin``             ``$prefix/bin``
-  ``prefix.sbin``            ``$prefix/sbin``
-  ``prefix.etc``             ``$prefix/etc``
-  ``prefix.include``         ``$prefix/include``
-  ``prefix.lib``             ``$prefix/lib``
-  ``prefix.lib64``           ``$prefix/lib64``
-  ``prefix.libexec``         ``$prefix/libexec``
-  ``prefix.share``           ``$prefix/share``
-  ``prefix.doc``             ``$prefix/doc``
-  ``prefix.info``            ``$prefix/info``
+Attributes of this object are created on the fly when you request them,
+so any of the following will work:
 
-  ``prefix.man``             ``$prefix/man``
-  ``prefix.man[1-8]``        ``$prefix/man/man[1-8]``
+======================  =======================
+Prefix Attribute        Location
+======================  =======================
+``prefix.bin``          ``$prefix/bin``
+``prefix.lib64``        ``$prefix/lib64``
+``prefix.share.man``    ``$prefix/share/man``
+``prefix.foo.bar.baz``  ``$prefix/foo/bar/baz``
+======================  =======================
 
-  ``prefix.share_man``       ``$prefix/share/man``
-  ``prefix.share_man[1-8]``  ``$prefix/share/man[1-8]``
-  =========================  ================================================
 
 .. _spec-objects:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2408,15 +2408,21 @@ is handy when a package supports additional variants like
 Blas and Lapack libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Different packages provide implementation of ``Blas`` and ``Lapack``
+Multiple packages provide implementations of ``Blas`` and ``Lapack``
 routines.  The names of the resulting static and/or shared libraries
 differ from package to package. In order to make the ``install()`` method
 independent of the choice of ``Blas`` implementation, each package which
 provides it sets up ``self.spec.blas_libs`` to point to the correct
 ``Blas`` libraries.  The same applies to packages which provide
 ``Lapack``. Package developers are advised to use these variables, for
-example ``spec['blas'].blas_libs.joined()`` instead of hard-coding
-``join_path(spec['blas'].prefix.lib, 'libopenblas.so')``.
+example ``spec['blas'].blas_libs.joined()`` instead of hard-coding them:
+
+.. code-block:: python
+
+   if 'openblas' in spec:
+       libs = join_path(spec['blas'].prefix.lib, 'libopenblas.so')
+   elif 'intel-mkl' in spec:
+       ...
 
 .. _prefix-objects:
 
@@ -2463,6 +2469,14 @@ Prefix Attribute        Location
 ``prefix.share.man``    ``$prefix/share/man``
 ``prefix.foo.bar.baz``  ``$prefix/foo/bar/baz``
 ======================  =======================
+
+Of course, this only works if your file or directory is a valid Python
+variable name. If your file or directory contains dashes or dots, use
+``join_path`` instead:
+
+.. code-block:: python
+
+   join_path(prefix.lib, 'libz.a')
 
 
 .. _spec-objects:
@@ -2562,23 +2576,25 @@ of its dependencies satisfy the provided spec.
 Accessing Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^
 
-You may need to get at some file or binary that's in the prefix of one
-of your dependencies.  You can do that by sub-scripting the spec:
+You may need to get at some file or binary that's in the installation
+prefix of one of your dependencies. You can do that by sub-scripting
+the spec:
 
 .. code-block:: python
 
-   my_mpi = spec['mpi']
+   spec['mpi']
 
 The value in the brackets needs to be some package name, and spec
 needs to depend on that package, or the operation will fail.  For
 example, the above code will fail if the ``spec`` doesn't depend on
-``mpi``.  The value returned and assigned to ``my_mpi``, is itself
-just another ``Spec`` object, so you can do all the same things you
-would do with the package's own spec:
+``mpi``.  The value returned is itself just another ``Spec`` object,
+so you can do all the same things you would do with the package's
+own spec:
 
 .. code-block:: python
 
-   mpicc = join_path(my_mpi.prefix.bin, 'mpicc')
+   spec['mpi'].prefix.bin
+   spec['mpi'].version
 
 .. _multimethods:
 
@@ -3076,7 +3092,7 @@ Filtering functions
      .. code-block:: python
 
         filter_file(r'#!/usr/bin/perl',
-                    '#!/usr/bin/env perl', join_path(prefix.bin, 'bib2xhtml'))
+                    '#!/usr/bin/env perl', prefix.bin.bib2xhtml)
 
   #. Switching the compilers used by ``mpich``'s MPI wrapper scripts from
      ``cc``, etc. to the compilers used by the Spack build:
@@ -3084,10 +3100,10 @@ Filtering functions
      .. code-block:: python
 
         filter_file('CC="cc"', 'CC="%s"' % self.compiler.cc,
-                    join_path(prefix.bin, 'mpicc'))
+                    prefix.bin.mpicc)
 
         filter_file('CXX="c++"', 'CXX="%s"' % self.compiler.cxx,
-                    join_path(prefix.bin, 'mpicxx'))
+                    prefix.bin.mpicxx)
 
 :py:func:`change_sed_delimiter(old_delim, new_delim, *filenames) <spack.change_sed_delim>`
     Some packages, like TAU, have a build system that can't install
@@ -3124,12 +3140,10 @@ File functions
 
   .. code-block:: python
 
-     install('my-header.h', join_path(prefix.include))
+     install('my-header.h', prefix.include)
 
-:py:func:`join_path(prefix, *args) <spack.join_path>`
-  Like ``os.path.join``, this joins paths using the OS path separator.
-  However, this version allows an arbitrary number of arguments, so
-  you can string together many path components.
+:py:func:`join_path(*paths) <spack.join_path>`
+  An alias for ``os.path.join``. This joins paths using the OS path separator.
 
 :py:func:`mkdirp(*paths) <spack.mkdirp>`
   Create each of the directories in ``paths``, creating any parent

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1045,7 +1045,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         touch(join_path(self.prefix.lib, library_name + dso_suffix))
         touch(join_path(self.prefix.lib, library_name + '.a'))
 
-        mkdirp(self.prefix.man1)
+        mkdirp(self.prefix.man.man1)
 
         packages_dir = spack.store.layout.build_packages_path(self.spec)
         dump_packages(self.spec, packages_dir)

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -44,6 +44,11 @@ def test_multilevel_attributes():
     assert prefix.man.man8    == '/usr/man/man8'
     assert prefix.foo.bar.baz == '/usr/foo/bar/baz'
 
+    share = prefix.share
+
+    assert isinstance(share, Prefix)
+    assert share.man == '/usr/share/man'
+
 
 def test_string_like_behavior():
     """Test string-like behavior of the prefix object"""

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -22,40 +22,40 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-"""
-This file contains utilities for managing the installation prefix of a package.
-"""
-import os
+"""Tests various features of :py:class:`spack.util.prefix.Prefix`"""
+
+from spack.util.prefix import Prefix
 
 
-class Prefix(str):
-    """This class represents an installation prefix, but provides useful
-    attributes for referring to directories inside the prefix.
+def test_prefix_attributes():
+    """Test normal prefix attributes like ``prefix.bin``"""
+    prefix = Prefix('/usr')
 
-    Attributes of this object are created on the fly when you request them,
-    so any of the following is valid:
+    assert prefix.bin     == '/usr/bin'
+    assert prefix.lib     == '/usr/lib'
+    assert prefix.include == '/usr/include'
 
-    >>> prefix = Prefix('/usr')
-    >>> prefix.bin
-    /usr/bin
-    >>> prefix.lib64
-    /usr/lib64
-    >>> prefix.share.man
-    /usr/share/man
-    >>> prefix.foo.bar.baz
-    /usr/foo/bar/baz
 
-    Prefix objects behave identically to strings. In fact, they
-    subclass ``str``. So operators like ``+`` are legal::
+def test_multilevel_attributes():
+    """Test attributes of attributes, like ``prefix.share.man``"""
+    prefix = Prefix('/usr/')
 
-        print('foobar ' + prefix)
+    assert prefix.share.man   == '/usr/share/man'
+    assert prefix.man.man8    == '/usr/man/man8'
+    assert prefix.foo.bar.baz == '/usr/foo/bar/baz'
 
-    This prints ``foobar /usr``. All of this is meant to make custom
-    installs easy.
-    """
 
-    def __new__(cls, path):
-        return super(Prefix, cls).__new__(cls, path)
+def test_string_like_behavior():
+    """Test string-like behavior of the prefix object"""
+    prefix = Prefix('/usr')
 
-    def __getattr__(self, attr):
-        return Prefix(os.path.join(self, attr))
+    assert prefix == '/usr'
+    assert isinstance(prefix, str)
+
+    assert prefix + '/bin' == '/usr/bin'
+    assert '--prefix=%s' % prefix == '--prefix=/usr'
+    assert '--prefix={0}'.format(prefix) == '--prefix=/usr'
+
+    assert prefix.find('u', 1)
+    assert prefix.upper() == '/USR'
+    assert prefix.lstrip('/') == 'usr'

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -53,9 +53,5 @@ class Prefix(str):
     This prints ``foobar /usr``. All of this is meant to make custom
     installs easy.
     """
-
-    def __new__(cls, path):
-        return super(Prefix, cls).__new__(cls, path)
-
     def __getattr__(self, attr):
         return Prefix(os.path.join(self, attr))

--- a/var/spack/repos/builtin/packages/bwa/package.py
+++ b/var/spack/repos/builtin/packages/bwa/package.py
@@ -51,5 +51,5 @@ class Bwa(Package):
         mkdirp(prefix.doc)
         install('README.md', prefix.doc)
         install('NEWS.md', prefix.doc)
-        mkdirp(prefix.man1)
-        install('bwa.1', prefix.man1)
+        mkdirp(prefix.man.man1)
+        install('bwa.1', prefix.man.man1)

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -186,6 +186,6 @@ class Git(AutotoolsPackage):
         prefix = self.prefix
 
         with working_dir('git-manpages'):
-            install_tree('man1', prefix.share_man1)
-            install_tree('man5', prefix.share_man5)
-            install_tree('man7', prefix.share_man7)
+            install_tree('man1', prefix.share.man.man1)
+            install_tree('man5', prefix.share.man.man5)
+            install_tree('man7', prefix.share.man.man7)

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -70,7 +70,7 @@ class Libdwarf(Package):
             make.add_default_arg('ARFLAGS=rcs')
 
             # Dwarf doesn't provide an install, so we have to do it.
-            mkdirp(prefix.bin, prefix.include, prefix.lib, prefix.man1)
+            mkdirp(prefix.bin, prefix.include, prefix.lib, prefix.man.man1)
 
             with working_dir('libdwarf'):
                 extra_config_args = []
@@ -103,4 +103,4 @@ class Libdwarf(Package):
 
                 install('dwarfdump',      prefix.bin)
                 install('dwarfdump.conf', prefix.lib)
-                install('dwarfdump.1',    prefix.man1)
+                install('dwarfdump.1',    prefix.man.man1)

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -52,10 +52,8 @@ class Libdwarf(Package):
 
     parallel = False
 
-
     def patch(self):
         filter_file(r'^typedef struct Elf Elf;$', '', 'libdwarf/libdwarf.h.in')
-
 
     def install(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/mercurial/package.py
+++ b/var/spack/repos/builtin/packages/mercurial/package.py
@@ -57,14 +57,14 @@ class Mercurial(PythonPackage):
         prefix = self.prefix
 
         # Install man pages
-        mkdirp(prefix.man1)
-        mkdirp(prefix.man5)
-        mkdirp(prefix.man8)
+        mkdirp(prefix.man.man1)
+        mkdirp(prefix.man.man5)
+        mkdirp(prefix.man.man8)
         with working_dir('doc'):
-            install('hg.1', prefix.man1)
-            install('hgignore.5', prefix.man5)
-            install('hgrc.5', prefix.man5)
-            install('hg-ssh.8', prefix.man8)
+            install('hg.1', prefix.man.man1)
+            install('hgignore.5', prefix.man.man5)
+            install('hgrc.5', prefix.man.man5)
+            install('hg-ssh.8', prefix.man.man8)
 
         # Install completion scripts
         contrib = join_path(prefix, 'contrib')

--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class Pigz(MakefilePackage):
-    """A parallel implementation of gzip for modern multi-processor, 
+    """A parallel implementation of gzip for modern multi-processor,
        multi-core machines."""
 
     homepage = "http://zlib.net/pigz/"
@@ -41,6 +41,6 @@ class Pigz(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        mkdirp(prefix.man1)
+        mkdirp(prefix.man.man1)
         install('pigz', "%s/pigz" % prefix.bin)
-        install('pigz.1', "%s/pigz.1" % prefix.man1)
+        install('pigz.1', "%s/pigz.1" % prefix.man.man1)

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -249,4 +249,4 @@ class Scotch(Package):
         install_tree('bin', prefix.bin)
         install_tree('lib', prefix.lib)
         install_tree('include', prefix.include)
-        install_tree('man/man1', prefix.share_man1)
+        install_tree('man/man1', prefix.share.man.man1)


### PR DESCRIPTION
Previously, the following prefix attributes worked great:

* `prefix.bin`
* `prefix.lib`

but as soon as you needed something new, you were S.O.L.:

* `prefix.examples`
* `prefix.bin.perl`

This led to several PRs adding new attributes to the `Prefix` class:

* #4321 added `prefix.include64`
* #3905 added `prefix.bin64`
* 295ffd8c506821ed079d2151fb21cd27979d7387 added `prefix.share_man[1-8]`

This is cumbersome, and more often than not leads to people using `join_path(prefix, 'examples')`. I've never been a big fan of `join_path`. It's just plain ugly...

With this PR, these limitations have been removed. Now, any prefix attribute you can think of works:

* `prefix.foo.bar.baz == $prefix/foo/bar/baz`

All prefix attributes are defined on the fly, so they don't need to be declared beforehand. This means that most of the uses of `join_path` are now obsolete. I won't remove all uses of `join_path` in this PR, but we should encourage users to do this from now on.