### PR TITLE
boost: call_once_variadic.patch is already part of 1.56.0

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -156,7 +156,7 @@ class Boost(Package):
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl_r')
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl')
 
-    patch('call_once_variadic.patch', when='@:1.56.0%gcc@5:')
+    patch('call_once_variadic.patch', when='@:1.55.9999%gcc@5:')
 
     # Patch fix for PGI compiler
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')


### PR DESCRIPTION
Fix #5692