### PR TITLE
pkgconf: New package

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Pkgconf(AutotoolsPackage):
+    """pkgconf is a program which helps to configure compiler and linker
+    flags for development frameworks. It is similar to pkg-config from
+    freedesktop.org, providing additional functionality while also
+    maintaining compatibility."""
+
+    homepage = "http://pkgconf.org/"
+    url      = "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.3.8.tar.xz"
+
+    version('1.3.8', '484ba3360d983ce07416843d5bc916a8')
+
+    @run_after('install')
+    def link_pkg_config(self):
+        symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))
+        symlink('pkgconf.1',
+                '{0}/pkg-config.1'.format(self.prefix.share.man.man1))


### PR DESCRIPTION
pkgconf is a new pkg-config implementation with additional features and no external dependencies.

For a detailed comparison, see: http://pkgconf.org/features.html

(This is just the new package split out of #5198 based on @davydden's advice.)