### PR TITLE
Fix environment dependency collection bug

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -191,9 +191,9 @@ def set_build_environment_variables(pkg, env, dirty):
         dirty (bool): Skip unsetting the user's environment settings
     """
     # Gather information about various types of dependencies
-    build_deps      = pkg.spec.dependencies(deptype=('build', 'test'))
-    link_deps       = pkg.spec.traverse(root=False, deptype=('link'))
-    build_link_deps = list(build_deps) + list(link_deps)
+    build_deps      = set(pkg.spec.dependencies(deptype=('build', 'test')))
+    link_deps       = set(pkg.spec.traverse(root=False, deptype=('link')))
+    build_link_deps = build_deps | link_deps
     rpath_deps      = get_rpath_deps(pkg)
 
     build_prefixes      = [dep.prefix for dep in build_deps]


### PR DESCRIPTION
Fixes https://github.com/LLNL/spack/issues/5564

#5132 added a bug in dependency collection: a generator storing link dependencies was iterated over twice. The first iteration exhausted it and so they were not available when retrieved the second time.