### PR TITLE
Added support for querying by tags

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -31,10 +31,7 @@ import spack.spec
 import spack.store
 from spack.util.pattern import Args
 
-__all__ = [
-    'add_common_arguments',
-    'filter_by_tags'
-]
+__all__ = ['add_common_arguments']
 
 _arguments = {}
 
@@ -52,42 +49,6 @@ def add_common_arguments(parser, list_of_arguments):
             raise KeyError(message.format(argument))
         x = _arguments[argument]
         parser.add_argument(*x.flags, **x.kwargs)
-
-
-def filter_by_tags(specs_or_packages, tags):
-    """Filter the set of specs passed as argument by tags.
-
-    Args:
-        specs_or_packages: list of items to be filtered
-        tags: tags to be used for filtering
-
-    Returns:
-        list of items in specs that have all the tag in tags
-    """
-
-    # If the list is empty, return early
-    if not specs_or_packages:
-        return []
-
-    # Else, try to have a uniform access to packages for both list
-    # of specs and list of packages
-    item = specs_or_packages[0]
-    if isinstance(item, spack.spec.Spec):
-        package = lambda x: x.package
-    else:
-        package = lambda x: x
-
-    # Restrict to elements that have the 'tags' attribute defined
-    has_tags = lambda x: hasattr(package(x), 'tags')
-    specs_or_packages = [x for x in specs_or_packages if has_tags(x)]
-
-    # Filter by required tags
-    specs_or_packages = [
-        x for x in specs_or_packages
-        if all(t in package(x).tags for t in tags)
-    ]
-
-    return specs_or_packages
 
 
 class ConstraintAction(argparse.Action):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -27,6 +27,7 @@ import argparse
 
 import spack.cmd
 import spack.modules
+import spack.spec
 import spack.store
 from spack.util.pattern import Args
 
@@ -66,16 +67,14 @@ def filter_by_tags(specs_or_packages, tags):
 
     # If the list is empty, return early
     if not specs_or_packages:
-        return
+        return []
 
     # Else, try to have a uniform access to packages for both list
     # of specs and list of packages
-    try:
-        # This statement is needed to check if I am dealing
-        # with a list of specs
-        specs_or_packages[0].package
+    item = specs_or_packages[0]
+    if isinstance(item, spack.spec.Spec):
         package = lambda x: x.package
-    except AttributeError:
+    else:
         package = lambda x: x
 
     # Restrict to elements that have the 'tags' attribute defined
@@ -83,10 +82,10 @@ def filter_by_tags(specs_or_packages, tags):
     specs_or_packages = [x for x in specs_or_packages if has_tags(x)]
 
     # Filter by required tags
-    for tag in tags:
-        specs_or_packages = [
-            x for x in specs_or_packages if tag in package(x).tags
-        ]
+    specs_or_packages = [
+        x for x in specs_or_packages
+        if all(t in package(x).tags for t in tags)
+    ]
 
     return specs_or_packages
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -26,7 +26,6 @@ import sys
 
 import llnl.util.tty as tty
 import spack.cmd.common.arguments as arguments
-
 from spack.cmd import display_specs
 
 description = "list and search installed packages"
@@ -54,7 +53,7 @@ def setup_parser(subparser):
         const='deps',
         help='show full dependency DAG of installed packages')
 
