### PR TITLE
slepc: fix download url

### DIFF
--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -32,7 +32,7 @@ class Slepc(Package):
     """
 
     homepage = "http://www.grycap.upv.es/slepc"
-    url = "http://slepc.upv.es/download/download.php?filename=slepc-3.6.2.tar.gz"
+    url = "http://slepc.upv.es/download/distrib/slepc-3.6.2.tar.gz"
 
     version('3.7.4', '2fb782844e3bc265a8d181c3c3e2632a4ca073111c874c654f1365d33ca2eb8a')
     version('3.7.3', '3ef9bcc645a10c1779d56b3500472ceb66df692e389d635087d30e7c46424df9')


### PR DESCRIPTION
I have only tested the latest version (`3.7.4`), but this url suggest that all versions have the same new url:
```
http://slepc.upv.es/download/distrib/slepc-3.6.3.tar.gz
```