### PR TITLE
libwebsockets: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -49,5 +49,5 @@ class IsaacServer(CMakePackage):
     depends_on('libjpeg-turbo', type='link')
     depends_on('jansson', type='link')
     depends_on('boost@1.56:', type='link')
-    depends_on('libwebsockets', type='link')
+    depends_on('libwebsockets@2.1.1:', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')

--- a/var/spack/repos/builtin/packages/libwebsockets/package.py
+++ b/var/spack/repos/builtin/packages/libwebsockets/package.py
@@ -31,6 +31,8 @@ class Libwebsockets(CMakePackage):
     homepage = "https://github.com/warmcat/libwebsockets"
     url      = "https://github.com/warmcat/libwebsockets/archive/v2.1.0.tar.gz"
 
+    version('2.2.1', '1f641cde2ab3687db3d553f68fe0f620')
+    version('2.1.1', '674684ffb90d4a0bcf7a075eb7b90192')
     version('2.1.0', '4df3be57dee43aeebd54a3ed56568f50')
     version('2.0.3', 'a025156d606d90579e65d53ccd062a94')
     version('1.7.9', '7b3692ead5ae00fd0e1d56c080170f07')


### PR DESCRIPTION
both new versions fix a nasty bug leading to a hanging connection on connect.

### Misc

Bump dependency requirement in `isaac-server`: ISAAC server did hang in docker containers due to a bug in libwebsockets