### PR TITLE
Add a package for VarDictJava@1.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/vardictjava/package.py
+++ b/var/spack/repos/builtin/packages/vardictjava/package.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import glob
+
+
+class Vardictjava(Package):
+    """VarDictJava is a variant discovery program written in Java.
+    It is a partial Java port of VarDict variant caller."""
+
+    homepage = "https://github.com/AstraZeneca-NGS/VarDictJava"
+    url      = "https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v1.5.1/VarDict-1.5.1.tar"
+
+    version('1.5.1', '8c0387bcc1f7dc696b04e926c48b27e6')
+
+    depends_on('java@8:', type='run')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install('bin/VarDict', prefix.bin)
+
+        mkdirp(prefix.lib)
+        files = [x for x in glob.glob("lib/*jar")]
+        for f in files:
+            install(f, prefix.lib)


### PR DESCRIPTION
This is a simple package that drops their shell wrapper into prefix.bin and their jar files into prefix.lib (based on the approach used by the picard package).