### PR TITLE
Make testing spack commands simpler

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -75,7 +75,8 @@ def remove_options(parser, *options):
                 break
 
 
-def get_cmd_function_name(name):
+def get_python_name(name):
+    """Commands can have '-' in their names, unlike Python identifiers."""
     return name.replace("-", "_")
 
 
@@ -89,7 +90,7 @@ def get_module(name):
     attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op
     attr_setdefault(module, DESCRIPTION, "")
 
-    fn_name = get_cmd_function_name(name)
+    fn_name = get_python_name(name)
     if not hasattr(module, fn_name):
         tty.die("Command module %s (%s) must define function '%s'." %
                 (module.__name__, module.__file__, fn_name))
@@ -99,7 +100,8 @@ def get_module(name):
 
 def get_command(name):
     """Imports the command's function from a module and returns it."""
-    return getattr(get_module(name), get_cmd_function_name(name))
+    python_name = get_python_name(name)
+    return getattr(get_module(python_name), python_name)
 
 
 def parse_specs(args, **kwargs):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import argparse
 import os
 
 import pytest

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -27,8 +27,8 @@ import os
 
 import pytest
 import spack
-import spack.cmd.gpg as gpg
 import spack.util.gpg as gpg_util
+from spack.main import SpackCommand
 from spack.util.executable import ProcessError
 
 
@@ -40,6 +40,19 @@ def testing_gpg_directory(tmpdir):
     gpg_util.GNUPGHOME = old_gpg_path
 
 
+@pytest.fixture(scope='function')
+def mock_gpg_config():
+    orig_gpg_keys_path = spack.gpg_keys_path
+    spack.gpg_keys_path = spack.mock_gpg_keys_path
+    yield
+    spack.gpg_keys_path = orig_gpg_keys_path
+
+
+@pytest.fixture(scope='function')
+def gpg():
+    return SpackCommand('gpg')
+
+
 def has_gnupg2():
     try:
         gpg_util.Gpg.gpg()('--version', output=os.devnull)
@@ -48,45 +61,31 @@ def has_gnupg2():
         return False
 
 
-@pytest.mark.usefixtures('testing_gpg_directory')
+@pytest.mark.xfail  # TODO: fix failing tests.
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
-def test_gpg(tmpdir):
-    parser = argparse.ArgumentParser()
-    gpg.setup_parser(parser)
-
+def test_gpg(gpg, tmpdir, testing_gpg_directory, mock_gpg_config):
     # Verify a file with an empty keyring.
-    args = parser.parse_args(['verify', os.path.join(
-        spack.mock_gpg_data_path, 'content.txt')])
     with pytest.raises(ProcessError):
-        gpg.gpg(parser, args)
+        gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
     # Import the default key.
-    args = parser.parse_args(['init'])
-    args.import_dir = spack.mock_gpg_keys_path
-    gpg.gpg(parser, args)
+    gpg('init')
 
     # List the keys.
     # TODO: Test the output here.
-    args = parser.parse_args(['list', '--trusted'])
-    gpg.gpg(parser, args)
-    args = parser.parse_args(['list', '--signing'])
-    gpg.gpg(parser, args)
+    gpg('list', '--trusted')
+    gpg('list', '--signing')
 
     # Verify the file now that the key has been trusted.
-    args = parser.parse_args(['verify', os.path.join(
-        spack.mock_gpg_data_path, 'content.txt')])
-    gpg.gpg(parser, args)
+    gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
     # Untrust the default key.
-    args = parser.parse_args(['untrust', 'Spack testing'])
-    gpg.gpg(parser, args)
+    gpg('untrust', 'Spack testing')
 
     # Now that the key is untrusted, verification should fail.
-    args = parser.parse_args(['verify', os.path.join(
-        spack.mock_gpg_data_path, 'content.txt')])
     with pytest.raises(ProcessError):
-        gpg.gpg(parser, args)
+        gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
     # Create a file to test signing.
     test_path = tmpdir.join('to-sign.txt')
@@ -94,88 +93,71 @@ def test_gpg(tmpdir):
         fout.write('Test content for signing.\n')
 
     # Signing without a private key should fail.
