### PR TITLE
redundans: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-fastaindex/package.py
+++ b/var/spack/repos/builtin/packages/py-fastaindex/package.py
@@ -30,8 +30,8 @@ class PyFastaindex(PythonPackage):
        with 4 columns storing counts for A, C, G & T for each sequence.."""
 
     homepage = "https://github.com/lpryszcz/FastaIndex"
-    url      = "https://github.com/lpryszcz/FastaIndex/archive/0.11c.tar.gz"
+    url      = "https://pypi.io/packages/source/F/FastaIndex/FastaIndex-0.11rc7.tar.gz"
 
-    version('0.11c', 'c29476d62beec98006a64cd3bea307b6')
+    version('0.11rc7', '882c973d968d9db596edfd0fbb07e3a8')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-fastaindex/package.py
+++ b/var/spack/repos/builtin/packages/py-fastaindex/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyFastaindex(PythonPackage):
+    """FastA index (.fai) handler compatible with samtools faidx is extended
+       with 4 columns storing counts for A, C, G & T for each sequence.."""
+
+    homepage = "https://github.com/lpryszcz/FastaIndex"
+    url      = "https://github.com/lpryszcz/FastaIndex/archive/0.11c.tar.gz"
+
+    version('0.11c', 'c29476d62beec98006a64cd3bea307b6')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pyscaf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscaf/package.py
@@ -35,3 +35,4 @@ class PyPyscaf(PythonPackage):
     version('0.12a4', 'c67526747eb04d1e28279ac310916d40')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-fastaindex', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyscaf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscaf/package.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class PyPyscaf(PythonPackage):
+    """pyScaf orders contigs from genome assemblies utilising several types of
+       information"""
+
+    homepage = "https://pypi.python.org/pypi/pyScaf"
+    url      = "https://pypi.io/packages/source/p/pyScaf/pyScaf-0.12a4.tar.gz"
+
+    version('0.12a4', 'c67526747eb04d1e28279ac310916d40')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/redundans/package.py
+++ b/var/spack/repos/builtin/packages/redundans/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Redundans(Package):
+    """Redundans pipeline assists an assembly of heterozygous genomes."""
+
+    homepage = "https://github.com/Gabaldonlab/redundans"
+    url      = "https://github.com/Gabaldonlab/redundans/archive/v0.13c.tar.gz"
+
+    version('0.13c', '2003fb7c70521f5e430553686fd1a594')
+
+    depends_on('python', type=('build', 'run'))
+    depends_on('py-pyscaf', type=('build', 'run'))
+    depends_on('py-fastaindex', type=('build', 'run'))
+    depends_on('perl', type=('build', 'run'))
+    depends_on('sspace-standard')
+    depends_on('bwa')
+    depends_on('last')
+    depends_on('gapcloser')
+    depends_on('parallel')
+    depends_on('snap-berkeley')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install('redundans.py', prefix.bin)
+        with working_dir('bin'):
+            install('fasta2homozygous.py', prefix.bin)
+            install('fasta2split.py', prefix.bin)
+            install('fastq2insert_size.py', prefix.bin)
+            install('fastq2mates.py', prefix.bin)
+            install('fastq2shuffled.py', prefix.bin)
+            install('fastq2sspace.py', prefix.bin)
+            install('filterReads.py', prefix.bin)


### PR DESCRIPTION
adding new package redundans along with dependencies py-pyscaf and py-fastaindex. 
pypi.io [link](https://pypi.io/packages/source/f/FastaIndex/FastaIndex-0.11rc7.tar.gz)  for py-fastaindex doesn't work, resorting to github release.