### PR TITLE
Fix caffe build issue with python 3

### DIFF
--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -84,4 +84,8 @@ class Caffe(CMakePackage):
                 '-DUSE_LEVELDB=%s' % ('+leveldb' in spec),
                 '-DUSE_LMDB=%s' % ('+lmdb' in spec)]
 
+        if spec.satisfies('+python'):
+            version = spec['python'].version.up_to(1)
+            args.append('-Dpython_version=%s' % version)
+
         return args


### PR DESCRIPTION
Caffe's CMakeList.txt has:

```
set(python_version "2" CACHE STRING "Specify which Python version to use")
```

If we are compiling caffe with `python@3:`, then caffe finds python from `/usr/bin/`:

```
-- Could NOT find PythonInterp: Found unsuitable version "2.6.6", but required is at least "2.7" (found /usr/bin/python2)
-- Could NOT find PythonLibs: Found unsuitable version "2.6.6", but required is at least "2.7" (found /usr/lib64/libpython2.6.so)
-- To find NumPy Python interpretator is required to be found.
-- Could NOT find NumPy (missing: NUMPY_INCLUDE_DIR NUMPY_VERSION) (Required is at least version "1.7.1")
....
--
-- Configuring done
CMake Error at CMakeLists.txt:104 (add_dependencies):
  The dependency target "pycaffe" of target "pytest" does not exist.
```

this patch make sure correct python is detected : 

```
-- Found PythonInterp: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/python-3.5.2-khm3cldd/bin/python3 (found suitable version "3.5.2", minimum required is "3.0")
-- Found PythonLibs: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/python-3.5.2-khm3cldd/lib/libpython3.5m.so (found suitable version "3.5.2", minimum required is "3.0")
-- Found NumPy: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/install_home/bbpviz/install/linux-rhel6-x86_64/gcc-5.3.0/py-numpy-1.13.1-qpfzvjyh/lib/python3.5/site-packages/numpy/core/include (found suitable version "1.13.1", minimum required is "1.7.1")
```