### PR TITLE
Boost: develop

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -41,6 +41,11 @@ class Boost(Package):
     list_url = "http://sourceforge.net/projects/boost/files/boost/"
     list_depth = 1
 
+    version('develop',
+            git='https://github.com/boostorg/boost.git',
+            branch='develop',
+            submodules=True)
+
     version('1.65.0', '5512d3809801b0a1b9dd58447b70915d',
             url='https://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.bz2')
 


### PR DESCRIPTION
Adds a development version of boost, based on their github [super repo](https://github.com/boostorg/boost).
Git clones the submodules forever, but it installs! :)

Useful for testing since boost tends to break complex software dependencies quite often. This helps testing it before releases.

- [x] rebase after #5182 was merged