### PR TITLE
Prefer later versions of compilers by default

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -317,6 +317,9 @@ class DefaultConcretizer(object):
             # No compiler with a satisfactory spec was found
             raise UnavailableCompilerVersionError(other_compiler)
 
+        # By default, prefer later versions of compilers
+        compiler_list = sorted(
+            compiler_list, key=lambda x: (x.name, x.version), reverse=True)
         ppk = PackagePrefs(other_spec.name, 'compiler')
         matches = sorted(compiler_list, key=ppk)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -259,7 +259,10 @@ def database(tmpdir_factory, builtin_mock, config):
 
     with spack.store.db.write_transaction():
         for spec in spack.store.db.query():
-            t.uninstall(spec)
+            if spec.package.installed:
+                t.uninstall(spec)
+            else:
+                spack.store.db.remove(spec)
 
     install_path.remove(rec=1)
     spack.store.root = str(spack_install_path)


### PR DESCRIPTION
Fixes #3724

Prior to this commit, Spack chooses whatever compiler appears first in compilers.yaml when there are no preferences. This changes the logic to prefer newer compiler versions by default.