### PR TITLE
qt creator does not build with newer sqlite

### DIFF
--- a/var/spack/repos/builtin/packages/qt-creator/package.py
+++ b/var/spack/repos/builtin/packages/qt-creator/package.py
@@ -37,6 +37,7 @@ class QtCreator(Package):
     version('4.1.0',  '657727e4209befa4bf5889dff62d9e0a')
 
     depends_on("qt")
+    depends_on("sqlite@3.8.5")
 
     def install(self, spec, prefix):
         os.environ['INSTALL_ROOT'] = self.prefix


### PR DESCRIPTION
This is a bit of a hack, but qt-creator has a transitive dependence on sqlite (qt-creator -> qt -> python -> sqlite). With sqlite 3.18.0, qt-creator fails to build because of redfinitions of types. It appears this happens because qt-creator ships with its own sqlite that it uses to build, however, spack adds the include path of the transitive dependence sqlite. The header file of the qt-creator sqlite has different macro formats for #ifndef and #define pairs than the 3.18.0 sqlite and thus two versions of the sqlite headers are included. By forcing qt-creator to depend on the older 3.8.5 sqlite, the header files use the same macro format and thus only get included once. The macro in 3.8.5 is `_SQLITE3_H_`, while the 3.18.0 removes the leading and ending underscore and is thus `SQLITE3_H`. I hope that all made sense.

Anyway, I don't know if there is a way to hide a transitive dependence, as that would be a real solution. I also did not see a way to tell qt-creator to use an external sqlite. In the absence of being able to do either of those, this PR is my work around. @tgamblin @becker33 @adamjstewart let me know if you have any thoughts.