### PR TITLE
Fix future import in hdf5-blosc

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-blosc/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-blosc/package.py
@@ -22,7 +22,6 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-from __future__ import print_function
 import os
 import shutil
 import sys


### PR DESCRIPTION
Fixes #3676.

Well, it doesn't really fix the issue that:
```python
from __future__ import print_function
```
breaks a package, but it does remove the offending line from `hdf5-blosc`.