### PR TITLE
adding gnat dependency for variant languages=all

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -86,6 +86,7 @@ class Gcc(AutotoolsPackage):
     depends_on('isl@0.15:', when='@6:')
     depends_on('zlib', when='@6:')
     depends_on('gnat', when='languages=ada')
+    depends_on('gnat', when='languages=all')
     depends_on('binutils~libiberty', when='+binutils')
     depends_on('zip', type='build', when='languages=java')
     depends_on('zip', type='build', when='@:6 languages=all')


### PR DESCRIPTION
The GCC package has a variant languages:

```
    languages [all]    all, ada, brig, c,      Compilers and runtime libraries to
                       c++, fortran, go,       build
                       java, jit, lto,         
                       objc, obj-c++         
```

The packages.py file contains the following statement:

    depends_on('gnat', when='languages=ada')

When trying to build it with languages=all, I would expect that it keeps the dependency on gnat, since all should include ada, which is not the case:

```
spack install gcc@5.4.0+binutils~piclibs languages=all ^binutils@2.28 ^gmp@6.1.2 ^gnat@2016 ^isl@0.18 ^mpc@1.0.3 ^mpfr@3.1.5 ^zip@3.0 ^zlib@1.2.11 %gcc@4.8.5 arch=linux-centos7-x86_64
==> Error: gcc does not depend on gnat or zip
```

Adding

`depends_on('gnat', when='languages=all')`

solves this problem.