### PR TITLE
Add universal build_type variant to CMakePackage

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -69,7 +69,7 @@ class CMakePackage(PackageBase):
 
     build_time_test_callbacks = ['check']
 
-    # https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
     variant('build_type', default='RelWithDebInfo',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -71,6 +71,7 @@ class CMakePackage(PackageBase):
 
     # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
     variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     depends_on('cmake', type='build')

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -29,7 +29,7 @@ import platform
 
 import spack.build_environment
 from llnl.util.filesystem import working_dir, join_path
-from spack.directives import depends_on
+from spack.directives import depends_on, variant
 from spack.package import PackageBase, run_after
 
 
@@ -49,11 +49,6 @@ class CMakePackage(PackageBase):
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:meth:`~.CMakePackage.build_type`          | Specify the value  |
-        |                                               | for the            |
-        |                                               | CMAKE_BUILD_TYPE   |
-        |                                               | variable           |
-        +-----------------------------------------------+--------------------+
         | :py:meth:`~.CMakePackage.root_cmakelists_dir` | Location of the    |
         |                                               | root CMakeLists.txt|
         +-----------------------------------------------+--------------------+
@@ -74,14 +69,11 @@ class CMakePackage(PackageBase):
 
     build_time_test_callbacks = ['check']
 
+    # https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html
+    variant('build_type', default='RelWithDebInfo',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+
     depends_on('cmake', type='build')
-
-    def build_type(self):
-        """Returns the correct value for the ``CMAKE_BUILD_TYPE`` variable
-
-        :return: value for ``CMAKE_BUILD_TYPE``
-        """
-        return 'RelWithDebInfo'
 
     @property
     def root_cmakelists_dir(self):
@@ -108,8 +100,8 @@ class CMakePackage(PackageBase):
     def _std_args(pkg):
         """Computes the standard cmake arguments for a generic package"""
         try:
-            build_type = pkg.build_type()
-        except AttributeError:
+            build_type = pkg.spec.variants['build_type'].value
+        except KeyError:
             build_type = 'RelWithDebInfo'
 
         args = ['-DCMAKE_INSTALL_PREFIX:PATH={0}'.format(pkg.prefix),

--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -36,8 +36,6 @@ class Alquimia(CMakePackage):
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')
-    variant('debug',  default=False,
-            description='Builds a debug version of the libraries')
 
     depends_on('mpi')
     depends_on('hdf5')
@@ -52,10 +50,6 @@ class Alquimia(CMakePackage):
         options = ['-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
                    '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
                    '-DUSE_XSDK_DEFAULTS=YES',
-                   '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                       'DEBUG' if '+debug' in spec else 'RELEASE'),
-                   '-DXSDK_ENABLE_DEBUG:STRING=%s' % (
-                       'YES' if '+debug' in spec else 'NO'),
                    '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                        'ON' if '+shared' in spec else 'OFF'),
                    '-DTPL_ENABLE_MPI:BOOL=ON',

--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -37,6 +37,11 @@ class Benchmark(CMakePackage):
     version('1.1.0', '66b2a23076cf70739525be0092fc3ae3')
     version('1.0.0', '1474ff826f8cd68067258db75a0835b8')
 
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo',
+                    'MinSizeRel', 'Coverage'))
+
     def patch(self):
         filter_file(
             r'add_cxx_compiler_flag..fstrict.aliasing.',

--- a/var/spack/repos/builtin/packages/bml/package.py
+++ b/var/spack/repos/builtin/packages/bml/package.py
@@ -36,14 +36,5 @@ class Bml(CMakePackage):
     version('develop', git='https://github.com/qmmd/bml', branch='master')
     version('1.1.0', git='https://github.com/qmmd/bml', tag='v1.1.0')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("blas")
     depends_on("lapack")
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -53,6 +53,9 @@ class CbtfArgonavis(CMakePackage):
     version('1.8', branch='master',
             git='https://github.com/OpenSpeedShop/cbtf-argonavis.git')
 
+    variant('build_type', default='None', values=('None'),
+            description='CMake build type')
+
     depends_on("cmake@3.0.2:", type='build')
     depends_on("boost@1.50.0:1.59.0")
     depends_on("papi")
@@ -64,9 +67,6 @@ class CbtfArgonavis(CMakePackage):
     parallel = False
 
     build_directory = 'build_cbtf_argonavis'
-
-    def build_type(self):
-        return 'None'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -68,6 +68,8 @@ class CbtfKrell(CMakePackage):
             description="Build mpi experiment collector for mpich2 MPI.")
     variant('mpich', default=False,
             description="Build mpi experiment collector for mpich MPI.")
+    variant('build_type', default='None', values=('None'),
+            description='CMake build type')
 
     # Dependencies for cbtf-krell
     depends_on("cmake@3.0.2:", type='build')
@@ -128,9 +130,6 @@ class CbtfKrell(CMakePackage):
             MPIOptions.append('-DMPT_DIR=%s' % spec['mpt'].prefix)
 
         cmakeOptions.extend(MPIOptions)
-
-    def build_type(self):
-        return 'None'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/cbtf-lanl/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-lanl/package.py
@@ -51,6 +51,9 @@ class CbtfLanl(CMakePackage):
     version('1.8', branch='master',
             git='http://git.code.sf.net/p/cbtf-lanl/cbtf-lanl')
 
+    variant('build_type', default='None', values=('None'),
+            description='CMake build type')
+
     depends_on("cmake@3.0.2:", type='build')
     # Dependencies for cbtf-krell
     depends_on("mrnet@5.0.1:+lwthreads")
@@ -61,9 +64,6 @@ class CbtfLanl(CMakePackage):
     parallel = False
 
     build_directory = 'build_cbtf_lanl'
-
-    def build_type(self):
-        return 'None'
 
     def cmake_args(self):
 

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -58,6 +58,8 @@ class Cbtf(CMakePackage):
 
     variant('runtime', default=False,
             description="build only the runtime libraries and collectors.")
+    variant('build_type', default='None', values=('None'),
+            description='CMake build type')
 
     depends_on("cmake@3.0.2:", type='build')
     depends_on("boost@1.50.0:1.59.0")
@@ -69,9 +71,6 @@ class Cbtf(CMakePackage):
     parallel = False
 
     build_directory = 'build_cbtf'
-
-    def build_type(self):
-        return 'None'
 
     def cmake_args(self):
 

--- a/var/spack/repos/builtin/packages/clamr/package.py
+++ b/var/spack/repos/builtin/packages/clamr/package.py
@@ -42,25 +42,12 @@ class Clamr(CMakePackage):
         values=('opengl', 'mpe', 'none'),
         description='Build with specified graphics support')
     variant(
-        'build', default='relwithdebinfo',
-        values=('debug', 'release', 'relwithdebinfo'),
-        description='Build type')
-    variant(
         'precision', default='mixed',
         values=('single', 'mixed', 'full'),
         description='single, mixed, or full double precision values')
 
     depends_on('mpi')
     depends_on('mpe', when='graphics=mpe')
-
-    def build_type(self):
-        spec = self.spec
-        if 'build=debug' in spec:
-            return 'Debug'
-        elif 'build=release' in spec:
-            return 'Release'
-        else:
-            return 'RelWithDebInfo'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -50,7 +50,6 @@ class Clhep(CMakePackage):
     version('2.2.0.5', '1584e8ce6ebf395821aed377df315c7c')
     version('2.2.0.4', '71d2c7c2e39d86a0262e555148de01c1')
 
-    variant('debug', default=False, description="Switch to the debug version of CLHEP.")
     variant('cxx11', default=True, description="Compile using c++11 dialect.")
     variant('cxx14', default=False, description="Compile using c++14 dialect.")
 
@@ -64,14 +63,6 @@ class Clhep(CMakePackage):
                     % (self.stage.path, self.spec.version))
 
     root_cmakelists_dir = 'CLHEP'
