### PR TITLE
Add package for lftp

### DIFF
--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -42,12 +42,11 @@ class Lftp(AutotoolsPackage):
     depends_on('zlib')
 
     def configure_args(self):
-        args = []
-        args.append('--with-expat={0}'.format(self.spec['expat'].prefix))
-        args.append('--with-libiconv={0}'.format(self.spec['libiconv'].prefix))
-        args.append('--with-openssl={0}'.format(self.spec['openssl'].prefix))
-        args.append('--with-readline={0}'.format(self.spec['readline'].prefix))
-        args.append('--with-zlib={0}'.format(self.spec['zlib'].prefix))
-
-        args.append('--disable-dependency-tracking')
-        return args
+        return [
+            '--with-expat={0}'.format(self.spec['expat'].prefix),
+            '--with-libiconv={0}'.format(self.spec['libiconv'].prefix),
+            '--with-openssl={0}'.format(self.spec['openssl'].prefix),
+            '--with-readline={0}'.format(self.spec['readline'].prefix),
+            '--with-zlib={0}'.format(self.spec['zlib'].prefix),
+            '--disable-dependency-tracking',
+        ]

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -1,0 +1,53 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Lftp(AutotoolsPackage):
+    """LFTP is a sophisticated file transfer program supporting a number
+       of network protocols (ftp, http, sftp, fish, torrent)."""
+
+    homepage = "http://lftp.yar.ru/"
+    url      = "http://lftp.yar.ru/ftp/lftp-4.7.7.tar.gz"
+
+    version('4.7.7', 'ddc71b3b11a1af465e829075ae14b3ff')
+
+    depends_on('expat')
+    depends_on('libiconv')
+    depends_on('ncurses')
+    depends_on('openssl')
+    depends_on('readline')
+    depends_on('zlib')
+
+    def configure_args(self):
+        args = []
+        args.append('--with-expat={0}'.format(self.spec['expat'].prefix))
+        args.append('--with-libiconv={0}'.format(self.spec['libiconv'].prefix))
+        args.append('--with-openssl={0}'.format(self.spec['openssl'].prefix))
+        args.append('--with-readline={0}'.format(self.spec['readline'].prefix))
+        args.append('--with-zlib={0}'.format(self.spec['zlib'].prefix))
+
+        args.append('--disable-dependency-tracking')
+        return args


### PR DESCRIPTION
Add a package for lftp.

Minimally tested on CentOS 7.

There's one potential problem:  `ldd` shows me this:

```
[hartzelg@lb097hmdev spack-lftp]$ ldd /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lftp-4.7.7-v6psktkhlioyfdcx4pzydyms6ocuyqud/bin/lftp
        linux-vdso.so.1 =>  (0x00002aaaaaaab000)
        libexpat.so.1 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/expat-2.2.0-7qhabmvnbgwkv6phrsvaiewsxg3anijo/lib/libexpat.so.1 (0x00002aaaaaaaf000)
        libssl.so.1.0.0 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/openssl-1.0.2k-3kq2xnggmaws2wiwbulate2lmulw7s54/lib/libssl.so.1.0.0 (0x00002aaaaacd9000)
        libz.so.1 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/zlib-1.2.11-yrijbmajetpxrkyaa4uclsyw62zbhc5m/lib/libz.so.1 (0x00002aaaaaf4c000)
        libcrypto.so.1.0.0 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/openssl-1.0.2k-3kq2xnggmaws2wiwbulate2lmulw7s54/lib/libcrypto.so.1.0.0 (0x00002aaaab16a000)
        libiconv.so.2 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/libiconv-1.15-bli6oh4rawy6bwdqa7ylbp7wt5tkynyv/lib/libiconv.so.2 (0x00002aaaab5bb000)
        libreadline.so.7 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/readline-7.0-kb65ucdvdtspudnrvf6vs5z6jjk7vlxq/lib/libreadline.so.7 (0x00002aaaab8ba000)
        libutil.so.1 => /lib64/libutil.so.1 (0x00002aaaabb13000)
        libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00002aaaabd16000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaabf41000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00002aaaac145000)
        libm.so.6 => /lib64/libm.so.6 (0x00002aaaac44d000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00002aaaac750000)
        libc.so.6 => /lib64/libc.so.6 (0x00002aaaac966000)
        libncursesw.so.6 => /home/hartzelg/tmp/spack-lftp/opt/spack/linux-centos7-x86_64/gcc-4.8.5/ncurses-6.0-75hnzrecoib5eqdvfchl6n2jgcxc6dgo/lib/libncursesw.so.6 (0x00002aaaacd29000)
        /lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
```

`libtinfo` seems to be curses related, and I'm wondering if it should be coming along with libcurses.

The rest appear to be system-ish libraries that Spack does not try to provide.