### PR TITLE
Added custom messages for conflicts directive

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -263,7 +263,7 @@ def _depends_on(pkg, spec, when=None, type=None):
 
 
 @directive('conflicts')
-def conflicts(conflict_spec, when=None):
+def conflicts(conflict_spec, when=None, msg=None):
     """Allows a package to define a conflict.
 
     Currently, a "conflict" is a concretized configuration that is known
@@ -280,14 +280,16 @@ def conflicts(conflict_spec, when=None):
     Args:
         conflict_spec (Spec): constraint defining the known conflict
         when (Spec): optional constraint that triggers the conflict
+        msg (str): optional user defined message
     """
     def _execute(pkg):
         # If when is not specified the conflict always holds
         condition = pkg.name if when is None else when
         when_spec = parse_anonymous_spec(condition, pkg.name)
 
+        # Save in a list the conflicts and the associated custom messages
         when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
-        when_spec_list.append(when_spec)
+        when_spec_list.append((when_spec, msg))
     return _execute
 
 

--- a/var/spack/repos/builtin/packages/espresso/package.py
+++ b/var/spack/repos/builtin/packages/espresso/package.py
@@ -75,8 +75,17 @@ class Espresso(Package):
     patch('dspev_drv_elpa.patch', when='@6.1 ^elpa@2016.05.003')
 
     # We can't ask for scalapack or elpa if we don't want MPI
-    conflicts('+scalapack', when='~mpi')
-    conflicts('+elpa', when='~mpi')
+    conflicts(
+        '+scalapack',
+        when='~mpi',
+        msg='scalapack is a parallel library and needs MPI support'
+    )
+
+    conflicts(
+        '+elpa',
+        when='~mpi',
+        msg='elpa is a parallel library and needs MPI support'
+    )
 
     # Elpa is formally supported by @:5.4.0, but QE configure searches
     # for it in the wrong folders (or tries to download it within


### PR DESCRIPTION
fixes #4965

Users can now add an optional custom message to the conflicts directive. Layout on screen has been changed to improve readability and the long spec is shown in tree format. Two conflicts in `espresso` have been modified to showcase the feature.

