### PR TITLE
Missing perl dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -46,6 +46,7 @@ class Glib(AutotoolsPackage):
     depends_on('libffi')
     depends_on('zlib')
     depends_on('gettext')
+    depends_on('perl', type=('build', 'run'))
     depends_on('pcre+utf', when='@2.48:')
     depends_on('util-linux', when='+libmount')
 
@@ -70,3 +71,11 @@ class Glib(AutotoolsPackage):
             args.append('--disable-libmount')
 
         return args
+
+    @run_before('install')
+    def filter_sbang(self):
+        # Filter sbang before install so Spack's sbang hook can fix it up
+        perl = join_path(self.spec['perl'].prefix.bin, 'perl')
+        files = ['gobject/glib-mkenums']
+
+        filter_file('^#! /usr/bin/perl', '#!{0}'.format(perl), *files)

--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -43,3 +43,4 @@ class Libx11(AutotoolsPackage):
     depends_on('inputproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')
+    depends_on('perl', type='build')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class Likwid(Package):
@@ -47,7 +48,24 @@ class Likwid(Package):
     # TODO: check
     # depends_on('gnuplot', type='run')
 
+    depends_on('perl', type=('build', 'run'))
+
     supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
+
+    def patch(self):
+        files = glob.glob('perl/*.*') + glob.glob('bench/perl/*.*')
+
+        # Allow the scripts to find Spack's perl
+        filter_file('^#!/usr/bin/perl -w', '#!/usr/bin/env perl', *files)
+        filter_file('^#!/usr/bin/perl', '#!/usr/bin/env perl', *files)
+
+    @run_before('install')
+    def filter_sbang(self):
+        # Filter sbang before install so Spack's sbang hook can fix it up
+        perl = join_path(self.spec['perl'].prefix.bin, 'perl')
+        files = ['perl/feedGnuplot'] + glob.glob('filters/*')
+
+        filter_file('^#!/usr/bin/perl', '#!{0}'.format(perl), *files)
 
     def install(self, spec, prefix):
         if self.compiler.name not in self.supported_compilers:

--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -39,6 +39,7 @@ class SharedMimeInfo(AutotoolsPackage):
     depends_on('glib')
     depends_on('libxml2')
     depends_on('intltool', type='build')
+    depends_on('gettext', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):


### PR DESCRIPTION
While building packages in a minimal chroot, I found some packages that are missing a dependency on perl and/or hardcore perl paths in their scripts.