-    arguments.add_common_arguments(subparser, ['long', 'very_long'])
+    arguments.add_common_arguments(subparser, ['long', 'very_long', 'tags'])
 
     subparser.add_argument('-f', '--show-flags',
                            action='store_true',
@@ -119,10 +118,14 @@ def find(parser, args):
 
     # Exit early if no package matches the constraint
     if not query_specs and args.constraint:
-        msg = "No package matches the query: {0}".format(
-            ' '.join(args.constraint))
+        msg = "No package matches the query: {0}"
+        msg = msg.format(' '.join(args.constraint))
         tty.msg(msg)
         return
+
+    # If tags have been specified on the command line, filter by tags
+    if args.tags:
+        query_specs = arguments.filter_by_tags(query_specs, args.tags)
 
     # Display the result
     if sys.stdout.isatty():

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -25,6 +25,7 @@
 import sys
 
 import llnl.util.tty as tty
+import spack
 import spack.cmd.common.arguments as arguments
 from spack.cmd import display_specs
 
@@ -125,7 +126,8 @@ def find(parser, args):
 
     # If tags have been specified on the command line, filter by tags
     if args.tags:
-        query_specs = arguments.filter_by_tags(query_specs, args.tags)
+        packages_with_tags = spack.repo.packages_with_tags(*args.tags)
+        query_specs = [x for x in query_specs if x.name in packages_with_tags]
 
     # Display the result
     if sys.stdout.isatty():

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -26,12 +26,12 @@ from __future__ import print_function
 
 import textwrap
 
+from llnl.util.tty.colify import *
+
 import llnl.util.tty.color as color
 import spack
 import spack.fetch_strategy as fs
 import spack.spec
-
-from llnl.util.tty.colify import *
 
 from six.moves import zip_longest
 
@@ -234,6 +234,16 @@ def print_text_info(pkg):
 
     else:
         print("    None")
+
+    print()
+    print("Tags: ")
+    if hasattr(pkg, 'tags'):
+        tags = sorted(pkg.tags)
+        colify(tags, indent=4)
+    else:
+        print("    None")
+
+    print()
 
 
 def info(parser, args):

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -26,14 +26,14 @@ from __future__ import print_function
 
 import textwrap
 
+from six.moves import zip_longest
+
 from llnl.util.tty.colify import *
 
 import llnl.util.tty.color as color
 import spack
 import spack.fetch_strategy as fs
 import spack.spec
-
-from six.moves import zip_longest
 
 description = 'get detailed information on a particular package'
 section = 'basic'
@@ -162,6 +162,14 @@ def print_text_info(pkg):
 
     color.cprint(section_title('Homepage: ') + pkg.homepage)
 
+    print()
+    print("Tags: ")
+    if hasattr(pkg, 'tags'):
+        tags = sorted(pkg.tags)
+        colify(tags, indent=4)
+    else:
+        print("    None")
+
     color.cprint('')
     color.cprint(section_title('Preferred version:  '))
 
@@ -232,14 +240,6 @@ def print_text_info(pkg):
             )
             print(line)
 
-    else:
-        print("    None")
-
-    print()
-    print("Tags: ")
-    if hasattr(pkg, 'tags'):
-        tags = sorted(pkg.tags)
-        colify(tags, indent=4)
     else:
         print("    None")
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -156,19 +156,19 @@ def print_text_info(pkg):
     color.cprint('')
     color.cprint(section_title('Description:'))
     if pkg.__doc__:
-        print(pkg.format_doc(indent=4))
+        color.cprint(pkg.format_doc(indent=4))
     else:
-        print("    None")
+        color.cprint("    None")
 
     color.cprint(section_title('Homepage: ') + pkg.homepage)
 
-    print()
-    print("Tags: ")
+    color.cprint('')
+    color.cprint(section_title("Tags: "))
     if hasattr(pkg, 'tags'):
         tags = sorted(pkg.tags)
         colify(tags, indent=4)
     else:
-        print("    None")
+        color.cprint("    None")
 
     color.cprint('')
     color.cprint(section_title('Preferred version:  '))
@@ -223,7 +223,7 @@ def print_text_info(pkg):
         if deps:
             colify(deps, indent=4)
         else:
-            print('    None')
+            color.cprint('    None')
 
     color.cprint('')
     color.cprint(section_title('Virtual Packages: '))
@@ -241,9 +241,9 @@ def print_text_info(pkg):
             print(line)
 
     else:
-        print("    None")
+        color.cprint("    None")
 
