### PR TITLE
Correct boost +mpi for Cray compiler wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -207,8 +207,21 @@ class Boost(Package):
                                                        spack_cxx))
 
             if '+mpi' in spec:
-                f.write('using mpi : %s ;\n' %
-                        join_path(spec['mpi'].prefix.bin, 'mpicxx'))
+
+                # Use the correct mpi compiler.  If the compiler options are
+                # empty or undefined, Boost will attempt to figure out the
+                # correct options by running "${mpicxx} -show" or something
+                # similar, but that doesn't work with the Cray compiler
+                # wrappers.  Since Boost doesn't use the MPI C++ bindings,
+                # that can be used as a compiler option instead.
+
+                mpi_line = 'using mpi : %s' % spec['mpi'].mpicxx
+
+                if 'platform=cray' in spec:
+                    mpi_line += ' : <define>MPICH_SKIP_MPICXX'
+
+                f.write(mpi_line + ' ;\n')
+
             if '+python' in spec:
                 f.write(self.bjam_python_line(spec))
 


### PR DESCRIPTION
The boost package should not hardcode `"mpicxx"` as the compiler to use with the variant `+mpi`.

I ran into this issue when attempting to install `boost +mpi +python ^python@3:` on a system with the Cray compiler wrapper `CC` instead of the normal MPI wrapper `mpicxx`.

At first, it seemed like the boost package installed correctly, or at least it didn't fail with an error.  But that's because boost will just silently refuse to compile the Boost MPI library if the MPI compile doesn't work, with just some warnings like this:
```
MPI auto-detection failed: unknown wrapper compiler /opt/cray/mpt/7.2.4/gni/mpich2-gnu/49/bin/mpicxx
Please report this error to the Boost mailing list: http://www.boost.org
You will need to manually configure MPI support.
```
and this:
```
warning: skipping optional Message Passing Interface (MPI) library.
note: to enable MPI support, add "using mpi ;" to user-config.jam.
note: to suppress this message, pass "--without-mpi" to bjam.
note: otherwise, you can safely ignore this message.
```
and then the MPI library just doesn't exist after the install is done:
```
$ cd ~/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/boost-1.63.0-aehtg2wu2aht3eybqubbrdqtimcxngfm/lib/
$ ls libboost_python*
libboost_python-mt.a          libboost_python.so         libboost_python3-mt.so.1.63.0
libboost_python-mt.so         libboost_python.so.1.63.0  libboost_python3.a
libboost_python-mt.so.1.63.0  libboost_python3-mt.a      libboost_python3.so
libboost_python.a             libboost_python3-mt.so     libboost_python3.so.1.63.0
$ ls libboost_mpi*
ls: cannot access libboost_mpi*: No such file or directory
```

After I made the changes in this pull request (using `spec['mpi'].mpicxx` and adding the `MPICH_SKIP_MPICXX` option), the Boost MPI library compiled and installed correctly:
```
$ cd ~/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/boost-1.63.0-aehtg2wu2aht3eybqubbrdqtimcxngfm/lib/
$ ls libboost_python*
libboost_python-mt.a          libboost_python.so         libboost_python3-mt.so.1.63.0
libboost_python-mt.so         libboost_python.so.1.63.0  libboost_python3.a
libboost_python-mt.so.1.63.0  libboost_python3-mt.a      libboost_python3.so
libboost_python.a             libboost_python3-mt.so     libboost_python3.so.1.63.0
$ ls libboost_mpi*
libboost_mpi-mt.a          libboost_mpi.so            libboost_mpi_python-mt.so.1.63.0
libboost_mpi-mt.so         libboost_mpi.so.1.63.0     libboost_mpi_python.a
libboost_mpi-mt.so.1.63.0  libboost_mpi_python-mt.a   libboost_mpi_python.so
libboost_mpi.a             libboost_mpi_python-mt.so  libboost_mpi_python.so.1.63.0
```