### PR TITLE
Fix variant satisfaction check for indirect dependencies

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1868,6 +1868,7 @@ class Spec(object):
         pkg = spack.repo.get(self.fullname)
         conditions = pkg.dependencies[name]
 
+        substitute_abstract_variants(self)
         # evaluate when specs to figure out constraints on the dependency.
         dep = None
         for when_spec, dep_spec in conditions.items():

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -42,7 +42,8 @@ def test_transitive_dependents(builtin_mock):
     out, err = dependents('--transitive', 'libelf')
     actual = set(re.split(r'\s+', out.strip()))
     assert actual == set(
-        ['callpath', 'dyninst', 'libdwarf', 'mpileaks', 'multivalue_variant'])
+        ['callpath', 'dyninst', 'libdwarf', 'mpileaks', 'multivalue_variant',
+         'singlevalue-variant-dependent'])
 
 
 def test_immediate_installed_dependents(builtin_mock, database):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -307,6 +307,20 @@ class TestSpecSematics(object):
         # Check that conditional dependencies are treated correctly
         assert '^b' in a
 
+    def test_unsatisfied_single_valued_variant(self):
+        a = Spec('a foobar=baz')
+        a.concretize()
+        assert '^b' not in a
+
+        mv = Spec('multivalue_variant')
+        mv.concretize()
+        assert 'a@1.0' not in mv
+
+    def test_indirect_unsatisfied_single_valued_variant(self):
+        spec = Spec('singlevalue-variant-dependent')
+        spec.concretize()
+        assert 'a@1.0' not in spec
+
     def test_unsatisfiable_multi_value_variant(self):
 
         # Semantics for a multi-valued variant is different

--- a/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue_variant/package.py
@@ -52,6 +52,8 @@ class MultivalueVariant(Package):
 
     depends_on('mpi')
     depends_on('callpath')
+    depends_on('a')
+    depends_on('a@1.0', when='fee=barbaz')
 
     def install(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin.mock/packages/singlevalue-variant-dependent/package.py
+++ b/var/spack/repos/builtin.mock/packages/singlevalue-variant-dependent/package.py
@@ -25,46 +25,15 @@
 from spack import *
 
 
-class A(AutotoolsPackage):
+class SinglevalueVariantDependent(Package):
     """Simple package with one optional dependency"""
 
     homepage = "http://www.example.com"
-    url      = "http://www.example.com/a-1.0.tar.gz"
+    url      = "http://www.example.com/archive-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-    version('2.0', '2.0_a_hash')
 
-    variant(
-        'foo',
-        values=('bar', 'baz', 'fee'),
-        default='bar',
-        description='',
-        multi=True
-    )
-
-    variant(
-        'foobar',
-        values=('bar', 'baz', 'fee'),
-        default='bar',
-        description='',
-        multi=False
-    )
-
-    depends_on('b', when='foobar=bar')
-
-    def with_or_without_fee(self, activated):
-        if not activated:
-            return '--no-fee'
-        return '--fee-all-the-time'
-
-    def autoreconf(self, spec, prefix):
-        pass
-
-    def configure(self, spec, prefix):
-        pass
-
-    def build(self, spec, prefix):
-        pass
+    depends_on('multivalue_variant fee=baz')
 
     def install(self, spec, prefix):
         pass


### PR DESCRIPTION
Fixes #4898

Constraints that were supposed to be conditionally activated for
specified values of a single-valued variant were being activated
unconditionally in the case that the variant was associated with
an implicit dependency. For example if X->Y->Z and Y places a
conditional constraint on Z for a given single-valued variant on
Y, then it would have been applied unconditionally when
concretizing X.