### PR TITLE
Change Version formatting properties and functions to return Version objects

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -490,6 +490,21 @@ version.joined       123
    Python properties don't need parentheses. ``version.dashed`` is correct.
    ``version.dashed()`` is incorrect.
 
+In addition, these version properties can be combined with ``up_to()``.
+For example:
+
+.. code-block:: python
+
+   >>> version = Version('1.2.3')
+   >>> version.up_to(2).dashed
+   Version('1-2')
+   >>> version.underscored.up_to(2)
+   Version('1_2')
+
+
+As you can see, order is not important. Just keep in mind that ``up_to()`` and
+the other version properties return ``Version`` objects, not strings.
+
 If a URL cannot be derived systematically, or there is a special URL for one
 of its versions, you can add an explicit URL for a particular version:
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -435,6 +435,24 @@ def test_formatted_strings():
         assert v.joined == '123'
 
 
+def test_up_to():
+    version = Version('1.23.4')
+
+    assert version.up_to(1) == Version('1')
+    assert version.up_to(2) == Version('1.23')
+    assert version.up_to(3) == Version('1.23.4')
+
+    assert version.up_to(-1) == Version('1.23')
+    assert version.up_to(-2) == Version('1')
+
+    assert version.up_to(2).dotted == '1.23'
+    assert version.up_to(2).dashed == '1-23'
+    assert version.up_to(2).underscored == '1_23'
+    assert version.up_to(2).joined == '123'
+
+    assert version.up_to(2).up_to(1) == Version('1')
+
+
 def test_repr_and_str():
 
     def check_repr_and_str(vrs):

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -426,35 +426,47 @@ def test_satisfaction_with_lists():
 
 
 def test_formatted_strings():
-    versions = '1.2.3b', '1_2_3b', '1-2-3b'
+    versions = (
+        '1.2.3b', '1_2_3b', '1-2-3b',
+        '1.2-3b', '1.2_3b', '1-2.3b',
+        '1-2_3b', '1_2.3b', '1_2-3b'
+    )
     for item in versions:
         v = Version(item)
-        assert v.dotted == '1.2.3b'
-        assert v.dashed == '1-2-3b'
-        assert v.underscored == '1_2_3b'
-        assert v.joined == '123b'
+        assert v.dotted == Version('1.2.3b')
+        assert v.dashed == Version('1-2-3b')
+        assert v.underscored == Version('1_2_3b')
+        assert v.joined == Version('123b')
+
+        assert v.dotted.dashed == Version('1-2-3b')
+        assert v.dotted.underscored == Version('1_2_3b')
+        assert v.dotted.dotted == Version('1.2.3b')
 
 
 def test_up_to():
-    version = Version('1.23-4_5b')
+    v = Version('1.23-4_5b')
 
-    assert version.up_to(1) == Version('1')
-    assert version.up_to(2) == Version('1.23')
-    assert version.up_to(3) == Version('1.23-4')
-    assert version.up_to(4) == Version('1.23-4_5')
-    assert version.up_to(5) == Version('1.23-4_5b')
+    assert v.up_to(1) == Version('1')
+    assert v.up_to(2) == Version('1.23')
+    assert v.up_to(3) == Version('1.23-4')
+    assert v.up_to(4) == Version('1.23-4_5')
+    assert v.up_to(5) == Version('1.23-4_5b')
 
-    assert version.up_to(-1) == Version('1.23-4_5')
-    assert version.up_to(-2) == Version('1.23-4')
-    assert version.up_to(-3) == Version('1.23')
-    assert version.up_to(-4) == Version('1')
+    assert v.up_to(-1) == Version('1.23-4_5')
+    assert v.up_to(-2) == Version('1.23-4')
+    assert v.up_to(-3) == Version('1.23')
+    assert v.up_to(-4) == Version('1')
 
-    assert version.up_to(2).dotted == '1.23'
-    assert version.up_to(2).dashed == '1-23'
-    assert version.up_to(2).underscored == '1_23'
-    assert version.up_to(2).joined == '123'
+    assert v.up_to(2).dotted == Version('1.23')
+    assert v.up_to(2).dashed == Version('1-23')
+    assert v.up_to(2).underscored == Version('1_23')
+    assert v.up_to(2).joined == Version('123')
 