-
-    def build_type(self):
-        spec = self.spec
-
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'MinSizeRel'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -71,6 +71,9 @@ class Dealii(CMakePackage):
             description='Compile with 64 bit indices support')
     variant('optflags', default=False,
             description='Compile using additional optimization flags')
+    variant('build_type', default='DebugRelease',
+            description='The build type to build',
+            values=('Debug', 'Release', 'DebugRelease'))
 
     # required dependencies, light version
     depends_on("blas")
@@ -135,10 +138,6 @@ class Dealii(CMakePackage):
     for p in ['+arpack', '+hdf5', '+netcdf', '+p4est', '+petsc',
               '+slepc', '+trilinos']:
         conflicts(p, when='~mpi')
-
-    def build_type(self):
-        # CMAKE_BUILD_TYPE should be DebugRelease | Debug | Release
-        return 'DebugRelease'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -50,6 +50,9 @@ class Eccodes(CMakePackage):
             description="Enable OpenMP threads")
     variant('memfs', default=False,
             description="Memory based access to definitions/samples")
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'Production'))
 
     depends_on('netcdf', when='+netcdf')
     depends_on('openjpeg', when='+jpeg')

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -40,9 +40,6 @@ class Eigen(CMakePackage):
     version('3.2.8', '64f4aef8012a424c7e079eaf0be71793ab9bc6e0')
     version('3.2.7', 'cc1bacbad97558b97da6b77c9644f184')
 
