### PR TITLE
r-xml: updated url and added version 3.98-1.9

### DIFF
--- a/var/spack/repos/builtin/packages/r-xml/package.py
+++ b/var/spack/repos/builtin/packages/r-xml/package.py
@@ -33,7 +33,6 @@ class RXml(RPackage):
     homepage = "https://cran.r-project.org/web/packages/XML/index.html"
     url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.9.tar.gz"
     list_url = homepage
-    
     version('3.98-1.9', '70dd9d711cf3cbd218eb2b870aee9503')
     version('3.98-1.5', 'd1cfcd56f7aec96a84ffca91aea507ee')
     version('3.98-1.4', '1a7f3ce6f264eeb109bfa57bedb26c14')

--- a/var/spack/repos/builtin/packages/r-xml/package.py
+++ b/var/spack/repos/builtin/packages/r-xml/package.py
@@ -30,9 +30,11 @@ class RXml(RPackage):
     (including DTDs), both local and accessible via HTTP or FTP. Also offers
     access to an 'XPath' "interpreter"."""
 
-    homepage = "http://www.omegahat.net/RSXML"
-    url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.4.tar.gz"
-
+    homepage = "https://cran.r-project.org/web/packages/XML/index.html"
+    url      = "https://cran.r-project.org/src/contrib/XML_3.98-1.9.tar.gz"
+    list_url = homepage
+    
+    version('3.98-1.9', '70dd9d711cf3cbd218eb2b870aee9503')
     version('3.98-1.5', 'd1cfcd56f7aec96a84ffca91aea507ee')
     version('3.98-1.4', '1a7f3ce6f264eeb109bfa57bedb26c14')
 


### PR DESCRIPTION
Updated url for package r-xml. The previous one expired. Added version 3.98-1.9.