### PR TITLE
patch: get correct directory for a given package object

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -23,14 +23,26 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 import os
+import os.path
+import inspect
 
 import spack
 import spack.error
-import spack.stage
 import spack.fetch_strategy as fs
-
+import spack.stage
 from llnl.util.filesystem import join_path
 from spack.util.executable import which
+
+
+def absolute_path_for_package(pkg):
+    """Returns the absolute path to the ``package.py`` file implementing
+    the recipe for the package passed as argument.
+
+    Args:
+        pkg: a valid package object
+    """
+    m = inspect.getmodule(pkg)
+    return os.path.abspath(m.__file__)
 
 
 class Patch(object):
@@ -90,7 +102,7 @@ class FilePatch(Patch):
     def __init__(self, pkg, path_or_url, level):
         super(FilePatch, self).__init__(pkg, path_or_url, level)
 
-        pkg_dir = spack.repo.dirname_for_package_name(pkg.name)
+        pkg_dir = os.path.dirname(absolute_path_for_package(pkg))
         self.path = join_path(pkg_dir, path_or_url)
         if not os.path.isfile(self.path):
             raise NoSuchPatchFileError(pkg.name, self.path)


### PR DESCRIPTION
fixes #4236
fixes #5002

This should be the quickest fix for the two issues listed above. I didn't follow the suggestion in #4307 because `RepoPath` is supposed to provide the same API as `Repo`. Turning:
```python
def dirname_for_package_name(self, pkg_name):
    ...
```
into:
```python
def dirname_for_package(self, pkg):
    ...
```
will break this consistency. The function `Repo.dirname_for_package` is used by `filename_for_package` in contexts where the package doesn't exist and we want to know what would be the name for it, like:
```console
$ spack create <url>
```
so it can't be deleted altogether. Refactoring this part will require maybe more discussion, hence the minimal fix.