### PR TITLE
Make --trusted default when running spack gpg list

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -82,7 +82,7 @@ def setup_parser(subparser):
 
     list = subparsers.add_parser('list')
     list.add_argument('--trusted', action='store_true',
-                      help='list trusted keys')
+                      default=True, help='list trusted keys')
     list.add_argument('--signing', action='store_true',
                       help='list keys which may be used for signing')
     list.set_defaults(func=gpg_list)

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -98,6 +98,7 @@ def test_gpg(gpg, tmpdir, testing_gpg_directory):
 
     # List the keys.
     # TODO: Test the output here.
+    gpg('list')
     gpg('list', '--trusted')
     gpg('list', '--signing')
 


### PR DESCRIPTION
Currently running `spack gpg list` with no arguments returns nothing. You must supply either the `--trusted` or the `--signing` options. The idea here is to return some initial data to the user when the command is run. The alternative is to return an error, telling the user to select one of the two options.

This fixes #5677 