### PR TITLE
Version: Dev -> Develop

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -37,7 +37,7 @@ class Libsplash(CMakePackage):
     homepage = "https://github.com/ComputationalRadiationPhysics/libSplash"
     url      = "https://github.com/ComputationalRadiationPhysics/libSplash/archive/v1.4.0.tar.gz"
 
-    version('dev', branch='dev',
+    version('develop', branch='dev',
             git='https://github.com/ComputationalRadiationPhysics/libSplash.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/libSplash.git')

--- a/var/spack/repos/builtin/packages/mallocmc/package.py
+++ b/var/spack/repos/builtin/packages/mallocmc/package.py
@@ -40,7 +40,7 @@ class Mallocmc(CMakePackage):
     homepage = "https://github.com/ComputationalRadiationPhysics/mallocMC"
     url      = "https://github.com/ComputationalRadiationPhysics/mallocMC/archive/2.2.0crp.tar.gz"
 
-    version('dev', branch='dev',
+    version('develop', branch='dev',
             git='https://github.com/ComputationalRadiationPhysics/mallocMC.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/mallocMC.git')

--- a/var/spack/repos/builtin/packages/pngwriter/package.py
+++ b/var/spack/repos/builtin/packages/pngwriter/package.py
@@ -38,7 +38,7 @@ class Pngwriter(CMakePackage):
     homepage = "http://pngwriter.sourceforge.net/"
     url      = "https://github.com/pngwriter/pngwriter/archive/0.5.6.tar.gz"
 
-    version('dev', branch='dev',
+    version('develop', branch='dev',
             git='https://github.com/pngwriter/pngwriter.git')
     version('master', branch='master',
             git='https://github.com/pngwriter/pngwriter.git')


### PR DESCRIPTION
Adjust the [HZDR CRP packages](https://github.com/ComputationalRadiationPhysics) with the properly defined version label "develop" which is now standardized in spack.