### PR TITLE
Allow packages to be installed from yaml file

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -77,6 +77,9 @@ the dependencies"""
     subparser.add_argument(
         '--fake', action='store_true', dest='fake',
         help="fake install. just remove prefix and create a fake file")
+    subparser.add_argument(
+        '-f', '--file', action='store_true', dest='file',
+        help="install from file. Read specs to install from .yaml files")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
@@ -320,7 +323,13 @@ def install(parser, args, **kwargs):
     })
 
     # Spec from cli
-    specs = spack.cmd.parse_specs(args.package, concretize=True)
+    specs = []
+    if args.file:
+        for file in args.package:
+            with open(file, 'r') as f:
+                specs.append(spack.spec.Spec.from_yaml(f))
+    else:
+        specs = spack.cmd.parse_specs(args.package, concretize=True)
     if len(specs) == 0:
         tty.error('The `spack install` command requires a spec to install.')
 


### PR DESCRIPTION
Just what it says. 

Introduces the `-f` or `--file` option for the install command. When this option is invoked, the install command will accept a list of files instead of a list of specs. Each file should be a complete yaml representation of a concrete spec. These specs will be installed.