### PR TITLE
libpng: zlib flags more elegant

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -58,6 +58,6 @@ class Libpng(AutotoolsPackage):
             #   https://sourceforge.net/p/libpng/bugs/210/#33f1
             # '--with-zlib=' + self.spec['zlib'].prefix,
             'CFLAGS={0}'.format(self.spec['zlib'].headers.include_flags),
-            'LDFLAGS={0}'.format(self.spec['zlib'].libs.ld_flags)
+            'LDFLAGS={0}'.format(self.spec['zlib'].libs.search_flags)
         ]
         return args

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -57,7 +57,7 @@ class Libpng(AutotoolsPackage):
             # not honored, see
             #   https://sourceforge.net/p/libpng/bugs/210/#33f1
             # '--with-zlib=' + self.spec['zlib'].prefix,
-            'CFLAGS=-I{0}'.format(self.spec['zlib'].prefix.include),
-            'LDFLAGS=-L{0}'.format(self.spec['zlib'].prefix.lib)
+            'CFLAGS={0}'.format(self.spec['zlib'].headers.include_flags),
+            'LDFLAGS={0}'.format(self.spec['zlib'].libs.ld_flags)
         ]
         return args


### PR DESCRIPTION
Add `-I` and `-L` flags for zlib more elegant to `libpng` as suggested by @hartzell (via @junghans). Follow-up to #5581