### PR TITLE
Return an error exit code if spack cd does not succeed.

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -88,14 +88,13 @@ function spack {
             _sp_arg="$1"; shift
             if [ "$_sp_arg" = "-h" ]; then
                 command spack cd -h
-                return 0
             else
                 LOC="$(spack location $_sp_arg "$@")"
                 if [[ -d "$LOC" ]] ; then
                     cd "$LOC"
-                    return 0
+                else
+                    return 1
                 fi
-                return 1
             fi
             return
             ;;

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -88,11 +88,14 @@ function spack {
             _sp_arg="$1"; shift
             if [ "$_sp_arg" = "-h" ]; then
                 command spack cd -h
+                return 0
             else
                 LOC="$(spack location $_sp_arg "$@")"
                 if [[ -d "$LOC" ]] ; then
                     cd "$LOC"
+                    return 0
                 fi
+                return 1
             fi
             return
             ;;


### PR DESCRIPTION
I noticed `spack cd` was always returning `0` regardless of success. Not sure if this suffices, but I tested it and it seems to work like I expect.

```
machine:~ user$ spack cd zlib
machine:zlib-1.2.11 user$ echo $?
0
machine:zlib-1.2.11 user$ spack cd blah
==> Error: Package blah not found.
machine:zlib-1.2.11 user$ echo $?
1
machine:zlib-1.2.11 user$ spack cd -h
usage: spack cd [-h] [-m | -r | -i | -p | -P | -s | -S | -b] ...

cd to spack directories in the shell

positional arguments:
  spec               spec of package to fetch directory for

optional arguments:
  -h, --help         show this help message and exit
  -m, --module-dir   spack python module directory
  -r, --spack-root   spack installation root
  -i, --install-dir  install prefix for spec (spec need not be installed)
  -p, --package-dir  directory enclosing a spec's package.py file
  -P, --packages     top-level packages directory for Spack
  -s, --stage-dir    stage directory for a spec
  -S, --stages       top level stage directory
  -b, --build-dir    checked out or expanded source directory for a spec
                     (requires it to be staged first)
machine:zlib-1.2.11 user$ echo $?
0
```