### PR TITLE
Make jpeg a virtual dependency.

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -34,4 +34,4 @@ packages:
       scalapack: [netlib-scalapack]
       szip: [libszip, libaec]
       tbb: [intel-tbb]
-      jpeg: [libjpeg, libjpeg-turbo]
+      jpeg: [libjpeg-turbo, libjpeg]

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -34,3 +34,4 @@ packages:
       scalapack: [netlib-scalapack]
       szip: [libszip, libaec]
       tbb: [intel-tbb]
+      jpeg: [libjpeg, libjpeg-turbo]

--- a/var/spack/repos/builtin/packages/isaac-server/jpeg.patch
+++ b/var/spack/repos/builtin/packages/isaac-server/jpeg.patch
@@ -1,0 +1,34 @@
+diff --git a/server/src/Broker.cpp b/server/src/Broker.cpp
+index 03d60f4..aab449f 100644
+--- a/server/src/Broker.cpp
++++ b/server/src/Broker.cpp
+@@ -108,14 +108,14 @@ MetaDataClient* Broker::addDataClient()
+ 	}
+ 	boolean isaac_jpeg_fill_input_buffer(j_decompress_ptr cinfo)
+ 	{
+-		return true;
++		return TRUE;
+ 	}
+ 	void isaac_jpeg_skip_input_data(j_decompress_ptr cinfo,long num_bytes)
+ 	{
+ 	}
+ 	boolean isaac_jpeg_resync_to_restart(j_decompress_ptr cinfo, int desired)
+ 	{
+-		return true;
++		return TRUE;
+ 	}
+ 	void isaac_jpeg_term_source(j_decompress_ptr cinfo)
+ 	{
+diff --git a/server/src/URIImageConnector.cpp b/server/src/URIImageConnector.cpp
+index 0b11800..e843aa4 100644
+--- a/server/src/URIImageConnector.cpp
++++ b/server/src/URIImageConnector.cpp
+@@ -40,7 +40,7 @@ void isaac_init_destination(j_compress_ptr cinfo)
+ }
+ boolean isaac_jpeg_empty_output_buffer(j_compress_ptr cinfo)
+ {
+-	return true;
++	return TRUE;
+ }
+ void isaac_jpeg_term_destination(j_compress_ptr cinfo)
+ {

--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -42,10 +42,13 @@ class IsaacServer(CMakePackage):
     #         'Support for RTP streams, e.g. to Twitch or Youtube')
 
     depends_on('cmake@3.3:', type='build')
-    depends_on('libjpeg-turbo', type='link')
+    depends_on('jpeg', type='link')
     depends_on('jansson', type='link')
     depends_on('boost@1.56:', type='link')
     depends_on('libwebsockets@2.1.1:', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')
+
+    # Until the pull request is merged: https://github.com/ComputationalRadiationPhysics/isaac/pull/70
+    patch('jpeg.patch')
 
     root_cmakelists_dir = 'server'

--- a/var/spack/repos/builtin/packages/isaac/package.py
+++ b/var/spack/repos/builtin/packages/isaac/package.py
@@ -44,7 +44,7 @@ class Isaac(CMakePackage):
     #         description='Generate kernels via Alpaka, for CPUs or GPUs')
 
     depends_on('cmake@3.3:', type='build')
-    depends_on('libjpeg-turbo', type='link')
+    depends_on('jpeg', type='link')
     depends_on('jansson', type='link')
     depends_on('boost@1.56:', type='link')
     depends_on('cuda@7.0:', type='link', when='+cuda')

--- a/var/spack/repos/builtin/packages/jasper/package.py
+++ b/var/spack/repos/builtin/packages/jasper/package.py
@@ -38,7 +38,7 @@ class Jasper(AutotoolsPackage):
     variant('debug', default=False,
             description='Builds debug versions of the libraries')
 
-    depends_on('libjpeg-turbo')
+    depends_on('jpeg')
 
     # Fixes a bug (still in upstream as of v.1.900.1) where an assertion fails
     # when certain JPEG-2000 files with an alpha channel are processed

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -37,6 +37,8 @@ class LibjpegTurbo(AutotoolsPackage):
     version('1.5.0', '3fc5d9b6a8bce96161659ae7a9939257')
     version('1.3.1', '2c3a68129dac443a72815ff5bb374b05')
 
+    provides('jpeg')
+
     # Can use either of these. But in the current version of the package
     # only nasm is used. In order to use yasm an environmental variable
     # NASM must be set.

--- a/var/spack/repos/builtin/packages/libjpeg/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Jpeg(AutotoolsPackage):
+class Libjpeg(AutotoolsPackage):
     """libjpeg is a widely used free library with functions for handling the
     JPEG image data format. It implements a JPEG codec (encoding and decoding)
     alongside various utilities for handling JPEG data."""
@@ -35,3 +35,5 @@ class Jpeg(AutotoolsPackage):
 
     version('9b', '6a9996ce116ec5c52b4870dbcd6d3ddb')
     version('9a', '3353992aecaee1805ef4109aadd433e7')
+
+    provides('jpeg')

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -35,9 +35,6 @@ class Libtiff(AutotoolsPackage):
     version('4.0.6', 'd1d2e940dea0b5ad435f21f03d96dd72')
     version('4.0.3', '051c1068e6a0627f461948c365290410')
 
-    variant('turbo', default=False, description='use libjpeg-turbo')
-
-    depends_on('jpeg', when='-turbo')
-    depends_on('libjpeg-turbo', when='+turbo')
+    depends_on('jpeg')
     depends_on('zlib')
     depends_on('xz')

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -80,8 +80,8 @@ class Opencv(CMakePackage):
 
     depends_on('zlib', when='+zlib')
     depends_on('libpng', when='+png')
-    depends_on('libjpeg-turbo', when='+jpeg')
-    depends_on('libtiff+turbo', when='+tiff')
+    depends_on('jpeg', when='+jpeg')
+    depends_on('libtiff', when='+tiff')
 
     depends_on('jasper', when='+jasper')
     depends_on('cuda', when='+cuda')
@@ -150,7 +150,7 @@ class Opencv(CMakePackage):
             ])
 
         if '+jpeg' in spec:
-            libjpeg = spec['libjpeg-turbo']
+            libjpeg = spec['jpeg']
             args.extend([
                 '-DBUILD_JPEG:BOOL=OFF',
                 '-DJPEG_LIBRARY:FILEPATH={0}'.format(


### PR DESCRIPTION
This implements #1286

@ax3l, I had to fix 'isaac-server'. Could you, please, check if it is installed correctly with both libjpeg and libjpeg-turbo. And a question regarding 'isaac': are you sure that a header-only library needs all those dependencies?
@bvanessen, @mwilliammyers, @mathstuf, @alalazo could you check if I didn't break 'opencv'? 