### PR TITLE
PETSc requires metis build with compatible numerical precision

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -100,8 +100,10 @@ class Petsc(Package):
 
     # Other dependencies
     depends_on('boost', when='@:3.5+boost')
-    depends_on('metis@5:~int64', when='+metis~int64')
-    depends_on('metis@5:+int64', when='+metis+int64')
+    depends_on('metis@5:~int64+real64', when='+metis~int64+double')
+    depends_on('metis@5:+int64', when='+metis+int64~double')
+    depends_on('metis@5:~int64+real64', when='+metis~int64+double')
+    depends_on('metis@5:+int64', when='+metis+int64~double')
 
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('parmetis', when='+metis+mpi')


### PR DESCRIPTION
Commit-type: bug-fix, portability-fix
Funded-by: IDEAS
Project: xSDK
Time: .4 hours
Reported-by: Stanislav Y Sergienko <ssergien@anl.gov>