### PR TITLE
extensions: create install prefixes

### DIFF
--- a/var/spack/repos/builtin.mock/packages/extendee/package.py
+++ b/var/spack/repos/builtin.mock/packages/extendee/package.py
@@ -36,4 +36,4 @@ class Extendee(Package):
     version('1.0', 'hash-extendee-1.0')
 
     def install(self, spec, prefix):
-        pass
+        mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension1/package.py
@@ -36,4 +36,4 @@ class Extension1(Package):
     version('1.0', 'hash-extension1-1.0')
 
     def install(self, spec, prefix):
-        pass
+        mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension2/package.py
@@ -38,4 +38,4 @@ class Extension2(Package):
     version('1.0', 'hash-extension2-1.0')
 
     def install(self, spec, prefix):
-        pass
+        mkdirp(prefix.bin)


### PR DESCRIPTION
Tests fail locally because the install prefix doesn't exist. Make them
exist.