### PR TITLE
Colorize spack info. Adds prominence to preferred version.

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -72,7 +72,7 @@ def variant(s):
 
 
 class VariantFormatter(object):
-    def __init__(self, variants, max_widths=(25, 20, 35)):
+    def __init__(self, variants, max_widths=(30, 20, 30)):
         self.variants = variants
         self.headers = ('Name [Default]', 'Allowed values', 'Description')
         # Set max headers lengths
@@ -143,7 +143,6 @@ class VariantFormatter(object):
                         name, allowed, description, fillvalue=''
                 ):
                     yield "    " + self.fmt % t
-                yield ''  # Trigger a new line
 
 
 def print_text_info(pkg):
@@ -161,8 +160,7 @@ def print_text_info(pkg):
     else:
         print("    None")
 
-    whitespaces = ''.join([' '] * (len(header) - len('Homepage: ')))
-    color.cprint(section_title('Homepage:') + whitespaces + pkg.homepage)
+    color.cprint(section_title('Homepage: ') + pkg.homepage)
 
     color.cprint('')
     color.cprint(section_title('Preferred version:  '))
@@ -186,7 +184,7 @@ def print_text_info(pkg):
         _, _, preferred = l.pop()
 
         f = fs.for_package_version(pkg, preferred)
-        line = '@*c    {0}'.format(pad(preferred)) + '@.@*{' + str(f) + '}@.'
+        line = version('    {0}'.format(pad(preferred))) + str(f)
         color.cprint(line)
         color.cprint('')
         color.cprint(section_title('Safe versions:  '))

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -39,7 +39,7 @@ description = 'get detailed information on a particular package'
 section = 'basic'
 level = 'short'
 
-header_color = '@*k'
+header_color = '@*b'
 plain_format = '@.'
 
 
@@ -165,27 +165,33 @@ def print_text_info(pkg):
     color.cprint(section_title('Homepage:') + whitespaces + pkg.homepage)
 
     color.cprint('')
-    color.cprint(section_title('Safe versions:  '))
+    color.cprint(section_title('Preferred version:  '))
 
     if not pkg.versions:
         color.cprint(version('    None'))
+        color.cprint('')
+        color.cprint(section_title('Safe versions:  '))
+        color.cprint(version('    None'))
     else:
         pad = padder(pkg.versions, 4)
+
+        # Here we sort first on the fact that a version is marked
+        # as preferred in the package, then on the fact that the
+        # version is not develop, then lexicographically
         l = [
-            (value.get('preferred', False), key)
+            (value.get('preferred', False), not key.isdevelop(), key)
             for key, value in pkg.versions.items()
         ]
+        l = sorted(l)
+        _, _, preferred = l.pop()
 
-        _, first = l[0]
-        l = l[1:]
-
-        f = fs.for_package_version(pkg, first)
-        line = '@*c    {0}'.format(pad(first)) + '@*k' + str(f) + '@.'
-        color.cprint('')
+        f = fs.for_package_version(pkg, preferred)
+        line = '@*c    {0}'.format(pad(preferred)) + '@.@*{' + str(f) + '}@.'
         color.cprint(line)
         color.cprint('')
+        color.cprint(section_title('Safe versions:  '))
 
-        for _, v in reversed(sorted(l)):
+        for v in reversed(sorted(pkg.versions)):
             f = fs.for_package_version(pkg, v)
             line = version('    {0}'.format(pad(v))) + str(f)
             color.cprint(line)

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -1,0 +1,40 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import pytest
+
+from spack.main import SpackCommand
+
+info = SpackCommand('info')
+
+
+@pytest.mark.parametrize('pkg', [
+    'openmpi',
+    'trilinos',
+    'boost',
+    'python',
+    'dealii'
+])
+def test_it_just_runs(pkg):
+    info(pkg)


### PR DESCRIPTION
fixes #2708

This uses `llnl.util.tty.color` to colorize the output of `spack info`. It also adds a section to display the preferred version before listing all the safe versions in order.