### PR TITLE
Massive conversion from Package to CMakePackage

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -333,6 +333,7 @@ def set_module_variables_for_package(pkg, module):
     m.make = MakeExecutable('make', jobs)
     m.gmake = MakeExecutable('gmake', jobs)
     m.scons = MakeExecutable('scons', jobs)
+    m.ninja = MakeExecutable('ninja', jobs)
 
     # easy shortcut to os.environ
     m.env = os.environ

--- a/var/spack/repos/builtin/packages/adept-utils/package.py
+++ b/var/spack/repos/builtin/packages/adept-utils/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class AdeptUtils(Package):
+class AdeptUtils(CMakePackage):
     """Utility libraries for LLNL performance tools."""
 
     homepage = "https://github.com/llnl/adept-utils"
@@ -34,11 +34,6 @@ class AdeptUtils(Package):
     version('1.0.1', '731a310717adcb004d9d195130efee7d')
     version('1.0',   '5c6cd9badce56c945ac8551e34804397')
 
-    depends_on("boost")
-    depends_on("mpi")
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake(*std_cmake_args)
-        make()
-        make("install")
+    depends_on('boost')
+    depends_on('mpi')
+    depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -23,10 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.util.environment import *
 
 
-class Apex(Package):
+class Apex(CMakePackage):
     homepage = "http://github.com/khuck/xpress-apex"
     url      = "http://github.com/khuck/xpress-apex/archive/v0.1.tar.gz"
 
@@ -38,19 +37,13 @@ class Apex(Package):
     depends_on("activeharmony@4.5:")
     depends_on("ompt-openmp")
 
-    def install(self, spec, prefix):
-
-        path = get_path("PATH")
-        path.remove(spec["binutils"].prefix.bin)
-        path_set("PATH", path)
-        with working_dir("build", create=True):
-            cmake('-DBOOST_ROOT=%s' % spec['boost'].prefix,
-                  '-DUSE_BFD=TRUE',
-                  '-DBFD_ROOT=%s' % spec['binutils'].prefix,
-                  '-DUSE_ACTIVEHARMONY=TRUE',
-                  '-DACTIVEHARMONY_ROOT=%s' % spec['activeharmony'].prefix,
-                  '-DUSE_OMPT=TRUE',
-                  '-DOMPT_ROOT=%s' % spec['ompt-openmp'].prefix,
-                  '..', *std_cmake_args)
-            make()
-            make("install")
+    def cmake_args(self):
+        return [
+            '-DBOOST_ROOT=%s' % spec['boost'].prefix,
+            '-DUSE_BFD=TRUE',
+            '-DBFD_ROOT=%s' % spec['binutils'].prefix,
+            '-DUSE_ACTIVEHARMONY=TRUE',
+            '-DACTIVEHARMONY_ROOT=%s' % spec['activeharmony'].prefix,
+            '-DUSE_OMPT=TRUE',
+            '-DOMPT_ROOT=%s' % spec['ompt-openmp'].prefix,
+        ]

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class Archer(Package):
+class Archer(CMakePackage):
     """ARCHER, a data race detection tool for large OpenMP applications."""
 
     homepage = "https://github.com/PRUNERS/ARCHER"
@@ -34,23 +34,24 @@ class Archer(Package):
 
     version('1.0.0', '790bfaf00b9f57490eb609ecabfe954a')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@3.4.3:', type='build')
     depends_on('llvm')
     depends_on('ninja', type='build')
     depends_on('llvm-openmp-ompt')
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
+        return [
+            '-G', 'Ninja',
+            '-DCMAKE_C_COMPILER=clang',
+            '-DCMAKE_CXX_COMPILER=clang++',
+            '-DOMP_PREFIX:PATH=%s' % spec['llvm-openmp-ompt'].prefix,
+        ]
 
-        with working_dir('spack-build', create=True):
-            cmake_args = std_cmake_args[:]
-            cmake_args.extend([
-                '-G', 'Ninja',
-                '-DCMAKE_C_COMPILER=clang',
-                '-DCMAKE_CXX_COMPILER=clang++',
-                '-DOMP_PREFIX:PATH=%s' % spec['llvm-openmp-ompt'].prefix,
-            ])
-
-            cmake('..', *cmake_args)
-            ninja = Executable('ninja')
+    # TODO: Add better ninja support to CMakePackage
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
             ninja()
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
             ninja('install')

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Armadillo(Package):
+class Armadillo(CMakePackage):
     """Armadillo is a high quality linear algebra library (matrix maths)
     for the C++ language, aiming towards a good balance between speed and
     ease of use."""
@@ -40,19 +40,21 @@ class Armadillo(Package):
 
     variant('hdf5', default=False, description='Include HDF5 support')
 
-    depends_on('cmake@2.8:', type='build')
+    depends_on('cmake@2.8.12:', type='build')
     depends_on('arpack-ng')  # old arpack causes undefined symbols
     depends_on('blas')
     depends_on('lapack')
     depends_on('superlu@5.2:')
     depends_on('hdf5', when='+hdf5')
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
+        spec = self.spec
+
         arpack = find_libraries('libarpack', root=spec[
                                 'arpack-ng'].prefix.lib, shared=True)
         superlu = find_libraries('libsuperlu', root=spec[
                                  'superlu'].prefix, shared=False, recurse=True)
