### PR TITLE
Add sbang hook support for node-js

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -104,6 +104,8 @@ lines=0
 while read line && ((lines < 2)) ; do
     if [[ "$line" = '#!'* ]]; then
         interpreter="${line#\#!}"
+    elif [[ "$line" = '//!'*node* ]]; then
+        interpreter="${line#//!}"
     elif [[ "$line" = '--!'*lua* ]]; then
         interpreter="${line#--!}"
     fi

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -62,12 +62,15 @@ def filter_shebang(path):
     if original.startswith(new_sbang_line):
         return
 
+    # In the following, newlines have to be excluded in the regular expression
+    # else any mention of "lua" in the document will lead to spurious matches.
+
     # Use --! instead of #! on second line for lua.
-    if re.search(r'^#!(/[^/]*)*lua\b', original):
+    if re.search(r'^#!(/[^/\n]*)*lua\b', original):
         original = re.sub(r'^#', '--', original)
 
     # Use //! instead of #! on second line for node.js.
-    if re.search(r'^#!(/[^/]*)*node\b', original):
+    if re.search(r'^#!(/[^/\n]*)*node\b', original):
         original = re.sub(r'^#', '//', original)
 
     # Change non-writable files to be writable if needed.

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -66,6 +66,10 @@ def filter_shebang(path):
     if re.search(r'^#!(/[^/]*)*lua\b', original):
         original = re.sub(r'^#', '--', original)
 
+    # Use //! instead of #! on second line for node.js.
+    if re.search(r'^#!(/[^/]*)*node\b', original):
+        original = re.sub(r'^#', '//', original)
+
     # Change non-writable files to be writable if needed.
     saved_mode = None
     if not os.access(path, os.W_OK):


### PR DESCRIPTION
I'm migrating our current ```spack``` version from one from march to a current one. While doing that I'm going to open PR's for a couple of things that should be upstream. Most of these will be new packages of different versions of existing ones. This one is a bit different:

It adds hook-magic for node-js files. This seems to have caused problems with ```py-jupyter-notebook``` at some point in history. However I didn't run into problems when installing our software stack even without it, feel free to close this if you prefer it not to be merged.