-    assert version.up_to(2).up_to(1) == Version('1')
+    assert v.dotted.up_to(2) == Version('1.23') == v.up_to(2).dotted
+    assert v.dashed.up_to(2) == Version('1-23') == v.up_to(2).dashed
+    assert v.underscored.up_to(2) == Version('1_23') == v.up_to(2).underscored
+
+    assert v.up_to(2).up_to(1) == Version('1')
 
 
 def test_repr_and_str():

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -204,6 +204,8 @@ def test_underscores():
     assert_ver_eq('2_0', '2_0')
     assert_ver_eq('2.0', '2_0')
     assert_ver_eq('2_0', '2.0')
+    assert_ver_eq('2-0', '2_0')
+    assert_ver_eq('2_0', '2-0')
 
 
 def test_rpm_oddities():
@@ -433,47 +435,49 @@ def test_formatted_strings():
     )
     for item in versions:
         v = Version(item)
-        assert v.dotted == Version('1.2.3b')
-        assert v.dashed == Version('1-2-3b')
-        assert v.underscored == Version('1_2_3b')
-        assert v.joined == Version('123b')
+        assert v.dotted.string == '1.2.3b'
+        assert v.dashed.string == '1-2-3b'
+        assert v.underscored.string == '1_2_3b'
+        assert v.joined.string == '123b'
 
-        assert v.dotted.dashed == Version('1-2-3b')
-        assert v.dotted.underscored == Version('1_2_3b')
-        assert v.dotted.dotted == Version('1.2.3b')
+        assert v.dotted.dashed.string == '1-2-3b'
+        assert v.dotted.underscored.string == '1_2_3b'
+        assert v.dotted.dotted.string == '1.2.3b'
+        assert v.dotted.joined.string == '123b'
 
 
 def test_up_to():
     v = Version('1.23-4_5b')
 
-    assert v.up_to(1) == Version('1')
-    assert v.up_to(2) == Version('1.23')
-    assert v.up_to(3) == Version('1.23-4')
-    assert v.up_to(4) == Version('1.23-4_5')
-    assert v.up_to(5) == Version('1.23-4_5b')
+    assert v.up_to(1).string == '1'
+    assert v.up_to(2).string == '1.23'
+    assert v.up_to(3).string == '1.23-4'
+    assert v.up_to(4).string == '1.23-4_5'
+    assert v.up_to(5).string == '1.23-4_5b'
 
-    assert v.up_to(-1) == Version('1.23-4_5')
-    assert v.up_to(-2) == Version('1.23-4')
-    assert v.up_to(-3) == Version('1.23')
-    assert v.up_to(-4) == Version('1')
+    assert v.up_to(-1).string == '1.23-4_5'
+    assert v.up_to(-2).string == '1.23-4'
+    assert v.up_to(-3).string == '1.23'
+    assert v.up_to(-4).string == '1'
 
-    assert v.up_to(2).dotted == Version('1.23')
-    assert v.up_to(2).dashed == Version('1-23')
-    assert v.up_to(2).underscored == Version('1_23')
-    assert v.up_to(2).joined == Version('123')
+    assert v.up_to(2).dotted.string == '1.23'
+    assert v.up_to(2).dashed.string == '1-23'
+    assert v.up_to(2).underscored.string == '1_23'
+    assert v.up_to(2).joined.string == '123'
 
-    assert v.dotted.up_to(2) == Version('1.23') == v.up_to(2).dotted
-    assert v.dashed.up_to(2) == Version('1-23') == v.up_to(2).dashed
-    assert v.underscored.up_to(2) == Version('1_23') == v.up_to(2).underscored
+    assert v.dotted.up_to(2).string == '1.23' == v.up_to(2).dotted.string
+    assert v.dashed.up_to(2).string == '1-23' == v.up_to(2).dashed.string
+    assert v.underscored.up_to(2).string == '1_23'
+    assert v.up_to(2).underscored.string == '1_23'
 
-    assert v.up_to(2).up_to(1) == Version('1')
+    assert v.up_to(2).up_to(1).string == '1'
 
 
 def test_repr_and_str():
 
     def check_repr_and_str(vrs):
         a = Version(vrs)
-        assert repr(a) == 'Version(\'' + vrs + '\')'
+        assert repr(a) == "Version('" + vrs + "')"
         b = eval(repr(a))
         assert a == b
         assert str(a) == vrs
@@ -491,17 +495,17 @@ def test_get_item():
     b = a[0:2]
     assert isinstance(b, Version)
     assert b == Version('0.1')
