### PR TITLE
Various fixes to package name URL parsing

### DIFF
--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -334,6 +334,8 @@ def name_parsed_correctly(pkg, name):
         pkg_name = pkg_name[2:]
     elif pkg_name.startswith('py-'):
         pkg_name = pkg_name[3:]
+    elif pkg_name.startswith('perl-'):
+        pkg_name = pkg_name[5:]
     elif pkg_name.startswith('octave-'):
         pkg_name = pkg_name[7:]
 

--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -124,6 +124,8 @@ def test_url_strip_version_suffixes(url, expected):
     ('converge_install_2.3.16', '2.3.16', 'converge'),
     # Download type - src
     ('jpegsrc.v9b', '9b', 'jpeg'),
+    # Download type - archive
+    ('coinhsl-archive-2014.01.17', '2014.01.17', 'coinhsl'),
     # Download type - std
     ('ghostscript-fonts-std-8.11', '8.11', 'ghostscript-fonts'),
     # Download version - release

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -290,6 +290,7 @@ def strip_name_suffixes(path, version):
         'install',
         'src',
         '(open)?[Ss]ources?',
+        '[._-]archive',
         '[._-]std',
 
         # Download version


### PR DESCRIPTION
Previously, `spack url summary` believed that we were parsing Perl package names incorrectly because we read them as `extutils-makemaker` instead of `perl-extutils-makemaker`. The package name for `coinhsl` was also being incorrectly parsed.

### Before
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1776
    Names correctly parsed:    1577/1776 (88.80%)
    Versions correctly parsed: 1631/1776 (91.84%)
```
```
$ spack url parse file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz
==> Parsing URL: file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz

==> Matched version regex  0: r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
==> Matched  name   regex  7: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz
                             --------------- ~~~~~~~~~~
    name:    coinhsl-archive
    version: 2014.01.17
```
### After
```
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          1776
    Names correctly parsed:    1583/1776 (89.13%)
    Versions correctly parsed: 1631/1776 (91.84%)
```
```
$ spack url parse file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz
==> Parsing URL: file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz

==> Matched version regex  0: r'^[a-zA-Z+._-]+[._-]v?(\\d[\\d._-]*)$'
==> Matched  name   regex  7: r'^([A-Za-z\\d+\\._-]+)$'

==> Detected:
    file:///Users/Adam/spack/coinhsl-archive-2014.01.17.tar.gz
                             -------         ~~~~~~~~~~
    name:    coinhsl
    version: 2014.01.17
```