### PR TITLE
Fix log error parsing bug introduced in c830eda

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -114,8 +114,8 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     assert "'install'\nAFTER INSTALL" in out
 
 
-def _test_install_output_on_build_error(builtin_mock, mock_archive, mock_fetch,
-                                        config, install_mockery, capfd):
+def test_install_output_on_build_error(builtin_mock, mock_archive, mock_fetch,
+                                       config, install_mockery, capfd):
     # capfd interferes with Spack's capturing
     with capfd.disabled():
         out = install('build-error', fail_on_error=False)

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -86,7 +86,7 @@ def parse_log_events(logfile, context=6):
 
     log_events = []
     for i, line in enumerate(lines):
-        if re.search('\berror:', line, re.IGNORECASE):
+        if re.search(r'\berror:', line, re.IGNORECASE):
             event = LogEvent(
                 line.strip(),
                 i + 1,

--- a/var/spack/repos/builtin.mock/packages/build-error/package.py
+++ b/var/spack/repos/builtin.mock/packages/build-error/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class BuildError(Package):
+    """This package has an install method that fails in a build script."""
+
+    homepage = "http://www.example.com/trivial_install"
+    url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version('1.0', 'foobarbaz')
+
+    def install(self, spec, prefix):
+        with open('configure', 'w') as f:
+            f.write("""#!/bin/sh\n
+echo 'checking build system type... x86_64-apple-darwin16.6.0'
+echo 'checking host system type... x86_64-apple-darwin16.6.0'
+echo 'checking for gcc... /Users/gamblin2/src/spack/lib/spack/env/clang/clang'
+echo 'checking whether the C compiler works... yes'
+echo 'checking for C compiler default output file name... a.out'
+echo 'checking for suffix of executables...'
+echo 'configure: error: in /path/to/some/file:'
+echo 'configure: error: cannot run C compiled programs.'
+exit 1
+""")
+        configure()


### PR DESCRIPTION
Fix a bug introduced in #5236.

- `'\b'` in regular expression needs to be in a raw string (`r'\b'`)
- Regression test that would've caught this was unintentionally disabled
- Reviewer (me) didn't catch this either 😬 

- [x] This fixes the string and properly adds the test.

@aprokop 
