### PR TITLE
Add missing dependencies to unixodbc

### DIFF
--- a/var/spack/repos/builtin/packages/unixodbc/package.py
+++ b/var/spack/repos/builtin/packages/unixodbc/package.py
@@ -34,3 +34,6 @@ class Unixodbc(AutotoolsPackage):
     url      = "http://www.unixodbc.org/unixODBC-2.3.4.tar.gz"
 
     version('2.3.4', 'bd25d261ca1808c947cb687e2034be81')
+
+    depends_on('libiconv')
+    depends_on('libtool')


### PR DESCRIPTION
This package was missing a couple dependencies:
```
$ otool -L /Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/unixodbc-2.3.4-pz4czpp3clpiodpm5byyvdagz3ypf56l/lib/libodbc.dylib 
/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/unixodbc-2.3.4-pz4czpp3clpiodpm5byyvdagz3ypf56l/lib/libodbc.dylib:
	/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/unixodbc-2.3.4-pz4czpp3clpiodpm5byyvdagz3ypf56l/lib/libodbc.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/libtool-2.4.6-q23qd54bfr5xuap4czntyfaysgxduc53/lib/libltdl.7.dylib (compatibility version 11.0.0, current version 11.1.0)
	/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/libiconv-1.15-3pfd5n5zhqyqxvtt7gfc6ggjafdpuf2e/lib/libiconv.2.dylib (compatibility version 9.0.0, current version 9.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
```
Some of the installed binaries also link to `libedit`. However, adding a `libedit` dependency didn't seem to work.