### PR TITLE
Add package for the Python regex library

### DIFF
--- a/var/spack/repos/builtin/packages/py-regex/package.py
+++ b/var/spack/repos/builtin/packages/py-regex/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyRegex(PythonPackage):
+    """Alternative regular expression module, to replace re."""
+
+    homepage = "https://pypi.python.org/pypi/regex/"
+    url      = "https://pypi.io/packages/source/r/regex/regex-2017.07.11.tar.gz"
+
+    version('2017.07.11', '95f81ebb5273c7ad9a0c4d1ac5a94eb4')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Lightly tested on CentOS 7 with `python@2.7.13` and `python@3.6.0`.

This is my first python library package.  I based the url on the one that py-virtualenv uses.  

Feedback encouraged....