### PR TITLE
Pull request for new version of SZ1.4.11

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -35,6 +35,8 @@ class Sz(AutotoolsPackage):
     version('develop', git='https://github.com/disheng222/SZ.git',
             branch='master')
     version('1.4.11.0', '10dee28b3503821579ce35a50e352cc6')
+    version('1.4.10.0', '82e23dc5a51bcce1f70ba7e3b68a5965')
+    version('1.4.9.2',  '028ce90165b7a4c4051d4c0189f193c0')
 
     variant('fortran', default=False,
             description='Enable fortran compilation')

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -30,11 +30,11 @@ class Sz(AutotoolsPackage):
     """Error-bounded Lossy Compressor for HPC Data."""
 
     homepage = "https://collab.cels.anl.gov/display/ESR/SZ"
-    url      = "https://github.com/disheng222/SZ/archive/v1.4.9.2.tar.gz"
+    url      = "https://github.com/disheng222/SZ/archive/v1.4.11.0.tar.gz"
 
     version('develop', git='https://github.com/disheng222/SZ.git',
             branch='master')
-    version('1.4.9.2', '028ce90165b7a4c4051d4c0189f193c0')
+    version('1.4.11.0', '10dee28b3503821579ce35a50e352cc6')
 
     variant('fortran', default=False,
             description='Enable fortran compilation')


### PR DESCRIPTION
Hi,
I didn't realize the previous SPACK version I was working on is not the latest one. 
I have pulled the SPACK again, and there should be no merge conflicts now. 
Please use the latest version of SZ instead in your package. 
We added the executable (called sz) in the new version, and also fixed some bugs. 

Thanks.

Best,
Sheng 