### PR TITLE
bambam: new package

### DIFF
--- a/var/spack/repos/builtin/packages/bambam/package.py
+++ b/var/spack/repos/builtin/packages/bambam/package.py
@@ -54,3 +54,4 @@ class Bambam(MakefilePackage):
                                self.spec['samtools'].prefix.lib)
         spack_env.prepend_path('LIBRARY_PATH',
                                self.spec['bamtools'].prefix.lib.bamtools)
+        run_env.prepend_path('PATH', prefix.scripts)

--- a/var/spack/repos/builtin/packages/bambam/package.py
+++ b/var/spack/repos/builtin/packages/bambam/package.py
@@ -23,30 +23,34 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-import os
 
 
-class Bamtools(CMakePackage):
-    """C++ API & command-line toolkit for working with BAM data."""
+class Bambam(MakefilePackage):
+    """Bambam is a tool used to facilitate NGS analysis."""
 
-    homepage = "https://github.com/pezmaster31/bamtools"
-    url      = "https://github.com/pezmaster31/bamtools/archive/v2.4.0.tar.gz"
+    homepage = "http://udall-lab.byu.edu/Research/Software/BamBam"
+    url      = "https://downloads.sourceforge.net/project/bambam/bambam-1.4.tgz"
 
-    version('2.4.1', '41cadf513f2744256851accac2bc7baa')
-    version('2.4.0', '6139d00c1b1fe88fe15d094d8a74d8b9')
-    version('2.3.0', 'd327df4ba037d6eb8beef65d7da75ebc')
-    version('2.2.3', '6eccd3e45e4ba12a68daa3298998e76d')
+    version('1.4', '4a8a70bd26a68170a97e32bbca15a89f')
 
-    depends_on('zlib', type='link')
+    depends_on('perl', type=('build', 'run'))
+    depends_on('samtools+old-structure')
+    depends_on('bamtools')
+    depends_on('htslib')
+    depends_on('zlib')
 
-    def cmake_args(self):
-        args = []
-        rpath = self.rpath
-        rpath.append(os.path.join(self.prefix.lib, "bamtools"))
-        args.append("-DCMAKE_INSTALL_RPATH=%s" % ':'.join(rpath))
-        return args
+    def edit(self, spec, prefix):
+        makefile = FileFilter('makefile')
+        makefile.filter('INC = *', 'INC = -I%s ' %
+                        self.spec['bamtools'].prefix.include)
 
-    @run_after('install')
-    def install_extra_lib(self):
-        with working_dir('lib'):
-            install('libbamtools-utils.a', prefix.lib.bamtools)
+    def install(self, spec, prefix):
+        install_tree('bin', prefix.bin)
+        install_tree('lib', prefix.lib)
+        install_tree('scripts', prefix.scripts)
+
+    def setup_environment(self, spack_env, run_env):
+        spack_env.prepend_path('LIBRARY_PATH',
+                               self.spec['samtools'].prefix.lib)
+        spack_env.prepend_path('LIBRARY_PATH',
+                               self.spec['bamtools'].prefix.lib.bamtools)

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import glob
 
 
 class Samtools(Package):
@@ -36,6 +37,11 @@ class Samtools(Package):
     version('1.4', '8cbd7d2a0ec16d834babcd6c6d85d691')
     version('1.3.1', 'a7471aa5a1eb7fc9cc4c6491d73c2d88')
     version('1.2', '988ec4c3058a6ceda36503eebecd4122')
+
+    # For older packages that depend on samtools, this variant includes
+    # libbam.a and header files in the installed package. This is similar to
+    # the package structure of samtools version 0.1.19 and below.
+    variant('old-structure', default=False, description='Enable include and lib directories')
 
     depends_on("ncurses")
     # htslib became standalone @1.3.1, must use corresponding version
@@ -52,3 +58,10 @@ class Samtools(Package):
         else:
             make("prefix=%s" % prefix)
             make("prefix=%s" % prefix, "install")
+        if '+old-structure' in spec:
+            mkdirp(prefix.include)
+            mkdirp(prefix.lib)
+            install('libbam.a', prefix.lib)
+            files = glob.iglob("*.h")
+            for file in files:
+                install(file, prefix.include)


### PR DESCRIPTION
Adding new package bambam with some edits to samtools and bamtools packages.

This bambam package was released March 2016, but it still uses the old file structure of samtools, when include and lib directories were created upon compilation/installation. For this, I have created a variant in the samtools package that gives the user the option to include these directories with their samtools installation. Bambam requires the samtools libraries and headers, and I know I have at least one or two more packages that will be requiring this on my list.

As for the bamtools edit, bambam required the libbamtools-util library for compilation, so I added that to the existing bamtools library.
