### PR TITLE
lbann: add depends_on hwloc

### DIFF
--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -49,6 +49,7 @@ class Lbann(CMakePackage):
                when=('build_type=Debug'))
     depends_on('cuda', when='+gpu')
     depends_on('mpi')
+    depends_on('hwloc')
     depends_on('opencv@3.2.0: +openmp +core +highgui +imgproc +jpeg +png +tiff +zlib', when='+opencv')
     depends_on('protobuf@3.0.2:')
     depends_on('cnpy')


### PR DESCRIPTION
LBANN makes some hwloc calls but was missing an explicit dependency.