### PR TITLE
Make vcftools actually install its libraries

### DIFF
--- a/var/spack/repos/builtin/packages/vcftools/package.py
+++ b/var/spack/repos/builtin/packages/vcftools/package.py
@@ -45,7 +45,7 @@ class Vcftools(AutotoolsPackage):
     # this needs to be in sync with what setup_environment adds to
     # PERL5LIB below
     def configure_args(self):
-        return ['--with-pmdir=lib']
+        return ['--with-pmdir={0}'.format(self.prefix.lib)]
 
     @run_before('install')
     def filter_sbang(self):
@@ -72,4 +72,4 @@ class Vcftools(AutotoolsPackage):
             filter_file(match, substitute, *files, **kwargs)
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PERL5LIB', join_path(self.prefix, 'lib'))
+        run_env.prepend_path('PERL5LIB', self.prefix.lib)


### PR DESCRIPTION
The vcftools package was installing its Perl libraries into a directory in the staging directory named 'lib', instead of installing them into `prefix.lib` because I was passing a silly value to the `--with-pmdir`option.

The result was that any attempt to run one of the scripts in the package failed with something like:

> Can't locate VcfStats.pm in @INC (you may need to install the
> VcfStats module) [...]

This fix provides the correct information in `configure_args`.

Tested lightly on CentOS 7.