### PR TITLE
Adding OpenMP variant to Trilinos. Also building NetCDF with PNetCDF directly, for Trilinos.

### DIFF
--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -43,7 +43,7 @@ class Nalu(CMakePackage):
 
     # Currently Nalu only builds static libraries; To be fixed soon
     depends_on('yaml-cpp+fpic~shared')
-    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+openmp@master')
+    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf@master')
 
     def build_type(self):
         if '+debug' in self.spec:

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -43,7 +43,7 @@ class Nalu(CMakePackage):
 
     # Currently Nalu only builds static libraries; To be fixed soon
     depends_on('yaml-cpp+fpic~shared')
-    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf@master')
+    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+openmp@master')
 
     def build_type(self):
         if '+debug' in self.spec:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -231,6 +231,11 @@ class Trilinos(CMakePackage):
             # Only choose one type of superlu
             raise RuntimeError('The superlu-dist and superlu variant' +
                                ' cannot be used together')
+        if ('+pnetcdf' in self.spec and
+            self.spec.satisfies('@11.14.1:12.10.1')):
+            # PnetCDF was implemented in > v12.10.1
+            raise RuntimeError('The pnetcdf variant' +
+                               ' can only be used with Trilinos > v12.10.1')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -167,9 +167,13 @@ class Trilinos(CMakePackage):
     conflicts('+fortrilinos', when='~fortran')
     conflicts('+fortrilinos', when='@:99')
     conflicts('+fortrilinos', when='@master')
+    # Can only use one type of SuperLU
     conflicts('+superlu-dist', when='+superlu')
-    conflicts('+superlu-dist', when='@11.14.1:11.14.3')
-    conflicts('+pnetcdf', when='@11.14.1:12.10.1')
+    # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
+    # deprecated SuperLUDist v3.3 together with an Amesos patch is working.
+    conflicts('+superlu-dist', when='@:11.14.3')
+    # PnetCDF was only added after v12.10.1
+    conflicts('+pnetcdf', when='@:12.10.1')
 
     # ###################### Dependencies ##########################
 
@@ -223,7 +227,6 @@ class Trilinos(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        self.variants_check()
 
         cxx_flags = []
         options = []

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -167,6 +167,9 @@ class Trilinos(CMakePackage):
     conflicts('+fortrilinos', when='~fortran')
     conflicts('+fortrilinos', when='@:99')
     conflicts('+fortrilinos', when='@master')
+    conflicts('+superlu-dist', when='+superlu')
+    conflicts('+superlu-dist', when='@11.14.1:11.14.3')
+    conflicts('+pnetcdf', when='@11.14.1:12.10.1')
 
     # ###################### Dependencies ##########################
 
@@ -217,25 +220,6 @@ class Trilinos(CMakePackage):
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"
         return url.format(version.dashed)
-
-    # check that the combination of variants makes sense
-    def variants_check(self):
-        if ('+superlu-dist' in self.spec and
-            self.spec.satisfies('@11.14.1:11.14.3')):
-            # For Trilinos v11 we need to force SuperLUDist=OFF, since only the
-            # deprecated SuperLUDist v3.3 together with an Amesos patch is
-            # working.
-            raise RuntimeError('The superlu-dist variant can only be used' +
-                               ' with Trilinos @12.0.1:')
-        if '+superlu-dist' in self.spec and '+superlu' in self.spec:
-            # Only choose one type of superlu
-            raise RuntimeError('The superlu-dist and superlu variant' +
-                               ' cannot be used together')
-        if ('+pnetcdf' in self.spec and
-            self.spec.satisfies('@11.14.1:12.10.1')):
-            # PnetCDF was implemented in > v12.10.1
-            raise RuntimeError('The pnetcdf variant' +
-                               ' can only be used with Trilinos > v12.10.1')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -149,6 +149,8 @@ class Trilinos(CMakePackage):
             description='Enable DataTransferKit')
     variant('fortrilinos',  default=False,
             description='Enable ForTrilinos')
+    variant('openmp',       default=False,
+            description='Enable OpenMP')
 
     resource(name='dtk',
              git='https://github.com/ornl-cees/DataTransferKit',
@@ -181,9 +183,9 @@ class Trilinos(CMakePackage):
 
     # MPI related dependencies
     depends_on('mpi')
-    depends_on('netcdf+mpi')
-    depends_on('parallel-netcdf', when="+pnetcdf@master")
-    depends_on('parallel-netcdf', when="+pnetcdf@12.10.2:")
+    depends_on('netcdf+mpi', when="~pnetcdf")
+    depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@master")
+    depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@12.10.2:")
     depends_on('parmetis', when='+metis')
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see
@@ -342,7 +344,8 @@ class Trilinos(CMakePackage):
                 '-DTrilinos_ENABLE_SEACASEpu:BOOL=ON',
                 '-DTrilinos_ENABLE_SEACASExodiff:BOOL=ON',
                 '-DTrilinos_ENABLE_SEACASNemspread:BOOL=ON',
-                '-DTrilinos_ENABLE_SEACASNemslice:BOOL=ON'
+                '-DTrilinos_ENABLE_SEACASNemslice:BOOL=ON',
+                '-DTrilinos_ENABLE_SEACASIoss:BOOL=ON'
             ])
         else:
             options.extend([
@@ -522,6 +525,17 @@ class Trilinos(CMakePackage):
             ])
 
         # ################# Miscellaneous Stuff ######################
+
+        # OpenMP
+        if '+openmp' in spec:
+            options.extend([
+                '-DTrilinos_ENABLE_OpenMP:BOOL=ON',
+                '-DKokkos_ENABLE_OpenMP:BOOL=ON'
+            ])
+            if '+tpetra' in spec:
+                options.extend([
+                    '-DTpetra_INST_OPENMP:BOOL=ON'
+                ])
 
         # Fortran lib
         if '+fortran' in spec:


### PR DESCRIPTION
Adding an OpenMP variant to Trilinos and enabling it for Nalu by default. Also I found that NetCDF should be built with PNetCDF support directly when `+pnetcdf`.