### PR TITLE
One liner to fix tag for Amrex development branch

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -35,7 +35,7 @@ class Amrex(CMakePackage):
 
     version('17.06', git='https://github.com/AMReX-Codes/amrex.git', commit='836d3c7')
     version('master', git='https://github.com/AMReX-Codes/amrex.git', tag='master')
-    version('develop', git='https://github.com/AMReX-Codes/amrex.git', tag='develop')
+    version('develop', git='https://github.com/AMReX-Codes/amrex.git', tag='development')
 
     variant('dims',
         default='3',


### PR DESCRIPTION
The tag for amrex to download the develop version was incorrect. It was `develop` but needed to be `development`