### PR TITLE
Changed every 'fpic' variant to 'pic'

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -103,13 +103,12 @@ class Adios(AutotoolsPackage):
         spec = self.spec
         self.validate(spec)
 
-        extra_args = []
-
-        # required, otherwise building its python bindings on ADIOS will fail
-        extra_args.append("CFLAGS=-fPIC")
-
-        # always build external MXML, even in ADIOS 1.10.0+
-        extra_args.append('--with-mxml=%s' % spec['mxml'].prefix)
+        extra_args = [
+            # required, otherwise building its python bindings will fail
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
+            # always build external MXML, even in ADIOS 1.10.0+
+            '--with-mxml={0}'.format(spec['mxml'].prefix)
+        ]
 
         if '+shared' in spec:
             extra_args.append('--enable-shared')

--- a/var/spack/repos/builtin/packages/arpack/package.py
+++ b/var/spack/repos/builtin/packages/arpack/package.py
@@ -60,7 +60,9 @@ class Arpack(Package):
 
         # Be sure to use the Spack compiler wrapper
         makefile.filter('^FC.*', 'FC = {0}'.format(os.environ['F77']))
-        makefile.filter('^FFLAGS.*', 'FFLAGS = -O2 -g -fPIC')
+        makefile.filter(
+            '^FFLAGS.*', 'FFLAGS = -O2 -g {0}'.format(self.compiler.pic_flag)
+        )
 
         if not which('ranlib'):
             makefile.filter('^RANLIB.*', 'RANLIB = touch')

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -78,7 +78,7 @@ class Cantera(Package):
             'CXX={0}'.format(os.environ['CXX']),
             'F77={0}'.format(os.environ['F77']),
             'FORTRAN={0}'.format(os.environ['FC']),
-            'cc_flags=-fPIC',
+            'cc_flags={0}'.format(self.compiler.pic_flag),
             # Allow Spack environment variables to propagate through to SCons
             'env_vars=all'
         ]

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -51,7 +51,7 @@ class Hdf(AutotoolsPackage):
         spec = self.spec
 
         config_args = [
-            'CFLAGS=-fPIC',
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
             '--with-jpeg={0}'.format(spec['jpeg'].prefix),
             '--with-zlib={0}'.format(spec['zlib'].prefix),
             '--disable-netcdf',  # must be disabled to build NetCDF with HDF4

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -74,7 +74,7 @@ class Lammps(MakefilePackage):
             config.append('CCFLAGS = -fopenmp')
             config.append('LINKFLAGS = -fopenmp $(OPTFLAGS)')
 
-        config.append('SHFLAGS = -fPIC')
+        config.append('SHFLAGS = {0}'.format(self.compiler.pic_flag))
         config.append('DEPFLAGS = -M')
         config.append('LINK = c++')
 

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -91,7 +91,7 @@ class Metis(Package):
             raise InstallError('METIS@:4 does not support the following '
                                'variants: gdb, int64, real64.')
 
-        options = ['COPTIONS=-fPIC']
+        options = ['COPTIONS={0}'.format(self.compiler.pic_flag)]
         if '+debug' in spec:
             options.append('OPTFLAGS=-g -O0')
         make(*options)
@@ -119,7 +119,7 @@ class Metis(Package):
             install(sharefile, prefix.share)
 
         if '+shared' in spec:
-            shared_flags = ['-fPIC', '-shared']
+            shared_flags = [self.compiler.pic_flag, '-shared']
             if sys.platform == 'darwin':
                 shared_suffix = 'dylib'
                 shared_flags.extend(['-Wl,-all_load', 'libmetis.a'])

--- a/var/spack/repos/builtin/packages/mxml/package.py
+++ b/var/spack/repos/builtin/packages/mxml/package.py
@@ -50,7 +50,7 @@ class Mxml(AutotoolsPackage):
     def configure_args(self):
         return [
             # ADIOS build with -fPIC, so we need it too (avoid linkage issue)
-            'CFLAGS=-fPIC',
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
             # Default is non-shared, but avoid any future surprises
             '--disable-shared',
         ]

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -39,7 +39,7 @@ class Nalu(CMakePackage):
             git='https://github.com/NaluCFD/Nalu.git', branch='master')
 
     # Currently Nalu only builds static libraries; To be fixed soon
-    depends_on('yaml-cpp+fpic~shared')
+    depends_on('yaml-cpp+pic~shared')
     depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf@master')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -133,7 +133,7 @@ class Netcdf(AutotoolsPackage):
             config_args.append('--disable-shared')
             # We don't have shared libraries but we still want it to be
             # possible to use this library in shared builds
