### PR TITLE
Fix copyright years in spack create template

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -46,7 +46,7 @@ level = "short"
 
 package_template = '''\
 ##############################################################################
-# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.


### PR DESCRIPTION
Since I had to adapt this for two new packages now, I guess it is easier to simply update the template. :-)