### PR TITLE
Improve version detection of release versions

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -57,6 +57,8 @@ from spack.url import *
     ('gromacs-4.6.1-tar', 'gromacs-4.6.1'),
     # Download type - sh
     ('Miniconda2-4.3.11-Linux-x86_64.sh', 'Miniconda2-4.3.11'),
+    # Download version - release
+    ('v1.0.4-release', 'v1.0.4'),
     # Download version - stable
     ('libevent-2.0.21-stable', 'libevent-2.0.21'),
     # Download version - final

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -183,6 +183,7 @@ def strip_version_suffixes(path):
         'sh',
 
         # Download version
+        'release',
         'stable',
         '[Ff]inal',
         'rel',


### PR DESCRIPTION
### Before
```
$ spack url parse https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz
==> Parsing URL: https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz

==> Matched version regex 10: r'^(?:[a-zA-Z\\d+-]+-)?v?(\\d[\\da-zA-Z.-]*)$'
==> Matched  name   regex  0: r'github\\.com/[^/]+/([^/]+)'

==> Detected:
    https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz
                                --------          ~~~~~~~~~~~~~
    name:    revbayes
    version: 1.0.4-release

==> Substituting version 9.9.9b:
    https://github.com/revbayes/revbayes/archive/v9.9.9b.tar.gz
                                --------          ~~~~~~
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1718
    Names correctly parsed:    1534/1718 (89.29%)
    Versions correctly parsed: 1594/1718 (92.78%)
```
### After
```
$ spack url parse https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz
==> Parsing URL: https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz

==> Matched version regex  1: r'^v?(\\d[\\d._-]*)$'
==> Matched  name   regex  0: r'github\\.com/[^/]+/([^/]+)'

==> Detected:
    https://github.com/revbayes/revbayes/archive/v1.0.4-release.tar.gz
                                --------          ~~~~~
    name:    revbayes
    version: 1.0.4

==> Substituting version 9.9.9b:
    https://github.com/revbayes/revbayes/archive/v9.9.9b-release.tar.gz
                                --------          ~~~~~~
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1718
    Names correctly parsed:    1534/1718 (89.29%)
    Versions correctly parsed: 1594/1718 (92.78%)
```