### PR TITLE
bugfix for module_cmd

### DIFF
--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -112,7 +112,7 @@ def test_get_module_cmd_from_bash_ticks(save_env):
 
 
 def test_get_module_cmd_from_bash_parens(save_env):
-    os.environ['BASH_FUNC_module()'] = '() { eval $(echo fill bash $*)\n}'
+    os.environ['BASH_FUNC_module()'] = '() { eval $(echo fill sh $*)\n}'
 
     module_cmd = get_module_cmd()
     module_cmd_list = module_cmd('list', output=str, error=str)

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -97,7 +97,7 @@ def get_module_cmd_from_bash(bashopts=''):
     module_cmd = which(args[0])
     if module_cmd:
         for arg in args[1:]:
-            if arg == 'bash':
+            if arg in ('bash', 'sh'):
                 module_cmd.add_default_arg('python')
                 break
             else:


### PR DESCRIPTION
Bash is often linked to sh. This fixes a bug in the code for when bash is linked to sh and the module function calls sh.

Also changed one of the tests to this model to make sure we don't reintroduce a bug in it.