-            CFLAGS.append('-fPIC')
+            CFLAGS.append(self.compiler.pic_flag)
 
         if '+dap' in spec:
             config_args.append('--enable-dap')

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -46,9 +46,9 @@ class NetlibScalapack(CMakePackage):
         description='Build the shared library version'
     )
     variant(
-        'fpic',
+        'pic',
         default=False,
-        description='Build with -fpic compiler option'
+        description='Build position independent code'
     )
 
     provides('scalapack')
@@ -87,10 +87,10 @@ class NetlibScalapack(CMakePackage):
             '-DBLAS_LIBRARIES=%s' % (blas.joined(';'))
         ])
 
-        if '+fpic' in spec:
+        if '+pic' in spec:
             options.extend([
-                "-DCMAKE_C_FLAGS=-fPIC",
-                "-DCMAKE_Fortran_FLAGS=-fPIC"
+                "-DCMAKE_C_FLAGS=%s" % self.compiler.pic_flag,
+                "-DCMAKE_Fortran_FLAGS=%s" % self.compiler.pic_flag
             ])
 
         return options

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -41,4 +41,8 @@ class Otf2(AutotoolsPackage):
     version('1.2.1', '8fb3e11fb7489896596ae2c7c83d7fc8')
 
     def configure_args(self):
-        return ["--enable-shared", "CFLAGS=-fPIC", "CXXFLAGS=-fPIC"]
+        return [
+            '--enable-shared',
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
+            'CXXFLAGS={0}'.format(self.compiler.pic_flag)
+        ]

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -40,7 +40,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
     variant('cxx', default=True, description='Build the C++ Interface')
     variant('fortran', default=True, description='Build the Fortran Interface')
