### PR TITLE
autoconf, automake: Add missing perl dependency

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -39,8 +39,29 @@ class Autoconf(AutotoolsPackage):
     # Note: m4 is not a pure build-time dependency of autoconf. m4 is
     # needed when autoconf runs, not only when autoconf is built.
     depends_on('m4@1.4.6:', type=('build', 'run'))
+    depends_on('perl', type=('build', 'run'))
 
     build_directory = 'spack-build'
+
+    def patch(self):
+        # The full perl shebang might be too long; we have to fix this here
+        # because autom4te is called during the build
+        filter_file('^#! @PERL@ -w',
+                    '#! /usr/bin/env perl',
+                    'bin/autom4te.in')
+
+    @run_after('install')
+    def filter_sbang(self):
+        # We have to do this after install because otherwise the install
+        # target will try to rebuild the binaries (filter_file updates the
+        # timestamps)
+        perl = join_path(self.spec['perl'].prefix.bin, 'perl')
+
+        # Revert sbang, so Spack's sbang hook can fix it up
+        filter_file('^#! /usr/bin/env perl',
+                    '#! {0} -w'.format(perl),
+                    '{0}/autom4te'.format(self.prefix.bin),
+                    backup=False)
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -36,8 +36,16 @@ class Automake(AutotoolsPackage):
     version('1.11.6', '0286dc30295b62985ca51919202ecfcc')
 
     depends_on('autoconf', type='build')
+    depends_on('perl', type=('build', 'run'))
 
     build_directory = 'spack-build'
+
+    def patch(self):
+        # The full perl shebang might be too long
+        for file in ('aclocal', 'automake'):
+            filter_file('^#!@PERL@ -w',
+                        '#!/usr/bin/env perl',
+                        't/wrap/{0}.in'.format(file))
 
     def _make_executable(self, name):
         return Executable(join_path(self.prefix.bin, name))

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -31,6 +31,7 @@ class Automake(AutotoolsPackage):
     homepage = 'http://www.gnu.org/software/automake/'
     url      = 'http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz'
 
+    version('1.15.1', '95df3f2d6eb8f81e70b8cb63a93c8853')
     version('1.15',   '716946a105ca228ab545fc37a70df3a3')
     version('1.14.1', 'd052a3e884631b9c7892f2efce542d75')
     version('1.11.6', '0286dc30295b62985ca51919202ecfcc')


### PR DESCRIPTION
While building a few packages in a minimal chroot, I noticed that autoconf and automake are missing a perl dependency. When adding it, a few of the tools fail because the shebang is too long, so we have to fix those up. We also have to remove `-w` from the shebang because of https://unix.stackexchange.com/questions/14887/the-way-to-use-usr-bin-env-sed-f-in-shebang. Fun times.

This also seems to fix #3719 for me (Fedora 26).