### PR TITLE
Rename the gpu variant to cuda

### DIFF
--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -39,7 +39,7 @@ class Caffe(CMakePackage):
     version('rc3', '84e39223115753b48312a8bf48c31f59')
     version('rc2', 'c331932e34b5e2f5022fcc34c419080f')
 
-    variant('gpu', default=False,
+    variant('cuda', default=False,
             description='Builds with support for GPUs via CUDA and cuDNN')
     variant('opencv', default=True,
             description='Build with OpenCV support')
@@ -54,7 +54,7 @@ class Caffe(CMakePackage):
 
     depends_on('boost')
     depends_on('boost +python', when='+python')
-    depends_on('cuda', when='+gpu')
+    depends_on('cuda', when='+cuda')
     depends_on('blas')
     depends_on('protobuf')
     depends_on('glog')
@@ -75,8 +75,8 @@ class Caffe(CMakePackage):
         spec = self.spec
         args = ['-DBLAS={0}'.format('open' if spec['blas'].name == 'openblas'
                 else spec['blas'].name),
-                '-DCPU_ONLY=%s' % ('~gpu' in spec),
-                '-DUSE_CUDNN=%s' % ('+gpu' in spec),
+                '-DCPU_ONLY=%s' % ('~cuda' in spec),
+                '-DUSE_CUDNN=%s' % ('+cuda' in spec),
                 '-DBUILD_python=%s' % ('+python' in spec),
                 '-DBUILD_python_layer=%s' % ('+python' in spec),
                 '-DBUILD_matlab=%s' % ('+matlab' in spec),


### PR DESCRIPTION
This is to be consistent with other packages when enabling cuda, I had to rename it to this as I have another package that I am building which depends on this which requires cuda.