### PR TITLE
multi-valued variants comparison fix

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -369,6 +369,15 @@ class MultiValuedVariant(AbstractVariant):
         # Otherwise we want all the values in `other` to be also in `self`
         return all(v in self.value for v in other.value)
 
+    def _cmp_key(self):
+        if isinstance(self.value, basestring):
+            return self.name, self.value
+        try:
+            iter(self.value)
+            return self.name, tuple(sorted(self.value))
+        except:
+            return self.name, self.value
+
 
 class SingleValuedVariant(MultiValuedVariant):
     """A variant that can hold multiple values, but one at a time."""

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -267,9 +267,6 @@ class AbstractVariant(object):
         # to a set
         self._value = tuple(sorted(set(value)))
 
-    def _cmp_key(self):
-        return self.name, self.value
-
     def copy(self):
         """Returns an instance of a variant equivalent to self
 
@@ -370,13 +367,7 @@ class MultiValuedVariant(AbstractVariant):
         return all(v in self.value for v in other.value)
 
     def _cmp_key(self):
-        if isinstance(self.value, basestring):
-            return self.name, self.value
-        try:
-            iter(self.value)
-            return self.name, tuple(sorted(self.value))
-        except:
-            return self.name, self.value
+        return self.name, tuple(sorted(self.value))
 
 
 class SingleValuedVariant(MultiValuedVariant):
@@ -418,6 +409,9 @@ class SingleValuedVariant(MultiValuedVariant):
     def __contains__(self, item):
         return item == self.value
 
+    def _cmp_key(self):
+        return self.name, self.value
+
     def yaml_entry(self):
         return self.name, self.value
 
@@ -441,6 +435,9 @@ class BoolValuedVariant(SingleValuedVariant):
 
     def __contains__(self, item):
         return item is self.value
+
+    def _cmp_key(self):
+        return self.name, self.value
 
     def __str__(self):
         return '{0}{1}'.format('+' if self.value else '~', self.name)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -192,7 +192,6 @@ def implicit_variant_conversion(method):
     return convert
 
 
-@lang.key_ordering
 class AbstractVariant(object):
     """A variant that has not yet decided who it wants to be. It behaves like
     a multi valued variant which **could** do things.
@@ -345,6 +344,7 @@ class AbstractVariant(object):
         )
 
 
+@lang.key_ordering
 class MultiValuedVariant(AbstractVariant):
     """A variant that can hold multiple values at once."""
     @implicit_variant_conversion


### PR DESCRIPTION
Fixes https://github.com/LLNL/spack/issues/5587

@alalazo, @tgamblin 

While debugging #5587 I noticed the following:

```
(Pdb) x = spec.copy(deps=('link', 'run'))
(Pdb) x
    mpfr@3.1.5%gcc@4.6.1 patches=88dfefa6d39c9fd5a26a40d9bbc73df8da93f946c65c06038026261d78d919f5,dfd62a42a239c427bb44087b4a520edbcd65bae6ad1fbe07303c96ee8696afbd arch=linux-rhel6-x86_64 ^gmp@6.1.2%gcc@4.6.1 arch=linux-rhel6-x86_64
(Pdb) installed_spec
    mpfr@3.1.5%gcc@4.6.1 patches=dfd62a42a239c427bb44087b4a520edbcd65bae6ad1fbe07303c96ee8696afbd,88dfefa6d39c9fd5a26a40d9bbc73df8da93f946c65c06038026261d78d919f5 arch=linux-rhel6-x86_64 ^gmp@6.1.2%gcc@4.6.1 arch=linux-rhel6-x86_64
```

And noticed the patches are differently-ordered in the two specs, which led me to look at `_cmp_key` for variants. It looks like multi-valued variants arbitrarily order their values which was resulting in a failed comparison.

This is hackish and WIP but demonstrates the issue.