### PR TITLE
Adding a bit more Mellanox MXM capability to OpenMPI.

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -52,6 +52,18 @@ def _verbs_dir():
         return None
 
 
+def _mxm_dir():
+    """Look for default directory where the Mellanox package is
+    installed. Return None if not found.
+    """
+    # Only using default directory; make this more flexible in the future
+    path = "/opt/mellanox/mxm"
+    if os.path.isdir(path):
+        return path
+    else:
+        return None
+
+
 class Openmpi(AutotoolsPackage):
     """The Open MPI Project is an open source Message Passing Interface
        implementation that is developed and maintained by a consortium
@@ -248,6 +260,17 @@ class Openmpi(AutotoolsPackage):
         line = '--with-{0}'.format(opt)
         path = _verbs_dir()
         if (path is not None) and (path not in ('/usr', '/usr/local')):
+            line += '={0}'.format(path)
+        return line
+
+    def with_or_without_mxm(self, activated):
+        opt = 'mxm'
+        # If the option has not been activated return --without-mxm
+        if not activated:
+            return '--without-{0}'.format(opt)
+        line = '--with-{0}'.format(opt)
+        path = _mxm_dir()
+        if (path is not None):
             line += '={0}'.format(path)
         return line
 


### PR DESCRIPTION
So OpenMPI is a high profile package and I don't want to mess this up, but this should add in the capability to at least use the default location of MXM if it exists and if MXM is explicitly turned on in the fabrics variant.