### PR TITLE
Fix Autotools build error due to missing m4 and MPICC/MPICXX

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -67,6 +67,7 @@ class Adios(AutotoolsPackage):
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
+    depends_on('m4', type='build')
     depends_on('libtool@:2.4.2', type='build')
     depends_on('python', type='build')
 
@@ -121,6 +122,8 @@ class Adios(AutotoolsPackage):
             extra_args.append('--enable-shared')
 
         if '+mpi' in spec:
+            env['MPICC'] = spec['mpi'].mpicc
+            env['MPICXX'] = spec['mpi'].mpicxx
             extra_args.append('--with-mpi=%s' % spec['mpi'].prefix)
         else:
             extra_args.append('--without-mpi')


### PR DESCRIPTION
Fix below two issues:

m4 dependency missing:

```
/gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/spack/build_systems/autotools.py:210, in autoreconf:
     7             missing = [x for x in autotools if x not in spec]
     8             if missing:
     9                 msg = 'Cannot generate configure: missing dependencies {0}'
  >> 10                raise RuntimeError(msg.format(missing))
     11            tty.msg('Configure script not found: trying to generate it')
     12            tty.warn('*********************************************************')
```

ADIOS [doc](http://users.nccs.gov/~pnorbert/ADIOS-UsersManual-1.9.0.pdf) suggest to set `MPICC`, `MPICXX`. Without this I got : 

```
env/intel/icc... gcc3
checking whether we are using the GNU C++ compiler... yes
checking whether /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/intel/icpc accepts -g... yes
checking dependency style of /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/intel/icpc... gcc3
checking for mpicc... no
checking for hcc... no
checking for mpxlc_r... no
checking for mpxlc... no
checking for mpcc... no
checking for cmpicc... no
checking for MPI_Init... no
checking for MPI_Init in -lmpi... no
checking for MPI_Init in -lmpich... no
configure: error: could not find mpi library for C
```