### PR TITLE
Package/minighost

### DIFF
--- a/var/spack/repos/builtin/packages/minighost/package.py
+++ b/var/spack/repos/builtin/packages/minighost/package.py
@@ -1,0 +1,94 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import tarfile
+
+from spack import *
+
+
+class Minighost(MakefilePackage):
+    """Proxy Application. A Finite Difference proxy
+       application which implements a difference stencil
+       across a homogenous three dimensional domain.
+    """
+
+    homepage = "http://mantevo.org"
+    url      = "http://mantevo.org/downloads/releaseTarballs/miniapps/MiniGhost/miniGhost_1.0.1.tar.gz"
+
+    version('1.0.1', '2a4ac4383e9be00f87b6067c3cfe6463')
+
+    variant('mpi', default=True, description='Enable MPI Support')
+
+    depends_on('mpi', when='+mpi')
+
+    parallel = False
+
+    @property
+    def build_targets(self):
+        targets = ['--directory=miniGhost_ref']
+
+        if '+mpi' in self.spec:
+            targets.append('PROTOCOL=-D_MG_MPI')
+            targets.append('FC={0}'.format(self.spec['mpi'].mpif77))
+            targets.append('CC={0}'.format(self.spec['mpi'].mpicc))
+            targets.append(
+                'LIBS=-lm -lgfortran -lmpi_usempi -lmpi_mpifh -lmpi')
+        else:
+            targets.append('PROTOCOL=-D_MG_SERIAL')
+            targets.append('FC=f77')
+            targets.append('CC=cc')
+            targets.append('LIBS=-lm -lgfortran')
+
+        if '%gcc' in self.spec:
+            targets.append('COMPILER_SUITE=gnu')
+        elif '%cce' in self.spec:
+            targets.append('COMPILER_SUITE=cray')
+        elif '%intel' in self.spec:
+            targets.append('COMPILER_SUITE=intel')
+        elif '%pgi' in self.spec:
+            targets.append('COMPILER_SUITE=pgi')
+
+        return targets
+
+    def edit(self, spec, prefix):
+        inner_tar = tarfile.open(
+            'miniGhost_ref_{}.tar.gz'.format(self.version.up_to(3)))
+        inner_tar.extractall()
+
+    def install(self, spec, prefix):
+        # Manual Installation
+        mkdirp(prefix.bin)
+        mkdirp(prefix.doc)
+
+        install('miniGhost_ref/miniGhost.x', prefix.bin)
+        install('miniGhost_ref/default-settings.h', prefix.bin)
+
+        if '+mpi' in spec:
+            install('miniGhost_ref/runtest.mpi', prefix.bin)
+            install('miniGhost_ref/runtest.mpi.ds', prefix.bin)
+        else:
+            install('miniGhost_ref/runtest.serial', prefix.bin)
+
+        install('README', prefix.doc)

--- a/var/spack/repos/builtin/packages/minighost/package.py
+++ b/var/spack/repos/builtin/packages/minighost/package.py
@@ -74,7 +74,7 @@ class Minighost(MakefilePackage):
 
     def edit(self, spec, prefix):
         inner_tar = tarfile.open(
-            'miniGhost_ref_{}.tar.gz'.format(self.version.up_to(3)))
+            'miniGhost_ref_{0}.tar.gz'.format(self.version.up_to(3)))
         inner_tar.extractall()
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Adding miniGhost package.   This package is the package discussed in #4768 .  Using `LIBS+=` from the `build_targets` or directly in the Makefile didn't not work without the flags.