### PR TITLE
Change glog from Autotools to CMakePackage

### DIFF
--- a/var/spack/repos/builtin/packages/glog/package.py
+++ b/var/spack/repos/builtin/packages/glog/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class Glog(AutotoolsPackage):
+class Glog(CMakePackage):
     """C++ implementation of the Google logging module."""
 
     homepage = "https://github.com/google/glog"
@@ -35,3 +35,6 @@ class Glog(AutotoolsPackage):
     version('0.3.3', 'c1f86af27bd9c73186730aa957607ed0')
 
     depends_on('gflags')
+
+    def cmake_args(self):
+        return ['-DBUILD_SHARED_LIBS=TRUE']


### PR DESCRIPTION
Installing glog with system gcc worked fine. But I have also `gcc 5.3.0` compiled by Spack. While compiling with this newer gcc I had multiple link errors:

```

libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/demangle_unittest src/demangle_unittest-demangle_unittest.o -pthread  ./.libs/libglog.so -lunwind -L/usr/lib64 -lgtest -lgflags -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/symbolize_unittest src/symbolize_unittest-symbolize_unittest.o -pthread  ./.libs/libglog.so -lunwind -L/usr/lib64 -lgtest -lgflags -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/logging_striptest0 src/logging_striptest0-logging_striptest_main.o  ./.libs/libglog.so -lgflags -lunwind -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/utilities_unittest src/utilities_unittest-utilities_unittest.o -pthread  ./.libs/libglog.so -lunwind -L/usr/lib64 -lgtest -lgflags -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/stacktrace_unittest src/stacktrace_unittest-stacktrace_unittest.o  ./.libs/libglog.so -lgflags -lunwind -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/logging_striptest2 src/logging_striptest2-logging_striptest2.o  ./.libs/libglog.so -lgflags -lunwind -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
libtool: link: /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/lib/spack/env/gcc/g++ -pthread -I/usr/include -pthread -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -DNO_FRAME_POINTER -pthread -o .libs/signalhandler_unittest src/signalhandler_unittest-signalhandler_unittest.o -pthread  ./.libs/libglog.so -lunwind -L/usr/lib64 -lgtest -lgflags -lpthread -pthread -Wl,-rpath -Wl,/gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.4-3lulcx7y/lib
src/demangle_unittest-demangle_unittest.o: In function `testing::Message::GetString() const':
demangle_unittest.cc:(.text._ZNK7testing7Message9GetStringEv[_ZNK7testing7Message9GetStringEv]+0x22): undefined reference to `testing::internal::StrStreamToString(std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*)'
collect2: error: ld returned 1 exit status
make: *** [demangle_unittest] Error 1
make: *** Waiting for unfinished jobs....
src/stl_logging_unittest-stl_logging_unittest.o: In function `testing::Message::GetString() const':
stl_logging_unittest.cc:(.text._ZNK7testing7Message9GetStringEv[_ZNK7testing7Message9GetStringEv]+0x22): undefined reference to `testing::internal::StrStreamToString(std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*)'
collect2: error: ld returned 1 exit status
make: *** [stl_logging_unittest] Error 1
src/symbolize_unittest-symbolize_unittest.o: In function `testing::Message::GetString() const':
symbolize_unittest.cc:(.text._ZNK7testing7Message9GetStringEv[_ZNK7testing7Message9GetStringEv]+0x22): undefined reference to `testing::internal::StrStreamToString(std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*)'
collect2: error: ld returned 1 exit status
src/logging_unittest-logging_unittest.o: In function `testing::Message::GetString() const':
logging_unittest.cc:(.text._ZNK7testing7Message9GetStringEv[_ZNK7testing7Message9GetStringEv]+0x22): undefined reference to `testing::internal::StrStreamToString(std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*)'
collect2: error: ld returned 1 exit status
make: *** [symbolize_unittest] Error 1
make: *** [logging_unittest] Error 1
==> Error: ProcessError: Command exited with statu
```

Using `CMake` it seems more stable:

```
$ spack install -v glog %gcc@5.3.0
....
-version.cmake
-- Installing: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/lib/cmake/glog/glog-targets.cmake
-- Installing: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/lib/cmake/glog/glog-targets-relwithdebinfo.cmake
==> Successfully installed glog
  Fetch: 0.01s.  Build: 25.37s.  Total: 25.37s.
[+] /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472

$ $ ll /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/lib/
total 1024
drwxr-xr-x 3 kumbhar-adm bbp   4096 Sep  9 19:24 cmake
lrwxrwxrwx 1 kumbhar-adm bbp     16 Sep  9 19:24 libglog.so -> libglog.so.0.3.5
-rwxr-xr-x 1 kumbhar-adm bbp 935738 Sep  9 19:24 libglog.so.0
lrwxrwxrwx 1 kumbhar-adm bbp     12 Sep  9 19:24 libglog.so.0.3.5 -> libglog.so.0