### PR TITLE
Helper script now supports JAVA_{ARGS,OPTS}

### DIFF
--- a/var/spack/repos/builtin/packages/trimmomatic/trimmomatic.sh
+++ b/var/spack/repos/builtin/packages/trimmomatic/trimmomatic.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # convenience wrapper for the trimmomatic.jar file
-java -jar trimmomatic.jar "$@"
+java $JAVA_ARGS $JAVA_OPTS -jar trimmomatic.jar "$@"


### PR DESCRIPTION
Make it possible to pass addition arguments to the
JVM.

Apparently there are two vars and they are [commonly *both* used][1].

Go figure.

[1]: https://stackoverflow.com/questions/23507639/is-it-same-mean-java-args-and-java-opts