-        cmake_args = [
+        return [
             # ARPACK support
             '-DARPACK_LIBRARY={0}'.format(arpack.joined()),
             # BLAS support
@@ -65,9 +67,3 @@ class Armadillo(Package):
             # HDF5 support
             '-DDETECT_HDF5={0}'.format('ON' if '+hdf5' in spec else 'OFF')
         ]
-
-        cmake_args.extend(std_cmake_args)
-        cmake('.', *cmake_args)
-
-        make()
-        make('install')

--- a/var/spack/repos/builtin/packages/automaded/package.py
+++ b/var/spack/repos/builtin/packages/automaded/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Automaded(Package):
+class Automaded(CMakePackage):
     """AutomaDeD (Automata-based Debugging for Dissimilar parallel
        tasks) is a tool for automatic diagnosis of performance and
        correctness problems in MPI applications. It creates
@@ -45,9 +45,7 @@ class Automaded(Package):
     depends_on('mpi')
     depends_on('boost')
     depends_on('callpath')
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8:', type='build')
 
-    def install(self, spec, prefix):
-        cmake("-DSTATE_TRACKER_WITH_CALLPATH=ON", *std_cmake_args)
-        make()
-        make("install")
+    def cmake_args(self):
+        return ['-DSTATE_TRACKER_WITH_CALLPATH=ON']

--- a/var/spack/repos/builtin/packages/bear/package.py
+++ b/var/spack/repos/builtin/packages/bear/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Bear(Package):
+class Bear(CMakePackage):
     """Bear is a tool that generates a compilation database for clang tooling
     from non-cmake build systems."""
     homepage = "https://github.com/rizsotto/Bear"
@@ -34,11 +34,5 @@ class Bear(Package):
     version('2.2.0', '87250cc3a9a697e7d1e8972253a35259')
     version('2.0.4', 'fd8afb5e8e18f8737ba06f90bd77d011')
 
-    depends_on('cmake', type='build')
-    depends_on("python")
-
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-
-        make("all")
-        make("install")
+    depends_on('python')
+    depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/bpp-core/package.py
+++ b/var/spack/repos/builtin/packages/bpp-core/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class BppCore(Package):
+class BppCore(CMakePackage):
     """Bio++ core library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
@@ -33,9 +33,7 @@ class BppCore(Package):
 
     version('2.2.0', '5789ed2ae8687d13664140cd77203477')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.6:', type='build')
 
-    def install(self, spec, prefix):
-        cmake('-DBUILD_TESTING=FALSE', '.', *std_cmake_args)
-        make()
-        make('install')
+    def cmake_args(self):
+        return ['-DBUILD_TESTING=FALSE']

--- a/var/spack/repos/builtin/packages/bpp-phyl/package.py
+++ b/var/spack/repos/builtin/packages/bpp-phyl/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class BppPhyl(Package):
+class BppPhyl(CMakePackage):
     """Bio++ phylogeny library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
@@ -33,11 +33,9 @@ class BppPhyl(Package):
 
     version('2.2.0', '5c40667ec0bf37e0ecaba321be932770')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.6:', type='build')
     depends_on('bpp-core')
     depends_on('bpp-seq')
 
-    def install(self, spec, prefix):
-        cmake('-DBUILD_TESTING=FALSE', '.', *std_cmake_args)
-        make()
-        make('install')
+    def cmake_args(self):
+        return ['-DBUILD_TESTING=FALSE']

--- a/var/spack/repos/builtin/packages/bpp-seq/package.py
+++ b/var/spack/repos/builtin/packages/bpp-seq/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class BppSeq(Package):
+class BppSeq(CMakePackage):
     """Bio++ seq library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
@@ -33,10 +33,8 @@ class BppSeq(Package):
 
     version('2.2.0', '44adef0ff4d5ca4e69ccf258c9270633')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.6:', type='build')
     depends_on('bpp-core')
 
-    def install(self, spec, prefix):
-        cmake('-DBUILD_TESTING=FALSE', '.', *std_cmake_args)
-        make()
-        make('install')
+    def cmake_args(self):
+        return ['-DBUILD_TESTING=FALSE']

--- a/var/spack/repos/builtin/packages/bpp-suite/package.py
+++ b/var/spack/repos/builtin/packages/bpp-suite/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class BppSuite(Package):
+class BppSuite(CMakePackage):
     """BppSuite is a suite of ready-to-use programs for phylogenetic and
        sequence analysis."""
 
@@ -34,13 +34,8 @@ class BppSuite(Package):
 
     version('2.2.0', 'd8b29ad7ccf5bd3a7beb701350c9e2a4')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.6:', type='build')
     depends_on('texinfo', type='build')
     depends_on('bpp-core')
     depends_on('bpp-seq')
     depends_on('bpp-phyl')
-
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-        make()
-        make('install')

--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -28,7 +28,7 @@ import sys
 from spack import *
 
 
-class CBlosc(Package):
+class CBlosc(CMakePackage):
     """Blosc, an extremely fast, multi-threaded, meta-compressor library"""
     homepage = "http://www.blosc.org"
     url      = "https://github.com/Blosc/c-blosc/archive/v1.11.1.tar.gz"
@@ -42,15 +42,21 @@ class CBlosc(Package):
 
     variant('avx2', default=True, description='Enable AVX2 support')
 
-    depends_on("cmake", type='build')
-    depends_on("snappy")
-    depends_on("zlib")
+    depends_on('cmake@2.8.10:', type='build')
+    depends_on('snappy')
+    depends_on('zlib')
 
-    def install(self, spec, prefix):
-        avx2 = '-DDEACTIVATE_AVX2=%s' % ('ON' if '~avx2' in spec else 'OFF')
-        cmake('.', avx2, *std_cmake_args)
+    def cmake_args(self):
+        args = []
 
-        make()
-        make("install")
+        if '+avx2' in self.spec:
+            args.append('-DDEACTIVATE_AVX2=OFF')
+        else:
+            args.append('-DDEACTIVATE_AVX2=ON')
+
+        return args
+
+    @run_after('install')
+    def darwin_fix(self):
         if sys.platform == 'darwin':
-            fix_darwin_install_name(prefix.lib)
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/callpath/package.py
+++ b/var/spack/repos/builtin/packages/callpath/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Callpath(Package):
+class Callpath(CMakePackage):
     """Library for representing callpaths consistently in
        distributed-memory performance tools."""
 
@@ -35,20 +35,20 @@ class Callpath(Package):
     version('1.0.2', 'b1994d5ee7c7db9d27586fc2dcf8f373')
     version('1.0.1', '0047983d2a52c5c335f8ba7f5bab2325')
 
-    depends_on("elf", type="link")
-    depends_on("libdwarf")
-    depends_on("dyninst")
-    depends_on("adept-utils")
-    depends_on("mpi")
-    depends_on('cmake', type='build')
+    depends_on('elf', type='link')
+    depends_on('libdwarf')
+    depends_on('dyninst')
+    depends_on('adept-utils')
+    depends_on('mpi')
+    depends_on('cmake@2.8:', type='build')
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
         # TODO: offer options for the walker used.
-        cmake_args = std_cmake_args
+        args = ["-DCALLPATH_WALKER=dyninst"]
+
         if spec.satisfies("^dyninst@9.3.0:"):
             std_flag = self.compiler.cxx11_flag
-            cmake_args.append("-DCMAKE_CXX_FLAGS='{0} -fpermissive'".format(
+            args.append("-DCMAKE_CXX_FLAGS='{0} -fpermissive'".format(
                 std_flag))
-        cmake('.', "-DCALLPATH_WALKER=dyninst", *cmake_args)
-        make()
-        make("install")
+
+        return args

--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -23,11 +23,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
-import shutil
 
 
-class Cereal(Package):
+class Cereal(CMakePackage):
     """cereal is a header-only C++11 serialization library. cereal takes
        arbitrary data types and reversibly turns them into different
        representations, such as compact binary encodings, XML, or
@@ -54,25 +52,18 @@ class Cereal(Package):
 
     depends_on('cmake@2.6.2:', type='build')
 
-    def install(self, spec, prefix):
+    def patch(self):
         # Don't use -Werror
         filter_file(r'-Werror', '', 'CMakeLists.txt')
 
-        # configure
+    def cmake_args(self):
         # Boost is only used for self-tests, which we are not running (yet?)
-        cmake('.',
-              '-DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE',
-              '-DSKIP_PORTABILITY_TEST=TRUE',
-              *std_cmake_args)
+        return [
+            '-DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE',
+            '-DSKIP_PORTABILITY_TEST=TRUE',
+        ]
 
-        # Build
-        make()
-
-        # Install
-        shutil.rmtree(join_path(prefix, 'doc'), ignore_errors=True)
-        shutil.rmtree(join_path(prefix, 'include'), ignore_errors=True)
-        shutil.rmtree(join_path(prefix, 'lib'), ignore_errors=True)
-        shutil.copytree('doc', join_path(prefix, 'doc'), symlinks=True)
-        shutil.copytree('include', join_path(prefix, 'include'), symlinks=True)
-        # Create empty directory to avoid linker warnings later
-        os.mkdir(join_path(prefix, 'lib'))
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            install_tree('doc', prefix.doc)
+            install_tree('include', prefix.include)

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Cgal(Package):
+class Cgal(CMakePackage):
     """The Computational Geometry Algorithms Library (CGAL) is a C++ library
     that aims to provide easy access to efficient and reliable algorithms in
     computational geometry. CGAL is used in various areas needing geometric
@@ -42,8 +42,9 @@ class Cgal(Package):
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')
-    variant('debug', default=False,
-            description='Builds a debug version of the libraries')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
 
     # ---- See "7 CGAL Libraries" at:
     # http://doc.cgal.org/latest/Manual/installation.html
@@ -57,6 +58,8 @@ class Cgal(Package):
             description='Build utilities to read/write image files')
     variant('demos', default=False,
             description='Build CGAL demos')
+
+    depends_on('cmake@2.8.11:', type='build')
 
     # Essential Third Party Libraries
     depends_on('boost+thread+system')
@@ -82,18 +85,12 @@ class Cgal(Package):
     # depends_on('esbtl')
     # depends_on('intel-tbb')
 
-    # Build dependencies
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
+    def cmake_args(self):
         # Installation instructions:
         # http://doc.cgal.org/latest/Manual/installation.html
+        spec = self.spec
 
-        options = std_cmake_args + [
-            # CGAL supports only Release and Debug build type. Any
-            # other build type will raise an error at configure time
-            '-DCMAKE_BUILD_TYPE:STRING=%s' %
-            ('Debug' if '+debug' in spec else 'Release'),
+        return [
             '-DBUILD_SHARED_LIBS:BOOL=%s' %
             ('ON' if '+shared' in spec else 'OFF'),
             '-DWITH_CGAL_Core:BOOL=%s' %
@@ -101,9 +98,5 @@ class Cgal(Package):
             '-DWITH_CGAL_ImageIO:BOOL=%s' %
             ('YES' if '+imageio' in spec else 'NO'),
             '-DWITH_CGAL_Qt5:BOOL=%s' %
-            ('YES' if '+demos' in spec else 'NO')]
-
-        with working_dir('spack-build', create=True):
-            cmake('..', *options)
-            make()
-            make('install')
+            ('YES' if '+demos' in spec else 'NO'),
+        ]

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Cgns(Package):
+class Cgns(CMakePackage):
     """The CFD General Notation System (CGNS) provides a general, portable,
     and extensible standard for the storage and retrieval of computational
     fluid dynamics (CFD) analysis data."""
@@ -37,11 +37,12 @@ class Cgns(Package):
 
     variant('hdf5', default=True, description='Enable HDF5 interface')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8:', type='build')
     depends_on('hdf5', when='+hdf5')
 
-    def install(self, spec, prefix):
-        cmake_args = std_cmake_args[:]
+    def cmake_args(self):
+        spec = self.spec
+        cmake_args = []
 
         if self.compiler.f77 and self.compiler.fc:
             cmake_args.append('-DCGNS_ENABLE_FORTRAN=ON')
@@ -66,8 +67,4 @@ class Cgns(Package):
         else:
             cmake_args.append('-DCGNS_ENABLE_HDF5=OFF')
 
-        with working_dir('spack-build', create=True):
-            cmake('..', *cmake_args)
-
-            make()
-            make('install')
+        return cmake_args

--- a/var/spack/repos/builtin/packages/cleverleaf/package.py
+++ b/var/spack/repos/builtin/packages/cleverleaf/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Cleverleaf(Package):
+class Cleverleaf(CMakePackage):
     """CleverLeaf is a hydrodynamics mini-app that extends CloverLeaf with
        Adaptive Mesh Refinement using the SAMRAI toolkit from Lawrence
        Livermore National Laboratory. The primary goal of CleverLeaf is
@@ -40,12 +40,7 @@ class Cleverleaf(Package):
     version('develop', git='https://github.com/UK-MAC/CleverLeaf_ref.git',
             branch='develop')
 
-    depends_on("samrai@3.8.0:")
-    depends_on("hdf5+mpi")
-    depends_on("boost")
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake(*std_cmake_args)
-        make()
-        make("install")
+    depends_on('samrai@3.8.0:')
+    depends_on('hdf5+mpi')
+    depends_on('boost')
+    depends_on('cmake@3.1:', type='build')

--- a/var/spack/repos/builtin/packages/cmocka/package.py
+++ b/var/spack/repos/builtin/packages/cmocka/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Cmocka(Package):
+class Cmocka(CMakePackage):
     """Unit-testing framework in pure C"""
     homepage = "https://cmocka.org/"
     url      = "https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz"
@@ -33,13 +33,7 @@ class Cmocka(Package):
     version('1.1.1', '6fbff4e42589566eda558db98b97623e')
     version('1.1.0', '59c9aa5735d9387fb591925ec53523ec')
     version('1.0.1', 'ed861e501a21a92b2af63e466df2015e')
+
+    depends_on('cmake@2.6.0:', type='build')
+
     parallel = False
-
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-
-            make()
-            make("install")

--- a/var/spack/repos/builtin/packages/cnmem/package.py
+++ b/var/spack/repos/builtin/packages/cnmem/package.py
@@ -25,13 +25,10 @@
 from spack import *
 
 
-class Cnmem(Package):
+class Cnmem(CMakePackage):
     """CNMem mempool for CUDA devices"""
     homepage = "https://github.com/NVIDIA/cnmem"
 
     version('git', git='https://github.com/NVIDIA/cnmem.git', branch="master")
 
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-        make()
-        make('install')
+    depends_on('cmake@2.8.8:', type='build')

--- a/var/spack/repos/builtin/packages/cram/package.py
+++ b/var/spack/repos/builtin/packages/cram/package.py
@@ -25,18 +25,13 @@
 from spack import *
 
 
-class Cram(Package):
+class Cram(CMakePackage):
     """Cram runs many small MPI jobs inside one large MPI job."""
     homepage = "https://github.com/llnl/cram"
     url      = "http://github.com/llnl/cram/archive/v1.0.1.tar.gz"
 
     version('1.0.1', 'c73711e945cf5dc603e44395f6647f5e')
 
-    extends('python')
-    depends_on("mpi")
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake(".", *std_cmake_args)
-        make()
-        make("install")
+    extends('python@2.7:')
+    depends_on('mpi')
+    depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Dakota(Package):
+class Dakota(CMakePackage):
     """The Dakota toolkit provides a flexible, extensible interface between
     analysis codes and iterative systems analysis methods. Dakota
     contains algorithms for:
@@ -49,8 +49,6 @@ class Dakota(Package):
 
     version('6.3', '05a58d209fae604af234c894c3f73f6d')
 
-    variant('debug', default=False,
-            description='Builds a debug version of the libraries')
     variant('shared', default=True,
             description='Enables the build of shared libraries')
     variant('mpi', default=True, description='Activates MPI support')
@@ -61,28 +59,20 @@ class Dakota(Package):
 
     depends_on('python')
     depends_on('boost')
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8.9:', type='build')
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
+    def cmake_args(self):
+        spec = self.spec
 
-        options.extend([
-            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                'Debug' if '+debug' in spec else 'Release'),
+        args = [
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF')])
+                'ON' if '+shared' in spec else 'OFF'),
+        ]
 
         if '+mpi' in spec:
-            options.extend([
+            args.extend([
                 '-DDAKOTA_HAVE_MPI:BOOL=ON',
-                '-DMPI_CXX_COMPILER:STRING=%s' % join_path(
-                    spec['mpi'].prefix.bin, 'mpicxx')])
+                '-DMPI_CXX_COMPILER:STRING=%s' % join_path(spec['mpi'].mpicxx),
+            ])
 
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+        return args

--- a/var/spack/repos/builtin/packages/damselfly/package.py
+++ b/var/spack/repos/builtin/packages/damselfly/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Damselfly(Package):
+class Damselfly(CMakePackage):
     """Damselfly is a model-based parallel network simulator."""
     homepage = "https://github.com/llnl/damselfly"
     url      = "https://github.com/llnl/damselfly"
@@ -33,10 +33,4 @@ class Damselfly(Package):
     version('1.0', '05cf7e2d8ece4408c0f2abb7ab63fd74c0d62895',
             git='https://github.com/llnl/damselfly.git', tag='v1.0')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('-DCMAKE_BUILD_TYPE=release', '..', *std_cmake_args)
-            make()
-            make('install')
+    depends_on('cmake@2.6:', type='build')

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Doxygen(Package):
+class Doxygen(CMakePackage):
     """Doxygen is the de facto standard tool for generating documentation
     from annotated C++ sources, but it also supports other popular programming
     languages such as C, Objective-C, C#, PHP, Java, Python, IDL (Corba,
@@ -49,9 +49,3 @@ class Doxygen(Package):
 
     # optional dependencies
     depends_on("graphviz", when="+graphviz", type='run')
-
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/gflags/package.py
+++ b/var/spack/repos/builtin/packages/gflags/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Gflags(Package):
+class Gflags(CMakePackage):
     """The gflags package contains a C++ library that implements
     commandline flags processing. It includes built-in support for
     standard types such as string and the ability to define flags
@@ -37,11 +37,7 @@ class Gflags(Package):
 
     version('2.1.2', 'ac432de923f9de1e9780b5254884599f')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8.12:', type='build')
 
-    def install(self, spec, prefix):
-        cmake("-DCMAKE_INSTALL_PREFIX=" + prefix,
-              "-DBUILD_SHARED_LIBS=ON")
-        make()
-        make("test")
-        make("install")
+    def cmake_args(self):
+        return ['-DBUILD_SHARED_LIBS=ON']

--- a/var/spack/repos/builtin/packages/glm/package.py
+++ b/var/spack/repos/builtin/packages/glm/package.py
@@ -25,11 +25,9 @@
 from spack import *
 
 
-class Glm(Package):
+class Glm(CMakePackage):
     """OpenGL Mathematics (GLM) is a header only C++ mathematics library for
-       graphics software based on the OpenGL Shading Language (GLSL)
-       specification.
-
+    graphics software based on the OpenGL Shading Language (GLSL) specification
     """
 
     homepage = "https://github.com/g-truc/glm"
@@ -37,10 +35,4 @@ class Glm(Package):
 
     version('0.9.7.1', '61af6639cdf652d1cdd7117190afced8')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-            make()
-            make("install")
+    depends_on('cmake@2.6:', type='build')

--- a/var/spack/repos/builtin/packages/graphlib/package.py
+++ b/var/spack/repos/builtin/packages/graphlib/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Graphlib(Package):
+class Graphlib(CMakePackage):
     """Library to create, manipulate, and export graphs Graphlib."""
     homepage = "https://github.com/LLNL/graphlib"
     url      = "https://github.com/LLNL/graphlib/archive/v2.0.0.tar.gz"
@@ -33,10 +33,4 @@ class Graphlib(Package):
     version('2.0.0', '43c6df84f1d38ba5a5dce0ae19371a70')
     version('3.0.0', '625d199f97ab1b84cbc8daabcaee5e2a')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake(".", *std_cmake_args)
-
-        make()
-        make("install")
+    depends_on('cmake@2.6:', type='build')

--- a/var/spack/repos/builtin/packages/grib-api/package.py
+++ b/var/spack/repos/builtin/packages/grib-api/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class GribApi(Package):
+class GribApi(CMakePackage):
     """The ECMWF GRIB API is an application program interface accessible from
        C, FORTRAN and Python programs developed for encoding and decoding WMO
        FM-92 GRIB edition 1 and edition 2 messages."""
@@ -40,42 +40,41 @@ class GribApi(Package):
     variant('netcdf', default=False, description='Enable netcdf encoding/decoding using netcdf library')
     variant('jpeg', default=True, description='Enable jpeg 2000 for grib 2 decoding/encoding')
     variant('png', default=False, description='Enable png for decoding/encoding')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'Production'))
 
