### PR TITLE
module files: system paths are excluded from path inspection

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -61,6 +61,7 @@ import spack.build_environment as build_environment
 import spack.environment
 import spack.tengine as tengine
 import spack.util.path
+import spack.util.environment
 import spack.error
 
 #: Root folders where the various module files should be written
@@ -473,7 +474,9 @@ class BaseContext(tengine.Context):
         """List of environment modifications to be processed."""
         # Modifications guessed inspecting the spec prefix
         env = spack.environment.inspect_path(
-            self.spec.prefix, prefix_inspections
+            self.spec.prefix,
+            prefix_inspections,
+            exclude=spack.util.environment.is_system_path
         )
 
         # Modifications that are coded at package level

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -30,7 +30,7 @@ from spack import spack_root
 from spack.environment import EnvironmentModifications
 from spack.environment import RemovePath, PrependPath, AppendPath
 from spack.environment import SetEnv, UnsetEnv
-from spack.util.environment import filter_system_paths
+from spack.util.environment import filter_system_paths, is_system_path
 
 
 def test_inspect_path(tmpdir):
@@ -58,6 +58,20 @@ def test_inspect_path(tmpdir):
     assert 'LIBRARY_PATH' in names
     assert 'LD_LIBRARY_PATH' in names
     assert 'CPATH' in names
+
+
+def test_exclude_paths_from_inspection():
+    inspections = {
+        'lib': ['LIBRARY_PATH', 'LD_LIBRARY_PATH'],
+        'lib64': ['LIBRARY_PATH', 'LD_LIBRARY_PATH'],
+        'include': ['CPATH']
+    }
+
+    env = environment.inspect_path(
+        '/usr', inspections, exclude=is_system_path
+    )
+
+    assert len(env) == 0
 
 
 @pytest.fixture()

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -30,8 +30,21 @@ system_dirs = [os.path.join(p, s) for s in suffixes for p in system_paths] + \
     system_paths
 
 
+def is_system_path(path):
+    """Predicate that given a path returns True if it is a system path,
+    False otherwise.
+
+    Args:
+        path (str): path to a directory
+
+    Returns:
+        True or False
+    """
+    return os.path.normpath(path) in system_dirs
+
+
 def filter_system_paths(paths):
-    return [p for p in paths if os.path.normpath(p) not in system_dirs]
+    return [p for p in paths if not is_system_path(p)]
 
 
 def get_path(name):


### PR DESCRIPTION
closes #5201

Currently, if a user sets an external package to have a prefix that is one of the system paths (like `/usr`) the module files that are generated will prepend `/usr/bin` to `PATH`, etc. This is particularly nasty at the time when a module file is unloaded, and e.g. paths like `/usr/bin` will be discarded from `PATH`.

This PR solves the issue skipping system paths when a prefix inspection is made to generate module files.