### PR TITLE
Fix crashes when running spack install under nohup

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -54,6 +54,7 @@ calls you can make from within the install() function.
 import inspect
 import multiprocessing
 import os
+import errno
 import shutil
 import sys
 import traceback
@@ -582,9 +583,10 @@ def fork(pkg, function, dirty=False):
         # '[Errno 22] Invalid argument') then just use os.devnull
         try:
             input_stream = lang.duplicate_stream(sys.stdin)
-        except:
-            tty.debug("Using devnull as input_stream")
-            input_stream = open(os.devnull)
+        except OSError as e:
+            if e.errno == errno.EINVAL:
+                tty.debug("Using devnull as input_stream")
+                input_stream = open(os.devnull)
         p = multiprocessing.Process(
             target=child_execution,
             args=(child_connection, input_stream)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -577,8 +577,14 @@ def fork(pkg, function, dirty=False):
     parent_connection, child_connection = multiprocessing.Pipe()
     try:
         # Forward sys.stdin to be able to activate / deactivate
-        # verbosity pressing a key at run-time
-        input_stream = lang.duplicate_stream(sys.stdin)
+        # verbosity pressing a key at run-time.  When sys.stdin can't
+        # be duplicated (e.g. running under nohup, which results in an
+        # '[Errno 22] Invalid argument') then just use os.devnull
+        try:
+            input_stream = lang.duplicate_stream(sys.stdin)
+        except:
+            tty.debug("Using devnull as input_stream")
+            input_stream = open(os.devnull)
         p = multiprocessing.Process(
             target=child_execution,
             args=(child_connection, input_stream)


### PR DESCRIPTION
Fixes #4919

For reasons that I do not entire understand, duplicate_stream() throws
an '[Errno 22] Invalid argument' exception when it tries to
`os.fdopen()` the duplicated file descriptor generated by
`os.dup(original.fileno())`.  See spack/llnl/util/lang.py, line
394-ish.

This happens when run under `nohup`, which supposedly has hooked
`stdin` to `/dev/null`.

It seems like opening and using `devnull` on the `input_stream` in
this situation is a reasonable way to handle the problem.