### PR TITLE
Relaxed constraints on config.yaml structure

### DIFF
--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -38,7 +38,6 @@ schema = {
         'config': {
             'type': 'object',
             'default': {},
-            'additionalProperties': False,
             'properties': {
                 'install_tree': {'type': 'string'},
                 'install_hash_length': {'type': 'integer', 'minimum': 1},


### PR DESCRIPTION
This PR allows additional unused properties at the top-level of the config.yaml file. Having these properties permits to use two different versions of Spack, one of which adds a new property, without receiving error messages due to the presence of this new property in a configuration cache stored in the user's home.

---

Currently adding an entry to `config.yaml` and switching back to a version of Spack where this entry is not allowed gives an error similar to:
```console
$ spack help
Traceback (most recent call last):
  File "/home/mculpo/PycharmProjects/spack/bin/spack", line 80, in <module>
    import spack.main  # noqa
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/__init__.py", line 84, in <module>
    import spack.repository
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/repository.py", line 44, in <module>
    import spack.spec
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 120, in <module>
    import spack.store
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/store.py", line 58, in <module>
    config = spack.config.get_config("config")
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/config.py", line 409, in get_config
    data = scope.get_section(section)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/config.py", line 180, in get_section
    data   = _read_config_file(path, schema)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/config.py", line 282, in _read_config_file
    validate_section(data, schema)
  File "/home/mculpo/PycharmProjects/spack/lib/spack/spack/config.py", line 152, in validate_section
    raise ConfigFormatError(e, data)
spack.config.ConfigFormatError: /home/mculpo/.spack/config.yaml:1: Additional properties are not allowed ('template_dirs' was unexpected)
```