### PR TITLE
tbb: add 2018

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -35,7 +35,8 @@ class IntelTbb(Package):
     homepage = "http://www.threadingbuildingblocks.org/"
 
     # Only version-specific URL's work for TBB
-    # can also use https://github.com/01org/tbb/releases/
+    version('2018.0', 'e54de69981905ad69eb9cf0226b9bf5f9a4ba065',
+            url='https://github.com/01org/tbb/archive/2018.tar.gz')
     version('2017.6', 'c0a722fd1ae66b40aeab25da6049086ef5f02f17',
             url='https://github.com/01org/tbb/archive/2017_U6.tar.gz')
     version('2017.5', '26f720729d322913912e99d1e4a36bd10625d3ca',


### PR DESCRIPTION
from the release notes

> If you build Intel(R) TBB from sources with GCC 6, specify
        the -flifetime-dse=1 option to prevent crashes at runtime,
        or use Intel(R) TBB makefiles that automatically set this option.

my understanding that we use TBB's makefiles, so this should happen automatically.