### PR TITLE
mlhka: new package

### DIFF
--- a/var/spack/repos/builtin/packages/mlhka/package.py
+++ b/var/spack/repos/builtin/packages/mlhka/package.py
@@ -36,12 +36,8 @@ class Mlhka(Package):
     version('2.1', git='https://github.com/rossibarra/MLHKA.git',
             commit='e735ddd39073af58da21b00b27dea203736e5467')
 
-    def patch(self):
-        command_line = (spack_cxx, 'MLHKA_version{0}.cpp'.format(self.version),
-                        '-o', 'MLHKA')
-        subprocess.Popen(command_line)
-
     def install(self, spec, prefix):
+        cxx = which('c++')
+        cxx('MLHKA_version{0}.cpp'.format(self.version), '-o', 'MLHKA')
         mkdirp(prefix.bin)
-        with working_dir(self.stage.source_path):
-            install('MLHKA', prefix.bin)
+        install('MLHKA', prefix.bin)

--- a/var/spack/repos/builtin/packages/mlhka/package.py
+++ b/var/spack/repos/builtin/packages/mlhka/package.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import subprocess
 
 
 class Mlhka(Package):

--- a/var/spack/repos/builtin/packages/mlhka/package.py
+++ b/var/spack/repos/builtin/packages/mlhka/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import subprocess
+
+
+class Mlhka(Package):
+    """A maximum likelihood ratio test of natural selection, using polymorphism
+       and divergence data."""
+
+    homepage = "https://wright.eeb.utoronto.ca"
+    url      = "https://github.com/rossibarra/MLHKA"
+
+    version('2.1', git='https://github.com/rossibarra/MLHKA.git',
+            commit='e735ddd39073af58da21b00b27dea203736e5467')
+
+    def patch(self):
+        command_line = (spack_cxx, 'MLHKA_version{0}.cpp'.format(self.version),
+                        '-o', 'MLHKA')
+        subprocess.Popen(command_line)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.stage.source_path):
+            install('MLHKA', prefix.bin)


### PR DESCRIPTION
adding new package mlhka. In install phase, installing the binary only works if I specify `with working_dir(self.stage.source_path)`. If that's not specified I get a file not found error