### PR TITLE
dump environment in sourceable form

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -72,4 +72,4 @@ def dump_environment(path):
     """Dump the current environment out to a file."""
     with open(path, 'w') as env_file:
         for key, val in sorted(os.environ.items()):
-            env_file.write("%s=%s\n" % (key, val))
+            env_file.write('export %s="%s"\n' % (key, val))


### PR DESCRIPTION
First, quote the environment variable values.  Second, export the
variables. sorry, this is bourn-shell syntax.  Happy to consider a
shell-independent way to do this, but spack is already using sh-like
"env=value"