### PR TITLE
Add two python packages for editing mach-O headers. 

### DIFF
--- a/var/spack/repos/builtin/packages/py-macholib/package.py
+++ b/var/spack/repos/builtin/packages/py-macholib/package.py
@@ -35,6 +35,3 @@ class PyMacholib(PythonPackage):
 
     depends_on('py-setuptools', type='build')
 
-    def build_args(self, spec, prefix):
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/py-macholib/package.py
+++ b/var/spack/repos/builtin/packages/py-macholib/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyMacholib(PythonPackage):
+    """Python package for Mach-O header analysis and editing"""
+
+    homepage = "https://pypi.python.org/pypi/macholib"
+    url = "https://pypi.io/packages/source/m/macholib/macholib-1.8.tar.gz"
+
+    version('1.8', '65af8f20dada7bdb2a142afbec51330e')
+
+    depends_on('py-setuptools', type='build')
+
+    def build_args(self, spec, prefix):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/py-macholib/package.py
+++ b/var/spack/repos/builtin/packages/py-macholib/package.py
@@ -34,4 +34,3 @@ class PyMacholib(PythonPackage):
     version('1.8', '65af8f20dada7bdb2a142afbec51330e')
 
     depends_on('py-setuptools', type='build')
-

--- a/var/spack/repos/builtin/packages/py-machotools/package.py
+++ b/var/spack/repos/builtin/packages/py-machotools/package.py
@@ -35,4 +35,3 @@ class PyMachotools(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-macholib', type=('build', 'run'))
-

--- a/var/spack/repos/builtin/packages/py-machotools/package.py
+++ b/var/spack/repos/builtin/packages/py-machotools/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyMachotools(PythonPackage):
+    """Python package for editing Mach-O headers using macholib"""
+
+    homepage = "https://pypi.python.org/pypi/machotools"
+    url = "https://pypi.io/packages/source/m/machotools/machotools-0.2.0.tar.gz"
+
+    version('0.2.0', 'bcc68332c4a80b4f84ec9c8083465416')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-macholib', type=('build', 'run'))
+
+    def build_args(self, spec, prefix):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/py-machotools/package.py
+++ b/var/spack/repos/builtin/packages/py-machotools/package.py
@@ -36,6 +36,3 @@ class PyMachotools(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-macholib', type=('build', 'run'))
 
-    def build_args(self, spec, prefix):
-        args = []
-        return args


### PR DESCRIPTION
Much faster than calling otool and install_name_tool directly. It would be nice to somehow use these python packages in spack.