### PR TITLE
muscle: fix

### DIFF
--- a/var/spack/repos/builtin/packages/muscle/package.py
+++ b/var/spack/repos/builtin/packages/muscle/package.py
@@ -35,6 +35,11 @@ class Muscle(MakefilePackage):
 
     version('3.8.1551', '1b7c9661f275a82d3cf708f923736bf8')
 
+    def edit(self, spec, prefix):
+        makefile = FileFilter('Makefile')
+        makefile.filter('-static', '')
+        makefile.filter('-funroll-loops', '')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('muscle', prefix.bin)


### PR DESCRIPTION
fixing muscle. Previously, with the `-static` flag, the build would fail:
```
/usr/bin/ld: cannot find -lm
/usr/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
make: *** [muscle] Error 1
/tmp/las_thoma15/spack-stage/
```
Build is now successful