### PR TITLE
fix armadillo macro expansions

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -84,7 +84,6 @@ class Armadillo(CMakePackage):
                 csf.write("#undef linux\n\n")
                 csf.write(contents)
 
-
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -33,6 +33,7 @@ class Armadillo(CMakePackage):
     homepage = "http://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-7.200.1.tar.xz"
 
+    version('8.100.1', 'd9762d6f097e0451d0cfadfbda295e7c')
     version('7.950.1', 'c06eb38b12cae49cab0ce05f96147147')
     # NOTE: v7.900.1 download url seems broken is no v7.950.1?
     version('7.900.1', '5ef71763bd429a3d481499878351f3be')

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -70,6 +70,7 @@ class Armadillo(CMakePackage):
                 "compiler_setup.hpp"
             )
 
+            # Make sure this path exists, extract_dir may not be correct
             if not os.path.isfile(compiler_setup):
                 raise RuntimeError(
                     "Could not find [{0}] to add #undef linux to.".format(
@@ -77,6 +78,11 @@ class Armadillo(CMakePackage):
                     )
                 )
 
+            # Open the file and read it in, then seek to the beginning
+            # and add two lines at the beginning of the file
+            #
+            #     // added by spack to prevent path mangling
+            #     #undef linux
             with open(compiler_setup, "r+") as csf:
                 contents = csf.read()
                 csf.seek(0, 0)

--- a/var/spack/repos/builtin/packages/armadillo/undef_linux.patch
+++ b/var/spack/repos/builtin/packages/armadillo/undef_linux.patch
@@ -1,0 +1,4 @@
+--- a/include/armadillo_bits/compiler_setup.hpp
++++ b/include/armadillo_bits/compiler_setup.hpp
+@@ -0,0 +1 @@
++#undef linux


### PR DESCRIPTION
- most compilers `#define linux 1`
    - armadillo does raw pasting of include directories in code
    - this means macro expansion of `linux-x86_64` -> `1-x86_64`
- new version, previous download url seems broken
- lib64 instead of lib?
    - needs verification, was required for intel, works for others

This is some ridiculous hacking, but it seems to work.  This PR needs review over the patching, there **has** to be a better way to get the extracted archive directory....RIGHT????

I found it by `__dict__` crawling.  Which is never exactly promising.

Fixes #2061 
Fixes #2808