### PR TITLE
Make spack perform clean installations by default (2).

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -94,11 +94,13 @@ _arguments['recurse_dependencies'] = Args(
 
 _arguments['clean'] = Args(
     '--clean', action='store_false', dest='dirty',
-    help='clean environment before installing package')
+    help='clean environment before installing package',
+    default=None)
 
 _arguments['dirty'] = Args(
     '--dirty', action='store_true', dest='dirty',
-    help='do NOT clean environment before installing')
+    help='do NOT clean environment before installing',
+    default=None)
 
 _arguments['long'] = Args(
     '-l', '--long', action='store_true',


### PR DESCRIPTION
Another way to fix #5069.

Standard actions 'store_false' and 'store_true' have their default values set to True and False respectively. So, if we want argparse to return None in case neither --clean nor --dirty is specified explicitly, this looks like the way to go.