### PR TITLE
Remove automatic definition of 'module' command in setup-env.sh

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -909,23 +909,13 @@ What follows are three steps describing how to install and use environment-modul
      ``spack install environment-modules~X`` (The ``~X`` variant builds without Xorg
      dependencies, but ``environment-modules`` works fine too.)
 
-#. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. you can add
-   it with the following script (or apply the updates to your ``.bashrc`` file
-   manually):
+#. To make the ``module`` command available in your shell, you can add
+   it with the following commands (which modify ``.bashrc``):
 
        .. code-block:: sh
 
-          TMP=`tempfile`
-          echo >$TMP
           MODULE_HOME=`spack location --install-dir environment-modules`
-          MODULE_VERSION=`ls -1 $MODULE_HOME/Modules | head -1`
-          ${MODULE_HOME}/Modules/${MODULE_VERSION}/bin/add.modules <$TMP
-          cp .bashrc $TMP
-          echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
-          cat $TMP >>.bashrc
-
-    This is added to your ``.bashrc`` (or similar) files, enabling Environment
-    Modules when you log in.
+          ${MODULE_HOME}/Modules/bin/add.modules
         
 #. Test that the ``module`` command is found with:
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -909,37 +909,23 @@ What follows are three steps describing how to install and use environment-modul
      ``spack install environment-modules~X`` (The ``~X`` variant builds without Xorg
      dependencies, but ``environment-modules`` works fine too.)
 
-#. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. 
+#. Add ``modulecmd`` to ``PATH`` and create a ``module`` command. you can add
+   it with the following script (or apply the updates to your ``.bashrc`` file
+   manually):
 
-   * If you are using ``bash`` or ``ksh``, Spack can currently do this for you as well.
-     After installing ``environment-modules`` following the step
-     above, source Spack's shell integration script. This will automatically
-     detect the lack of ``modulecmd`` and ``module``, and use the installed
-     ``environment-modules`` from ``spack bootstrap`` or ``spack install``.
-     
-     .. code-block:: console
+       .. code-block:: sh
 
-        # For bash/zsh users
-        $ export SPACK_ROOT=/path/to/spack
-        $ . $SPACK_ROOT/share/spack/setup-env.sh
+          TMP=`tempfile`
+          echo >$TMP
+          MODULE_HOME=`spack location --install-dir environment-modules`
+          MODULE_VERSION=`ls -1 $MODULE_HOME/Modules | head -1`
+          ${MODULE_HOME}/Modules/${MODULE_VERSION}/bin/add.modules <$TMP
+          cp .bashrc $TMP
+          echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
+          cat $TMP >>.bashrc
 
-
-   * If you prefer to do it manually,  you can activate with the following 
-     script (or apply the updates to your ``.bashrc`` file manually):
-
-         .. code-block:: sh
-
-            TMP=`tempfile`
-            echo >$TMP
-            MODULE_HOME=`spack location --install-dir environment-modules`
-            MODULE_VERSION=`ls -1 $MODULE_HOME/Modules | head -1`
-            ${MODULE_HOME}/Modules/${MODULE_VERSION}/bin/add.modules <$TMP
-            cp .bashrc $TMP
-            echo "MODULE_VERSION=${MODULE_VERSION}" > .bashrc
-            cat $TMP >>.bashrc
-
-      This is added to your ``.bashrc`` (or similar) files, enabling Environment
-      Modules when you log in.
+    This is added to your ``.bashrc`` (or similar) files, enabling Environment
+    Modules when you log in.
         
 #. Test that the ``module`` command is found with:
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -44,8 +44,6 @@ For ``csh`` and ``tcsh`` instead:
 
    $ source $SPACK_ROOT/share/spack/setup-env.csh
 
-When ``bash`` and ``ksh`` users update their environment with ``setup-env.sh``, it will check for spack-installed environment modules and add the ``module`` command to their environment; This only occurs if the module command is not already available. You can install ``environment-modules`` with ``spack bootstrap`` as described in :ref:`InstallEnvironmentModules`.
-
 .. note::
   You can put the source line in your ``.bashrc`` or ``.cshrc`` to
   have Spack's shell support available on the command line at any login.
@@ -56,10 +54,11 @@ Using module files via Spack
 ----------------------------
 
 If you have installed a supported module system either manually or through
-``spack bootstrap`` and have enabled shell support, you should be able to
-run either ``module avail`` or ``use -l spack`` to see what module/dotkit
-files have been installed.  Here is sample output of those programs,
-showing lots of installed packages.
+``spack bootstrap`` and have enabled shell support (as described in
+:ref:`InstallEnvironmentModules`), you should be able to run either
+``module avail`` or ``use -l spack`` to see what module/dotkit files have been
+installed.  Here is sample output of those programs, showing lots of installed
+packages.
 
 .. code-block:: console
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -53,12 +53,12 @@ For ``csh`` and ``tcsh`` instead:
 Using module files via Spack
 ----------------------------
 