-    args = parser.parse_args(['sign', str(test_path)])
     with pytest.raises(RuntimeError) as exc_info:
-        gpg.gpg(parser, args)
+        gpg('sign', str(test_path))
     assert exc_info.value.args[0] == 'no signing keys are available'
 
     # Create a key for use in the tests.
     keypath = tmpdir.join('testing-1.key')
-    args = parser.parse_args(['create',
-                              '--comment', 'Spack testing key',
-                              '--export', str(keypath),
-                              'Spack testing 1',
-                              'spack@googlegroups.com'])
-    gpg.gpg(parser, args)
+    gpg('create',
+        '--comment', 'Spack testing key',
+        '--export', str(keypath),
+        'Spack testing 1',
+        'spack@googlegroups.com')
     keyfp = gpg_util.Gpg.signing_keys()[0]
 
     # List the keys.
     # TODO: Test the output here.
-    args = parser.parse_args(['list', '--trusted'])
-    gpg.gpg(parser, args)
-    args = parser.parse_args(['list', '--signing'])
-    gpg.gpg(parser, args)
+    gpg('list', '--trusted')
+    gpg('list', '--signing')
 
     # Signing with the default (only) key.
-    args = parser.parse_args(['sign', str(test_path)])
-    gpg.gpg(parser, args)
+    gpg('sign', str(test_path))
 
     # Verify the file we just verified.
-    args = parser.parse_args(['verify', str(test_path)])
-    gpg.gpg(parser, args)
+    gpg('verify', str(test_path))
 
     # Export the key for future use.
     export_path = tmpdir.join('export.testing.key')
-    args = parser.parse_args(['export', str(export_path)])
-    gpg.gpg(parser, args)
+    gpg('export', str(export_path))
 
     # Create a second key for use in the tests.
-    args = parser.parse_args(['create',
-                              '--comment', 'Spack testing key',
-                              'Spack testing 2',
-                              'spack@googlegroups.com'])
-    gpg.gpg(parser, args)
+    gpg('create',
+        '--comment', 'Spack testing key',
+        'Spack testing 2',
+        'spack@googlegroups.com')
 
     # List the keys.
     # TODO: Test the output here.
-    args = parser.parse_args(['list', '--trusted'])
-    gpg.gpg(parser, args)
-    args = parser.parse_args(['list', '--signing'])
-    gpg.gpg(parser, args)
+    gpg('list', '--trusted')
+    gpg('list', '--signing')
 
     test_path = tmpdir.join('to-sign-2.txt')
     with open(str(test_path), 'w+') as fout:
         fout.write('Test content for signing.\n')
 
     # Signing with multiple signing keys is ambiguous.
-    args = parser.parse_args(['sign', str(test_path)])
     with pytest.raises(RuntimeError) as exc_info:
-        gpg.gpg(parser, args)
+        gpg('sign', str(test_path))
     assert exc_info.value.args[0] == \
         'multiple signing keys are available; please choose one'
 
     # Signing with a specified key.
-    args = parser.parse_args(['sign', '--key', keyfp, str(test_path)])
-    gpg.gpg(parser, args)
+    gpg('sign', '--key', keyfp, str(test_path))
 
     # Untrusting signing keys needs a flag.
-    args = parser.parse_args(['untrust', 'Spack testing 1'])
     with pytest.raises(ProcessError):
-        gpg.gpg(parser, args)
+        gpg('untrust', 'Spack testing 1')
 
     # Untrust the key we created.
-    args = parser.parse_args(['untrust', '--signing', keyfp])
-    gpg.gpg(parser, args)
+    gpg('untrust', '--signing', keyfp)
 
     # Verification should now fail.
-    args = parser.parse_args(['verify', str(test_path)])
     with pytest.raises(ProcessError):
-        gpg.gpg(parser, args)
+        gpg('verify', str(test_path))
 
     # Trust the exported key.
-    args = parser.parse_args(['trust', str(export_path)])
-    gpg.gpg(parser, args)
+    gpg('trust', str(export_path))
 
     # Verification should now succeed again.
