### PR TITLE
Requested changes related to mumps compilation

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -142,7 +142,7 @@ class IntelMkl(IntelInstaller):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up MKLROOT for everyone using MKL package
         spack_env.set('MKLROOT', self.prefix)
-        spack_env.set('SPACK_COMPILER_EXTRA_RPATHS',
+        spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
                           join_path(self.prefix.lib, 'intel64'))
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -142,6 +142,8 @@ class IntelMkl(IntelInstaller):
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up MKLROOT for everyone using MKL package
         spack_env.set('MKLROOT', self.prefix)
+        spack_env.set('SPACK_COMPILER_EXTRA_RPATHS',
+                          join_path(self.prefix.lib, 'intel64'))
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('MKLROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -143,7 +143,7 @@ class IntelMkl(IntelInstaller):
         # set up MKLROOT for everyone using MKL package
         spack_env.set('MKLROOT', self.prefix)
         spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
-                          join_path(self.prefix.lib, 'intel64'))
+                              join_path(self.prefix.lib, 'intel64'))
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('MKLROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -83,7 +83,14 @@ class IntelMpi(IntelInstaller):
         else:
             raise RuntimeError('No suitable bindir found')
 
-        self.spec.mpicc = join_path(bindir, 'mpicc')
-        self.spec.mpicxx = join_path(bindir, 'mpicxx')
-        self.spec.mpifc = join_path(bindir, 'mpif90')
-        self.spec.mpif77 = join_path(bindir, 'mpif77')
+        if '%intel' in self.spec:
+            self.spec.mpicc = join_path(bindir, 'mpiicc')
+            self.spec.mpicxx = join_path(bindir, 'mpiicpc')
+            self.spec.mpifc = join_path(bindir, 'mpiifort')
+            self.spec.mpif77 = join_path(bindir, 'mpiifort')
+        else:
+            self.spec.mpicc = join_path(bindir, 'mpicc')
+            self.spec.mpicxx = join_path(bindir, 'mpicxx')
+            self.spec.mpifc = join_path(bindir, 'mpif90')
+            self.spec.mpif77 = join_path(bindir, 'mpif77')
+

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -83,14 +83,7 @@ class IntelMpi(IntelInstaller):
         else:
             raise RuntimeError('No suitable bindir found')
 
-        if '%intel' in self.spec:
-            self.spec.mpicc = join_path(bindir, 'mpiicc')
-            self.spec.mpicxx = join_path(bindir, 'mpiicpc')
-            self.spec.mpifc = join_path(bindir, 'mpiifort')
-            self.spec.mpif77 = join_path(bindir, 'mpiifort')
-        else:
-            self.spec.mpicc = join_path(bindir, 'mpicc')
-            self.spec.mpicxx = join_path(bindir, 'mpicxx')
-            self.spec.mpifc = join_path(bindir, 'mpif90')
-            self.spec.mpif77 = join_path(bindir, 'mpif77')
-
+        self.spec.mpicc = join_path(bindir, 'mpicc')
+        self.spec.mpicxx = join_path(bindir, 'mpicxx')
+        self.spec.mpifc = join_path(bindir, 'mpif90')
+        self.spec.mpif77 = join_path(bindir, 'mpif77')

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -160,7 +160,7 @@ class Mumps(Package):
                  'FC = {0}'.format(self.spec['mpi'].mpifc),
                  "SCALAP = %s" % scalapack.ld_flags,
                  "MUMPS_TYPE = par"])
-            if (self.spec.satisfies('%xl_r' or '%xl')) and self.spec.satisfies('^spectrum-mpi'): # noqa
+            if (self.spec.satisfies('%xl_r' or '%xl')) and self.spec.satisfies('^spectrum-mpi'):  # noqa
                 makefile_conf.extend(
                     ['FL = {0}'.format(self.spec['mpi'].mpicc)])
             else:

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -61,7 +61,6 @@ class Mumps(Package):
     variant('shared', default=True, description='Build shared libraries')
 
     depends_on('scotch + esmumps', when='~ptscotch+scotch')
