### PR TITLE
py-deeptools: new package and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-deeptools/package.py
+++ b/var/spack/repos/builtin/packages/py-deeptools/package.py
@@ -25,23 +25,20 @@
 from spack import *
 
 
-class Bcftools(Package):
-    """BCFtools is a set of utilities that manipulate variant calls in the
-       Variant Call Format (VCF) and its binary counterpart BCF. All
-       commands work transparently with both VCFs and BCFs, both
-       uncompressed and BGZF-compressed."""
+class PyDeeptools(PythonPackage):
+    """deepTools addresses the challenge of handling the large amounts of data
+       that are now routinely generated from DNA sequencing centers."""
 
-    homepage = "http://samtools.github.io/bcftools/"
-    url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
+    homepage = "https://github.com/fidelram/deepTools"
+    url      = "https://github.com/fidelram/deepTools/archive/2.5.2.tar.gz"
 
-    version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
-    version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
+    version('2.5.2', '76d6550f9341e9d751508ae8f6e76310')
 
-    depends_on('zlib')
-    depends_on('bzip2', when="@1.4:")
-    # build fails without xz
-    depends_on('xz', when="@1.4")
-
-    def install(self, spec, prefix):
-        make("prefix=%s" % prefix, "all")
-        make("prefix=%s" % prefix, "install")
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy@1.8.0:', type=('build', 'run'))
+    depends_on('py-scipy@0.17.0:', type=('build', 'run'))
+    depends_on('py-py2bit@0.1.0:', type=('build', 'run'))
+    depends_on('py-pybigwig@0.2.1:', type=('build', 'run'))
+    depends_on('py-pysam@0.8:', type=('build', 'run'))
+    depends_on('py-matplotlib@1.4.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-deeptools/package.py
+++ b/var/spack/repos/builtin/packages/py-deeptools/package.py
@@ -29,16 +29,17 @@ class PyDeeptools(PythonPackage):
     """deepTools addresses the challenge of handling the large amounts of data
        that are now routinely generated from DNA sequencing centers."""
 
-    homepage = "https://github.com/fidelram/deepTools"
-    url      = "https://github.com/fidelram/deepTools/archive/2.5.2.tar.gz"
+    homepage = "https://pypi.io/packages/source/d/deepTools"
+    url      = "https://pypi.io/packages/source/d/deepTools/deepTools-2.5.2.tar.gz"
 
-    version('2.5.2', '76d6550f9341e9d751508ae8f6e76310')
+    version('2.5.2', 'ba8a44c128c6bb1ed4ebdb20bf9ae9c2')
 
     depends_on('python@2.7:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-numpy@1.8.0:', type=('build', 'run'))
+    depends_on('py-numpy@1.9.0:', type=('build', 'run'))
     depends_on('py-scipy@0.17.0:', type=('build', 'run'))
-    depends_on('py-py2bit@0.1.0:', type=('build', 'run'))
+    depends_on('py-py2bit@0.2.0:', type=('build', 'run'))
     depends_on('py-pybigwig@0.2.1:', type=('build', 'run'))
-    depends_on('py-pysam@0.8:', type=('build', 'run'))
+    depends_on('py-pysam@0.8.2:', type=('build', 'run'))
     depends_on('py-matplotlib@1.4.0:', type=('build', 'run'))
+    depends_on('py-numpydoc@0.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-py2bit/package.py
+++ b/var/spack/repos/builtin/packages/py-py2bit/package.py
@@ -29,7 +29,7 @@ class PyPy2bit(PythonPackage):
     """A package for accessing 2bit files using lib2bit."""
 
     homepage = "https://pypi.python.org/pypi/py2bit"
-    url      = "https://pypi.python.org/packages/b2/ad/72d0d1cf2a588d9d2b16f5e531063aa33d1c80bf424e810fc1dfe5c5dc72/py2bit-0.2.1.tar.gz#md5=eaf5b1c80a0bbf0b35af1f002f83a556"
+    url      = "https://pypi.io/packages/source/p/py2bit/py2bit-0.2.1.tar.gz"
 
     version('0.2.1', 'eaf5b1c80a0bbf0b35af1f002f83a556')
 

--- a/var/spack/repos/builtin/packages/py-py2bit/package.py
+++ b/var/spack/repos/builtin/packages/py-py2bit/package.py
@@ -25,23 +25,12 @@
 from spack import *
 
 
-class Bcftools(Package):
-    """BCFtools is a set of utilities that manipulate variant calls in the
-       Variant Call Format (VCF) and its binary counterpart BCF. All
-       commands work transparently with both VCFs and BCFs, both
-       uncompressed and BGZF-compressed."""
+class PyPy2bit(PythonPackage):
+    """A package for accessing 2bit files using lib2bit."""
 
-    homepage = "http://samtools.github.io/bcftools/"
-    url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
+    homepage = "https://pypi.python.org/pypi/py2bit"
+    url      = "https://pypi.python.org/packages/b2/ad/72d0d1cf2a588d9d2b16f5e531063aa33d1c80bf424e810fc1dfe5c5dc72/py2bit-0.2.1.tar.gz#md5=eaf5b1c80a0bbf0b35af1f002f83a556"
 
-    version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
-    version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
+    version('0.2.1', 'eaf5b1c80a0bbf0b35af1f002f83a556')
 
-    depends_on('zlib')
-    depends_on('bzip2', when="@1.4:")
-    # build fails without xz
-    depends_on('xz', when="@1.4")
-
-    def install(self, spec, prefix):
-        make("prefix=%s" % prefix, "all")
-        make("prefix=%s" % prefix, "install")
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pybigwig/package.py
+++ b/var/spack/repos/builtin/packages/py-pybigwig/package.py
@@ -29,9 +29,9 @@ class PyPybigwig(PythonPackage):
     """A package for accessing bigWig files using libBigWig."""
 
     homepage = "https://pypi.python.org/pypi/pyBigWig"
-    url      = "https://pypi.python.org/packages/4d/7c/911e92392cf2d70d1a0da8fbb95be1e203f3cf9f858e030e98d4882c9ec7/pyBigWig-0.3.4.tar.gz#md5=8e0a91e26e87eeaa071408a3a749bfa9"
+    url      = "https://pypi.io/packages/source/p/pyBigWig/pyBigWig-0.3.4.tar.gz"
 
     version('0.3.4', '8e0a91e26e87eeaa071408a3a749bfa9')
 
     depends_on('py-setuptools', type='build')
-    depends_on('curl', type='build')
+    depends_on('curl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pybigwig/package.py
+++ b/var/spack/repos/builtin/packages/py-pybigwig/package.py
@@ -25,23 +25,13 @@
 from spack import *
 
 
-class Bcftools(Package):
-    """BCFtools is a set of utilities that manipulate variant calls in the
-       Variant Call Format (VCF) and its binary counterpart BCF. All
-       commands work transparently with both VCFs and BCFs, both
-       uncompressed and BGZF-compressed."""
+class PyPybigwig(PythonPackage):
+    """A package for accessing bigWig files using libBigWig."""
 
-    homepage = "http://samtools.github.io/bcftools/"
-    url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
+    homepage = "https://pypi.python.org/pypi/pyBigWig"
+    url      = "https://pypi.python.org/packages/4d/7c/911e92392cf2d70d1a0da8fbb95be1e203f3cf9f858e030e98d4882c9ec7/pyBigWig-0.3.4.tar.gz#md5=8e0a91e26e87eeaa071408a3a749bfa9"
 
-    version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
-    version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
+    version('0.3.4', '8e0a91e26e87eeaa071408a3a749bfa9')
 
-    depends_on('zlib')
-    depends_on('bzip2', when="@1.4:")
-    # build fails without xz
-    depends_on('xz', when="@1.4")
-
-    def install(self, spec, prefix):
-        make("prefix=%s" % prefix, "all")
-        make("prefix=%s" % prefix, "install")
+    depends_on('py-setuptools', type='build')
+    depends_on('curl', type='build')

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -35,5 +35,5 @@ class PyPysam(PythonPackage):
     version('0.11.2.2', '56230cd5f55b503845915b76c22d620a')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython@0.24.1:', type='build')
+    depends_on('py-cython@0.21:', type='build')
     depends_on('bcftools')

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -30,11 +30,10 @@ class PyPysam(PythonPackage):
        sets."""
 
     homepage = "https://pypi.python.org/pypi/pysam"
-    url      = "https://pypi.python.org/packages/a4/1b/b6dfd92aea876647d20d9a8bd8618e4f2af6300539426be83c8bb0912d6f/pysam-0.11.2.2.tar.gz#md5=56230cd5f55b503845915b76c22d620a"
+    url      = "https://pypi.io/packages/source/p/pysam/pysam-0.11.2.2.tar.gz"
 
     version('0.11.2.2', '56230cd5f55b503845915b76c22d620a')
 
-    depends_on('python', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython@0.24.1:', type=('build', 'run'))
+    depends_on('py-cython@0.24.1:', type='build')
     depends_on('bcftools')

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -25,23 +25,16 @@
 from spack import *
 
 
-class Bcftools(Package):
-    """BCFtools is a set of utilities that manipulate variant calls in the
-       Variant Call Format (VCF) and its binary counterpart BCF. All
-       commands work transparently with both VCFs and BCFs, both
-       uncompressed and BGZF-compressed."""
+class PyPysam(PythonPackage):
+    """A python module for reading, manipulating and writing genomic data
+       sets."""
 
-    homepage = "http://samtools.github.io/bcftools/"
-    url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
+    homepage = "https://pypi.python.org/pypi/pysam"
+    url      = "https://pypi.python.org/packages/a4/1b/b6dfd92aea876647d20d9a8bd8618e4f2af6300539426be83c8bb0912d6f/pysam-0.11.2.2.tar.gz#md5=56230cd5f55b503845915b76c22d620a"
 
-    version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
-    version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
+    version('0.11.2.2', '56230cd5f55b503845915b76c22d620a')
 
-    depends_on('zlib')
-    depends_on('bzip2', when="@1.4:")
-    # build fails without xz
-    depends_on('xz', when="@1.4")
-
-    def install(self, spec, prefix):
-        make("prefix=%s" % prefix, "all")
-        make("prefix=%s" % prefix, "install")
+    depends_on('python', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-cython@0.24.1:', type=('build', 'run'))
+    depends_on('bcftools')


### PR DESCRIPTION
Adding new package py-deeptools, along with dependencies that are new: py-pysam, py-py2bit, and py-pybigwig.

Bcftools is also included in this with a fix, needed for py-pysam as well as the bcftools build itself. Without the dependency 'xz', the build failed with:
```
make[1]: Entering directory `/tmp/las_thoma15/spack-stage/spack-stage-3CIvLV/bcftools-1.4/htslib-1.4'
gcc -g -Wall -O2 -I.  -c -o kfunc.o kfunc.c
gcc -g -Wall -Wc++-compat -O2 -I. -Ihtslib-1.4 -DPLUGINPATH=\"/opt/rit/app/spack/linux-rhel7-x86_64/gcc-7.1.0/bcftools-1.4-7mpshlw27x5dqzy6zjsqxvjobfr7wrj2/libexec/bcftools\" -I.   -c -o main.o main.c
gcc  -o test/test-rbuf test/test-rbuf.o -lm -lz -ldl 
gcc -g -Wall -O2 -I.  -c -o knetfile.o knetfile.c
gcc -g -Wall -O2 -I.  -c -o kstring.o kstring.c
gcc -g -Wall -O2 -I.  -c -o bcf_sr_sort.o bcf_sr_sort.c
gcc -g -Wall -O2 -I.  -c -o bgzf.o bgzf.c
gcc -g -Wall -O2 -I.  -c -o errmod.o errmod.c
gcc -g -Wall -O2 -I.  -c -o faidx.o faidx.c
gcc -g -Wall -O2 -I.  -c -o hfile.o hfile.c
gcc -g -Wall -O2 -I.  -c -o hfile_net.o hfile_net.c
echo '#define HTS_VERSION "1.4"' > version.h
gcc -g -Wall -O2 -I.  -c -o md5.o md5.c
gcc -g -Wall -O2 -I.  -c -o multipart.o multipart.c
gcc -g -Wall -O2 -I.  -c -o probaln.o probaln.c
gcc -g -Wall -O2 -I.  -c -o realn.o realn.c
gcc -g -Wall -O2 -I.  -c -o regidx.o regidx.c
gcc -g -Wall -O2 -I.  -c -o sam.o sam.c
gcc -g -Wall -O2 -I.  -c -o synced_bcf_reader.o synced_bcf_reader.c
gcc -g -Wall -O2 -I.  -c -o vcf_sweep.o vcf_sweep.c
gcc -g -Wall -O2 -I.  -c -o tbx.o tbx.c
gcc -g -Wall -O2 -I.  -c -o textutils.o textutils.c
gcc -g -Wall -O2 -I.  -c -o thread_pool.o thread_pool.c
gcc -g -Wall -O2 -I.  -c -o vcf.o vcf.c
gcc -g -Wall -O2 -I.  -c -o vcfutils.o vcfutils.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_codecs.o cram/cram_codecs.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_decode.o cram/cram_decode.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_encode.o cram/cram_encode.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_external.o cram/cram_external.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_index.o cram/cram_index.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_io.o cram/cram_io.c
gcc -g -Wall -O2 -I.  -c -o cram/cram_samtools.o cram/cram_samtools.c
cram/cram_io.c:60:10: fatal error: lzma.h: No such file or directory
 #include <lzma.h>
          ^~~~~~~~
compilation terminated.
make[1]: *** [cram/cram_io.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory `/tmp/las_thoma15/spack-stage/spack-stage-3CIvLV/bcftools-1.4/htslib-1.4'
make: *** [htslib-1.4/libhts.a] Error 2
```
A similar error was produced when building py-pysam when I had not had bcftools listed as a dependency. Adding xz to bcftools and bcftools to py-sam fixed this issue and all built successfully. This issue has been previously reported on the bcftools github: [https://github.com/samtools/bcftools/issues/570](url)
as well as a mention in this issue: [https://github.com/samtools/bcftools/issues/581](url).

I did only include xz as a dependency for bcftools in version 1.4, in case the issue is fixed in future versions and lzma is not required by default. I can most definitely change any of this on request! 