### PR TITLE
Add package for freebayes

### DIFF
--- a/var/spack/repos/builtin/packages/freebayes/package.py
+++ b/var/spack/repos/builtin/packages/freebayes/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Freebayes(MakefilePackage):
+    """Bayesian haplotype-based genetic polymorphism discovery and
+       genotyping."""
+
+    homepage = "https://github.com/ekg/freebayes"
+    url      = "https://github.com/ekg/freebayes/archive/v1.1.0.tar.gz"
+
+    version('1.1.0', git='https://github.com/ekg/freebayes.git',
+            commit='39e5e4bcb801556141f2da36aba1df5c5c60701f',
+            submodules=True)
+
+    depends_on('cmake', type='build')
+    depends_on('zlib')
+
+    parallel=False
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter('Makefile')
+        b = prefix.bin
+        makefile.filter('cp bin/freebayes bin/bamleftalign /usr/local/bin/',
+                        'cp bin/freebayes bin/bamleftalign {0}'.format(b))
+
+    @run_before('install')
+    def make_prefix_dot_bin(self):
+        mkdir(prefix.bin)

--- a/var/spack/repos/builtin/packages/freebayes/package.py
+++ b/var/spack/repos/builtin/packages/freebayes/package.py
@@ -30,7 +30,6 @@ class Freebayes(MakefilePackage):
        genotyping."""
 
     homepage = "https://github.com/ekg/freebayes"
-    url      = "https://github.com/ekg/freebayes/archive/v1.1.0.tar.gz"
 
     version('1.1.0', git='https://github.com/ekg/freebayes.git',
             commit='39e5e4bcb801556141f2da36aba1df5c5c60701f',

--- a/var/spack/repos/builtin/packages/freebayes/package.py
+++ b/var/spack/repos/builtin/packages/freebayes/package.py
@@ -38,7 +38,7 @@ class Freebayes(MakefilePackage):
     depends_on('cmake', type='build')
     depends_on('zlib')
 
-    parallel=False
+    parallel = False
 
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')


### PR DESCRIPTION
Installed and lightly tested on CentOS 7.

This is my first package that recursively clones git submodules.  I have one nagging doubt/question.

I don't need a checksum when I build the package.  But, if I copy the cached tarball (which seems to be the result of the recursive clone) into my local mirror, then I get a warning that there is no digest to validate against.

Here's a little simulation using Spack's cache.  In real life, I would copy the tarball from Spack's cache into my local mirror and build/deploy using that mirror.

```
[hartzelg@lb097hmdev spack-freebayes]$ (module purge; spack stage freebayes)
==> Trying to clone git repository: https://github.com/ekg/freebayes.git at commit 39e5e4bcb801556141f2da36aba1df5c5c60701f                                                                                                     ==> No checksum needed when fetching with git                                                                   ==> Already staged freebayes-1.1.0-gqudept5bqy5yco5k4eyofor2amophuv in /home/hartzelg/tmp/spack-freebayes/var/spack/stage/freebayes-1.1.0-gqudept5bqy5yco5k4eyofor2amophuv                                                      [hartzelg@lb097hmdev spack-freebayes]$ (module purge; spack install freebayes)
==> zlib is already installed in /home/hartzelg/tmp/spack-freebayes/opt/spack/linux-centos7-x86_64/gcc-4.8.5/zlib-1.2.11-yrijbmajetpxrkyaa4uclsyw62zbhc5m
==> cmake is already installed in /home/hartzelg/tmp/spack-freebayes/opt/spack/linux-centos7-x86_64/gcc-4.8.5/cmake-3.8.1-ncxngnbsypc2j3m5j4ohdo3fzlu73tfw                                                                      ==> Installing freebayes                                                                                        ==> Using cached archive: /home/hartzelg/tmp/spack-freebayes/var/spack/cache/freebayes/freebayes-1.1.0.tar.gz
==> Warning: Fetching from mirror without a checksum!                                                             This package is normally checked out from a version control system, but it has been archived on a spack mirror.  This means we cannot know a checksum for the tarball in advance. Be sure that your connection to this mirror is secure!                                                                                                      ==> Already staged freebayes-1.1.0-gqudept5bqy5yco5k4eyofor2amophuv in /home/hartzelg/tmp/spack-freebayes/var/spack/stage/freebayes-1.1.0-gqudept5bqy5yco5k4eyofor2amophuv
==> Ran patch() for freebayes
==> Building freebayes [MakefilePackage]
==> Executing phase : 'edit'
[...]
```

For packages that download tarballs directly,  are checksums for tarballs fetched from a local mirror verified?

Is there a way to add a checksum to a package fetched via `git`?  I tried checksumming the tarball myself and adding it to the version definition but it seemed to be ignored.