-    variant('debug', default=False,
-            description='Builds the library in debug mode')
-
     variant('metis', default=True, description='Enables metis backend')
     variant('scotch', default=True, description='Enables scotch backend')
     variant('fftw', default=True, description='Enables FFTW backend')
@@ -58,9 +55,3 @@ class Eigen(CMakePackage):
     depends_on('suite-sparse', when='+suitesparse')
     depends_on('mpfr@2.3.0:', when='+mpfr')
     depends_on('gmp', when='+mpfr')
-
-    def build_type(self):
-        if '+debug' in self.spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -47,6 +47,9 @@ class Eigen(CMakePackage):
             description='Enables SuiteSparse support')
     variant('mpfr', default=True,
             description='Enables support for multi-precisions FP via mpfr')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     # TODO : dependency on googlehash, superlu, adolc missing
     depends_on('metis@5:', when='+metis')

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -36,8 +36,6 @@ class Elemental(CMakePackage):
     version('0.87.7', '6c1e7442021c59a36049e37ea69b8075')
     version('0.87.6', '9fd29783d45b0a0e27c0df85f548abe9')
 
-    variant('debug', default=False,
-            description='Builds a debug version of the libraries')
     variant('shared', default=True,
             description='Enables the build of shared libraries')
     variant('hybrid', default=True,
@@ -84,15 +82,6 @@ class Elemental(CMakePackage):
         return find_libraries(
             'libEl', root=self.prefix, shared=shared, recurse=True
         )
-
-    def build_type(self):
-        """Returns the correct value for the ``CMAKE_BUILD_TYPE`` variable
-        :return: value for ``CMAKE_BUILD_TYPE``
-        """
-        if '+debug' in self.spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -59,6 +59,9 @@ class Elemental(CMakePackage):
             ' Requires local build of BLAS library.')
     variant('scalapack', default=False,
             description='Build with ScaLAPACK library')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
 
     # Note that this forces us to use OpenBLAS until #1712 is fixed
     depends_on('blas', when='~openmp_blas ~int64_blas')

--- a/var/spack/repos/builtin/packages/espressopp/package.py
+++ b/var/spack/repos/builtin/packages/espressopp/package.py
@@ -39,7 +39,6 @@ class Espressopp(CMakePackage):
     version('1.9.4.1', '0da74a6d4e1bfa6a2a24fca354245a4f')
     version('1.9.4', 'f2a27993a83547ad014335006eea74ea')
 
-    variant('debug', default=False, description='Build debug version')
     variant('ug', default=False, description='Build user guide')
     variant('pdf', default=False, description='Build user guide in pdf format')
     variant('dg', default=False, description='Build developer guide')
@@ -59,13 +58,6 @@ class Espressopp(CMakePackage):
     depends_on('py-matplotlib', when="+pdf", type='build')
     depends_on("texlive", when="+pdf", type='build')
     depends_on("doxygen", when="+dg", type='build')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         return ['-DEXTERNAL_MPI4PY=ON', '-DEXTERNAL_BOOST=ON']

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -57,6 +57,10 @@ class Fenics(CMakePackage):
             description='Enables the build of shared libraries')
     variant('doc',          default=False,
             description='Builds the documentation')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo',
+                    'MinSizeRel', 'Developer'))
 
     # not part of spack list for now
     # variant('petsc4py',     default=True,  description='Uses PETSc4py')

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -55,8 +55,6 @@ class Fenics(CMakePackage):
             description='Enables the shared memory support')
     variant('shared',       default=True,
             description='Enables the build of shared libraries')
-    variant('debug',        default=False,
-            description='Builds a debug version of the libraries')
     variant('doc',          default=False,
             description='Builds the documentation')
 
