### PR TITLE
scorep: Fix build with GCC 7

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/gcc7.patch
+++ b/var/spack/repos/builtin/packages/scorep/gcc7.patch
@@ -1,0 +1,42 @@
+diff -ru scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_gcc_version_compatibility.h scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_gcc_version_compatibility.h
+--- scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_gcc_version_compatibility.h	2017-08-15 14:46:27.353875030 +0200
++++ scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_gcc_version_compatibility.h	2017-08-15 14:52:18.458118812 +0200
+@@ -27,6 +27,11 @@
+     DECL_SECTION_NAME( decl ) = build_string( strlen( section ), section )
+ #endif
+ 
++#if SCOREP_GCC_PLUGIN_TARGET_VERSION < 7000
++#define SET_DECL_ALIGN( decl, align ) \
++    DECL_ALIGN( decl ) = ( align )
++#endif
++
+ #if SCOREP_GCC_PLUGIN_TARGET_VERSION >= 5000
+ #define varpool_finalize_decl( decl ) varpool_node::finalize_decl( decl )
+ #define cgraph_get_node( decl ) cgraph_node::get( decl )
+diff -ru scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c
+--- scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c	2017-08-15 14:46:27.353875030 +0200
++++ scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c	2017-08-15 14:52:56.220854113 +0200
+@@ -194,7 +194,7 @@
+                                         TREE_TYPE( region_descr_value ) );
+ 
+     /* Align the struct generously, so that it works for 32 and 64 bit */
+-    DECL_ALIGN( region_descr_var )      = 64 * BITS_PER_UNIT;
++    SET_DECL_ALIGN( region_descr_var, 64 * BITS_PER_UNIT );
+     DECL_USER_ALIGN( region_descr_var ) = 1;
+ 
+     /* The struct is 64 bytes, because of reserved entries */
+diff -ru scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h
+--- scorep-3.1.orig/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h	2017-08-15 14:46:27.353875030 +0200
++++ scorep-3.1/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h	2017-08-15 14:49:26.163888408 +0200
+@@ -23,6 +23,11 @@
+ #include "stringpool.h"
+ #include "basic-block.h"
+ #include "tree-ssa-alias.h"
++
++#if SCOREP_GCC_PLUGIN_TARGET_VERSION >= 7000
++#include "tree-vrp.h"
++#endif
++
+ #include "tree-ssanames.h"
+ #include "internal-fn.h"
+ #include "gimple-expr.h"

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -40,6 +40,8 @@ class Scorep(AutotoolsPackage):
     version('1.4.2', '3b9a042b13bdd5836452354e6567f71e')
     version('1.3',   '9db6f957b7f51fa01377a9537867a55c')
 
+    patch('gcc7.patch')
+
     ##########
     # Dependencies for SCORE-P are quite tight. See the homepage for more
     # information.


### PR DESCRIPTION
Score-P's GCC plugin currently does not compile with GCC 7. This PR fixes that (the patch has already been sent to the upstream developers).