### PR TITLE
Fixed bug in `spack env` due to missing argument.

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -113,7 +113,8 @@ _arguments['clean'] = Args(
     '--clean',
     action=CleanOrDirtyAction,
     dest='dirty',
-    help='clean environment before installing package',
+    help='sanitize the environment from variables that can affect how ' +
+         ' packages find libraries or headers',
     nargs=0
 )
 
@@ -121,7 +122,7 @@ _arguments['dirty'] = Args(
     '--dirty',
     action=CleanOrDirtyAction,
     dest='dirty',
-    help='do NOT clean environment before installing',
+    help='maintain the current environment without trying to sanitize it',
     nargs=0
 )
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -24,12 +24,13 @@
 ##############################################################################
 from __future__ import print_function
 
-import os
 import argparse
+import os
 
 import llnl.util.tty as tty
-import spack.cmd
 import spack.build_environment as build_env
+import spack.cmd
+import spack.cmd.common.arguments as arguments
 
 description = "show install environment for a spec, and run commands"
 section = "build"
@@ -37,6 +38,7 @@ level = "long"
 
 
 def setup_parser(subparser):
+    arguments.add_common_arguments(subparser, ['clean', 'dirty'])
     subparser.add_argument(
         'spec', nargs=argparse.REMAINDER,
         help="specs of package environment to emulate")
@@ -54,17 +56,17 @@ def env(parser, args):
     if sep in args.spec:
         s = args.spec.index(sep)
         spec = args.spec[:s]
-        cmd  = args.spec[s + 1:]
+        cmd = args.spec[s + 1:]
     else:
         spec = args.spec[0]
-        cmd  = args.spec[1:]
+        cmd = args.spec[1:]
 
     specs = spack.cmd.parse_specs(spec, concretize=True)
     if len(specs) > 1:
         tty.die("spack env only takes one spec.")
     spec = specs[0]
 
-    build_env.setup_package(spec.package)
+    build_env.setup_package(spec.package, args.dirty)
 
     if not cmd:
         # If no command act like the "env" command and print out env vars.

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -24,14 +24,25 @@
 ##############################################################################
 import pytest
 
-from spack.main import SpackCommand
+from spack.main import SpackCommand, SpackCommandError
 
 info = SpackCommand('env')
 
 
 @pytest.mark.parametrize('pkg', [
-    'zlib'
+    ('zlib',),
+    ('zlib', '--')
 ])
 @pytest.mark.usefixtures('config')
 def test_it_just_runs(pkg):
-    info(pkg)
+    info(*pkg)
+
+
+@pytest.mark.parametrize('pkg,error_cls', [
+    ('zlib libszip', SpackCommandError),
+    ('', IndexError)
+])
+@pytest.mark.usefixtures('config')
+def test_it_just_fails(pkg, error_cls):
+    with pytest.raises(error_cls):
+        info(pkg)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1,0 +1,37 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import pytest
+
+from spack.main import SpackCommand
+
+info = SpackCommand('env')
+
+
+@pytest.mark.parametrize('pkg', [
+    'zlib'
+])
+@pytest.mark.usefixtures('config')
+def test_it_just_runs(pkg):
+    info(pkg)


### PR DESCRIPTION
This command broke after #5109. It was using the default value for the `dirty` argument in `setup_package`. Now it adopts the same logic as in `spack install`. Trivial unit test included.