### PR TITLE
Do not rely on implicit variables for cflags in CMakePackage

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2438,7 +2438,7 @@ There are three primary idioms that can be combined to create whatever
 behavior the package requires.
 
 1. The default behavior for packages inheriting from
-``AutotoolsPackage`` or ``CmakePackage``.
+``AutotoolsPackage``.
 
 .. code-block:: python
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -125,15 +125,6 @@ class CMakePackage(PackageBase):
         """
         return join_path(self.stage.source_path, 'spack-build')
 
-    def default_flag_handler(self, spack_env, flag_val):
-        # Relies on being the first thing that can affect the spack_env
-        # EnvironmentModification after it is instantiated or no other
-        # method trying to affect these variables. Currently both are true
-        # flag_val is a tuple (flag, value_list)
-        spack_env.set(flag_val[0].upper(),
-                      ' '.join(flag_val[1]))
-        return []
-
     def cmake_args(self):
         """Produces a list containing all the arguments that must be passed to
         cmake, except:


### PR DESCRIPTION
I've received bug reports that not all CMake packages make use of the implicit variables (CFLAGS, CXXFLAGS, etc) for their generated makefiles. 

I've reverted the default flag handler for cmake packages in response, and updated the documentation.

If someone has a better idea for how to propagate compiler flags through CMake in a programmatic way that exposes those flags to the build system, let me know and let's build another PR for that.