-    assert repr(b) == 'Version(\'0.1\')'
+    assert repr(b) == "Version('0.1')"
     assert str(b) == '0.1'
     b = a[0:3]
     assert isinstance(b, Version)
     assert b == Version('0.1_2')
-    assert repr(b) == 'Version(\'0.1_2\')'
+    assert repr(b) == "Version('0.1_2')"
     assert str(b) == '0.1_2'
     b = a[1:]
     assert isinstance(b, Version)
     assert b == Version('1_2-3')
-    assert repr(b) == 'Version(\'1_2-3\')'
+    assert repr(b) == "Version('1_2-3')"
     assert str(b) == '1_2-3'
     # Raise TypeError on tuples
     with pytest.raises(TypeError):

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -426,24 +426,28 @@ def test_satisfaction_with_lists():
 
 
 def test_formatted_strings():
-    versions = '1.2.3', '1_2_3', '1-2-3'
+    versions = '1.2.3b', '1_2_3b', '1-2-3b'
     for item in versions:
         v = Version(item)
-        assert v.dotted == '1.2.3'
-        assert v.dashed == '1-2-3'
-        assert v.underscored == '1_2_3'
-        assert v.joined == '123'
+        assert v.dotted == '1.2.3b'
+        assert v.dashed == '1-2-3b'
+        assert v.underscored == '1_2_3b'
+        assert v.joined == '123b'
 
 
 def test_up_to():
-    version = Version('1.23.4')
+    version = Version('1.23-4_5b')
 
     assert version.up_to(1) == Version('1')
     assert version.up_to(2) == Version('1.23')
-    assert version.up_to(3) == Version('1.23.4')
+    assert version.up_to(3) == Version('1.23-4')
+    assert version.up_to(4) == Version('1.23-4_5')
+    assert version.up_to(5) == Version('1.23-4_5b')
 
-    assert version.up_to(-1) == Version('1.23')
-    assert version.up_to(-2) == Version('1')
+    assert version.up_to(-1) == Version('1.23-4_5')
+    assert version.up_to(-2) == Version('1.23-4')
+    assert version.up_to(-3) == Version('1.23')
+    assert version.up_to(-4) == Version('1')
 
     assert version.up_to(2).dotted == '1.23'
     assert version.up_to(2).dashed == '1-23'

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -135,25 +135,76 @@ class Version(object):
 
     @property
     def dotted(self):
+        """The dotted representation of the version.
+
+        Example:
+        >>> version = Version('1-2-3')
+        >>> version.dotted
+        '1.2.3'
+
+        Returns:
+            str: The elements of the version, separated by dots
+        """
         return '.'.join(str(x) for x in self.version)
 
     @property
     def underscored(self):
+        """The underscored representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3')
+        >>> version.underscored
+        '1_2_3'
+
+        Returns:
+            str: The elements of the version, separated by underscores
+        """
         return '_'.join(str(x) for x in self.version)
 
     @property
     def dashed(self):
+        """The dashed representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3')
+        >>> version.dashed
+        '1-2-3'
+
+        Returns:
+            str: The elements of the version, separated by dashes
+        """
         return '-'.join(str(x) for x in self.version)
 
     @property
     def joined(self):
+        """The joined representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3')
+        >>> version.joined
+        '123'
+
+        Returns:
+            str: The version with no separator characters
+        """
         return ''.join(str(x) for x in self.version)
 
     def up_to(self, index):
-        """Return a version string up to the specified component, exclusive.
-           e.g., if this is 10.8.2, self.up_to(2) will return '10.8'.
+        """The version up to the specified component.
+
+        Examples:
+        >>> version = Version('1.23.4')
+        >>> version.up_to(1)
+        Version('1')
+        >>> version.up_to(2)
+        Version('1.23')
+        >>> version.up_to(3)
+        Version('1.23.4')
+
+        Returns:
+            Version: The first index components of the version
         """
-        return '.'.join(str(x) for x in self[:index])
+        return Version('.'.join(str(x) for x in self[:index]))
 
     def lowest(self):
         return self

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -139,12 +139,12 @@ class Version(object):
         Example:
         >>> version = Version('1-2-3b')
         >>> version.dotted
-        '1.2.3b'
+        Version('1.2.3b')
 
         Returns:
-            str: The elements of the version, separated by dots
+            Version: The version with separator characters replaced by dots
         """
