### PR TITLE
Removed default value for the function argument 'dirty'

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -175,7 +175,7 @@ def set_compiler_environment_variables(pkg, env):
     return env
 
 
-def set_build_environment_variables(pkg, env, dirty=False):
+def set_build_environment_variables(pkg, env, dirty):
     """Ensure a clean install environment when we build packages.
 
     This involves unsetting pesky environment variables that may
@@ -229,7 +229,7 @@ def set_build_environment_variables(pkg, env, dirty=False):
     # Install root prefix
     env.set(SPACK_INSTALL, spack.store.root)
 
-    # Stuff in here sanitizes the build environemnt to eliminate
+    # Stuff in here sanitizes the build environment to eliminate
     # anything the user has set that may interfere.
     if not dirty:
         # Remove these vars from the environment during build because they
@@ -447,7 +447,7 @@ def load_external_modules(pkg):
             load_module(dep.external_module)
 
 
-def setup_package(pkg, dirty=False):
+def setup_package(pkg, dirty):
     """Execute all environment setup routines."""
     spack_env = EnvironmentModifications()
     run_env = EnvironmentModifications()
@@ -513,7 +513,7 @@ def setup_package(pkg, dirty=False):
     spack_env.apply_modifications()
 
 
-def fork(pkg, function, dirty=False):
+def fork(pkg, function, dirty):
     """Fork a child process to do part of a spack build.
 
     Args:


### PR DESCRIPTION
This change is done to avoid inconsistencies during refactoring. The rationale is that functions at different levels in the call stack all define a default for the 'dirty' argument. This PR removes the default value for all the functions except the top-level one (`PackageBase.do_install`).

In this way not defining 'dirty' will result in an error, instead of the default value being used. This will reduce the risk of having an inconsistent behavior after a refactoring.