### PR TITLE
Make Executable return str instead of unicode.

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -168,12 +168,15 @@ class Executable(object):
         tty.debug(cmd_line)
 
         try:
+            # We set universal_newlines=True to tell Python3
+            # to return a string instead of bytes.
             proc = subprocess.Popen(
                 cmd,
                 stdin=istream,
                 stderr=estream,
                 stdout=ostream,
-                env=env)
+                env=env,
+                universal_newlines=True)
             out, err = proc.communicate()
 
             rc = self.returncode = proc.returncode
@@ -184,9 +187,9 @@ class Executable(object):
             if output is str or error is str:
                 result = ''
                 if output is str:
-                    result += out.decode('utf-8')
+                    result += out
                 if error is str:
-                    result += err.decode('utf-8')
+                    result += err
                 return result
 
         except OSError as e:


### PR DESCRIPTION
If I understood it correctly, the idea of calling decode('utf-8') was to get strings instead of binaries, which Popen.communicate() returns by default in Python3. Unfortunately, this leads to a problem described in  #5032. Another way to tell Popen.communicate() that we want to get strings is to set universal_newlines=True. After this change Executable returns <type 'str'> with Python2 and <class 'str'> with Python3.

Fixes #5032 
Fixes #4339 
Fixes #3842
Closes #4355