### PR TITLE
dealii: workaround for concretization bug

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -113,8 +113,8 @@ class Dealii(CMakePackage):
     depends_on("hdf5+mpi",         when='+hdf5+mpi')
     # FIXME: concretizer bug. The two lines mimic what comes from PETSc
     # but we should not need it
-    depends_on("metis@5:+int64",   when='+metis+int64')
-    depends_on("metis@5:~int64",   when='+metis~int64')
+    depends_on("metis@5:+int64+real64",   when='+metis+int64')
+    depends_on("metis@5:~int64+real64",   when='+metis~int64')
     depends_on("netcdf+mpi",       when="+netcdf+mpi")
     depends_on("netcdf-cxx",       when='+netcdf+mpi')
     depends_on("oce",              when='+oce')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -123,6 +123,8 @@ class Trilinos(CMakePackage):
             description='Compile with Amesos')
     variant('amesos2',      default=True,
             description='Compile with Amesos2')
+    variant('anasazi',       default=True,
+            description='Compile with Anasazi')
     variant('ifpack',       default=True,
             description='Compile with Ifpack')
     variant('ifpack2',      default=True,
@@ -305,6 +307,8 @@ class Trilinos(CMakePackage):
                 'ON' if '+gtest' in spec else 'OFF'),
             '-DTrilinos_ENABLE_Teuchos:BOOL=%s' % (
                 'ON' if '+teuchos' in spec else 'OFF'),
+            '-DTrilinos_ENABLE_Anasazi:BOOL=%s' % (
+                'ON' if '+anasazi' in spec else 'OFF'),
         ])
 
         if '+xsdkflags' in spec:


### PR DESCRIPTION
also add `anasazi` to `trilinos`, which was removed recently when all the variants for its packages were introduced.