### PR TITLE
Make GCC binutils variant default to False

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -69,7 +69,7 @@ class Gcc(AutotoolsPackage):
             multi=True,
             description='Compilers and runtime libraries to build')
     variant('binutils',
-            default=sys.platform != 'darwin',
+            default=False,
             description='Build via binutils')
     variant('piclibs',
             default=False,


### PR DESCRIPTION
Fixes #4972 (@samfux84)
Fixes #3943 (@JusticeForMikeBrown)
Fixes #2722 (@weijianwen)
Fixes #2301 (@aprokop)
Fixes #2044 (@adamjstewart @svenevs)
Fixes #1866 (@willfurnass @sknigh @jcftang @baberlevi)
Fixes #1487 (@Astran @eschnett)

I have also received separate reports from @ssergien and @befritz that `gcc+binutils` does not build but `gcc~binutils` does.

I have personally never been able to get `gcc+binutils` to build. I've tried on CentOS 6, CentOS 7, Fedora, and macOS. I've tried multiple versions of GCC and binutils.

I'm fine with keeping this variant around, but until it works reliably it certainly shouldn't be the default. GCC is one of the first packages that new Spack users try to build. It needs to _Just Work_.