### PR TITLE
libSplash: no HDF5 Fortran

### DIFF
--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -50,6 +50,6 @@ class Libsplash(CMakePackage):
     variant('mpi', default=True,
             description='Enable parallel I/O (one-file aggregation) support')
 
-    depends_on('hdf5@1.8.6:')
+    depends_on('hdf5@1.8.6:~fortran')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
libSplash is a C++-only library that does not depend on the Fortran bindings of HDF5.

Also reduces potential points that can (and often do) break in the dependencies.