### PR TITLE
augustus: url fix

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -30,10 +30,11 @@ class Augustus(MakefilePackage):
        genomic sequences"""
 
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
-    url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.2.3.tar.gz"
+    url      = "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz"
 
     version('3.3',   '9ebe494df78ebf6a43091cfc8551050c')
-    version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830')
+    version('3.2.3', 'b8c47ea8d0c45aa7bb9a82626c8ff830',
+            url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')
 
     depends_on('bamtools')
     depends_on('gsl')


### PR DESCRIPTION
Fixing url for augustus. We need v 3.2.3 but sometime after the new version came out the urls got moved around