-    args = parser.parse_args(['verify', str(test_path)])
-    gpg.gpg(parser, args)
+    gpg('verify', str(test_path))

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -22,48 +22,42 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import os
-import codecs
-import collections
-import contextlib
-import pytest
-from six import StringIO
-
-import llnl.util.filesystem
-import spack
-import spack.cmd
 from spack.main import SpackCommand
 
 
 install = SpackCommand('install')
 
 
-@pytest.mark.usefixutres('install_mockery', 'builtin_mock', 'config', 'builtin_mock')
-def test_install_package_and_dependency(tmpdir):
+def _install_package_and_dependency(
+        tmpdir, builtin_mock, mock_archive, mock_fetch, config,
+        install_mockery):
+
     tmpdir.chdir()
-    install('--log-format=junit', 'libdwarf')
+    install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
 
-    files = os.listdir()
-    assert len(files) == 1
-    assert files[0].endswith('xml')
+    files = tmpdir.listdir()
+    filename = tmpdir.join('test.xml')
+    assert filename in files
 
-    content = open(files[0]).read()
+    content = filename.open().read()
     assert 'tests="2"' in content
     assert 'failures="0"' in content
     assert 'errors="0"' in content
 
 
-@pytest.mark.usefixutres('install_mockery', 'builtin_mock', 'config', 'builtin_mock')
-def _install_package_and_dependency(tmpdir):
+def test_install_package_already_installed(
+        tmpdir, builtin_mock, mock_archive, mock_fetch, config,
+        install_mockery):
+
     tmpdir.chdir()
-    install('libelf')
-    install('--log-format=junit', 'libdwarf')
+    install('libdwarf')
+    install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
 
-    files = os.listdir()
-    assert len(files) == 1
-    assert files[0].endswith('xml')
+    files = tmpdir.listdir()
+    filename = tmpdir.join('test.xml')
+    assert filename in files
 
-    content = open(files[0]).read()
+    content = filename.open().read()
     assert 'tests="2"' in content
     assert 'failures="0"' in content
     assert 'errors="0"' in content

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -22,194 +22,51 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import argparse
+import os
 import codecs
 import collections
 import contextlib
-import unittest
+import pytest
 from six import StringIO
 
 import llnl.util.filesystem
 import spack
 import spack.cmd
-import spack.cmd.install as install
-
-FILE_REGISTRY = collections.defaultdict(StringIO)
+from spack.main import SpackCommand
 
 
-# Monkey-patch open to write module files to a StringIO instance
-@contextlib.contextmanager
-def mock_open(filename, mode, *args):
-    if not mode == 'wb':
-        message = 'test.test_install : unexpected opening mode for mock_open'
-        raise RuntimeError(message)
-
-    FILE_REGISTRY[filename] = StringIO()
-
-    try:
-        yield FILE_REGISTRY[filename]
-    finally:
-        handle = FILE_REGISTRY[filename]
-        FILE_REGISTRY[filename] = handle.getvalue()
-        handle.close()
+install = SpackCommand('install')
 
 
-class MockSpec(object):
+@pytest.mark.usefixutres('install_mockery', 'builtin_mock', 'config', 'builtin_mock')
+def test_install_package_and_dependency(tmpdir):
+    tmpdir.chdir()
+    install('--log-format=junit', 'libdwarf')
 
-    def __init__(self, name, version, hashStr=None):
-        self._dependencies = {}
-        self.name = name
-        self.version = version
-        self.hash = hashStr if hashStr else hash((name, version))
+    files = os.listdir()
+    assert len(files) == 1
+    assert files[0].endswith('xml')
 
