### PR TITLE
Add --show-log-on-error option to `spack install`

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -60,28 +60,28 @@ the dependencies"""
         '-j', '--jobs', action='store', type=int,
         help="explicitly set number of make jobs. default is #cpus")
     subparser.add_argument(
-        '--keep-prefix', action='store_true', dest='keep_prefix',
+        '--keep-prefix', action='store_true',
         help="don't remove the install prefix if installation fails")
     subparser.add_argument(
-        '--keep-stage', action='store_true', dest='keep_stage',
+        '--keep-stage', action='store_true',
         help="don't remove the build stage if installation succeeds")
     subparser.add_argument(
-        '--restage', action='store_true', dest='restage',
+        '--restage', action='store_true',
         help="if a partial install is detected, delete prior state")
     subparser.add_argument(
         '--source', action='store_true', dest='install_source',
         help="install source files in prefix")
     subparser.add_argument(
-        '-n', '--no-checksum', action='store_true', dest='no_checksum',
+        '-n', '--no-checksum', action='store_true',
         help="do not check packages against checksum")
     subparser.add_argument(
-        '-v', '--verbose', action='store_true', dest='verbose',
+        '-v', '--verbose', action='store_true',
         help="display verbose build output while installing")
     subparser.add_argument(
-        '--fake', action='store_true', dest='fake',
+        '--fake', action='store_true',
         help="fake install. just remove prefix and create a fake file")
     subparser.add_argument(
-        '-f', '--file', action='store_true', dest='file',
+        '-f', '--file', action='store_true',
         help="install from file. Read specs to install from .yaml files")
 
     cd_group = subparser.add_mutually_exclusive_group()
@@ -93,7 +93,7 @@ the dependencies"""
         help="spec of the package to install"
     )
     subparser.add_argument(
-        '--run-tests', action='store_true', dest='run_tests',
+        '--run-tests', action='store_true',
         help="run package level tests during installation"
     )
     subparser.add_argument(

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -785,6 +785,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         """Allow a stage object to be set to override the default."""
         self._stage = stage
 
+    @property
+    def env_path(self):
+        return os.path.join(self.stage.source_path, 'spack-build.env')
+
+    @property
+    def log_path(self):
+        return os.path.join(self.stage.source_path, 'spack-build.out')
+
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least
         # one element (the root package). In case there are resources
@@ -1331,20 +1339,11 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                     self.stage.chdir_to_source()
 
                     # Save the build environment in a file before building.
-                    env_path = join_path(os.getcwd(), 'spack-build.env')
-
-                    # Redirect I/O to a build log (and optionally to
-                    # the terminal)
-                    log_path = join_path(os.getcwd(), 'spack-build.out')
-
-                    # FIXME : refactor this assignment
-                    self.log_path = log_path
-                    self.env_path = env_path
-                    dump_environment(env_path)
+                    dump_environment(self.env_path)
 
                     # Spawn a daemon that reads from a pipe and redirects
                     # everything to log_path
-                    with log_output(log_path, echo, True) as logger:
+                    with log_output(self.log_path, echo, True) as logger:
                         for phase_name, phase_attr in zip(
                                 self.phases, self._InstallPhase_phases):
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -142,3 +142,18 @@ def test_install_with_source(
         spec.prefix.share, 'trivial-install-test-package', 'src')
     assert filecmp.cmp(os.path.join(mock_archive.path, 'configure'),
                        os.path.join(src, 'configure'))
+
+
+def test_show_log_on_error(builtin_mock, mock_archive, mock_fetch,
+                           config, install_mockery, capfd):
+    """Make sure --show-log-on-error works."""
+    with capfd.disabled():
+        out = install('--show-log-on-error', 'build-error',
+                      fail_on_error=False)
+    assert isinstance(install.error, spack.build_environment.ChildError)
+    assert install.error.pkg.name == 'build-error'
+    assert 'Full build log:' in out
+
+    errors = [line for line in out.split('\n')
+              if 'configure: error: cannot run C compiled programs' in line]
+    assert len(errors) == 2


### PR DESCRIPTION
#5387 should be merged before this.

- [x] converted `log_path` and `env_path` to properties of PackageBase.
- [x] InstallErrors in build_environment are now annotated with the package
  that caused them, in the 'pkg' attribute.
- [x] Add `--show-log-on-error` option to `spack install` that catches
  InstallErrors and prints the log to stderr if it exists.

Note that adding a reference to the Pakcage allows a lot of stuff
currently handled by do_install() and build_environment to be handled
externally.

@pramodskumbhar: does this do what you wanted in #5016?

@alalazo @adamjstewart 