-    depends_on('cmake', type='build')
     depends_on('libpng', when='+png')
     depends_on('netcdf', when='+netcdf')
     depends_on('jasper', when='+jpeg')
+    depends_on('cmake@2.8.11:', type='build')
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
-        options.append('-DBUILD_SHARED_LIBS=BOTH')
+    def cmake_args(self):
+        spec = self.spec
+        args = ['-DBUILD_SHARED_LIBS=BOTH']
 
         # We will add python support later.
-        options.append('-DENABLE_PYTHON=OFF')
+        args.append('-DENABLE_PYTHON=OFF')
 
         # Disable FORTRAN interface if we don't have it.
         if (self.compiler.f77 is None) or (self.compiler.fc is None):
-            options.append('-DENABLE_FORTRAN=OFF')
+            args.append('-DENABLE_FORTRAN=OFF')
 
         if '+netcdf' in spec:
-            options.append('-DENABLE_NETCDF=ON')
-            options.append('-DNETCDF_PATH=%s' % spec['netcdf'].prefix)
+            args.append('-DENABLE_NETCDF=ON')
+            args.append('-DNETCDF_PATH=%s' % spec['netcdf'].prefix)
         else:
-            options.append('-DENABLE_NETCDF=OFF')
+            args.append('-DENABLE_NETCDF=OFF')
 
         if '+jpeg' in spec:
-            options.append('-DENABLE_JPG=ON')
-            options.append('-DJASPER_PATH=%s' % spec['jasper'].prefix)
+            args.append('-DENABLE_JPG=ON')
+            args.append('-DJASPER_PATH=%s' % spec['jasper'].prefix)
         else:
-            options.append('-DENABLE_JPG=OFF')
+            args.append('-DENABLE_JPG=OFF')
 
         if '+png' in spec:
-            options.append('-DENABLE_PNG=ON')
+            args.append('-DENABLE_PNG=ON')
         else:
-            options.append('-DENABLE_PNG=OFF')
+            args.append('-DENABLE_PNG=OFF')
 
-        with working_dir('spack-build', create=True):
-            cmake('..', *options)
-            make()
-            make('install')
+        return args

--- a/var/spack/repos/builtin/packages/hepmc/package.py
+++ b/var/spack/repos/builtin/packages/hepmc/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class Hepmc(Package):
+class Hepmc(CMakePackage):
     """The HepMC package is an object oriented, C++ event record for
        High Energy Physics Monte Carlo generators and simulation."""
 
@@ -39,17 +39,10 @@ class Hepmc(Package):
     version('2.06.06', '102e5503537a3ecd6ea6f466aa5bc4ae')
     version('2.06.05', '2a4a2a945adf26474b8bdccf4f881d9c')
 
-    depends_on("cmake", type='build')
+    depends_on('cmake@2.6:', type='build')
 
-    def install(self, spec, prefix):
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-        options = [source_directory]
-        options.append('-Dmomentum:STRING=GEV')
-        options.append('-Dlength:STRING=MM')
-        options.extend(std_cmake_args)
-
-        with working_dir(build_directory, create=True):
-            cmake(*options)
-            make()
-            make('install')
+    def cmake_args(self):
+        return [
+            '-Dmomentum:STRING=GEV',
+            '-Dlength:STRING=MM',
+        ]

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Jsoncpp(Package):
+class Jsoncpp(CMakePackage):
     """JsonCpp is a C++ library that allows manipulating JSON values,
     including serialization and deserialization to and from strings.
     It can also preserve existing comment in unserialization/serialization
@@ -36,14 +36,14 @@ class Jsoncpp(Package):
 
     version('1.7.3', 'aff6bfb5b81d9a28785429faa45839c5')
 
-    depends_on('cmake', type='build')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo',
+                    'MinSizeRel', 'Coverage'))
+
+    depends_on('cmake@3.1:', type='build')
+    # TODO: Add a 'test' deptype
     # depends_on('python', type='test')
 
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', '-DBUILD_SHARED_LIBS=ON', *std_cmake_args)
-
-            make()
-            if self.run_tests:
-                make('test')  # Python needed to run tests
-            make('install')
+    def cmake_args(self):
+        return ['-DBUILD_SHARED_LIBS=ON']

--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Kealib(Package):
+class Kealib(CMakePackage):
     """An HDF5 Based Raster File Format
 
     KEALib provides an implementation of the GDAL data model.
@@ -46,16 +46,13 @@ class Kealib(Package):
 
     version('1.4.5', '112e9c42d980b2d2987a3c15d0833a5d')
 
-    depends_on("hdf5")
+    depends_on('hdf5')
+    depends_on('cmake@2.8.10:', type='build')
 
