### PR TITLE
Spec attributes with a reference to their owner update automatically

### DIFF
--- a/lib/spack/spack/test/util/lang.py
+++ b/lib/spack/spack/test/util/lang.py
@@ -1,0 +1,64 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import llnl.util.lang
+
+
+def test_owner_referencing():
+
+    class A(object):
+
+        def __init__(self):
+            self.owner = None
+            self.parent = None
+
+    class B(object):
+
+        a = llnl.util.lang.OwnerReferencing(
+            name='_a', factory=A, owner_name='owner'
+        )
+
+    foo = B()
+
+    assert foo.a.owner == foo
+    assert foo.a.parent is None
+
+    new_a = A()
+
+    assert new_a.owner is None
+    assert new_a.parent is None
+
+    foo.a = new_a
+
+    assert foo.a.owner == foo
+    assert new_a.owner == foo
+    assert foo.a.parent is None
+
+    # Accessing through the class permits to tweak the descriptor
+    B.a.owner_name = 'parent'
+    foo.a = A()
+
+    assert foo.a.owner is None
+    assert foo.a.parent == foo

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -623,7 +623,7 @@ class TestVariantMapTest(object):
 
     def test_invalid_values(self):
         # Value with invalid type
-        a = VariantMap(None)
+        a = VariantMap()
         with pytest.raises(TypeError):
             a['foo'] = 2
 
@@ -644,7 +644,7 @@ class TestVariantMapTest(object):
 
     def test_set_item(self):
         # Check that all the three types of variants are accepted
-        a = VariantMap(None)
+        a = VariantMap()
 
         a['foo'] = BoolValuedVariant('foo', True)
         a['bar'] = SingleValuedVariant('bar', 'baz')
@@ -652,7 +652,7 @@ class TestVariantMapTest(object):
 
     def test_substitute(self):
         # Check substitution of a key that exists
-        a = VariantMap(None)
+        a = VariantMap()
         a['foo'] = BoolValuedVariant('foo', True)
         a.substitute(SingleValuedVariant('foo', 'bar'))
 
@@ -663,13 +663,13 @@ class TestVariantMapTest(object):
 
     def test_satisfies_and_constrain(self):
         # foo=bar foobar=fee feebar=foo
-        a = VariantMap(None)
+        a = VariantMap()
         a['foo'] = MultiValuedVariant('foo', 'bar')
         a['foobar'] = SingleValuedVariant('foobar', 'fee')
         a['feebar'] = SingleValuedVariant('feebar', 'foo')
 
         # foo=bar,baz foobar=fee shared=True
-        b = VariantMap(None)
+        b = VariantMap()
         b['foo'] = MultiValuedVariant('foo', 'bar, baz')
         b['foobar'] = SingleValuedVariant('foobar', 'fee')
         b['shared'] = BoolValuedVariant('shared', True)
@@ -681,7 +681,7 @@ class TestVariantMapTest(object):
         assert not b.satisfies(a, strict=True)
 
         # foo=bar,baz foobar=fee feebar=foo shared=True
-        c = VariantMap(None)
+        c = VariantMap()
         c['foo'] = MultiValuedVariant('foo', 'bar, baz')
         c['foobar'] = SingleValuedVariant('foobar', 'fee')
         c['feebar'] = SingleValuedVariant('feebar', 'foo')
@@ -691,7 +691,7 @@ class TestVariantMapTest(object):
         assert a == c
 
     def test_copy(self):
-        a = VariantMap(None)
+        a = VariantMap()
         a['foo'] = BoolValuedVariant('foo', True)
         a['bar'] = SingleValuedVariant('bar', 'baz')
         a['foobar'] = MultiValuedVariant('foobar', 'a, b, c, d, e')
@@ -700,7 +700,7 @@ class TestVariantMapTest(object):
         assert a == c
 
     def test_str(self):
-        c = VariantMap(None)
+        c = VariantMap()
         c['foo'] = MultiValuedVariant('foo', 'bar, baz')
         c['foobar'] = SingleValuedVariant('foobar', 'fee')
         c['feebar'] = SingleValuedVariant('feebar', 'foo')

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -437,9 +437,9 @@ class VariantMap(lang.HashableMap):
     if the key is not already present.
     """
 
-    def __init__(self, spec):
+    def __init__(self):
         super(VariantMap, self).__init__()
-        self.spec = spec
+        self.spec = None
 
     def __setitem__(self, name, vspec):
         # Raise a TypeError if vspec is not of the right type
@@ -547,7 +547,7 @@ class VariantMap(lang.HashableMap):
         Returns:
             VariantMap: a copy of self
         """
-        clone = VariantMap(self.spec)
+        clone = VariantMap()
         for name, variant in self.items():
             clone[name] = variant.copy()
         return clone


### PR DESCRIPTION
This PR introduces a new descriptor in the `llnl.util.lang` module, that intercepts the assignments and updates automatically the reference an attribute maintains to its current owner. This aims to be more
declarative on the nature of certain attributes of `Spec` and ensure a safer refactoring of those parts.

Suggestions for better naming are welcome.