### PR TITLE
Add cpu_target variant to openblas

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -50,6 +50,10 @@ class Openblas(MakefilePackage):
     variant('openmp', default=False, description="Enable OpenMP support.")
     variant('pic', default=True, description='Build position independent code')
 
+    variant('cpu_target', default='',
+	    description='Set CPU target architecture (leave empty for '
+                        'autodetection; GENERIC, SSE_GENERIC, NEHALEM, ...)')
+
     # virtual dependency
     provides('blas')
     provides('lapack')
@@ -109,6 +113,10 @@ class Openblas(MakefilePackage):
             make_defs += [
                 'TARGET=PILEDRIVER',
                 'TARGET=ARMV8'
+            ]
+        if self.spec.variants['cpu_target'].value:
+            make_defs += [
+                'TARGET={}'.format(self.spec.variants['cpu_target'].value)
             ]
         if self.spec.satisfies('%gcc@:4.8.4'):
             make_defs += ['NO_AVX2=1']

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -51,7 +51,7 @@ class Openblas(MakefilePackage):
     variant('pic', default=True, description='Build position independent code')
 
     variant('cpu_target', default='',
-	    description='Set CPU target architecture (leave empty for '
+                    description='Set CPU target architecture (leave empty for '
                         'autodetection; GENERIC, SSE_GENERIC, NEHALEM, ...)')
 
     # virtual dependency

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -116,7 +116,7 @@ class Openblas(MakefilePackage):
             ]
         if self.spec.variants['cpu_target'].value:
             make_defs += [
-                'TARGET={}'.format(self.spec.variants['cpu_target'].value)
+                'TARGET={0}'.format(self.spec.variants['cpu_target'].value)
             ]
         if self.spec.satisfies('%gcc@:4.8.4'):
             make_defs += ['NO_AVX2=1']

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -108,15 +108,15 @@ class Openblas(MakefilePackage):
             'FC={0}'.format(spack_f77),
             'MAKE_NO_J=1'
         ]
-        # invoke make with the correct TARGET for aarch64
-        if 'aarch64' in spack.architecture.sys_type():
-            make_defs += [
-                'TARGET=PILEDRIVER',
-                'TARGET=ARMV8'
-            ]
         if self.spec.variants['cpu_target'].value:
             make_defs += [
                 'TARGET={0}'.format(self.spec.variants['cpu_target'].value)
+            ]
+        # invoke make with the correct TARGET for aarch64
+        elif 'aarch64' in spack.architecture.sys_type():
+            make_defs += [
+                'TARGET=PILEDRIVER',
+                'TARGET=ARMV8'
             ]
         if self.spec.satisfies('%gcc@:4.8.4'):
             make_defs += ['NO_AVX2=1']


### PR DESCRIPTION
closes #4275 

This PR creates the ```cpu_target``` variant for openblas. We had the issue of building openblas on cluster nodes which had a more modern CPU architecture, with the architecture specific optimisations automatically turned on. This lead to ```illegal instruction``` failures (e.g., in matplotlib) on the frontends.