### PR TITLE
Adding assert statements

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -649,13 +649,16 @@ class Database(object):
 
     def _get_matching_spec_key(self, spec, **kwargs):
         """Get the exact spec OR get a single spec that matches."""
-        key = spec.dag_hash()
-        if key not in self._data:
+        key = ''
+        if spec.concrete:
+            key = spec.dag_hash()
+        if key in self._data:
+            return key
+        else:
             match = self.query_one(spec, **kwargs)
             if match:
                 return match.dag_hash()
-            raise KeyError("No such spec in database! %s" % spec)
-        return key
+            raise KeyError("No such spec in database! %s" %spec)
 
     @_autospec
     def get_record(self, spec, **kwargs):

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -571,8 +571,12 @@ def graph_dot(specs, deptype=None, static=False, out=None):
                 deps.add((provider, spec.name))
 
         else:
-            def key_label(s):
-                return s.dag_hash(), "%s/%s" % (s.name, s.dag_hash(7))
+            if spec.concrete:
+                def key_label(s):
+                    return s.dag_hash(), "%s/%s" % (s.name, s.dag_hash(7))
+            else:
+                def key_label(s):
+                    return hash(s._cmp_key()), s.name
 
             for s in spec.traverse(deptype=deptype):
                 skey, slabel = key_label(s)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1,4 +1,3 @@
-
 ##############################################################################
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
@@ -1439,6 +1438,7 @@ class Spec(object):
         return syaml_dict([(self.name, d)])
 
     def to_dict(self):
+        assert self.concrete
         node_list = []
         for s in self.traverse(order='pre', deptype=('link', 'run')):
             node = s.to_node_dict()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1369,10 +1369,12 @@ class Spec(object):
 
     @property
     def prefix(self):
+        assert self.concrete
         return Prefix(spack.store.layout.path_for_spec(self))
 
     def dag_hash(self, length=None):
         """Return a hash of the entire spec DAG, including connectivity."""
+        assert self.concrete
         if self._hash:
             return self._hash[:length]
         else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1,3 +1,4 @@
+
 ##############################################################################
 # Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
@@ -1386,8 +1387,7 @@ class Spec(object):
             if sys.version_info[0] >= 3:
                 b32_hash = b32_hash.decode('utf-8')
 
-            if self.concrete:
-                self._hash = b32_hash
+            self._hash = b32_hash
             return b32_hash[:length]
 
     def dag_hash_bit_prefix(self, bits):

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -84,16 +84,18 @@ def test_dynamic_dot_graph_mpileaks(builtin_mock):
 
     dot = stream.getvalue()
 
-    mpileaks_hash, mpileaks_lbl = s._cmp_key(), s.name
-    mpi_hash, mpi_lbl = s['mpi']._cmp_key(), s['mpi'].name
+    mpileaks_hash, mpileaks_lbl = hash(s._cmp_key()), s.name
+    mpi_hash, mpi_lbl = hash(s['mpi']._cmp_key()), s['mpi'].name
     callpath_hash, callpath_lbl = (
-        s['callpath']._cmp_key(), s['callpath'].name)
+        hash(s['callpath']._cmp_key()), s['callpath'].name)
     dyninst_hash, dyninst_lbl = (
-        s['dyninst']._cmp_key(), s['dyninst'].name)
+        hash(s['dyninst']._cmp_key()), s['dyninst'].name)
     libdwarf_hash, libdwarf_lbl = (
-        s['libdwarf']._cmp_key(), s['libdwarf'].name)
+        hash(s['libdwarf']._cmp_key()), s['libdwarf'].name)
     libelf_hash, libelf_lbl = (
-        s['libelf']._cmp_key(), s['libelf'].name)
+        hash(s['libelf']._cmp_key()), s['libelf'].name)
+
+    print dot
 
     assert '  "%s" [label="%s"]\n' % (mpileaks_hash, mpileaks_lbl) in dot
     assert '  "%s" [label="%s"]\n' % (callpath_hash, callpath_lbl) in dot

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -84,16 +84,16 @@ def test_dynamic_dot_graph_mpileaks(builtin_mock):
 
     dot = stream.getvalue()
 
