### PR TITLE
Improve grammar in build log error message.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -739,8 +739,13 @@ class ChildError(spack.error.SpackError):
             # the build log with errors highlighted.
             if self.build_log:
                 events = parse_log_events(self.build_log)
-                out.write("\n%d errors in build log:\n" % len(events))
-                out.write(make_log_context(events))
+                nerr = len(events)
+                if nerr > 0:
+                    if nerr == 1:
+                        out.write("\n1 error found in build log:\n")
+                    else:
+                        out.write("\n%d errors found in build log:\n" % nerr)
+                    out.write(make_log_context(events))
 
         else:
             # The error happened in in the Python code, so try to show


### PR DESCRIPTION
- "1 error found" instead of "1 errors found"

- don't print any build log context if no errors were found; just refer
  the user to the build log.