### PR TITLE
Link extra_rpaths from compilers.yaml at build time

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -328,8 +328,10 @@ IFS=':' read -ra extra_rpaths <<< "$SPACK_COMPILER_EXTRA_RPATHS"
 for extra_rpath in "${extra_rpaths[@]}"; do
     if [[ $mode == ccld ]]; then
         $add_rpaths && args=("$rpath$extra_rpath" "${args[@]}")
+        args=("-L$extra_rpath" "${args[@]}")
     elif [[ $mode == ld ]]; then
         $add_rpaths && args=("-rpath" "$extra_rpath" "${args[@]}")
+        args=("-L$extra_rpath" "${args[@]}")
     fi
 done
 


### PR DESCRIPTION
Fixes #5137 

Users can specify that extra directories need to be RPATHed for a given compiler in compilers.yaml using the ```extra_rpaths``` entry, but this does not also ensure that the libraries are linked at build time. This modifies the logic so each extra RPATH directory also gets a ```-L``` entry so the directory is available at build time.