### PR TITLE
Fix Protobuf URLs

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -58,12 +58,6 @@ class Protobuf(CMakePackage):
                 self.all_urls, self.list_url, self.list_depth)
         ))
 
-    def url_for_version(self, version):
-        """Ignore additional source artifacts uploaded with releases,
-           fix for https://github.com/LLNL/spack/issues/5356"""
-        return ("https://github.com/google/protobuf/archive/"
-                "v{0}.tar.gz".format(version.dotted))
-
     def cmake_args(self):
         args = [
             '-Dprotobuf_BUILD_TESTS:BOOL=OFF',

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -33,9 +33,10 @@ class Protobuf(CMakePackage):
     root_cmakelists_dir = "cmake"
 
     version('3.4.0', '1d077a7d4db3d75681f5c333f2de9b1a')
-    version('3.2.0', '61d899b8369781f6dd1e62370813392d')
-    version('3.1.0', '14a532a7538551d5def317bfca41dace')
-    version('3.0.2', '845b39e4b7681a2ddfd8c7f528299fbb')
+    version('3.3.0', 'f0f712e98de3db0c65c0c417f5e7aca8')
+    version('3.2.0', 'efaa08ae635664fb5e7f31421a41a995')
+    version('3.1.0', '39d6a4fa549c0cce164aa3064b1492dc')
+    version('3.0.2', '7349a7f43433d72c6d805c6ca22b7eeb')
     # does not build with CMake:
     # version('2.5.0', '9c21577a03adc1879aba5b52d06e25cf')
 
@@ -45,6 +46,17 @@ class Protobuf(CMakePackage):
 
     # first fixed in 3.4.0: https://github.com/google/protobuf/pull/3406
     patch('pkgconfig.patch', when='@:3.3.2')
+
+    def fetch_remote_versions(self):
+        """fix for https://github.com/LLNL/spack/issues/5356"""
+        return dict(map(lambda u:
+                        (u, self.url_for_version(Version(u))),
+                        self.versions))
+
+    def url_for_version(self, version):
+        """fix for https://github.com/LLNL/spack/issues/5356"""
+        return ("https://github.com/google/protobuf/archive/"
+                "v{0}.tar.gz".format(version.dotted))
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -23,6 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
+import spack.util.web
 
 
 class Protobuf(CMakePackage):
@@ -48,13 +49,18 @@ class Protobuf(CMakePackage):
     patch('pkgconfig.patch', when='@:3.3.2')
 
     def fetch_remote_versions(self):
-        """fix for https://github.com/LLNL/spack/issues/5356"""
-        return dict(map(lambda u:
-                        (u, self.url_for_version(Version(u))),
-                        self.versions))
+        """Ignore additional source artifacts uploaded with releases,
+           only keep known versions
+           fix for https://github.com/LLNL/spack/issues/5356"""
+        return dict(map(
+            lambda u: (u, self.url_for_version(u)),
+            spack.util.web.find_versions_of_archive(
+                self.all_urls, self.list_url, self.list_depth)
+        ))
 
     def url_for_version(self, version):
-        """fix for https://github.com/LLNL/spack/issues/5356"""
+        """Ignore additional source artifacts uploaded with releases,
+           fix for https://github.com/LLNL/spack/issues/5356"""
         return ("https://github.com/google/protobuf/archive/"
                 "v{0}.tar.gz".format(version.dotted))
 


### PR DESCRIPTION
GitHub releases with additional `.tar.gz` source archive uploads to their actual tag tend to return random selections of which archive shall be taken. Related to  #5356

This fixes it for protobuf with a hack to prioritize *GitHub Source Archives* over *additional release artifacts*. The interesting observation is also, that the pick from the `list_url` is also *not deterministic*.

I would propose to rewrite `lib/spack/spack/util/web` to use for pages, links and versions an ordered dict to get at least determinism into the version url fetching.

Before (note the wrong pick in the `3.3.0` & `3.4.0` release!):
```
$ spack checksum protobuf
==> Found 10 versions of protobuf:

  3.4.1     https://github.com/google/protobuf/archive/v3.4.1.tar.gz
  3.4.0rc3  https://github.com/google/protobuf/archive/v3.4.0rc3.tar.gz
  3.4.0rc2  https://github.com/google/protobuf/archive/v3.4.0rc2.tar.gz
  3.4.0rc1  https://github.com/google/protobuf/archive/v3.4.0rc1.tar.gz
  3.4.0     https://github.com/google/protobuf/releases/download/v3.4.0/protobuf-ruby-3.4.0.tar.gz
  3.3.2     https://github.com/google/protobuf/archive/v3.3.2.tar.gz
  3.3.1     https://github.com/google/protobuf/archive/v3.3.1.tar.gz
  3.3.0rc1  https://github.com/google/protobuf/archive/v3.3.0rc1.tar.gz
  3.3.0     https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-ruby-3.3.0.tar.gz
  3.2.1     https://github.com/google/protobuf/archive/v3.2.1.tar.gz
```

Now:
```
$ spack checksum protobuf
==> Found 10 versions of protobuf:
  
  3.4.1     https://github.com/google/protobuf/archive/v3.4.1.tar.gz
  3.4.0rc3  https://github.com/google/protobuf/archive/v3.4.0rc3.tar.gz
  3.4.0rc2  https://github.com/google/protobuf/archive/v3.4.0rc2.tar.gz
  3.4.0rc1  https://github.com/google/protobuf/archive/v3.4.0rc1.tar.gz
  3.4.0     https://github.com/google/protobuf/archive/v3.4.0.tar.gz
  3.3.2     https://github.com/google/protobuf/archive/v3.3.2.tar.gz
  3.3.1     https://github.com/google/protobuf/archive/v3.3.1.tar.gz
  3.3.0rc1  https://github.com/google/protobuf/archive/v3.3.0rc1.tar.gz
  3.3.0     https://github.com/google/protobuf/archive/v3.3.0.tar.gz
  3.2.1     https://github.com/google/protobuf/archive/v3.2.1.tar.gz
```