### PR TITLE
Patches: the underlying MV variant now uses the property setter

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1813,9 +1813,10 @@ class Spec(object):
                         patches.append(patch.sha256)
             if patches:
                 # Special-case: keeps variant values unique but ordered.
-                s.variants['patches'] = MultiValuedVariant('patches', ())
-                mvar = s.variants['patches']
-                mvar._value = mvar._original_value = tuple(dedupe(patches))
+                mvar = s.variants.setdefault(
+                    'patches', MultiValuedVariant('patches', ())
+                )
+                mvar.value = patches
 
         # Apply patches required on dependencies by depends_on(..., patch=...)
         for dspec in self.traverse_edges(deptype=all,
@@ -1834,13 +1835,10 @@ class Spec(object):
             if patches:
                 # note that we use a special multi-valued variant and
                 # keep the patches ordered.
-                if 'patches' not in dspec.spec.variants:
-                    mvar = MultiValuedVariant('patches', ())
-                    dspec.spec.variants['patches'] = mvar
-                else:
-                    mvar = dspec.spec.variants['patches']
-                mvar._value = mvar._original_value = tuple(
-                    dedupe(list(mvar._value) + patches))
+                mvar = dspec.spec.variants.setdefault(
+                    'patches', MultiValuedVariant('patches', ())
+                )
+                mvar.value = mvar.value + tuple(patches)
 
         for s in self.traverse():
             if s.external_module:

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -99,9 +99,11 @@ def test_patch_in_spec(builtin_mock, config):
     spec.concretize()
     assert 'patches' in list(spec.variants.keys())
 
-    # foo, bar, baz
-    assert (('b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',
-             '7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730',
+    # Here the order is bar, foo, baz. Note that MV variants order
+    # lexicographically based on the hash, not on the position of the
+    # patch directive.
+    assert (('7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730',
+             'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c',
              'bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c') ==
             spec.variants['patches'].value)
 
@@ -131,8 +133,8 @@ def test_multiple_patched_dependencies(builtin_mock, config):
     # URL patches
     assert 'patches' in list(spec['fake'].variants.keys())
     # urlpatch.patch, urlpatch.patch.gz
-    assert (('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
-             '1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd') ==
+    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
+             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
             spec['fake'].variants['patches'].value)
 
 
@@ -159,8 +161,8 @@ def test_conditional_patched_dependencies(builtin_mock, config):
     # URL patches
     assert 'patches' in list(spec['fake'].variants.keys())
     # urlpatch.patch, urlpatch.patch.gz
-    assert (('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
-             '1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd') ==
+    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
+             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
             spec['fake'].variants['patches'].value)
 
 
@@ -187,6 +189,6 @@ def test_conditional_patched_deps_with_conditions(builtin_mock, config):
     # URL patches
     assert 'patches' in list(spec['fake'].variants.keys())
     # urlpatch.patch, urlpatch.patch.gz
-    assert (('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
-             '1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd') ==
+    assert (('1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd',
+             'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234') ==
             spec['fake'].variants['patches'].value)


### PR DESCRIPTION
refers #5587
closes #5593

The implementation introduced in #5476 used `dedupe` to set a private member of a `MultiValuedVariant` object. `dedupe` is meant to give a stable deduplication of the items in a sequence, and *returns an object whose value depends on the order of the items in its argument*. 

Now the private member is set implicitly using the associated property setter. The logic changes from stable deduplication to a totally ordered deduplication (i.e. instead of `dedupe(t)` it uses `sorted(set(t))`). 

This should also grant that packages that shuffle the same set of patch directives maintain the same hash. I didn't try that out, but looking at the implementation I expect:
```python
class A(Package):
    
    patch('foo.patch')
    patch('bar.patch')
    patch('baz.patch')
```
to have a different hash in `develop` with respect to:
```python
class A(Package):
    
    # The order of directives changes here
    patch('bar.patch')
    patch('baz.patch')
    patch('foo.patch')
```
while it should give the same hash now. 

~@tgamblin Was the previous implementation done on purpose out of concerns of the order of application of patches?~

EDIT: after reading the code in #5476 I can say for sure that the answer to the question above is yes. This PR is currently a work in progress because I need to figure out the best way to ensure the right order of application for patches.

Probably there are also workarounds that could maintain the same logic as in `develop`, even though I argue that setting private attributes to by-pass a setter is not a best-practice (and fires back sometimes :smile:).