### PR TITLE
Show build log on build failure

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -334,31 +334,41 @@ def install(parser, args, **kwargs):
         tty.error('The `spack install` command requires a spec to install.')
 
     for spec in specs:
+        saved_do_install = PackageBase.do_install
+        decorator = lambda fn: fn
+
         # Check if we were asked to produce some log for dashboards
         if args.log_format is not None:
             # Compute the filename for logging
             log_filename = args.log_file
             if not log_filename:
                 log_filename = default_log_file(spec)
+
             # Create the test suite in which to log results
             test_suite = TestSuite(spec)
-            # Decorate PackageBase.do_install to get installation status
-            PackageBase.do_install = junit_output(
-                spec, test_suite
-            )(PackageBase.do_install)
+
+            # Temporarily decorate PackageBase.do_install to monitor
+            # recursive calls.
+            decorator = junit_output(spec, test_suite)
 
         # Do the actual installation
-        if args.things_to_install == 'dependencies':
-            # Install dependencies as-if they were installed
-            # for root (explicit=False in the DB)
-            kwargs['explicit'] = False
-            for s in spec.dependencies():
-                p = spack.repo.get(s)
-                p.do_install(**kwargs)
-        else:
-            package = spack.repo.get(spec)
-            kwargs['explicit'] = True
-            package.do_install(**kwargs)
+        try:
+            # decorate the install if necessary
+            PackageBase.do_install = decorator(PackageBase.do_install)
+
+            if args.things_to_install == 'dependencies':
+                # Install dependencies as-if they were installed
+                # for root (explicit=False in the DB)
+                kwargs['explicit'] = False
+                for s in spec.dependencies():
+                    p = spack.repo.get(s)
+                    p.do_install(**kwargs)
+            else:
+                package = spack.repo.get(spec)
+                kwargs['explicit'] = True
+                package.do_install(**kwargs)
+        finally:
+            PackageBase.do_install = saved_do_install
 
         # Dump log file if asked to
         if args.log_format is not None:

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -45,11 +45,27 @@ class SpackError(Exception):
         # traceback as a string and print it in the parent.
         self.traceback = None
 
+        # we allow exceptions to print debug info via print_context()
+        # before they are caught at the top level. If they *haven't*
+        # printed context early, we do it by default when die() is
+        # called, so we need to remember whether it's been called.
+        self.printed = False
+
     @property
     def long_message(self):
         return self._long_message
 
-    def die(self):
+    def print_context(self):
+        """Print extended debug information about this exception.
+
+        This is usually printed when the top-level Spack error handler
+        calls ``die()``, but it acn be called separately beforehand if a
+        lower-level error handler needs to print error context and
+        continue without raising the exception to the top level.
+        """
+        if self.printed:
+            return
+
         # basic debug message
         tty.error(self.message)
         if self.long_message:
@@ -66,6 +82,11 @@ class SpackError(Exception):
                 # run parent exception hook.
                 sys.excepthook(*sys.exc_info())
 
+        sys.stderr.flush()
+        self.printed = True
+
+    def die(self):
+        self.print_context()
         sys.exit(1)
 
     def __str__(self):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -34,9 +34,10 @@ import os
 import inspect
 import pstats
 import argparse
-import tempfile
+from six import StringIO
 
 import llnl.util.tty as tty
+from llnl.util.tty.log import log_output
 from llnl.util.tty.color import *
 
 import spack
@@ -367,7 +368,7 @@ class SpackCommand(object):
         install('-v', 'mpich')
 
     Use this to invoke Spack commands directly from Python and check
-    their stdout and stderr.
+    their output.
     """
     def __init__(self, command):
         """Create a new SpackCommand that invokes ``command`` when called."""
@@ -375,9 +376,6 @@ class SpackCommand(object):
         self.parser.add_command(command)
         self.command_name = command
         self.command = spack.cmd.get_command(command)
-
-        self.returncode = None
-        self.error = None
 
     def __call__(self, *argv, **kwargs):
         """Invoke this SpackCommand.
