### PR TITLE
Download from pypi.io, not pypi.python.org

### DIFF
--- a/var/spack/repos/builtin/packages/py-3to2/package.py
+++ b/var/spack/repos/builtin/packages/py-3to2/package.py
@@ -30,6 +30,6 @@ class Py3to2(PythonPackage):
     for Python version 3.x into Python version 2.x."""
 
     homepage = "https://pypi.python.org/pypi/3to2"
-    url      = "https://pypi.python.org/packages/source/3/3to2/3to2-1.1.1.zip"
+    url      = "https://pypi.io/packages/source/3/3to2/3to2-1.1.1.zip"
 
     version('1.1.1', 'cbeed28e350dbdaef86111ace3052824')

--- a/var/spack/repos/builtin/packages/py-apache-libcloud/package.py
+++ b/var/spack/repos/builtin/packages/py-apache-libcloud/package.py
@@ -29,7 +29,8 @@ class PyApacheLibcloud(PythonPackage):
     """Python library for multiple cloud provider APIs"""
 
     homepage = "http://libcloud.apache.org"
+    url      = "https://pypi.io/packages/source/a/apache-libcloud/apache-libcloud-1.2.1.tar.gz"
 
-    version('1.2.1', '912e6fb1f2d13f7d3b58ee982b9f9d1f', url="https://pypi.python.org/packages/dd/b5/7b8b5796177345b6a7c1f3d4fda9fbbe9aeef000ac33f3aac06f176845d0/apache-libcloud-1.2.1.tar.gz")
+    version('1.2.1', '912e6fb1f2d13f7d3b58ee982b9f9d1f')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-argcomplete/package.py
+++ b/var/spack/repos/builtin/packages/py-argcomplete/package.py
@@ -29,7 +29,7 @@ class PyArgcomplete(PythonPackage):
     """Bash tab completion for argparse."""
 
     homepage = "https://pypi.python.org/pypi/argcomplete"
-    url      = "https://pypi.python.org/packages/source/a/argcomplete/argcomplete-1.1.1.tar.gz"
+    url      = "https://pypi.io/packages/source/a/argcomplete/argcomplete-1.1.1.tar.gz"
 
     version('1.1.1', '89a3839096c9f991ad33828e72d21abf')
 

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -31,7 +31,7 @@ class PyAstropy(PythonPackage):
     Python astronomy packages."""
 
     homepage = 'http://www.astropy.org/'
-    url = 'https://pypi.python.org/packages/source/a/astropy/astropy-1.1.2.tar.gz'
+    url = 'https://pypi.io/packages/source/a/astropy/astropy-1.1.2.tar.gz'
 
     version('1.1.2',     'cbe32023b5b1177d1e2498a0d00cda51')
     version('1.1.post1', 'b52919f657a37d45cc45f5cb0f58c44d')

--- a/var/spack/repos/builtin/packages/py-bleach/package.py
+++ b/var/spack/repos/builtin/packages/py-bleach/package.py
@@ -29,7 +29,7 @@ class PyBleach(PythonPackage):
     """An easy whitelist-based HTML-sanitizing tool."""
 
     homepage = "http://github.com/mozilla/bleach"
-    url      = "https://pypi.python.org/packages/99/00/25a8fce4de102bf6e3cc76bc4ea60685b2fee33bde1b34830c70cacc26a7/bleach-1.5.0.tar.gz"
+    url      = "https://pypi.io/packages/source/b/bleach/bleach-1.5.0.tar.gz"
 
     version('1.5.0', 'b663300efdf421b3b727b19d7be9c7e7')
 

--- a/var/spack/repos/builtin/packages/py-blessings/package.py
+++ b/var/spack/repos/builtin/packages/py-blessings/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyBlessings(PythonPackage):
     """A nicer, kinder way to write to the terminal """
     homepage = "https://github.com/erikrose/blessings"
-    url      = "https://pypi.python.org/packages/source/b/blessings/blessings-1.6.tar.gz"
+    url      = "https://pypi.io/packages/source/b/blessings/blessings-1.6.tar.gz"
 
     version('1.6', '4f552a8ebcd4982693c92571beb99394')
 

--- a/var/spack/repos/builtin/packages/py-bottleneck/package.py
+++ b/var/spack/repos/builtin/packages/py-bottleneck/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyBottleneck(PythonPackage):
     """A collection of fast NumPy array functions written in Cython."""
     homepage = "https://pypi.python.org/pypi/Bottleneck/1.0.0"
-    url      = "https://pypi.python.org/packages/source/B/Bottleneck/Bottleneck-1.0.0.tar.gz"
+    url      = "https://pypi.io/packages/source/B/Bottleneck/Bottleneck-1.0.0.tar.gz"
 
     version('1.0.0', '380fa6f275bd24f27e7cf0e0d752f5d2')
 

--- a/var/spack/repos/builtin/packages/py-csvkit/package.py
+++ b/var/spack/repos/builtin/packages/py-csvkit/package.py
@@ -30,7 +30,7 @@ class PyCsvkit(PythonPackage):
     formats"""
 
     homepage = 'http://csvkit.rtfd.org/'
-    url      = "https://pypi.python.org/packages/source/c/csvkit/csvkit-0.9.1.tar.gz"
+    url      = "https://pypi.io/packages/source/c/csvkit/csvkit-0.9.1.tar.gz"
 
     version('0.9.1', '48d78920019d18846933ee969502fff6')
 

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyDask(PythonPackage):
     """Minimal task scheduling abstraction"""
     homepage = "https://github.com/dask/dask/"
-    url      = "https://pypi.python.org/packages/source/d/dask/dask-0.8.1.tar.gz"
+    url      = "https://pypi.io/packages/source/d/dask/dask-0.8.1.tar.gz"
 
     version('0.8.1', '5dd8e3a3823b3bc62c9a6d192e2cb5b4')
 

--- a/var/spack/repos/builtin/packages/py-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-dateutil/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyDateutil(PythonPackage):
     """Extensions to the standard Python datetime module."""
     homepage = "https://pypi.python.org/pypi/dateutil"
-    url      = "https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/python-dateutil/python-dateutil-2.4.0.tar.gz"
 
     version('2.4.0', '75714163bb96bedd07685cdb2071b8bc')
     version('2.4.2', '4ef68e1c485b09e9f034e10473e5add2')

--- a/var/spack/repos/builtin/packages/py-dbf/package.py
+++ b/var/spack/repos/builtin/packages/py-dbf/package.py
@@ -30,6 +30,6 @@ class PyDbf(PythonPackage):
     .dbf files (including memos)"""
 
     homepage = 'https://pypi.python.org/pypi/dbf'
-    url      = "https://pypi.python.org/packages/source/d/dbf/dbf-0.96.005.tar.gz"
+    url      = "https://pypi.io/packages/source/d/dbf/dbf-0.96.005.tar.gz"
 
     version('0.96.005', 'bce1a1ed8b454a30606e7e18dd2f8277')

--- a/var/spack/repos/builtin/packages/py-decorator/package.py
+++ b/var/spack/repos/builtin/packages/py-decorator/package.py
@@ -30,7 +30,7 @@ class PyDecorator(PythonPackage):
        for the average programmer, and to popularize decorators by showing
        various non-trivial examples."""
     homepage = "https://github.com/micheles/decorator"
-    url      = "https://pypi.python.org/packages/source/d/decorator/decorator-4.0.9.tar.gz"
+    url      = "https://pypi.io/packages/source/d/decorator/decorator-4.0.9.tar.gz"
 
     version('4.0.9', 'f12c5651ccd707e12a0abaa4f76cd69a')
 

--- a/var/spack/repos/builtin/packages/py-emcee/package.py
+++ b/var/spack/repos/builtin/packages/py-emcee/package.py
@@ -30,7 +30,7 @@ class PyEmcee(PythonPackage):
     Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler."""
 
     homepage = "http://dan.iel.fm/emcee/current/"
-    url = "https://pypi.python.org/packages/source/e/emcee/emcee-2.1.0.tar.gz"
+    url = "https://pypi.io/packages/source/e/emcee/emcee-2.1.0.tar.gz"
 
     version('2.1.0', 'c6b6fad05c824d40671d4a4fc58dfff7')
 

--- a/var/spack/repos/builtin/packages/py-entrypoints/package.py
+++ b/var/spack/repos/builtin/packages/py-entrypoints/package.py
@@ -23,31 +23,17 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-from spack.package import PackageBase
 
 
 class PyEntrypoints(PythonPackage):
     """Discover and load entry points from installed packages."""
 
     homepage = "https://pypi.python.org/pypi/entrypoints"
-    url      = "https://pypi.python.org/packages/f8/ad/0e77a853c745a15981ab51fa9a0cb4eca7a7a007b4c1970106ee6ba01e0c/entrypoints-0.2.2-py2.py3-none-any.whl"
+    url      = "https://pypi.io/packages/source/e/entrypoints/entrypoints-0.2.3.tar.gz"
 
     import_modules = ['entrypoints']
 
-    version('0.2.2', '73bd7ce92c19b25dc5a20aff41be996a', expand=False)
+    version('0.2.3', '0d3ad1b0130d91e3596ef3a59f25a56c')
 
     depends_on('python@2.7:', type=('build', 'run'))
-
-    depends_on('py-pip', type='build')
     depends_on('py-configparser', when='^python@:2.8', type=('build', 'run'))
-
-    phases = ['install']
-
-    def install(self, spec, prefix):
-        pip = which('pip')
-        pip('install', self.stage.archive_file, '--prefix={0}'.format(prefix))
-
-    run_after('install')(PackageBase._run_default_install_time_test_callbacks)
-
-    # Check that self.prefix is there after installation
-    run_after('install')(PackageBase.sanity_check_prefix)

--- a/var/spack/repos/builtin/packages/py-epydoc/package.py
+++ b/var/spack/repos/builtin/packages/py-epydoc/package.py
@@ -29,6 +29,6 @@ class PyEpydoc(PythonPackage):
     """Epydoc is a tool for generating API documentation documentation for
        Python modules, based on their docstrings."""
     homepage = "https://pypi.python.org/pypi/epydoc"
-    url      = "https://pypi.python.org/packages/source/e/epydoc/epydoc-3.0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/e/epydoc/epydoc-3.0.1.tar.gz"
 
     version('3.0.1', '36407974bd5da2af00bf90ca27feeb44')

--- a/var/spack/repos/builtin/packages/py-funcsigs/package.py
+++ b/var/spack/repos/builtin/packages/py-funcsigs/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyFuncsigs(PythonPackage):
     """Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2."""
     homepage = "https://pypi.python.org/pypi/funcsigs"
-    url      = "https://pypi.python.org/packages/source/f/funcsigs/funcsigs-0.4.tar.gz"
+    url      = "https://pypi.io/packages/source/f/funcsigs/funcsigs-0.4.tar.gz"
 
     version('0.4', 'fb1d031f284233e09701f6db1281c2a5')
 

--- a/var/spack/repos/builtin/packages/py-functools32/package.py
+++ b/var/spack/repos/builtin/packages/py-functools32/package.py
@@ -30,6 +30,6 @@ class PyFunctools32(PythonPackage):
     PyPy."""
 
     homepage = "https://github.com/MiCHiLU/python-functools32"
-    url      = "https://pypi.python.org/packages/source/f/functools32/functools32-3.2.3-2.tar.gz"
+    url      = "https://pypi.io/packages/source/f/functools32/functools32-3.2.3-2.tar.gz"
 
     version('3.2.3-2', '09f24ffd9af9f6cd0f63cb9f4e23d4b2')

--- a/var/spack/repos/builtin/packages/py-git2/package.py
+++ b/var/spack/repos/builtin/packages/py-git2/package.py
@@ -31,9 +31,9 @@ class PyGit2(PythonPackage):
     """
 
     homepage = "http://www.pygit2.org/"
+    url      = "https://pypi.io/packages/source/p/pygit2/pygit2-0.24.1.tar.gz"
 
-    version('0.24.1', 'dd98b6a9fded731e36ca5a40484c8545',
-        url="https://pypi.python.org/packages/aa/56/84dcce942a48d4b7b970cfb7a779b8db1d904e5ec5f71e7a67a63a23a4e2/pygit2-0.24.1.tar.gz")
+    version('0.24.1', 'dd98b6a9fded731e36ca5a40484c8545')
 
     extends('python')
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -30,7 +30,7 @@ class PyH5py(PythonPackage):
     HDF5 library from Python."""
 
     homepage = "https://pypi.python.org/pypi/h5py"
-    url      = "https://pypi.python.org/packages/source/h/h5py/h5py-2.4.0.tar.gz"
+    url      = "https://pypi.io/packages/source/h/h5py/h5py-2.4.0.tar.gz"
 
     version('2.6.0', 'ec476211bd1de3f5ac150544189b0bf4')
     version('2.5.0', '6e4301b5ad5da0d51b0a1e5ac19e3b74')

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -29,7 +29,7 @@ class PyHtml5lib(PythonPackage):
     """HTML parser based on the WHATWG HTML specification."""
 
     homepage = "https://github.com/html5lib/html5lib-python"
-    url      = "https://pypi.python.org/packages/ae/ae/bcb60402c60932b32dfaf19bb53870b29eda2cd17551ba5639219fb5ebf9/html5lib-0.9999999.tar.gz"
+    url      = "https://pypi.io/packages/source/h/html5lib/html5lib-0.9999999.tar.gz"
 
     version('0.9999999', 'ef43cb05e9e799f25d65d1135838a96f')
 

--- a/var/spack/repos/builtin/packages/py-iminuit/package.py
+++ b/var/spack/repos/builtin/packages/py-iminuit/package.py
@@ -29,7 +29,7 @@ class PyIminuit(PythonPackage):
     """Interactive IPython-Friendly Minimizer based on SEAL Minuit2."""
 
     homepage = "https://pypi.python.org/pypi/iminuit"
-    url      = "https://pypi.python.org/packages/source/i/iminuit/iminuit-1.2.tar.gz"
+    url      = "https://pypi.io/packages/source/i/iminuit/iminuit-1.2.tar.gz"
 
     version('1.2', '4701ec472cae42015e26251703e6e984')
 

--- a/var/spack/repos/builtin/packages/py-jsonschema/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema/package.py
@@ -29,7 +29,7 @@ class PyJsonschema(PythonPackage):
     """Jsonschema: An(other) implementation of JSON Schema for Python."""
 
     homepage = "http://github.com/Julian/jsonschema"
-    url      = "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-2.5.1.tar.gz"
+    url      = "https://pypi.io/packages/source/j/jsonschema/jsonschema-2.5.1.tar.gz"
 
     version('2.5.1', '374e848fdb69a3ce8b7e778b47c30640')
 

--- a/var/spack/repos/builtin/packages/py-lit/package.py
+++ b/var/spack/repos/builtin/packages/py-lit/package.py
@@ -32,7 +32,7 @@ class PyLit(PythonPackage):
        interface as possible."""
 
     homepage = "https://pypi.python.org/pypi/lit"
-    url      = "https://pypi.python.org/packages/5b/a0/dbed2c8dfb220eb9a5a893257223cd0ff791c0fbc34ce2f1a957fa4b6c6f/lit-0.5.0.tar.gz"
+    url      = "https://pypi.io/packages/source/l/lit/lit-0.5.0.tar.gz"
 
     version('0.5.0',  '8144660cc692be8fb903395a5f06564d')
 

--- a/var/spack/repos/builtin/packages/py-lockfile/package.py
+++ b/var/spack/repos/builtin/packages/py-lockfile/package.py
@@ -37,7 +37,7 @@ class PyLockfile(PythonPackage):
        possibilities it provides than as production-quality code.
     """
     homepage = "https://pypi.python.org/pypi/lockfile"
-    url      = "https://pypi.python.org/packages/source/l/lockfile/lockfile-0.10.2.tar.gz"
+    url      = "https://pypi.io/packages/source/l/lockfile/lockfile-0.10.2.tar.gz"
 
     version('0.10.2', '1aa6175a6d57f082cd12e7ac6102ab15')
 

--- a/var/spack/repos/builtin/packages/py-logilab-common/package.py
+++ b/var/spack/repos/builtin/packages/py-logilab-common/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyLogilabCommon(PythonPackage):
     """Common modules used by Logilab projects"""
     homepage = "https://www.logilab.org/project/logilab-common"
-    url      = "https://pypi.python.org/packages/a7/31/1650d23e44794d46935d82b86e73454cc83b814cbe1365260ccce8a2f4c6/logilab-common-1.2.0.tar.gz"
+    url      = "https://pypi.io/packages/source/l/logilab-common/logilab-common-1.2.0.tar.gz"
 
     version('1.2.0', 'f7b51351b7bfe052746fa04c03253c0b')
 

--- a/var/spack/repos/builtin/packages/py-macs2/package.py
+++ b/var/spack/repos/builtin/packages/py-macs2/package.py
@@ -30,7 +30,7 @@ class PyMacs2(PythonPackage):
     """MACS2 Model-based Analysis of ChIP-Seq"""
 
     homepage = "https://github.com/taoliu/MACS"
-    url      = "https://pypi.python.org/packages/9f/99/a8ac96b357f6b0a6f559fe0f5a81bcae12b98579551620ce07c5183aee2c/MACS2-2.1.1.20160309.tar.gz"
+    url      = "https://pypi.io/packages/source/M/MACS2/MACS2-2.1.1.20160309.tar.gz"
 
     version('2.1.1.20160309', '2008ba838f83f34f8e0fddefe2a3a0159f4a740707c68058f815b31ddad53d26')
 

--- a/var/spack/repos/builtin/packages/py-mako/package.py
+++ b/var/spack/repos/builtin/packages/py-mako/package.py
@@ -30,7 +30,7 @@ class PyMako(PythonPackage):
        ideas from the existing templating languages."""
 
     homepage = "https://pypi.python.org/pypi/mako"
-    url = "https://pypi.python.org/packages/source/M/Mako/Mako-1.0.1.tar.gz"
+    url = "https://pypi.io/packages/source/M/Mako/Mako-1.0.1.tar.gz"
 
     version('1.0.4', 'c5fc31a323dd4990683d2f2da02d4e20')
     version('1.0.1', '9f0aafd177b039ef67b90ea350497a54')

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -31,7 +31,7 @@ class PyMock(PythonPackage):
     they have been used."""
 
     homepage = "https://github.com/testing-cabal/mock"
-    url      = "https://pypi.python.org/packages/source/m/mock/mock-1.3.0.tar.gz"
+    url      = "https://pypi.io/packages/source/m/mock/mock-1.3.0.tar.gz"
 
     version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad')
     version('1.3.0', '73ee8a4afb3ff4da1b4afa287f39fdeb')

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -33,7 +33,7 @@ class PyMpi4py(PythonPackage):
 
     """
     homepage = "https://pypi.python.org/pypi/mpi4py"
-    url      = "https://pypi.python.org/packages/source/m/mpi4py/mpi4py-1.3.1.tar.gz"
+    url      = "https://pypi.io/packages/source/m/mpi4py/mpi4py-1.3.1.tar.gz"
 
     version('2.0.0', '4f7d8126d7367c239fd67615680990e3')
     version('1.3.1', 'dbe9d22bdc8ed965c23a7ceb6f32fc3c')

--- a/var/spack/repos/builtin/packages/py-mpmath/package.py
+++ b/var/spack/repos/builtin/packages/py-mpmath/package.py
@@ -28,6 +28,6 @@ from spack import *
 class PyMpmath(PythonPackage):
     """A Python library for arbitrary-precision floating-point arithmetic."""
     homepage = "http://mpmath.org"
-    url      = "https://pypi.python.org/packages/source/m/mpmath/mpmath-all-0.19.tar.gz"
+    url      = "https://pypi.io/packages/source/m/mpmath/mpmath-all-0.19.tar.gz"
 
     version('0.19', 'd1b7e19dd6830d0d7b5e1bc93d46c02c')

--- a/var/spack/repos/builtin/packages/py-nestle/package.py
+++ b/var/spack/repos/builtin/packages/py-nestle/package.py
@@ -29,7 +29,7 @@ class PyNestle(PythonPackage):
     """Nested sampling algorithms for evaluating Bayesian evidence."""
 
     homepage = "http://kbarbary.github.io/nestle/"
-    url = "https://pypi.python.org/packages/source/n/nestle/nestle-0.1.1.tar.gz"
+    url = "https://pypi.io/packages/source/n/nestle/nestle-0.1.1.tar.gz"
 
     version('0.1.1', '4875c0f9a0a8e263c1d7f5fa6ce604c5')
 

--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -29,7 +29,7 @@ class PyNetworkx(PythonPackage):
     """NetworkX is a Python package for the creation, manipulation, and study
     of the structure, dynamics, and functions of complex networks."""
     homepage = "http://networkx.github.io/"
-    url      = "https://pypi.python.org/packages/source/n/networkx/networkx-1.11.tar.gz"
+    url      = "https://pypi.io/packages/source/n/networkx/networkx-1.11.tar.gz"
 
     version('1.11', '6ef584a879e9163013e9a762e1cf7cd1')
 

--- a/var/spack/repos/builtin/packages/py-numexpr/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr/package.py
@@ -28,10 +28,9 @@ from spack import *
 class PyNumexpr(PythonPackage):
     """Fast numerical expression evaluator for NumPy"""
     homepage = "https://pypi.python.org/pypi/numexpr"
-    url      = "https://pypi.python.org/packages/source/n/numexpr/numexpr-2.4.6.tar.gz"
+    url      = "https://pypi.io/packages/source/n/numexpr/numexpr-2.6.1.tar.gz"
 
-    version('2.6.1', '6365245705b446426df9543ad218dd8e',
-            url="https://pypi.python.org/packages/c6/f0/11628fa4d332d8fe9ab0ba8e9bfe0e065fb6b5324859171ee72d84e079c0/numexpr-2.6.1.tar.gz")
+    version('2.6.1', '6365245705b446426df9543ad218dd8e')
     version('2.5',   '84f66cced45ba3e30dcf77a937763aaa')
     version('2.4.6', '17ac6fafc9ea1ce3eb970b9abccb4fbd')
 

--- a/var/spack/repos/builtin/packages/py-pathspec/package.py
+++ b/var/spack/repos/builtin/packages/py-pathspec/package.py
@@ -30,8 +30,8 @@ class PyPathspec(PythonPackage):
     making it easier to write, find and run tests."""
 
     homepage = "https://pypi.python.org/pypi/pathspec"
+    url      = "https://pypi.io/packages/source/p/pathspec/pathspec-0.3.4.tar.gz"
 
-    version('0.3.4', '2a4af9bf2dee98845d583ec61a00d05d',
-        url='https://pypi.python.org/packages/14/9d/c9d790d373d6f6938d793e9c549b87ad8670b6fa7fc6176485e6ef11c1a4/pathspec-0.3.4.tar.gz')
+    version('0.3.4', '2a4af9bf2dee98845d583ec61a00d05d')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-periodictable/package.py
+++ b/var/spack/repos/builtin/packages/py-periodictable/package.py
@@ -30,7 +30,7 @@ class PyPeriodictable(PythonPackage):
     making it easier to write, find and run tests."""
 
     homepage = "https://pypi.python.org/pypi/periodictable"
-    url      = "https://pypi.python.org/packages/source/p/periodictable/periodictable-1.4.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/periodictable/periodictable-1.4.1.tar.gz"
 
     version('1.4.1', '7246b63cc0b6b1be6e86b6616f9e866e')
 

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -29,10 +29,10 @@ class PyPetsc4py(PythonPackage):
     """This package provides Python bindings for the PETSc package.
     """
     homepage = "https://pypi.python.org/pypi/petsc4py"
-    url      = "https://pypi.python.org/packages/b3/d5/84a71e3ccc13bf90b5055d264e5b256d161ae513392d0f28e8a7ac80d15c/petsc4py-3.7.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/petsc4py/petsc4py-3.7.0.tar.gz"
 
     version('3.7.0', '816a20040a6a477bd637f397c9fb5b6d')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-mpi4py', type=('build', 'run'))
-    depends_on('petsc+mpi')    
+    depends_on('petsc+mpi')

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -33,7 +33,7 @@ class PyPillow(PythonPackage):
     capabilities."""
 
     homepage = "https://python-pillow.org/"
-    url = "https://pypi.python.org/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
+    url = "https://pypi.io/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
 
     # TODO: This version should be deleted once the next release comes out.
     # TODO: It fixes a bug that prevented us from linking to Tk/Tcl.

--- a/var/spack/repos/builtin/packages/py-pmw/package.py
+++ b/var/spack/repos/builtin/packages/py-pmw/package.py
@@ -29,6 +29,6 @@ class PyPmw(PythonPackage):
     """Pmw is a toolkit for building high-level compound widgets, or
        megawidgets, constructed using other widgets as component parts."""
     homepage = "https://pypi.python.org/pypi/Pmw"
-    url      = "https://pypi.python.org/packages/source/P/Pmw/Pmw-2.0.0.tar.gz"
+    url      = "https://pypi.io/packages/source/P/Pmw/Pmw-2.0.0.tar.gz"
 
     version('2.0.0', 'c7c3f26c4f5abaa99807edefee578fc0')

--- a/var/spack/repos/builtin/packages/py-ppft/package.py
+++ b/var/spack/repos/builtin/packages/py-ppft/package.py
@@ -29,7 +29,7 @@ class PyPpft(PythonPackage):
     """Distributed and parallel python """
 
     homepage = "https://github.com/uqfoundation/ppft"
-    url      = "https://pypi.org/packages/source/p/ppft/ppft-1.6.4.7.1.zip"
+    url      = "https://pypi.io/packages/source/p/ppft/ppft-1.6.4.7.1.zip"
 
     version('1.6.4.7.1',  '2b196a03bfbc102773f849c6b21e617b')
     version('1.6.4.6',   'e533432bfba4b5a523a07d58011df209')

--- a/var/spack/repos/builtin/packages/py-prettytable/package.py
+++ b/var/spack/repos/builtin/packages/py-prettytable/package.py
@@ -32,7 +32,7 @@ class PyPrettytable(PythonPackage):
     """
 
     homepage = "https://code.google.com/archive/p/prettytable/"
-    url      = "https://pypi.python.org/packages/e0/a1/36203205f77ccf98f3c6cf17cf068c972e6458d7e58509ca66da949ca347/prettytable-0.7.2.tar.gz"
+    url      = "https://pypi.io/packages/source/p/prettytable/prettytable-0.7.2.tar.gz"
 
     version('0.7.2', 'a6b80afeef286ce66733d54a0296b13b')
 

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -34,7 +34,7 @@ class PyProtobuf(PythonPackage):
     and using a variety of languages."""
 
     homepage = 'https://developers.google.com/protocol-buffers/'
-    url      = 'https://pypi.python.org/packages/source/p/protobuf/protobuf-3.0.0b2.tar.gz'
+    url      = 'https://pypi.io/packages/source/p/protobuf/protobuf-3.0.0b2.tar.gz'
 
     version('3.0.0b2', 'f0d3bd2394345a9af4a277cd0302ae83')
     version('2.6.1', '6bf843912193f70073db7f22e2ea55e2')

--- a/var/spack/repos/builtin/packages/py-psutil/package.py
+++ b/var/spack/repos/builtin/packages/py-psutil/package.py
@@ -31,7 +31,7 @@ class PyPsutil(PythonPackage):
     in Python."""
 
     homepage = "https://pypi.python.org/pypi/psutil"
-    url      = "https://pypi.python.org/packages/d9/c8/8c7a2ab8ec108ba9ab9a4762c5a0d67c283d41b13b5ce46be81fdcae3656/psutil-5.0.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/psutil/psutil-5.0.1.tar.gz"
 
     version('5.0.1', '153dc8be94badc4072016ceeac7808dc')
 

--- a/var/spack/repos/builtin/packages/py-pycrypto/package.py
+++ b/var/spack/repos/builtin/packages/py-pycrypto/package.py
@@ -30,7 +30,7 @@ class PyPycrypto(PythonPackage):
     """The Python Cryptography Toolkit"""
 
     homepage = "https://www.dlitz.net/software/pycrypto/"
-    url      = "https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz"
 
     version('2.6.1', '55a61a054aa66812daf5161a0d5d7eda')
 

--- a/var/spack/repos/builtin/packages/py-pycurl/package.py
+++ b/var/spack/repos/builtin/packages/py-pycurl/package.py
@@ -30,7 +30,7 @@ class PyPycurl(PythonPackage):
     objects identified by a URL from a Python program."""
 
     homepage = "http://pycurl.io/"
-    url      = "https://pypi.python.org/packages/source/p/pycurl/pycurl-7.43.0.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pycurl/pycurl-7.43.0.tar.gz"
 
     version('7.43.0', 'c94bdba01da6004fa38325e9bd6b9760')
 

--- a/var/spack/repos/builtin/packages/py-pydatalog/package.py
+++ b/var/spack/repos/builtin/packages/py-pydatalog/package.py
@@ -28,6 +28,6 @@ from spack import *
 class PyPydatalog(PythonPackage):
     """pyDatalog adds logic programming to Python."""
     homepage = 'https://pypi.python.org/pypi/pyDatalog/'
-    url      = 'https://pypi.python.org/packages/09/0b/2670eb9c0027aacfb5b5024ca75e5fee2f1261180ab8797108ffc941158a/pyDatalog-0.17.1.zip'
+    url      = 'https://pypi.io/packages/source/p/pyDatalog/pyDatalog-0.17.1.zip'
 
     version('0.17.1', '6b2682301200068d208d6f2d01723939')

--- a/var/spack/repos/builtin/packages/py-pyelftools/package.py
+++ b/var/spack/repos/builtin/packages/py-pyelftools/package.py
@@ -29,6 +29,6 @@ class PyPyelftools(PythonPackage):
     """A pure-Python library for parsing and analyzing ELF files and DWARF
        debugging information"""
     homepage = "https://pypi.python.org/pypi/pyelftools"
-    url      = "https://pypi.python.org/packages/source/p/pyelftools/pyelftools-0.23.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pyelftools/pyelftools-0.23.tar.gz"
 
     version('0.23', 'aa7cefa8bd2f63d7b017440c9084f310')

--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -29,7 +29,7 @@ import os
 class PyPyside(PythonPackage):
     """Python bindings for Qt."""
     homepage = "https://pypi.python.org/pypi/pyside"
-    url      = "https://pypi.python.org/packages/source/P/PySide/PySide-1.2.2.tar.gz"
+    url      = "https://pypi.io/packages/source/P/PySide/PySide-1.2.2.tar.gz"
 
     version('1.2.4', '3cb7174c13bd45e3e8f77638926cb8c0')  # rpath problems
     version('1.2.2', 'c45bc400c8a86d6b35f34c29e379e44d', preferred=True)

--- a/var/spack/repos/builtin/packages/py-python-daemon/package.py
+++ b/var/spack/repos/builtin/packages/py-python-daemon/package.py
@@ -38,7 +38,7 @@ class PyPythonDaemon(PythonPackage):
        to enter a daemon state.
     """
     homepage = "https://pypi.python.org/pypi/python-daemon/"
-    url      = "https://pypi.python.org/packages/source/p/python-daemon/python-daemon-2.0.5.tar.gz"
+    url      = "https://pypi.io/packages/source/p/python-daemon/python-daemon-2.0.5.tar.gz"
 
     version('2.0.5', '73e7f49f525c51fa4a995aea4d80de41')
 

--- a/var/spack/repos/builtin/packages/py-readme-renderer/package.py
+++ b/var/spack/repos/builtin/packages/py-readme-renderer/package.py
@@ -30,7 +30,7 @@ class PyReadmeRenderer(PythonPackage):
     for Warehouse."""
 
     homepage = "https://github.com/pypa/readme_renderer"
-    url      = "https://pypi.python.org/packages/f2/6e/ef1bc3a24eb14e14574aba9dc1bd50bc9a5e7cc880e8ff9cadd385b4fb37/readme_renderer-16.0.tar.gz"
+    url      = "https://pypi.io/packages/source/r/readme_renderer/readme_renderer-16.0.tar.gz"
 
     version('16.0', '70321cea986956bcf2deef9981569f39')
 

--- a/var/spack/repos/builtin/packages/py-restview/package.py
+++ b/var/spack/repos/builtin/packages/py-restview/package.py
@@ -29,7 +29,7 @@ class PyRestview(PythonPackage):
     """A viewer for ReStructuredText documents that renders them on the fly."""
 
     homepage = "https://mg.pov.lt/restview/"
-    url = "https://pypi.python.org/packages/source/r/restview/restview-2.6.1.tar.gz"
+    url = "https://pypi.io/packages/source/r/restview/restview-2.6.1.tar.gz"
 
     version('2.6.1', 'ac8b70e15b8f1732d1733d674813666b')
 

--- a/var/spack/repos/builtin/packages/py-rpy2/package.py
+++ b/var/spack/repos/builtin/packages/py-rpy2/package.py
@@ -33,7 +33,7 @@ class PyRpy2(PythonPackage):
 
     """
     homepage = "https://pypi.python.org/pypi/rpy2"
-    url = "https://pypi.python.org/packages/source/r/rpy2/rpy2-2.5.4.tar.gz"
+    url = "https://pypi.io/packages/source/r/rpy2/rpy2-2.5.4.tar.gz"
 
     version('2.5.4', '115a20ac30883f096da2bdfcab55196d')
     version('2.5.6', 'a36e758b633ce6aec6a5f450bfee980f')

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -30,7 +30,7 @@ class PyScikitImage(PythonPackage):
     filtering, warping, color manipulation, object detection, etc."""
 
     homepage = "http://scikit-image.org/"
-    url      = "https://pypi.python.org/packages/source/s/scikit-image/scikit-image-0.12.3.tar.gz"
+    url      = "https://pypi.io/packages/source/s/scikit-image/scikit-image-0.12.3.tar.gz"
 
     version('0.12.3', '04ea833383e0b6ad5f65da21292c25e1')
 

--- a/var/spack/repos/builtin/packages/py-shiboken/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken/package.py
@@ -29,7 +29,7 @@ import os
 class PyShiboken(PythonPackage):
     """Shiboken generates bindings for C++ libraries using CPython."""
     homepage = "https://shiboken.readthedocs.org/"
-    url      = "https://pypi.python.org/packages/source/S/Shiboken/Shiboken-1.2.2.tar.gz"
+    url      = "https://pypi.io/packages/source/S/Shiboken/Shiboken-1.2.2.tar.gz"
 
     version('1.2.2', '345cfebda221f525842e079a6141e555')
 

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -29,7 +29,7 @@ class PySlepc4py(PythonPackage):
     """This package provides Python bindings for the SLEPc package.
     """
     homepage = "https://pypi.python.org/pypi/slepc4py"
-    url      = "https://pypi.python.org/packages/b4/dd/116fbdf865f6f9eda779c5d31bc5b68f37ef3dd5dbfc3feb4aaba1565560/slepc4py-3.7.0.tar.gz"
+    url      = "https://pypi.io/packages/source/s/slepc4py/slepc4py-3.7.0.tar.gz"
 
     version('3.7.0', 'c4775e88b0825c7313629c01de60ecb2')
 

--- a/var/spack/repos/builtin/packages/py-sncosmo/package.py
+++ b/var/spack/repos/builtin/packages/py-sncosmo/package.py
@@ -30,7 +30,7 @@ class PySncosmo(PythonPackage):
     analysis."""
 
     homepage = "http://sncosmo.readthedocs.io/"
-    url = "https://pypi.python.org/packages/source/s/sncosmo/sncosmo-1.2.0.tar.gz"
+    url = "https://pypi.io/packages/source/s/sncosmo/sncosmo-1.2.0.tar.gz"
 
     version('1.2.0', '028e6d1dc84ab1c17d2f3b6378b2cb1e')
 

--- a/var/spack/repos/builtin/packages/py-sqlalchemy/package.py
+++ b/var/spack/repos/builtin/packages/py-sqlalchemy/package.py
@@ -29,6 +29,6 @@ class PySqlalchemy(PythonPackage):
     """The Python SQL Toolkit and Object Relational Mapper"""
 
     homepage = 'http://www.sqlalchemy.org/'
-    url      = "https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-1.0.12.tar.gz"
+    url      = "https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-1.0.12.tar.gz"
 
     version('1.0.12', '6d19ef29883bbebdcac6613cf391cac4')

--- a/var/spack/repos/builtin/packages/py-sympy/package.py
+++ b/var/spack/repos/builtin/packages/py-sympy/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PySympy(PythonPackage):
     """SymPy is a Python library for symbolic mathematics."""
     homepage = "https://pypi.python.org/pypi/sympy"
-    url      = "https://pypi.python.org/packages/source/s/sympy/sympy-0.7.6.tar.gz"
+    url      = "https://pypi.io/packages/source/s/sympy/sympy-0.7.6.tar.gz"
 
     version('0.7.6', '3d04753974306d8a13830008e17babca')
     version('1.0', '43e797de799f00f9e8fd2307dba9fab1')

--- a/var/spack/repos/builtin/packages/py-tappy/package.py
+++ b/var/spack/repos/builtin/packages/py-tappy/package.py
@@ -29,7 +29,7 @@ class PyTappy(PythonPackage):
     """Python TAP interface module for unit tests"""
     homepage = "https://github.com/mblayman/tappy"
     # base https://pypi.python.org/pypi/cffi
-    url      = "https://pypi.python.org/packages/source/t/tap.py/tap.py-1.6.tar.gz"
+    url      = "https://pypi.io/packages/source/t/tap.py/tap.py-1.6.tar.gz"
 
     version('1.6', 'c8bdb93ad66e05f939905172a301bedf')
 

--- a/var/spack/repos/builtin/packages/py-twisted/package.py
+++ b/var/spack/repos/builtin/packages/py-twisted/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyTwisted(PythonPackage):
     """An asynchronous networking framework written in Python"""
     homepage = "https://twistedmatrix.com/"
-    url      = "https://pypi.python.org/packages/source/T/Twisted/Twisted-15.3.0.tar.bz2"
+    url      = "https://pypi.io/packages/source/T/Twisted/Twisted-15.3.0.tar.bz2"
 
     version('15.4.0', '5337ffb6aeeff3790981a2cd56db9655')
     version('15.3.0', 'b58e83da2f00b3352afad74d0c5c4599')

--- a/var/spack/repos/builtin/packages/py-unittest2/package.py
+++ b/var/spack/repos/builtin/packages/py-unittest2/package.py
@@ -30,7 +30,7 @@ class PyUnittest2(PythonPackage):
     testing framework in Python 2.7 and onwards."""
 
     homepage = "https://pypi.python.org/pypi/unittest2"
-    url      = "https://pypi.python.org/packages/source/u/unittest2/unittest2-1.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/u/unittest2/unittest2-1.1.0.tar.gz"
 
     version('1.1.0', 'f72dae5d44f091df36b6b513305ea000')
 

--- a/var/spack/repos/builtin/packages/py-unittest2py3k/package.py
+++ b/var/spack/repos/builtin/packages/py-unittest2py3k/package.py
@@ -31,7 +31,7 @@ class PyUnittest2py3k(PythonPackage):
     version of unittest2."""
 
     homepage = "https://pypi.python.org/pypi/unittest2py3k"
-    url      = "https://pypi.python.org/packages/source/u/unittest2py3k/unittest2py3k-0.5.1.tar.gz"
+    url      = "https://pypi.io/packages/source/u/unittest2py3k/unittest2py3k-0.5.1.tar.gz"
 
     version('0.5.1', '8824ff92044310d9365f90d892bf0f09')
 

--- a/var/spack/repos/builtin/packages/py-urwid/package.py
+++ b/var/spack/repos/builtin/packages/py-urwid/package.py
@@ -28,7 +28,7 @@ from spack import *
 class PyUrwid(PythonPackage):
     """A full-featured console UI library"""
     homepage = "http://urwid.org/"
-    url      = "https://pypi.python.org/packages/source/u/urwid/urwid-1.3.0.tar.gz"
+    url      = "https://pypi.io/packages/source/u/urwid/urwid-1.3.0.tar.gz"
 
     version('1.3.0', 'a989acd54f4ff1a554add464803a9175')
 

--- a/var/spack/repos/builtin/packages/py-vcversioner/package.py
+++ b/var/spack/repos/builtin/packages/py-vcversioner/package.py
@@ -29,7 +29,7 @@ class PyVcversioner(PythonPackage):
     """Vcversioner: Take version numbers from version control."""
 
     homepage = "https://github.com/habnabit/vcversioner"
-    url      = "https://pypi.python.org/packages/source/v/vcversioner/vcversioner-2.16.0.0.tar.gz"
+    url      = "https://pypi.io/packages/source/v/vcversioner/vcversioner-2.16.0.0.tar.gz"
 
     version('2.16.0.0', 'aab6ef5e0cf8614a1b1140ed5b7f107d')
 

--- a/var/spack/repos/builtin/packages/py-xlrd/package.py
+++ b/var/spack/repos/builtin/packages/py-xlrd/package.py
@@ -30,6 +30,6 @@ class PyXlrd(PythonPackage):
     spreadsheet files"""
 
     homepage = 'http://www.python-excel.org/'
-    url      = "https://pypi.python.org/packages/source/x/xlrd/xlrd-0.9.4.tar.gz"
+    url      = "https://pypi.io/packages/source/x/xlrd/xlrd-0.9.4.tar.gz"
 
     version('0.9.4', '911839f534d29fe04525ef8cd88fe865')


### PR DESCRIPTION
I've been meaning to do this for a very long time.

PyPI recently (last year) changed its download URLs so that they include a hash in them. For example:
https://pypi.python.org/packages/c0/3a/40967d9f5675fbb097ffec170f59c2ba19fc96373e73ad47c2cae9a30aed/numpy-1.13.1.zip#md5=2c3c0f4edf720c3a7b525dacc825b9ae

This has the consequence that you can no longer guess the URL for a particular version based on the version number alone. pypi.io seems to be a service designed to mimic the behavior of the old pypi.python.org URLs. This allows us to use nicely formatted URLs like:
https://pypi.io/packages/source/n/numpy/numpy-1.13.1.zip

This PR converts every package that previously downloaded from pypi.python.org to pypi.io.