### PR TITLE
Version fixes for py-csvkit

### DIFF
--- a/var/spack/repos/builtin/packages/py-csvkit/package.py
+++ b/var/spack/repos/builtin/packages/py-csvkit/package.py
@@ -35,7 +35,8 @@ class PyCsvkit(PythonPackage):
     version('0.9.1', '48d78920019d18846933ee969502fff6')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-dateutil@2.2', type=('build', 'run'))
+    depends_on('py-dateutil@2.2', type=('build', 'run'), when='@0.9.1')
+    depends_on('py-dateutil', type=('build', 'run'), when='@0.9.2:')
     depends_on('py-dbf@0.94.003', type=('build', 'run'))
     depends_on('py-xlrd', type=('build', 'run'))
     depends_on('py-sqlalchemy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-csvkit/package.py
+++ b/var/spack/repos/builtin/packages/py-csvkit/package.py
@@ -35,9 +35,9 @@ class PyCsvkit(PythonPackage):
     version('0.9.1', '48d78920019d18846933ee969502fff6')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-dateutil', type=('build', 'run'))
-    depends_on('py-dbf', type=('build', 'run'))
+    depends_on('py-dateutil@2.2', type=('build', 'run'))
+    depends_on('py-dbf@0.94.003', type=('build', 'run'))
     depends_on('py-xlrd', type=('build', 'run'))
     depends_on('py-sqlalchemy', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-openpyxl', type=('build', 'run'))
+    depends_on('py-openpyxl@2.2.0-b1', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-dateutil/package.py
@@ -33,6 +33,7 @@ class PyDateutil(PythonPackage):
     version('2.4.0', '75714163bb96bedd07685cdb2071b8bc')
     version('2.4.2', '4ef68e1c485b09e9f034e10473e5add2')
     version('2.5.2', 'eafe168e8f404bf384514f5116eedbb6')
+    version('2.2',   'c1f654d0ff7e33999380a8ba9783fd5c')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-dateutil/package.py
@@ -30,10 +30,10 @@ class PyDateutil(PythonPackage):
     homepage = "https://pypi.python.org/pypi/dateutil"
     url      = "https://pypi.io/packages/source/p/python-dateutil/python-dateutil-2.4.0.tar.gz"
 
+    version('2.2',   'c1f654d0ff7e33999380a8ba9783fd5c')
     version('2.4.0', '75714163bb96bedd07685cdb2071b8bc')
     version('2.4.2', '4ef68e1c485b09e9f034e10473e5add2')
     version('2.5.2', 'eafe168e8f404bf384514f5116eedbb6')
-    version('2.2',   'c1f654d0ff7e33999380a8ba9783fd5c')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-dbf/package.py
+++ b/var/spack/repos/builtin/packages/py-dbf/package.py
@@ -33,3 +33,4 @@ class PyDbf(PythonPackage):
     url      = "https://pypi.io/packages/source/d/dbf/dbf-0.96.005.tar.gz"
 
     version('0.96.005', 'bce1a1ed8b454a30606e7e18dd2f8277')
+    version('0.94.003', '33a659ec90d7e8d8ffcd69d2189c0c6c')

--- a/var/spack/repos/builtin/packages/py-openpyxl/package.py
+++ b/var/spack/repos/builtin/packages/py-openpyxl/package.py
@@ -32,6 +32,7 @@ class PyOpenpyxl(PythonPackage):
     url      = "https://pypi.io/packages/source/o/openpyxl/openpyxl-2.4.5.tar.gz"
 
     version('2.4.5', '3de13dc9b731e1a9dd61b873d9b35a8a')
+    version('2.2.0-b1', 'eeefabe384f6e53166c8c2e6abe5d11b')
 
     depends_on('python@2.6:2.8,3.0:3.1,3.3:')
 


### PR DESCRIPTION
Spack doesn't (or can't?) check versions in python package requirements. py-csvkit will install, but running any of the commands will fail when it doesn't find preferred dependency versions.