### PR TITLE
Make spack perform clean installations by default.

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -83,6 +83,7 @@ the dependencies"""
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
+    subparser.set_defaults(dirty=False)
 
     subparser.add_argument(
         'package',


### PR DESCRIPTION
Do we really want Spack to perform dirty installations by default? If no, this PR fixes that.