### PR TITLE
Fix matplotlib build issue with intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -103,6 +103,11 @@ class PyMatplotlib(PythonPackage):
     # depends_on('ttconv')
     depends_on('py-six@1.9.0:', type=('build', 'run'))
 
+    @run_before('build')
+    def set_cc(self):
+        if self.spec.satisfies('%intel'):
+            env['CC'] = spack_cxx
+
     @run_after('install')
     def set_backend(self):
         spec = self.spec


### PR DESCRIPTION
While building matplotlib  with intel compiler we get:

```
spack install  'py-matplotlib@2.0.2+image%intel@17.0.4^py-numpy+blas+lapack@1.13.1^python@3.5.2^intel-mkl
.....

building 'matplotlib._qhull' extension
/gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/intel/icc -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -fPIC -DMPL_DEVNULL=/dev/null -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__qhull_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__STDC_FORMAT_MACROS=1 -I/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/intel-17.0.4/py-numpy-1.13.1-i6vgp46b/lib/python3.5/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/intel-17.0.4/python-3.5.2-hjra2u5w/include/python3.5m -c src/qhull_wrap.c -o build/temp.linux-x86_64-3.5/src/qhull_wrap.o
In file included from src/qhull_wrap.c(10):
/usr/include/qhull/qhull_a.h(106): error: expected a ";"
  template <typename T>
           ^

compilation aborted for src/qhull_wrap.c (code 2)
```

this has been discussed in matplotlib/matplotlib#4518 and matplotlib/matplotlib#4524. This [comment](https://github.com/matplotlib/matplotlib/pull/4524#issuecomment-111877022) suggest use of `icpc`.

I was able to build matplotlib with icc 17. 