### PR TITLE
Added variants to libfabric

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -33,3 +33,32 @@ class Libfabric(AutotoolsPackage):
     url      = "https://github.com/ofiwg/libfabric/releases/download/v1.5.0/libfabric-1.5.0.tar.gz"
 
     version('1.5.0', 'fda3e9b31ebe184f5157288d059672d6')
+
+    fabrics = ('psm',
+               'psm2',
+               'sockets',
+               'verbs',
+               'usnic',
+               'mxm',
+               'gni',
+               'xpmem',
+               'udp',
+               'rxm',
+               'rxd')
+
+    variant(
+       'fabrics',
+       default='sockets',
+       description='A list of enabled fabrics',
+       values=fabrics,
+       multi=True
+    )
+
+    def configure_args(self):
+        args = []
+
+        args.extend(['--enable-%s=%s' %
+                     (f, 'yes' if 'fabrics=%s' % f in self.spec else 'no')
+                     for f in self.fabrics])
+
+        return args


### PR DESCRIPTION
Can now specify transports using a multivalued variant. 

For example:
``` bash
spack install libfabric fabrics=udp,verbs,sockets
```