### PR TITLE
GCC: Add strip variant to reduce installation size

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -73,6 +73,9 @@ class Gcc(AutotoolsPackage):
     variant('piclibs',
             default=False,
             description='Build PIC versions of libgfortran.a and libstdc++.a')
+    variant('strip',
+            default=False,
+            description='Strip executables to greatly reduce installation size')
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
@@ -235,6 +238,12 @@ class Gcc(AutotoolsPackage):
         if sys.platform == 'darwin':
             return ['bootstrap']
         return []
+
+    @property
+    def install_targets(self):
+        if '+strip' in self.spec:
+            return ['install-strip']
+        return ['install']
 
     @property
     def spec_dir(self):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -75,7 +75,7 @@ class Gcc(AutotoolsPackage):
             description='Build PIC versions of libgfortran.a and libstdc++.a')
     variant('strip',
             default=False,
-            description='Strip executables to greatly reduce installation size')
+            description='Strip executables to reduce installation size')
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')


### PR DESCRIPTION
Stripping the executables of GCC greatly reduces the installed package size:
6.2.0: 1.3G -> 296M
7.1.0 974M -> 206M

["install-strip" is a standard installation target.](https://www.gnu.org/prep/standards/html_node/Standard-Targets.html) Perhaps Spack itself should be adapted to make it an option for all packages.