### PR TITLE
fix install method of cereal

### DIFF
--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -63,7 +63,3 @@ class Cereal(CMakePackage):
             '-DSKIP_PORTABILITY_TEST=TRUE',
         ]
 
-    def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            install_tree('doc', prefix.doc)
-            install_tree('include', prefix.include)

--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -62,3 +62,8 @@ class Cereal(CMakePackage):
             '-DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE',
             '-DSKIP_PORTABILITY_TEST=TRUE',
         ]
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            install_tree('doc', prefix.doc)
+        install_tree('include', prefix.include)

--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -62,4 +62,3 @@ class Cereal(CMakePackage):
             '-DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE',
             '-DSKIP_PORTABILITY_TEST=TRUE',
         ]
-

--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -60,4 +60,3 @@ class Cereal(CMakePackage):
             '-DJUST_INSTALL_CEREAL=On',
             '-DWITH_WERROR=Off',
         ]
-

--- a/var/spack/repos/builtin/packages/cereal/package.py
+++ b/var/spack/repos/builtin/packages/cereal/package.py
@@ -52,18 +52,12 @@ class Cereal(CMakePackage):
 
     depends_on('cmake@2.6.2:', type='build')
 
-    def patch(self):
-        # Don't use -Werror
-        filter_file(r'-Werror', '', 'CMakeLists.txt')
-
     def cmake_args(self):
         # Boost is only used for self-tests, which we are not running (yet?)
         return [
             '-DCMAKE_DISABLE_FIND_PACKAGE_Boost=TRUE',
             '-DSKIP_PORTABILITY_TEST=TRUE',
+            '-DJUST_INSTALL_CEREAL=On',
+            '-DWITH_WERROR=Off',
         ]
 
-    def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            install_tree('doc', prefix.doc)
-        install_tree('include', prefix.include)


### PR DESCRIPTION
The include line failed when I tried to install it, I'm not too sure why it is there in the first place, removing it solved my problem and it seems to be a working installation. 