@@ -147,8 +145,6 @@ class Fenics(CMakePackage):
         spec = self.spec
 
         return [
-            '-DCMAKE_BUILD_TYPE:STRING={0}'.format(
-                'Debug' if '+debug' in spec else 'RelWithDebInfo'),
             '-DDOLFIN_ENABLE_DOCS:BOOL={0}'.format(
                 self.cmake_is_on('+doc')),
             '-DBUILD_SHARED_LIBS:BOOL={0}'.format(

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -146,8 +146,6 @@ class Fenics(CMakePackage):
         return 'ON' if option in self.spec else 'OFF'
 
     def cmake_args(self):
-        spec = self.spec
-
         return [
             '-DDOLFIN_ENABLE_DOCS:BOOL={0}'.format(
                 self.cmake_is_on('+doc')),

--- a/var/spack/repos/builtin/packages/flecsale/package.py
+++ b/var/spack/repos/builtin/packages/flecsale/package.py
@@ -33,7 +33,6 @@ class Flecsale(CMakePackage):
 
     version('develop', git='https://github.com/laristra/flecsale', branch='master', submodules=True)
 
-    variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True,
             description='Build on top of mpi conduit for mpi inoperability')
 
@@ -42,13 +41,6 @@ class Flecsale(CMakePackage):
     depends_on("flecsi+mpi", when='+mpi')
     depends_on("python")
     depends_on("openssl")
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         options = [

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -41,20 +41,12 @@ class Flecsi(CMakePackage):
 
     version('develop', git='https://github.com/laristra/flecsi', branch='master', submodules=True)
 
-    variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True,
             description='Build on top of mpi conduit for mpi inoperability')
 
     depends_on("cmake@3.1:", type='build')
     depends_on("legion+shared", when='~mpi')
     depends_on("legion+shared+mpi", when='+mpi')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         options = ['-DENABLE_UNIT_TESTS=ON']

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -41,7 +41,6 @@ class Geant4(CMakePackage):
     version('10.01.p03', '4fb4175cc0dabcd517443fbdccd97439')
 
     variant('qt', default=True, description='Enable Qt support')
-    variant('debug', default=False, description='Build debug version')
 
     depends_on('cmake@3.5:', type='build')
 
@@ -53,13 +52,6 @@ class Geant4(CMakePackage):
     depends_on("vecgeom")
     depends_on("xerces-c")
     depends_on("qt@4.8:", when="+qt")
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -46,8 +46,6 @@ class Gmsh(CMakePackage):
 
     variant('shared',      default=True,
             description='Enables the build of shared libraries')
-    variant('debug',       default=False,
-            description='Builds the library in debug mode')
     variant('mpi',         default=True,
             description='Builds MPI support for parser and solver')
     variant('fltk',        default=False,
@@ -127,9 +125,6 @@ class Gmsh(CMakePackage):
         else:
             # Builds and installs static library
             options.append('-DENABLE_BUILD_LIB:BOOL=ON')
-
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
 
         if '+mpi' in spec:
             options.append('-DENABLE_MPI:BOOL=ON')

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -48,7 +48,6 @@ class Gromacs(CMakePackage):
     variant('mpi', default=True, description='Activate MPI support')
     variant('shared', default=True,
             description='Enables the build of shared libraries')
-    variant('debug', default=False, description='Enables debug mode')
     variant(
         'double', default=False,
         description='Produces a double precision version of the executables')
@@ -78,11 +77,6 @@ class Gromacs(CMakePackage):
 
         if '~shared' in self.spec:
             options.append('-DBUILD_SHARED_LIBS:BOOL=OFF')
-
-        if '+debug' in self.spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Release')
 
         if '+cuda' in self.spec:
             options.append('-DGMX_GPU:BOOL=ON')

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -53,6 +53,10 @@ class Gromacs(CMakePackage):
         description='Produces a double precision version of the executables')
     variant('plumed', default=False, description='Enable PLUMED support')
     variant('cuda', default=False, description='Enable CUDA support')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
+                    'Reference', 'RelWithAssert', 'Profile'))
 
     depends_on('mpi', when='+mpi')
     depends_on('plumed+mpi', when='+plumed+mpi')

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -40,10 +40,3 @@ class Hpx(CMakePackage):
     def cmake_args(self):
         args = ['-DHPX_BUILD_EXAMPLES=OFF', '-DHPX_MALLOC=system']
         return args
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -36,7 +36,6 @@ class Lbann(CMakePackage):
     version('develop', git='https://github.com/LLNL/lbann.git', branch="develop")
     version('0.91', '83b0ec9cd0b7625d41dfb06d2abd4134')
 
