### PR TITLE
libsodium: update URLs

### DIFF
--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -32,6 +32,8 @@ class Libsodium(AutotoolsPackage):
     url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.13.tar.gz"
     list_url = "https://download.libsodium.org/libsodium/releases/old"
 
+    version('1.0.13', 'f38aac160a4bd05f06f743863e54e499')
+    version('1.0.12', 'c308e3faa724b630b86cc0aaf887a5d4')
     version('1.0.11', 'b58928d035064b2a46fb564937b83540')
     version('1.0.10', 'ea89dcbbda0b2b6ff6a1c476231870dd')
     version('1.0.3', 'b3bcc98e34d3250f55ae196822307fab')

--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -29,7 +29,7 @@ class Libsodium(AutotoolsPackage):
     """Sodium is a modern, easy-to-use software library for encryption,
     decryption, signatures, password hashing and more."""
     homepage = "https://download.libsodium.org/doc/"
-    url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.11.tar.gz"
+    url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.13.tar.gz"
     list_url = "https://download.libsodium.org/libsodium/releases/old"
 
     version('1.0.11', 'b58928d035064b2a46fb564937b83540')
@@ -43,5 +43,7 @@ class Libsodium(AutotoolsPackage):
     def url_for_version(self, version):
         url = 'https://download.libsodium.org/libsodium/releases/'
         if version < Version('1.0.4'):
+            url += 'old/unsupported/'
+        elif version < Version('1.0.12'):
             url += 'old/'
         return url + 'libsodium-{0}.tar.gz'.format(version)


### PR DESCRIPTION
updates the URLs for libsodium releases. Fixes broken builds (404).