### PR TITLE
Add a QMakePackage base class

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2118,7 +2118,10 @@ The classes that are currently provided by Spack are:
     | :py:class:`.CMakePackage`     | Specialized class for packages   |
     |                               | built using CMake                |
     +-------------------------------+----------------------------------+
-    | :py:class:`.WafPackage`       | Specialize class for packages    |
+    | :py:class:`.QMakePackage`     | Specialized class for packages   |
+    |                               | build using QMake                |
+    +-------------------------------+----------------------------------+
+    | :py:class:`.WafPackage`       | Specialized class for packages   |
     |                               | built using Waf                  |
     +-------------------------------+----------------------------------+
     | :py:class:`.RPackage`         | Specialized class for            |

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -172,6 +172,7 @@ from spack.package import Package, run_before, run_after, on_package_attributes
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.qmake import QMakePackage
 from spack.build_systems.waf import WafPackage
 from spack.build_systems.python import PythonPackage
 from spack.build_systems.r import RPackage
@@ -185,6 +186,7 @@ __all__ += [
     'MakefilePackage',
     'AutotoolsPackage',
     'CMakePackage',
+    'QMakePackage',
     'WafPackage',
     'PythonPackage',
     'RPackage',

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import inspect
+
+from spack.directives import depends_on
+from spack.package import PackageBase, run_after
+
+
+class QMakePackage(PackageBase):
+    """Specialized class for packages built using qmake.
+
+    For more information on the qmake build system, see:
+    http://doc.qt.io/qt-5/qmake-manual.html
+
+    This class provides three phases that can be overridden:
+
+    1. :py:meth:`~.QMakePackage.qmake`
+    2. :py:meth:`~.QMakePackage.build`
+    3. :py:meth:`~.QMakePackage.install`
+
+    They all have sensible defaults and for many packages the only thing
+    necessary will be to override :py:meth:`~.QMakePackage.qmake_args`.
+
+    """
+    #: Phases of a qmake package
+    phases = ['qmake', 'build', 'install']
+
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
+    build_system_class = 'QMakePackage'
+
+    depends_on('qt', type='build')
+
+    def qmake_args(self):
+        """Produces a list containing all the arguments that must be passed to
+        qmake
+        """
+        return []
+
+    def qmake(self, spec, prefix):
+        """Run ``qmake`` to configure the project and generate a Makefile."""
+        inspect.getmodule(self).qmake(*self.qmake_args())
+
+    def build(self, spec, prefix):
+        """Make the build targets"""
+        inspect.getmodule(self).make()
+
+    def install(self, spec, prefix):
+        """Make the install targets"""
+        inspect.getmodule(self).make('install')
+
+    # Check that self.prefix is there after installation
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -43,7 +43,6 @@ class QMakePackage(PackageBase):
 
     They all have sensible defaults and for many packages the only thing
     necessary will be to override :py:meth:`~.QMakePackage.qmake_args`.
-
     """
     #: Phases of a qmake package
     phases = ['qmake', 'build', 'install']
@@ -51,6 +50,9 @@ class QMakePackage(PackageBase):
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'QMakePackage'
+
+    #: Callback names for build-time test
+    build_time_test_callbacks = ['check']
 
     depends_on('qt', type='build')
 
@@ -71,6 +73,15 @@ class QMakePackage(PackageBase):
     def install(self, spec, prefix):
         """Make the install targets"""
         inspect.getmodule(self).make('install')
+
+    # Tests
+
+    def check(self):
+        """Searches the Makefile for a ``check:`` target and runs it if found.
+        """
+        self._if_make_target_execute('check')
+
+    run_after('build')(PackageBase._run_default_build_time_test_callbacks)
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/cmd/build.py
+++ b/lib/spack/spack/cmd/build.py
@@ -34,6 +34,7 @@ level = "long"
 build_system_to_phase = {
     AutotoolsPackage: 'build',
     CMakePackage: 'build',
+    QMakePackage: 'build',
     WafPackage: 'build',
     PythonPackage: 'build',
     PerlPackage: 'build',

--- a/lib/spack/spack/cmd/configure.py
+++ b/lib/spack/spack/cmd/configure.py
@@ -38,6 +38,7 @@ level = "long"
 build_system_to_phase = {
     AutotoolsPackage: 'configure',
     CMakePackage: 'cmake',
+    QMakePackage: 'qmake',
     WafPackage: 'configure',
     PerlPackage: 'configure',
 }

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -193,6 +193,18 @@ class CMakePackageTemplate(PackageTemplate):
         return args"""
 
 
+class QMakePackageTemplate(PackageTemplate):
+    """Provides appropriate overrides for QMake-based packages"""
+
+    base_class_name = 'QMakePackage'
+
+    body = """\
+    def qmake_args(self):
+        # FIXME: If not needed delete this function
+        args = []
+        return args"""
+
+
 class SconsPackageTemplate(PackageTemplate):
     """Provides appropriate overrides for SCons-based packages"""
 
@@ -363,6 +375,7 @@ templates = {
     'autotools':  AutotoolsPackageTemplate,
     'autoreconf': AutoreconfPackageTemplate,
     'cmake':      CMakePackageTemplate,
+    'qmake':      QMakePackageTemplate,
     'scons':      SconsPackageTemplate,
     'waf':        WafPackageTemplate,
     'bazel':      BazelPackageTemplate,
@@ -426,18 +439,19 @@ class BuildSystemGuesser:
         # uses. If the regular expression matches a file contained in the
         # archive, the corresponding build system is assumed.
         clues = [
-            ('/configure$',         'autotools'),
-            ('/configure.(in|ac)$', 'autoreconf'),
-            ('/Makefile.am$',       'autoreconf'),
-            ('/CMakeLists.txt$',    'cmake'),
-            ('/SConstruct$',        'scons'),
-            ('/waf$',               'waf'),
-            ('/setup.py$',          'python'),
-            ('/NAMESPACE$',         'r'),
-            ('/WORKSPACE$',         'bazel'),
-            ('/Build.PL$',          'perlbuild'),
-            ('/Makefile.PL$',       'perlmake'),
-            ('/(GNU)?[Mm]akefile$', 'makefile'),
+            ('/configure$',          'autotools'),
+            ('/configure\.(in|ac)$', 'autoreconf'),
+            ('/Makefile\.am$',       'autoreconf'),
+            ('/CMakeLists\.txt$',    'cmake'),
+            ('/SConstruct$',         'scons'),
+            ('/waf$',                'waf'),
+            ('/setup\.py$',          'python'),
+            ('/NAMESPACE$',          'r'),
+            ('/WORKSPACE$',          'bazel'),
+            ('/Build\.PL$',          'perlbuild'),
+            ('/Makefile\.PL$',       'perlmake'),
+            ('/.*\.pro$',            'qmake'),
+            ('/(GNU)?[Mm]akefile$',  'makefile'),
         ]
 
         # Peek inside the compressed file.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -439,19 +439,19 @@ class BuildSystemGuesser:
         # uses. If the regular expression matches a file contained in the
         # archive, the corresponding build system is assumed.
         clues = [
-            ('/configure$',          'autotools'),
-            ('/configure\.(in|ac)$', 'autoreconf'),
-            ('/Makefile\.am$',       'autoreconf'),
-            ('/CMakeLists\.txt$',    'cmake'),
-            ('/SConstruct$',         'scons'),
-            ('/waf$',                'waf'),
-            ('/setup\.py$',          'python'),
-            ('/NAMESPACE$',          'r'),
-            ('/WORKSPACE$',          'bazel'),
-            ('/Build\.PL$',          'perlbuild'),
-            ('/Makefile\.PL$',       'perlmake'),
-            ('/.*\.pro$',            'qmake'),
-            ('/(GNU)?[Mm]akefile$',  'makefile'),
+            (r'/configure$',          'autotools'),
+            (r'/configure\.(in|ac)$', 'autoreconf'),
+            (r'/Makefile\.am$',       'autoreconf'),
+            (r'/CMakeLists\.txt$',    'cmake'),
+            (r'/SConstruct$',         'scons'),
+            (r'/waf$',                'waf'),
+            (r'/setup\.py$',          'python'),
+            (r'/NAMESPACE$',          'r'),
+            (r'/WORKSPACE$',          'bazel'),
+            (r'/Build\.PL$',          'perlbuild'),
+            (r'/Makefile\.PL$',       'perlmake'),
+            (r'/.*\.pro$',            'qmake'),
+            (r'/(GNU)?[Mm]akefile$',  'makefile'),
         ]
 
         # Peek inside the compressed file.

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -34,6 +34,7 @@ import spack.stage
     params=[
         ('configure',      'autotools'),
         ('CMakeLists.txt', 'cmake'),
+        ('project.pro',    'qmake'),
         ('SConstruct',     'scons'),
         ('waf',            'waf'),
         ('setup.py',       'python'),

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -23,10 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
-class QtCreator(Package):
+class QtCreator(QMakePackage):
     """The Qt Creator IDE."""
     homepage = 'https://www.qt.io/ide/'
     url      = 'http://download.qt.io/official_releases/qtcreator/4.1/4.1.0/qt-creator-opensource-src-4.1.0.tar.gz'
@@ -36,11 +35,10 @@ class QtCreator(Package):
 
     version('4.1.0',  '657727e4209befa4bf5889dff62d9e0a')
 
-    depends_on("qt")
+    depends_on("qt@5.5.0:", type='build')
 
-    def install(self, spec, prefix):
-        os.environ['INSTALL_ROOT'] = self.prefix
-        qmake = which('qmake')
-        qmake('-r')
-        make()
-        make("install")
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set('INSTALL_ROOT', self.prefix)
+
+    def qmake_args(self):
+        return ['-r']

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -36,7 +36,7 @@ class QtCreator(QMakePackage):
     version('4.3.1', '6769ea47f287e2d9e30ff92acb899eef')
     version('4.1.0', '657727e4209befa4bf5889dff62d9e0a')
 
-    depends_on('qt@5.5.0:+opengl')
+    depends_on('qt@5.6.0:+opengl')
     depends_on('sqlite@3.8.10.2')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -23,21 +23,25 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import shutil
 
 
 class QtCreator(QMakePackage):
     """The Qt Creator IDE."""
     homepage = 'https://www.qt.io/ide/'
-    url      = 'http://download.qt.io/official_releases/qtcreator/4.1/4.1.0/qt-creator-opensource-src-4.1.0.tar.gz'
+    url      = 'http://download.qt.io/official_releases/qtcreator/4.3/4.3.1/qt-creator-opensource-src-4.3.1.tar.gz'
 
     list_url = 'http://download.qt.io/official_releases/qtcreator/'
     list_depth = 2
 
-    version('4.1.0',  '657727e4209befa4bf5889dff62d9e0a')
+    version('4.3.1', '6769ea47f287e2d9e30ff92acb899eef')
+    version('4.1.0', '657727e4209befa4bf5889dff62d9e0a')
 
-    depends_on('qt@5.5.0:+opengl', type='build')
+    depends_on('qt@5.5.0:+opengl')
     depends_on('sqlite@3.8.10.2')
+
+    def url_for_version(self, version):
+        url = 'http://download.qt.io/official_releases/qtcreator/{0}/{1}/qt-creator-opensource-src-{1}.tar.gz'
+        return url.format(version.up_to(2), version)
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('INSTALL_ROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -44,6 +44,9 @@ class QtCreator(QMakePackage):
     # sqlite as the bundled copy.
     depends_on('sqlite@3.8.10.2')
 
+    # Qt Creator 4.3.0+ requires a C++14 compiler
+    conflicts('%gcc@:4.8', when='@4.3.0:')
+
     def url_for_version(self, version):
         url = 'http://download.qt.io/official_releases/qtcreator/{0}/{1}/qt-creator-opensource-src-{1}.tar.gz'
         return url.format(version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import shutil
 
 
 class QtCreator(QMakePackage):
@@ -35,7 +36,8 @@ class QtCreator(QMakePackage):
 
     version('4.1.0',  '657727e4209befa4bf5889dff62d9e0a')
 
-    depends_on("qt@5.5.0:", type='build')
+    depends_on('qt@5.5.0:+opengl', type='build')
+    depends_on('sqlite@3.8.10.2')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.set('INSTALL_ROOT', self.prefix)

--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -37,6 +37,11 @@ class QtCreator(QMakePackage):
     version('4.1.0', '657727e4209befa4bf5889dff62d9e0a')
 
     depends_on('qt@5.6.0:+opengl')
+    # Qt Creator comes bundled with its own copy of sqlite. Qt has a build
+    # dependency on Python, which has a dependency on sqlite. If Python is
+    # built with a different version of sqlite than the bundled copy, it will
+    # cause symbol conflict. Force Spack to build with the same version of
+    # sqlite as the bundled copy.
     depends_on('sqlite@3.8.10.2')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -33,9 +33,12 @@ class Qwt(QMakePackage):
     ranges of type double.
     """
     homepage = "http://qwt.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/qwt/qwt/5.2.2/qwt-5.2.2.tar.bz2"
+    url      = "https://sourceforge.net/projects/qwt/files/qwt/6.1.3/qwt-6.1.3.tar.bz2"
 
+    version('6.1.3', '19d1f5fa5e22054d22ee3accc37c54ba')
     version('5.2.2', '70d77e4008a6cc86763737f0f24726ca')
+
+    depends_on('qt+opengl')
 
     def patch(self):
         # Subvert hardcoded prefix

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -42,5 +42,5 @@ class Qwt(QMakePackage):
 
     def patch(self):
         # Subvert hardcoded prefix
-        filter_file('/usr/local/qwt-$$VERSION', self.prefix, 'qwtconfig.pri',
-                    string=True)
+        filter_file(r'/usr/local/qwt-\$\$(QWT_)?VERSION.*',
+                    self.prefix, 'qwtconfig.pri')

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Qwt(Package):
+class Qwt(QMakePackage):
     """The Qwt library contains GUI Components and utility classes which are
     primarily useful for programs with a technical background. Beside a
     framework for 2D plots it provides scales, sliders, dials, compasses,
@@ -37,14 +37,7 @@ class Qwt(Package):
 
     version('5.2.2', '70d77e4008a6cc86763737f0f24726ca')
 
-    depends_on("qt")
-
-    def install(self, spec, prefix):
-
+    def patch(self):
         # Subvert hardcoded prefix
-        filter_file(r'/usr/local/qwt-\$\$VERSION', prefix, 'qwtconfig.pri')
-
-        qmake = which('qmake')
-        qmake()
-        make()
-        make("install")
+        filter_file('/usr/local/qwt-$$VERSION', self.prefix, 'qwtconfig.pri',
+                    string=True)

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -39,6 +39,9 @@ class Qwt(QMakePackage):
     version('5.2.2', '70d77e4008a6cc86763737f0f24726ca')
 
     depends_on('qt+opengl')
+    # Qwt 6.1.1 and older use a constant that was removed in Qt 5.4
+    # https://bugs.launchpad.net/ubuntu/+source/qwt-qt5/+bug/1485213
+    depends_on('qt@:5.3', when='@:6.1.1')
 
     def patch(self):
         # Subvert hardcoded prefix

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -33,8 +33,12 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "www.sqlite.org"
 
+    version('3.20.0', 'e262a28b73cc330e7e83520c8ce14e4d',
+            url='https://www.sqlite.org/2017/sqlite-autoconf-3200000.tar.gz')
     version('3.18.0', 'a6687a8ae1f66abc8df739aeadecfd0c',
             url='https://www.sqlite.org/2017/sqlite-autoconf-3180000.tar.gz')
+    version('3.8.10.2', 'a18bfc015cd49a1e7a961b7b77bc3b37',
+            url='https://www.sqlite.org/2015/sqlite-autoconf-3081002.tar.gz')
     version('3.8.5', '0544ef6d7afd8ca797935ccc2685a9ed',
             url='https://www.sqlite.org/2014/sqlite-autoconf-3080500.tar.gz')
 


### PR DESCRIPTION
This PR adds Spack support for the qmake build system.

Unfortunately, I'm not able to test this. I am unable to install `qt` on macOS (see #2363 and #2496) or on CentOS 6. I even tried using `qt` built with Anaconda but that didn't work either. There are a few things that I would like to see tested before this is merged:

1. ~Do these packages need `qt` as a build/link dependency or just build? Run `ldd -r` on any dynamic executables or shared libraries to confirm.~ Pretty sure it is a link dependency too.
2. ~Are these packages actually using Spack's compiler wrappers? Add `echo "USING SPACK'S COMPILER WRAPPERS"` to `lib/spack/env/cc` to confirm. There are a few [qmake variables](http://doc.qt.io/qt-5/qmake-variable-reference.html) that can be set including `QMAKE_CC` and `QMAKE_CXX`, as well as some RPATH-related variables that could be set.~ The compiler wrappers are being used.
3. ~Do packages built with `qmake` come with any build-time or install-time tests? Check the generated Makefile for targets like `check` or `test`.~ Found one with a `check:` target.

@jrood-nrel added the `qwt` package in #4911, while @lee218llnl added the `qt-creator` package in #1659. Would either of you be willing to test this, or tell me your secret for getting `qt` installed?