### PR TITLE
llvm: patch lldb for gcc-7

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm_gcc7.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm_gcc7.patch
@@ -1,0 +1,10 @@
+--- a/tools/lldb/include/lldb/Utility/TaskPool.h	2016-09-06 16:57:50.000000000 -0400
++++ b/tools/lldb/include/lldb/Utility/TaskPool.h	2017-08-29 16:29:41.448584015 -0400
+@@ -28,6 +28,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <functional>
+ #include <future>
+ #include <list>
+ #include <queue>

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -324,6 +324,10 @@ class Llvm(CMakePackage):
     conflicts('+clang_extra', when='~clang')
     conflicts('+lldb',        when='~clang')
 
+    # Github issue #4986
+    patch('llvm_gcc7.patch', when='@4.0.0+lldb ^gcc@7.0:')
+    patch('llvm_gcc7.patch', when='@4.0.1+lldb ^gcc@7.0:')
+
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -325,7 +325,7 @@ class Llvm(CMakePackage):
     conflicts('+lldb',        when='~clang')
 
     # Github issue #4986
-    patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb ^gcc@7.0:')
+    patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb %gcc@7.0:')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -325,8 +325,7 @@ class Llvm(CMakePackage):
     conflicts('+lldb',        when='~clang')
 
     # Github issue #4986
-    patch('llvm_gcc7.patch', when='@4.0.0+lldb ^gcc@7.0:')
-    patch('llvm_gcc7.patch', when='@4.0.1+lldb ^gcc@7.0:')
+    patch('llvm_gcc7.patch', when='@4.0.0:4.0.1+lldb ^gcc@7.0:')
 
     def setup_environment(self, spack_env, run_env):
         spack_env.append_flags('CXXFLAGS', self.compiler.cxx11_flag)


### PR DESCRIPTION
Fix #4986.

Tested `spack install llvm@4.0.0 %gcc@7.1.0`.

EDIT: Fixed ^ to % for gcc.