-    def _deptype_norm(self, deptype):
-        if deptype is None:
-            return spack.alldeps
-        # Force deptype to be a tuple so that we can do set intersections.
-        if isinstance(deptype, str):
-            return (deptype,)
-        return deptype
-
-    def _find_deps(self, where, deptype):
-        deptype = self._deptype_norm(deptype)
-
-        return [dep.spec
-                for dep in where.values()
-                if deptype and any(d in deptype for d in dep.deptypes)]
-
-    def dependencies(self, deptype=None):
-        return self._find_deps(self._dependencies, deptype)
-
-    def dependents(self, deptype=None):
-        return self._find_deps(self._dependents, deptype)
-
-    def traverse(self, order=None):
-        for _, spec in self._dependencies.items():
-            yield spec.spec
-        yield self
-
-    def dag_hash(self):
-        return self.hash
-
-    @property
-    def short_spec(self):
-        return '-'.join([self.name, str(self.version), str(self.hash)])
+    content = open(files[0]).read()
+    assert 'tests="2"' in content
+    assert 'failures="0"' in content
+    assert 'errors="0"' in content
 
 
-class MockPackage(object):
+@pytest.mark.usefixutres('install_mockery', 'builtin_mock', 'config', 'builtin_mock')
+def _install_package_and_dependency(tmpdir):
+    tmpdir.chdir()
+    install('libelf')
+    install('--log-format=junit', 'libdwarf')
 
-    def __init__(self, spec, buildLogPath):
-        self.name = spec.name
-        self.spec = spec
-        self.installed = False
-        self.build_log_path = buildLogPath
+    files = os.listdir()
+    assert len(files) == 1
+    assert files[0].endswith('xml')
 
-    def do_install(self, *args, **kwargs):
-        for x in self.spec.dependencies():
-            x.package.do_install(*args, **kwargs)
-        self.installed = True
+    content = open(files[0]).read()
+    assert 'tests="2"' in content
+    assert 'failures="0"' in content
+    assert 'errors="0"' in content
 
-
-class MockPackageDb(object):
-
-    def __init__(self, init=None):
-        self.specToPkg = {}
-        if init:
-            self.specToPkg.update(init)
-
-    def get(self, spec):
-        return self.specToPkg[spec]
-
-
-def mock_fetch_log(path):
-    return []
-
-
-specX = MockSpec('X', '1.2.0')
-specY = MockSpec('Y', '2.3.8')
-specX._dependencies['Y'] = spack.spec.DependencySpec(
-    specX, specY, spack.alldeps)
-pkgX = MockPackage(specX, 'logX')
-pkgY = MockPackage(specY, 'logY')
-specX.package = pkgX
-specY.package = pkgY
-
-
-# TODO: add test(s) where Y fails to install
-class InstallTestJunitLog(unittest.TestCase):
-    """Tests test-install where X->Y"""
-
-    def setUp(self):
-        super(InstallTestJunitLog, self).setUp()
-        install.PackageBase = MockPackage
-        # Monkey patch parse specs
-
-        def monkey_parse_specs(x, concretize):
-            if x == ['X']:
-                return [specX]
-            elif x == ['Y']:
-                return [specY]
-            return []
-
-        self.parse_specs = spack.cmd.parse_specs
-        spack.cmd.parse_specs = monkey_parse_specs
-
-        # Monkey patch os.mkdirp
-        self.mkdirp = llnl.util.filesystem.mkdirp
-        llnl.util.filesystem.mkdirp = lambda x: True
-
-        # Monkey patch open
-        self.codecs_open = codecs.open
-        codecs.open = mock_open
-
-        # Clean FILE_REGISTRY
-        FILE_REGISTRY.clear()
-
-        pkgX.installed = False
-        pkgY.installed = False
-
-        # Monkey patch pkgDb
-        self.saved_db = spack.repo
-        pkgDb = MockPackageDb({specX: pkgX, specY: pkgY})
-        spack.repo = pkgDb
-
-    def tearDown(self):
-        # Remove the monkey patched test_install.open
-        codecs.open = self.codecs_open
-
-        # Remove the monkey patched os.mkdir
-        llnl.util.filesystem.mkdirp = self.mkdirp
-        del self.mkdirp
-
-        # Remove the monkey patched parse_specs
-        spack.cmd.parse_specs = self.parse_specs
-        del self.parse_specs
-        super(InstallTestJunitLog, self).tearDown()
-
-        spack.repo = self.saved_db
-
-    def test_installing_both(self):
-        parser = argparse.ArgumentParser()
-        install.setup_parser(parser)
-        args = parser.parse_args(['--log-format=junit', 'X'])
-        install.install(parser, args)
-        self.assertEqual(len(FILE_REGISTRY), 1)
-        for _, content in FILE_REGISTRY.items():
-            self.assertTrue('tests="2"' in content)
-            self.assertTrue('failures="0"' in content)
-            self.assertTrue('errors="0"' in content)
-
-    def test_dependency_already_installed(self):
-        pkgX.installed = True
-        pkgY.installed = True
-        parser = argparse.ArgumentParser()
-        install.setup_parser(parser)
-        args = parser.parse_args(['--log-format=junit', 'X'])
-        install.install(parser, args)
-        self.assertEqual(len(FILE_REGISTRY), 1)
-        for _, content in FILE_REGISTRY.items():
-            self.assertTrue('tests="2"' in content)
-            self.assertTrue('failures="0"' in content)
-            self.assertTrue('errors="0"' in content)
-            self.assertEqual(
-                sum('skipped' in line for line in content.split('\n')), 2)
+    skipped = [line for line in content.split('\n') if 'skipped' in line]
+    assert len(skipped) == 2

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -70,15 +70,20 @@ def test_remove_and_add_tcl(database, parser):
     # Remove existing modules [tcl]
     args = parser.parse_args(['rm', '-y', 'mpileaks'])
     module_files = _get_module_files(args)
