### PR TITLE
Update libbson and libmongoc to 1.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/libbson/package.py
+++ b/var/spack/repos/builtin/packages/libbson/package.py
@@ -30,8 +30,9 @@ class Libbson(AutotoolsPackage):
     parsing, and iterating BSON documents."""
 
     homepage = "https://github.com/mongodb/libbson"
-    url      = "https://github.com/mongodb/libbson/releases/download/1.6.3/libbson-1.6.3.tar.gz"
+    url      = "https://github.com/mongodb/libbson/releases/download/1.7.0/libbson-1.7.0.tar.gz"
 
+    version('1.7.0', 'e196ad77dd8458ebc1166e6135030b63')
     version('1.6.3', 'b7bdb314197106fcfb4af105a582d343')
     version('1.6.2', 'c128a2ae3e35295e1176465be60f19db')
     version('1.6.1', '4d6779451bc5764a7d4982c01e7bd8c2')

--- a/var/spack/repos/builtin/packages/libmongoc/package.py
+++ b/var/spack/repos/builtin/packages/libmongoc/package.py
@@ -29,17 +29,43 @@ class Libmongoc(AutotoolsPackage):
     """libmongoc is a client library written in C for MongoDB."""
 
     homepage = "https://github.com/mongodb/mongo-c-driver"
-    url      = "https://github.com/mongodb/mongo-c-driver/releases/download/1.6.3/mongo-c-driver-1.6.3.tar.gz"
+    url      = "https://github.com/mongodb/mongo-c-driver/releases/download/1.7.0/mongo-c-driver-1.7.0.tar.gz"
 
+    version('1.7.0', '21acf3584e92631422bc91e9e3cf4f76')
     version('1.6.3', '0193610cf1d98aae7008f272a1000972')
     version('1.6.2', 'aac86df153282cda1e4905cca181631a')
     version('1.6.1', '826946de9a15f7f453aefecdc76b1c0d')
 
+    variant('ssl', default=True, description='Enable SSL support.')
+    variant('snappy', default=True, description='Enable Snappy support.')
+    variant('zlib', default=True, description='Enable zlib support.')
+
     depends_on('libbson')
 
+    depends_on('openssl', when='+ssl')
+    depends_on('snappy', when='+snappy')
+    depends_on('zlib', when='+zlib')
+
     def configure_args(self):
+        spec = self.spec
+
         args = [
             '--disable-automatic-init-and-cleanup',
             '--with-libbson=system'
         ]
+
+        if '+ssl' in spec:
+            args.append('--enable-ssl=openssl')
+        else:
+            args.append('--enable-ssl=no')
+
+        if spec.satisfies('@1.7.0:'):
+            # --with-{snappy,zlib}=system are currently broken and cause
+            # configure to not find the dependencies. We still want to
+            # explicitly disable them when appropriate.
+            if '+snappy' not in spec:
+                args.append('--with-snappy=no')
+            if '+zlib' not in spec:
+                args.append('--with-zlib=no')
+
         return args


### PR DESCRIPTION
This also introduces the ssl, snappy and zlib variants for libmongoc.