### PR TITLE
Make CMake the default build system

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -438,11 +438,13 @@ class BuildSystemGuesser:
         # A list of clues that give us an idea of the build system a package
         # uses. If the regular expression matches a file contained in the
         # archive, the corresponding build system is assumed.
+        # NOTE: Order is important here. If a package supports multiple
+        # build systems, we choose the first match in this list.
         clues = [
+            (r'/CMakeLists\.txt$',    'cmake'),
             (r'/configure$',          'autotools'),
             (r'/configure\.(in|ac)$', 'autoreconf'),
             (r'/Makefile\.am$',       'autoreconf'),
-            (r'/CMakeLists\.txt$',    'cmake'),
             (r'/SConstruct$',         'scons'),
             (r'/waf$',                'waf'),
             (r'/setup\.py$',          'python'),


### PR DESCRIPTION
This change was requested by @ax3l in https://github.com/LLNL/spack/pull/4846#issuecomment-317069670.

When you use `spack create` to create a new package, Spack looks at the contents of the tarball to decide what build system it uses. If it contains a `configure` script, we assume it uses Autotools. If it contains a `CMakeLists.txt`, we assume it uses CMake.

Previously, if the tarball contained both files (presumably supporting both build systems) we chose Autotools by default. With this change, CMake becomes chosen instead. Let me know if there are any other build systems we should reorder.