### PR TITLE
explicitly add libiconv dependency to libxslt

### DIFF
--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -43,6 +43,7 @@ class Libxslt(AutotoolsPackage):
     variant('crypto',  default=True,
             description='Build libexslt with crypto support')
 
+    depends_on("libiconv")
     depends_on("libxml2")
     depends_on("xz")
     depends_on("zlib")


### PR DESCRIPTION
this is a fix to an installation that failed due to configure for some reason not finding the libiconv shipped with glibc, but still trying to link against it
see http://xmlsoft.org/FAQ.html