### PR TITLE
Update git to @2.14.1, requires pcre+jit variant

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -44,6 +44,11 @@ class Git(AutotoolsPackage):
 
     releases = [
         {
+            'version': '2.14.1',
+            'md5': 'e965a37b3d277f2e7e78f5b04de28e2a',
+            'md5_manpages': 'da2e75ea3972b9e93fb47023e3bf1401',
+        },
+        {
             'version': '2.13.0',
             'md5': 'd0f14da0ef1d22f1ce7f7876fadcb39f',
             'md5_manpages': 'fda8d6d5314eb5a47e315405830f9970',
@@ -145,7 +150,8 @@ class Git(AutotoolsPackage):
     depends_on('gettext')
     depends_on('libiconv')
     depends_on('openssl')
-    depends_on('pcre')
+    depends_on('pcre', when='@:2.13')
+    depends_on('pcre+jit', when='@2.14:')
     depends_on('perl')
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -39,12 +39,18 @@ class Pcre(AutotoolsPackage):
 
     patch('intel.patch', when='@8.38')
 
+    variant('jit', default=False,
+            description='Enable JIT support.')
+
     variant('utf', default=True,
             description='Enable support for UTF-8/16/32, '
             'incompatible with EBCDIC.')
 
     def configure_args(self):
         args = []
+
+        if '+jit' in self.spec:
+            args.append('--enable-jit')
 
         if '+utf' in self.spec:
             args.append('--enable-utf')


### PR DESCRIPTION
Update the git package to git@1.14.1.

This requires a pcre that has been built with `--enable-jit`, so I've
added a variant to pcre to support that and arranged so that gits
before 2.14 depend on pcre and after 2.14 depend on pcre+jit.

Lightly tested on CentOS 7.