### PR TITLE
New package allpaths-lg

### DIFF
--- a/var/spack/repos/builtin/packages/allpaths-lg/package.py
+++ b/var/spack/repos/builtin/packages/allpaths-lg/package.py
@@ -34,9 +34,11 @@ class AllpathsLg(AutotoolsPackage):
 
     version('52488', 'bde9008e236d87708a48eb83af6d6d5b')
 
-    conflicts('%gcc@:4.6,6.0:')
+    # compiles with gcc 4.7.0 to 4.9.4)
+    conflicts('%gcc@:4.6.4,5.1.0:')
 
     def build(self, spec, prefix):
         if not spec.satisfies('%gcc'):
-            raise InstallError("ALLPATHS-LG requires the GCC compiler for building")
+            raise InstallError("ALLPATHS-LG requires GCC"
+                               " for building")
         make()

--- a/var/spack/repos/builtin/packages/allpaths-lg/package.py
+++ b/var/spack/repos/builtin/packages/allpaths-lg/package.py
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class AllpathsLg(AutotoolsPackage):
+    """ALLPATHS-LG is our original short read assembler and it works on both
+       small and large (mammalian size) genomes."""
+
+    homepage = "http://www.broadinstitute.org/software/allpaths-lg/blog/"
+    url      = "ftp://ftp.broadinstitute.org/pub/crd/ALLPATHS/Release-LG/latest_source_code/LATEST_VERSION.tar.gz"
+
+    version('52488', 'bde9008e236d87708a48eb83af6d6d5b')
+
+    conflicts('%gcc@:4.6,6.0:')
+
+    def build(self, spec, prefix):
+        if not spec.satisfies('%gcc'):
+            raise InstallError("ALLPATHS-LG requires the GCC compiler for building")
+        make()

--- a/var/spack/repos/builtin/packages/allpaths-lg/package.py
+++ b/var/spack/repos/builtin/packages/allpaths-lg/package.py
@@ -36,9 +36,10 @@ class AllpathsLg(AutotoolsPackage):
 
     # compiles with gcc 4.7.0 to 4.9.4)
     conflicts('%gcc@:4.6.4,5.1.0:')
-
-    def build(self, spec, prefix):
-        if not spec.satisfies('%gcc'):
-            raise InstallError("ALLPATHS-LG requires GCC"
-                               " for building")
-        make()
+    conflicts('%cce')
+    conflicts('%clang')
+    conflicts('%intel')
+    conflicts('%nag')
+    conflicts('%pgi')
+    conflicts('%xl')
+    conflicts('%xl_r')


### PR DESCRIPTION
adding new package allpaths-lg. Package docs require gcc 4.7 or newer for building. Compiled successfully with 4.8.5, but failed with 7.1.0, 6.1.0, and 5.4.0 