### PR TITLE
Tell configure about gmp (partial fix for #5564)

### DIFF
--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -42,3 +42,9 @@ class Mpfr(AutotoolsPackage):
 
     patch('vasprintf.patch', when='@3.1.5')
     patch('strtofr.patch',   when='@3.1.5')
+
+    def configure_args(self):
+        args = [
+            '--with-gmp=' + self.spec['gmp'].prefix,
+        ]
+        return args


### PR DESCRIPTION
This is a partial fix for #5564.

This package used to trust that `configure` would discover `gmp` from its environment.

It's safer to tell it where to find `gmp` explicitly.

This does that by adding a configure_args() that provides a `--with-gmp=...` argument for configure.

Lightly tested on CentOS 7.

I'm still running in to something that looks like #5578.