### PR TITLE
Fix allinea-forge and allinea-reports installation

### DIFF
--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -48,5 +48,5 @@ class AllineaForge(Package):
         return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
 
     def install(self, spec, prefix):
-        textinstall = which('textinstall.sh')
+        textinstall = which(join_path(self.stage.source_path, 'textinstall.sh'))
         textinstall('--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -48,5 +48,5 @@ class AllineaForge(Package):
         return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
 
     def install(self, spec, prefix):
-        textinstall = which(join_path(self.stage.source_path, 'textinstall.sh'))
+        textinstall = Executable('./textinstall.sh')
         textinstall('--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/allinea-reports/package.py
+++ b/var/spack/repos/builtin/packages/allinea-reports/package.py
@@ -48,5 +48,5 @@ class AllineaReports(Package):
         return url + "allinea-reports-%s-Redhat-6.0-x86_64.tar" % version
 
     def install(self, spec, prefix):
-        textinstall = which('textinstall.sh')
+        textinstall = which(join_path(self.stage.source_path, 'textinstall.sh'))
         textinstall('--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/allinea-reports/package.py
+++ b/var/spack/repos/builtin/packages/allinea-reports/package.py
@@ -48,5 +48,5 @@ class AllineaReports(Package):
         return url + "allinea-reports-%s-Redhat-6.0-x86_64.tar" % version
 
     def install(self, spec, prefix):
-        textinstall = which(join_path(self.stage.source_path, 'textinstall.sh'))
+        textinstall = Executable('./textinstall.sh')
         textinstall('--accept-licence', prefix)


### PR DESCRIPTION
Fix below error : 

```
→ spack install -v allinea-forge
==> Installing allinea-forge
==> Using cached archive: /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/var/spack/cache/allinea-forge/allinea-forge-6.0.4.tar
==> Already staged allinea-forge-6.0.4-hhqjib4p5cdy2ckk3kjjpuru4nvgpybd in /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/var/spack/stage/allinea-forge-6.0.4-hhqjib4p5cdy2ckk3kjjpuru4nvgpybd
==> No patches needed for allinea-forge
==> Building allinea-forge [Package]
==> Found already existing license /gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/etc/spack/licenses/allinea-forge/Licence
==> Executing phase : 'install'
==> Error: TypeError: 'NoneType' object is not callable
/gpfs/bbp.cscs.ch/home/kumbhar/workarena/systems/lugviz/softwares/sources/spack/var/spack/repos/builtin/packages/allinea-forge/package.py:52, in install:
     50       def install(self, spec, prefix):
     51           textinstall = which('textinstall.sh')
  >> 52           textinstall('--accept-licence', prefix)
```