### PR TITLE
Fix preference for X.Y version when mixed with X.Y.Z versions

### DIFF
--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -112,9 +112,17 @@ class PackagePrefs(object):
 
         # integer is the index of the first spec in order that satisfies
         # spec, or it's a number larger than any position in the order.
-        return next(
+        match_index = next(
             (i for i, s in enumerate(spec_order) if spec.satisfies(s)),
             len(spec_order))
+        if match_index < len(spec_order) and spec_order[match_index] == spec:
+            # If this is called with multiple specs that all satisfy the same
+            # minimum index in spec_order, the one which matches that element
+            # of spec_order exactly is considered slightly better. Note
+            # that because this decreases the value by less than 1, it is not
+            # better than a match which occurs at an earlier index.
+            match_index -= 0.5
+        return match_index
 
     @classproperty
     @classmethod

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -102,6 +102,11 @@ class TestConcretizePreferences(object):
         spec = concretize('mpileaks')
         assert spec.version == spack.spec.Version('2.2')
 
+    def test_preferred_versions_mixed_version_types(self):
+        update_packages('mixedversions', 'version', ['2.0'])
+        spec = concretize('mixedversions')
+        assert spec.version == spack.spec.Version('2.0')
+
     def test_preferred_providers(self):
         """Test preferred providers of virtual packages are
         applied correctly

--- a/var/spack/repos/builtin.mock/packages/mixedversions/package.py
+++ b/var/spack/repos/builtin.mock/packages/mixedversions/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mixedversions(Package):
+    url = "http://www.fake-mixedversions.org/downloads/mixedversions-1.0.tar.gz"
+
+    version('2.0.1', 'hashc')
+    version('2.0', 'hashb')
+    version('1.0.1', 'hasha')
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
Fixes #4133

For packages which contain a mix of versions with formats X.Y and
X.Y.Z, if the user entered an X.Y version as a preference in
packages.yaml, Spack would get confused and favor any version A.B.Z
where X=A and Y=B. In the case where there is a mix of these version
types, this commit updates preferences so Spack will favor an exact
match.