-    print()
+    color.cprint('')
 
 
 def info(parser, args):

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -30,11 +30,13 @@ import fnmatch
 import re
 import sys
 
+from six import StringIO
+
 import llnl.util.tty as tty
+from llnl.util.tty.colify import colify
+
 import spack
 import spack.cmd.common.arguments as arguments
-from llnl.util.tty.colify import colify
-from six import StringIO
 
 description = "list and search available packages"
 section = "basic"

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -29,11 +29,12 @@ import cgi
 import fnmatch
 import re
 import sys
-from six import StringIO
 
 import llnl.util.tty as tty
 import spack
+import spack.cmd.common.arguments as arguments
 from llnl.util.tty.colify import colify
+from six import StringIO
 
 description = "list and search available packages"
 section = "basic"
@@ -59,6 +60,8 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--format', default='name_only', choices=formatters,
         help='format to be used to print the output [default: name_only]')
+
+    arguments.add_common_arguments(subparser, ['tags'])
 
 
 def filter_by_name(pkgs, args):
@@ -183,5 +186,12 @@ def list(parser, args):
     pkgs = set(spack.repo.all_package_names())
     # Filter the set appropriately
     sorted_packages = filter_by_name(pkgs, args)
+
+    # Filter by tags
+    if args.tags:
+        sorted_packages = [spack.repo.get(x) for x in sorted_packages]
+        sorted_packages = arguments.filter_by_tags(sorted_packages, args.tags)
+        sorted_packages = [x.name for x in sorted_packages]
+
     # Print to stdout
     formatters[args.format](sorted_packages)

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -191,9 +191,9 @@ def list(parser, args):
 
     # Filter by tags
     if args.tags:
-        sorted_packages = [spack.repo.get(x) for x in sorted_packages]
-        sorted_packages = arguments.filter_by_tags(sorted_packages, args.tags)
-        sorted_packages = [x.name for x in sorted_packages]
+        packages_with_tags = set(spack.repo.packages_with_tags(*args.tags))
+        sorted_packages = set(sorted_packages) & packages_with_tags
+        sorted_packages = sorted(sorted_packages)
 
     # Print to stdout
     formatters[args.format](sorted_packages)

--- a/lib/spack/spack/file_cache.py
+++ b/lib/spack/spack/file_cache.py
@@ -35,7 +35,7 @@ class FileCache(object):
     """This class manages cached data in the filesystem.
 
     - Cache files are fetched and stored by unique keys.  Keys can be relative
-      paths, so that thre can be some hierarchy in the cache.
+      paths, so that there can be some hierarchy in the cache.
 
     - The FileCache handles locking cache files for reading and writing, so
       client code need not manage locks for cache entries.

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -435,7 +435,7 @@ class Repo(object):
         self._create_namespace()
 
         # Unique filename for cache of virtual dependency providers
-        self._cache_file = 'providers/%s-index.yaml' % self.namespace
+        self._providers_cache_file = 'providers/%s-index.yaml' % self.namespace
 
     def _create_namespace(self):
         """Create this repo's namespace module and insert it into sys.modules.
@@ -626,7 +626,7 @@ class Repo(object):
                 self._provider_index = ProviderIndex.from_yaml(f)
 
         # Read the old ProviderIndex, or make a new one.
-        key = self._cache_file
+        key = self._providers_cache_file
         index_existed = spack.misc_cache.init_entry(key)
         if index_existed and not self._needs_update:
             with spack.misc_cache.read_transaction(key) as f:
@@ -692,7 +692,7 @@ class Repo(object):
     def _fast_package_check(self):
         """List packages in the repo and check whether index is up to date.
 
-        Both of these opreations require checking all `package.py`
+        Both of these operations require checking all `package.py`
         files so we do them at the same time.  We list the repo
         directory and look at package.py files, and we compare the
         index modification date with the ost recently modified package
@@ -700,15 +700,14 @@ class Repo(object):
 
         The implementation here should try to minimize filesystem
         calls.  At the moment, it is O(number of packages) and makes
-        about one stat call per package.  This is resonably fast, and
+        about one stat call per package.  This is reasonably fast, and
         avoids actually importing packages in Spack, which is slow.
-
         """
         if self._all_package_names is None:
             self._all_package_names = []
 
             # Get index modification time.
