### PR TITLE
Fix CMake minimum version

### DIFF
--- a/var/spack/repos/builtin/packages/libgpuarray/package.py
+++ b/var/spack/repos/builtin/packages/libgpuarray/package.py
@@ -38,5 +38,6 @@ class Libgpuarray(CMakePackage):
     version('0.6.0', '98a4ec1b4c8f225f0b89c18b899a000b')
 
     depends_on('cuda')
+    depends_on('cmake@3:', type='build')
 
     extends('python')


### PR DESCRIPTION
Fix:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.0 or higher is required.  You are running version 2.8.12.2
```