### PR TITLE
pkg-config: aclocal env

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -44,15 +44,18 @@ class PkgConfig(AutotoolsPackage):
 
     parallel = False
 
-    @when('platform=cray')
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         """spack built pkg-config on cray's requires adding /usr/local/
         and /usr/lib64/  to PKG_CONFIG_PATH in order to access cray '.pc'
-        files."""
-        spack_env.append_path('PKG_CONFIG_PATH', '/usr/lib64/pkgconfig')
-        spack_env.append_path('PKG_CONFIG_PATH', '/usr/local/lib64/pkgconfig')
+        files.
+        Adds the ACLOCAL path for autotools."""
         spack_env.append_path('ACLOCAL_PATH',
                               join_path(self.prefix.share, 'aclocal'))
+        if 'platform=cray' in self.spec:
+            spack_env.append_path('PKG_CONFIG_PATH',
+                                  '/usr/lib64/pkgconfig')
+            spack_env.append_path('PKG_CONFIG_PATH',
+                                  '/usr/local/lib64/pkgconfig')
 
     def configure_args(self):
         config_args = ['--enable-shared']


### PR DESCRIPTION
Always sets the `pkg-config` environment hints for autotools.

Required dependency for `autoreconf` of ZeroMQ when build from source (e.g. v4.2.2) via autotools in `autogen.sh` step for `autoreconf`. (Otherwise errors such as [this one](https://stackoverflow.com/questions/36367008/how-to-fix-missing-some-pkg-config-macros-error) will occur.)

~~**Reviewers:** will the `platform=cray` version of this function will be executed on cray, **too**? I want to set the `ACLOCAL_PATH` for all platforms and not for all platforms but cray.~~ refactored