### PR TITLE
Add version 2.19.1.403 to bcl2fastq2 package

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -37,8 +37,8 @@ class Bcl2fastq2(Package):
        files."""
 
     homepage = "https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html"
-    url      = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-18-0-12-tar.zip"
 
+    version('2.19.1.403', 'baba7a02767fd868e87cb36781d2be26')
     version('2.18.0.12', 'fbe06492117f65609c41be0c27e3215c')
     # 2.17.1.14 is no longer distributed.  If you have a copy of the
     # source tarball, you can drop it into a local mirror w/ the name
@@ -61,9 +61,16 @@ class Bcl2fastq2(Package):
 
     root_cmakelists_dir = 'src'
 
+    # v2.17.1.14 and v2.18.0.12 were available via HTTP.
+    # v2.19.1.403 is only available via ftp.
+    # who knows what the future will hold.
     def url_for_version(self, version):
-        url = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v{0}-tar.zip"
-        return url.format(version.dashed)
+        if version.string == '2.19.1.403':
+           return "ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/bcl2fastq/bcl2fastq2-v2.19.1-tar.zip"
+        else:
+            url = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v{0}-tar.zip"
+            # - required to change the version from dots to dashes.
+            return url.format(version.dashed)
 
     # Illumina tucks the source inside a gzipped tarball inside a zip
     # file.  We let the normal Spack expansion bit unzip the zip file,

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -66,7 +66,7 @@ class Bcl2fastq2(Package):
     # who knows what the future will hold.
     def url_for_version(self, version):
         if version.string == '2.19.1.403':
-           return "ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/bcl2fastq/bcl2fastq2-v2.19.1-tar.zip"
+            return "ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/bcl2fastq/bcl2fastq2-v2.19.1-tar.zip"
         else:
             url = "https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v{0}-tar.zip"
             # - required to change the version from dots to dashes.


### PR DESCRIPTION
Heads up, the download location changed (domain name AND protocol).

Most of this was work by Dave Sailors.