### PR TITLE
Limit make_jobs for boost < 1.59

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -341,7 +341,11 @@ class Boost(Package):
         b2name = './b2' if spec.satisfies('@1.47:') else './bjam'
 
         b2 = Executable(b2name)
-        b2_options = ['-j', '%s' % make_jobs]
+        jobs = make_jobs
+        # in 1.59 max jobs became dynamic
+        if jobs > 64 and spec.satisfies('@:1.58'):
+            jobs = 64
+        b2_options = ['-j', '%s' % jobs]
 
         threadingOpts = self.determine_b2_options(spec, b2_options)
 


### PR DESCRIPTION
Earlier versions of boost had a fixed maximum number of jobs.  In 1.54 it was 64, it bumped once or twice afterwards and in 1.59 ([this commit][commit]) it became dynamic.

I need 1.54 for as a prereq for bcl2fastq but I can't build it on my 144 core build box because make_jobs is 144.

This fixes that.

[commit]: https://github.com/boostorg/build/commit/316e26ca718afc65d6170029284521392524e4f8