### PR TITLE
Add a new package for fastjar

### DIFF
--- a/var/spack/repos/builtin/packages/fastjar/package.py
+++ b/var/spack/repos/builtin/packages/fastjar/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Fastjar(AutotoolsPackage):
+    """Fastjar is a version of Sun's 'jar' utility, written entirely in C."""
+
+    homepage = "http://savannah.nongnu.org/projects/fastjar/"
+    url      = "http://download.savannah.gnu.org/releases/fastjar/fastjar-0.98.tar.gz"
+
+    version('0.98', 'd2d264d343d4d0e1575832cc1023c3bf')
+
+    depends_on('zlib')


### PR DESCRIPTION
Stealing this from #2624. It is no longer needed for the IcedTea package, but I'm sure someone will find it useful someday.

Builds on both macOS with clang and CentOS with GCC.