### PR TITLE
New package for canu

### DIFF
--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -34,8 +34,9 @@ class Canu(MakefilePackage):
 
     version('1.5', '65df275baa28ecf11b15dfd7343361e3')
 
-    depends_on('perl')
+    depends_on('gnuplot')
     depends_on('jdk')
+    depends_on('perl')
 
     build_directory = 'src'
 
@@ -43,7 +44,7 @@ class Canu(MakefilePackage):
         # Use our perl, not whatever is in the environment
         perl=self.spec['perl'].prefix.bin.perl
         filter_file(r'^#!/usr/bin/env perl',
-                    '#!{0}'.format(perl)
+                    '#!{0}'.format(perl),
                     'src/pipelines/canu.pl')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -1,0 +1,60 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Canu(MakefilePackage):
+    """A single molecule sequence assembler for genomes large and
+       small."""
+
+    homepage = "http://canu.readthedocs.io/"
+    url      = "https://github.com/marbl/canu/archive/v1.5.tar.gz"
+
+    version('1.5', '65df275baa28ecf11b15dfd7343361e3')
+
+    depends_on('perl')
+    depends_on('jdk')
+
+    build_directory = 'src'
+
+    def patch(self):
+        # Use our perl, not whatever is in the environment
+        perl=self.spec['perl'].prefix.bin.perl
+        filter_file(r'^#!/usr/bin/env perl',
+                    '#!{0}'.format(perl)
+                    'src/pipelines/canu.pl')
+
+    def install(self, spec, prefix):
+        # replicate the Makefile logic here:
+        # https://github.com/marbl/canu/blob/master/src/Makefile#L344
+        uname = which('uname')
+        ostype = uname(output=str).strip()
+        machinetype = uname('-m', output=str).strip()
+        if machinetype == 'x86_64':
+            machinetype = 'amd64'
+        target_dir = '{0}-{1}'.format(ostype, machinetype)
+        bin = join_path(target_dir, 'bin')
+
+        install_tree(bin, prefix.bin)

--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -34,15 +34,15 @@ class Canu(MakefilePackage):
 
     version('1.5', '65df275baa28ecf11b15dfd7343361e3')
 
-    depends_on('gnuplot')
-    depends_on('jdk')
-    depends_on('perl')
+    depends_on('gnuplot', type='run')
+    depends_on('jdk', type='run')
+    depends_on('perl', type='run')
 
     build_directory = 'src'
 
     def patch(self):
         # Use our perl, not whatever is in the environment
-        perl=self.spec['perl'].prefix.bin.perl
+        perl = self.spec['perl'].prefix.bin.perl
         filter_file(r'^#!/usr/bin/env perl',
                     '#!{0}'.format(perl),
                     'src/pipelines/canu.pl')


### PR DESCRIPTION
Add a package for canu.

There's a top-level perl script, which is touched up to use a spack-built perl instead of `#!/usr/bin/env perl`.  It's self-contained, it uses `FindBin` to locate it's libraries.

There's also a barely mentioned dependency on gnuplot.
