### PR TITLE
Improved error message for unsatisfiable specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1985,10 +1985,18 @@ class Spec(object):
             try:
                 changed |= spec_deps[dep.name].constrain(dep)
             except UnsatisfiableSpecError as e:
-                e.message = "Invalid spec: '%s'. "
-                e.message += "Package %s requires %s %s, but spec asked for %s"
-                e.message %= (spec_deps[dep.name], dep.name,
-                              e.constraint_type, e.required, e.provided)
+                fmt = 'An unsatisfiable constraint has been detected for spec:'
+                fmt += '\n\n{0}\n\n'.format(spec_deps[dep.name].tree(indent=4))
+                fmt += 'while trying to concretize the partial spec:'
+                fmt += '\n\n{0}\n\n'.format(self.tree(indent=4))
+                fmt += '{0} requires for {1} {2} {3}, but spec asked for {4}'
+                e.message = fmt.format(
+                    self.name,
+                    dep.name,
+                    e.constraint_type,
+                    e.required,
+                    e.provided
+                )
                 raise e
 
         # Add merged spec to my deps and recurse

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1990,7 +1990,7 @@ class Spec(object):
                 fmt += '\n\n{0}\n\n'.format(spec_deps[dep.name].tree(indent=4))
                 fmt += 'while trying to concretize the partial spec:'
                 fmt += '\n\n{0}\n\n'.format(self.tree(indent=4))
-                fmt += '{0} requires for {1} {2} {3}, but spec asked for {4}'
+                fmt += '{0} requires {1} {2} {3}, but spec asked for {4}'
                 e.message = fmt.format(
                     self.name,
                     dep.name,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1985,7 +1985,8 @@ class Spec(object):
             try:
                 changed |= spec_deps[dep.name].constrain(dep)
             except UnsatisfiableSpecError as e:
-                fmt = 'An unsatisfiable constraint has been detected for spec:'
+                fmt = 'An unsatisfiable {0}'.format(e.constraint_type)
+                fmt += ' constraint has been detected for spec:'
                 fmt += '\n\n{0}\n\n'.format(spec_deps[dep.name].tree(indent=4))
                 fmt += 'while trying to concretize the partial spec:'
                 fmt += '\n\n{0}\n\n'.format(self.tree(indent=4))


### PR DESCRIPTION
Fixes #5066

This PR improves the error message for unsatisfiable specs by showing in tree format both the spec that cannot satisfy the constraint and the spec that asked for that constraint. After that follows a readable (?) error message.

---

The new error message for the example in #5066 is:
```hconsole
$ spack spec  mfem@3.2~debug+examples+hypre+lapack~mpfr+mpi+netcdf~openmp+petsc+suite-sparse+sundials+superlu-dist~threadsafe %gcc
Input spec
--------------------------------
mfem@3.2%gcc~debug+examples+hypre+lapack~mpfr+mpi+netcdf~openmp+petsc+suite-sparse+sundials+superlu-dist~threadsafe

Normalized
--------------------------------
mfem@3.2%gcc~debug+examples+hypre+lapack~mpfr+mpi+netcdf~openmp+petsc+suite-sparse+sundials+superlu-dist~threadsafe
    ^blas
    ^cmake@2.8:
    ^hdf5
        ^zlib@1.2.5:
    ^hypre@develop~internal-superlu
        ^lapack
        ^mpi
    ^metis@5:
    ^netcdf
        ^m4
    ^parmetis
    ^petsc@develop
        ^python@2.6:2.8
            ^bzip2
            ^ncurses
                ^pkg-config
            ^openssl
            ^readline
            ^sqlite
        ^sowing
    ^suite-sparse
    ^sundials@2.7:+hypre
    ^superlu-dist

Concretized
--------------------------------
==> Error: An unsatisfiable version constraint has been detected for spec:

    superlu-dist@5.1.3%gcc@4.8~int64 arch=linux-ubuntu14-x86_64 
        ^metis@5.1.0%gcc@4.8~debug~gdb~int64~real64+shared arch=linux-ubuntu14-x86_64 
            ^cmake@3.9.0%gcc@4.8~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu14-x86_64 
                ^ncurses@6.0%gcc@4.8~symlinks arch=linux-ubuntu14-x86_64 
                    ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 
                ^openssl@1.0.2k%gcc@4.8 arch=linux-ubuntu14-x86_64 
                    ^zlib@1.2.11%gcc@4.8+pic+shared arch=linux-ubuntu14-x86_64 
        ^openblas@0.2.20%gcc@4.8~openmp+pic+shared arch=linux-ubuntu14-x86_64 
        ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 
            ^hwloc
        ^parmetis@4.0.3%gcc@4.8~debug~gdb+shared arch=linux-ubuntu14-x86_64 


while trying to concretize the partial spec:

    petsc@develop%gcc@4.8+boost~complex~debug+double+hdf5+hypre~int64+metis+mpi~mumps+shared+superlu-dist~trilinos arch=linux-ubuntu14-x86_64 
        ^hypre@develop%gcc@4.8~int64~internal-superlu+shared arch=linux-ubuntu14-x86_64 
            ^openblas@0.2.20%gcc@4.8~openmp+pic+shared arch=linux-ubuntu14-x86_64 
            ^openmpi@2.1.1%gcc@4.8~cuda fabrics= ~java schedulers= ~sqlite3~thread_multiple+vt arch=linux-ubuntu14-x86_64 
                ^hwloc
                    ^pkg-config@0.29.2%gcc@4.8+internal_glib arch=linux-ubuntu14-x86_64 
        ^sowing@1.1.23-p1%gcc@4.8 arch=linux-ubuntu14-x86_64 


petsc requires superlu-dist version develop, but spec asked for 5.1.3
```