### PR TITLE
libpng: zlib path

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -51,3 +51,13 @@ class Libpng(AutotoolsPackage):
     version('1.2.57', 'dfcda3603e29dcc11870c48f838ef75b')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended
+
+    def configure_args(self):
+        args = [
+            # not honored, see
+            #   https://sourceforge.net/p/libpng/bugs/210/#33f1
+            # '--with-zlib=' + self.spec['zlib'].prefix,
+            'CFLAGS=-I{0}'.format(self.spec['zlib'].prefix.include),
+            'LDFLAGS=-L{0}'.format(self.spec['zlib'].prefix.lib)
+        ]
+        return args


### PR DESCRIPTION
explicitly set the zlib path for libpng configure.

Unfortunately, the standard [`--with-zlib=/the/zlib/path`](https://sourceforge.net/p/libpng/bugs/210/#33f1) is not supported (yet?) or broken in `libpng`, so we set flags. 

Reviewers: Please cross-check if this works well with additional flags set by users, so e.g. a user's `-O3` is still propagated.

fixes:
```
     [ ... ]
     92    checking for memset... yes
     93    checking for pow... no
     94    checking for pow in -lm... yes
     95    checking for clock_gettime... yes
     96    checking for zlibVersion in -lz... no
     97    checking for z_zlibVersion in -lz... no
  >> 98    configure: error: zlib not installed
```

Seen on a minimal ubuntu image (yes, zlib is not installed in *all* environments ^^)