### PR TITLE
make yorick extendable.

### DIFF
--- a/var/spack/repos/builtin/packages/yorick/package.py
+++ b/var/spack/repos/builtin/packages/yorick/package.py
@@ -51,6 +51,8 @@ class Yorick(Package):
 
     depends_on('libx11', when='+X')
 
+    extendable = True
+
     def url_for_version(self, version):
         url = "https://github.com/dhmunro/yorick/archive/y_{0}.tar.gz"
         return url.format(version.underscored)


### PR DESCRIPTION
Spack can be used to install plugins (see https://github.com/dhmunro/yorick-z for example.)