### PR TITLE
ISAAC 1.3.1: New version

### DIFF
--- a/var/spack/repos/builtin/packages/isaac/package.py
+++ b/var/spack/repos/builtin/packages/isaac/package.py
@@ -39,6 +39,7 @@ class Isaac(CMakePackage):
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('1.3.1', '7fe075f9af68d05355eaba0e224f20ca')
     version('1.3.0', 'c8a794da9bb998ef0e75449bfece1a12')
 
     variant('cuda', default=True,


### PR DESCRIPTION
adds a new release of isaac.
(1.3.0 forgot to bump the internal version number in include macros)