### PR TITLE
Openblas ilp64

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -47,6 +47,7 @@ class Openblas(MakefilePackage):
         default=True,
         description='Build shared libraries as well as static libs.'
     )
+    variant('ilp64', default=False, description='64 bit integers')
     variant('openmp', default=False, description="Enable OpenMP support.")
     variant('pic', default=True, description='Build position independent code')
 
@@ -128,6 +129,10 @@ class Openblas(MakefilePackage):
         # Add support for OpenMP
         if '+openmp' in self.spec:
             make_defs += ['USE_OPENMP=1']
+
+        # 64bit ints
+        if '+ilp64' in self.spec:
+            make_defs += ['INTERFACE64=1']
 
         return make_defs
 


### PR DESCRIPTION
also add a dummy to `atlas` for consistency.