-    def install(self, spec, prefix):
-        with working_dir('trunk', create=False):
-            cmake_args = []
-            cmake_args.append("-DCMAKE_INSTALL_PREFIX=%s" % prefix)
-            cmake_args.append("-DHDF5_INCLUDE_DIR=%s" %
-                              spec['hdf5'].prefix.include)
-            cmake_args.append("-DHDF5_LIB_PATH=%s" % spec['hdf5'].prefix.lib)
-            cmake('.', *cmake_args)
+    root_cmakelists_dir = 'trunk'
 
-            make()
-            make("install")
+    def cmake_args(self):
+        return [
+            '-DHDF5_INCLUDE_DIR=%s' % spec['hdf5'].prefix.include,
+            '-DHDF5_LIB_PATH=%s' % spec['hdf5'].prefix.lib,
+        ]

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Kripke(Package):
+class Kripke(CMakePackage):
     """Kripke is a simple, scalable, 3D Sn deterministic particle
        transport proxy/mini app.
     """
@@ -38,21 +38,20 @@ class Kripke(Package):
     variant('mpi',    default=True, description='Build with MPI.')
     variant('openmp', default=True, description='Build with OpenMP enabled.')
 
-    depends_on('mpi', when="+mpi")
+    depends_on('mpi', when='+mpi')
+    depends_on('cmake@3.0:', type='build')
+
+    def cmake_args(self):
+        def enabled(variant):
+            return (1 if variant in spec else 0)
+
+        return [
+            '-DENABLE_OPENMP=%d' % enabled('+openmp'),
+            '-DENABLE_MPI=%d' % enabled('+mpi'),
+        ]
 
     def install(self, spec, prefix):
-        with working_dir('build', create=True):
-            def enabled(variant):
-                return (1 if variant in spec else 0)
-
-            cmake('-DCMAKE_INSTALL_PREFIX:PATH=.',
-                  '-DENABLE_OPENMP=%d' % enabled('+openmp'),
-                  '-DENABLE_MPI=%d' % enabled('+mpi'),
-                  '..',
-                  *std_cmake_args)
-            make()
-
-            # Kripke does not provide install target, so we have to copy
-            # things into place.
-            mkdirp(prefix.bin)
-            install('kripke', prefix.bin)
+        # Kripke does not provide install target, so we have to copy
+        # things into place.
+        mkdirp(prefix.bin)
+        install('kripke', prefix.bin)

--- a/var/spack/repos/builtin/packages/libemos/package.py
+++ b/var/spack/repos/builtin/packages/libemos/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Libemos(Package):
+class Libemos(CMakePackage):
     """The Interpolation library (EMOSLIB) includes Interpolation software and
        BUFR & CREX encoding/decoding routines."""
 
@@ -37,27 +37,27 @@ class Libemos(Package):
 
     variant('eccodes', default=False,
             description="Use eccodes instead of grib-api for GRIB decoding")
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'Production'))
 
-    depends_on('cmake', type='build')
     depends_on('eccodes', when='+eccodes')
     depends_on('grib-api', when='~eccodes')
     depends_on('fftw+float+double')
+    depends_on('cmake@2.8.11:', type='build')
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
+    def cmake_args(self):
+        spec = self.spec
+        args = []
 
         if spec.satisfies('+eccodes'):
-            options.append('-DENABLE_ECCODES=ON')
-            options.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
+            args.append('-DENABLE_ECCODES=ON')
+            args.append('-DECCODES_PATH=%s' % spec['eccodes'].prefix)
         else:
-            options.append('-DENABLE_ECCODES=OFF')
-            options.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
+            args.append('-DENABLE_ECCODES=OFF')
+            args.append('-DGRIB_API_PATH=%s' % spec['grib-api'].prefix)
 
         # To support long pathnames that spack generates
-        options.append('-DCMAKE_Fortran_FLAGS=-ffree-line-length-none')
+        args.append('-DCMAKE_Fortran_FLAGS=-ffree-line-length-none')
 
-        with working_dir('spack-build', create=True):
-            cmake('..', *options)
-            make()
-            make('install')
+        return args

--- a/var/spack/repos/builtin/packages/llvm-lld/package.py
+++ b/var/spack/repos/builtin/packages/llvm-lld/package.py
@@ -25,28 +25,24 @@
 from spack import *
 
 
-class LlvmLld(Package):
+class LlvmLld(CMakePackage):
     """lld - The LLVM Linker
        lld is a new set of modular code for creating linker tools."""
     homepage = "http://lld.llvm.org"
     url      = "http://llvm.org/releases/3.4/lld-3.4.src.tar.gz"
 
-    depends_on('llvm')
-
     version('3.4', '3b6a17e58c8416c869c14dd37682f78e')
 
-    depends_on('cmake', type='build')
+    depends_on('llvm')
+    depends_on('cmake@2.8:', type='build')
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
         if 'CXXFLAGS' in env and env['CXXFLAGS']:
             env['CXXFLAGS'] += ' ' + self.compiler.cxx11_flag
         else:
             env['CXXFLAGS'] = self.compiler.cxx11_flag
 
-        with working_dir('spack-build', create=True):
-            cmake('..',
-                  '-DLLD_PATH_TO_LLVM_BUILD=%s' % spec['llvm'].prefix,
-                  '-DLLVM_MAIN_SRC_DIR=%s' % spec['llvm'].prefix,
-                  *std_cmake_args)
-            make()
-            make("install")
+        return [
+            '-DLLD_PATH_TO_LLVM_BUILD=%s' % spec['llvm'].prefix,
+            '-DLLVM_MAIN_SRC_DIR=%s' % spec['llvm'].prefix,
+        ]

--- a/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class LlvmOpenmpOmpt(Package):
+class LlvmOpenmpOmpt(CMakePackage):
     """The OpenMP subproject provides an OpenMP runtime for use with the
        OpenMP implementation in Clang. This branch includes experimental
        changes for OMPT, the OpenMP Tools interface"""
@@ -42,25 +42,26 @@ class LlvmOpenmpOmpt(Package):
             git='https://github.com/OpenMPToolsInterface/LLVM-openmp.git',
             commit='982a08bcf3df9fb5afc04ac3bada47f19cc4e3d3')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8:', type='build')
     depends_on('llvm')
     depends_on('ninja', type='build')
 
-    def install(self, spec, prefix):
+    def cmake_args(self):
+        return [
+            '-G', 'Ninja',
+            '-DCMAKE_C_COMPILER=clang',
+            '-DCMAKE_CXX_COMPILER=clang++',
+            '-DCMAKE_BUILD_TYPE=Release',
+            '-DLIBOMP_OMPT_SUPPORT=on',
+            '-DLIBOMP_OMPT_BLAME=on',
+            '-DLIBOMP_OMPT_TRACE=on'
+        ]
 
-        with working_dir('spack-build', create=True):
-            cmake_args = std_cmake_args[:]
-            cmake_args.extend([
-                '-G', 'Ninja',
-                '-DCMAKE_C_COMPILER=clang',
-                '-DCMAKE_CXX_COMPILER=clang++',
-                '-DCMAKE_BUILD_TYPE=Release',
-                '-DLIBOMP_OMPT_SUPPORT=on',
-                '-DLIBOMP_OMPT_BLAME=on',
-                '-DLIBOMP_OMPT_TRACE=on'
-            ])
-
-            cmake('..', *cmake_args)
-            ninja = Executable('ninja')
+    # TODO: Add better ninja support to CMakePackage
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
             ninja()
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
             ninja('install')

