### PR TITLE
modules: specialized configure_options for external packages

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -457,16 +457,24 @@ class BaseContext(tengine.Context):
     def configure_options(self):
         pkg = self.spec.package
 
+        # If the spec is external Spack doesn't know its configure options
+        if self.spec.external:
+            msg = 'unknown, software installed outside of Spack'
+            return msg
+
         # This is quite simple right now, but contains information on how
         # to call different build system classes.
         for attr in ('configure_args', 'cmake_args'):
             try:
                 configure_args = getattr(pkg, attr)()
                 return ' '.join(configure_args)
-            except (AttributeError, IOError):
+            except (AttributeError, IOError, KeyError):
+                # The method doesn't exist in the current spec,
+                # or it's not usable
                 pass
 
-        # The default is to return None
+        # Returning a false-like value makes the default templates skip
+        # the configure option section
         return None
 
     @tengine.context_property

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -236,3 +236,13 @@ class TestLmod(object):
 
         content = modulefile_content('mpileaks arch=x86-linux')
         assert 'Override even better!' in content
+
+    @pytest.mark.usefixtures('config')
+    def test_external_configure_args(
+            self, factory
+    ):
+        # If this package is detected as an external, its configure option line
+        # in the module file starts with 'unknown'
+        writer, spec = factory('externaltool')
+
+        assert 'unknown' in writer.context.configure_options


### PR DESCRIPTION
closes #5473

Prior to this PR we were not exiting early for external packages, which caused the `configure_options` property of the contexts to fail with e.g. a key error because the DAG gets truncated for them. More importantly Spack configure options don't make any sense for externals.

Now we exit early, and leave a message in the module file clarifying that this package has been installed outside of Spack.