### PR TITLE
Update hdfgroup packages to new URL structure

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -443,26 +443,31 @@ Version URLs
 By default, each version's URL is extrapolated from the ``url`` field
 in the package.  For example, Spack is smart enough to download
 version ``8.2.1.`` of the ``Foo`` package above from
-``http://example.com/foo-8.2.1.tar.gz``.
+http://example.com/foo-8.2.1.tar.gz.
 
 If the URL is particularly complicated or changes based on the release,
 you can override the default URL generation algorithm by defining your
-own ``url_for_version()`` function. For example, the developers of HDF5
-keep changing the archive layout, so the ``url_for_version()`` function
-looks like:
+own ``url_for_version()`` function. For example, the download URL for
+OpenMPI contains the major.minor version in one spot and the
+major.minor.patch version in another:
 
-.. literalinclude:: ../../../var/spack/repos/builtin/packages/hdf5/package.py
-   :pyobject: Hdf5.url_for_version
+https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
 
-With the use of this ``url_for_version()``, Spack knows to download HDF5 ``1.8.16``
-from ``http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.16/src/hdf5-1.8.16.tar.gz``
-but download HDF5 ``1.10.0`` from ``http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0/src/hdf5-1.10.0.tar.gz``.
+In order to handle this, you can define a ``url_for_version()`` function
+like so:
 
-You'll notice that HDF5's ``url_for_version()`` function makes use of a special
+.. literalinclude:: ../../../var/spack/repos/builtin/packages/openmpi/package.py
+   :pyobject: Openmpi.url_for_version
+
+With the use of this ``url_for_version()``, Spack knows to download OpenMPI ``2.1.1``
+from http://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2
+but download OpenMPI ``1.10.7`` from http://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.7.tar.bz2.
+
+You'll notice that OpenMPI's ``url_for_version()`` function makes use of a special
 ``Version`` function called ``up_to()``. When you call ``version.up_to(2)`` on a
 version like ``1.10.0``, it returns ``1.10``. ``version.up_to(1)`` would return
 ``1``. This can be very useful for packages that place all ``X.Y.*`` versions in
-a single directory and then places all ``X.Y.Z`` versions in a subdirectory.
+a single directory and then places all ``X.Y.Z`` versions in a sub-directory.
 
 There are a few ``Version`` properties you should be aware of. We generally
 prefer numeric versions to be separated by dots for uniformity, but not all
@@ -493,9 +498,6 @@ of its versions, you can add an explicit URL for a particular version:
    version('8.2.1', '4136d7b4c04df68b686570afa26988ac',
            url='http://example.com/foo-8.2.1-special-version.tar.gz')
 
-This is common for Python packages that download from PyPi. Since newer
-download URLs often contain a unique hash for each version, there is no
-way to guess the URL systematically.
 
 When you supply a custom URL for a version, Spack uses that URL
 *verbatim* and does not perform extrapolation.

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -25,15 +25,16 @@
 from spack import *
 
 
-class Hdf(Package):
+class Hdf(AutotoolsPackage):
     """HDF4 (also known as HDF) is a library and multi-object
     file format for storing and managing data between machines."""
 
-    homepage = "https://www.hdfgroup.org/products/hdf4/"
-    url      = "https://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.11/src/hdf-4.2.11.tar.gz"
-    list_url = "https://www.hdfgroup.org/ftp/HDF/releases/"
-    list_depth = 3
+    homepage = "https://support.hdfgroup.org/products/hdf4/"
+    url      = "https://support.hdfgroup.org/ftp/HDF/releases/HDF4.2.13/src/hdf-4.2.13.tar.gz"
+    list_url = "https://support.hdfgroup.org/ftp/HDF/releases"
+    list_depth = 2
 
+    version('4.2.13', 'a6aa950b3fce5162b96496d8ea0b82bf')
     version('4.2.12', '79fd1454c899c05e34a3da0456ab0c1c')
     version('4.2.11', '063f9928f3a19cc21367b71c3b8bbf19')
 
@@ -46,10 +47,11 @@ class Hdf(Package):
     depends_on('bison', type='build')
     depends_on('flex',  type='build')
 
