### PR TITLE
Repalce ftp:// with http:// for gdbm, mesa-glu and udunits2.

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -33,7 +33,7 @@ class Gdbm(AutotoolsPackage):
     manipulate a hashed database."""
 
     homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
-    url      = "ftp://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
+    url      = "http://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
 
     version('1.13',  '8929dcda2a8de3fd2367bdbf66769376')
     version('1.12',  '9ce96ff4c99e74295ea19040931c8fb9')

--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -30,7 +30,7 @@ class MesaGlu(AutotoolsPackage):
     """This package provides the Mesa OpenGL Utility library."""
 
     homepage = "https://www.mesa3d.org"
-    url      = "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.0.tar.gz"
+    url      = "https://www.mesa3d.org/archive/glu/glu-9.0.0.tar.gz"
 
     version('9.0.0', 'bbc57d4fe3bd3fb095bdbef6fcb977c4')
 

--- a/var/spack/repos/builtin/packages/udunits2/package.py
+++ b/var/spack/repos/builtin/packages/udunits2/package.py
@@ -29,7 +29,7 @@ class Udunits2(AutotoolsPackage):
     """Automated units conversion"""
 
     homepage = "http://www.unidata.ucar.edu/software/udunits"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.24.tar.gz"
+    url      = "https://www.gfd-dennou.org/arch/ucar/unidata/pub/udunits/udunits-2.2.24.tar.gz"
 
     version('2.2.24', '898b90dc1890f172c493406d0f26f531')
     version('2.2.23', '9f66006accecd621a4c3eda4ba9fa7c9')


### PR DESCRIPTION
Repalce ftp:// with http:// for easier package downloading behind the firewall. One plus benefit is that `spack checksum` works for them now.