### PR TITLE
Fix node-js : requires openssl min 1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -50,7 +50,7 @@ class NodeJs(Package):
     depends_on('python@2.7:2.8', type='build')
     # depends_on('bash-completion', when="+bash-completion")
     depends_on('icu4c', when='+icu4c')
-    depends_on('openssl', when='+openssl')
+    depends_on('openssl@1.0.2d:', when='+openssl')
 
     def install(self, spec, prefix):
         options = []


### PR DESCRIPTION
I see below error:

```
==> No patches needed for node-js
==> Building node-js [Package]
==> Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'install'

18 errors found in build log:
     [ ... ]
     9154  /usr/bin/ld: skipping incompatible /usr/lib/libdl.so when searching for -ldl
     9155  /usr/bin/ld: skipping incompatible /usr/lib/librt.so when searching for -lrt
     9156  /usr/bin/ld: skipping incompatible /usr/lib/libm.so when searching for -lm
     9157  /usr/bin/ld: skipping incompatible /usr/lib/libpthread.so when searching for -lpthread
     9158  /usr/bin/ld: skipping incompatible /usr/lib/libc.so when searching for -lc
     9159  ../src/tls_wrap.cc: In member function ‘void node::TLSWrap::InitSSL()’:
  >> 9160  ../src/tls_wrap.cc:145:64: error: ‘SSL_set_cert_cb’ was not declared in this scope
     9161     SSL_set_cert_cb(ssl_, SSLWrap<TLSWrap>::SSLCertCallback, this);
     9162                                                                  ^
     9163  ../src/node_crypto.cc: In function ‘int node::crypto::SSL_CTX_use_certificate_chain(SSL_CTX*, X509*, stack_st_X509*, X509**, X509**)’:
  >> 9164  ../src/node_crypto.cc:519:42: error: ‘SSL_CTX_add1_chain_cert’ was not declared in this scope
     9165         r = SSL_CTX_add1_chain_cert(ctx, ca);
     9166                                            ^
     9167  make[1]: *** [/tmp/kumbhar-adm/spack-stage/spack-stage-6r6emZ/node-v7.1.0/out/Release/obj.target/node/src/tls_wrap.o] Error 1
     9168  make[1]: *** Waiting for unfinished jobs....
     9169  ../src/node_crypto.cc: In static member function ‘static void node::crypto::SSLWrap<Base>::CertCbDone(const v8::FunctionCallbackInfo<v8::Value>&)’:
  >> 9170  ../src/node_crypto.cc:2380:51: error: there are no arguments to ‘SSL_CTX_get0_certificate’ that depend on a template parameter, so a declaration of ‘SSL_CTX_get0_certificate’ must be available [-fpermissive]
     9171       X509* x509 = SSL_CTX_get0_certificate(sc->ctx_);
     9172                                                     ^
     9173  ../src/node_crypto.cc:2380:51: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
  >> 9174  ../src/node_crypto.cc:2381:54: error: there are no arguments to ‘SSL_CTX_get0_privatekey’ that depend on a template parameter, so a declaration of ‘SSL_CTX_get0_privatekey’ must be available [-fpermissive]
     9175       EVP_PKEY* pkey = SSL_CTX_get0_privatekey(sc->ctx_);
     9176                                                        ^
  >> 9177  ../src/node_crypto.cc:2384:51: error: there are no argument
```

this https://github.com/nodejs/node/issues/2783 says:

> Your copy of openssl is too old, you need 1.0.2.