### PR TITLE
Improve PDToolkit support for different compilers

### DIFF
--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -45,8 +45,20 @@ class Pdt(AutotoolsPackage):
     version('3.19',   '5c5e1e6607086aa13bf4b1b9befc5864')
     version('3.18.1', 'e401534f5c476c3e77f05b7f73b6c4f2')
 
+    def patch(self):
+        if self.spec.satisfies('%clang'):
+            filter_file(r'PDT_GXX=g\+\+ ', r'PDT_GXX=clang++ ', 'ductape/Makefile')
+
     def configure(self, spec, prefix):
-        configure('-prefix={0}'.format(prefix))
+        options = ['-prefix=%s' % prefix]
+        if self.compiler.name == 'xl':
+            options.append('-XLC')
+        elif self.compiler.name == 'intel':
+            options.append('-icpc')
+        elif self.compiler.name == 'pgi':
+            options.append('-pgCC')
+
+        configure(*options)
 
     @run_after('install')
     def link_arch_dirs(self):

--- a/var/spack/repos/builtin/packages/pdt/package.py
+++ b/var/spack/repos/builtin/packages/pdt/package.py
@@ -47,7 +47,8 @@ class Pdt(AutotoolsPackage):
 
     def patch(self):
         if self.spec.satisfies('%clang'):
-            filter_file(r'PDT_GXX=g\+\+ ', r'PDT_GXX=clang++ ', 'ductape/Makefile')
+            filter_file(r'PDT_GXX=g\+\+ ',
+                        r'PDT_GXX=clang++ ', 'ductape/Makefile')
 
     def configure(self, spec, prefix):
         options = ['-prefix=%s' % prefix]


### PR DESCRIPTION
PDT dependency of TAU profiler doesn't use `CC`, `CXX` eb variables and need command line argument for compiler identification: 

```
$ ./configure --help
Program Database Toolkit (PDT) Configuration
--------------------------------------------
Looks like an x86_64 machine...
Looking for C++ compilers ... done
Usage: ./configure [-KAI|-KCC|-GNU|-CC|-c++|-cxx|-xlC|-pgCC|-icpc|-ecpc]
                   [-arch=ibm64|ibm64linux|solaris2-64|sunx86_64|IRIXO32|
                    IRIXN32|IRIX64|ia64|i386_linux|crayxmt|arm64_linux|ibm64linux]
                   [-help]
                   [-compdir=<compdir>]
                   [-enable-old-headers]
                   [-useropt=<options>]
                   [-prefix=<dir>]
                   [-exec-prefix=<dir>]
```

If we don't pass compiler id then it uses gcc and result in link time errors while building tau: 

```
checking whether gcc and cc understand -c and -o together... pgc++    -O2 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib64 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/mpich-3.2-4hf64twr/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib -I../include -DPGI -DTAU_DOT_H_LESS_HEADERS   -w         -DTAU_USE_SIZE_INSTEAD_OF_SIZEOF  -DTAU_DYNINST -DTAU_DYNINST41PLUS  -I/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/include -c tau_selective.dyn.cpp -o tau_selective_dyn.o
pgc++   -O2 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib64 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/mpich-3.2-4hf64twr/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib -c -o ompragma_f.o ompragma_f.cc
pgc++   -O2 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib64 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/mpich-3.2-4hf64twr/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib -c -o ompregion.o ompregion.cc
pgc++    -O2 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib64 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/mpich-3.2-4hf64twr/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib -I../include -DPGI -DTAU_DOT_H_LESS_HEADERS   -w         -DTAU_USE_SIZE_INSTEAD_OF_SIZEOF  -DTAU_DYNINST -DTAU_DYNINST41PLUS -I/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/include -c tau_instrument.dyn.cpp -o tau_instrument.dyn.o
pgc++   -O2 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/tau-2.26.3-xmerxzzw/lib64 -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/mpich-3.2-4hf64twr/lib -Wl,-rpath,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib -c -o handler.o handler.cc
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbMisc.o): In function `_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.179':
pdbMisc.cc:(.text+0x6b): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_create(unsigned long&, unsigned long)'
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbMisc.o): In function `_GLOBAL__sub_I__ZN3PDBC2EPc':
pdbMisc.cc:(.text.startup+0x2d): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()'
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbItem.o): In function `_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.62':
pdbItem.cc:(.text+0x6b): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_create(unsigned long&, unsigned long)'
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbItem.o): In function `pdbItem::print(std::ostream&) const':
pdbItem.cc:(.text+0x13b): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::compare(char const*) const'
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbItem.o): In function `pdbItem::process(PDB*)':
pdbItem.cc:(.text+0x1c96): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::rfind(char const*, unsigned long, unsigned long) const'
pdbItem.cc:(.text+0x1ced): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long)'
pdbItem.cc:(.text+0x1d0c): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
pdbItem.cc:(.text+0x1d89): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long)'
pdbItem.cc:(.text+0x1da8): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
pdbItem.cc:(.text+0x1de8): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/pgi-17.4/pdt-3.24-rmtfuok7/lib/libpdb.a(pdbItem.o): In function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::operator+<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cx
```

This patch fix this. Tested with Intel and PGI compilers.