### PR TITLE
ZeroMQ: C++ Headers (cppzmq)

### DIFF
--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Cppzmq(CMakePackage):
+    """C++ binding for 0MQ"""
+
+    homepage = "http://www.zeromq.org"
+    url      = "https://github.com/zeromq/cppzmq/archive/v4.2.2.tar.gz"
+
+    version('develop', branch='master',
+            git='https://github.com/zeromq/cppzmq.git')
+
+    version('4.2.2', 'bd809b47296e77fe9f192bd9dafd5cc3')
+
+    depends_on('cmake@3.0.0:', type='build')
+    depends_on('zeromq@4.2.2')


### PR DESCRIPTION
Adds the cppzmq library, adding a C++ API to ZeroMQ (`libzmq`).

In order to find the autotools-build `libzmq`, this requires the ~~upcoming~~ *new 4.2.2* cppzmq release (or [development branch](https://github.com/zeromq/cppzmq/pull/133)).

Follow-up to #4785 and #4737