+
     for item in module_files:
         assert os.path.exists(item)
+
     module.module(parser, args)
+
     for item in module_files:
         assert not os.path.exists(item)
 
     # Add them back [tcl]
     args = parser.parse_args(['refresh', '-y', 'mpileaks'])
+
     module.module(parser, args)
+
     for item in module_files:
         assert os.path.exists(item)
 

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -22,22 +22,12 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import argparse
-import pytest
+import spack
+from spack.main import SpackCommand
 
-from spack.cmd.python import *
-
-
-@pytest.fixture(scope='module')
-def parser():
-    """Returns the parser for the ``python`` command"""
-    parser = argparse.ArgumentParser()
-    setup_parser(parser)
-    return parser
+python = SpackCommand('python')
 
 
-def test_python(parser):
-    args = parser.parse_args([
-        '-c', 'import spack; print(spack.spack_version)'
-    ])
-    python(parser, args)
+def test_python():
+    out, err = python('-c', 'import spack; print(spack.spack_version)')
+    assert out.strip() == str(spack.spack_version)

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -24,7 +24,9 @@
 ##############################################################################
 import pytest
 import spack.store
-import spack.cmd.uninstall
+from spack.main import SpackCommand, SpackCommandError
+
+uninstall = SpackCommand('uninstall')
 
 
 class MockArgs(object):
@@ -37,20 +39,21 @@ class MockArgs(object):
         self.yes_to_all = True
 
 
-def test_uninstall(database):
-    parser = None
-    uninstall = spack.cmd.uninstall.uninstall
-    # Multiple matches
-    args = MockArgs(['mpileaks'])
-    with pytest.raises(SystemExit):
-        uninstall(parser, args)
-    # Installed dependents
-    args = MockArgs(['libelf'])
-    with pytest.raises(SystemExit):
-        uninstall(parser, args)
-    # Recursive uninstall
-    args = MockArgs(['callpath'], all=True, dependents=True)
-    uninstall(parser, args)
+def test_multiple_matches(database):
+    """Test unable to uninstall when multiple matches."""
+    with pytest.raises(SpackCommandError):
+        uninstall('-y', 'mpileaks')
+
+
+def test_installed_dependents(database):
+    """Test can't uninstall when ther are installed dependents."""
+    with pytest.raises(SpackCommandError):
+        uninstall('-y', 'libelf')
+
+
+def test_recursive_uninstall(database):
+    """Test recursive uninstall."""
+    uninstall('-y', '-a', '--dependents', 'callpath')
 
     all_specs = spack.store.layout.all_specs()
     assert len(all_specs) == 8

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -22,18 +22,13 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import argparse
+import re
 import pytest
