### PR TITLE
Fix for spack gpg test failures on CentOS 7 with system gpg.

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -88,7 +88,7 @@ def setup_parser(subparser):
     list.set_defaults(func=gpg_list)
 
     init = subparsers.add_parser('init')
-    init.add_argument('import_dir',type=str,
+    init.add_argument('import_dir', type=str,
                       help=argparse.SUPPRESS)
     init.set_defaults(func=gpg_init)
     init.set_defaults(import_dir=spack.gpg_keys_path)

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -25,6 +25,7 @@
 from spack.util.gpg import Gpg
 import spack
 import os
+import argparse
 
 description = "handle GPG actions for spack"
 section = "developer"
@@ -88,8 +89,7 @@ def setup_parser(subparser):
 
     init = subparsers.add_parser('init')
     init.add_argument('import_dir',type=str,
-                      help='directory to import keys to trust;'+
-                           'defaults to spack/var/spack/gpg')
+                      help=argparse.SUPPRESS)
     init.set_defaults(func=gpg_init)
     init.set_defaults(import_dir=spack.gpg_keys_path)
 

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -87,6 +87,9 @@ def setup_parser(subparser):
     list.set_defaults(func=gpg_list)
 
     init = subparsers.add_parser('init')
+    init.add_argument('import_dir',type=str,
+                      help='directory to import keys to trust;'+
+                           'defaults to spack/var/spack/gpg')
     init.set_defaults(func=gpg_init)
     init.set_defaults(import_dir=spack.gpg_keys_path)
 

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -59,6 +59,7 @@ def has_gnupg2():
     except Exception:
         return False
 
+
 @pytest.mark.xfail  # TODO: fix failing tests.
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
@@ -68,7 +69,7 @@ def test_gpg(gpg, tmpdir, testing_gpg_directory, mock_gpg_config):
         gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
     # Import the default key.
-    gpg('init',spack.mock_gpg_keys_path)
+    gpg('init', spack.mock_gpg_keys_path)
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -59,7 +59,6 @@ def has_gnupg2():
     except Exception:
         return False
 
-
 @pytest.mark.xfail  # TODO: fix failing tests.
 @pytest.mark.skipif(not has_gnupg2(),
                     reason='These tests require gnupg2')
@@ -68,8 +67,8 @@ def test_gpg(gpg, tmpdir, testing_gpg_directory, mock_gpg_config):
     with pytest.raises(ProcessError):
         gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
-    # Import the default key.
-    gpg('init')
+    # Trust the default key.
+    gpg('init',spack.mock_gpg_keys_path)
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -67,7 +67,7 @@ def test_gpg(gpg, tmpdir, testing_gpg_directory, mock_gpg_config):
     with pytest.raises(ProcessError):
         gpg('verify', os.path.join(spack.mock_gpg_data_path, 'content.txt'))
 
-    # Trust the default key.
+    # Import the default key.
     gpg('init',spack.mock_gpg_keys_path)
 
     # List the keys.


### PR DESCRIPTION
Add the option input_path to spack gpg init so it can be changed to mock_gpg path.