-            index_mtime = spack.misc_cache.mtime(self._cache_file)
+            index_mtime = spack.misc_cache.mtime(self._providers_cache_file)
 
             for pkg_name in os.listdir(self.packages_path):
                 # Skip non-directories in the package root.
@@ -754,8 +753,7 @@ class Repo(object):
 
     def all_package_names(self):
         """Returns a sorted list of all package names in the Repo."""
-        self._fast_package_check()
-        return self._all_package_names
+        return self._fast_package_check()
 
     def all_packages(self):
         """Iterator over all packages in the repository.

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -26,7 +26,6 @@ import argparse
 
 import pytest
 import spack.cmd.find
-import spack.cmd.find as find
 from spack.util.pattern import Bunch
 
 
@@ -34,7 +33,7 @@ from spack.util.pattern import Bunch
 def parser():
     """Returns the parser for the module command"""
     prs = argparse.ArgumentParser()
-    find.setup_parser(prs)
+    spack.cmd.find.setup_parser(prs)
     return prs
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -22,12 +22,41 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import argparse
+
+import pytest
 import spack.cmd.find
+import spack.cmd.find as find
 from spack.util.pattern import Bunch
+
+
+@pytest.fixture(scope='module')
+def parser():
+    """Returns the parser for the module command"""
+    prs = argparse.ArgumentParser()
+    find.setup_parser(prs)
+    return prs
+
+
+@pytest.fixture()
+def specs():
+    s = []
+    return s
+
+
+@pytest.fixture()
+def mock_display(monkeypatch, specs):
+    """Monkeypatches the display function to return its first argument"""
+
+    def display(x, *args, **kwargs):
+        specs.extend(x)
+
+    monkeypatch.setattr(spack.cmd.find, 'display_specs', display)
 
 
 def test_query_arguments():
     query_arguments = spack.cmd.find.query_arguments
+
     # Default arguments
     args = Bunch(
         only_missing=False,
@@ -36,6 +65,7 @@ def test_query_arguments():
         explicit=False,
         implicit=False
     )
+
     q_args = query_arguments(args)
     assert 'installed' in q_args
     assert 'known' in q_args
@@ -43,11 +73,39 @@ def test_query_arguments():
     assert q_args['installed'] is True
     assert q_args['known'] is any
     assert q_args['explicit'] is any
+
     # Check that explicit works correctly
     args.explicit = True
     q_args = query_arguments(args)
     assert q_args['explicit'] is True
+
     args.explicit = False
     args.implicit = True
     q_args = query_arguments(args)
     assert q_args['explicit'] is False
+
+
+@pytest.mark.usefixtures('database', 'mock_display')
+class TestFindWithTags(object):
+
+    def test_tag1(self, parser, specs):
+
+        args = parser.parse_args(['--tags', 'tag1'])
+        spack.cmd.find.find(parser, args)
+
+        assert len(specs) == 2
+        assert 'mpich' in [x.name for x in specs]
+        assert 'mpich2' in [x.name for x in specs]
+
+    def test_tag2(self, parser, specs):
+        args = parser.parse_args(['--tags', 'tag2'])
+        spack.cmd.find.find(parser, args)
+
+        assert len(specs) == 1
+        assert 'mpich' in [x.name for x in specs]
+
+    def test_tag2_tag3(self, parser, specs):
+        args = parser.parse_args(['--tags', 'tag2', '--tags', 'tag3'])
+        spack.cmd.find.find(parser, args)
+
+        assert len(specs) == 0

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -26,7 +26,6 @@ import argparse
 
 import pytest
 import spack.cmd.info
-import spack.cmd.info as info
 
 from spack.main import SpackCommand
 
@@ -36,7 +35,7 @@ info = SpackCommand('info')
 def parser():
     """Returns the parser for the module command"""
     prs = argparse.ArgumentParser()
-    info.setup_parser(prs)
+    spack.cmd.info.setup_parser(prs)
     return prs
 
 

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -31,6 +31,7 @@ from spack.main import SpackCommand
 
 info = SpackCommand('info')
 
+
 @pytest.fixture(scope='module')
 def parser():
     """Returns the parser for the module command"""
@@ -51,7 +52,7 @@ def mock_print(monkeypatch, info_lines):
     def _print(*args):
         info_lines.extend(args)
 
-    monkeypatch.setattr(spack.cmd.info, 'print', _print, raising=False)
+    monkeypatch.setattr(spack.cmd.info.color, 'cprint', _print, raising=False)
 
 
 @pytest.mark.parametrize('pkg', [

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -22,11 +22,37 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
+import argparse
+
 import pytest
+import spack.cmd.info
+import spack.cmd.info as info
 
 from spack.main import SpackCommand
 
 info = SpackCommand('info')
+
+@pytest.fixture(scope='module')
+def parser():
+    """Returns the parser for the module command"""
+    prs = argparse.ArgumentParser()
+    info.setup_parser(prs)
+    return prs
+
+
+@pytest.fixture()
+def info_lines():
+    lines = []
+    return lines
+
+
+@pytest.fixture()
+def mock_print(monkeypatch, info_lines):
+
+    def _print(*args):
+        info_lines.extend(args)
+
+    monkeypatch.setattr(spack.cmd.info, 'print', _print, raising=False)
 
 
 @pytest.mark.parametrize('pkg', [
@@ -38,3 +64,29 @@ info = SpackCommand('info')
 ])
 def test_it_just_runs(pkg):
     info(pkg)
+
+
+@pytest.mark.parametrize('pkg_query', [
+    'hdf5',
+    'cloverleaf3d',
+    'trilinos'
+])
+@pytest.mark.usefixtures('mock_print')
+def test_info_fields(pkg_query, parser, info_lines):
+
+    expected_fields = (
+        'Description:',
+        'Homepage:',
+        'Safe versions:',
+        'Variants:',
+        'Installation Phases:',
+        'Virtual Packages:',
+        'Tags:'
+    )
+
+    args = parser.parse_args([pkg_query])
+    spack.cmd.info.info(parser, args)
+
+    for text in expected_fields:
+        match = [x for x in info_lines if text in x]
+        assert match

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -26,14 +26,13 @@ import argparse
 
 import pytest
 import spack.cmd.list
-import spack.cmd.list as list
 
 
 @pytest.fixture(scope='module')
 def parser():
     """Returns the parser for the module command"""
     prs = argparse.ArgumentParser()
-    list.setup_parser(prs)
+    spack.cmd.list.setup_parser(prs)
     return prs
 
 

--- a/var/spack/repos/builtin.mock/packages/mpich2/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich2/package.py
@@ -31,6 +31,8 @@ class Mpich2(Package):
     list_url   = "http://www.mpich.org/static/downloads/"
     list_depth = 2
 
+    tags = ['tag1', 'tag3']
+
     version('1.5', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
     version('1.4', 'foobarbaz')
     version('1.3', 'foobarbaz')

--- a/var/spack/repos/builtin/packages/aspa/package.py
+++ b/var/spack/repos/builtin/packages/aspa/package.py
@@ -28,10 +28,9 @@ import glob
 
 class Aspa(MakefilePackage):
     """A fundamental premise in ExMatEx is that scale-bridging performed in
