### PR TITLE
Restrict openfoam to using openmpi+thread_multiple

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -292,6 +292,10 @@ class OpenfoamCom(Package):
 
     provides('openfoam')
     depends_on('mpi')
+
+    # After 1712 require openmpi+thread_multiple for collated output
+    conflicts('^openmpi~thread_multiple', when='@1712:')
+
     depends_on('zlib')
     depends_on('fftw')
     depends_on('boost')


### PR DESCRIPTION
partially resolves #5428

- The newest openfoam version requires openmpi+thread_multiple for
  collated output.

Added in two safety mechanisms.

- A spec-level conflict, but also raise an InstallError if the mpi
  provider has resolved to openmpi without the +thread_multiple
  variant. This additional check unfortunately seems to be required
  for the additional openmpi constraint, since openfoam only directly
  depends_on 'mpi', not on 'openmpi'.

  Without this runtime check, the user could easily compile and
  install with the incorrect openmpi configuration and experience
  various issues with openfoam.