-#    depends_on('scotch + esmumps + mpi', when='+ptscotch')
     depends_on('scotch + esmumps ~ metis + mpi', when='+ptscotch')
     depends_on('metis@5:', when='+metis')
     depends_on('parmetis', when="+parmetis")

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -61,7 +61,8 @@ class Mumps(Package):
     variant('shared', default=True, description='Build shared libraries')
 
     depends_on('scotch + esmumps', when='~ptscotch+scotch')
-    depends_on('scotch + esmumps + mpi', when='+ptscotch')
+#    depends_on('scotch + esmumps + mpi', when='+ptscotch')
+    depends_on('scotch + esmumps ~ metis + mpi', when='+ptscotch')
     depends_on('metis@5:', when='+metis')
     depends_on('parmetis', when="+parmetis")
     depends_on('blas')

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -81,6 +81,7 @@ class Scotch(Package):
 
         shared = '+shared' in self.spec
         libraries = ['libscotch', 'libscotcherr']
+        zlibs     = []
 
         if '+mpi' in self.spec:
             libraries = ['libptscotch', 'libptscotcherr'] + libraries
@@ -89,9 +90,17 @@ class Scotch(Package):
         elif '~mpi+esmumps' in self.spec:
             libraries = ['libesmumps'] + libraries
 
-        return find_libraries(
+        scotchlibs = find_libraries(
             libraries, root=self.prefix, recurse=True, shared=shared
         )
+        if '+compression' in self.spec:
+            zlibs = find_libraries(
+                ['libz'], root=self.spec['zlib'].prefix, recurse=True, shared=shared
+        )
+
+        return scotchlibs + zlibs
+
+
 
     def patch(self):
         self.configure()

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -94,13 +94,9 @@ class Scotch(Package):
             libraries, root=self.prefix, recurse=True, shared=shared
         )
         if '+compression' in self.spec:
-            zlibs = find_libraries(
-                ['libz'], root=self.spec['zlib'].prefix, recurse=True, shared=shared
-        )
+            zlibs = self.spec['zlib'].libs
 
         return scotchlibs + zlibs
-
-
 
     def patch(self):
         self.configure()


### PR DESCRIPTION
(I have not submitted previous pull request to spack, so apologies in advance for mistakes):

These changes arise from attempts to compile mumps on fedora 25 and ubuntu 16.04.
The approximate mumps installation command in question is:
with gcc:
```
spack install   mumps+metis+parmetis+scotch+ptscotch ^intel-mpi@5.0.3 ^intel-mkl@11.2.4+shared~openmp
```
with intel:
```
spack install   mumps+metis+parmetis+scotch+ptscotch%intel@17.0.4 ^intel-mpi@5.0.3 ^intel-mkl@11.2.4+shared~openmp ^cmake%gcc@6.3.1 ^bison%gcc@6.3.1 ^flex%gcc@6.3.1
```
intel mpi and intel mkl are required. Both are specified in packages.yaml as external packages

The changes below arise mostly from attempted fixes to errors 

 - mumps compilation was failing due to scotch metis.h errors. The spack scotch package removes metis.h when installed with '~metis' hence the change

- mumps was installing but tests were failing due to missing mkl symbols, so added 'intel64' to  SPACK_COMPILER_EXTRA_RPATHS  for intel mkl

- on ubuntu 16.04 mumps compilation was failing due  to missing libz symbols used by scotch library; changed scotch package to address this

- intel mpi changed to use mpiicc, mpiifort etc with intel compiler


Comments from original commit:
* add mpii* wrappers for use with intel compilers
 * in mumps package, scotch is compiled without metis option when
   ptscotch variant is selected. This removes confusion over which
   metis.h to use

 * for intel mkl, add SPACK_COMPILER_EXTRA_RPATHS ending in 'intel64'

 * scotch lib requires libz when compression is turned on.  This
   caused a link issue on some Ubuntu distributions (not
   redhat). Change Scotch package to add -lz when needed