-    variant('fpic', default=True,
+    variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
 
     depends_on('mpi')
@@ -53,12 +53,18 @@ class ParallelNetcdf(AutotoolsPackage):
         spec = self.spec
 
         args = ['--with-mpi={0}'.format(spec['mpi'].prefix)]
-        args.append('SEQ_CC=%s' % spack_cc)
+        args.append('SEQ_CC={0}'.format(spack_cc))
 
-        if '+fpic' in spec:
-            args.extend(['CFLAGS=-fPIC', 'CXXFLAGS=-fPIC', 'FFLAGS=-fPIC'])
+        if '+pic' in spec:
+            args.extend([
+                'CFLAGS={0}'.format(self.compiler.pic_flag),
+                'CXXFLAGS={0}'.format(self.compiler.pic_flag),
+                'FFLAGS={0}'.format(self.compiler.pic_flag)
+            ])
+
         if '~cxx' in spec:
             args.append('--disable-cxx')
+
         if '~fortran' in spec:
             args.append('--disable-fortran')
 

--- a/var/spack/repos/builtin/packages/parmgridgen/package.py
+++ b/var/spack/repos/builtin/packages/parmgridgen/package.py
@@ -47,8 +47,8 @@ class Parmgridgen(Package):
     def install(self, spec, prefix):
         make_opts = [
             'make=make',
-            'COPTIONS=-fPIC',
-            'LDOPTIONS=-fPIC',
+            'COPTIONS={0}'.format(self.compiler.pic_flag),
+            'LDOPTIONS={0}'.format(self.compiler.pic_flag),
             'CC={0}'.format(self.compiler.cc),
             'LD={0}'.format(self.compiler.cc),
             'LIBDIR=-L../..',

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -88,5 +88,8 @@ class Scorep(AutotoolsPackage):
         if '~shmem' in spec:
             config_args.append("--without-shmem")
 
-        config_args.extend(["CFLAGS=-fPIC", "CXXFLAGS=-fPIC"])
+        config_args.extend([
+            'CFLAGS={0}'.format(self.compiler.pic_flag),
+            'CXXFLAGS={0}'.format(self.compiler.pic_flag)
+        ])
         return config_args

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -129,7 +129,9 @@ class Scotch(Package):
             if self.spec.satisfies('platform=darwin'):
                 makefile_inc.extend([
                     'LIB       = .dylib',
-                    'CLIBFLAGS = -dynamiclib -fPIC',
+                    'CLIBFLAGS = -dynamiclib {0}'.format(
+                        self.compiler.pic_flag
+                    ),
                     'RANLIB    = echo',
                     'AR        = $(CC)',
                     'ARFLAGS   = -dynamiclib $(LDFLAGS) -Wl,-install_name -Wl,%s/$(notdir $@) -undefined dynamic_lookup -o ' % prefix.lib  # noqa
@@ -137,12 +139,12 @@ class Scotch(Package):
             else:
                 makefile_inc.extend([
                     'LIB       = .so',
-                    'CLIBFLAGS = -shared -fPIC',
+                    'CLIBFLAGS = -shared {0}'.format(self.compiler.pic_flag),
                     'RANLIB    = echo',
                     'AR        = $(CC)',
                     'ARFLAGS   = -shared $(LDFLAGS) -o'
                 ])
-            cflags.append('-fPIC')
+            cflags.append(self.compiler.pic_flag)
         else:
             makefile_inc.extend([
                 'LIB       = .a',

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -58,8 +58,8 @@ class Sundials(Package):
         cmake_args = std_cmake_args[:]
         cmake_args.extend([
             '-DBUILD_SHARED_LIBS=ON',
-            '-DCMAKE_C_FLAGS=-fPIC',
-            '-DCMAKE_Fortran_FLAGS=-fPIC',
+            '-DCMAKE_C_FLAGS={0}'.format(self.compiler.pic_flag),
+            '-DCMAKE_Fortran_FLAGS={0}'.format(self.compiler.pic_flag),
             '-DEXAMPLES_ENABLE=ON',
             '-DEXAMPLES_INSTALL=ON',
             '-DFCMIX_ENABLE=ON'

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -38,7 +38,7 @@ class Superlu(Package):
     version('5.2.1', '3a1a9bff20cb06b7d97c46d337504447')
     version('4.3', 'b72c6309f25e9660133007b82621ba7c')
 
-    variant('fpic',    default=True,
+    variant('pic',    default=True,
             description='Build with position independent code')
 
     depends_on('cmake', when='@5.2.1:', type='build')
@@ -51,7 +51,7 @@ class Superlu(Package):
             '-DBLAS_blas_LIBRARY={0}'.format(spec['blas'].libs.joined())
         ]
 
-        if '+fpic' in spec:
+        if '+pic' in spec:
             cmake_args.extend([
                 '-DCMAKE_POSITION_INDEPENDENT_CODE=ON'
             ])
@@ -89,7 +89,7 @@ class Superlu(Package):
             'CDEFS      = -DAdd_'
         ])
 
-        if '+fpic' in spec:
+        if '+pic' in spec:
             config.extend([
                 # Use these lines instead when pic_flag capability arrives
                 'CFLAGS     = -O3 {0}'.format(self.compiler.pic_flag),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -177,7 +177,7 @@ class Trilinos(CMakePackage):
 
     # ###################### Dependencies ##########################
 
-    # Everything should be compiled with -fpic
+    # Everything should be compiled position independent (-fpic)
     depends_on('blas')
     depends_on('lapack')
     depends_on('boost', when='+boost')
@@ -207,7 +207,7 @@ class Trilinos(CMakePackage):
     depends_on('superlu-dist', when='@12.6.2:+superlu-dist')
     depends_on('superlu-dist@develop', when='@develop+superlu-dist')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0+superlu-dist')
-    depends_on('superlu+fpic@4.3', when='+superlu')
+    depends_on('superlu+pic@4.3', when='+superlu')
     # Trilinos can not be built against 64bit int hypre
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0+hypre')

--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -36,7 +36,7 @@ class YamlCpp(CMakePackage):
 
     variant('shared', default=True,
             description='Enable build of shared libraries')
-    variant('fpic',   default=True,
+    variant('pic',   default=True,
             description='Build with position independent code')
 
     depends_on('boost', when='@:0.5.3')
@@ -49,7 +49,7 @@ class YamlCpp(CMakePackage):
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                 'ON' if '+shared' in spec else 'OFF'),
             '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
-                'ON' if '+fpic' in spec else 'OFF'),
+                'ON' if '+pic' in spec else 'OFF'),
         ])
 
         return options

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -76,7 +76,7 @@ class Zoltan(Package):
         if '+shared' in spec:
             config_args.append('RANLIB=echo')
             config_args.append('--with-ar=$(CXX) -shared $(LDFLAGS) -o')
-            config_cflags.append('-fPIC')
+            config_cflags.append(self.compiler.pic_flag)
             if spec.satisfies('%gcc'):
                 config_args.append('--with-libs={0}'.format('-lgfortran'))
 


### PR DESCRIPTION
fixes #2463
closes #2479 (supersedes)

Every variant that activates compilation of position independent code has been changed to 'pic'. Hardcoded compiler flags in modified packages have been substituted with `self.compiler.pic_flag`.