### PR TITLE
Fix Scalasca build error

### DIFF
--- a/var/spack/repos/builtin/packages/scalasca/package.py
+++ b/var/spack/repos/builtin/packages/scalasca/package.py
@@ -63,4 +63,9 @@ class Scalasca(AutotoolsPackage):
         config_args.append("--with-cube=%s" % spec['cube'].prefix.bin)
         config_args.append("--with-otf2=%s" % spec['otf2'].prefix.bin)
 
+        if self.spec['mpi'].name == 'openmpi':
+            config_args.append("--with-mpi=openmpi")
+        elif self.spec.satisfies('^mpich@3:'):
+            config_args.append("--with-mpi=mpich3")
+
         return config_args


### PR DESCRIPTION
    Build system "usually" autodetects mpi library but this is
    not the case on many platforms. Provide mpi library name/version
    as part for configure args.

While building on local ubuntu system (where mpich is installed) I got:

```
checking for mpiicc... no
checking for mpcc... no
checking for SGI MPT... no
checking for mpicc... no
configure: error: mpicc found but cannot determine MPI library. Select MPI using --with-mpi=bullxmpi|hp|lam|mpibull2|mpich|mpich2|mpich3|openmpi|platform|scali
==> Error: ProcessError: Command exited with status 1:
    '/home/guest/workarena/softwares/sources/spack/var/spack/stage/scalasca-2.3.1-plaa7ebtpniat7izgeekrrs72623ww4u/scalasca-2.3.1/configure' '--prefix=/home/guest/workarena/softwares/sources/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.1/scalasca-2.3.1-plaa7ebtpniat7izgeekrrs72623ww4u' '--enable-shared' '--with-cube=/home/guest/workarena/softwares/sources/spack/opt/spack/linux-ubuntu16-x86_64/gcc-5.4.1/cube-4.3.5-7722qcaoslo2uouxxzuu7lefmsqgs
```

there are other mpi options but `mpich3` and `openmpi` is most common (for basic users at least).
