### PR TITLE
spec.patches: access values rather than keys

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2535,8 +2535,9 @@ class Spec(object):
 
             # if not found in this package, check immediate dependents
             # for dependency patches
-            for dep in self._dependents:
-                patch = dep.parent.package.lookup_patch(sha256)
+            for dep_spec in self._dependents.values():
+                patch = dep_spec.parent.package.lookup_patch(sha256)
+
                 if patch:
                     patches.append(patch)
 


### PR DESCRIPTION
Fix #5602

@tgamblin @becker33

This fixes a loop that was iterating through the keys of a dictionary when it was intending to use the values.