### PR TITLE
Spec.concretize() sets mutual spec-package references

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -465,12 +465,8 @@ def setup_package(pkg, dirty):
     # code ensures that all packages in the DAG have pieces of the
     # same spec object at build time.
     #
-    # This is safe for the build process, b/c the build process is a
-    # throwaway environment, but it is kind of dirty.
-    #
-    # TODO: Think about how to avoid this fix and do something cleaner.
     for s in pkg.spec.traverse():
-        s.package.spec = s
+        assert s.package.spec is s
 
     # Trap spack-tracked compiler flags as appropriate.
     # Must be before set_compiler_environment_variables


### PR DESCRIPTION
The correct place to set the mutual references between spec and package objects at the end of concretization. After a call to concretize we should now be ensured that spec is the same object as spec.package.spec.

Code in `build_environment.py` that was performing the same operation has been turned into an assertion to be defensive on the new behavior.

----

Needed by #3183 after the merge of #5332 (but it seems of general use, hence the PR)