--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Mariadb(Package):
+class Mariadb(CMakePackage):
     """MariaDB turns data into structured information in a wide array of
     applications, ranging from banking to websites. It is an enhanced, drop-in
     replacement for MySQL. MariaDB is used because it is fast, scalable and
@@ -45,18 +45,10 @@ class Mariadb(Package):
             'operations in the mariadb client library.')
 
     depends_on('boost')
-    depends_on('cmake')
+    depends_on('cmake@2.6:', type='build')
     depends_on('jemalloc')
     depends_on('libaio')
     depends_on('libedit')
     depends_on('libevent', when='+nonblocking')
     depends_on('ncurses')
     depends_on('zlib')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-
-            cmake('..', *std_cmake_args)
-
-            make()
-            make('install')

--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Mbedtls(Package):
+class Mbedtls(CMakePackage):
     """mbed TLS (formerly known as PolarSSL) makes it trivially easy for
        developers to include cryptographic and SSL/TLS capabilities in
        their (embedded) products, facilitating this functionality with a
@@ -42,10 +42,9 @@ class Mbedtls(Package):
     version('2.1.3', '7eb4cf1dfa68578a2c8dbd0b6fa752dd')
     version('1.3.16', '4144d7320c691f721aeb9e67a1bc38e0')
 
-    depends_on('cmake', type='build')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release', 'Coverage', 'ASan', 'ASanDbg',
+                    'MemSan', 'MemSanDbg', 'Check', 'CheckFull'))
 
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-
-        make()
-        make("install")
+    depends_on('cmake@2.6:', type='build')

--- a/var/spack/repos/builtin/packages/mitos/package.py
+++ b/var/spack/repos/builtin/packages/mitos/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Mitos(Package):
+class Mitos(CMakePackage):
     """Mitos is a library and a tool for collecting sampled memory
     performance data to view with MemAxes"""
 
@@ -40,10 +40,4 @@ class Mitos(Package):
     depends_on('dyninst@8.2.1:')
     depends_on('hwloc')
     depends_on('mpi')
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-            make()
-            make("install")
+    depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/msgpack-c/package.py
+++ b/var/spack/repos/builtin/packages/msgpack-c/package.py
@@ -25,17 +25,11 @@
 from spack import *
 
 
-class MsgpackC(Package):
+class MsgpackC(CMakePackage):
     """A small, fast binary interchange format convertible to/from JSON"""
     homepage = "http://www.msgpack.org"
     url      = "https://github.com/msgpack/msgpack-c/archive/cpp-1.4.1.tar.gz"
 
     version('1.4.1', 'e2fd3a7419b9bc49e5017fdbefab87e0')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake('.', *std_cmake_args)
-
-        make()
-        make("install")
+    depends_on('cmake@2.8.12:', type='build')

--- a/var/spack/repos/builtin/packages/muster/package.py
+++ b/var/spack/repos/builtin/packages/muster/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Muster(Package):
+class Muster(CMakePackage):
     """The Muster library provides implementations of sequential and
        parallel K-Medoids clustering algorithms. It is intended as a
        general framework for parallel cluster analysis, particularly
@@ -38,11 +38,6 @@ class Muster(Package):
     version('1.0.1', 'd709787db7e080447afb6571ac17723c')
     version('1.0',   '2eec6979a4a36d3a65a792d12969be16')
 
-    depends_on("boost")
-    depends_on("mpi")
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        cmake(".", *std_cmake_args)
-        make()
-        make("install")
+    depends_on('boost')
+    depends_on('mpi')
+    depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/ompt-openmp/package.py
+++ b/var/spack/repos/builtin/packages/ompt-openmp/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class OmptOpenmp(Package):
+class OmptOpenmp(CMakePackage):
     """LLVM/Clang OpenMP runtime with OMPT support. This is a fork of the
        OpenMPToolsInterface/LLVM-openmp fork of the official LLVM OpenMP
        mirror.  This library provides a drop-in replacement of the OpenMP
@@ -37,13 +37,8 @@ class OmptOpenmp(Package):
 
     version('0.1', '2334e6a84b52da41b27afd9831ed5370')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@2.8:', type='build')
 
-    def install(self, spec, prefix):
-        with working_dir("runtime/build", create=True):
-            cmake('-DCMAKE_C_COMPILER=%s' % self.compiler.cc,
-                  '-DCMAKE_CXX_COMPILER=%s' % self.compiler.cxx,
-                  '-DCMAKE_INSTALL_PREFIX=%s' % prefix,
-                  '..', *std_cmake_args)
-            make()
-            make("install")
+    conflicts('%gcc@:4.7')
+
+    root_cmakelists_dir = 'runtime'

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class Openscenegraph(Package):
+class Openscenegraph(CMakePackage):
     """OpenSceneGraph is an open source, high performance 3D graphics toolkit
        that's used in a variety of visual simulation applications."""
 
@@ -36,42 +36,34 @@ class Openscenegraph(Package):
     version('3.2.3', '02ffdad7744c747d8fad0d7babb58427')
     version('3.1.5', '1c90b851b109849c985006486ef59822')
 
-    variant('debug', default=False, description='Builds a debug version of the library')
     variant('shared', default=True, description='Builds a shared version of the library')
 
     depends_on('cmake@2.8.7:', type='build')
     depends_on('qt@4:')
     depends_on('zlib')
 
-    def install(self, spec, prefix):
-        build_type = 'Debug' if '+debug' in spec else 'Release'
+    def cmake_args(self):
+        spec = self.spec
+
         shared_status = 'ON' if '+shared' in spec else 'OFF'
 
-        cmake_args = std_cmake_args[:]
-        cmake_args.extend([
-            '-DCMAKE_BUILD_TYPE={0}'.format(build_type),
+        args = [
             '-DDYNAMIC_OPENSCENEGRAPH={0}'.format(shared_status),
             '-DDYNAMIC_OPENTHREADS={0}'.format(shared_status),
-        ])
+            '-DZLIB_INCLUDE_DIR={0}'.format(spec['zlib'].prefix.include),
+            '-DZLIB_LIBRARY={0}/libz.{1}'.format(spec['zlib'].prefix.lib,
+                                                 dso_suffix),
+            '-DBUILD_OSG_APPLICATIONS=OFF',
+            '-DOSG_NOTIFY_DISABLED=ON',
+            '-DLIB_POSTFIX=',
+        ]
 
         # NOTE: This is necessary in order to allow OpenSceneGraph to compile
         # despite containing a number of implicit bool to int conversions.
         if spec.satisfies('%gcc'):
