### PR TITLE
add man-db package and friends

### DIFF
--- a/var/spack/repos/builtin/packages/check/package.py
+++ b/var/spack/repos/builtin/packages/check/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Check(AutotoolsPackage):
+    """Check is a unit testing framework for C. It features a simple interface
+    for defining unit tests, putting little in the way of the developer. Tests
+    are run in a separate address space, so both assertion failures and code
+    errors that cause segmentation faults or other signals can be caught. Test
+    results are reportable in the following: Subunit, TAP, XML, and a generic
+    logging format."""
+
+    homepage = "https://libcheck.github.io/check/index.html"
+    url      = "https://downloads.sourceforge.net/project/check/check/0.10.0/check-0.10.0.tar.gz"
+
+    version('0.10.0', '53c5e5c77d090e103a17f3ed7fd7d8b8')

--- a/var/spack/repos/builtin/packages/groff/gropdf.patch
+++ b/var/spack/repos/builtin/packages/groff/gropdf.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index bc156ce..70c6f85 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -896,6 +896,8 @@ $(GNULIBDIRS): FORCE
+ 	  $(MAKE) ACLOCAL=: AUTOCONF=: AUTOHEADER=: AUTOMAKE=: $(do) ;; \
+ 	esac
+ 
++$(SHPROGDIRS): $(PROGDEPDIRS)
++
+ $(OTHERDIRS): $(PROGDEPDIRS) $(CCPROGDIRS) $(CPROGDIRS) $(SHPROGDIRS)
+ 
+ $(INCDIRS) $(PROGDEPDIRS) $(SHPROGDIRS) $(OTHERDIRS): FORCE

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -34,4 +34,29 @@ class Groff(AutotoolsPackage):
     homepage = "https://www.gnu.org/software/groff/"
     url      = "http://ftp.gnu.org/gnu/groff/groff-1.22.3.tar.gz"
 
+    # TODO: add html variant, spack doesn't have netpbm and its too
+    # complicated for me to find out at this point in time.
+    # See brew scripts for groff for guidance:
+    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/groff.rb
+    # Seems troublesome...netpbm requires groff?
+    variant('pdf', default=True, description='Build the `gropdf` executable.')
+
+    depends_on('binutils')
+    depends_on('coreutils')
+    depends_on('gawk')
+    depends_on('gmake')
+    depends_on('sed')
+    depends_on('ghostscript', when='+pdf')
+
     version('1.22.3', 'cc825fa64bc7306a885f2fb2268d3ec5')
