### PR TITLE
module files: restricted token expansion + case sensitivity

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -309,8 +309,9 @@ def refresh(module_types, specs, args):
             try:
                 x.write(overwrite=True)
             except Exception as e:
-                msg = 'Could not write module file because of {0}: [{1}]'
-                tty.warn(msg.format(str(e), x.layout.filename))
+                msg = 'Could not write module file [{0}]'
+                tty.warn(msg.format(x.layout.filename))
+                tty.warn('\t--> {0} <--'.format(str(e)))
 
 
 def module(parser, args):

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -37,7 +37,12 @@ def _for_each_enabled(spec, method_name):
     """Calls a method for each enabled module"""
     for name in enabled:
         generator = spack.modules.module_types[name](spec)
-        getattr(generator, method_name)()
+        try:
+            getattr(generator, method_name)()
+        except RuntimeError as e:
+            msg = 'cannot perform the requested {0} operation on module files'
+            msg += ' [{1}]'
+            tty.warn(msg.format(method_name, str(e)))
 
 
 post_install = lambda spec: _for_each_enabled(spec, 'write')

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -559,9 +559,27 @@ class BaseContext(tengine.Context):
         blacklist = self.conf.environment_blacklist
 
         # We may have tokens to substitute in environment commands
+
+        # Prepare a suitable transformation dictionary for the names
+        # of the environment variables. This means:
+        #
+        # 1. raising on invalid tokens
+        # 2. turn the valid tokens uppercase
+        #
         transform = _token_invalidator(
             'token {0} cannot be expanded in an environment variable name'
         )
+        valid_tokens = (
+            'PACKAGE',
+            'VERSION',
+            'COMPILER',
+            'COMPILERNAME',
+            'COMPILERVER',
+            'ARCHITECTURE'
+        )
+        for token in valid_tokens:
+            transform[token] = str.upper
+
         for x in env:
             x.name = self.spec.format(x.name, transform=transform)
             try:
@@ -569,7 +587,7 @@ class BaseContext(tengine.Context):
                 x.value = self.spec.format(x.value)
             except AttributeError:
                 pass
-            x.name = str(x.name).replace('-', '_').upper()
+            x.name = str(x.name).replace('-', '_')
 
         return [(type(x).__name__, x) for x in env if x.name not in blacklist]
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2821,9 +2821,10 @@ class Spec(object):
         return colorize_spec(self)
 
     def format(self, format_string='$_$@$%@+$+$=', **kwargs):
-        """
-        Prints out particular pieces of a spec, depending on what is
-        in the format string.  The format strings you can provide are::
+        """Prints out particular pieces of a spec, depending on what is
+        in the format string.
+
+        The format strings you can provide are::
 
             $_   Package name
             $.   Full package name (with namespace)
@@ -2865,13 +2866,40 @@ class Spec(object):
 
         Anything else is copied verbatim into the output stream.
 
