### PR TITLE
plumed: fixed possible linking issue

### DIFF
--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -148,7 +148,12 @@ class Plumed(AutotoolsPackage):
         # with MPI you should use:
         #
         # > ./configure CXX="$MPICXX"
-        configure_opts = []
+
+        # The configure.ac script may detect the wrong linker for
+        # LD_RO which causes issues at link time. Here we work around
+        # the issue saying we have no LD_RO executable.
+        configure_opts = ['--disable-ld-r']
+
         # If using MPI then ensure the correct compiler wrapper is used.
         if '+mpi' in spec:
             configure_opts.extend([


### PR DESCRIPTION
Due to the logic in configure.ac, we may be using both the system linker (`LD_RO='ld -r -o'`) and the linker tied to the compiler (`LD=$CXX`). This may produce weird link-time errors when the two executables are not the same.

The PR works around the issue by saying LD_RO does not exist.