-        heterogeneous MPMD materials science simulations will place important
-        demands upon the exascale ecosystem that need to be identified and
-        quantified.
-        tags = proxy-app
+    heterogeneous MPMD materials science simulations will place important
+    demands upon the exascale ecosystem that need to be identified and
+    quantified.
     """
     tags = ['proxy-app']
     homepage = "http://www.exmatex.org/aspa.html"


### PR DESCRIPTION
Fixes #4781 
Fixes #1456
Fixes #1526

The querying commands `spack list`, `spack find` and `spack info` have been modified to support querying by tags. Tests have been added to check that the feature is working correctly under what I think will be the most frequent use cases.

##### spack list
```console
$ spack list --tags proxy-app
==> 8 packages.
aspa  cloverleaf3d  hpccg  miniaero  miniamr  minife  pathfinder  tealeaf
```

##### spack find
```console
$ spack find
==> 70 installed packages.
-- linux-ubuntu14-x86_64 / gcc@4.8 ------------------------------
autoconf@2.69  cloverleaf3d@1.0  flex@2.6.1        hdf5@1.10.1      libevent@2.0.21      libtool@2.4.6  mpich@3.2             netlib-scalapack@2.0.2  openmpi@2.1.1      scotch@6.0.4        voropp@0.4.6
automake@1.15  cmake@3.8.0       flex@2.6.1        hdf5@1.10.1      libpciaccess@0.13.4  libxc@3.0.0    mumps@5.1.1           netlib-scalapack@2.0.2  openssl@1.0.2k     szip@2.1            xz@5.2.3
bison@3.0.4    cmake@3.8.1       gettext@0.19.8.1  help2man@1.47.4  libpciaccess@0.13.5  libxml2@2.9.4  ncurses@6.0           netlib-scalapack@2.0.2  parmetis@4.0.3     szip@2.1.1          zlib@1.2.11
boost@1.63.0   fftw@3.3.6-pl2    gflags@2.1.2      hwloc@1.11.6     libsigsegv@2.10      m4@1.4.18      netcdf@4.4.1.1        openblas@0.2.19         pkg-config@0.29.2  tar@1.29
bzip2@1.0.6    fftw@3.3.6-pl2    glog@0.3.4        hwloc@1.11.7     libsigsegv@2.11      metis@5.1.0    netcdf-fortran@4.4.4  openmpi@2.1.0           qhull@2015.2       util-macros@1.19.1

-- linux-ubuntu14-x86_64 / gcc@6.3.0 ----------------------------
autoconf@2.69  boost@1.63.0  cmake@3.8.1              folly@2017.06.05.00  glog@0.3.4       libsigsegv@2.11  m4@1.4.18    openssl@1.0.2k     zlib@1.2.11
automake@1.15  bzip2@1.0.6   double-conversion@2.0.1  gflags@2.1.2         libevent@2.0.21  libtool@2.4.6    ncurses@6.0  pkg-config@0.29.2

$ spack find --tags proxy-app
==> 1 installed packages.
-- linux-ubuntu14-x86_64 / gcc@4.8 ------------------------------
cloverleaf3d@1.0
```

##### spack info
```console
$ spack info cloverleaf3d
MakefilePackage:    cloverleaf3d

Description:
    Proxy Application. CloverLeaf3D is 3D version of the CloverLeaf mini-
    app. CloverLeaf is a mini-app that solves the compressible Euler
    equations on a Cartesian grid, using an explicit, second-order accurate
    method.

Homepage:           http://uk-mac.github.io/CloverLeaf3D/

Safe versions:  
    1.0    http://mantevo.org/downloads/releaseTarballs/miniapps/CloverLeaf3D/CloverLeaf3D-1.0.tar.gz

Variants:
    Name [Default]    Allowed values    Description


    openacc [off]     True, False       Enable OpenACC Support


Installation Phases:
    edit    build    install

Build Dependencies:
    mpi

Link Dependencies:
    mpi

Run Dependencies:
    None

Virtual Packages: 
    None

Tags: 
    proxy-app

```



