### PR TITLE
Paraview requires CMake version 3.3 or higher

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -68,6 +68,7 @@ class Paraview(CMakePackage):
     # depends_on('protobuf') # version mismatches?
     # depends_on('sqlite') # external version not supported
     depends_on('zlib')
+    depends_on('cmake@3.3:', type='build')
 
     patch('stl-reader-pv440.patch', when='@4.4.0')
 


### PR DESCRIPTION
Fix below error:

```
==> 'cmake' '/gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/var/spack/stage/paraview-5.4.0-l'-DVTK_USE_SYSTEM_ZLIB:BOOL=ON' '-DPARAVIEW_USE_MPI:BOOL=ON' '-DMPIEXEC:FILEPATH=/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/intel-17.0.4/intel-mpi-2017.3.196-s2b64uud/bin/mpiexec'

CMake Error at CMakeLists.txt:31 (cmake_minimum_required):
  CMake 3.3 or higher is required.  You are running version 2.8.12.2

```

Paraview [doc](https://www.paraview.org/Wiki/ParaView:Build_And_Install) says:

```
The ParaView build process requires CMake version 3.3 or higher and a working compiler. 
```

The `CMakePackage` base class just specify `depends_on('cmake')` resulting into above mentioned error.