### PR TITLE
Fix name detection in HeaderList and LibraryList

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -712,8 +712,8 @@ class HeaderList(FileList):
         for x in self.basenames:
             name = x
 
-            # Valid extensions include: ['.hpp', '.hh', '.h']
-            for ext in ['.hpp', '.hh', '.h']:
+            # Valid extensions include: ['.cuh', '.hpp', '.hh', '.h']
+            for ext in ['.cuh', '.hpp', '.hh', '.h']:
                 i = name.rfind(ext)
                 if i != -1:
                     names.append(name[:i])

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -647,19 +647,6 @@ class FileList(collections.Sequence):
         """
         return list(dedupe(os.path.basename(x) for x in self.files))
 
-    @property
-    def names(self):
-        """Stable de-duplication of file names in the list without extensions
-
-        >>> h = HeaderList(['/dir1/a.h', '/dir2/b.h', '/dir3/a.h'])
-        >>> h.names
-        ['a', 'b']
-
-        Returns:
-            list of strings: A list of files without extensions
-        """
-        return list(dedupe(x.split('.')[0] for x in self.basenames))
-
     def __getitem__(self, item):
         cls = type(self)
         if isinstance(item, numbers.Integral):
@@ -708,6 +695,34 @@ class HeaderList(FileList):
             list of strings: A list of header files
         """
         return self.files
+
+    @property
+    def names(self):
+        """Stable de-duplication of header names in the list without extensions
+
+        >>> h = HeaderList(['/dir1/a.h', '/dir2/b.h', '/dir3/a.h'])
+        >>> h.names
+        ['a', 'b']
+
+        Returns:
+            list of strings: A list of files without extensions
+        """
+        names = []
+
+        for x in self.basenames:
+            name = x
+
+            # Valid extensions include: ['.hpp', '.hh', '.h']
+            for ext in ['.hpp', '.hh', '.h']:
+                i = name.rfind(ext)
+                if i != -1:
+                    names.append(name[:i])
+                    break
+            else:
+                # No valid extension, should we still include it?
+                names.append(name)
+
+        return list(dedupe(names))
 
     @property
     def include_flags(self):
@@ -833,7 +848,24 @@ class LibraryList(FileList):
         Returns:
             list of strings: A list of library names
         """
-        return list(dedupe(x.split('.')[0][3:] for x in self.basenames))
+        names = []
+
+        for x in self.basenames:
+            name = x
+            if x.startswith('lib'):
+                name = x[3:]
+
+            # Valid extensions include: ['.dylib', '.so', '.a']
+            for ext in ['.dylib', '.so', '.a']:
+                i = name.rfind(ext)
+                if i != -1:
+                    names.append(name[:i])
+                    break
+            else:
+                # No valid extension, should we still include it?
+                names.append(name)
+
+        return list(dedupe(names))
 
     @property
     def search_flags(self):

--- a/lib/spack/spack/test/file_list.py
+++ b/lib/spack/spack/test/file_list.py
@@ -51,13 +51,13 @@ def library_list():
 @pytest.fixture()
 def header_list():
     """Returns an instance of header list"""
-    # Test all valid extensions: ['.h', '.hpp', '.hh']
+    # Test all valid extensions: ['.h', '.hpp', '.hh', '.cuh']
     h = [
         '/dir1/Python.h',
         '/dir2/date.time.h',
         '/dir1/pyconfig.hpp',
         '/dir3/core.hh',
-        'pymem.h',
+        'pymem.cuh',
     ]
     h = HeaderList(h)
     h.add_macro('-DBOOST_LIB_NAME=boost_regex')
@@ -148,14 +148,14 @@ class TestHeaderList(object):
 
     def test_joined_and_str(self, header_list):
         s1 = header_list.joined()
-        expected = '/dir1/Python.h /dir2/date.time.h /dir1/pyconfig.hpp /dir3/core.hh pymem.h'  # noqa: E501
+        expected = '/dir1/Python.h /dir2/date.time.h /dir1/pyconfig.hpp /dir3/core.hh pymem.cuh'  # noqa: E501
         assert s1 == expected
 
         s2 = str(header_list)
         assert s1 == s2
 
         s3 = header_list.joined(';')
-        expected = '/dir1/Python.h;/dir2/date.time.h;/dir1/pyconfig.hpp;/dir3/core.hh;pymem.h'  # noqa: E501
+        expected = '/dir1/Python.h;/dir2/date.time.h;/dir1/pyconfig.hpp;/dir3/core.hh;pymem.cuh'  # noqa: E501
         assert s3 == expected
 
     def test_flags(self, header_list):


### PR DESCRIPTION
@alalazo @davydden 

Our previous name detection in HeaderList and LibraryList was very primitive. We were searching for the first period in the filename and assuming everything after it was an extension. In https://github.com/LLNL/spack/pull/5097#discussion_r133383164, @pramodskumbhar pointed out that some libraries, like `libpython3.6.dylib`, include a period in the library name. We also can't search for the last period, as some libraries are versioned, like `libmpi.so.20.10.1`. This PR searches for common library and header extensions and uses that to strip extensions.