### PR TITLE
Nghttp2 new package

### DIFF
--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -32,7 +32,3 @@ class Nghttp2(AutotoolsPackage):
     url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
 
     version('1.26.0', '83fa813b22bacbc6ea80dfb24847569f')
-
-    def configure_args(self):
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -33,11 +33,6 @@ class Nghttp2(AutotoolsPackage):
 
     version('1.26.0', '83fa813b22bacbc6ea80dfb24847569f')
 
-    # FIXME: Add dependencies if required.
-    # depends_on('foo')
-
     def configure_args(self):
-        # FIXME: Add arguments other than --prefix
-        # FIXME: If not needed delete this function
         args = []
         return args

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Nghttp2(AutotoolsPackage):
+    """nghttp2 is an implementation of HTTP/2 and its header compression algorithm HPACK in C."""
+
+    homepage = "https://nghttp2.org/"
+    url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
+
+    version('1.26.0', '83fa813b22bacbc6ea80dfb24847569f')
+
+    # FIXME: Add dependencies if required.
+    # depends_on('foo')
+
+    def configure_args(self):
+        # FIXME: Add arguments other than --prefix
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -26,7 +26,8 @@ from spack import *
 
 
 class Nghttp2(AutotoolsPackage):
-    """nghttp2 is an implementation of HTTP/2 and its header compression algorithm HPACK in C."""
+    """nghttp2 is an implementation of HTTP/2 and its header compression
+       algorithm HPACK in C."""
 
     homepage = "https://nghttp2.org/"
     url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"


### PR DESCRIPTION
Add a package for nghttp2, which is useful for the soon-to-be-submitted update adding HTTP/2 support to the curl package.

@peetsv gets any credit and most of the blame for this work, I'm just passing it over the wall.