### PR TITLE
ADIOS: Fix Build (Autotools)

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -142,7 +142,7 @@ class Adios(AutotoolsPackage):
             env['MPICC'] = spec['mpi'].mpicc
             env['MPICXX'] = spec['mpi'].mpicxx
 
-        extra_args += self.with_or_without('mpi', activation='prefix')
+        extra_args += self.with_or_without('mpi', activation_value='prefix')
         extra_args += self.with_or_without('infiniband')
 
         # Transforms
@@ -152,7 +152,7 @@ class Adios(AutotoolsPackage):
         variants += ['hdf5', 'netcdf']
 
         for x in variants:
-            extra_args += self.with_or_without(x, activation='prefix')
+            extra_args += self.with_or_without(x, activation_value='prefix')
 
         # Staging transports
         def with_staging(name):
@@ -160,6 +160,6 @@ class Adios(AutotoolsPackage):
                 return spec['libevpath'].prefix
             return spec[name].prefix
 
-        extra_args += self.with_or_without('staging', activation=with_staging)
+        extra_args += self.with_or_without('staging', activation_value=with_staging)
 
         return extra_args

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -49,17 +49,26 @@ class Adios(AutotoolsPackage):
     variant('fortran', default=False,
             description='Enable Fortran bindings support')
 
-    variant('mpi', default=True, description='Enable MPI support')
-    variant('infiniband', default=False, description='Enable infiniband support')
+    variant('mpi', default=True,
+            description='Enable MPI support')
+    variant('infiniband', default=False,
+            description='Enable infiniband support')
 
     # transforms
-    variant('zlib', default=True, description='Enable zlib transform support')
-    variant('bzip2', default=False, description='Enable bzip2 transform support')
-    variant('szip', default=False, description='Enable szip transform support')
-    variant('zfp', default=True, description='Enable ZFP transform support')
-    variant('sz', default=True, description='Enable SZ transform support')
+    variant('zlib', default=True,
+            description='Enable zlib transform support')
+    variant('bzip2', default=False,
+            description='Enable bzip2 transform support')
+    variant('szip', default=False,
+            description='Enable szip transform support')
+    variant('zfp', default=True,
+            description='Enable ZFP transform support')
+    variant('sz', default=True,
+            description='Enable SZ transform support')
     # transports and serial file converters
-    variant('hdf5', default=False, description='Enable parallel HDF5 transport and serial bp2h5 converter')
+    variant('hdf5', default=False,
+            description='Enable parallel HDF5 transport and serial bp2h5 ' +
+                        'converter')
     variant('netcdf', default=False, description='Enable netcdf support')
 
     variant(
@@ -160,6 +169,9 @@ class Adios(AutotoolsPackage):
                 return spec['libevpath'].prefix
             return spec[name].prefix
 
-        extra_args += self.with_or_without('staging', activation_value=with_staging)
+        extra_args += self.with_or_without(
+            'staging',
+            activation_value=with_staging
+        )
 
         return extra_args


### PR DESCRIPTION
This fixes the build of the ADIOS package.
The `with_or_without` interface of the Autotools builds seems to have changed, this fixes it.