### PR TITLE
BUG: external mxml library for adios breaks linkage (issue #4605)

### DIFF
--- a/var/spack/repos/builtin/packages/mxml/package.py
+++ b/var/spack/repos/builtin/packages/mxml/package.py
@@ -48,5 +48,9 @@ class Mxml(AutotoolsPackage):
             return 'https://github.com/michaelrsweet/mxml/releases/download/release-{0}/mxml-{0}.tar.gz'.format(version)
 
     def configure_args(self):
-        # Default is non-shared, but avoid any future surprises
-        return ['--disable-shared']
+        return [
+            # ADIOS build with -fPIC, so we need it too (avoid linkage issue)
+            'CFLAGS=-fPIC',
+            # Default is non-shared, but avoid any future surprises
+            '--disable-shared',
+        ]


### PR DESCRIPTION
Fixes #4605 

This is a continuation of #3696.