### PR TITLE
Set default cmake build_type to 'Release' for llvm

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -84,7 +84,7 @@ class CMakePackage(PackageBase):
 
     # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
     variant('build_type', default='RelWithDebInfo',
-            description='Cmake build type',
+            description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     depends_on('cmake', type='build')

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -84,7 +84,7 @@ class CMakePackage(PackageBase):
 
     # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
     variant('build_type', default='RelWithDebInfo',
-            description='The build type to build',
+            description='Cmake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     depends_on('cmake', type='build')

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -71,7 +71,7 @@ class Llvm(CMakePackage):
             description="Build all supported targets, default targets "
             "<current arch>,NVPTX,AMDGPU,CppBackend")
     variant('build_type', default='Release',
-            description='Cmake build type',
+            description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     # Build dependency

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -70,6 +70,9 @@ class Llvm(CMakePackage):
     variant('all_targets', default=True,
             description="Build all supported targets, default targets "
             "<current arch>,NVPTX,AMDGPU,CppBackend")
+    variant('build_type', default='Release',
+            description='Cmake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
     # Build dependency
     depends_on('cmake@3.4.3:', type='build')


### PR DESCRIPTION
Fixes #5258

I wasn't aware of this, but it appears that Package subclasses can override the variants of their parents. The llvm Cmake package was using the default Cmake build_type ```RelWithDebInfo``` which was significantly increasing the size of the package. This redefines the ```build_type``` variant for llvm and sets the default value to ```Release```.

Another option would be to set the default ```build_type``` to Release for all Cmake packages. I opted to set this specifically for llvm because it seemed particularly important that llvm control its default build type.