### PR TITLE
Moab depends on BLAS.

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -49,7 +49,7 @@ class Moab(AutotoolsPackage):
             description='Required to enable the hdf5 (default I/O) format')
     variant('netcdf', default=False,
             description='Required to enable the ExodusII reader/writer.')
-    variant('pnetcdf', default=False, 
+    variant('pnetcdf', default=False,
             description='Enable pnetcdf (AKA parallel-netcdf) support')
     variant('netcdf', default=False,
             description='Required to enable the ExodusII reader/writer.')
@@ -57,7 +57,7 @@ class Moab(AutotoolsPackage):
     variant('cgm', default=False, description='Enable common geometric module')
     variant('metis', default=True, description='Enable metis link')
     variant('parmetis', default=True, description='Enable parmetis link')
-    variant('irel', default=False, description='Enable irel interface') 
+    variant('irel', default=False, description='Enable irel interface')
     variant('fbigeom', default=False, description='Enable fbigeom interface')
     variant('coupler', default=True, description='Enable mbcoupler tool')
 
@@ -79,6 +79,7 @@ class Moab(AutotoolsPackage):
     # depends_on('cgns', when='+cgns')
     # depends_on('vtk', when='+vtk')
 
+    depends_on('blas')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5', when='+hdf5')
     depends_on('hdf5+mpi', when='+hdf5+mpi')


### PR DESCRIPTION
I can't build MOAB without adding `depends_on('blas')` to the `package.py`.  Without this addition, the configure step fails with "BLAS not found".  