### PR TITLE
New Package: C-Ares

### DIFF
--- a/var/spack/repos/builtin/packages/cares/package.py
+++ b/var/spack/repos/builtin/packages/cares/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Cares(CMakePackage):
+    """c-ares: A C library for asynchronous DNS requests"""
+
+    homepage = "https://c-ares.haxx.se"
+    url      = "https://github.com/c-ares/c-ares/archive/cares-1_13_0.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/c-ares/c-ares.git')
+
+    version('1.13.0', 'cdb21052a7eb85261da22f83c0654cfd')
+
+    def url_for_version(self, version):
+        url = "https://github.com/c-ares/c-ares/archive/cares-{0}.tar.gz"
+        return url.format(version.underscored)


### PR DESCRIPTION
Adds the [c-ares](https://github.com/c-ares/c-ares) library, a C library for asynchronous DNS requests.

Required for the google gRPC library.

Note: 1.13.0 (latest release) is the first version with cmake config package support.