In the current branch the error message is:
```console
$ spack spec espresso+scalapack~mpi
Input spec
--------------------------------
espresso~mpi+scalapack

Normalized
--------------------------------
espresso~mpi+scalapack
    ^blas
    ^fftw~mpi
    ^lapack

Concretized
--------------------------------
==> Error: Conflicts in concretized spec "espresso@6.1.0%gcc@4.8+elpa~hdf5~mpi~openmp+scalapack arch=linux-ubuntu14-x86_64 /bzaylez"

List of matching conflicts for spec:

    espresso@6.1.0%gcc@4.8+elpa~hdf5~mpi~openmp+scalapack arch=linux-ubuntu14-x86_64 
        ^elpa@2016.05.004%gcc@4.8~openmp arch=linux-ubuntu14-x86_64 
            ^netlib-scalapack@2.0.2%gcc@4.8 build_type=RelWithDebInfo ~pic+shared arch=linux-ubuntu14-x86_64 
                ^cmake@3.9.0%gcc@4.8~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu14-x86_64 
                    ^ncurses@6.0%gcc@4.8~symlinks arch=linux-ubuntu14-x86_64 
                        ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 
                    ^openssl@1.0.2k%gcc@4.8 arch=linux-ubuntu14-x86_64 
                        ^zlib@1.2.11%gcc@4.8+pic+shared arch=linux-ubuntu14-x86_64 
                ^openblas@0.2.20%gcc@4.8~openmp+pic+shared arch=linux-ubuntu14-x86_64 
                ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 
                    ^hwloc@1.11.7%gcc@4.8~cuda+libxml2+pci arch=linux-ubuntu14-x86_64 
                        ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14-x86_64 
                            ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14-x86_64 
                                ^m4@1.4.18%gcc@4.8+sigsegv arch=linux-ubuntu14-x86_64 
                                    ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14-x86_64 
                            ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14-x86_64 
                        ^libxml2@2.9.4%gcc@4.8~python arch=linux-ubuntu14-x86_64 
                            ^xz@5.2.3%gcc@4.8 arch=linux-ubuntu14-x86_64 
        ^fftw@3.3.6-pl2%gcc@4.8+double+float+long_double~mpi~openmp~pfft_patches~quad arch=linux-ubuntu14-x86_64 

1. "+elpa" conflicts with "espresso~mpi" [elpa is a parallel library and needs MPI support]
2. "+scalapack" conflicts with "espresso~mpi" [scalapack is a parallel library and needs MPI support]
```
while in `develop` it looks like:
```console
$ spack spec espresso+scalapack~mpi
Input spec
--------------------------------
espresso~mpi+scalapack

Normalized
--------------------------------
espresso~mpi+scalapack
    ^blas
    ^fftw~mpi
    ^lapack

Concretized
--------------------------------
==> Error: Conflicts in concretized spec "espresso@6.1.0%gcc@4.8+elpa~hdf5~mpi~openmp+scalapack arch=linux-ubuntu14-x86_64 /bzaylez"

List of matching conflicts:

1. "+elpa" conflicts with "espresso~mpi" in spec "espresso@6.1.0%gcc@4.8+elpa~hdf5~mpi~openmp+scalapack arch=linux-ubuntu14-x86_64 ^cmake@3.9.0%gcc@4.8~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu14-x86_64 ^elpa@2016.05.004%gcc@4.8~openmp arch=linux-ubuntu14-x86_64 ^fftw@3.3.6-pl2%gcc@4.8+double+float+long_double~mpi~openmp~pfft_patches~quad arch=linux-ubuntu14-x86_64 ^hwloc@1.11.7%gcc@4.8~cuda+libxml2+pci arch=linux-ubuntu14-x86_64 ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libxml2@2.9.4%gcc@4.8~python arch=linux-ubuntu14-x86_64 ^m4@1.4.18%gcc@4.8+sigsegv arch=linux-ubuntu14-x86_64 ^ncurses@6.0%gcc@4.8~symlinks arch=linux-ubuntu14-x86_64 ^netlib-scalapack@2.0.2%gcc@4.8 build_type=RelWithDebInfo ~pic+shared arch=linux-ubuntu14-x86_64 ^openblas@0.2.20%gcc@4.8~openmp+pic+shared arch=linux-ubuntu14-x86_64 ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 ^openssl@1.0.2k%gcc@4.8 arch=linux-ubuntu14-x86_64 ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14-x86_64 ^xz@5.2.3%gcc@4.8 arch=linux-ubuntu14-x86_64 ^zlib@1.2.11%gcc@4.8+pic+shared arch=linux-ubuntu14-x86_64"
2. "+scalapack" conflicts with "espresso~mpi" in spec "espresso@6.1.0%gcc@4.8+elpa~hdf5~mpi~openmp+scalapack arch=linux-ubuntu14-x86_64 ^cmake@3.9.0%gcc@4.8~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu14-x86_64 ^elpa@2016.05.004%gcc@4.8~openmp arch=linux-ubuntu14-x86_64 ^fftw@3.3.6-pl2%gcc@4.8+double+float+long_double~mpi~openmp~pfft_patches~quad arch=linux-ubuntu14-x86_64 ^hwloc@1.11.7%gcc@4.8~cuda+libxml2+pci arch=linux-ubuntu14-x86_64 ^libpciaccess@0.13.5%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libsigsegv@2.11%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libtool@2.4.6%gcc@4.8 arch=linux-ubuntu14-x86_64 ^libxml2@2.9.4%gcc@4.8~python arch=linux-ubuntu14-x86_64 ^m4@1.4.18%gcc@4.8+sigsegv arch=linux-ubuntu14-x86_64 ^ncurses@6.0%gcc@4.8~symlinks arch=linux-ubuntu14-x86_64 ^netlib-scalapack@2.0.2%gcc@4.8 build_type=RelWithDebInfo ~pic+shared arch=linux-ubuntu14-x86_64 ^openblas@0.2.20%gcc@4.8~openmp+pic+shared arch=linux-ubuntu14-x86_64 ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 ^openssl@1.0.2k%gcc@4.8 arch=linux-ubuntu14-x86_64 ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 ^util-macros@1.19.1%gcc@4.8 arch=linux-ubuntu14-x86_64 ^xz@5.2.3%gcc@4.8 arch=linux-ubuntu14-x86_64 ^zlib@1.2.11%gcc@4.8+pic+shared arch=linux-ubuntu14-x86_64"
```