### PR TITLE
Improve caffe dependency detection with extra CMake flags

### DIFF
--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -82,7 +82,13 @@ class Caffe(CMakePackage):
                 '-DBUILD_matlab=%s' % ('+matlab' in spec),
                 '-DUSE_OPENCV=%s' % ('+opencv' in spec),
                 '-DUSE_LEVELDB=%s' % ('+leveldb' in spec),
-                '-DUSE_LMDB=%s' % ('+lmdb' in spec)]
+                '-DUSE_LMDB=%s' % ('+lmdb' in spec),
+                '-DGFLAGS_ROOT_DIR=%s' % spec['gflags'].prefix,
+                '-DGLOG_ROOT_DIR=%s' % spec['glog'].prefix,
+                ]
+
+        if spec.satisfies('^openblas'):
+            env['OpenBLAS_HOME'] = spec['openblas'].prefix
 
         if spec.satisfies('+python'):
             version = spec['python'].version.up_to(1)

--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
 #
 # This file is part of Spack.
@@ -89,6 +89,12 @@ class Caffe(CMakePackage):
 
         if spec.satisfies('^openblas'):
             env['OpenBLAS_HOME'] = spec['openblas'].prefix
+
+        if spec.satisfies('+lmdb'):
+            env['LMDB_DIR'] = spec['lmdb'].prefix
+
+        if spec.satisfies('+leveldb'):
+            env['LEVELDB_ROOT'] = spec['leveldb'].prefix
 
         if spec.satisfies('+python'):
             version = spec['python'].version.up_to(1)


### PR DESCRIPTION
Caffe's CMake finds different installations of dependency resulting in link issues. Here is example where I install dependencies in `new_spack_path` and Caffe find some from `old_path`: 

```
==> openblas is already installed in /some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/openblas-0.2.20-tgtgdmq2
==> Installing caffe
==> Using cached archive: /gpfs/bbp.cscs.ch/scratch/gss/bgq/kumbhar-adm/SPACK_HOME/var/spack/cache/caffe/caffe-1.0.tar.gz
==> Already staged caffe-1.0-5oxpymqlimusuqdvzvrtv4llf66i3hr2 in /gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/var/spack/stage/caffe-1.0-5oxpymqlimusuqdvzvrtv4llf66i3hr2
==> No patches needed for caffe
==> Building caffe [CMakePackage]
==> Executing phase: 'cmake'
==> 'cmake' '/gpfs/bbp.cscs.ch/home/kumbhar-adm/SPACK_HOME/spack/var/spack/stage/caffe-1.0-5oxpymqlimusuqdvzvrtv4llf66i3hr2/caffe-1.0' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:PATH=/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/caffe-1.0-5oxpymql' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=FALSE' '-DCMAKE_INSTALL_RPATH:STRING=/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/caffe-1.0-5oxpymql/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/caffe-1.0-5oxpymql/lib64:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/boost-1.63.0-v7d3x5l5/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/bzip2-1.0.6-npjovari/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/python-2.7.13-dhkjobme/lib:/usr/lib:/usr/lib:/usr/lib:/usr/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/zlib-1.2.11-cabzx2gn/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/gflags-2.1.2-tfqqvp7z/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/hdf5-1.8.16-xchtpxec/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/libszip-2.1.1-ythud6pf/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/lmdb-0.9.21-nkcy3nck/lib:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/openblas-0.2.20-tgtgdmq2/lib:/usr/lib64:/usr/lib64:/usr/lib64:/usr/lib64:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/cuda-8.0.44-pgyvlyab/lib64:/some_path/new_spack_path/install/linux-rhel6-x86_64/gcc-5.3.0/protobuf-3.4.0-omw3vxeb/lib64' '-DBLAS=open' '-DCPU_ONLY=False' '-DUSE_CUDNN=True' '-DBUILD_python=True' '-DBUILD_python_layer=True' '-DBUILD_matlab=False' '-DUSE_OPENCV=False' '-DUSE_LEVELDB=False' '-DUSE_LMDB=True' '-Dpython_version=2'
-- Boost version: 1.63.0
-- Found the following Boost libraries:
--   system
…
-- Found gflags  (include: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/gflags-2.1.2-tfqqvp7z/include, library: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/gflags-2.1.2-tfqqvp7z/lib/libgflags.so)
-- Found glog    (include: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/include, library: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/glog-0.3.5-owsws472/lib/libglog.so)
-- Found PROTOBUF Compiler: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/protobuf-3.4.0-omw3vxeb/bin/protoc
-- HDF5: Using hdf5 compiler wrapper to determine C configuration
-- HDF5: Using hdf5 compiler wrapper to determine CXX configuration
-- Found lmdb    (include: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/lmdb-0.9.21-nkcy3nck/include, library: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/lmdb-0.9.21-nkcy3nck/lib/liblmdb.so)
CUDA detected: 8.0
-- Added CUDA NVCC flags for: sm_35
-- Found OpenBLAS libraries: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/openblas-0.2.20-tgtgdmq2/lib/libopenblas.so
-- Found OpenBLAS include: /some_path/old_path/install/linux-rhel6-x86_64/gcc-5.3.0/openblas-0.2.20-tgtgdmq2/include
```

this change make sure all CMake/ENV variables are set.

Check Caffe [CMake Modules](https://github.com/BVLC/caffe/tree/master/cmake/Modules).