### PR TITLE
[WIP]: Sambamba new package

### DIFF
--- a/var/spack/repos/builtin/packages/sambamba/Makefile.patch
+++ b/var/spack/repos/builtin/packages/sambamba/Makefile.patch
@@ -1,0 +1,11 @@
+--- sambamba/Makefile.orig	2017-09-07 14:31:28.563896131 -0700
++++ sambamba/Makefile	2017-09-07 14:31:35.337912872 -0700
+@@ -20,7 +20,7 @@
+ 
+ else
+ 
+-LINK_CMD=gcc -Wl,--gc-sections -o build/sambamba build/sambamba.o $(STATIC_LIB_SUBCMD) -l:libphobos2-ldc.a -l:libdruntime-ldc.a  -lrt -lpthread -lm
++LINK_CMD=gcc -Wl,--gc-sections -o build/sambamba build/sambamba.o $(STATIC_LIB_SUBCMD) -l:libphobos2-ldc.a -l:libdruntime-ldc.a  -lrt -lpthread -lm -ldl
+ DMD_STATIC_LIBS=-L-Lhtslib -L-l:libhts.a -L-l:libphobos2.a -L-Llz4/lib -L-l:liblz4.a
+ 
+ define split-debug

--- a/var/spack/repos/builtin/packages/sambamba/package.py
+++ b/var/spack/repos/builtin/packages/sambamba/package.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Sambamba(Package):
+    """Sambamba: process your BAM data faster (bioinformatics)"""
+
+    homepage = "http://lomereiter.github.io/sambamba/"
+
+    version('0.6.6', git='https://github.com/lomereiter/sambamba.git',
+            tag='v0.6.6', submodules=True)
+
+    depends_on('ldc~shared_libs', type=('build', 'link'))
+    depends_on('python', type='build')
+
+    resource(
+        name='undeaD',
+        git='https://github.com/dlang/undeaD.git',
+        tag='v1.0.7',
+    )
+
+    patch('Makefile.patch')
+    parallel = False
+
+    def install(self, spec, prefix):
+        make('sambamba-ldmd2-64')
+        mkdirp(prefix.bin)
+        for filename in ('build/sambamba', 'build/sambamba.debug'):
+            install(filename, prefix.bin)

--- a/var/spack/repos/builtin/packages/sambamba/package.py
+++ b/var/spack/repos/builtin/packages/sambamba/package.py
@@ -33,7 +33,7 @@ class Sambamba(Package):
     version('0.6.6', git='https://github.com/lomereiter/sambamba.git',
             tag='v0.6.6', submodules=True)
 
-    depends_on('ldc~shared_libs', type=('build', 'link'))
+    depends_on('ldc~shared', type=('build', 'link'))
     depends_on('python', type='build')
 
     resource(


### PR DESCRIPTION
Depends on the ldc package (#5279) that alalazo's working on.

It requires a patch to the Makefile because one of ldc's library functions mentions dlopen.  I *think* that ldc should be handling this.  See the discusssion in #5279.

It also requires a "static" ldc.  Again, see #5279.

Finally, it needs "undeaD" as a resource, but I'm guessing at the appropriate release.  See lomereiter/sambamba#312.

Also need to investigate whether it requires `parallel=False` (`spack create` added that...).