### PR TITLE
Update recipe for cgns to avoid build warnings/errors:

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -40,6 +40,8 @@ class Cgns(CMakePackage):
     depends_on('cmake@2.8:', type='build')
     depends_on('hdf5', when='+hdf5')
 
+    parallel = False
+
     def cmake_args(self):
         spec = self.spec
         cmake_args = []
@@ -52,18 +54,9 @@ class Cgns(CMakePackage):
         if '+hdf5' in spec:
             cmake_args.extend([
                 '-DCGNS_ENABLE_HDF5=ON',
-                '-DHDF5_NEEDS_ZLIB=ON'
+                '-DHDF5_DIR=%s' % spec['hdf5'].prefix
             ])
 
-            if spec.satisfies('^hdf5+mpi'):
-                cmake_args.append('-DHDF5_NEEDS_MPI=ON')
-            else:
-                cmake_args.append('-DHDF5_NEEDS_MPI=OFF')
-
-            if spec.satisfies('^hdf5+szip'):
-                cmake_args.append('-DHDF5_NEEDS_SZIP=ON')
-            else:
-                cmake_args.append('-DHDF5_NEEDS_SZIP=OFF')
         else:
             cmake_args.append('-DCGNS_ENABLE_HDF5=OFF')
 


### PR DESCRIPTION
+ The recipe for cgns seems to be wrong. CMake complains about variables set but not used (`HDF5_NEEDS_ZLIB`, `HDF5_NEEDS_MPI` and `HDF5_NEEDS_SZIP`) and fails to find HDF5.
+ This change-set removes these variables from the cmake configure line, replacing them with `'-DHDF5_DIR=%s' % spec['hdf5'].prefix`
+ cgns also has trouble with parallel make, so I set `parallel = False`.

