### PR TITLE
Simplified Spec.__init__ signature by removing the '*dep_like' argument

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -970,7 +970,7 @@ class SpecBuildInterface(ObjectWrapper):
 @key_ordering
 class Spec(object):
 
-    def __init__(self, spec_like, *dep_like, **kwargs):
+    def __init__(self, spec_like, **kwargs):
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
             self._dup(spec_like)
@@ -1012,22 +1012,6 @@ class Spec(object):
         # Allow a spec to be constructed with an external path.
         self.external_path = kwargs.get('external_path', None)
         self.external_module = kwargs.get('external_module', None)
-
-        # This allows users to construct a spec DAG with literals.
-        # Note that given two specs a and b, Spec(a) copies a, but
-        # Spec(a, b) will copy a but just add b as a dep.
-        deptypes = ()
-        for dep in dep_like:
-
-            if isinstance(dep, (list, tuple)):
-                # Literals can be deptypes -- if there are tuples in the
-                # list, they will be used as deptypes for the following Spec.
-                deptypes = tuple(dep)
-                continue
-
-            spec = dep if isinstance(dep, Spec) else Spec(dep)
-            self._add_dependency(spec, deptypes)
-            deptypes = ()
 
     @property
     def external(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -328,61 +328,96 @@ class TestConcretize(object):
         assert spec['externaltool'].compiler.satisfies('gcc')
         assert spec['stuff'].compiler.satisfies('gcc')
 
-    def test_find_spec_parents(self):
+    def test_find_spec_parents(self, spec_from_dict):
         """Tests the spec finding logic used by concretization. """
-        s = Spec('a +foo',
-                 Spec('b +foo',
-                      Spec('c'),
-                      Spec('d +foo')),
-                 Spec('e +foo'))
+        s = spec_from_dict({
+            'a +foo': {
+                'b +foo': {
+                    'c': None,
+                    'd+foo': None
+                },
+                'e +foo': None
+            }
+        })
 
         assert 'a' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_children(self):
-        s = Spec('a',
-                 Spec('b +foo',
-                      Spec('c'),
-                      Spec('d +foo')),
-                 Spec('e +foo'))
+    def test_find_spec_children(self, spec_from_dict):
+        s = spec_from_dict({
+            'a': {
+                'b +foo': {
+                    'c': None,
+                    'd+foo': None
+                },
+                'e +foo': None
+            }
+        })
+
         assert 'd' == find_spec(s['b'], lambda s: '+foo' in s).name
-        s = Spec('a',
-                 Spec('b +foo',
-                      Spec('c +foo'),
-                      Spec('d')),
-                 Spec('e +foo'))
+
+        s = spec_from_dict({
+            'a': {
+                'b +foo': {
+                    'c+foo': None,
+                    'd': None
+                },
+                'e +foo': None
+            }
+        })
+
         assert 'c' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_sibling(self):
-        s = Spec('a',
-                 Spec('b +foo',
-                      Spec('c'),
-                      Spec('d')),
-                 Spec('e +foo'))
+    def test_find_spec_sibling(self, spec_from_dict):
+
+        s = spec_from_dict({
+            'a': {
+                'b +foo': {
+                    'c': None,
+                    'd': None
+                },
+                'e +foo': None
+            }
+        })
+
         assert 'e' == find_spec(s['b'], lambda s: '+foo' in s).name
         assert 'b' == find_spec(s['e'], lambda s: '+foo' in s).name
 
-        s = Spec('a',
-                 Spec('b +foo',
-                      Spec('c'),
-                      Spec('d')),
-                 Spec('e',
-                      Spec('f +foo')))
+        s = spec_from_dict({
+            'a': {
+                'b +foo': {
+                    'c': None,
+                    'd': None
+                },
+                'e': {
+                    'f +foo': None
+                }
+            }
+        })
+
         assert 'f' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_self(self):
-        s = Spec('a',
-                 Spec('b +foo',
-                      Spec('c'),
-                      Spec('d')),
-                 Spec('e'))
+    def test_find_spec_self(self, spec_from_dict):
+        s = spec_from_dict({
+            'a': {
+                'b +foo': {
+                    'c': None,
+                    'd': None
+                },
+                'e': None
+            }
+        })
         assert 'b' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_none(self):
-        s = Spec('a',
-                 Spec('b',
-                      Spec('c'),
-                      Spec('d')),
-                 Spec('e'))
+    def test_find_spec_none(self, spec_from_dict):
+        s = spec_from_dict({
+            'a': {
+                'b': {
+                    'c': None,
+                    'd': None
+                },
+                'e': None
+            }
+        })
         assert find_spec(s['b'], lambda s: '+foo' in s) is None
 
     def test_compiler_child(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -328,9 +328,9 @@ class TestConcretize(object):
         assert spec['externaltool'].compiler.satisfies('gcc')
         assert spec['stuff'].compiler.satisfies('gcc')
 
-    def test_find_spec_parents(self, spec_from_dict):
+    def test_find_spec_parents(self):
         """Tests the spec finding logic used by concretization. """
-        s = spec_from_dict({
+        s = Spec.from_literal({
             'a +foo': {
                 'b +foo': {
                     'c': None,
@@ -342,8 +342,8 @@ class TestConcretize(object):
 
         assert 'a' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_children(self, spec_from_dict):
-        s = spec_from_dict({
+    def test_find_spec_children(self):
+        s = Spec.from_literal({
             'a': {
                 'b +foo': {
                     'c': None,
@@ -355,7 +355,7 @@ class TestConcretize(object):
 
         assert 'd' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-        s = spec_from_dict({
+        s = Spec.from_literal({
             'a': {
                 'b +foo': {
                     'c+foo': None,
@@ -367,9 +367,9 @@ class TestConcretize(object):
 
         assert 'c' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_sibling(self, spec_from_dict):
+    def test_find_spec_sibling(self):
 
-        s = spec_from_dict({
+        s = Spec.from_literal({
             'a': {
                 'b +foo': {
                     'c': None,
@@ -382,7 +382,7 @@ class TestConcretize(object):
         assert 'e' == find_spec(s['b'], lambda s: '+foo' in s).name
         assert 'b' == find_spec(s['e'], lambda s: '+foo' in s).name
 
-        s = spec_from_dict({
+        s = Spec.from_literal({
             'a': {
                 'b +foo': {
                     'c': None,
@@ -396,8 +396,8 @@ class TestConcretize(object):
 
         assert 'f' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_self(self, spec_from_dict):
-        s = spec_from_dict({
+    def test_find_spec_self(self):
+        s = Spec.from_literal({
             'a': {
                 'b +foo': {
                     'c': None,
@@ -408,8 +408,8 @@ class TestConcretize(object):
         })
         assert 'b' == find_spec(s['b'], lambda s: '+foo' in s).name
 
-    def test_find_spec_none(self, spec_from_dict):
-        s = spec_from_dict({
+    def test_find_spec_none(self):
+        s = Spec.from_literal({
             'a': {
                 'b': {
                     'c': None,

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -42,7 +42,6 @@ import spack.database
 import spack.directory_layout
 import spack.platforms.test
 import spack.repository
-import spack.spec
 import spack.stage
 import spack.util.executable
 import spack.util.pattern
@@ -62,59 +61,6 @@ def no_stdin_duplication(monkeypatch):
     """
     monkeypatch.setattr(llnl.util.lang, 'duplicate_stream',
                         lambda x: StringIO())
-
-
-@pytest.fixture()
-def spec_from_dict():
-    """Returns a factory that builds a Spec from a dictionary. This allows
-    the construction of a DAG with literals in tests.
-
-    The dictionary must have a single top level key, representing the root,
-    and as many secondary level keys as needed in the spec. The definition
-    is recursive.
-
-    Examples:
-        A simple spec ``foo`` with no dependencies:
-
-            {'foo': None}
-
-        A spec ``foo`` with a ``(build, link)`` dependency ``bar``:
-
-            {'foo':
-                {'bar:build,link': None}}
-
-    """
-    def _impl(spec_dict):
-
-        # The invariant is that the top level dictionary must have
-        # only one key
-        assert len(spec_dict) == 1
-
-        # Construct the top-level spec
-        spec_like, dep_like = next(iter(spec_dict.items()))
-        spec = spack.spec.Spec(spec_like)
-
-        if dep_like is None:
-            return spec
-
-        # If there are dependencies, recurse
-        for s, dependencies in dep_like.items():
-
-            if isinstance(s, spack.spec.Spec):
-                # If it is a spec, just add it
-                spec._add_dependency(s, ())
-                continue
-
-            name, dep_types = s.split(':')[0], tuple(s.split(':')[1:])
-            if dep_types:
-                dep_types = tuple(dep_types[0].split(','))
-
-            dependency_spec = _impl({name: dependencies})
-            spec._add_dependency(dependency_spec, dep_types)
-
-        return spec
-
-    return _impl
 
 
 @pytest.fixture(autouse=True)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -42,6 +42,7 @@ import spack.database
 import spack.directory_layout
 import spack.platforms.test
 import spack.repository
+import spack.spec
 import spack.stage
 import spack.util.executable
 import spack.util.pattern
@@ -61,6 +62,59 @@ def no_stdin_duplication(monkeypatch):
     """
     monkeypatch.setattr(llnl.util.lang, 'duplicate_stream',
                         lambda x: StringIO())
+
+
+@pytest.fixture()
+def spec_from_dict():
+    """Returns a factory that builds a Spec from a dictionary. This allows
+    the construction of a DAG with literals in tests.
+
+    The dictionary must have a single top level key, representing the root,
+    and as many secondary level keys as needed in the spec. The definition
+    is recursive.
+
+    Examples:
+        A simple spec ``foo`` with no dependencies:
+
+            {'foo': None}
+
+        A spec ``foo`` with a ``(build, link)`` dependency ``bar``:
+
+            {'foo':
+                {'bar:build,link': None}}
+
+    """
+    def _impl(spec_dict):
+
+        # The invariant is that the top level dictionary must have
+        # only one key
+        assert len(spec_dict) == 1
+
+        # Construct the top-level spec
+        spec_like, dep_like = next(iter(spec_dict.items()))
+        spec = spack.spec.Spec(spec_like)
+
+        if dep_like is None:
+            return spec
+
+        # If there are dependencies, recurse
+        for s, dependencies in dep_like.items():
+
+            if isinstance(s, spack.spec.Spec):
+                # If it is a spec, just add it
+                spec._add_dependency(s, ())
+                continue
+
+            name, dep_types = s.split(':')[0], tuple(s.split(':')[1:])
+            if dep_types:
+                dep_types = tuple(dep_types[0].split(','))
+
+            dependency_spec = _impl({name: dependencies})
+            spec._add_dependency(dependency_spec, dep_types)
+
+        return spec
+
+    return _impl
 
 
 @pytest.fixture(autouse=True)

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -29,65 +29,82 @@ from spack.spec import Spec
 @pytest.fixture(
     params=[
         # Normalize simple conditionals
-        ('optional-dep-test', Spec('optional-dep-test')),
-        ('optional-dep-test~a', Spec('optional-dep-test~a')),
-        ('optional-dep-test+a', Spec('optional-dep-test+a', Spec('a'))),
-        ('optional-dep-test a=true', Spec(
-            'optional-dep-test a=true', Spec('a')
-        )),
-        ('optional-dep-test a=true', Spec('optional-dep-test+a', Spec('a'))),
-        ('optional-dep-test@1.1', Spec('optional-dep-test@1.1', Spec('b'))),
-        ('optional-dep-test%intel', Spec(
-            'optional-dep-test%intel', Spec('c')
-        )),
-        ('optional-dep-test%intel@64.1', Spec(
-            'optional-dep-test%intel@64.1', Spec('c'), Spec('d')
-        )),
-        ('optional-dep-test%intel@64.1.2', Spec(
-            'optional-dep-test%intel@64.1.2', Spec('c'), Spec('d')
-        )),
-        ('optional-dep-test%clang@35', Spec(
-            'optional-dep-test%clang@35', Spec('e')
-        )),
+        ('optional-dep-test', {'optional-dep-test': None}),
+        ('optional-dep-test~a', {'optional-dep-test~a': None}),
+        ('optional-dep-test+a', {'optional-dep-test+a': {'a': None}}),
+        ('optional-dep-test a=true', {
+            'optional-dep-test a=true': {
+                'a': None
+            }}),
+        ('optional-dep-test a=true', {
+            'optional-dep-test+a': {
+                'a': None
+            }}),
+        ('optional-dep-test@1.1', {'optional-dep-test@1.1': {'b': None}}),
+        ('optional-dep-test%intel', {'optional-dep-test%intel': {'c': None}}),
+        ('optional-dep-test%intel@64.1', {
+            'optional-dep-test%intel@64.1': {
+                'c': None,
+                'd': None
+            }}),
+        ('optional-dep-test%intel@64.1.2', {
+            'optional-dep-test%intel@64.1.2': {
+                'c': None,
+                'd': None
+            }}),
+        ('optional-dep-test%clang@35', {
+            'optional-dep-test%clang@35': {
+                'e': None
+            }}),
         # Normalize multiple conditionals
-        ('optional-dep-test+a@1.1',  Spec(
-            'optional-dep-test+a@1.1', Spec('a'), Spec('b')
-        )),
-        ('optional-dep-test+a%intel', Spec(
-            'optional-dep-test+a%intel', Spec('a'), Spec('c')
-        )),
-        ('optional-dep-test@1.1%intel', Spec(
-            'optional-dep-test@1.1%intel', Spec('b'), Spec('c')
-        )),
-        ('optional-dep-test@1.1%intel@64.1.2+a', Spec(
-            'optional-dep-test@1.1%intel@64.1.2+a',
-            Spec('b'),
-            Spec('a'),
-            Spec('c'),
-            Spec('d')
-        )),
-        ('optional-dep-test@1.1%clang@36.5+a', Spec(
-            'optional-dep-test@1.1%clang@36.5+a',
-            Spec('b'),
-            Spec('a'),
-            Spec('e')
-        )),
+        ('optional-dep-test+a@1.1', {
+            'optional-dep-test+a@1.1': {
+                'a': None,
+                'b': None
+            }}),
+        ('optional-dep-test+a%intel', {
+            'optional-dep-test+a%intel': {
+                'a': None,
+                'c': None
+            }}),
+        ('optional-dep-test@1.1%intel', {
+            'optional-dep-test@1.1%intel': {
+                'b': None,
+                'c': None
+            }}),
+        ('optional-dep-test@1.1%intel@64.1.2+a', {
+            'optional-dep-test@1.1%intel@64.1.2+a': {
+                'a': None,
+                'b': None,
+                'c': None,
+                'd': None
+            }}),
+        ('optional-dep-test@1.1%clang@36.5+a', {
+            'optional-dep-test@1.1%clang@36.5+a': {
+                'b': None,
+                'a': None,
+                'e': None
+            }}),
         # Chained MPI
-        ('optional-dep-test-2+mpi', Spec(
-            'optional-dep-test-2+mpi',
-            Spec('optional-dep-test+mpi', Spec('mpi'))
-        )),
+        ('optional-dep-test-2+mpi', {
+            'optional-dep-test-2+mpi': {
+                'optional-dep-test+mpi': {'mpi': None}
+            }}),
         # Each of these dependencies comes from a conditional
         # dependency on another.  This requires iterating to evaluate
         # the whole chain.
-        ('optional-dep-test+f', Spec(
-            'optional-dep-test+f', Spec('f'), Spec('g'), Spec('mpi')
-        ))
+        ('optional-dep-test+f', {
+            'optional-dep-test+f': {
+                'f': None,
+                'g': None,
+                'mpi': None
+            }})
     ]
 )
-def spec_and_expected(request):
-    """Parameters for te normalization test."""
-    return request.param
+def spec_and_expected(request, spec_from_dict):
+    """Parameters for the normalization test."""
+    spec, d = request.param
+    return spec, spec_from_dict(d)
 
 
 def test_normalize(spec_and_expected, config, builtin_mock):

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -101,10 +101,10 @@ from spack.spec import Spec
             }})
     ]
 )
-def spec_and_expected(request, spec_from_dict):
+def spec_and_expected(request):
     """Parameters for the normalization test."""
     spec, d = request.param
-    return spec, spec_from_dict(d)
+    return spec, Spec.from_literal(d)
 
 
 def test_normalize(spec_and_expected, config, builtin_mock):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -359,8 +359,8 @@ class TestSpecDag(object):
         })
 
         # What it should look like after normalization
-        mpich = 'mpich'
-        libelf = 'libelf@1.8.11'
+        mpich = Spec('mpich')
+        libelf = Spec('libelf@1.8.11')
         expected_normalized = Spec.from_literal({
             'mpileaks': {
                 'callpath': {

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -388,7 +388,7 @@ class TestSpecDag(object):
                 },
                 mpich: None
             }
-        }, unique=False)
+        }, normal=False)
 
         # All specs here should be equal under regular equality
         specs = (spec, expected_flat, expected_normalized, non_unique_nodes)


### PR DESCRIPTION
The `*dep_like` argument of `Spec.__init__` is meant only for unit tests. This PR removes it from the call signature and introduces a static method `Spec.from_literal` to be used in tests.