### PR TITLE
blas_lapack: add multithreading variant consistent in all implementations.

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -54,7 +54,13 @@ class Atlas(Package):
             url='http://sourceforge.net/projects/math-atlas/files/Developer%20%28unstable%29/3.11.34/atlas3.11.34.tar.bz2')
 
     variant('shared', default=True, description='Builds shared library')
-    variant('pthread', default=False, description='Use multithreaded libraries')
+
+    variant(
+        'multithreading', default='none',
+        description='Multithreading support',
+        values=('pthreads', 'none'),
+        multi=False
+    )
 
     provides('blas')
     provides('lapack')
@@ -118,7 +124,7 @@ class Atlas(Package):
         # libsatlas.[so,dylib,dll ] contains all serial APIs (serial lapack,
         # serial BLAS), and all ATLAS symbols needed to support them. Whereas
         # libtatlas.[so,dylib,dll ] is parallel (multithreaded) version.
-        is_threaded = '+pthread' in self.spec
+        is_threaded = self.spec.satisfies('multithreading=pthreads')
         if '+shared' in self.spec:
             to_find = ['libtatlas'] if is_threaded else ['libsatlas']
             shared = True

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -56,7 +56,7 @@ class Atlas(Package):
     variant('shared', default=True, description='Builds shared library')
 
     variant(
-        'multithreading', default='none',
+        'threads', default='none',
         description='Multithreading support',
         values=('pthreads', 'none'),
         multi=False
@@ -124,7 +124,7 @@ class Atlas(Package):
         # libsatlas.[so,dylib,dll ] contains all serial APIs (serial lapack,
         # serial BLAS), and all ATLAS symbols needed to support them. Whereas
         # libtatlas.[so,dylib,dll ] is parallel (multithreaded) version.
-        is_threaded = self.spec.satisfies('multithreading=pthreads')
+        is_threaded = self.spec.satisfies('threads=pthreads')
         if '+shared' in self.spec:
             to_find = ['libtatlas'] if is_threaded else ['libsatlas']
             shared = True

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -72,10 +72,10 @@ class Elemental(CMakePackage):
     depends_on('blas', when='~openmp_blas ~int64_blas')
     # Hack to forward variant to openblas package
     # Allow Elemental to build internally when using 8-byte ints
-    depends_on('openblas +openmp', when='blas=openblas +openmp_blas ~int64_blas')
+    depends_on('openblas multithreading=openmp', when='blas=openblas +openmp_blas ~int64_blas')
 
     depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl +openmp', when='blas=mkl +openmp_blas ~int64_blas')
+    depends_on('intel-mkl multithreading=openmp', when='blas=mkl +openmp_blas ~int64_blas')
     depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
 
     # Note that this forces us to use OpenBLAS until #1712 is fixed

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -72,10 +72,10 @@ class Elemental(CMakePackage):
     depends_on('blas', when='~openmp_blas ~int64_blas')
     # Hack to forward variant to openblas package
     # Allow Elemental to build internally when using 8-byte ints
-    depends_on('openblas multithreading=openmp', when='blas=openblas +openmp_blas ~int64_blas')
+    depends_on('openblas threads=openmp', when='blas=openblas +openmp_blas ~int64_blas')
 
     depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl multithreading=openmp', when='blas=mkl +openmp_blas ~int64_blas')
+    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas ~int64_blas')
     depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
 
     # Note that this forces us to use OpenBLAS until #1712 is fixed

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -63,6 +63,10 @@ class IntelMkl(IntelPackage):
     provides('scalapack')
     provides('mkl')
 
+    if sys.platform == 'darwin':
+        # there is no libmkl_gnu_thread on macOS
+        conflicts('threads=openmp', when='%gcc')
+
     @property
     def license_required(self):
         # The Intel libraries are provided without requiring a license as of
@@ -100,9 +104,6 @@ class IntelMkl(IntelPackage):
                 omp_libs = find_libraries(
                     omp_threading, root=omp_root, shared=shared)
             elif '%gcc' in spec:
-                if sys.platform == 'darwin':
-                    raise InstallError('MKL does not support openmp threading '
-                                       'with GCC on macOS')
                 mkl_threading = ['libmkl_gnu_thread']
 
                 gcc = Executable(self.compiler.cc)

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -101,7 +101,8 @@ class IntelMkl(IntelPackage):
                     omp_threading, root=omp_root, shared=shared)
             elif '%gcc' in spec:
                 if sys.platform == 'darwin':
-                    raise InstallError('MKL does not support openmp threading with GCC on macOS')  # NOQA: ignore=E501
+                    raise InstallError('MKL does not support openmp threading '
+                                       'with GCC on macOS')
                 mkl_threading = ['libmkl_gnu_thread']
 
                 gcc = Executable(self.compiler.cc)
@@ -163,10 +164,9 @@ class IntelMkl(IntelPackage):
             raise InstallError('No MPI found for scalapack')
 
         integer = 'ilp64' if '+ilp64' in self.spec else 'lp64'
