### PR TITLE
Don't check package.installed in _mark_concrete if value=True

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1888,7 +1888,7 @@ class Spec(object):
         unless there is a need to force a spec to be concrete.
         """
         for s in self.traverse(deptype_query=all):
-            if s.concrete and s.package.installed:
+            if (not value) and s.concrete and s.package.installed:
                 continue
             s._normal = value
             s._concrete = value

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -32,6 +32,7 @@ import os.path
 import pytest
 import spack
 import spack.store
+from spack.test.conftest import MockPackageMultiRepo
 from spack.util.executable import Executable
 from llnl.util.tty.colify import colify
 
@@ -378,6 +379,22 @@ def test_110_no_write_with_exception_on_install(database):
     # reload DB and make sure cmake was not written.
     with install_db.read_transaction():
         assert install_db.query('cmake', installed=any) == []
+
+
+def test_115_reindex_with_packages_not_in_repo(database, refresh_db_on_exit):
+    install_db = database.mock.db
+
+    saved_repo = spack.repo
+    # Dont add any package definitions to this repository, the idea is that
+    # packages should not have to be defined in the repository once they are
+    # installed
+    mock_repo = MockPackageMultiRepo([])
+    try:
+        spack.repo = mock_repo
+        spack.store.db.reindex(spack.store.layout)
+        _check_db_sanity(install_db)
+    finally:
+        spack.repo = saved_repo
 
 
 def test_external_entries_in_db(database):


### PR DESCRIPTION
Fixes https://github.com/LLNL/spack/issues/5633

@becker33 @tgamblin

spec and spec.package.spec can refer to different objects in the database. When these two instances of spec differ in terms of the value of the 'concrete' property, Spec._mark_concrete can fail when checking Spec.package.installed (which requires package.spec to be concrete). This skips the check for spec.package.installed when _mark_concrete is called with 'True' (in other words, when the database is marking all specs as being concrete).

For a concrete example of

> spec and spec.package.spec can refer to different objects in the database.

In #5633 we have a case like X->Y where X is libtiff and Y is libjpeg-turbo which itself has 1 build dependency

* repository.get was first called with the non-concrete copy of `libjpeg-turbo@1.5.0%gcc@4.6.1 arch=linux-rhel6-x86_64` (this happens sometime during concretization), so the package stored in repository has package.spec.concrete = False
* database however stores a copy of `libjpeg-turbo@1.5.0%gcc@4.6.1 arch=linux-rhel6-x86_64` and considers it concrete (because it marks it as such) and it is ok with omitting the dependency because it is a build dep
* `database._add` assigns the concrete version of 'libjpeg-turbo@1.5.0%gcc@4.6.1 arch=linux-rhel6-x86_64' to libtiff
* when that libjpeg spec calls package, it will match the repository key of the package associated with the non-concrete spec and so it will get that package