### PR TITLE
Make test_inspect_path work on Mac OS X without XCode

### DIFF
--- a/lib/spack/spack/test/modules.py
+++ b/lib/spack/spack/test/modules.py
@@ -27,6 +27,7 @@ import contextlib
 from six import StringIO
 
 import pytest
+
 import spack.modules
 import spack.spec
 
@@ -105,8 +106,13 @@ def test_update_dictionary_extending_list():
     assert target['baz'] == 'foobaz'
 
 
-def test_inspect_path():
-    env = spack.modules.inspect_path('/usr')
+def test_inspect_path(tmpdir):
+    tmpdir.chdir()
+    tmpdir.mkdir('bin')
+    tmpdir.mkdir('lib')
+    tmpdir.mkdir('include')
+
+    env = spack.modules.inspect_path(str(tmpdir))
     names = [item.name for item in env]
     assert 'PATH' in names
     assert 'LIBRARY_PATH' in names


### PR DESCRIPTION
- Mac OS X Sierra has no `/usr/include` by default
- Instead of assuming there's an `include` directory in `/usr`, mock up a directory that looks like we expect.