### PR TITLE
Feature/pr quantities

### DIFF
--- a/var/spack/repos/builtin/packages/py-quantities/package.py
+++ b/var/spack/repos/builtin/packages/py-quantities/package.py
@@ -29,7 +29,7 @@ class PyQuantities(PythonPackage):
     """Support for physical quantities with units, based on numpy"""
 
     homepage = "http://python-quantities.readthedocs.org"
-    url      = "https://pypi.io/packages/source/q/quantities/quantities-0.11.1.tar.gz"
+    url      = "https://pypi.io/packages/source/q/quantities/quantities-0.12.1.tar.gz"
 
     version('0.12.1', '9c9ecda15e905cccfc420e5341199512')
 

--- a/var/spack/repos/builtin/packages/py-quantities/package.py
+++ b/var/spack/repos/builtin/packages/py-quantities/package.py
@@ -31,7 +31,10 @@ class PyQuantities(PythonPackage):
     homepage = "http://python-quantities.readthedocs.org"
     url      = "https://pypi.io/packages/source/q/quantities/quantities-0.11.1.zip"
 
+    version('0.12.1', 'f4c6287bfd2e93322b25a7c1311a0243')
     version('0.11.1', 'f4c6287bfd2e93322b25a7c1311a0243')
+
+    conflicts('py-numpy@1.13:', when='@:0.11.99')
 
     depends_on('python@2.6.0:')
     depends_on('py-numpy@1.4.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-quantities/package.py
+++ b/var/spack/repos/builtin/packages/py-quantities/package.py
@@ -29,10 +29,9 @@ class PyQuantities(PythonPackage):
     """Support for physical quantities with units, based on numpy"""
 
     homepage = "http://python-quantities.readthedocs.org"
-    url      = "https://pypi.io/packages/source/q/quantities/quantities-0.11.1.zip"
+    url      = "https://pypi.io/packages/source/q/quantities/quantities-0.11.1.tar.gz"
 
-    version('0.12.1', 'f4c6287bfd2e93322b25a7c1311a0243')
-    version('0.11.1', 'f4c6287bfd2e93322b25a7c1311a0243')
+    version('0.12.1', '9c9ecda15e905cccfc420e5341199512')
 
     conflicts('py-numpy@1.13:', when='@:0.11.99')
 

--- a/var/spack/repos/builtin/packages/py-quantities/package.py
+++ b/var/spack/repos/builtin/packages/py-quantities/package.py
@@ -32,6 +32,8 @@ class PyQuantities(PythonPackage):
     url      = "https://pypi.io/packages/source/q/quantities/quantities-0.12.1.tar.gz"
 
     version('0.12.1', '9c9ecda15e905cccfc420e5341199512')
+    version('0.11.1', 'f4c6287bfd2e93322b25a7c1311a0243',
+            url="https://pypi.io/packages/source/q/quantities/quantities-0.11.1.zip")
 
     conflicts('py-numpy@1.13:', when='@:0.11.99')
 


### PR DESCRIPTION
I removed the old version, as 0.11.1 has only a zip download and 0.12.1 has only a .tar.gz download. How can I teach spack to look for both? Alternatively we could switch to their github releases, there they have .tar.gz for all versions

@adamjstewart which do you prefer?