-        *Example:*  ``$_$@$+`` translates to the name, version, and options
-        of the package, but no dependencies, arch, or compiler.
+        Args:
+            format_string (str): string containing the format to be expanded
+
+            **kwargs (dict): the following list of keywords is supported
+
+                - color (bool): True if returned string is colored
+
+                - transform (dict): maps full-string formats to a callable \
+                that accepts a string and returns another one
+
+        Examples:
+
+            The following line:
+
+            .. code-block:: python
+
+                s = spec.format('$_$@$+')
+
+            translates to the name, version, and options of the package, but no
+            dependencies, arch, or compiler.
 
         TODO: allow, e.g., ``$6#`` to customize short hash length
         TODO: allow, e.g., ``$//`` for full hash.
         """
         color = kwargs.get('color', False)
+
+        # Set up a dictionary of transformations for named tokens.
+        # The default is to leave the string unchanged.
+        #
+        # The expression `lambda: lambda x: x` is the shortest and neatest
+        # way to have a factory of identity functions in python
+        tr = collections.defaultdict(lambda: lambda x: x)
+        tr.update(kwargs.get('transform', {}))
+
         length = len(format_string)
         out = StringIO()
         named = escape = compiler = False
@@ -2950,37 +2978,41 @@ class Spec(object):
                 named_str = named_str.upper()
                 if named_str == 'PACKAGE':
                     name = self.name if self.name else ''
-                    write(fmt % self.name, '@')
+                    write(fmt % tr[named_str](self.name), '@')
                 if named_str == 'VERSION':
                     if self.versions and self.versions != _any_version:
-                        write(fmt % str(self.versions), '@')
+                        write(fmt % tr[named_str](str(self.versions)), '@')
                 elif named_str == 'COMPILER':
                     if self.compiler:
-                        write(fmt % self.compiler, '%')
+                        write(fmt % tr[named_str](self.compiler), '%')
                 elif named_str == 'COMPILERNAME':
                     if self.compiler:
-                        write(fmt % self.compiler.name, '%')
+                        write(fmt % tr[named_str](self.compiler.name), '%')
                 elif named_str in ['COMPILERVER', 'COMPILERVERSION']:
                     if self.compiler:
-                        write(fmt % self.compiler.versions, '%')
+                        write(fmt % tr[named_str](self.compiler.versions), '%')
                 elif named_str == 'COMPILERFLAGS':
                     if self.compiler:
-                        write(fmt % str(self.compiler_flags), '%')
+                        write(
+                            fmt % tr[named_str](str(self.compiler_flags)), '%'
+                        )
                 elif named_str == 'OPTIONS':
-                    if self.variants:
-                        write(fmt % str(self.variants), '+')
+                    # Not all concretized specs have variants, but we still
+                    # want to run the transformation function on the variants
+                    if hasattr(self, 'variants'):
+                        write(fmt % tr[named_str](str(self.variants)), '+')
                 elif named_str == 'ARCHITECTURE':
                     if self.architecture and str(self.architecture):
-                        write(fmt % str(self.architecture), '=')
+                        write(fmt % tr[named_str](str(self.architecture)), '=')
                 elif named_str == 'SHA1':
                     if self.dependencies:
-                        out.write(fmt % str(self.dag_hash(7)))
+                        out.write(fmt % tr[named_str](str(self.dag_hash(7))))
                 elif named_str == 'SPACK_ROOT':
-                    out.write(fmt % spack.prefix)
+                    out.write(fmt % tr[named_str](spack.prefix))
                 elif named_str == 'SPACK_INSTALL':
-                    out.write(fmt % spack.store.root)
+                    out.write(fmt % tr[named_str](spack.store.root))
                 elif named_str == 'PREFIX':
-                    out.write(fmt % self.prefix)
+                    out.write(fmt % tr[named_str](self.prefix))
                 elif named_str.startswith('HASH'):
                     if named_str.startswith('HASH:'):
                         _, hashlen = named_str.split(':')

--- a/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
@@ -13,6 +13,7 @@ tcl:
     environment:
       set:
         FOO: 'foo'
+        OMPI_MCA_mpi_leave_pinned: '1'
       unset:
         - BAR
 

--- a/lib/spack/spack/test/data/modules/tcl/invalid_naming_scheme.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/invalid_naming_scheme.yaml
@@ -1,0 +1,5 @@
+enable:
+  - tcl
+tcl:
+  # ${OPTIONS} is not allowed in the naming scheme, see #2884
+  naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${OPTIONS}'

--- a/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
@@ -1,0 +1,21 @@
+enable:
+  - tcl
+tcl:
+  all:
+    filter:
+      environment_blacklist':
+        - CMAKE_PREFIX_PATH
+    environment:
+      set:
+        '${PACKAGE}_ROOT_${PREFIX}': '${PREFIX}'
+
+  'platform=test target=x86_64':
+    environment:
+      set:
+        FOO_${OPTIONS}: 'foo'
+      unset:
+        - BAR
+
+  'platform=test target=x86_32':
+    load:
+      - 'foo/bar'

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -168,6 +168,26 @@ class TestTcl(object):
 
         assert writer.conf.naming_scheme == expected
 
+    def test_invalid_naming_scheme(self, factory, patch_configuration):
+        """Tests the evaluation of an invalid naming scheme."""
+
+        patch_configuration('invalid_naming_scheme')
+
+        # Test that having invalid tokens in the naming scheme raises
+        # a RuntimeError
+        writer, _ = factory('mpileaks')
+        with pytest.raises(RuntimeError):
+            writer.layout.use_name
+
+    def test_invalid_token_in_env_name(self, factory, patch_configuration):
+        """Tests setting environment variables with an invalid name."""
+
+        patch_configuration('invalid_token_in_env_var_name')
+
+        writer, _ = factory('mpileaks')
+        with pytest.raises(RuntimeError):
+            writer.write()
+
     def test_conflicts(self, modulefile_content, patch_configuration):
         """Tests adding conflicts to the module."""
 

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -121,6 +121,12 @@ class TestTcl(object):
                     if x.startswith('prepend-path CMAKE_PREFIX_PATH')
                     ]) == 0
         assert len([x for x in content if 'setenv FOO "foo"' in x]) == 1
+        assert len([
+            x for x in content if 'setenv OMPI_MCA_mpi_leave_pinned "1"' in x
+        ]) == 1
+        assert len([
+            x for x in content if 'setenv OMPI_MCA_MPI_LEAVE_PINNED "1"' in x
+        ]) == 0
         assert len([x for x in content if 'unsetenv BAR' in x]) == 1
         assert len([x for x in content if 'setenv MPILEAKS_ROOT' in x]) == 1
 


### PR DESCRIPTION
closes #2884 
closes #4684 

This PR restricts the token that can be expanded in the module file naming scheme and in the name of an environment variable to just `PACKAGE`, `VERSION`, `COMPILER`, `COMPILERNAME`, `COMPILERVER` and  `ARCHITECTURE` (as discussed in #2884). It does so extending `Spec.format` with an optional parameter that contains a list of transformation functions (one for each token, the default being the identity function).

This new mechanism is then exploited to solve #4684. This PR changes the behavior for the expansion of tokens in environment variable names so that it respects the case sensitivity of the literal parts (token expanded in that context are still made uppercase).

### PR in action

With a `modules.yaml` that looks like:
```yaml
modules:
  tcl:
    naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${COMPILERVER}-${OPTIONS}'
```
where `OPTIONS` is an invalid token, we get a warning and the module file is not written:
```console
$ spack install libszip
==> Installing libszip
==> Using cached archive: /home/mculpo/PycharmProjects/spack/var/spack/cache/libszip/libszip-2.1.1.tar.gz
==> Staging archive: /home/mculpo/PycharmProjects/spack/var/spack/stage/libszip-2.1.1-bg2wewqg2rfxg4rypj7u2lfvmhnxcug5/szip-2.1.1.tar.gz
==> Created stage in /home/mculpo/PycharmProjects/spack/var/spack/stage/libszip-2.1.1-bg2wewqg2rfxg4rypj7u2lfvmhnxcug5
==> No patches needed for libszip
==> Building libszip [AutotoolsPackage]
==> Executing phase: 'autoreconf'
==> Executing phase: 'configure'
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Warning: cannot perform the requested write operation on module files [token OPTIONS cannot be part of the module naming scheme]
==> Successfully installed libszip
  Fetch: 0.01s.  Build: 5.58s.  Total: 5.59s.
[+] /home/mculpo/PycharmProjects/spack/opt/spack/linux-ubuntu14.04-x86_64/gcc-7.2.0/libszip-2.1.1-bg2wewqg2rfxg4rypj7u2lfvmhnxcug5
```
The same holds true for:
```console
$ spack module refresh -m tcl libszip
==> You are about to regenerate tcl module files for:

-- linux-ubuntu14.04-x86_64 / gcc@4.8 ---------------------------
qabk3nm libszip@2.1.1

-- linux-ubuntu14.04-x86_64 / gcc@7.2.0 -------------------------
bg2wewq libszip@2.1.1

==> Do you want to proceed? [y/n] y
==> Error: token OPTIONS cannot be part of the module naming scheme
```

---

There are a few lines of comments in the commit messages, so in case we should rebase and merge this (instead of squashing it)?
