### PR TITLE
Boost: 1.65.1

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -46,6 +46,8 @@ class Boost(Package):
             branch='develop',
             submodules=True)
 
+    version('1.65.1', '41d7542ce40e171f3f7982aff008ff0d',
+            url='https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2')
     version('1.65.0', '5512d3809801b0a1b9dd58447b70915d',
             url='https://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.bz2')
 


### PR DESCRIPTION
Add hash & url of the latest boost bugfix release, 1.65.1:
http://www.boost.org/users/history/version_1_65_1.html

Besides other fixed issues, it adds compatibility for the upcoming CUDA 9 release.