-        return self.string.replace('-', '.').replace('_', '.')
+        return Version(self.string.replace('-', '.').replace('_', '.'))
 
     @property
     def underscored(self):
@@ -153,12 +153,13 @@ class Version(object):
         Example:
         >>> version = Version('1.2.3b')
         >>> version.underscored
-        '1_2_3b'
+        Version('1_2_3b')
 
         Returns:
-            str: The elements of the version, separated by underscores
+            Version: The version with separator characters replaced by
+                underscores
         """
-        return self.string.replace('.', '_').replace('-', '_')
+        return Version(self.string.replace('.', '_').replace('-', '_'))
 
     @property
     def dashed(self):
@@ -167,12 +168,12 @@ class Version(object):
         Example:
         >>> version = Version('1.2.3b')
         >>> version.dashed
-        '1-2-3b'
+        Version('1-2-3b')
 
         Returns:
-            str: The elements of the version, separated by dashes
+            Version: The version with separator characters replaced by dashes
         """
-        return self.string.replace('.', '-').replace('_', '-')
+        return Version(self.string.replace('.', '-').replace('_', '-'))
 
     @property
     def joined(self):
@@ -181,12 +182,13 @@ class Version(object):
         Example:
         >>> version = Version('1.2.3b')
         >>> version.joined
-        '123b'
+        Version('123b')
 
         Returns:
-            str: The version with no separator characters
+            Version: The version with separator characters removed
         """
-        return self.string.replace('.', '').replace('-', '').replace('_', '')
+        return Version(
+            self.string.replace('.', '').replace('-', '').replace('_', ''))
 
     def up_to(self, index):
         """The version up to the specified component.

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -200,6 +200,10 @@ class Version(object):
         Version('1.23')
         >>> version.up_to(3)
         Version('1.23.4')
+        >>> version.up_to(-1)
+        Version('1.23')
+        >>> version.up_to(-2)
+        Version('1')
 
         Returns:
             Version: The first index components of the version

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -130,85 +130,88 @@ class Version(object):
         self.version = tuple(int_if_int(seg) for seg in segments)
 
         # Store the separators from the original version string as well.
-        # last element of separators is ''
-        self.separators = tuple(re.split(segment_regex, string)[1:-1])
+        self.separators = tuple(re.split(segment_regex, string)[1:])
 
     @property
     def dotted(self):
         """The dotted representation of the version.
 
         Example:
-        >>> version = Version('1-2-3')
+        >>> version = Version('1-2-3b')
         >>> version.dotted
-        '1.2.3'
+        '1.2.3b'
 
         Returns:
             str: The elements of the version, separated by dots
         """
-        return '.'.join(str(x) for x in self.version)
+        return self.string.replace('-', '.').replace('_', '.')
 
     @property
     def underscored(self):
         """The underscored representation of the version.
 
         Example:
-        >>> version = Version('1.2.3')
+        >>> version = Version('1.2.3b')
         >>> version.underscored
-        '1_2_3'
+        '1_2_3b'
 
         Returns:
             str: The elements of the version, separated by underscores
         """
-        return '_'.join(str(x) for x in self.version)
+        return self.string.replace('.', '_').replace('-', '_')
 
     @property
     def dashed(self):
         """The dashed representation of the version.
 
         Example:
-        >>> version = Version('1.2.3')
+        >>> version = Version('1.2.3b')
         >>> version.dashed
-        '1-2-3'
+        '1-2-3b'
 
         Returns:
             str: The elements of the version, separated by dashes
         """
-        return '-'.join(str(x) for x in self.version)
+        return self.string.replace('.', '-').replace('_', '-')
 
     @property
     def joined(self):
         """The joined representation of the version.
 
         Example:
-        >>> version = Version('1.2.3')
+        >>> version = Version('1.2.3b')
         >>> version.joined
-        '123'
+        '123b'
 
         Returns:
             str: The version with no separator characters
         """
-        return ''.join(str(x) for x in self.version)
+        return self.string.replace('.', '').replace('-', '').replace('_', '')
 
     def up_to(self, index):
         """The version up to the specified component.
 
         Examples:
-        >>> version = Version('1.23.4')
+        >>> version = Version('1.23-4b')
         >>> version.up_to(1)
         Version('1')
         >>> version.up_to(2)
         Version('1.23')
         >>> version.up_to(3)
-        Version('1.23.4')
+        Version('1.23-4')
+        >>> version.up_to(4)
+        Version('1.23-4b')
         >>> version.up_to(-1)
-        Version('1.23')
+        Version('1.23-4')
         >>> version.up_to(-2)
+        Version('1.23')
+        >>> version.up_to(-3)
         Version('1')
 
         Returns:
             Version: The first index components of the version
         """
