### PR TITLE
ncl: Fix buffer overflow in ymake-filter

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -43,6 +43,8 @@ class Ncl(Package):
     patch('spack_ncl.patch')
     # Make ncl compile with hdf5 1.10
     patch('hdf5.patch')
+    # ymake-filter's buffer may overflow
+    patch('ymake-filter.patch')
 
     # This installation script is implemented according to this manual:
     # http://www.ncl.ucar.edu/Download/build_from_src.shtml

--- a/var/spack/repos/builtin/packages/ncl/ymake-filter.patch
+++ b/var/spack/repos/builtin/packages/ncl/ymake-filter.patch
@@ -1,0 +1,33 @@
+--- ncl_ncarg-6.4.0/config/ymake-filter.c.orig	2017-02-23 20:11:55.000000000 +0100
++++ ncl_ncarg-6.4.0/config/ymake-filter.c	2017-09-13 14:52:34.800989229 +0200
+@@ -150,13 +150,29 @@
+ getcppline()
+ {
+ 	int		c;
+-	static char	buf[2048];
++	static int	s = 2048;
++	static char	*buf = NULL;
+ 	char 		*p;
+ 
++	if (buf == NULL)
++	{
++		buf = malloc(s);
++	}
++
+ 	p = buf;
+ 
+ 	do
+ 	{
++		if (p >= buf + s)
++		{
++			char* old = buf;
++
++			/* Need to increase the size of buf. */
++			s += 1024;
++			buf = realloc(buf, s);
++			p = buf + (p - old);
++		}
++
+ 		switch(c = getchar())
+ 		{
+ 			/*


### PR DESCRIPTION
Fixes a problem in ymake-filter: The line buffer is currently hardcoded to be 2048 bytes large but some Makefiles contain lines longer than that. This caused the Makefiles to sometimes not be generated, consequently failing parts of the build.

This used to work with GCC 6 but since updating to GCC 7, I have observed sporadic errors when building ncl. The patch has already been forwarded to upstream.