### PR TITLE
ZeroMQ: C++ Headers (cppzmq)

### DIFF
--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Cppzmq(CMakePackage):
+    """C++ binding for 0MQ"""
+
+    homepage = "https://github.com/zeromq/cppzmq"
+    url      = "https://github.com/zeromq/cppzmq/archive/v4.2.1.tar.gz"
+
+    version('4.2.1', '72d1296f26341d136470c25320936683')
+
+    depends_on('cmake@2.8.12:', type='build')
+    # requires that the ZeroMQ package is built as CMakePackage!
+    depends_on('zeromq@4.2.2')

--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -30,6 +30,9 @@ class Zeromq(AutotoolsPackage):
     homepage = "http://zguide.zeromq.org/"
     url      = "http://download.zeromq.org/zeromq-4.1.2.tar.gz"
 
+    version('develop', branch='master',
+            git='https://github.com/zeromq/libzmq.git')
+
     version('4.2.2', '52499909b29604c1e47a86f1cb6a9115',
             url='https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz')
     version('4.1.4', 'a611ecc93fffeb6d058c0e6edf4ad4fb')
@@ -42,13 +45,13 @@ class Zeromq(AutotoolsPackage):
     depends_on("libsodium")
     depends_on("libsodium@:1.0.3", when='@:4.1.2')
 
-    depends_on('autoconf', type='build', when='@4.2.2')
-    depends_on('automake', type='build', when='@4.2.2')
-    depends_on('libtool', type='build', when='@4.2.2')
-    depends_on('pkg-config', type='build', when='@4.2.2')
+    depends_on('autoconf', type='build', when='@develop')
+    depends_on('automake', type='build', when='@develop')
+    depends_on('libtool', type='build', when='@develop')
+    depends_on('pkg-config', type='build', when='@develop')
 
     def autoreconf(self, spec, prefix):
-        if '@4.2.2' in spec:
+        if '@develop' in spec:
             bash = which('bash')
             bash('./autogen.sh')
 

--- a/var/spack/repos/builtin/packages/zeromq/package.py
+++ b/var/spack/repos/builtin/packages/zeromq/package.py
@@ -30,6 +30,8 @@ class Zeromq(AutotoolsPackage):
     homepage = "http://zguide.zeromq.org/"
     url      = "http://download.zeromq.org/zeromq-4.1.2.tar.gz"
 
+    version('4.2.2', '52499909b29604c1e47a86f1cb6a9115',
+            url='https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz')
     version('4.1.4', 'a611ecc93fffeb6d058c0e6edf4ad4fb')
     version('4.1.2', '159c0c56a895472f02668e692d122685')
     version('4.1.1', '0a4b44aa085644f25c177f79dc13f253')
@@ -39,6 +41,16 @@ class Zeromq(AutotoolsPackage):
 
     depends_on("libsodium")
     depends_on("libsodium@:1.0.3", when='@:4.1.2')
+
+    depends_on('autoconf', type='build', when='@4.2.2')
+    depends_on('automake', type='build', when='@4.2.2')
+    depends_on('libtool', type='build', when='@4.2.2')
+    depends_on('pkg-config', type='build', when='@4.2.2')
+
+    def autoreconf(self, spec, prefix):
+        if '@4.2.2' in spec:
+            bash = which('bash')
+            bash('./autogen.sh')
 
     def configure_args(self):
         config_args = ['--with-libsodium']


### PR DESCRIPTION
Adds ZeroMQ 4.2.2, which has a slightly modified build environment and fails when build from the [official tarball](https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz) (so we checkout [the git tag](https://github.com/zeromq/libzmq/issues/2621)). The `autoreconf` step depends on #4736.
- [x] update: I used the wrong tarball link, we can also use the `.tar.gz` instead and sha it
- but that release does not build with [some versions of CMake anyway](https://github.com/zeromq/libzmq/issues/2621#issuecomment-314782300)

Adds the C++ Headers for ZeroMQ aka `cppzmq` that first build with `libzmq` (ZeroMQ) [v4.2.2](https://github.com/zeromq/libzmq/pull/2295).

Unfortunately, in order to install the C++ headers of ZeroMQ, the `libzmq` (ZeroMQ package) needs to build [as `CMakePackage` instead of `AutotoolsPackage`](https://github.com/zeromq/cppzmq/pull/128). Otherwise, the [CMake module to find it is not created and installed](https://github.com/zeromq/libzmq/issues/2621#issuecomment-315297320).

Now, if we generally change the build to use CMake for ZeroMQ it seems to fail on already submitted versions... How do we proceed? Can we specify to build all further versions in `4.2.0:` with CMake and the older with autotools? Or shall I add a temporary `FindZeroMQ.cmake` in the patch step from [some issue I found on the internet](https://github.com/zeromq/cppzmq/issues/127)? :)

## Update

- [ ] I might just patch in https://github.com/zeromq/cppzmq/issues/132 and we can stay with autotools