### PR TITLE
somatic-sniper depends_on('curses')

### DIFF
--- a/var/spack/repos/builtin/packages/somatic-sniper/package.py
+++ b/var/spack/repos/builtin/packages/somatic-sniper/package.py
@@ -33,4 +33,6 @@ class SomaticSniper(CMakePackage):
 
     version('1.0.5.0', '64bc2b001c9a8089f2a05900f8a0abfe')
 
+    depends_on('ncurses')
+
     parallel = False


### PR DESCRIPTION
somatic-sniper installs its own copy of samtools, which needs curses.
I'm not sure why I didn't stumble on this in my dev environment, but I
just stumbled over it in a standalone build.