-    variant('debug', default=False, description='Builds a debug version of the libraries')
     variant('gpu', default=False, description='Builds with support for GPUs via CUDA and cuDNN')
     variant('opencv', default=True, description='Builds with support for image processing routines with OpenCV')
     variant('seq_init', default=False, description='Force serial initialization of weight matrices.')
@@ -47,13 +46,6 @@ class Lbann(CMakePackage):
     depends_on('mpi')
     depends_on('opencv@3.2.0', when='+opencv')
     depends_on('protobuf@3.0.2:')
-
-    def build_type(self):
-        if '+debug' in self.spec:
-            return 'Debug'
-        else:
-            return 'Release'
-
     def cmake_args(self):
         spec = self.spec
         # Environment variables

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -41,11 +41,11 @@ class Lbann(CMakePackage):
     variant('seq_init', default=False, description='Force serial initialization of weight matrices.')
 
     depends_on('elemental +openmp_blas +scalapack +shared +int64')
-    depends_on('elemental +openmp_blas +scalapack +shared +int64 +debug', when='+debug')
     depends_on('cuda', when='+gpu')
     depends_on('mpi')
     depends_on('opencv@3.2.0', when='+opencv')
     depends_on('protobuf@3.0.2:')
+
     def cmake_args(self):
         spec = self.spec
         # Environment variables

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -46,7 +46,6 @@ class Legion(CMakePackage):
     version('develop', git='https://github.com/StanfordLegion/legion', branch='master')
     version('17.02.0', '31ac3004e2fb0996764362d2b6f6844a')
 
-    variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True,
             description='Build on top of mpi conduit for mpi inoperability')
     variant('shared', default=True, description='Build shared libraries')
@@ -54,13 +53,6 @@ class Legion(CMakePackage):
     depends_on("cmake@3.1:", type='build')
     depends_on("gasnet", when='~mpi')
     depends_on("gasnet+mpi", when='+mpi')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         options = [

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -43,6 +43,10 @@ class Llvm(CMakePackage):
     version('3.0', 'a8e5f5f1c1adebae7b4a654c376a6005',
             url='http://llvm.org/releases/3.0/llvm-3.0.tar.gz')
 
+    # NOTE: The debug version of LLVM is an order of magnitude larger than
+    # the release version, and may take up 20-30 GB of space. If you want
+    # to save space, build with `build_type=Release`.
+
     variant('clang', default=True,
             description="Build the LLVM C/C++/Objective-C compiler frontend")
     variant('lldb', default=True, description="Build the LLVM debugger")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -43,10 +43,6 @@ class Llvm(CMakePackage):
     version('3.0', 'a8e5f5f1c1adebae7b4a654c376a6005',
             url='http://llvm.org/releases/3.0/llvm-3.0.tar.gz')
 
-    variant('debug', default=False,
-            description="Build a debug version of LLVM, this increases "
-            "binary size by an order of magnitude, make sure you have "
-            "20-30gb of space available to build this")
     variant('clang', default=True,
             description="Build the LLVM C/C++/Objective-C compiler frontend")
     variant('lldb', default=True, description="Build the LLVM debugger")
@@ -326,12 +322,6 @@ class Llvm(CMakePackage):
 
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
-
-    def build_type(self):
-        if '+debug' in self.spec:
-            return 'RelWithDebInfo'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mad-numdiff/package.py
+++ b/var/spack/repos/builtin/packages/mad-numdiff/package.py
@@ -34,12 +34,3 @@ class MadNumdiff(CMakePackage):
 
     version('develop', git='https://github.com/quinoacomputing/ndiff', branch='master')
     version('20150724', '7723c0f2499aea8fd960377c5bed28d8')
-
-    variant('debug', default=False, description='Build debug version')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -38,18 +38,9 @@ class Nalu(CMakePackage):
     version('master',
             git='https://github.com/NaluCFD/Nalu.git', branch='master')
 
-    variant('debug', default=False,
-            description='Builds a debug version')
-
     # Currently Nalu only builds static libraries; To be fixed soon
     depends_on('yaml-cpp+fpic~shared')
     depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf@master')
-
-    def build_type(self):
-        if '+debug' in self.spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/opencoarrays/package.py
+++ b/var/spack/repos/builtin/packages/opencoarrays/package.py
@@ -42,6 +42,11 @@ class Opencoarrays(CMakePackage):
     version('1.7.4', '85ba87def461e3ff5a164de2e6482930')
     version('1.6.2', '5a4da993794f3e04ea7855a6678981ba')
 
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo',
+                    'MinSizeRel', 'CodeCoverage'))
+
     depends_on('mpi')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -83,6 +83,8 @@ class Openspeedshop(CMakePackage):
     variant('rtfe', default=False,
             description="build for clusters heterogeneous processors \
                          on fe/be nodes.")
