### PR TITLE
Cleanup some depends_on flex that used explicit versions (#4600)

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -34,9 +34,8 @@ class Flex(AutotoolsPackage):
 
     version('2.6.4', '2882e3179748cc9f9c23ec593d6adc8d')
     version('2.6.3', 'a5f65570cd9107ec8a8ec88f17b31bb1')
-    # Problematic version:
+    # Avoid flex '2.6.2' (major bug)
     # See issue #2554; https://github.com/westes/flex/issues/113
-    # version('2.6.2', 'cc6d76c333db7653d5caf423a3335239')
     version('2.6.1', '05bcd8fb629e0ae130311e8a6106fa82')
     version('2.6.0', '760be2ee9433e822b6eb65318311c19d')
     version('2.5.39', '5865e76ac69c05699f476515592750d7')

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -100,7 +100,7 @@ class FoamExtend(Package):
     depends_on('mpi')
     depends_on('python')
     depends_on('zlib')
-    depends_on('flex@:2.6.1')  # <- restriction due to scotch
+    depends_on('flex',  type='build')
     depends_on('cmake', type='build')
 
     depends_on('scotch~metis',     when='~ptscotch+scotch')

--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -291,7 +291,7 @@ class OpenfoamCom(Package):
     depends_on('fftw')
     depends_on('boost')
     depends_on('cgal')
-    depends_on('flex@:2.6.1')  # <- restriction due to scotch
+    depends_on('flex',  type='build')
     depends_on('cmake', type='build')
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -91,7 +91,7 @@ class OpenfoamOrg(Package):
     provides('openfoam')
     depends_on('mpi')
     depends_on('zlib')
-    depends_on('flex@:2.6.1')  # <- restriction due to scotch
+    depends_on('flex',  type='build')
     depends_on('cmake', type='build')
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -51,7 +51,8 @@ class Scotch(Package):
     variant('int64', default=False,
             description='Use int64_t for SCOTCH_Num typedef')
 
-    depends_on('flex@:2.6.1', type='build')
+    # Does not build with flex 2.6.[23]
+    depends_on('flex@:2.6.1,2.6.4:', type='build')
     depends_on('bison', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('zlib', when='+compression')


### PR DESCRIPTION
- The buggy flex-2.6.2 has now been blacklisted in the corresponding
  flex package (also removed the md5sum to avoid suggesting that this
  version should be revived). The 2.6.3 has similar problems (at least
  for scotch), but 2.6.4 seems to work.

- Rejig flex restriction for scotch to exclude 2.6.2-2.6.3 only. Since
  flex-2.6.4 appears to be okay again, we can remove the flex version
  restriction that trickled through into the openfoam packages as a
  consequent of an spack spec bug.

- Make flex a build dependency for the openfoam packages
  (seems to have been an earlier oversight).