### PR TITLE
New version for mosh1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/mosh/package.py
+++ b/var/spack/repos/builtin/packages/mosh/package.py
@@ -35,6 +35,7 @@ class Mosh(AutotoolsPackage):
     homepage = "https://mosh.org/"
     url      = "https://mosh.org/mosh-1.2.6.tar.gz"
 
+    version('1.3.2', '5122f4d2b973ab7c38dcdac8c35cb61e')
     version('1.3.0', 'd961276995936953bf2d5a794068b076')
     version('1.2.6', 'bb4e24795bb135a754558176a981ee9e')
 

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -32,7 +32,7 @@ class Protobuf(CMakePackage):
     url      = "https://github.com/google/protobuf/archive/v3.2.0.tar.gz"
     root_cmakelists_dir = "cmake"
 
-    version('3.4.0', '4f47de212ef665ea619f5f97083c6781')
+    version('3.4.0', '1d077a7d4db3d75681f5c333f2de9b1a')
     version('3.2.0', '61d899b8369781f6dd1e62370813392d')
     version('3.1.0', '14a532a7538551d5def317bfca41dace')
     version('3.0.2', '845b39e4b7681a2ddfd8c7f528299fbb')


### PR DESCRIPTION
Required an update to the protobuf digest value, which seems to be amongst the set creamed by GitHub's change.

@tgamblin, @alalazo -- Is this an appropriate way to handle an example the digest conflicts or should I wait for something system wide?

