### PR TITLE
Add link dependency on xproto to xau (recent dependency mechanics changes?)

### DIFF
--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -37,9 +37,9 @@ class Libx11(AutotoolsPackage):
     depends_on('libxcb@1.1.92:')
 
     depends_on('xproto@7.0.17:', type='build')
-    depends_on('xextproto', type='build')
+    depends_on('xextproto', type=('build', 'link'))
     depends_on('xtrans', type='build')
-    depends_on('kbproto', type='build')
+    depends_on('kbproto', type=('build', 'link'))
     depends_on('inputproto', type='build')
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -35,6 +35,6 @@ class Libxau(AutotoolsPackage):
 
     version('1.0.8', 'a85cd601d82bc79c0daa280917572e20')
 
-    depends_on('xproto', type=('build','link'))
+    depends_on('xproto', type=('build', 'link'))
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxau/package.py
+++ b/var/spack/repos/builtin/packages/libxau/package.py
@@ -35,6 +35,6 @@ class Libxau(AutotoolsPackage):
 
     version('1.0.8', 'a85cd601d82bc79c0daa280917572e20')
 
-    depends_on('xproto', type='build')
+    depends_on('xproto', type=('build','link'))
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -36,6 +36,6 @@ class Libxrender(AutotoolsPackage):
 
     depends_on('libx11@1.6:')
 
-    depends_on('renderproto@0.9:', type='build')
+    depends_on('renderproto@0.9:', type=('build', 'link'))
     depends_on('pkg-config@0.9.0:', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
The libxcb build was failing like so:

```
1 error found in build log:
     [ ... ]
     131   checking whether to build developer documentation... yes
     132   checking for doxygen... /usr/bin/doxygen
     133   checking for dot... /usr/bin/dot
     134   checking for CHECK... no
     135   checking for XCBPROTO... yes
     136   checking for NEEDED... no
  >> 137   configure: error: Package requirements (pthread-stubs xau >= 0.99.2) were not met:
     138
     139   Package 'xproto', required by 'xau', not found
     140
     141   Consider adjusting the PKG_CONFIG_PATH environment variable if you
     142   installed software in a non-standard prefix.
     143
```

This adds a link dependency on libxproto that allows the libxcb build to
succeed.