### PR TITLE
savanna depends on adios+sz

### DIFF
--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +fortran +staging')
+    depends_on('adios +fortran +zlib +sz +zfp +staging')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +fortran +sz +staging')
+    depends_on('adios +fortran +staging')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 

--- a/var/spack/repos/builtin/packages/savanna/package.py
+++ b/var/spack/repos/builtin/packages/savanna/package.py
@@ -43,7 +43,7 @@ class Savanna(MakefilePackage):
 
     depends_on('mpi')
     depends_on('stc')
-    depends_on('adios +fortran +staging')
+    depends_on('adios +fortran +sz +staging')
     depends_on('mpix-launch-swift')
     depends_on('tau', when='+tau')
 


### PR DESCRIPTION
Explicitly adding variant sz to adios since it is no longer enabled by default in adios