### PR TITLE
Fix MeshKit installation by adding cgm to moab dependency

### DIFF
--- a/var/spack/repos/builtin/packages/meshkit/package.py
+++ b/var/spack/repos/builtin/packages/meshkit/package.py
@@ -45,7 +45,7 @@ class Meshkit(AutotoolsPackage):
     depends_on('mpi', when='+mpi')
     depends_on('netgen', when='+netgen')
     depends_on('cgm')
-    depends_on('moab+irel+fbigeom')
+    depends_on('moab+cgm+irel+fbigeom')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
spack spec  meshkit fails without this change.
Add cgm to moab, for resolving conflicts installing MeshKit on a new machine.
Use spack install meshkit ^cgm+oce, for geometry engine support, by default cgm is facet-based