+    variant('build_type', default='None', values=('None'),
+            description='CMake build type')
 
     # MPI variants
     variant('openmpi', default=False,
@@ -143,9 +145,6 @@ class Openspeedshop(CMakePackage):
     parallel = False
 
     build_directory = 'build_openspeedshop'
-
-    def build_type(self):
-        return 'None'
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -39,12 +39,3 @@ class Pegtl(CMakePackage):
     version('develop', git='https://github.com/taocpp/PEGTL', branch='master')
     version('2.1.4', 'e5288b6968e6e910287fce93dc5557bf')
     version('2.0.0', 'c772828e7188459338a920c21f9896db')
-
-    variant('debug', default=False, description='Build debug version')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/portage/package.py
+++ b/var/spack/repos/builtin/packages/portage/package.py
@@ -40,6 +40,7 @@ class Portage(CMakePackage):
 
     depends_on("cmake@3.1:", type='build')
     depends_on('mpi', when='+mpi')
+
     def cmake_args(self):
         options = ['-DENABLE_UNIT_TESTS=ON', '-DENABLE_APP_TESTS=ON']
 

--- a/var/spack/repos/builtin/packages/portage/package.py
+++ b/var/spack/repos/builtin/packages/portage/package.py
@@ -36,19 +36,10 @@ class Portage(CMakePackage):
 
     version('develop', git='https://github.com/laristra/portage', branch='master', submodules=True)
 
-    variant('debug', default=False, description='Build debug version')
     variant('mpi', default=True, description='Support MPI')
 
     depends_on("cmake@3.1:", type='build')
     depends_on('mpi', when='+mpi')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
-
     def cmake_args(self):
         options = ['-DENABLE_UNIT_TESTS=ON', '-DENABLE_APP_TESTS=ON']
 

--- a/var/spack/repos/builtin/packages/quinoa/package.py
+++ b/var/spack/repos/builtin/packages/quinoa/package.py
@@ -38,8 +38,6 @@ class Quinoa(CMakePackage):
 
     version('develop', git='https://github.com/quinoacomputing/quinoa', branch='master')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on('hdf5+mpi')
     depends_on("charm backend=mpi")
     depends_on("trilinos+exodus")
@@ -56,10 +54,3 @@ class Quinoa(CMakePackage):
     depends_on("pegtl")
 
     root_cmakelists_dir = 'src'
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -40,6 +40,10 @@ class Relion(CMakePackage):
     variant('cuda', default=False, description="enable compute on gpu")
     variant('double', default=False, description="double precision (cpu) code")
     variant('double-gpu', default=False, description="double precision (gpu) code")
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo',
+                    'Profiling', 'Benchmarking'))
 
     depends_on('mpi')
     depends_on('fftw+float+double')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -99,12 +99,6 @@ class Root(CMakePackage):
     # See https://sft.its.cern.ch/jira/browse/ROOT-7517
     conflicts('%intel')
 
-    def build_type(self):
-        if '+debug' in self.spec:
-            return 'Debug'
-        else:
-            return 'Release'
-
     def cmake_args(self):
         args = [
             '-Dcocoa=OFF',

--- a/var/spack/repos/builtin/packages/sas/package.py
+++ b/var/spack/repos/builtin/packages/sas/package.py
@@ -36,18 +36,9 @@ class Sas(CMakePackage):
     version('0.1.4', '20d7311258f2a59c9367ae1576c392b6')
     version('0.1.3', '1e6572afcc03318d16d7321d40eec0fd')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on('python@2.7:')
     depends_on('llvm@3.5:')
     depends_on('cmake@2.8:', type='build')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/symengine/package.py
+++ b/var/spack/repos/builtin/packages/symengine/package.py
@@ -55,6 +55,9 @@ class Symengine(CMakePackage):
             description='Enable thread safety option')
     variant('shared',       default=True,
             description='Enables the build of shared libraries')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
 
     # NOTE: mpir is a drop-in replacement for gmp
     # NOTE: [mpc,mpfr,flint,piranha] could also be built against mpir