@@ -389,26 +387,26 @@ class SpackCommand(object):
             fail_on_error (optional bool): Don't raise an exception on error
 
         Returns:
-            (str, str): output and error as a strings
+            (str): combined output and error as a string
 
         On return, if ``fail_on_error`` is False, return value of comman
         is set in ``returncode`` property, and the error is set in the
         ``error`` property.  Otherwise, raise an error.
         """
+        # set these before every call to clear them out
+        self.returncode = None
+        self.error = None
+
         args, unknown = self.parser.parse_known_args(
             [self.command_name] + list(argv))
 
         fail_on_error = kwargs.get('fail_on_error', True)
 
-        out, err = sys.stdout, sys.stderr
-        ofd, ofn = tempfile.mkstemp()
-        efd, efn = tempfile.mkstemp()
-
+        out = StringIO()
         try:
-            sys.stdout = open(ofn, 'w')
-            sys.stderr = open(efn, 'w')
-            self.returncode = _invoke_spack_command(
-                self.command, self.parser, args, unknown)
+            with log_output(out):
+                self.returncode = _invoke_spack_command(
+                    self.command, self.parser, args, unknown)
 
         except SystemExit as e:
             self.returncode = e.code
@@ -418,25 +416,13 @@ class SpackCommand(object):
             if fail_on_error:
                 raise
 
-        finally:
-            sys.stdout.flush()
-            sys.stdout.close()
-            sys.stderr.flush()
-            sys.stderr.close()
-            sys.stdout, sys.stderr = out, err
-
-            return_out = open(ofn).read()
-            return_err = open(efn).read()
-            os.unlink(ofn)
-            os.unlink(efn)
-
         if fail_on_error and self.returncode not in (None, 0):
             raise SpackCommandError(
                 "Command exited with code %d: %s(%s)" % (
                     self.returncode, self.command_name,
                     ', '.join("'%s'" % a for a in argv)))
 
-        return return_out, return_err
+        return out.getvalue()
 
 
 def _main(command, parser, args, unknown_args):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -760,10 +760,6 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             # Append the item to the composite
             composite_stage.append(stage)
 
-        # Create stage on first access.  Needed because fetch, stage,
-        # patch, and install can be called independently of each
-        # other, so `with self.stage:` in do_install isn't sufficient.
-        composite_stage.create()
         return composite_stage
 
     @property
@@ -772,6 +768,12 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             raise ValueError("Can only get a stage for a concrete package.")
         if self._stage is None:
             self._stage = self._make_stage()
+
+        # Create stage on first access.  Needed because fetch, stage,
+        # patch, and install can be called independently of each
+        # other, so `with self.stage:` in do_install isn't sufficient.
+        self._stage.create()
+
         return self._stage
 
     @stage.setter
@@ -1389,6 +1391,11 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             # Remove the install prefix if anything went wrong during install.
             if not keep_prefix:
                 self.remove_prefix()
+
+            # The subprocess *may* have removed the build stage. Mark it
+            # not created so that the next time self.stage is invoked, we
+            # check the filesystem for it.
+            self.stage.created = False
 
     def check_for_unfinished_installation(
             self, keep_prefix=False, restage=False):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -236,6 +236,10 @@ class Stage(object):
 
             self._lock = Stage.stage_locks[self.name]
 
+        # When stages are reused, we need to know whether to re-create
+        # it.  This marks whether it has been created/destroyed.
+        self.created = False
+
     def __enter__(self):
         """
         Entering a stage context will create the stage directory
@@ -521,6 +525,7 @@ class Stage(object):
                 mkdirp(self.path)
         # Make sure we can actually do something with the stage we made.
         ensure_access(self.path)
+        self.created = True
 
     def destroy(self):
         """Removes this stage directory."""
@@ -531,6 +536,9 @@ class Stage(object):
             os.getcwd()
         except OSError:
             os.chdir(os.path.dirname(self.path))
