### PR TITLE
relax qt dependency for paraview

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -52,9 +52,8 @@ class Paraview(CMakePackage):
     depends_on('py-numpy', when='+python', type='run')
     depends_on('py-matplotlib', when='+python', type='run')
     depends_on('mpi', when='+mpi')
-    depends_on('qt@:4', when='+qt')
-    # TODO# depends_on('qt@:4', when='@:5.2.0+qt')
-    # TODO# depends_on('qt@5',  when='@5.3.0:+qt')
+    depends_on('qt', when='@5.3.0:+qt')
+    depends_on('qt@:4', when='@:5.2.0+qt')
 
     depends_on('bzip2')
     depends_on('freetype')


### PR DESCRIPTION
- previously restricted everything to QT-4, but now only have that
  restriction for older paraview versions.