-If you have installed a supported module system either manually or through
-``spack bootstrap`` and have enabled shell support (as described in
-:ref:`InstallEnvironmentModules`), you should be able to run either
-``module avail`` or ``use -l spack`` to see what module/dotkit files have been
-installed.  Here is sample output of those programs, showing lots of installed
-packages.
+If you have enabled shell support and if module support is available, you
+should be able to run either ``module avail`` or ``use -l spack`` to see
+what module/dotkit files have been installed.  If module support is not
+available (the 'module' command is not available) you can add it using the
+instructions in :ref:`InstallEnvironmentModules`. Here is sample output of
+``module avail`` and ``use -l spack``, showing lots of installed packages.
 
 .. code-block:: console
 

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -21,8 +21,7 @@ directly with automatically generated module files.
 .. note::
 
    If your machine does not already have a module system installed,
-   we advise you to use either Environment Modules or LMod. See :ref:`InstallEnvironmentModules`
-   for more details.
+   you can add it with Spack as described in :ref:`InstallEnvironmentModules`.
 
 .. _shell-support:
 
@@ -53,11 +52,9 @@ For ``csh`` and ``tcsh`` instead:
 Using module files via Spack
 ----------------------------
 
-If you have enabled shell support and if module support is available, you
-should be able to run either ``module avail`` or ``use -l spack`` to see
-what module/dotkit files have been installed.  If module support is not
-available (the 'module' command is not available) you can add it using the
-instructions in :ref:`InstallEnvironmentModules`. Here is sample output of
+If you have enabled shell support and if you have a module system installed,
+you can run either ``module avail`` or ``use -l spack`` to see
+what module/dotkit files have been installed. Here is sample output of
 ``module avail`` and ``use -l spack``, showing lots of installed packages.
 
 .. code-block:: console

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -27,9 +27,7 @@
 #
 # This file is part of Spack and sets up the spack environment for
 # bash and zsh.  This includes dotkit support, module support, and
-# it also puts spack in your path.  The script also checks that
-# at least module support exists, and provides suggestions if it
-# doesn't. Source it like this:
+# it also puts spack in your path.  Source it like this:
 #
 #    . /path/to/spack/share/spack/setup-env.sh
 #
@@ -191,68 +189,19 @@ if [ -z "$_sp_source_file" ]; then
 fi
 
 #
-# Find root directory and add bin to path.
+# Set up modules and dotkit search paths in the user environment
 #
 _sp_share_dir=$(cd "$(dirname $_sp_source_file)" && pwd)
 _sp_prefix=$(cd "$(dirname $(dirname $_sp_share_dir))" && pwd)
 _spack_pathadd PATH       "${_sp_prefix%/}/bin"
-export SPACK_ROOT=${_sp_prefix}
 
-#
-# Determine which shell is being used
-#
-function _spack_determine_shell() {
-	ps -p $$ | tail -n 1 | awk '{print $4}' | sed 's/^-//' | xargs basename
-}
-export SPACK_SHELL=$(_spack_determine_shell)
-
-#
-# Check whether a function of the given name is defined
-#
-function _spack_fn_exists() {
-	type $1 2>&1 | grep -q 'function'
-}
-
-need_module="no"
-if ! _spack_fn_exists use && ! _spack_fn_exists module; then
-	need_module="yes"
-fi;
-
-#
-# build and make available environment-modules
-#
-if [ "${need_module}" = "yes" ]; then
-    #check if environment-modules is installed
-    module_prefix="$(spack location -i "environment-modules" 2>&1 || echo "not_installed")"
-    module_prefix=$(echo "${module_prefix}" | tail -n 1)
-    if [ "${module_prefix}" != "not_installed" ]; then
-        #activate it!
-        export MODULE_PREFIX=${module_prefix}
-        _spack_pathadd PATH "${MODULE_PREFIX}/Modules/bin"
-        module() { eval `${MODULE_PREFIX}/Modules/bin/modulecmd ${SPACK_SHELL} $*`; }
-        echo "INFO: Using spack managed module system."
-    else
-        echo "WARNING: A method for managing modules does not currently exist."
-        echo ""
-        echo "To resolve this you may either:"
-        echo "1. Allow spack to handle this by running 'spack bootstrap'"
-        echo "   and sourcing this script again."
-        echo "2. Install and activate a supported module managment engine manually"
-        echo "   Supported engines include: environment-modules and lmod"
-    fi;
-else
-    echo "INFO: Using system available module system."
-fi;
-
-#
-# Set up modules and dotkit search paths in the user environment
-#
 _sp_sys_type=$(spack-python -c 'print(spack.architecture.sys_type())')
 _sp_dotkit_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('dotkit')))")
 _sp_tcl_root=$(spack-python -c "print(spack.util.path.canonicalize_path(spack.config.get_config('config').get('module_roots', {}).get('tcl')))")
 _spack_pathadd DK_NODE    "${_sp_dotkit_root%/}/$_sp_sys_type"
 _spack_pathadd MODULEPATH "${_sp_tcl_root%/}/$_sp_sys_type"
 
+#
 # Add programmable tab completion for Bash
 #
 if [ -n "${BASH_VERSION:-}" ]; then


### PR DESCRIPTION
See: https://github.com/LLNL/spack/issues/5351

This removes automatic definition of the 'module' command in setup-env.sh

This retains the re-purposing of the `spack bootstrap` command as was done in #3057.