### PR TITLE
Improve version detection for URLs with dynamic after version

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -107,7 +107,9 @@ from spack.url import *
     # Combinations of multiple patterns - public
     ('dakota-6.3-public.src', 'dakota-6.3'),
     # Combinations of multiple patterns - universal
-    ('synergy-1.3.6p2-MacOSX-Universal', 'synergy-1.3.6p2')
+    ('synergy-1.3.6p2-MacOSX-Universal', 'synergy-1.3.6p2'),
+    # Combinations of multiple patterns - dynamic
+    ('snptest_v2.5.2_linux_x86_64_dynamic', 'snptest_v2.5.2'),
 ])
 def test_url_strip_version_suffixes(url, expected):
     stripped = strip_version_suffixes(url)

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -177,6 +177,7 @@ def strip_version_suffixes(path):
         '[Uu]niversal',
         'jar',
         'complete',
+        'dynamic',
         'oss',
         'gem',
         'tar',


### PR DESCRIPTION
Needed for #4900.

### Before
```
$ spack url parse http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz
==> Parsing URL: http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz

==> Error: Couldn't detect version in: http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz
```
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1759
    Names correctly parsed:    1563/1759 (88.86%)
    Versions correctly parsed: 1618/1759 (91.98%)
```
### After
```
$ spack url parse http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz
==> Parsing URL: http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz

==> Matched version regex  0: r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
==> Matched  name   regex  7: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    http://www.well.ox.ac.uk/~gav/resources/snptest_v2.5.2_linux_x86_64_dynamic.tgz
                                            -------  ~~~~~
    name:    snptest
    version: 2.5.2

==> Substituting version 9.9.9b:
    http://www.well.ox.ac.uk/~gav/resources/snptest_v9.9.9b_linux_x86_64_dynamic.tgz
                                            -------  ~~~~~~
```
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1759
    Names correctly parsed:    1563/1759 (88.86%)
    Versions correctly parsed: 1618/1759 (91.98%)
```