@@ -66,10 +69,6 @@ class Symengine(CMakePackage):
     depends_on('flint',    when='+flint~boostmp')
     depends_on('piranha',  when='+piranha~flint~boostmp')
 
-    def build_type(self):
-        # CMAKE_BUILD_TYPE should be  Debug | Release
-        return 'Release'
-
     def cmake_args(self):
         spec = self.spec
         options = []
@@ -77,7 +76,6 @@ class Symengine(CMakePackage):
         # See https://github.com/symengine/symengine/blob/master/README.md
         # for build options
         options.extend([
-            '-DCMAKE_BUILD_TYPE=Release',
             '-DWITH_SYMENGINE_RCP:BOOL=ON',
             '-DWITH_SYMENGINE_THREAD_SAFE:BOOL=%s' % (
                 'ON' if ('+thread_safe' or '+openmp') in spec else 'OFF'),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -93,8 +93,6 @@ class Trilinos(CMakePackage):
             description='Build python wrappers')
     variant('shared',       default=True,
             description='Enables the build of shared libraries')
-    variant('debug',        default=False,
-            description='Builds a debug version of the libraries')
     variant('boost',        default=True,
             description='Compile with Boost')
     variant('tpetra',       default=True,
@@ -241,8 +239,6 @@ class Trilinos(CMakePackage):
             '-DTrilinos_ENABLE_TESTS:BOOL=OFF',
             '-DTrilinos_ENABLE_EXAMPLES:BOOL=OFF',
             '-DTrilinos_ENABLE_CXX11:BOOL=ON',
-            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                'DEBUG' if '+debug' in spec else 'RELEASE'),
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                 'ON' if '+shared' in spec else 'OFF'),
 

--- a/var/spack/repos/builtin/packages/vc/package.py
+++ b/var/spack/repos/builtin/packages/vc/package.py
@@ -34,3 +34,8 @@ class Vc(CMakePackage):
     version('1.3.0', '77efc1c16691c7925d4b58f9b30cf03b')
     version('1.2.0', 'a5236df286b845d2fee5ef1e4d27549f')
     version('1.1.0', 'e354c1e3ea1d674b6f2af9c6fd230d81')
+
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebug',
+                    'RelWithDebInfo', 'MinSizeRel'))

--- a/var/spack/repos/builtin/packages/vc/package.py
+++ b/var/spack/repos/builtin/packages/vc/package.py
@@ -34,12 +34,3 @@ class Vc(CMakePackage):
     version('1.3.0', '77efc1c16691c7925d4b58f9b30cf03b')
     version('1.2.0', 'a5236df286b845d2fee5ef1e4d27549f')
     version('1.1.0', 'e354c1e3ea1d674b6f2af9c6fd230d81')
