### PR TITLE
Savanna

### DIFF
--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +staging')
+    depends_on('adios +flexpath +dataspaces')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +fortran +flexpath +dataspaces')
+    depends_on('adios +fortran +staging')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +flexpath +dataspaces')
+    depends_on('adios +fortran +flexpath +dataspaces')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -36,7 +36,8 @@ class Savanna(MakefilePackage):
 
     version('develop', git='https://github.com/CODARcode/savanna.git',
             branch='master', submodules=True)
-    version('0.5', '3f13adf29ec30f4acb2ba3fa07ed12b2')
+    version('0.5', git='https://github.com/CODARcode/savanna.git',
+            tag='0.5', submodules=True)
 
     variant('tau', default=False, description='Enable TAU profiling support')
 


### PR DESCRIPTION
Replaced installation of stable version 0.5 through tar.gz with git checkout. 
This way, the git submodule in the package is downloaded fully.