### PR TITLE
fix callpath bug

### DIFF
--- a/var/spack/repos/builtin/packages/callpath/package.py
+++ b/var/spack/repos/builtin/packages/callpath/package.py
@@ -48,7 +48,7 @@ class Callpath(Package):
         if spec.satisfies("^dyninst@9.3.0:"):
             std_flag = self.compiler.cxx11_flag
             cmake_args.append("-DCMAKE_CXX_FLAGS='{0} -fpermissive'".format(
-                    std_flag))
+                std_flag))
         cmake('.', "-DCALLPATH_WALKER=dyninst", *cmake_args)
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/callpath/package.py
+++ b/var/spack/repos/builtin/packages/callpath/package.py
@@ -46,7 +46,9 @@ class Callpath(Package):
         # TODO: offer options for the walker used.
         cmake_args = std_cmake_args
         if spec.satisfies("^dyninst@9.3.0:"):
-            cmake_args.append("-DCMAKE_CXX_FLAGS='-std=c++11 -fpermissive'")
+            std_flag = self.compiler.cxx11_flag
+            cmake_args.append("-DCMAKE_CXX_FLAGS='{0} -fpermissive'".format(
+                    std_flag))
         cmake('.', "-DCALLPATH_WALKER=dyninst", *cmake_args)
         make()
         make("install")


### PR DESCRIPTION
Callpath package.py had a bug when using gcc versions between 4.3 and 4.7. Fixed by using self.compiler.cxx11_flag instead of hardcoding.