### PR TITLE
Slightly better error matching when parsing spack logs

### DIFF
--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -86,7 +86,7 @@ def parse_log_events(logfile, context=6):
 
     log_events = []
     for i, line in enumerate(lines):
-        if re.search('error:', line, re.IGNORECASE):
+        if re.search('\berror:', line, re.IGNORECASE):
             event = LogEvent(
                 line.strip(),
                 i + 1,


### PR DESCRIPTION
When compiling llvm I got warnings that spack thought were errors. Things like this:
```
     11502 /home/xap/local/opt/spack/var/spack/stage/llvm-4.0.0-zy57t3src64pg4hijvf2hy2xzhwsbkab/llvm-4.0.0.src/lib/Support/YAMLParser.cpp:2119:5: note: here
  >> 11503 case Token::TK_Error:
     11504      ^~~~
     11505 /home/xap/local/opt/spack/var/spack/stage/llvm-4.0.0-zy57t3src64pg4hijvf2hy2xzhwsbkab/llvm-4.0.0.src/lib/Support/YAMLParser.cpp:2130:14: warning: this statement may fall through [-Wimplicit-fallthrough=]
     11506        getNext();
     11507        ~~~~~~~^~
```
The problem is that matching "error:" should really check that it is a word.

I *think* adding `\b` should fix it, but have not tested it, and there may be a better way to do this.
