### PR TITLE
IceT: Ill-Placed CMake Modules

### DIFF
--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -40,3 +40,7 @@ class Icet(CMakePackage):
 
     def cmake_args(self):
         return ['-DICET_USE_OPENGL:BOOL=OFF']
+
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        """Work-around for ill-placed CMake modules"""
+        spack_env.prepend_path('CMAKE_PREFIX_PATH', self.prefix.lib)


### PR DESCRIPTION
IceT places its CMake module in the wrong directory (prefix.lib), which is not included in the default CMake search paths (e.g. prefix.lib.cmake would be).

This fixes it for *directly* depending packages without the need to add
```yaml
    icet:
      environment:
        prepend_path:
          CMAKE_PREFIX_PATH: '${PREFIX}/lib'
```

to the `modules.yaml` as a workaround.