-    mpileaks_hash, mpileaks_lbl = s.dag_hash(), s.format('$_$/')
-    mpi_hash, mpi_lbl = s['mpi'].dag_hash(), s['mpi'].format('$_$/')
+    mpileaks_hash, mpileaks_lbl = s._cmp_key(), s.name
+    mpi_hash, mpi_lbl = s['mpi']._cmp_key(), s['mpi'].name
     callpath_hash, callpath_lbl = (
-        s['callpath'].dag_hash(), s['callpath'].format('$_$/'))
+        s['callpath']._cmp_key(), s['callpath'].name)
     dyninst_hash, dyninst_lbl = (
-        s['dyninst'].dag_hash(), s['dyninst'].format('$_$/'))
+        s['dyninst']._cmp_key(), s['dyninst'].name)
     libdwarf_hash, libdwarf_lbl = (
-        s['libdwarf'].dag_hash(), s['libdwarf'].format('$_$/'))
+        s['libdwarf']._cmp_key(), s['libdwarf'].name)
     libelf_hash, libelf_lbl = (
-        s['libelf'].dag_hash(), s['libelf'].format('$_$/'))
+        s['libelf']._cmp_key(), s['libelf'].name)
 
     assert '  "%s" [label="%s"]\n' % (mpileaks_hash, mpileaks_lbl) in dot
     assert '  "%s" [label="%s"]\n' % (callpath_hash, callpath_lbl) in dot

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -41,17 +41,6 @@ def check_yaml_round_trip(spec):
     assert spec.eq_dag(spec_from_yaml)
 
 
-def test_simple_spec():
-    spec = Spec('mpileaks')
-    check_yaml_round_trip(spec)
-
-
-def test_normal_spec(builtin_mock):
-    spec = Spec('mpileaks+debug~opt')
-    spec.normalize()
-    check_yaml_round_trip(spec)
-
-
 def test_external_spec(config, builtin_mock):
     spec = Spec('externaltool')
     spec.concretize()
@@ -62,9 +51,9 @@ def test_external_spec(config, builtin_mock):
     check_yaml_round_trip(spec)
 
 
-def test_ambiguous_version_spec(builtin_mock):
+def test_ambiguous_version_spec(config, builtin_mock):
     spec = Spec('mpileaks@1.0:5.0,6.1,7.3+debug~opt')
-    spec.normalize()
+    spec.concretize()
     check_yaml_round_trip(spec)
 
 
@@ -89,7 +78,7 @@ def test_yaml_subdag(config, builtin_mock):
         assert spec[dep].eq_dag(yaml_spec[dep])
 
 
-def test_using_ordered_dict(builtin_mock):
+def test_using_ordered_dict(config, builtin_mock):
     """ Checks that dicts are ordered
 
     Necessary to make sure that dag_hash is stable across python
@@ -110,7 +99,7 @@ def test_using_ordered_dict(builtin_mock):
     specs = ['mpileaks ^zmpi', 'dttop', 'dtuse']
     for spec in specs:
         dag = Spec(spec)
-        dag.normalize()
+        dag.concretize()
         from pprint import pprint
         pprint(dag.to_node_dict())
         break


### PR DESCRIPTION
I noticed that Spec.prefix should never be called on an abstract spec, so I added an assert statement.

I added a similar statement for Spec.dag_hash(), although that required slight changes to database and graph code. Once those were done the same was true for Spec.to_dict(), which underpins Spec.to_yaml() and Spec.to_json(), so I added an assert statement to it as well.

These follow my intuitions: It is nonsense to look for the prefix of an abstract spec, we can't know yet. Similarly for its hash. And we treat all read specs as concrete, so we'd better only write them once they're concrete as well.

Database._add already threw an error if the spec was not concrete, so there was no need to add to that.

Please comment or edit if you've noticed other invariants that should be enshrined in the code with assert statements, or of course any problem with these invariants.