-    def install(self, spec, prefix):
+    def configure_args(self):
+        spec = self.spec
+
         config_args = [
             'CFLAGS=-fPIC',
-            '--prefix={0}'.format(prefix),
             '--with-jpeg={0}'.format(spec['jpeg'].prefix),
             '--with-zlib={0}'.format(spec['zlib'].prefix),
             '--disable-netcdf',  # must be disabled to build NetCDF with HDF4
@@ -65,11 +67,4 @@ class Hdf(Package):
         else:
             config_args.append('--without-szlib')
 
-        configure(*config_args)
-
-        make()
-
-        if self.run_tests:
-            make('check')
-
-        make('install')
+        return config_args

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -32,19 +32,16 @@ class Hdf5(AutotoolsPackage):
     flexible and efficient I/O and for high volume and complex data.
     """
 
-    homepage = "http://www.hdfgroup.org/HDF5/"
-    url = "http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.gz"
-    list_url = "http://www.hdfgroup.org/ftp/HDF5/releases"
+    homepage = "https://support.hdfgroup.org/HDF5/"
+    url      = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz"
+    list_url = "https://support.hdfgroup.org/ftp/HDF5/releases"
     list_depth = 3
 
     version('1.10.1', '43a2f9466702fb1db31df98ae6677f15')
     version('1.10.0-patch1', '9180ff0ef8dc2ef3f61bd37a7404f295')
     version('1.10.0', 'bdc935337ee8282579cd6bc4270ad199')
-    version('1.8.18', 'dd2148b740713ca0295442ec683d7b1c',
-            # The link for the latest version differs from the links for
-            # the previous releases. Do not forget to remove this once
-            # the version 1.8.18 is not the latest one for the 1.8.* branch.
-            url='http://hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18.tar.gz')
+    version('1.8.19', '7f568e2464d4ab0a74d16b23956d900b')
+    version('1.8.18', 'dd2148b740713ca0295442ec683d7b1c')
     version('1.8.17', '7d572f8f3b798a628b8245af0391a0ca')
     version('1.8.16', 'b8ed9a36ae142317f88b0c7ef4b9c618')
     version('1.8.15', '03cccb5b33dbe975fdcd8ae9dc021f24')
@@ -76,6 +73,10 @@ class Hdf5(AutotoolsPackage):
     # (taken from hdf5@1.10.0patch1)
     conflicts('+threadsafe', when='+cxx')
     conflicts('+threadsafe', when='+fortran')
+
+    def url_for_version(self, version):
+        url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{0}/hdf5-{1}/src/hdf5-{1}.tar.gz"
+        return url.format(version.up_to(2), version)
 
     @property
     def libs(self):
@@ -279,26 +280,3 @@ HDF5 version {version} {version}
                 print('-' * 80)
                 raise RuntimeError("HDF5 install check failed")
         shutil.rmtree(checkdir)
-
-    def url_for_version(self, version):
-        # If we have a specific URL for this version, return it.
-        version_urls = self.version_urls()
-        if version in version_urls:
-            return version_urls[version]
-
-        base_url = "http://www.hdfgroup.org/ftp/HDF5/releases"
-
-        if version == Version("1.2.2"):
-            return "{0}/hdf5-{1}.tar.gz".format(base_url, version)
-        elif version < Version("1.6.6"):
-            return "{0}/hdf5-{1}/hdf5-{2}.tar.gz".format(
-                base_url, version.up_to(2), version)
-        elif version < Version("1.7"):
-            return "{0}/hdf5-{1}/hdf5-{2}/src/hdf5-{2}.tar.gz".format(
-                base_url, version.up_to(2), version)
-        elif version < Version("1.10"):
-            return "{0}/hdf5-{1}/src/hdf5-{1}.tar.gz".format(
-                base_url, version)
-        else:
-            return "{0}/hdf5-{1}/hdf5-{2}/src/hdf5-{2}.tar.gz".format(
-                base_url, version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -198,8 +198,8 @@ class Openmpi(AutotoolsPackage):
     conflicts('fabrics=mxm', when='@:1.5.3')  # MXM support was added in 1.5.4
 
     def url_for_version(self, version):
-        return "http://www.open-mpi.org/software/ompi/v%s/downloads/openmpi-%s.tar.bz2" % (
-            version.up_to(2), version)
+        url = "http://www.open-mpi.org/software/ompi/v{0}/downloads/openmpi-{1}.tar.bz2"
+        return url.format(version.up_to(2), version)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/szip/package.py
+++ b/var/spack/repos/builtin/packages/szip/package.py
@@ -33,13 +33,18 @@ class Szip(AutotoolsPackage):
     provided with HDF software products.
     """
 
-    homepage = "https://www.hdfgroup.org/doc_resource/SZIP/"
-    url = "http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz"
+    homepage = "https://support.hdfgroup.org/doc_resource/SZIP/"
+    url      = "https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz"
+    list_url = "https://support.hdfgroup.org/ftp/lib-external/szip"
+    list_depth = 2
 
-    version('2.1', '902f831bcefb69c6b635374424acbead')
+    version('2.1.1', 'dd579cf0f26d44afd10a0ad7291fc282')
+    version('2.1',   '902f831bcefb69c6b635374424acbead')
 
     def configure_args(self):
-        return ['--enable-production',
-                '--enable-shared',
-                '--enable-static',
-                '--enable-encoding']
+        return [
+            '--enable-production',
+            '--enable-shared',
+            '--enable-static',
+            '--enable-encoding',
+        ]


### PR DESCRIPTION
Closes #4626 

The HDF Group updated their website with a new repository structure that seems to be significantly more consistent than the old one (see `url_for_version` for `hdf5` package).

Also updates `hdf` to `AutotoolsPackage` and adds newer versions of `szip`, `hdf`, and `hdf5@1.8`.

@iulian787 @cyrush 