### PR TITLE
set CMAKE_PREFIX_PATH for cmake packages

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -145,6 +145,10 @@ class CMakePackage(PackageBase):
         args.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=FALSE')
         rpaths = ':'.join(spack.build_environment.get_rpaths(pkg))
         args.append('-DCMAKE_INSTALL_RPATH:STRING={0}'.format(rpaths))
+        # CMake's find_package() looks in CMAKE_PREFIX_PATH first, help CMake
+        # to find immediate link dependencies in right places:
+        deps = [d.prefix for d in pkg.spec.dependencies(deptype='link')]
+        args.append('-DCMAKE_PREFIX_PATH:STRING={0}'.format(';'.join(deps)))
         return args
 
     @property

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -147,7 +147,8 @@ class CMakePackage(PackageBase):
         args.append('-DCMAKE_INSTALL_RPATH:STRING={0}'.format(rpaths))
         # CMake's find_package() looks in CMAKE_PREFIX_PATH first, help CMake
         # to find immediate link dependencies in right places:
-        deps = [d.prefix for d in pkg.spec.dependencies(deptype='link')]
+        deps = [d.prefix for d in
+                pkg.spec.dependencies(deptype=('build', 'link'))]
         args.append('-DCMAKE_PREFIX_PATH:STRING={0}'.format(';'.join(deps)))
         return args
 


### PR DESCRIPTION
To be on the safe side and make CMake packages pick up direct dependencies from where we want, i think we shall set `CMAKE_PREFIX_PATH` which is the first place [find_package](https://cmake.org/cmake/help/v3.0/command/find_package.html) will look at.


**~~do not merge yet~~:** there are some issues i don't quite understand
```
$ spack install lammps
==> openmpi is already installed in /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/openmpi-2.1.1-4vl27tg7gal5kqxsfislmkta2cb2vus2
==> cmake is already installed in /Users/davydden/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/cmake-3.7.2-x2vsvmeg76dkdsslny3rhgwk66fej5nh
==> Installing lammps
==> Error: TypeError: sequence item 0: expected string, Spec found
TypeError: TypeError: sequence item 0: expected string, Spec found

/Users/davydden/spack/lib/spack/spack/build_environment.py:572, in child_process:
     26
     27                # build up some context from the offending package so we can
     28                # show that, too.
  >> 29                package_context = get_package_context(tb)
     30
     31                build_log = None
     32                if hasattr(pkg, 'log_path'):
```
especially given the fact that we call `spack.build_environment.get_rpaths()` just before this line.