### PR TITLE
Add beta warning for flag handlers

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2572,6 +2572,11 @@ passes those flags to the relevant environment variables (``CFLAGS``,
 packages, the default behavior is to inject the flags directly into the
 compiler commands using Spack's compiler wrappers.
 
+.. warning::
+
+   The flag handling methods described in this section are in beta.
+   The exact semantics are liable to change to improve usability.
+
 Individual packages can override the default behavior for the flag
 handling.  Packages can define a ``default_flag_handler`` method that
 applies to all sets of flags handled by Spack, or may define


### PR DESCRIPTION
Identify the flag handlers feature as beta.

I/We have come to believe that the initial implementation of this feature was significantly flawed. The methods will stay, but the exact semantics behind them are likely to change.

To minimize user pain as they change I've added a warning to the documentation saying that they are in beta.