### PR TITLE
Fix ffmpeg (add missing yasm dependency)

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -37,6 +37,8 @@ class Ffmpeg(AutotoolsPackage):
     variant('shared', default=True,
             description='build shared libraries')
 
+    depends_on('yasm@1.2.0:')
+
     def configure_args(self):
         spec = self.spec
         config_args = ['--enable-pic']


### PR DESCRIPTION
Add the ```yasm``` dependency to the ```ffmpeg```-package, while not strictly necessary resulting ```ffmpeg```-builds might be very slow (https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu) without it