-            cmake_args.extend([
+            args.extend([
                 '-DCMAKE_C_FLAGS=-fpermissive',
                 '-DCMAKE_CXX_FLAGS=-fpermissive',
             ])
 
-        with working_dir('spack-build', create=True):
-            cmake(
-                '..',
-                '-DZLIB_INCLUDE_DIR={0}'.format(spec['zlib'].prefix.include),
-                '-DZLIB_LIBRARY={0}/libz.{1}'.format(spec['zlib'].prefix.lib,
-                                                     dso_suffix),
-                '-DBUILD_OSG_APPLICATIONS=OFF',
-                '-DOSG_NOTIFY_DISABLED=ON',
-                '-DLIB_POSTFIX=',
-                *cmake_args
-            )
-            make()
-            make('install')
+        return args

--- a/var/spack/repos/builtin/packages/panda/package.py
+++ b/var/spack/repos/builtin/packages/panda/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class Panda(Package):
+class Panda(CMakePackage):
     """PANDA: Parallel AdjaceNcy Decomposition Algorithm"""
     homepage = "http://comopt.ifi.uni-heidelberg.de/software/PANDA/index.html"
     url      = "http://comopt.ifi.uni-heidelberg.de/software/PANDA/downloads/panda-2016-03-07.tar"
@@ -35,11 +35,5 @@ class Panda(Package):
 
     # Note: Panda can also be built without MPI support
 
-    depends_on("cmake", type="build")
-    depends_on("mpi")
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake("..", *std_cmake_args)
-            make()
-            make("install")
+    depends_on('cmake@2.6.4:', type='build')
+    depends_on('mpi')

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Paradiseo(Package):
+class Paradiseo(CMakePackage):
     """A C++ white-box object-oriented framework dedicated to the reusable
        design of metaheuristics."""
     homepage = "http://paradiseo.gforge.inria.fr/"
@@ -51,13 +51,11 @@ class Paradiseo(Package):
             description='Compile with (Experimental) EDO module')
 
     # variant('doc', default=False, description='Compile with documentation')
-    variant('debug',    default=False,
-            description='Builds a debug version of the libraries')
     variant('openmp',   default=False, description='Enable OpenMP support')
     variant('gnuplot',  default=False, description='Enable GnuPlot support')
 
     # Required dependencies
-    depends_on("cmake", type='build')
+    depends_on("cmake@2.8:", type='build')
 
     # Optional dependencies
     depends_on("mpi", when="+mpi")
@@ -73,13 +71,10 @@ class Paradiseo(Package):
     patch('fix_tests.patch')
     patch('fix_tutorials.patch')
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
+    def cmake_args(self):
+        spec = self.spec
 
-        options.extend([
-            '-DCMAKE_BUILD_TYPE:STRING=%s' % (
-                'Debug' if '+debug' in spec else 'Release'),
+        return [
             '-DINSTALL_TYPE:STRING=MIN',
             '-DMPI:BOOL=%s' % ('TRUE' if '+mpi' in spec else 'FALSE'),
             # Note: This requires a C++11 compatible compiler
@@ -91,14 +86,4 @@ class Paradiseo(Package):
                 'TRUE' if '+openmp' in spec else 'FALSE'),
             '-DENABLE_GNUPLOT:BOOL=%s' % (
                 'TRUE' if '+gnuplot' in spec else 'FALSE')
-        ])
-
-        with working_dir('spack-build', create=True):
-            # Configure
-            cmake('..', *options)
-
-            # Build, test and install
-            make("VERBOSE=1")
-            if self.run_tests:
-                make("test")
-            make("install")
+        ]

--- a/var/spack/repos/builtin/packages/pidx/package.py
+++ b/var/spack/repos/builtin/packages/pidx/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Pidx(Package):
+class Pidx(CMakePackage):
     """PIDX Parallel I/O Library.
 
     PIDX is an efficient parallel I/O library that reads and writes
@@ -37,11 +37,5 @@ class Pidx(Package):
     version('1.0', git='https://github.com/sci-visus/PIDX.git',
             commit='6afa1cf71d1c41263296dc049c8fabaf73c296da')
 
-    depends_on('cmake', type='build')
-    depends_on("mpi")
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-            make()
-            make("install")
+    depends_on('cmake@2.8.4:', type='build')
+    depends_on('mpi')

--- a/var/spack/repos/builtin/packages/piranha/package.py
+++ b/var/spack/repos/builtin/packages/piranha/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Piranha(Package):
+class Piranha(CMakePackage):
     """Piranha is a computer-algebra library for the symbolic manipulation of
     sparse multivariate polynomials and other closely-related symbolic objects
     (such as Poisson series)."""
@@ -40,7 +40,7 @@ class Piranha(Package):
             description='Build the Python bindings')
 
     # Build dependencies
-    depends_on('cmake@3.0:',  type='build')
+    depends_on('cmake@3.2.0:', type='build')
     extends('python',         when='+pyranha')
     depends_on('python@2.6:', type='build', when='+pyranha')
 
@@ -53,21 +53,8 @@ class Piranha(Package):
     depends_on('gmp')   # mpir is a drop-in replacement for this
     depends_on('mpfr')  # Could also be built against mpir
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
-
-        # Python bindings
-        options.extend([
-            '-DBUILD_PYRANHA=%s' % (
-                'ON' if '+python' in spec else 'OFF'),
+    def cmake_args(self):
+        return [
+            '-DBUILD_PYRANHA=%s' % ('ON' if '+python' in self.spec else 'OFF'),
             '-DBUILD_TESTS:BOOL=ON',
-        ])
-
-        with working_dir('spack-build', create=True):
-            cmake('..', *options)
-
-            make()
-            make('install')
-            if self.run_tests:
-                make('test')
+        ]

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -26,7 +26,7 @@ from spack import *
 import os
 
 
-class Psi4(Package):
+class Psi4(CMakePackage):
     """Psi4 is an open-source suite of ab initio quantum chemistry
     programs designed for efficient, high-accuracy simulations of
     a variety of molecular properties."""
@@ -36,20 +36,16 @@ class Psi4(Package):
 
     version('0.5', '53041b8a9be3958384171d0d22f9fdd0')
 
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
+
     # Required dependencies
     depends_on('blas')
     depends_on('lapack')
-    depends_on('boost'
-               '+chrono'
-               '+filesystem'
-               '+python'
-               '+regex'
-               '+serialization'
-               '+system'
-               '+timer'
-               '+thread')
+    depends_on('boost+chrono+filesystem+python+regex+serialization+system+timer+thread')
     depends_on('python')
-    depends_on('cmake', type='build')
+    depends_on('cmake@3.3:', type='build')
     depends_on('py-numpy', type=('build', 'run'))
 
     # Optional dependencies
@@ -59,8 +55,10 @@ class Psi4(Package):
     # depends_on('pcm-solver')
     # depends_on('chemps2')
 
-    def install(self, spec, prefix):
-        cmake_args = [
+    def cmake_args(self):
+        spec = self.spec
+
+        return [
             '-DBLAS_TYPE={0}'.format(spec['blas'].name.upper()),
             '-DBLAS_LIBRARIES={0}'.format(spec['blas'].libs.joined()),
             '-DLAPACK_TYPE={0}'.format(spec['lapack'].name.upper()),
@@ -71,16 +69,7 @@ class Psi4(Package):
             '-DENABLE_CHEMPS2=OFF'
         ]
 
-        cmake_args.extend(std_cmake_args)
-
-        with working_dir('spack-build', create=True):
-            cmake('..', *cmake_args)
-
-            make()
-            make('install')
-
-        self.filter_compilers(spec, prefix)
-
+    @run_after('install')
     def filter_compilers(self, spec, prefix):
         """Run after install to tell the configuration files to
         use the compilers that Spack built the package with.

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -25,14 +25,10 @@
 from spack import *
 
 
-class Raja(Package):
+class Raja(CMakePackage):
     """RAJA Parallel Framework."""
     homepage = "http://software.llnl.gov/RAJA/"
 
     version('git', git='https://github.com/LLNL/RAJA.git', branch="master")
 
-    def install(self, spec, prefix):
-        with working_dir('build', create=True):
-            cmake('..', *std_cmake_args)
-            make()
-            make('install')
+    depends_on('cmake@3.3:', type='build')

--- a/var/spack/repos/builtin/packages/ravel/package.py
+++ b/var/spack/repos/builtin/packages/ravel/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Ravel(Package):
+class Ravel(CMakePackage):
     """Ravel is a parallel communication trace visualization tool that
        orders events according to logical time."""
 
@@ -41,7 +41,5 @@ class Ravel(Package):
     depends_on('otf2')
     depends_on('qt@5:')
 
-    def install(self, spec, prefix):
-        cmake('-Wno-dev', *std_cmake_args)
-        make()
-        make("install")
+    def cmake_args(self):
+        return ['-Wno-dev']

--- a/var/spack/repos/builtin/packages/sdl2/package.py
+++ b/var/spack/repos/builtin/packages/sdl2/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Sdl2(Package):
+class Sdl2(CMakePackage):
     """Simple DirectMedia Layer is a cross-platform development library designed
     to provide low level access to audio, keyboard, mouse, joystick, and
     graphics hardware via OpenGL and Direct3D."""
