### PR TITLE
Use plain environment when expanding archives

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -325,7 +325,7 @@ class URLFetchStrategy(FetchStrategy):
                                          "spack-expanded-archive")
         mkdirp(tarball_container)
         os.chdir(tarball_container)
-        decompress(self.archive_file)
+        decompress(self.archive_file, env={})
 
         # Check for an exploding tarball, i.e. one that doesn't expand
         # to a single directory.  If the tarball *didn't* explode,


### PR DESCRIPTION
#3018 had been bugging me for a while.  In short, installing Boost with the Intel compiler would crash when attempting to expand the .tar.bz2 archive file.  But calling the tar command by hand would work fine.