### PR TITLE
Adios2: ZeroMQ

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -77,6 +77,7 @@ class Adios2(CMakePackage):
     # depends_on('pybind11@2.1.1:', when='+python')
 
     depends_on('mpi', when='+mpi')
+    depends_on('zeromq', when='+dataman')
 
     depends_on('hdf5', when='+hdf5')
     depends_on('hdf5+mpi', when='+hdf5+mpi')


### PR DESCRIPTION
During my last rebase the zeromq core dependency got missing.
Currently it's needed for [dataman](https://github.com/LLNL/spack/pull/4944#discussion_r130646573) WAN transports.

Close #5021