### PR TITLE
ncl: Fix temp directory and depend on esmf

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -86,6 +86,9 @@ class Ncl(Package):
     depends_on('hdf5+szip')
     depends_on('szip')
 
+    # ESMF is only required at runtime (for ESMF_regridding.ncl)
+    depends_on('esmf', type='run')
+
     # In Spack, we also do not have an option to compile netcdf without DAP
     # support, so we will tell the ncl configuration script that we have it.
 

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -186,7 +186,7 @@ class Ncl(Package):
             # Parent installation directory :
             '\'' + self.spec.prefix + '\'\n',
             # System temp space directory   :
-            '\'' + tempfile.mkdtemp(prefix='ncl_ncar_') + '\'\n',
+            '\'' + tempfile.gettempdir() + '\'\n',
             # Build NetCDF4 feature support (optional)?
             'y\n'
         ]


### PR DESCRIPTION
Currently, ncl is configured using a transient temp directory. This leads to warnings such as this when executing ncl later on:

```
warning:"/tmp/ncl_ncar_xxxxxx" tmp dir does not exist or is not writable: NCL functionality may be limited -- check TMPDIR environment variable
```

As this also breaks some functionality, use the system temp directory instead (typically `/tmp`).

esmf is required for some ncl scripts (such as `ESMF_regridding.ncl`).