### PR TITLE
Spack module command uses installed pkg repo

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -113,6 +113,12 @@ class NoMatch(Exception):
 @subcommand('loads')
 def loads(mtype, specs, args):
     """Prompt the list of modules associated with a list of specs"""
+    for spec in specs:
+        installed_repo_dir = os.path.join(
+            spack.store.layout.build_packages_path(spec), 'builtin')
+        repo = spack.repository.Repo(installed_repo_dir)
+        spack.repo.put_first(repo)
+
     # Get a comprehensive list of specs
     if args.recurse_dependencies:
         specs_from_user_constraint = specs[:]


### PR DESCRIPTION
Fixes #5293 

This is a WIP PR to address a case where `spack module loads` fails when a package is removed from the spack repository but is present as an installed package. Spack saves a copy of the package repo in every package installation prefix (for the package and its dependencies) so this retrieves that repo when constructing module files.