### PR TITLE
snappy: Update to 1.1.7

### DIFF
--- a/var/spack/repos/builtin/packages/snappy/package.py
+++ b/var/spack/repos/builtin/packages/snappy/package.py
@@ -25,10 +25,26 @@
 from spack import *
 
 
-class Snappy(AutotoolsPackage):
+class Snappy(CMakePackage):
     """A fast compressor/decompressor: https://code.google.com/p/snappy"""
 
-    homepage = "https://code.google.com/p/snappy"
-    url      = "https://github.com/google/snappy/releases/download/1.1.3/snappy-1.1.3.tar.gz"
+    homepage = "https://github.com/google/snappy"
+    url      = "https://github.com/google/snappy/archive/1.1.7.tar.gz"
 
-    version('1.1.3', '7358c82f133dc77798e4c2062a749b73')
+    version('1.1.7', 'ee9086291c9ae8deb4dac5e0b85bf54a')
+
+    @run_after('install')
+    def install_pkgconfig(self):
+        mkdirp(self.prefix.lib.pkgconfig)
+
+        with open(join_path(self.prefix.lib.pkgconfig, 'snappy.pc'), 'w') as f:
+            f.write('prefix={0}\n'.format(self.prefix))
+            f.write('exec_prefix=${prefix}\n')
+            f.write('libdir={0}\n'.format(self.prefix.lib))
+            f.write('includedir={0}\n'.format(self.prefix.include))
+            f.write('\n')
+            f.write('Name: Snappy\n')
+            f.write('Description: A fast compressor/decompressor.\n')
+            f.write('Version: {0}\n'.format(self.spec.version))
+            f.write('Cflags: -I${includedir}\n')
+            f.write('Libs: -L${libdir} -lsnappy\n')


### PR DESCRIPTION
Convert to CMakePackage and add a pkg-config file (otherwise libmongoc's pkg-config file does not contain all required flags).