-        return Version('.'.join(str(x) for x in self[:index]))
+        return self[:index]
 
     def lowest(self):
         return self
@@ -259,11 +262,9 @@ class Version(object):
             return self.version[idx]
 
         elif isinstance(idx, slice):
-            # Currently len(self.separators) == len(self.version) - 1
-            extendend_separators = self.separators + ('',)
             string_arg = []
 
-            pairs = zip(self.version[idx], extendend_separators[idx])
+            pairs = zip(self.version[idx], self.separators[idx])
             for token, sep in pairs:
                 string_arg.append(str(token))
                 string_arg.append(str(sep))

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -145,11 +145,11 @@ class Lua(Package):
 
     @property
     def lua_lib_dir(self):
-        return os.path.join('lib', 'lua', self.version.up_to(2))
+        return os.path.join('lib', 'lua', str(self.version.up_to(2)))
 
     @property
     def lua_share_dir(self):
-        return os.path.join('share', 'lua', self.version.up_to(2))
+        return os.path.join('share', 'lua', str(self.version.up_to(2)))
 
     def setup_dependent_package(self, module, dependent_spec):
         """

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -109,7 +109,7 @@ class Magics(Package):
         if '+metview' in spec:
             if '+qt' in spec:
                 options.append('-DENABLE_METVIEW=ON')
-                if int(spec['qt'].version.up_to(1)) == 5:
+                if spec['qt'].version[0] == 5:
                     options.append('-DENABLE_QT5=ON')
             else:
                 options.append('-DENABLE_METVIEW_NO_QT=ON')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -109,7 +109,7 @@ class Magics(Package):
         if '+metview' in spec:
             if '+qt' in spec:
                 options.append('-DENABLE_METVIEW=ON')
-                if spec['qt'].version.up_to(1) == '5':
+                if int(spec['qt'].version.up_to(1)) == 5:
                     options.append('-DENABLE_QT5=ON')
             else:
                 options.append('-DENABLE_METVIEW_NO_QT=ON')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -131,9 +131,9 @@ class Qt(Package):
         url = self.list_url
 
         if version >= Version('4.0'):
-            url += version.up_to(2) + '/'
+            url += str(version.up_to(2)) + '/'
         else:
-            url += version.up_to(1) + '/'
+            url += str(version.up_to(1)) + '/'
 
         if version >= Version('4.8'):
             url += str(version) + '/'

--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -49,7 +49,7 @@ class SublimeText(Package):
     depends_on('libxau', type='run')
 
     def url_for_version(self, version):
-        if int(version.up_to(1)) == 2:
+        if version[0] == 2:
             return "https://download.sublimetext.com/Sublime%20Text%20{0}%20x64.tar.bz2".format(version)
         else:
             return "https://download.sublimetext.com/sublime_text_3_build_{0}_x64.tar.bz2".format(version)

--- a/var/spack/repos/builtin/packages/sublime-text/package.py
+++ b/var/spack/repos/builtin/packages/sublime-text/package.py
@@ -49,7 +49,7 @@ class SublimeText(Package):
     depends_on('libxau', type='run')
 
     def url_for_version(self, version):
-        if version.up_to(1) == '2':
+        if int(version.up_to(1)) == 2:
             return "https://download.sublimetext.com/Sublime%20Text%20{0}%20x64.tar.bz2".format(version)
         else:
             return "https://download.sublimetext.com/sublime_text_3_build_{0}_x64.tar.bz2".format(version)


### PR DESCRIPTION
Also added better API docs.

In #4823, @akthoma discovered an interesting URL:
https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_3_x/ViennaRNA-2.3.5.tar.gz

In order to properly compute this URL based on the version number, we need to be able to do the following:
```python
def url_for_version(self, version):
    url = "https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_3_x/ViennaRNA-2.3.5.tar.gz"
    return url.format(version.up_to(2).underscored, version.dotted)
```
Previously, this wasn't possible because `version.up_to()` returned a string. Now that it returns a `Version` object, it is possible to string together `up_to()` with `dotted`, `dashed`, `underscored`, and `joined`.