### PR TITLE
Version: dev -> develop (for openfoam-org)

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -79,7 +79,7 @@ class OpenfoamOrg(Package):
 
     version('4.1', '318a446c4ae6366c7296b61184acd37c',
             url=baseurl + '/OpenFOAM-4.x/archive/version-4.1.tar.gz')
-    version('dev', git='https://github.com/OpenFOAM/OpenFOAM-dev.git')
+    version('develop', git='https://github.com/OpenFOAM/OpenFOAM-dev.git')
 
     variant('int64', default=False,
             description='Compile with 64-bit label')


### PR DESCRIPTION
This was the change that should have also been in PR #4947, except that my comment was too confusing