-
+from spack.url import UndetectableVersionError
+from spack.main import SpackCommand
 from spack.cmd.url import *
 
-
-@pytest.fixture(scope='module')
-def parser():
-    """Returns the parser for the ``url`` command"""
-    parser = argparse.ArgumentParser()
-    setup_parser(parser)
-    return parser
+url = SpackCommand('url')
 
 
 class MyPackage:
@@ -77,51 +72,64 @@ def test_version_parsed_correctly():
     assert not version_parsed_correctly(MyPackage('', ['0.18.0']), 'oce-0.18.0')   # noqa
 
 
-def test_url_parse(parser):
-    args = parser.parse_args(['parse', 'http://zlib.net/fossils/zlib-1.2.10.tar.gz'])
-    url(parser, args)
+def test_url_parse():
+    url('parse', 'http://zlib.net/fossils/zlib-1.2.10.tar.gz')
 
 
-@pytest.mark.xfail
-def test_url_parse_xfail(parser):
+def test_url_with_no_version_fails():
     # No version in URL
-    args = parser.parse_args(['parse', 'http://www.netlib.org/voronoi/triangle.zip'])
-    url(parser, args)
+    with pytest.raises(UndetectableVersionError):
+        url('parse', 'http://www.netlib.org/voronoi/triangle.zip')
 
 
-def test_url_list(parser):
-    args = parser.parse_args(['list'])
-    total_urls = url_list(args)
+def test_url_list():
+    out, err = url('list')
+    total_urls = len(out.split('\n'))
 
     # The following two options should not change the number of URLs printed.
-    args = parser.parse_args(['list', '--color', '--extrapolation'])
-    colored_urls = url_list(args)
+    out, err = url('list', '--color', '--extrapolation')
+    colored_urls = len(out.split('\n'))
     assert colored_urls == total_urls
 
     # The following options should print fewer URLs than the default.
     # If they print the same number of URLs, something is horribly broken.
     # If they say we missed 0 URLs, something is probably broken too.
-    args = parser.parse_args(['list', '--incorrect-name'])
-    incorrect_name_urls = url_list(args)
+    out, err = url('list', '--incorrect-name')
+    incorrect_name_urls = len(out.split('\n'))
     assert 0 < incorrect_name_urls < total_urls
 
-    args = parser.parse_args(['list', '--incorrect-version'])
-    incorrect_version_urls = url_list(args)
+    out, err = url('list', '--incorrect-version')
+    incorrect_version_urls = len(out.split('\n'))
     assert 0 < incorrect_version_urls < total_urls
 
-    args = parser.parse_args(['list', '--correct-name'])
-    correct_name_urls = url_list(args)
+    out, err = url('list', '--correct-name')
+    correct_name_urls = len(out.split('\n'))
     assert 0 < correct_name_urls < total_urls
 
-    args = parser.parse_args(['list', '--correct-version'])
-    correct_version_urls = url_list(args)
+    out, err = url('list', '--correct-version')
+    correct_version_urls = len(out.split('\n'))
     assert 0 < correct_version_urls < total_urls
 
 
-def test_url_summary(parser):
-    args = parser.parse_args(['summary'])
+def test_url_summary():
+    """Test the URL summary command."""
+    # test url_summary, the internal function that does the work
     (total_urls, correct_names, correct_versions,
-     name_count_dict, version_count_dict) = url_summary(args)
+     name_count_dict, version_count_dict) = url_summary(None)
 
     assert 0 < correct_names    <= sum(name_count_dict.values())    <= total_urls  # noqa
     assert 0 < correct_versions <= sum(version_count_dict.values()) <= total_urls  # noqa
+
+    # make sure it agrees with the actual command.
+    out, err = url('summary')
+    out_total_urls = int(
+        re.search(r'Total URLs found:\s*(\d+)', out).group(1))
+    assert out_total_urls == total_urls
+
+    out_correct_names = int(
+        re.search(r'Names correctly parsed:\s*(\d+)', out).group(1))
+    assert out_correct_names == correct_names
+
+    out_correct_versions = int(
+        re.search(r'Versions correctly parsed:\s*(\d+)', out).group(1))
+    assert out_correct_versions == correct_versions

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -287,6 +287,26 @@ def refresh_db_on_exit(database):
     yield
     database.refresh()
 
