### PR TITLE
Update go and go-bootstrap

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -46,10 +46,12 @@ class GoBootstrap(Package):
     # See: https://golang.org/doc/install/source#go14 and
     # https://github.com/golang/go/issues/17545 and
     # https://github.com/golang/go/issues/16352
+    version('1.4-bootstrap-20170531', 'd2cc61cb9f829b3510ee39c0c5568014',
+            url='https://storage.googleapis.com/golang/go1.4-bootstrap-20170531.tar.gz')
     version('1.4-bootstrap-20161024', '76e42c8152e8560ded880a6d1d1f53cb',
             url='https://storage.googleapis.com/golang/go1.4-bootstrap-20161024.tar.gz')
 
-    provides('golang@:1.4-bootstrap-20161024')
+    provides('golang@:1.4-bootstrap-20170531')
 
     depends_on('git', type=('build', 'link', 'run'))
 
@@ -64,10 +66,6 @@ class GoBootstrap(Package):
             r'^(.*)(\$GOROOT/src/cmd/api/run.go)(.*)$',
             r'# \1\2\3',
         )
-
-    @when('@1.5.0:')  # noqa: F811
-    def patch(self):
-        pass
 
     def install(self, spec, prefix):
         env['CGO_ENABLED'] = '0'

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -56,6 +56,7 @@ class Go(Package):
 
     extendable = True
 
+    version('1.8.3', '64e9380e07bba907e26a00cf5fcbe77e')
     version('1.8.1', '409dd21e7347dd1ea9efe64a700073cc')
     version('1.8',   '7743960c968760437b6e39093cfe6f67')
     version('1.7.5', '506de2d870409e9003e1440bcfeb3a65')


### PR DESCRIPTION
This updates go to 1.8.3 and go-bootstrap to 1.4-bootstrap-20170531.