### PR TITLE
Travis CI: speed-up build tests and increase coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,10 @@ coverage:
         threshold: 0.5
         paths:
           - lib/spack/spack/cmd
+      build_systems:
+        threshold: 0.5
+        paths:
+          - lib/spack/spack/build_systems
       core:
         threshold: 0.5
         paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - python: '2.7'
       os: linux
       language: python
-      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=hypre^mpich' ]
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
     - python: '3.3'
       os: linux
       language: python
@@ -45,7 +45,7 @@ matrix:
     - python: '3.6'
       os: linux
       language: python
-      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=hypre^mpich' ]
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
     - python: '2.7'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=astyle' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=tut' ]
     - python: '3.3'
       os: linux
       language: python
@@ -50,10 +54,6 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
-    - python: '3.6'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=astyle' ]
     - python: '2.7'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=perl-dbi' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openjpeg' ]
     - python: '3.3'
       os: linux
       language: python
@@ -88,6 +92,7 @@ addons:
       - mercurial
       - graphviz
       - gnupg2
+      - cmake
 
 # Work around Travis's lack of support for Python on OSX
 before_install:
@@ -114,6 +119,9 @@ before_script:
 
   # Need this to be able to compute the list of changed files
   - git fetch origin develop:develop
+
+  # Set up external dependencies for build tests, because the take too long to compile
+  - if [[ "$TEST_SUITE" == "build" ]]; then cp share/spack/qa/configuration/packages.yaml etc/spack/packages.yaml; fi
 
 #=============================================================================
 # Building

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - python: '2.7'
       os: linux
       language: python
-      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openblas' ]
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=astyle' ]
     - python: '3.3'
       os: linux
       language: python
@@ -53,7 +53,7 @@ matrix:
     - python: '3.6'
       os: linux
       language: python
-      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openblas' ]
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=astyle' ]
     - python: '2.7'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=tut' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=py-setuptools' ]
     - python: '3.3'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openjpeg' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=r-rcpp' ]
     - python: '3.3'
       os: linux
       language: python
@@ -93,6 +97,9 @@ addons:
       - graphviz
       - gnupg2
       - cmake
+      - r-base
+      - r-base-core
+      - r-base-dev
 
 # Work around Travis's lack of support for Python on OSX
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,30 +22,37 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
+# mpich (AutotoolsPackage)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
+# astyle (MakefilePackage)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=astyle' ]
+# tut (WafPackage)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=tut' ]
+# py-setuptools (PythonPackage)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=py-setuptools' ]
+# perl-dbi (PerlPackage)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=perl-dbi' ]
+# openjpeg (CMakePackage + external cmake)
     - python: '2.7'
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openjpeg' ]
+# r-rcpp (RPackage + external R)
     - python: '2.7'
       os: linux
       language: python
@@ -66,6 +73,7 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=unit, COVERAGE=true ]
+# mpich (AutotoolsPackage)
     - python: '3.6'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openblas' ]
     - python: '3.3'
       os: linux
       language: python
@@ -46,6 +50,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=mpich' ]
+    - python: '3.6'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=openblas' ]
     - python: '2.7'
       os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ matrix:
       os: linux
       language: python
       env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=py-setuptools' ]
+    - python: '2.7'
+      os: linux
+      language: python
+      env: [ TEST_SUITE=build, COVERAGE=true, 'SPEC=perl-dbi' ]
     - python: '3.3'
       os: linux
       language: python

--- a/share/spack/qa/configuration/packages.yaml
+++ b/share/spack/qa/configuration/packages.yaml
@@ -3,3 +3,7 @@ packages:
     buildable: False
     paths:
       cmake@2.8.12.2: /usr
+  r:
+    buildable: False
+    paths:
+      r@3.0.2: /usr

--- a/share/spack/qa/configuration/packages.yaml
+++ b/share/spack/qa/configuration/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  cmake:
+    buildable: False
+    paths:
+      cmake@2.8.12.2: /usr

--- a/var/spack/repos/builtin/packages/r-rcpp/package.py
+++ b/var/spack/repos/builtin/packages/r-rcpp/package.py
@@ -39,6 +39,8 @@ class RRcpp(RPackage):
     homepage = "http://dirk.eddelbuettel.com/code/rcpp.html"
     url      = "https://cran.r-project.org/src/contrib/Rcpp_0.12.9.tar.gz"
 
+    version('0.12.12', '97b36a3b567e3438067c4a7d0075fd90')
+    version('0.12.11', 'ea1710213cbb1d91b1d0318e6fa9aa37')
     version('0.12.9', '691c49b12794507288b728ede03668a5')
     version('0.12.6', 'db4280fb0a79cd19be73a662c33b0a8b')
     version('0.12.5', 'f03ec05b4e391cc46e7ce330e82ff5e2')


### PR DESCRIPTION
Fixes #5049 

This PR speeds-up build tests - and increases coverage doing it. The idea is to remove the build of `hypre ^mpich` (which was taking a long time to build, causing Travis timeouts) and substitute it with builds of more packages, chosen according to:

- their build system
- their build time

Currently we cover all build-systems apart from `QMakePackage` and `SconsPackage`. `cmake` and `r` are installed via `apt-get` and configured as externals. More details about the coverage deltas in the red crosses or green ticks below.