### PR TITLE
Add latest version of gmake

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -25,18 +25,33 @@
 from spack import *
 
 
-class Gmake(Package):
-    """GNU Make."""
+class Gmake(AutotoolsPackage):
+    """GNU Make is a tool which controls the generation of executables and
+    other non-source files of a program from the program's source files."""
 
-    homepage = "http://gnu.org/gnu/make"
-    url      = "https://ftp.gnu.org/gnu/make/make-4.0.tar.gz"
+    homepage = "https://www.gnu.org/software/make/"
+    url      = "https://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz"
 
-    version('4.0', 'b5e558f981326d9ca1bfdb841640721a')
+    version('4.2.1', '7d0dcb6c474b258aab4d54098f2cf5a7')
+    version('4.0',   'b5e558f981326d9ca1bfdb841640721a')
 
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix))
+    variant('guile', default=False, description='Support GNU Guile for embedded scripting')
 
-        make()
-        make('install')
-        with working_dir(prefix.bin):
+    depends_on('guile', when='+guile')
+
+    build_directory = 'spack-build'
+
+    def configure_args(self):
+        args = []
+
+        if '+guile' in self.spec:
+            args.append('--with-guile')
+        else:
+            args.append('--without-guile')
+
+        return args
+
+    @run_after('install')
+    def symlink_gmake(self):
+        with working_dir(self.prefix.bin):
             symlink('make', 'gmake')


### PR DESCRIPTION
Also makes the following changes:

- [x] Convert from `Package` to `AutotoolsPackage`
- [x] Update the description
- [x] Update the homepage, old one was a 404
- [x] Add a guile variant and dependency

Builds fine for me on CentOS 6. Even passes all the tests!