### PR TITLE
Add package for r-ada, update r-rpart version

### DIFF
--- a/var/spack/repos/builtin/packages/r-ada/package.py
+++ b/var/spack/repos/builtin/packages/r-ada/package.py
@@ -25,15 +25,20 @@
 from spack import *
 
 
-class RRpart(RPackage):
-    """Recursive partitioning for classification, regression and
-    survival trees."""
+class RAda(RPackage):
+    """Performs discrete, real, and gentle boost under both exponential
+    and logistic loss on a given data set."""
 
-    homepage = "https://cran.r-project.org/package=rpart"
-    url      = "https://cran.r-project.org/src/contrib/rpart_4.1-10.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rpart"
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://cran.r-project.org/web/packages/ada/index.html"
+    url      = "https://cran.r-project.org/src/contrib/ada_2.0-5.tar.gz"
 
-    version('4.1-11', 'f77b37cddf7e9a7b5993a52a750b8817')
-    version('4.1-10', '15873cded4feb3ef44d63580ba3ca46e')
+    version('2.0-5', '25ac0dc2650fba9e19f3d15c7c6721c1')
 
-    depends_on('r@2.15.0:')
+    depends_on('r-rpart', type=('build', 'run'))
+
+    def configure_args(self, spec, prefix):
+        # FIXME: Add arguments to pass to install via --configure-args
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/r-ada/package.py
+++ b/var/spack/repos/builtin/packages/r-ada/package.py
@@ -29,16 +29,9 @@ class RAda(RPackage):
     """Performs discrete, real, and gentle boost under both exponential
     and logistic loss on a given data set."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://cran.r-project.org/web/packages/ada/index.html"
     url      = "https://cran.r-project.org/src/contrib/ada_2.0-5.tar.gz"
 
     version('2.0-5', '25ac0dc2650fba9e19f3d15c7c6721c1')
 
     depends_on('r-rpart', type=('build', 'run'))
-
-    def configure_args(self, spec, prefix):
-        # FIXME: Add arguments to pass to install via --configure-args
-        # FIXME: If not needed delete this function
-        args = []
-        return args


### PR DESCRIPTION
Adds a package for r-ada.

Update the version for r-rpart because the previous version is
no longer at that URL.  The previous version *is* in the Archive,
but list_url does not seem to be able to find it.  This might be related to #2309.

@glennpj -- any ideas about the list_url?  If not, it seems like the old version of r-rpart is now unavailable.  Is that "ok"?