### PR TITLE
dealii: explicitly specify bzip2 libs

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -40,6 +40,14 @@ class Bzip2(Package):
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
 
+    # override default implementation
+    @property
+    def libs(self):
+        shared = '+shared' in self.spec
+        return find_libraries(
+            'libbz2', root=self.prefix, shared=shared, recurse=True
+        )
+
     def patch(self):
         # bzip2 comes with two separate Makefiles for static and dynamic builds
         # Tell both to use Spack's compiler wrapper instead of GCC

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -166,7 +166,10 @@ class Dealii(CMakePackage):
             '-DDEAL_II_COMPONENT_EXAMPLES=ON',
             '-DDEAL_II_WITH_THREADS:BOOL=ON',
             '-DBOOST_DIR=%s' % spec['boost'].prefix,
-            '-DBZIP2_DIR=%s' % spec['bzip2'].prefix,
+            # Cmake may still pick up system's bzip2, fix this:
+            '-DBZIP2_FOUND=true',
+            '-DBZIP2_INCLUDE_DIRS=%s' % spec['bzip2'].prefix.include,
+            '-DBZIP2_LIBRARIES=%s' % spec['bzip2'].libs.joined(';'),
             # CMake's FindBlas/Lapack may pickup system's blas/lapack instead
             # of Spack's. Be more specific to avoid this.
             # Note that both lapack and blas are provided in -DLAPACK_XYZ.


### PR DESCRIPTION
otherwise from `BZIP2_DIR` only `dealii` may end-up with:
```
#        DEAL_II_WITH_BZIP2 set up with external dependencies
#            BZIP2_VERSION = 1.0.6
#            BZIP2_DIR = /spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/bzip2-1.0.6-4vcfqu3netbuizhbtflvsrliinx7jogd
#            BZIP2_INCLUDE_DIRS = /usr/include
#            BZIP2_LIBRARIES = /usr/lib64/libbz2.so
```