### PR TITLE
Add package for Sniffles

### DIFF
--- a/var/spack/repos/builtin/packages/sniffles/package.py
+++ b/var/spack/repos/builtin/packages/sniffles/package.py
@@ -33,4 +33,10 @@ class Sniffles(CMakePackage):
 
     version('1.0.5', 'c2f2350d00418ba4d82c074e7f0b1832')
 
-    # FIXME: Still need to actually install the binaries
+    # the build process doesn't actually install anything, do it by hand
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        src = "bin/sniffles-core-{0}".format(spec.version.dotted)
+        binaries = ['sniffles', 'sniffles-debug']
+        for b in binaries:
+            install(join_path(src, b), join_path(prefix.bin, b))

--- a/var/spack/repos/builtin/packages/sniffles/package.py
+++ b/var/spack/repos/builtin/packages/sniffles/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Sniffles(CMakePackage):
+    """Structural variation caller using third generation sequencing."""
+
+    homepage = "https://github.com/fritzsedlazeck/Sniffles/wiki"
+    url      = "https://github.com/fritzsedlazeck/Sniffles/archive/v1.0.5.tar.gz"
+
+    version('1.0.5', 'c2f2350d00418ba4d82c074e7f0b1832')
+
+    # FIXME: Still need to actually install the binaries


### PR DESCRIPTION
Add a package for sniffles.

As this package stands, the only thing that it installs is a copy of `libz.a`.

I *think* that the problem is that the cmake config files don't set up an install target.  Or perhaps it's broken.  I'm not cmake-savvy enough to tell.

[Here are the installation instructions](https://github.com/fritzsedlazeck/Sniffles/wiki#how-to-build-sniffles).

Before I do something silly, like `mkdir prefix.bin` and then `cp ../bin/sniffles*/sniffles prefix.bin`, is there a better way?