@@ -35,11 +35,4 @@ class Sdl2(Package):
 
     version('2.0.5', 'd4055424d556b4a908aa76fad63abd3c')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-
-            make()
-            make('install')
+    depends_on('cmake@2.8.5:', type='build')

--- a/var/spack/repos/builtin/packages/sympol/package.py
+++ b/var/spack/repos/builtin/packages/sympol/package.py
@@ -26,14 +26,14 @@
 from spack import *
 
 
-class Sympol(Package):
+class Sympol(CMakePackage):
     """SymPol is a C++ tool to work with symmetric polyhedra"""
     homepage = "http://www.math.uni-rostock.de/~rehn/software/sympol.html"
     url      = "http://www.math.uni-rostock.de/~rehn/software/sympol-0.1.8.tar.gz"
 
     version('0.1.8', '7cba1997f8532c754cb7259bf70caacb')
 
-    depends_on("cmake", type='build')
+    depends_on("cmake@2.6:", type="build")
 
     depends_on("bliss")
     depends_on("boost")
@@ -41,8 +41,3 @@ class Sympol(Package):
     depends_on("lrslib")
 
     patch("lrs_mp_close.patch")
-
-    def install(self, spec, prefix):
-        cmake(".", *std_cmake_args)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/task/package.py
+++ b/var/spack/repos/builtin/packages/task/package.py
@@ -25,22 +25,15 @@
 from spack import *
 
 
-class Task(Package):
+class Task(CMakePackage):
     """Feature-rich console based todo list manager"""
     homepage = "http://www.taskwarrior.org"
     url      = "http://taskwarrior.org/download/task-2.4.4.tar.gz"
 
     version('2.4.4', '517450c4a23a5842df3e9905b38801b3')
 
-    depends_on('cmake', type='build')
-    depends_on("gnutls")
-    depends_on("libuuid")
-    # depends_on("gcc@4.8:")
+    depends_on('cmake@2.8:', type='build')
+    depends_on('gnutls')
+    depends_on('libuuid')
 
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('-DCMAKE_BUILD_TYPE=release',
-                  '..',
-                  *std_cmake_args)
-            make()
-            make("install")
+    conflicts('%gcc@:4.7')

--- a/var/spack/repos/builtin/packages/taskd/package.py
+++ b/var/spack/repos/builtin/packages/taskd/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Taskd(Package):
+class Taskd(CMakePackage):
     """TaskWarrior task synchronization daemon"""
 
     homepage = "http://www.taskwarrior.org"
@@ -33,14 +33,8 @@ class Taskd(Package):
 
     version('1.1.0', 'ac855828c16f199bdbc45fbc227388d0')
 
-    depends_on('cmake', type='build')
-    depends_on("libuuid")
-    depends_on("gnutls")
+    depends_on('libuuid')
+    depends_on('gnutls')
+    depends_on('cmake@2.8:', type='build')
 
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('-DCMAKE_BUILD_TYPE=release',
-                  '..',
-                  *std_cmake_args)
-            make()
-            make("install")
+    conflicts('%gcc@:4.7')

--- a/var/spack/repos/builtin/packages/tethex/package.py
+++ b/var/spack/repos/builtin/packages/tethex/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Tethex(Package):
+class Tethex(CMakePackage):
     """Tethex is designed to convert triangular (in 2D) or tetrahedral (in 3D)
     Gmsh's mesh to quadrilateral or hexahedral one respectively. These meshes
     can be used in software packages working with hexahedrals only - for
@@ -38,12 +38,13 @@ class Tethex(Package):
     version('0.0.7', '6c9e4a18a6637deb4400c6d77ec03184')
     version('develop', git='https://github.com/martemyev/tethex.git')
 
-    depends_on('cmake', type='build')
+    variant('build_type', default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release'))
+
+    depends_on('cmake@2.8:', type='build')
 
     def install(self, spec, prefix):
-        cmake('.')
-        make()
-
         # install by hand
         mkdirp(prefix.bin)
         install('tethex', prefix.bin)

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Visit(Package):
+class Visit(CMakePackage):
     """VisIt is an Open Source, interactive, scalable, visualization,
        animation and analysis tool."""
     homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
@@ -36,29 +36,26 @@ class Visit(Package):
     version('2.10.2', '253de0837a9d69fb689befc98ea4d068')
     version('2.10.1', '3cbca162fdb0249f17c4456605c4211e')
 
-    depends_on('cmake', type='build')
+    depends_on('cmake@3.0:', type='build')
     depends_on('vtk@6.1.0~opengl2')
     depends_on('qt@4.8.6')
     depends_on('python')
     depends_on('silo+shared')
     depends_on('hdf5~mpi')
 
-    def install(self, spec, prefix):
+    root_cmakelists_dir = 'src'
+
+    def cmake_args(self):
+        spec = self.spec
         qt_bin = spec['qt'].prefix.bin
 
-        with working_dir('spack-build', create=True):
-            cmake_args = std_cmake_args[:]
-            cmake_args.extend([
-                '-DVTK_MAJOR_VERSION=6',
-                '-DVTK_MINOR_VERSION=1',
-                '-DVISIT_USE_GLEW=OFF',
-                '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin),
-                '-DPYTHON_DIR:PATH={0}'.format(spec['python'].home),
-                '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix),
-                '-DVISIT_HDF5_DIR:PATH={0}'.format(spec['hdf5'].prefix),
-                '-DVISIT_VTK_DIR:PATH={0}'.format(spec['vtk'].prefix),
-            ])
-
-            cmake(join_path('..', 'src'), *cmake_args)
-            make()
-            make('install')
+        return [
+            '-DVTK_MAJOR_VERSION={0}'.format(spec['vtk'].version[0]),
+            '-DVTK_MINOR_VERSION={0}'.format(spec['vtk'].version[1]),
+            '-DVISIT_USE_GLEW=OFF',
+            '-DVISIT_LOC_QMAKE_EXE:FILEPATH={0}/qmake-qt4'.format(qt_bin),
+            '-DPYTHON_DIR:PATH={0}'.format(spec['python'].home),
+            '-DVISIT_SILO_DIR:PATH={0}'.format(spec['silo'].prefix),
+            '-DVISIT_HDF5_DIR:PATH={0}'.format(spec['hdf5'].prefix),
+            '-DVISIT_VTK_DIR:PATH={0}'.format(spec['vtk'].prefix),
+        ]

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -26,7 +26,7 @@
 from spack import *
 
 
-class Xrootd(Package):
+class Xrootd(CMakePackage):
     """The XROOTD project aims at giving high performance, scalable fault
        tolerant access to data repositories of many kinds."""
     homepage = "http://xrootd.org"
@@ -38,19 +38,4 @@ class Xrootd(Package):
     version('4.4.0', '58f55e56801d3661d753ff5fd33dbcc9')
     version('4.3.0', '39c2fab9f632f35e12ff607ccaf9e16c')
 
-    depends_on('cmake', type='build')
-
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
-
-        build_directory = join_path(self.stage.path, 'spack-build')
-        source_directory = self.stage.source_path
-
-        if '+debug' in spec:
-            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug')
-
-        with working_dir(build_directory, create=True):
-            cmake(source_directory, *options)
-            make()
-            make("install")
+    depends_on('cmake@2.6:', type='build')


### PR DESCRIPTION
Same as #2845 but for `CMakePackage` this time.

At this point, almost every package in Spack that uses CMake uses the `CMakePackage` base class. There are still a few complicated packages that I didn't want to deal with, like packages that use Autotools for older versions and CMake for newer versions.

Much like #2845, I'm sure there are at least a couple packages that I messed up, so please give this a thorough review. If you want me to split this up into 56 different PRs, I can do that, but I figured it would be easier to review all at once.