### PR TITLE
added albacore 1.2.4

### DIFF
--- a/var/spack/repos/builtin/packages/ont-albacore/package.py
+++ b/var/spack/repos/builtin/packages/ont-albacore/package.py
@@ -33,8 +33,9 @@ class OntAlbacore(Package):
     kits and Flow Cells."""
 
     homepage = "https://nanoporetech.com"
-    url = "https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-1.1.0-cp35-cp35m-manylinux1_x86_64.whl"
+    url = "https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-1.2.4-cp35-cp35m-manylinux1_x86_64.whl"
 
+    version('1.2.4', '559640bec4693af12e4d923e8d77adf6', expand=False)
     version('1.1.0', 'fab4502ea1bad99d813aa2629e03e83d', expand=False)
     extends('python')
 


### PR DESCRIPTION
From the vendor

```
Albacore v1.2.3 (and .4) for improved demultiplexing

Dear Nanopore Community,

We are releasing an updated version of Albacore (v1.2.3). This addresses the high number of "unclassified" reads that were being returned during demultiplexing, despite barcodes being physically present.

Cross-compatibility checks identified that some of the basecaller training processes for R9.5 were having a detrimental effect on the ability to correctly identify barcodes. v1.2.3 incorporates some immediate fixes for this, although work is ongoing to further improve barcode classification.

Those users who have run barcoding chemistry with R9.5 (FLO-MIN107) are recommended to re-run their data through this lastest Albacore version. More information about the software can be found in the Albacore protocol. You can download the new version from the links below:

Windows https://mirror.oxfordnanoportal.com/software/analysis/ont-albacore-1.2.4-amd64.msi 
Mac OS X https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-1.2.4-cp36-cp36m-macosx_10_11_x86_64.whl
Ubuntu 14 https://mirror.oxfordnanoportal.com/software/analysis/python3-ont-albacore_1.2.4-1~trusty_all.deb
Ubuntu 16 https://mirror.oxfordnanoportal.com/software/analysis/python3-ont-albacore_1.2.4-1~xenial_all.deb
Python 3.4 https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-1.2.4-cp34-cp34m-manylinux1_x86_64.whl
Python 3.5 https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-1.2.4-cp35-cp35m-manylinux1_x86_64.whl 

We apologise for any inconvenience caused, and look forward to your feedback.

UPDATE: v1.2.4 is now available, offering the same improvement for R9.4 chemistry. We advise users who have run barcoding chemistry wtih R9.4 (FLO-MIN106) to re-run their data through this latest Albacore version, available at the links above.
```