### PR TITLE
build boost with graph library even when +mpi

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -324,7 +324,6 @@ class Boost(Package):
         if not spec.satisfies('@1.43.0:'):
             withLibs.remove('random')
         if '+graph' in spec and '+mpi' in spec:
-            withLibs.remove('graph')
             withLibs.append('graph_parallel')
 
         # to make Boost find the user-config.jam


### PR DESCRIPTION
Our software stack depends on both ```graph``` and ```mpi```, this PR changes the ```+mpi``` variant of boost to also include the standard ```graph```-library. 