### PR TITLE
Fix libbsd's cdefs.h to be compatible with gcc 4.8.x

### DIFF
--- a/var/spack/repos/builtin/packages/libbsd/cdefs.h.patch
+++ b/var/spack/repos/builtin/packages/libbsd/cdefs.h.patch
@@ -1,0 +1,15 @@
+--- a/nclude/bsd/sys/cdefs.h.orig	2017-08-04 16:34:56.404995800 -0700
++++ b/include/bsd/sys/cdefs.h	2017-08-04 16:35:19.345043883 -0700
+@@ -25,10 +25,10 @@
+  */
+ 
+ #ifndef __has_include
+-#define __has_include 1
++#define __has_include(X) 1
+ #endif
+ #ifndef __has_include_next
+-#define __has_include_next 1
++#define __has_include_next(X) 1
+ #endif
+ 
+ #ifdef LIBBSD_OVERLAY

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -36,3 +36,5 @@ class Libbsd(AutotoolsPackage):
     url      = "https://libbsd.freedesktop.org/releases/libbsd-0.8.6.tar.xz"
 
     version('0.8.6', '4ab7bec639af17d0aacb50222b479110')
+
+    patch('cdefs.h.patch', when='%gcc@:4.8.5')

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -37,4 +37,4 @@ class Libbsd(AutotoolsPackage):
 
     version('0.8.6', '4ab7bec639af17d0aacb50222b479110')
 
-    patch('cdefs.h.patch', when='%gcc@:4.8.5')
+    patch('cdefs.h.patch', when='%gcc@:4')


### PR DESCRIPTION
See the discussion in #4945 (after the merge) for additional background.

libbsd builds with gcc@5.4.0 on CentOS 7, but not with the system's gcc@4.8.5.  Others have reported problems with gcc@4.8.3 on Fedora 19.

The problem boils down to the lack of support for the clang extension `__has_include_next`.  The immediate symptom seems to be the pre-processor using defining macro like this

```c
#define __has_include 1
```

then then tripping over an expansion of it like this:

```
blah.h:13:23: error: missing binary operator before token "("
```

This patch changes the macro definition to:

```c
#define __has_include(X) 1
```

which swallows the arguments with which the macro is invoked.

The end result is that libbsd builds for me on CentOS 7 using the system compiler.

I'm unsure about how to constrain the compiler version, this is the only system I have at hand to test.