+
+    # https://savannah.gnu.org/bugs/index.php?43581
+    # NOTE: always patch, even if not +pdf
+    def patch(self):
+        patch('gropdf.patch')
+
+    def configure_args(self):
+        args = [
+            "--without-x"
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Groff(AutotoolsPackage):
+    """Groff (GNU troff) is a typesetting system that reads
+    plain text mixed with formatting commands and produces
+    formatted output. Output may be PostScript or PDF, html, or
+    ASCII/UTF8 for display at the terminal."""
+
+    homepage = "https://www.gnu.org/software/groff/"
+    url      = "http://ftp.gnu.org/gnu/groff/groff-1.22.3.tar.gz"
+
+    version('1.22.3', 'cc825fa64bc7306a885f2fb2268d3ec5')

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -41,19 +41,18 @@ class Groff(AutotoolsPackage):
     # Seems troublesome...netpbm requires groff?
     variant('pdf', default=True, description='Build the `gropdf` executable.')
 
-    depends_on('binutils')
-    depends_on('coreutils')
-    depends_on('gawk')
-    depends_on('gmake')
-    depends_on('sed')
+    depends_on('gawk',  type='build')
+    depends_on('gmake', type='build')
+    depends_on('sed',   type='build')
     depends_on('ghostscript', when='+pdf')
 
     version('1.22.3', 'cc825fa64bc7306a885f2fb2268d3ec5')
 
     # https://savannah.gnu.org/bugs/index.php?43581
-    # NOTE: always patch, even if not +pdf
-    def patch(self):
-        patch('gropdf.patch')
+    # TODO: figure out why this patch does not actually work for parallel
+    # builds reliably.
+    # patch('gropdf.patch')
+    parallel = False
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Libpipeline(AutotoolsPackage):
+    """libpipeline is a C library for manipulating pipelines of subprocesses
+    in a flexible and convenient way."""
+
+    homepage = "http://libpipeline.nongnu.org/"
+    url      = "http://git.savannah.nongnu.org/cgit/libpipeline.git/snapshot/libpipeline-1.4.2.tar.gz"
+
+    version('1.4.2', '30cec7bcd6fee723adea6a54389f3da2')
+
+    depends_on('pkg-config')
+    depends_on('check')

--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -35,4 +35,6 @@ class Libpipeline(AutotoolsPackage):
     version('1.4.2', '30cec7bcd6fee723adea6a54389f3da2')
 
     depends_on('pkg-config')
-    depends_on('check')
+    # TODO: Add a 'test' deptype
+    # See https://github.com/LLNL/spack/issues/1279
+    # depends_on('check', type='test')

--- a/var/spack/repos/builtin/packages/libpipeline/package.py
+++ b/var/spack/repos/builtin/packages/libpipeline/package.py
@@ -34,7 +34,7 @@ class Libpipeline(AutotoolsPackage):
 
     version('1.4.2', '30cec7bcd6fee723adea6a54389f3da2')
 
-    depends_on('pkg-config')
+    depends_on('pkg-config', type='build')
     # TODO: Add a 'test' deptype
     # See https://github.com/LLNL/spack/issues/1279
     # depends_on('check', type='test')

--- a/var/spack/repos/builtin/packages/man-db/package.py
+++ b/var/spack/repos/builtin/packages/man-db/package.py
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class ManDb(AutotoolsPackage):
+    """man-db is an implementation of the standard Unix
+    documentation system accessed using the man command. It uses
+    a Berkeley DB database in place of the traditional
+    flat-text whatis databases."""
+
+    homepage = "http://www.nongnu.org/man-db/"
+    url      = "http://git.savannah.nongnu.org/cgit/man-db.git/snapshot/man-db-2.7.6.1.tar.gz"
+
+    version('2.7.6.1', '312761baade811db2b956af3432c285e')
+
+    depends_on('autoconf')
+    depends_on('automake')
+    depends_on('gettext')
+    depends_on('libpipeline')
+    depends_on('flex')
+    depends_on('groff')
+
+    #???
+    depends_on('bzip2')
+    depends_on('lzma')
+    depends_on('xz')
+
+    def configure_args(self):
+        spec = self.spec
+        args = [
+            '--disable-setuid',
+            # defaults to a location that needs root privs to write in
+            '--with-systemdtmpfilesdir={0}/tmp'.format(self.prefix)
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/man-db/package.py
+++ b/var/spack/repos/builtin/packages/man-db/package.py
@@ -41,15 +41,16 @@ class ManDb(AutotoolsPackage):
     depends_on('gettext')
     depends_on('libpipeline')
     depends_on('flex')
-    depends_on('groff')
+    depends_on('groff', type=('build', 'link', 'run'))
 
-    #???
-    depends_on('bzip2')
-    depends_on('lzma')
-    depends_on('xz')
+    # TODO: add gzip support via a new package.
+    # man pages are typically compressed, include all available
+    # compression libraries
+    depends_on('bzip2', type=('build', 'link', 'run'))
+    depends_on('lzma',  type=('build', 'link', 'run'))
+    depends_on('xz',    type=('build', 'link', 'run'))
 
     def configure_args(self):
-        spec = self.spec
         args = [
             '--disable-setuid',
             # defaults to a location that needs root privs to write in


### PR DESCRIPTION
Proposed closing #4839 :blush:

- not entirely sure if `check` is needed or if it can be avoided
- not sure what to do with the compression libraries
    - do I need to explicitly `'--with-bzip2={0}/bzip2'.format(self.spec['bzip2'].prefix.bin)`?
    - I just sort of assume that spack does that stuff but wasn't sure

Once you `spack load man-db` you should be able to view any other man page of things that show up in your `MANPATH` (for which many `spack` packages populate)!

@samfux84 does this work for you on that box?  I could very well have missed stuff given how quickly I threw this together :wink: