### PR TITLE
Add latest version of numpy and scipy

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -34,7 +34,7 @@ class PyNumpy(PythonPackage):
     number capabilities"""
 
     homepage = "http://www.numpy.org/"
-    url      = "https://pypi.io/packages/source/n/numpy/numpy-1.9.1.tar.gz"
+    url      = "https://pypi.io/packages/source/n/numpy/numpy-1.13.1.zip"
 
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
@@ -48,18 +48,16 @@ class PyNumpy(PythonPackage):
     # FIXME: numpy._build_utils and numpy.core.code_generators failed to import
     # FIXME: Is this expected?
 
-    version('1.13.0', 'fd044f0b8079abeaf5e6d2e93b2c1d03',
-            url="https://pypi.io/packages/source/n/numpy/numpy-1.13.0.zip")
-    version('1.12.1', 'c75b072a984028ac746a6a332c209a91',
-            url="https://pypi.io/packages/source/n/numpy/numpy-1.12.1.zip")
-    version('1.12.0', '33e5a84579f31829bbbba084fe0a4300',
-            url="https://pypi.io/packages/source/n/numpy/numpy-1.12.0.zip")
-    version('1.11.2', '03bd7927c314c43780271bf1ab795ebc')
-    version('1.11.1', '2f44a895a8104ffac140c3a70edbd450')
-    version('1.11.0', 'bc56fb9fc2895aa4961802ffbdb31d0b')
-    version('1.10.4', 'aed294de0aa1ac7bd3f9745f4f1968ad')
-    version('1.9.2',  'a1ed53432dbcd256398898d35bc8e645')
-    version('1.9.1',  '78842b73560ec378142665e712ae4ad9')
+    version('1.13.1', '2c3c0f4edf720c3a7b525dacc825b9ae')
+    version('1.13.0', 'fd044f0b8079abeaf5e6d2e93b2c1d03')
+    version('1.12.1', 'c75b072a984028ac746a6a332c209a91')
+    version('1.12.0', '33e5a84579f31829bbbba084fe0a4300')
+    version('1.11.2', '8308cc97be154d2f64a2387ea863c2ac')
+    version('1.11.1', '5caa3428b24aaa07e72c79d115140e46')
+    version('1.11.0', '19ce5c4eb16d663a0713daf0018a3021')
+    version('1.10.4', '510ffc322c635511e7be95d225b6bcbb')
+    version('1.9.2',  'e80c19d2fb25af576460bb7dac31c59a')
+    version('1.9.1',  '223532d8e1bdaff5d30936439701d6e1')
 
     variant('blas',   default=True, description='Build with BLAS support')
     variant('lapack', default=True, description='Build with LAPACK support')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -31,7 +31,7 @@ class PyScipy(PythonPackage):
     as routines for numerical integration and optimization."""
 
     homepage = "http://www.scipy.org/"
-    url = "https://pypi.io/packages/source/s/scipy/scipy-0.18.1.tar.gz"
+    url = "https://pypi.io/packages/source/s/scipy/scipy-0.19.1.tar.gz"
 
     install_time_test_callbacks = ['install_test', 'import_module_test']
 
@@ -49,6 +49,9 @@ class PyScipy(PythonPackage):
         'scipy.special._precompute'
     ]
 
+    # See https://github.com/LLNL/spack/issues/2737
+    version('0.19.1', '6b4d91b62f1926282b127194a06b72b3',
+            url="https://pypi.io/packages/source/s/scipy/scipy-0.19.1.tar.gz")
     version('0.19.0', '91b8396231eec780222a57703d3ec550',
             url="https://pypi.io/packages/source/s/scipy/scipy-0.19.0.zip")
     version('0.18.1', '5fb5fb7ccb113ab3a039702b6c2f3327')


### PR DESCRIPTION
Numpy seems to have stopped offering `.tar.gz` releases, so I switched all versions to use `.zip` for uniformity.