### PR TITLE
Protobuf: CMake

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -25,31 +25,25 @@
 from spack import *
 
 
-class Protobuf(AutotoolsPackage):
+class Protobuf(CMakePackage):
     """Google's data interchange format."""
 
     homepage = "https://developers.google.com/protocol-buffers"
     url      = "https://github.com/google/protobuf/archive/v3.2.0.tar.gz"
+    root_cmakelists_dir = "cmake"
 
     version('3.2.0', '61d899b8369781f6dd1e62370813392d')
     version('3.1.0', '14a532a7538551d5def317bfca41dace')
     version('3.0.2', '845b39e4b7681a2ddfd8c7f528299fbb')
-    version('2.5.0', '9c21577a03adc1879aba5b52d06e25cf')
+    # version('2.5.0', '9c21577a03adc1879aba5b52d06e25cf')
 
-    depends_on('automake', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    depends_on('zlib')
+    # depends_on('benchmark@develop')
 
     conflicts('%gcc@:4.6')  # Requires c++11
 
-    variant('shared', default=True, description='Build shared libraries.')
-
-    def configure_args(self):
-        if '+shared' in self.spec:
-            return ['--enable-shared=yes',
-                    '--enable-static=no']
-        else:
-            return ['--enable-shared=no',
-                    '--enable-static=yes',
-                    '--with-pic=yes']
+    def cmake_args(self):
+        args = [
+            '-Dprotobuf_BUILD_TESTS:BOOL=OFF'
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -42,6 +42,8 @@ class Protobuf(CMakePackage):
 
     conflicts('%gcc@:4.6')  # Requires c++11
 
+    patch('pkgconfig.patch', when='@:3.2.0')
+
     def cmake_args(self):
         args = [
             '-Dprotobuf_BUILD_TESTS:BOOL=OFF'

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -35,14 +35,15 @@ class Protobuf(CMakePackage):
     version('3.2.0', '61d899b8369781f6dd1e62370813392d')
     version('3.1.0', '14a532a7538551d5def317bfca41dace')
     version('3.0.2', '845b39e4b7681a2ddfd8c7f528299fbb')
+    # does not build with CMake:
     # version('2.5.0', '9c21577a03adc1879aba5b52d06e25cf')
 
     depends_on('zlib')
-    # depends_on('benchmark@develop')
 
     conflicts('%gcc@:4.6')  # Requires c++11
 
-    patch('pkgconfig.patch', when='@:3.2.0')
+    # first fixed in 3.4.0: https://github.com/google/protobuf/pull/3406
+    patch('pkgconfig.patch', when='@:3.3.2')
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -46,6 +46,7 @@ class Protobuf(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-Dprotobuf_BUILD_TESTS:BOOL=OFF'
+            '-Dprotobuf_BUILD_TESTS:BOOL=OFF',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'
         ]
         return args

--- a/var/spack/repos/builtin/packages/protobuf/pkgconfig.patch
+++ b/var/spack/repos/builtin/packages/protobuf/pkgconfig.patch
@@ -44,7 +44,7 @@ new file mode 100644
 index 0000000..2e30763
 --- /dev/null
 +++ b/cmake/protobuf.pc.cmake
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,11 @@
 +prefix=@CMAKE_INSTALL_PREFIX@
 +exec_prefix=@CMAKE_INSTALL_PREFIX@
 +libdir=@CMAKE_INSTALL_FULL_LIBDIR@
@@ -54,6 +54,5 @@ index 0000000..2e30763
 +Description: Google's Data Interchange Format
 +Version: @protobuf_VERSION@
 +Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
-+Libs.private: @LIBS@
 +Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
 +Conflicts: protobuf-lite

--- a/var/spack/repos/builtin/packages/protobuf/pkgconfig.patch
+++ b/var/spack/repos/builtin/packages/protobuf/pkgconfig.patch
@@ -1,0 +1,59 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 28dc90d..441bf55 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -1,5 +1,10 @@
+ include(GNUInstallDirs)
+ 
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf.pc.cmake
++               ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf-lite.pc.cmake
++               ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc @ONLY)
++
+ foreach(_library
+   libprotobuf-lite
+   libprotobuf
+@@ -17,6 +22,8 @@ endforeach()
+ install(TARGETS protoc EXPORT protobuf-targets
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+ 
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++
+ file(STRINGS extract_includes.bat.in _extract_strings
+   REGEX "^copy")
+ foreach(_extract_string ${_extract_strings})
+diff --git a/cmake/protobuf-lite.pc.cmake b/cmake/protobuf-lite.pc.cmake
+new file mode 100644
+index 0000000..cbe5426
+--- /dev/null
++++ b/cmake/protobuf-lite.pc.cmake
+@@ -0,0 +1,11 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++
++Name: Protocol Buffers
++Description: Google's Data Interchange Format
++Version: @protobuf_VERSION@
++Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
++Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
++Conflicts: protobuf
+diff --git a/cmake/protobuf.pc.cmake b/cmake/protobuf.pc.cmake
+new file mode 100644
+index 0000000..2e30763
+--- /dev/null
++++ b/cmake/protobuf.pc.cmake
+@@ -0,0 +1,12 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++
++Name: Protocol Buffers
++Description: Google's Data Interchange Format
++Version: @protobuf_VERSION@
++Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
++Libs.private: @LIBS@
++Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
++Conflicts: protobuf-lite


### PR DESCRIPTION
This rebuilds protobuf to be build with CMake, so cmake config packages are created and installed, too.

Unfortunately, this drops support for protobuf < 3.0.

Update: Also, it seems this build of protobuf [does not install a `pkg-config` file...](https://github.com/google/protobuf/issues/1384)
- [x] We might need to add a `.pc` file ourselves... (not too hard) https://github.com/google/protobuf/pull/3403 (before [protobuf 3.4](https://github.com/google/protobuf/pull/3406))

Needed for [gRPC](https://github.com/grpc/grpc) with external protobuf build (and anyone else that needs the protobuf CMake targets).

### Spack packages depending on Protobuf

those might need a quick build test:

- [ ] lbann (protobuf 3.0.2:) -> some opencv nonfree header issue?
- [ ] cntk (protobuf 3.10:) -> Error: There are no valid versions for spectrum-mpi that match ':'
- [x] caffe -> fails since `libprotobuf.a` is not build with `-fPIC` -> fixed
- [x] mosh -> fails on missing protobuf (pkg-config based autotools search) -> fixed