### PR TITLE
fastqvalidator: package fix

### DIFF
--- a/var/spack/repos/builtin/packages/fastqvalidator/package.py
+++ b/var/spack/repos/builtin/packages/fastqvalidator/package.py
@@ -31,26 +31,25 @@ class Fastqvalidator(MakefilePackage):
     homepage = "http://genome.sph.umich.edu/wiki/FastQValidator"
     url      = "https://github.com/statgen/fastQValidator/archive/v0.1.1a.tar.gz"
 
-    version('0.1.1a', '5c5de69527020b72b64f32987409bd12')
-
-    conflicts('%gcc@7:', when='@0.1.1a')  # statgen/fastQValidator#14
+    version('2017-01-10', commit='6d619a34749e9d33c34ef0d3e0e87324ca77f320',
+            git='https://github.com/statgen/fastQValidator.git')
 
     resource(
         name='libStatGen',
-        url='https://github.com/statgen/libStatGen/archive/v1.0.14.tar.gz',
-        sha256='70a504c5cc4838c6ac96cdd010644454615cc907df4e3794c999baf958fa734b',
+        git='https://github.com/statgen/libStatGen.git',
+        commit='9db9c23e176a6ce6f421a3c21ccadedca892ac0c'
     )
 
     @property
     def build_targets(self):
         return ['LIB_PATH_GENERAL={0}'.format(
-                join_path(self.stage.source_path, 'libStatGen-1.0.14'))]
+                join_path(self.stage.source_path, 'libStatGen'))]
 
     @property
     def install_targets(self):
         return [
             'INSTALLDIR={0}'.format(self.prefix.bin),
             'LIB_PATH_GENERAL={0}'.format(
-                join_path(self.stage.source_path, 'libStatGen-1.0.14')),
+                join_path(self.stage.source_path, 'libStatGen')),
             'install'
         ]


### PR DESCRIPTION
This fix removes the gcc-7.1.0 conflict. Uses most recent commits from FastQValidator as well as libStatGen, which was fixed for gcc 7.1.0 in https://github.com/statgen/fastQValidator/issues/14