### PR TITLE
Updating hypre package so that new v2.12.1 is supported and preferred.

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -36,6 +36,7 @@ class Hypre(Package):
     url      = "http://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz"
 
     version('develop', git='https://github.com/LLNL/hypre', tag='master')
+    version('2.12.1', git='https://github.com/LLNL/hypre', tag='v2.12.1', preferred='True')
     version('xsdk-0.2.0', git='https://github.com/LLNL/hypre', tag='xsdk-0.2.0')
     version('2.11.2', 'd507943a1a3ce5681c3308e2f3a6dd34')
     version('2.11.1', '3f02ef8fd679239a6723f60b7f796519')


### PR DESCRIPTION
A new version of hypre is out, v2.12.1.  This pull request adds this version to the hypre spack package and makes it preferred.