+
+@pytest.fixture()
+def install_mockery(tmpdir, config, builtin_mock):
+    """Hooks a fake install directory and a fake db into Spack."""
+    layout = spack.store.layout
+    db = spack.store.db
+    # Use a fake install directory to avoid conflicts bt/w
+    # installed pkgs and mock packages.
+    spack.store.layout = YamlDirectoryLayout(str(tmpdir))
+    spack.store.db = Database(str(tmpdir))
+    # We use a fake package, so skip the checksum.
+    spack.do_checksum = False
+    yield
+    # Turn checksumming back on
+    spack.do_checksum = True
+    # Restore Spack's layout.
+    spack.store.layout = layout
+    spack.store.db = db
+
+
 ##########
 # Fake archives and repositories
 ##########

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -33,25 +33,6 @@ from spack.spec import Spec
 import os
 
 
-@pytest.fixture()
-def install_mockery(tmpdir, config, builtin_mock):
-    """Hooks a fake install directory and a fake db into Spack."""
-    layout = spack.store.layout
-    db = spack.store.db
-    # Use a fake install directory to avoid conflicts bt/w
-    # installed pkgs and mock packages.
-    spack.store.layout = YamlDirectoryLayout(str(tmpdir))
-    spack.store.db = Database(str(tmpdir))
-    # We use a fake package, so skip the checksum.
-    spack.do_checksum = False
-    yield
-    # Turn checksumming back on
-    spack.do_checksum = True
-    # Restore Spack's layout.
-    spack.store.layout = layout
-    spack.store.db = db
-
-
 def fake_fetchify(url, pkg):
     """Fake the URL for a package so it downloads from a file."""
     fetcher = FetchStrategyComposite()

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -26,7 +26,7 @@ from spack import *
 
 
 class A(AutotoolsPackage):
-    """Simple package with no dependencies"""
+    """Simple package with one optional dependency"""
 
     homepage = "http://www.example.com"
     url      = "http://www.example.com/a-1.0.tar.gz"

--- a/var/spack/repos/builtin.mock/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin.mock/packages/libdwarf/package.py
@@ -41,4 +41,4 @@ class Libdwarf(Package):
     depends_on("libelf")
 
     def install(self, spec, prefix):
-        pass
+        touch(prefix.libdwarf)

--- a/var/spack/repos/builtin.mock/packages/libelf/package.py
+++ b/var/spack/repos/builtin.mock/packages/libelf/package.py
@@ -34,11 +34,4 @@ class Libelf(Package):
     version('0.8.10', '9db4d36c283d9790d8fa7df1f4d7b4d9')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix,
-                  "--enable-shared",
-                  "--disable-dependency-tracking",
-                  "--disable-debug")
-        make()
-
-        # The mkdir commands in libelf's intsall can fail in parallel
-        make("install", parallel=False)
+        touch(prefix.libelf)


### PR DESCRIPTION
This makes it easier to test command-line commands from within Spack's testing framework.  It adds a `SpackCommand` class so you can do this:

```python
from spack.main import SpackCommand
uninstall = SpackCommand('uninstall')
out, err = uninstall('-y', '-a', '--dependents', 'mpich')
```

No more creating parsers and all that from within command tests.  Just run the command like a user would and test that.  The commands return their error and their output so you can parse that, as well.  I've redone the command tests to use this instead of all the cruft that was there before.  I also removed a bunch of unnecessary mockery from the `spack install` test, and simplified the mocking of fetches a bit.

I hope this will make it easier to get coverage in some of the commands where we've been missing it.

- [x] Add `SpackCommand` to make testing commands easier
- [x] Rework tests of commands to use `SpackCommand`
- [x] Simplify mocking in the `cmd/install` test and in general
- [x] Move the `mock_archive` fixture up to the `conftest.py` level so all tests can use it
- [x] Make a `mock_fetch` fixture usable by all tests

