### PR TITLE
Update ROSE package to v0.9.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/hpccg/package.py
+++ b/var/spack/repos/builtin/packages/hpccg/package.py
@@ -1,0 +1,77 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Hpccg(MakefilePackage):
+    """Proxy Application. Intended to be the 'best approximation
+       to an unstructured implicit finite element or finite volume
+       application in 800 lines or fewer.'
+    """
+
+    homepage = "https://mantevo.org/about/applications/"
+    url      = "http://mantevo.org/downloads/releaseTarballs/miniapps/HPCCG/HPCCG-1.0.tar.gz"
+
+    tags = ['proxy-app']
+
+    version('1.0', '2e99da1a89de5ef0844da5e6ffbf39dc')
+
+    variant('mpi', default=True, description='Build with MPI support')
+    variant('openmp', default=True, description='Build with OpenMP support')
+
+    # Optional dependencies
+    depends_on('mpi', when='+mpi')
+
+    @property
+    def build_targets(self):
+        targets = []
+
+        if '+mpi' in self.spec:
+            targets.append('CXX={0}'.format(self.spec['mpi'].mpicxx))
+            targets.append('LINKER={0}'.format(self.spec['mpi'].mpicxx))
+            targets.append('USE_MPI=-DUSING_MPI')
+        else:
+            targets.append('CXX=c++')
+            targets.append('LINKER=c++')
+
+        if '+openmp' in self.spec:
+            targets.append('USE_OMP=-DUSING_OMP')
+            targets.append('OMP_FLAGS={0}'.format(self.compiler.openmp_flag))
+
+        # Remove Compiler Specific Optimization Flags
+        if '%gcc' not in self.spec:
+            targets.append('CPP_OPT_FLAGS=')
+
+        return targets
+
+    def install(self, spec, prefix):
+        # Manual installation
+        mkdirp(prefix.bin)
+        mkdirp(prefix.doc)
+
+        install('test_HPCCG', prefix.bin)
+        install('README', prefix.doc)
+        install('weakScalingRunScript', prefix.bin)
+        install('strongScalingRunScript', prefix.bin)

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -56,8 +56,8 @@ class Rose(AutotoolsPackage):
     variant('tests', default=False, description='Build the tests directory')
     variant('tutorial', default=False, description='Build the tutorial directory')
 
-    variant('intel_backend', default=False, description='Enable Intel backend compiler')
-    depends_on("intel@16.0.3", when='+intel_backend')
+    variant('mvapich2_backend', default=False, description='Enable mvapich2 backend compiler')
+    depends_on("mvapich2", when='+mvapich2_backend')
 
     variant('binanalysis', default=False, description='Enable binary analysis tooling')
     depends_on('libgcrypt', when='+binanalysis', type='build')
