### PR TITLE
PerlPackage: remove perllocal.pod files

### DIFF
--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -115,5 +115,17 @@ class PerlPackage(PackageBase):
         """Installs a Perl package."""
         self.build_executable('install')
 
+    @run_after('install')
+    def allow_activation(self):
+        # Remove files that appear in multiple packages,
+        # preventing them from being activated together.
+        # The main culprits are:
+        #   perllocal.pod - list and description of non-core packages.
+        culprits = ['perllocal.pod']
+        for dirpath, dirnames, filenames in os.walk(self.prefix):
+            for culprit in culprits:
+                if culprit in filenames:
+                    os.remove(join_path(dirpath, culprit))
+
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)


### PR DESCRIPTION
… to avoid conflicts during package activation.

The perllocal.pod files list and describe non-core packages installed by users; they are not used by perl itself. In a normal perl installation, the perllocal.pod files are appended when new packages are installed. Under spack, perl packages each create their own perllocal.pod file. During package activation, the multiple perllocal.pod files conflict with each other, so that only one perl package can be activated at any time.

The proposed solution involves removing the perllocal.pod files from each package during installation. An alternative method is suggested in #4541, which would avoid linking certain files during package activation. A more general alternative would be to warn about conflicting files while allowing activation to complete, similar to the way that `spack view` behaves.