-        if sys.platform != 'darwin':
-            mkl_root = self.prefix.compilers_and_libraries.linux.mkl.lib.intel64  # NOQA: ignore=E501
-        else:
-            mkl_root = self.prefix.mkl.lib
+        mkl_root = self.prefix.mkl.lib if sys.platform == 'darwin' else \
+            self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
+
         shared = True if '+shared' in self.spec else False
 
         libs = find_libraries(
@@ -179,7 +179,8 @@ class IntelMkl(IntelPackage):
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # set up MKLROOT for everyone using MKL package
-        mkl_root = self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
+        mkl_root = self.prefix.mkl.lib if sys.platform == 'darwin' else \
+            self.prefix.compilers_and_libraries.linux.mkl.lib.intel64
 
         spack_env.set('MKLROOT', self.prefix)
         spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS', mkl_root)

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -52,7 +52,7 @@ class IntelMkl(IntelPackage):
     variant('shared', default=True, description='Builds shared library')
     variant('ilp64', default=False, description='64 bit integers')
     variant(
-        'multithreading', default='none',
+        'threads', default='none',
         description='Multithreading support',
         values=('openmp', 'none'),
         multi=False
@@ -88,7 +88,7 @@ class IntelMkl(IntelPackage):
 
         omp_libs = LibraryList([])
 
-        if spec.satisfies('multithreading=openmp'):
+        if spec.satisfies('threads=openmp'):
             if '%intel' in spec:
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -50,7 +50,12 @@ class IntelMkl(IntelPackage):
 
     variant('shared', default=True, description='Builds shared library')
     variant('ilp64', default=False, description='64 bit integers')
-    variant('openmp', default=False, description='OpenMP multithreading layer')
+    variant(
+        'multithreading', default='none',
+        description='Multithreading support',
+        values=('openmp', 'none'),
+        multi=False
+    )
 
     provides('blas')
     provides('lapack')
@@ -82,7 +87,7 @@ class IntelMkl(IntelPackage):
 
         omp_libs = LibraryList([])
 
-        if '+openmp' in spec:
+        if spec.satisfies('multithreading=openmp'):
             if '%intel' in spec:
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -104,8 +104,12 @@ class IntelParallelStudio(IntelPackage):
             description='Builds shared library')
     variant('ilp64',    default=False,
             description='64 bit integers')
-    variant('openmp',   default=False,
-            description='OpenMP multithreading layer')
+    variant(
+        'multithreading', default='none',
+        description='Multithreading support',
+        values=('openmp', 'none'),
+        multi=False
+    )
 
     # Components available in all editions
     variant('daal', default=True,
@@ -168,7 +172,7 @@ class IntelParallelStudio(IntelPackage):
 
         omp_libs = LibraryList([])
 
-        if '+openmp' in spec:
+        if spec.satisfies('multithreading=openmp'):
             if '%intel' in spec:
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -105,7 +105,7 @@ class IntelParallelStudio(IntelPackage):
     variant('ilp64',    default=False,
             description='64 bit integers')
     variant(
-        'multithreading', default='none',
+        'threads', default='none',
         description='Multithreading support',
         values=('openmp', 'none'),
         multi=False
@@ -172,7 +172,7 @@ class IntelParallelStudio(IntelPackage):
 
         omp_libs = LibraryList([])
 
-        if spec.satisfies('multithreading=openmp'):
+        if spec.satisfies('threads=openmp'):
             if '%intel' in spec:
                 mkl_threading = ['libmkl_intel_thread']
                 omp_threading = ['libiomp5']

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -55,7 +55,7 @@ class Openblas(MakefilePackage):
                         'autodetection; GENERIC, SSE_GENERIC, NEHALEM, ...)')
 
     variant(
-        'multithreading', default='none',
+        'threads', default='none',
         description='Multithreading support',
         values=('pthreads', 'openmp', 'none'),
         multi=False
@@ -95,7 +95,7 @@ class Openblas(MakefilePackage):
                 'OpenBLAS requires both C and Fortran compilers!'
             )
         # Add support for OpenMP
-        if (self.spec.satisfies('multithreading=openmp') and
+        if (self.spec.satisfies('threads=openmp') and
             self.spec.satisfies('%clang')):
             if str(self.spec.compiler.version).endswith('-apple'):
                 raise InstallError("Apple's clang does not support OpenMP")
@@ -143,9 +143,9 @@ class Openblas(MakefilePackage):
             make_defs += ['BUILD_LAPACK_DEPRECATED=1']
 
         # Add support for multithreading
-        if self.spec.satisfies('multithreading=openmp'):
+        if self.spec.satisfies('threads=openmp'):
             make_defs += ['USE_OPENMP=1', 'USE_THREAD=1']
-        elif self.spec.satisfies('multithreading=pthreads'):
+        elif self.spec.satisfies('threads=pthreads'):
             make_defs += ['USE_OPENMP=0', 'USE_THREAD=1']
         else:
             make_defs += ['USE_OPENMP=0', 'USE_THREAD=0']
@@ -195,9 +195,9 @@ class Openblas(MakefilePackage):
         link_flags = spec['openblas'].libs.ld_flags
         if self.compiler.name == 'intel':
             link_flags += ' -lifcore'
-        if self.spec.satisfies('multithreading=pthreads'):
+        if self.spec.satisfies('threads=pthreads'):
             link_flags += ' -lpthread'
-        if spec.satisfies('multithreading=openmp'):
+        if spec.satisfies('threads=openmp'):
             link_flags += ' ' + self.compiler.openmp_flag
 
         output = compile_c_and_execute(

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -48,12 +48,18 @@ class Openblas(MakefilePackage):
         description='Build shared libraries as well as static libs.'
     )
     variant('ilp64', default=False, description='64 bit integers')
-    variant('openmp', default=False, description="Enable OpenMP support.")
     variant('pic', default=True, description='Build position independent code')
 
     variant('cpu_target', default='',
                     description='Set CPU target architecture (leave empty for '
                         'autodetection; GENERIC, SSE_GENERIC, NEHALEM, ...)')
+
+    variant(
+        'multithreading', default='none',
+        description='Multithreading support',
+        values=('pthreads', 'openmp', 'none'),
+        multi=False
+    )
 
     # virtual dependency
     provides('blas')
@@ -89,7 +95,8 @@ class Openblas(MakefilePackage):
                 'OpenBLAS requires both C and Fortran compilers!'
             )
         # Add support for OpenMP
-        if (('+openmp' in self.spec) and self.spec.satisfies('%clang')):
+        if (self.spec.satisfies('multithreading=openmp') and
+            self.spec.satisfies('%clang')):
             if str(self.spec.compiler.version).endswith('-apple'):
                 raise InstallError("Apple's clang does not support OpenMP")
             if '@:0.2.19' in self.spec:
@@ -134,9 +141,14 @@ class Openblas(MakefilePackage):
         # fix missing _dggsvd_ and _sggsvd_
         if self.spec.satisfies('@0.2.16'):
             make_defs += ['BUILD_LAPACK_DEPRECATED=1']
-        # Add support for OpenMP
-        if '+openmp' in self.spec:
-            make_defs += ['USE_OPENMP=1']
+
+        # Add support for multithreading
+        if self.spec.satisfies('multithreading=openmp'):
+            make_defs += ['USE_OPENMP=1', 'USE_THREAD=1']
+        elif self.spec.satisfies('multithreading=pthreads'):
+            make_defs += ['USE_OPENMP=0', 'USE_THREAD=1']
+        else:
+            make_defs += ['USE_OPENMP=0', 'USE_THREAD=0']
 
         # 64bit ints
         if '+ilp64' in self.spec:
@@ -183,8 +195,9 @@ class Openblas(MakefilePackage):
         link_flags = spec['openblas'].libs.ld_flags
         if self.compiler.name == 'intel':
             link_flags += ' -lifcore'
-        link_flags += ' -lpthread'
-        if '+openmp' in spec:
+        if self.spec.satisfies('multithreading=pthreads'):
+            link_flags += ' -lpthread'
+        if spec.satisfies('multithreading=openmp'):
             link_flags += ' ' + self.compiler.openmp_flag
 
         output = compile_c_and_execute(

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -198,7 +198,7 @@ class Openblas(MakefilePackage):
         if self.spec.satisfies('threads=pthreads'):
             link_flags += ' -lpthread'
         if spec.satisfies('threads=openmp'):
-            link_flags += ' ' + self.compiler.openmp_flag
+            link_flags += ' -lpthread ' + self.compiler.openmp_flag
 
         output = compile_c_and_execute(
             source_file, [include_flags], link_flags.split()


### PR DESCRIPTION
build on Ubuntu 16 + gcc 5.4.0:

- [x] `spack install openblas multithreading=none`
- [x] `spack install openblas multithreading=pthreads`
- [x] `spack install openblas multithreading=openmp`
- [x] `spack install atlas multithreading=none`
- [x] `spack install atlas multithreading=pthreads`
- [x] `spack install intel-mkl multithreading=none`
- [x] `spack install intel-mkl multithreading=openmp`
- [x] `spack install elemental`

macOS Sierra + clang + gfortran:
- [x] `spack install openblas multithreading=none`
- [x] `spack install openblas multithreading=pthreads `
- [x] `spack install mumps+mpi ^intel-mkl ^mpich`

in the later case for externally provided `intel-mkl@2018.0.128` in `opt/intel` we have:
```
LIBBLAS = -L/opt/intel/mkl/lib -L/usr/lib -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl
SCALAP = -L/opt/intel/mkl/lib -lmkl_scalapack_lp64 -lmkl_blacs_mpich_lp64
```

- [x] `spack install dealii+mpi~sundials ^intel-mkl ^mpich`

```
$ otool -L /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/dealii-develop-n6julmgj2gj6twxodwe275zys4ily3fw/lib/libdeal_II.dylib  | grep "mkl"
	@rpath/libmkl_scalapack_lp64.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libmkl_blacs_mpich_lp64.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libmkl_intel_lp64.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libmkl_core.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libmkl_sequential.dylib (compatibility version 0.0.0, current version 0.0.0)
```

p.s. `none` value is there as we need at least two values.

fixes https://github.com/LLNL/spack/issues/1697