@@ -95,9 +95,9 @@ class Rose(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        if '+intel_backend' in spec:
-            cc = spec['intel'].mpicc
-            cxx = spec['intel'].mpicxx
+        if '+mvapich2_backend' in spec:
+            cc = spec['mvapich2'].mpicc
+            cxx = spec['mvapich2'].mpicxx
         else:
             cc = spack_cc
             cxx = spack_cxx

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -96,8 +96,8 @@ class Rose(AutotoolsPackage):
         spec = self.spec
 
         if '+intel_backend' in spec:
-            cc = spec['mpi'].mpicc
-            cxx = spec['mpi'].mpicxx
+            cc = spec['intel'].mpicc
+            cxx = spec['intel'].mpicxx
         else:
             cc = spack_cc
             cxx = spack_cxx

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -97,7 +97,7 @@ class Rose(AutotoolsPackage):
         if '+intel_backend' in spec:
             cc = which('mpicc')
             cxx = which('mpic++')
-        else
+        else:
             cc = self.compiler.cc
             cxx = self.compiler.cxx
 

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -29,19 +29,18 @@
 from spack import *
 
 
-class Rose(Package):
+class Rose(AutotoolsPackage):
     """A compiler infrastructure to build source-to-source program
        transformation and analysis tools.
        (Developed at Lawrence Livermore National Lab)"""
 
     homepage = "http://rosecompiler.org/"
-    url = "https://github.com/rose-compiler/rose/archive/v0.9.7.tar.gz"
+    #url = "https://github.com/rose-compiler/rose/archive/v0.9.7.tar.gz"
 
-    version('0.9.7', 'e14ce5250078df4b09f4f40559d46c75')
-    version('master', branch='master',
+    version('0.9.9.0', commit='14d3ebdd7f83cbcc295e6ed45b45d2e9ed32b5ff',
             git='https://github.com/rose-compiler/rose.git')
-
-    patch('add_spack_compiler_recognition.patch')
+    version('dev', branch='master',
+            git='https://github.com/rose-compiler/rose-develop.git')
 
     depends_on("autoconf@2.69", type='build')
     depends_on("automake@1.14", type='build')
@@ -89,6 +88,7 @@ class Rose(Package):
         cxx = self.compiler.cxx
         return [
             '--disable-boost-version-check',
+            "--enable-edg_version=4.12",
             "--with-alternate_backend_C_compiler={0}".format(cc),
             "--with-alternate_backend_Cxx_compiler={0}".format(cxx),
             "--with-boost={0}".format(spec['boost'].prefix),
@@ -98,4 +98,9 @@ class Rose(Package):
             '--enable-tutorial-directory={0}'.format('no'),
         ]
 
+    @property
+    def build_directory(self):
+        return 'rose-build'
+
     install_targets = ["install-core"]
+

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -65,7 +65,7 @@ class Rose(AutotoolsPackage):
     variant('z3', default=False, description='Enable z3 theorem prover')
     depends_on('z3', when='+z3')
 
-    build_directory = 'spack-build'
+    build_directory = 'rose-build'
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')
@@ -99,11 +99,8 @@ class Rose(AutotoolsPackage):
             '--enable-tutorial-directory={0}'.format('no'),
         ]
 
-    @property
-    def build_directory(self):
-        return 'rose-build'
-
     def install(self, spec, prefix):
-        make('install-core')
-        with working_dir('tools'):
-            make('install')
+        with working_dir(self.build_directory):
+            make('install-core')
+            with working_dir('tools'):
+                make('install')

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -37,6 +37,7 @@ class Rose(AutotoolsPackage):
     homepage = "http://rosecompiler.org/"
     #url = "https://github.com/rose-compiler/rose/archive/v0.9.7.tar.gz"
 
+    version('0.9.7', 'e14ce5250078df4b09f4f40559d46c75')
     version('0.9.9.0', commit='14d3ebdd7f83cbcc295e6ed45b45d2e9ed32b5ff',
             git='https://github.com/rose-compiler/rose.git')
     version('dev', branch='master',
@@ -102,5 +103,7 @@ class Rose(AutotoolsPackage):
     def build_directory(self):
         return 'rose-build'
 
-    install_targets = ["install-core"]
-
+    def install(self, spec, prefix):
+        make('install-core')
+        with working_dir('tools'):
+            make('install')

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -43,11 +43,13 @@ class Rose(AutotoolsPackage):
             git='https://github.com/rose-compiler/rose.git')
     version('develop', branch='master',
             git='https://github.com/rose-compiler/rose-develop.git')
+    version('__ROSE_VERSION__', commit='__ROSE_COMMIT__', git='rose-dev@rosecompiler1.llnl.gov:rose/scratch/rose.git')
+ 
 
     depends_on("autoconf@2.69", type='build')
     depends_on("automake@1.14", type='build')
     depends_on("libtool@2.4", type='build')
-    depends_on("boost@1.47.0:")
+    depends_on("__BOOST_VERSION__")
 
     variant('debug', default=False, description='Enable compiler debugging symbols')
     variant('optimized', default=False, description='Enable compiler optimizations')

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -50,8 +50,10 @@ class Rose(AutotoolsPackage):
     depends_on("libtool@2.4", type='build')
     depends_on("boost@1.56.0")
 
-    variant('debug', default=False, description='Enable compiler debugging symbols')
-    variant('optimized', default=False, description='Enable compiler optimizations')
+    variant('debug', default=False,
+            description='Enable compiler debugging symbols')
+    variant('optimized', default=False,
+            description='Enable compiler optimizations')
 
     variant('tests', default=False, description='Build the tests directory')
     variant('tutorial', default=False, description='Build the tutorial directory')
@@ -59,14 +61,16 @@ class Rose(AutotoolsPackage):
     variant('mvapich2_backend', default=False, description='Enable mvapich2 backend compiler')
     depends_on("mvapich2", when='+mvapich2_backend')
 
-    variant('binanalysis', default=False, description='Enable binary analysis tooling')
+    variant('binanalysis', default=False,
+            description='Enable binary analysis tooling')
     depends_on('libgcrypt', when='+binanalysis', type='build')
     depends_on('py-binwalk', when='+binanalysis', type='run')
 
     variant('c', default=True, description='Enable c language support')
     variant('cxx', default=True, description='Enable c++ language support')
 
-    variant('fortran', default=False, description='Enable fortran language support')
+    variant('fortran', default=False,
+            description='Enable fortran language support')
 
     variant('java', default=False, description='Enable java language support')
     depends_on('jdk', when='+java')

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -49,6 +49,9 @@ class Rose(AutotoolsPackage):
     depends_on("libtool@2.4", type='build')
     depends_on("boost@1.47.0:")
 
+    variant('debug', default=False, description='Enable compiler debugging symbols')
+    variant('optimized', default=False, description='Enable compiler optimizations')
+
     variant('tests', default=False, description='Build the tests directory')
 
     variant('binanalysis', default=False, description='Enable binary analysis tooling')
@@ -104,7 +107,10 @@ class Rose(AutotoolsPackage):
             "--with-z3={0}".format(spec['z3'].prefix) if '+z3' in spec else '',
             '--disable-tests-directory' if '+tests' not in spec else '',
             '--enable-tutorial-directory={0}'.format('no'),
-            '--without-java' if '+java' not in spec else ''
+            '--without-java' if '+java' not in spec else '',
+            '--with-CXX_DEBUG=-g' if '+debug' in spec else '',
+            '--with-C_OPTIMIZE=-O0' if '+optimized' in spec else '',
+            '--with-CXX_OPTIMIZE=-O0' if '+optimized' in spec else '',
         ]
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -37,10 +37,11 @@ class Rose(AutotoolsPackage):
     homepage = "http://rosecompiler.org/"
     #url = "https://github.com/rose-compiler/rose/archive/v0.9.7.tar.gz"
 
