### PR TITLE
For Tk, also provide a symlink for wishX.X.

### DIFF
--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -53,3 +53,8 @@ class Tk(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         return ['--with-tcl={0}'.format(spec['tcl'].prefix.lib)]
+
+    @run_after('install')
+    def symlink_wish(self):
+        with working_dir(self.prefix.bin):
+            symlink('wish{0}'.format(self.version.up_to(2)), 'wish')


### PR DESCRIPTION
+ gitk (and possibly other tools) expects to find the Tk executable `wish`, so add a symlink with this name that points to the the versioned filename.
+ Example: `wish --> wish8.6`
+ Fixes #4167