### PR TITLE
Qt: disable OpenGL support by default

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -65,7 +65,7 @@ class Qt(Package):
             description="Build with D-Bus support.")
     variant('phonon',     default=False,
             description="Build with phonon support.")
-    variant('opengl',     default=True,
+    variant('opengl',     default=False,
             description="Build with OpenGL support.")
 
     patch('qt3krell.patch', when='@3.3.8b+krellpatch')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -53,8 +53,6 @@ class Qt(Package):
     # OpenSpeedShop project
     variant('krellpatch', default=False,
             description="Build with openspeedshop based patch.")
-    variant('mesa',       default=False,
-            description="Depend on mesa.")
     variant('gtk',        default=False,
             description="Build with gtkplus.")
     variant('webkit',     default=False,
@@ -109,7 +107,7 @@ class Qt(Package):
     depends_on("python", when='@5.7.0:', type='build')
 
     # OpenGL hardware acceleration
-    depends_on("mesa", when='@4:+mesa')
+    depends_on("mesa", when='@4:+opengl')
     depends_on("libxcb", when=sys.platform != 'darwin')
     depends_on("libx11", when=sys.platform != 'darwin')
 


### PR DESCRIPTION
See #4961 

`+opengl` is the only variant enabled by default for the `qt` package. Ironically, it is the only variant that doesn't work. Spack does not have a package that provides the OpenGL libraries. I thought `mesa` was supposed to, but it clearly isn't working. This PR disables the variant by default. If you happen to have OpenGL installed on your system and want to build `qt+opengl`, be my guest. But if you don't, the default variant should not fail for you.

P.S. We are missing the vast majority of Qt's dependencies. Run `./configure -list-libraries` if you are curious.

P.P.S. I hate Qt