### PR TITLE
add optional package maintainers

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -162,6 +162,11 @@ def print_text_info(pkg):
 
     color.cprint(section_title('Homepage: ') + pkg.homepage)
 
+    if pkg.maintainers != '':
+        mnt = " ".join(['@@' + m.strip() for m in pkg.maintainers.split(",")])
+        color.cprint('')
+        color.cprint(section_title('Maintainers: ') + mnt)
+
     color.cprint('')
     color.cprint(section_title('Preferred version:  '))
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -162,8 +162,8 @@ def print_text_info(pkg):
 
     color.cprint(section_title('Homepage: ') + pkg.homepage)
 
-    if pkg.maintainers != '':
-        mnt = " ".join(['@@' + m.strip() for m in pkg.maintainers.split(",")])
+    if len(pkg.maintainers) > 0:
+        mnt = " ".join(['@@' + m for m in pkg.maintainers])
         color.cprint('')
         color.cprint(section_title('Maintainers: ') + mnt)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -545,6 +545,9 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # Verbosity level, preserved across installs.
     _verbose = None
 
+    # Comma separated list of GitHub usernames of package maintainers
+    maintainers = ''
+
     def __init__(self, spec):
         # this determines how the package should be built.
         self.spec = spec

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -545,7 +545,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # Verbosity level, preserved across installs.
     _verbose = None
 
-    # List of strings which contains GitHub usernames of package maintainers.
+    #: List of strings which contains GitHub usernames of package maintainers.
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers = []
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -546,7 +546,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     _verbose = None
 
     # List of strings which contains GitHub usernames of package maintainers.
-    # Do not include @ here in order not to unnecessarily ping the users.
+    #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers = []
 
     def __init__(self, spec):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -545,8 +545,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # Verbosity level, preserved across installs.
     _verbose = None
 
-    # Comma separated list of GitHub usernames of package maintainers
-    maintainers = ''
+    # List of strings which contain GitHub usernames of package maintainers
+    maintainers = []
 
     def __init__(self, spec):
         # this determines how the package should be built.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -545,7 +545,8 @@ class PackageBase(with_metaclass(PackageMeta, object)):
     # Verbosity level, preserved across installs.
     _verbose = None
 
-    # List of strings which contain GitHub usernames of package maintainers
+    # List of strings which contains GitHub usernames of package maintainers.
+    # Do not include @ here in order not to unnecessarily ping the users.
     maintainers = []
 
     def __init__(self, spec):

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -32,6 +32,8 @@ class Dealii(CMakePackage):
     homepage = "https://www.dealii.org"
     url = "https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.tar.gz"
 
+    maintainers = 'davydden, jppelteret'
+
     # Don't add RPATHs to this package for the full build DAG.
     # only add for immediate deps.
     transitive_rpaths = False

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -32,7 +32,7 @@ class Dealii(CMakePackage):
     homepage = "https://www.dealii.org"
     url = "https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.tar.gz"
 
-    maintainers = 'davydden, jppelteret'
+    maintainers = ['davydden', 'jppelteret']
 
     # Don't add RPATHs to this package for the full build DAG.
     # only add for immediate deps.


### PR DESCRIPTION
fixes https://github.com/LLNL/spack/issues/2532

Currently prints:

```
$ spack info dealii
CMakePackage:   dealii

Description:
    C++ software library providing well-documented tools to build finite
    element codes for a broad variety of PDEs.

Homepage: https://www.dealii.org

Maintainers: @davydden @jppelteret

Preferred version:
    8.5.1      https://github.com/dealii/dealii/releases/download/v8.5.1/dealii-8.5.1.tar.gz
...
```

p.s. @jppelteret i hope you don't mind me adding you as dealii maintainer.