-    version('0.9.7', 'e14ce5250078df4b09f4f40559d46c75')
+    version('0.9.7.0', commit='992c21ad06893bc1e9e7688afe0562eee0fda021',
+            git='https://github.com/rose-compiler/rose.git')
     version('0.9.9.0', commit='14d3ebdd7f83cbcc295e6ed45b45d2e9ed32b5ff',
             git='https://github.com/rose-compiler/rose.git')
-    version('dev', branch='master',
+    version('develop', branch='master',
             git='https://github.com/rose-compiler/rose-develop.git')
 
     depends_on("autoconf@2.69", type='build')
@@ -87,9 +88,15 @@ class Rose(AutotoolsPackage):
         spec = self.spec
         cc = self.compiler.cc
         cxx = self.compiler.cxx
+
+        if spec.satisfies('@0.9.8:'):
+            edg = "4.12"
+        else:
+            edg = "4.9"
+
         return [
             '--disable-boost-version-check',
-            "--enable-edg_version=4.12",
+            '--enable-edg_version={0}'.format(edg),
             "--with-alternate_backend_C_compiler={0}".format(cc),
             "--with-alternate_backend_Cxx_compiler={0}".format(cxx),
             "--with-boost={0}".format(spec['boost'].prefix),
@@ -97,6 +104,7 @@ class Rose(AutotoolsPackage):
             "--with-z3={0}".format(spec['z3'].prefix) if '+z3' in spec else '',
             '--disable-tests-directory' if '+tests' not in spec else '',
             '--enable-tutorial-directory={0}'.format('no'),
+            '--without-java' if '+java' not in spec else ''
         ]
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -114,7 +114,16 @@ class Rose(AutotoolsPackage):
         ]
 
     def install(self, spec, prefix):
+        srun = which('srun')
+
         with working_dir(self.build_directory):
-            make('install-core')
-            with working_dir('tools'):
-                make('install')
+            if not srun:
+                # standard installation on dev machine
+                make('install-core')
+                with working_dir('tools'):
+                    make('install')
+            else:
+                # parallel installation on LC
+                srun('-ppdebug', 'make', '-j16', 'install-core')
+                with working_dir('tools'):
+                    srun('-ppdebug', 'make', '-j16', 'install')


### PR DESCRIPTION
@tgamblin I've tested this PR. However, I would like to add a `make install -C tools/`. How can I accomplish this while also running `make install-core` from the top-level? (In other words, two targets in different directories.)