### PR TITLE
HDF5: Fortran MPI needs Numactl

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -65,6 +65,7 @@ class Hdf5(AutotoolsPackage):
             description='Produce position-independent code (for shared libs)')
 
     depends_on('mpi', when='+mpi')
+    depends_on('numactl', when='+mpi+fortran')
     depends_on('szip', when='+szip')
     depends_on('zlib@1.1.2:')
 


### PR DESCRIPTION
When installing the default HDF5 (with defaults: `+fortran`, `+mpi`) with `clang@4.0.1` (and `gfortran@5.4.0` as `FC`), the linking of `libhdf5_fortran` fails on a missing `-lnuma` with the default `openmpi@2.1.1` during the `build` stage.

```bash
spack install hdf5 %clang@4.0.1
```

This fixes it by adding `numactl` which ships `libnuma`.

Note: Installs without MPI or Fortran succeeded already, so I only added it on `+mpi+fortran`.
```bash
spack install hdf5~mpi %clang@4.0.1
spack install hdf5~fortran %clang@4.0.1
```

- [x] depends on ~~#5371~~