### PR TITLE
fastx-toolkit: solving gcc 7.1.0 conflict

### DIFF
--- a/var/spack/repos/builtin/packages/fastx-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/fastx-toolkit/package.py
@@ -35,3 +35,5 @@ class FastxToolkit(AutotoolsPackage):
     version('0.0.14', 'bf1993c898626bb147de3d6695c20b40')
 
     depends_on('libgtextutils')
+
+    conflicts('%gcc@7.1.0:')


### PR DESCRIPTION
Tried compiling fastx-toolkit with gcc 7.1.0 and failed with:
```
fasta_formatter.cpp: In function ‘void parse_command_line(int, char**)’:
fasta_formatter.cpp:105:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
    usage();
    ~~~~~^~
fasta_formatter.cpp:107:3: note: here
   case 'i':
   ^~~~
cc1plus: all warnings being treated as errors
make[3]: *** [fasta_formatter.o] Error 1
make[3]: Leaving directory `/tmp/las_thoma15/spack-stage/spack-stage-a7Oulq/fastx_toolkit-0.0.14/src/fasta_formatter'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/tmp/las_thoma15/spack-stage/spack-stage-a7Oulq/fastx_toolkit-0.0.14/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/tmp/las_thoma15/spack-stage/spack-stage-a7Oulq/fastx_toolkit-0.0.14'
make: *** [all] Error 2
```

Compiled with gcc 6.3.0 instead and built successfully. Updated package.py to accommodate for conflict. 