-
-    variant('debug', default=False)
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -36,16 +36,7 @@ class Vecgeom(CMakePackage):
     version('0.3.rc', git='https://gitlab.cern.ch/VecGeom/VecGeom.git',
             tag='v0.3.rc')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on('cmake@3.5:', type='build')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         options = [

--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -39,16 +39,7 @@ class VotcaCsg(CMakePackage):
     version('develop', git='https://github.com/votca/csg', branch='master')
     version('1.4', 'd009e761e5e3afd51eed89c420610a67')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@2.8:", type='build')
     depends_on("votca-tools@1.4:1.4.999", when='@1.4:1.4.999')
     depends_on("votca-tools@develop", when='@develop')
     depends_on("gromacs~mpi@5.1:")
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/votca-ctp/package.py
+++ b/var/spack/repos/builtin/packages/votca-ctp/package.py
@@ -39,16 +39,7 @@ class VotcaCtp(CMakePackage):
 
     version('develop', git='https://github.com/votca/ctp', branch='master')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@2.8:", type='build')
     depends_on("votca-tools@develop", when='@develop')
     depends_on("votca-csg@develop", when='@develop')
     depends_on("votca-moo@develop", when='@develop')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/votca-moo/package.py
+++ b/var/spack/repos/builtin/packages/votca-moo/package.py
@@ -39,14 +39,5 @@ class VotcaMoo(CMakePackage):
 
     version('develop', git='https://github.com/votca/moo', branch='master')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@2.8:", type='build')
     depends_on("votca-tools@develop", when='@develop')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -39,18 +39,9 @@ class VotcaTools(CMakePackage):
     version('develop', git='https://github.com/votca/tools', branch='master')
     version('1.4', 'cd47868e9f28e2c7b9d01f95aa0185ca')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@2.8:", type='build')
     depends_on("expat")
     depends_on("fftw")
     depends_on("gsl")
     depends_on("boost")
     depends_on("sqlite")
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/votca-xtp/package.py
+++ b/var/spack/repos/builtin/packages/votca-xtp/package.py
@@ -39,17 +39,8 @@ class VotcaXtp(CMakePackage):
 
     version('develop', git='https://github.com/votca/xtp', branch='master')
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@2.8:", type='build')
     depends_on("votca-tools@develop", when='@develop')
     depends_on("votca-csg@develop", when='@develop')
     depends_on("votca-ctp@develop", when='@develop')
     depends_on("votca-moo@develop", when='@develop')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'

--- a/var/spack/repos/builtin/packages/vpic/package.py
+++ b/var/spack/repos/builtin/packages/vpic/package.py
@@ -40,17 +40,8 @@ class Vpic(CMakePackage):
 
     version('develop', git='https://github.com/lanl/vpic', branch='master', submodules=True)
 
-    variant('debug', default=False, description='Build debug version')
-
     depends_on("cmake@3.1:", type='build')
     depends_on('mpi')
-
-    def build_type(self):
-        spec = self.spec
-        if '+debug' in spec:
-            return 'Debug'
-        else:
-            return 'Release'
 
     def cmake_args(self):
         options = ['-DENABLE_INTEGRATED_TESTS=ON', '-DENABLE_UNIT_TESTS=ON']

--- a/var/spack/repos/builtin/packages/xsdktrilinos/package.py
+++ b/var/spack/repos/builtin/packages/xsdktrilinos/package.py
@@ -45,20 +45,18 @@ class Xsdktrilinos(CMakePackage):
             description='Compile with PETSc solvers')
     variant('shared',       default=True,
             description='Enables the build of shared libraries')
-    variant('debug',        default=False,
-            description='Builds a debug version of the libraries')
 
     # MPI related dependencies
     depends_on('mpi')
     depends_on('hypre~internal-superlu', when='+hypre')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0+hypre')
-    depends_on('hypre@develop~internal-superlu', when='@develop+hypre')    
+    depends_on('hypre@develop~internal-superlu', when='@develop+hypre')
     depends_on('petsc@xsdk-0.2.0+mpi~complex', when='@xsdk-0.2.0+petsc')
-    depends_on('petsc@develop+mpi~complex', when='@develop+petsc')    
+    depends_on('petsc@develop+mpi~complex', when='@develop+petsc')
     depends_on('trilinos@12.6.4', when='@12.6.4')
     depends_on('trilinos@12.8.1', when='@12.8.1')
     depends_on('trilinos@xsdk-0.2.0', when='@xsdk-0.2.0')
-    depends_on('trilinos@develop', when='@develop')    
+    depends_on('trilinos@develop', when='@develop')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/xSDKTrilinos/archive/trilinos-release-{0}.tar.gz"
@@ -75,8 +73,6 @@ class Xsdktrilinos(CMakePackage):
             '-DxSDKTrilinos_ENABLE_TESTS:BOOL=ON',
             '-DxSDKTrilinos_ENABLE_EXAMPLES:BOOL=ON',
             '-DTrilinos_INSTALL_DIR=%s' % spec['trilinos'].prefix,
-            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                'DEBUG' if '+debug' in spec else 'RELEASE'),
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                 'ON' if '+shared' in spec else 'OFF'),
             '-DTPL_ENABLE_MPI:BOOL=ON',


### PR DESCRIPTION
This PR adds a variant to every package that extends `CMakePackage` to control [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html). 

Instead of having every package override `build_type` on their own, I figure the best way to do this is to create a universal variant for all `CMakePackage` packages.

Still stumbling over a few hurdles. Apparently not all CMake packages have the same possible build types? @davydden Can you confirm that `dealii` only has the following possible values?
```python
# CMAKE_BUILD_TYPE should be DebugRelease | Debug | Release 
```
`symengine` may or may not be in the same boat. Does anyone know how to check what the possible values are for any given project? I want to make sure I didn't break any of the other packages.

So I need a way of being able to override the possible values of a variant in a subclass. A simple variable didn't do the trick as the variant was registered before the value was changed. @alalazo Any ideas?

Another question: do we want the values to be lowercase or CamelCase?

Just a heads up, this will change the variants (and therefore the specs/hashes) of every CMakePackage in Spack.

@mathstuf may also be interested in this discussion.