+
+        # mark as destroyed
+        self.created = False
 
 
 class ResourceStage(Stage):
@@ -573,8 +581,9 @@ class ResourceStage(Stage):
                 shutil.move(source_path, destination_path)
 
 
-@pattern.composite(method_list=['fetch', 'create', 'check', 'expand_archive',
-                                'restage', 'destroy', 'cache_local'])
+@pattern.composite(method_list=[
+    'fetch', 'create', 'created', 'check', 'expand_archive', 'restage',
+    'destroy', 'cache_local'])
 class StageComposite:
     """Composite for Stage type objects. The first item in this composite is
     considered to be the root package, and operations that return a value are
@@ -623,6 +632,7 @@ class DIYStage(object):
         self.archive_file = None
         self.path = path
         self.source_path = path
+        self.created = True
 
     def chdir(self):
         if os.path.isdir(self.path):

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -36,14 +36,14 @@ mpi_deps = ['fake']
 
 
 def test_immediate_dependencies(builtin_mock):
-    out, err = dependencies('mpileaks')
+    out = dependencies('mpileaks')
     actual = set(re.split(r'\s+', out.strip()))
     expected = set(['callpath'] + mpis)
     assert expected == actual
 
 
 def test_transitive_dependencies(builtin_mock):
-    out, err = dependencies('--transitive', 'mpileaks')
+    out = dependencies('--transitive', 'mpileaks')
     actual = set(re.split(r'\s+', out.strip()))
     expected = set(
         ['callpath', 'dyninst', 'libdwarf', 'libelf'] + mpis + mpi_deps)
@@ -52,7 +52,7 @@ def test_transitive_dependencies(builtin_mock):
 
 def test_immediate_installed_dependencies(builtin_mock, database):
     with color_when(False):
-        out, err = dependencies('--installed', 'mpileaks^mpich')
+        out = dependencies('--installed', 'mpileaks^mpich')
 
     lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
     hashes = set([re.split(r'\s+', l)[0] for l in lines])
@@ -65,7 +65,7 @@ def test_immediate_installed_dependencies(builtin_mock, database):
 
 def test_transitive_installed_dependencies(builtin_mock, database):
     with color_when(False):
-        out, err = dependencies('--installed', '--transitive', 'mpileaks^zmpi')
+        out = dependencies('--installed', '--transitive', 'mpileaks^zmpi')
 
     lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
     hashes = set([re.split(r'\s+', l)[0] for l in lines])

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -33,13 +33,13 @@ dependents = SpackCommand('dependents')
 
 
 def test_immediate_dependents(builtin_mock):
-    out, err = dependents('libelf')
+    out = dependents('libelf')
     actual = set(re.split(r'\s+', out.strip()))
     assert actual == set(['dyninst', 'libdwarf'])
 
 
 def test_transitive_dependents(builtin_mock):
-    out, err = dependents('--transitive', 'libelf')
+    out = dependents('--transitive', 'libelf')
     actual = set(re.split(r'\s+', out.strip()))
     assert actual == set(
         ['callpath', 'dyninst', 'libdwarf', 'mpileaks', 'multivalue_variant',
@@ -48,7 +48,7 @@ def test_transitive_dependents(builtin_mock):
 
 def test_immediate_installed_dependents(builtin_mock, database):
     with color_when(False):
-        out, err = dependents('--installed', 'libelf')
+        out = dependents('--installed', 'libelf')
 
     lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
     hashes = set([re.split(r'\s+', l)[0] for l in lines])
@@ -64,7 +64,7 @@ def test_immediate_installed_dependents(builtin_mock, database):
 
 def test_transitive_installed_dependents(builtin_mock, database):
     with color_when(False):
-        out, err = dependents('--installed', '--transitive', 'fake')
+        out = dependents('--installed', '--transitive', 'fake')
 
     lines = [l for l in out.strip().split('\n') if not l.startswith('--')]
     hashes = set([re.split(r'\s+', l)[0] for l in lines])

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -27,6 +27,7 @@ import os
 
 import pytest
 
+import spack
 import spack.cmd.install
 from spack.spec import Spec
 from spack.main import SpackCommand
@@ -42,7 +43,7 @@ def parser():
     return parser
 
 
-def _install_package_and_dependency(
+def test_install_package_and_dependency(
         tmpdir, builtin_mock, mock_archive, mock_fetch, config,
         install_mockery):
 
@@ -57,6 +58,9 @@ def _install_package_and_dependency(
     assert 'tests="2"' in content
     assert 'failures="0"' in content
     assert 'errors="0"' in content
+
+    s = Spec('libdwarf').concretized()
+    assert not spack.repo.get(s).stage.created
 
 
 def test_install_package_already_installed(
@@ -107,3 +111,22 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     # right place in the build log.
     assert "BEFORE INSTALL\n==> './configure'" in out
     assert "'install'\nAFTER INSTALL" in out
+
+
+def _test_install_output_on_build_error(builtin_mock, mock_archive, mock_fetch,
+                                        config, install_mockery, capfd):
+    # capfd interferes with Spack's capturing
+    with capfd.disabled():
+        out = install('build-error', fail_on_error=False)
+    assert isinstance(install.error, spack.build_environment.ChildError)
+    assert install.error.name == 'ProcessError'
+    assert 'configure: error: in /path/to/some/file:' in out
+    assert 'configure: error: cannot run C compiled programs.' in out
+
+
+def test_install_output_on_python_error(builtin_mock, mock_archive, mock_fetch,
+                                        config, install_mockery):
+    out = install('failing-build', fail_on_error=False)
+    assert isinstance(install.error, spack.build_environment.ChildError)
+    assert install.error.name == 'InstallError'
+    assert 'raise InstallError("Expected failure.")' in out

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -29,5 +29,5 @@ python = SpackCommand('python')
 
 
 def test_python():
-    out, err = python('-c', 'import spack; print(spack.spack_version)')
+    out = python('-c', 'import spack; print(spack.spack_version)')
     assert out.strip() == str(spack.spack_version)

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -83,30 +83,30 @@ def test_url_with_no_version_fails():
 
 
 def test_url_list():
-    out, err = url('list')
+    out = url('list')
     total_urls = len(out.split('\n'))
 
     # The following two options should not change the number of URLs printed.
-    out, err = url('list', '--color', '--extrapolation')
+    out = url('list', '--color', '--extrapolation')
     colored_urls = len(out.split('\n'))
     assert colored_urls == total_urls
 
     # The following options should print fewer URLs than the default.
     # If they print the same number of URLs, something is horribly broken.
     # If they say we missed 0 URLs, something is probably broken too.
-    out, err = url('list', '--incorrect-name')
+    out = url('list', '--incorrect-name')
     incorrect_name_urls = len(out.split('\n'))
     assert 0 < incorrect_name_urls < total_urls
 
-    out, err = url('list', '--incorrect-version')
+    out = url('list', '--incorrect-version')
     incorrect_version_urls = len(out.split('\n'))
     assert 0 < incorrect_version_urls < total_urls
 
-    out, err = url('list', '--correct-name')
+    out = url('list', '--correct-name')
     correct_name_urls = len(out.split('\n'))
     assert 0 < correct_name_urls < total_urls
 
-    out, err = url('list', '--correct-version')
+    out = url('list', '--correct-version')
     correct_version_urls = len(out.split('\n'))
     assert 0 < correct_version_urls < total_urls
 
@@ -121,7 +121,7 @@ def test_url_summary():
     assert 0 < correct_versions <= sum(version_count_dict.values()) <= total_urls  # noqa
 
     # make sure it agrees with the actual command.
-    out, err = url('summary')
+    out = url('summary')
     out_total_urls = int(
         re.search(r'Total URLs found:\s*(\d+)', out).group(1))
     assert out_total_urls == total_urls

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -1,0 +1,134 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from __future__ import print_function
+
+import re
+from six import StringIO
+
+from llnl.util.tty.color import colorize
+
+
+class LogEvent(object):
+    """Class representing interesting events (e.g., errors) in a build log."""
+    def __init__(self, text, line_no,
+                 pre_context='', post_context='', repeat_count=0):
+        self.text = text
+        self.line_no = line_no
+        self.pre_context = pre_context
+        self.post_context = post_context
+        self.repeat_count = repeat_count
+
+    @property
+    def start(self):
+        """First line in the log with text for the event or its context."""
+        return self.line_no - len(self.pre_context)
+
+    @property
+    def end(self):
+        """Last line in the log with text for event or its context."""
+        return self.line_no + len(self.post_context) + 1
+
+    def __getitem__(self, line_no):
+        """Index event text and context by actual line number in file."""
+        if line_no == self.line_no:
+            return self.text
+        elif line_no < self.line_no:
+            return self.pre_context[line_no - self.line_no]
+        elif line_no > self.line_no:
+            return self.post_context[line_no - self.line_no - 1]
+
+    def __str__(self):
+        """Returns event lines and context."""
+        out = StringIO()
+        for i in range(self.start, self.end):
+            if i == self.line_no:
+                out.write('  >> %-6d%s' % (i, self[i]))
+            else:
+                out.write('     %-6d%s' % (i, self[i]))
+        return out.getvalue()
+
+
+def parse_log_events(logfile, context=6):
+    """Extract interesting events from a log file as a list of LogEvent.
+
+    Args:
+        logfile (str): name of the build log to parse
+        context (int): lines of context to extract around each log event
+
+    Currently looks for lines that contain the string 'error:', ignoring case.
+
+    TODO: Extract warnings and other events from the build log.
+    """
+    with open(logfile, 'r') as f:
+        lines = [line for line in f]
+
+    log_events = []
+    for i, line in enumerate(lines):
+        if re.search('error:', line, re.IGNORECASE):
+            event = LogEvent(
+                line.strip(),
+                i + 1,
+                [l.rstrip() for l in lines[i - context:i]],
+                [l.rstrip() for l in lines[i + 1:i + context + 1]])
+            log_events.append(event)
+    return log_events
+
+
+def make_log_context(log_events):
+    """Get error context from a log file.
+
+    Args:
+        log_events (list of LogEvent): list of events created by, e.g.,
+            ``parse_log_events``
+
+    Returns:
+        str: context from the build log with errors highlighted
+
+    Parses the log file for lines containing errors, and prints them out
+    with line numbers and context.  Errors are highlighted with '>>' and
+    with red highlighting (if color is enabled).
+    """
+    error_lines = set(e.line_no for e in log_events)
+
+    out = StringIO()
+    next_line = 1
+    for event in log_events:
+        start = event.start
+
+        if start > next_line:
+            out.write('     [ ... ]\n')
+
+        if start < next_line:
+            start = next_line
+
+        for i in range(start, event.end):
+            if i in error_lines:
+                out.write(colorize('  @R{>> %-6d%s}\n' % (i, event[i])))
+            else:
+                out.write('     %-6d%s\n' % (i, event[i]))
+
+        next_line = event.end
+
+    return out.getvalue()


### PR DESCRIPTION
Currently, if you get a build error in Spack, you get this:

```console
$ spack install elfutils
==> Installing elfutils
==> Using cached archive: /Users/gamblin2/src/spack/var/spack/cache/elfutils/elfutils-0.163.tar.bz2
==> Staging archive: /Users/gamblin2/src/spack/var/spack/stage/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a/elfutils-0.163.tar.bz2
==> Created stage in /Users/gamblin2/src/spack/var/spack/stage/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a
==> No patches needed for elfutils
==> Building elfutils [AutotoolsPackage]
==> Executing phase : 'autoreconf'
==> Executing phase : 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/Users/gamblin2/src/spack/var/spack/stage/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a/elfutils-0.163/configure' '--prefix=/Users/gamblin2/src/spack/opt/spack/darwin-sierra-x86_64/clang-7.0.2-apple/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a' '--enable-maintainer-mode'
/Users/gamblin2/src/spack/lib/spack/spack/build_systems/autotools.py:268, in configure:
     260      def configure(self, spec, prefix):
     261          """Runs configure with the arguments specified in
     262          :py:meth:`~.AutotoolsPackage.configure_args`
     263          and an appropriately set prefix.
     264          """
     265          options = ['--prefix={0}'.format(prefix)] + self.configure_args()
     266  
     267          with working_dir(self.build_directory, create=True):
  >> 268              inspect.getmodule(self).configure(*options)

See build log for details:
  /private/var/folders/0s/q_y0zhfj6xdd5n7rn780zz6h001qr7/T/pytest-of-gamblin2/pytest-194/test_keep_exceptions0/tmp/spack-stage/spack-stage-wLLSsa/elfutils-0.163/spack-build.out
```

Spack is trying to be helpful by showing Python context for the package, but *usually* you don't get a Python error.  You get some type of build error, and you just want to look at the build log.  Also, with our various build system classes, the Python context is often in a class the user knows nothing about (like the `configure` method in `AutotoolsPackage` shown here), and doesn't really tell you what the issue is.

This PR changes the behavior.  If the error raised is a `ProcessError` from some script or tool invoked by the build process (e.g., `make` or `configure`), we'll show errors from the build log instead.  If the error is some other error (e.g. one that actually comes from Python code) we'll show Python context.  So, here's the new output:

```console
$ spack install elfutils
==> Installing elfutils
==> Using cached archive: /Users/gamblin2/src/spack/var/spack/cache/elfutils/elfutils-0.163.tar.bz2
==> Already staged elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a in /Users/gamblin2/src/spack/var/spack/stage/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a
==> No patches needed for elfutils
==> Building elfutils [AutotoolsPackage]
==> Executing phase : 'autoreconf'
==> Executing phase : 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/Users/gamblin2/src/spack/var/spack/stage/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a/elfutils-0.163/configure' '--prefix=/Users/gamblin2/src/spack/opt/spack/darwin-sierra-x86_64/clang-7.0.2-apple/elfutils-0.163-qyris2qgf3oq4fob5ss6hsfijy4crd6a' '--enable-maintainer-mode'

2 errors in build log:
     [ ... ]
     12    checking build system type... x86_64-apple-darwin16.6.0
     13    checking host system type... x86_64-apple-darwin16.6.0
     14    checking for gcc... /Users/gamblin2/src/spack/lib/spack/env/clang/clang
     15    checking whether the C compiler works... yes
     16    checking for C compiler default output file name... a.out
     17    checking for suffix of executables...
  >> 18    checking whether we are cross compiling... configure: error: in `/private/var/folders/0s/q_y0zhfj6xdd5n7rn780zz6h001qr7/T/pytest-of-gamblin2/pytest-194/test_keep_exceptions0/tmp/spack-stage/spack-stage-wLLSsa/elfutils-0.163':
  >> 19    configure: error: cannot run C compiled programs.

See build log for details:
  /private/var/folders/0s/q_y0zhfj6xdd5n7rn780zz6h001qr7/T/pytest-of-gamblin2/pytest-194/test_keep_exceptions0/tmp/spack-stage/spack-stage-wLLSsa/elfutils-0.163/spack-build.out
```

Users now get a chunk of the build log with the error lines highlighted.  If there are multiple errors, each will be shown with 6 lines of context before and after (with `[...]` in between the sections).  If color is enabled, the errors are highlighted in red.

Hopefully this means people won't need to take the extra step of opening the build log in their editor to see what happened, even if they didn't use `spack install -v`.

Tasks:
- [x] Add some code to parse build logs for errors
- [x] Make install failures display the errors from the build log if the error came from the build and not from Python.
- [x] Add some color support so that the highlighted error lines for both Python and build errors are shown in red.
- [x] Tests