### PR TITLE
mvapich2: Fix mpifort wrapper

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -235,6 +235,7 @@ class Mvapich2(AutotoolsPackage):
         mpicxx = join_path(bin, 'mpicxx')
         mpif77 = join_path(bin, 'mpif77')
         mpif90 = join_path(bin, 'mpif90')
+        mpifort = join_path(bin, 'mpifort')
 
         # Substitute Spack compile wrappers for the real
         # underlying compiler
@@ -243,8 +244,9 @@ class Mvapich2(AutotoolsPackage):
         filter_file(env['CXX'], self.compiler.cxx, mpicxx, **kwargs)
         filter_file(env['F77'], self.compiler.f77, mpif77, **kwargs)
         filter_file(env['FC'], self.compiler.fc, mpif90, **kwargs)
+        filter_file(env['FC'], self.compiler.fc, mpifort, **kwargs)
 
         # Remove this linking flag if present
         # (it turns RPATH into RUNPATH)
-        for wrapper in (mpicc, mpicxx, mpif77, mpif90):
+        for wrapper in (mpicc, mpicxx, mpif77, mpif90, mpifort):
             filter_file('-Wl,--enable-new-dtags', '', wrapper, **kwargs)


### PR DESCRIPTION
mvapich2 installs an `mpifort` wrapper that currently ends up calling Spack's compiler wrapper.