### PR TITLE
Add --with-mpi=spec['mpi'].name at configure step to avoid error when…

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -85,6 +85,7 @@ class Scorep(AutotoolsPackage):
             "--with-papi-lib=%s" % spec['papi'].prefix.lib,
             "--with-pdt=%s" % spec['pdt'].prefix.bin,
             "--enable-shared",
+            "--with-mpi=%s" % spec['mpi'].name
         ]
 
         if '~shmem' in spec:


### PR DESCRIPTION
… finding 2 MPI implementations