### PR TITLE
plumed: reworked patching applications, added new version

### DIFF
--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -22,7 +22,7 @@
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
-import subprocess
+import collections
 
 from spack import *
 
@@ -43,6 +43,7 @@ class Plumed(AutotoolsPackage):
     homepage = 'http://www.plumed.org/'
     url = 'https://github.com/plumed/plumed2/archive/v2.2.3.tar.gz'
 
+    version('2.3.3', '9f5729e406e79a06a16976fcb020e024')
     version('2.3.0', 'a9b5728f115dca8f0519111f1f5a6fa5')
     version('2.2.4', 'afb00da25a3fbd47acf377e53342059d')
     version('2.2.3', 'a6e3863e40aac07eb8cf739cbd14ecf8')
@@ -73,58 +74,41 @@ class Plumed(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
 
-    # Dictionary mapping PLUMED versions to the patches it provides
-    # interactively
-    plumed_patches = {
-        '2.3.0': {
-            'amber-14': '1',
-            'gromacs-2016.1': '2',
-            'gromacs-4.5.7': '3',
-            'gromacs-5.0.7': '4',
-            'gromacs-5.1.4': '5',
-            'lammps-6Apr13': '6',
-            'namd-2.8': '7',
-            'namd-2.9': '8',
-            'espresso-5.0.2': '9'
-        },
-        '2.2.4': {
-            'amber-14': '1',
-            'gromacs-4.5.7': '2',
-            'gromacs-4.6.7': '3',
-            'gromacs-5.0.7': '4',
-            'gromacs-5.1.2': '5',
-            'lammps-6Apr13': '6',
-            'namd-2.8': '7',
-            'namd-2.9': '8',
-            'espresso-5.0.2': '9'
-        },
-        '2.2.3': {
-            'amber-14': '1',
-            'gromacs-4.5.7': '2',
-            'gromacs-4.6.7': '3',
-            'gromacs-5.0.7': '4',
-            'gromacs-5.1.2': '5',
-            'lammps-6Apr13': '6',
-            'namd-2.8': '7',
-            'namd-2.9': '8',
-            'espresso-5.0.2': '9'
-        }
-    }
-
     force_autoreconf = True
 
     parallel = False
 
     def apply_patch(self, other):
-        plumed = subprocess.Popen(
-            [join_path(self.spec.prefix.bin, 'plumed'), 'patch', '-p'],
-            stdin=subprocess.PIPE
+
+        # The name of MD engines differ slightly from the ones used in Spack
+        format_strings = collections.defaultdict(
+            lambda: '{0.name}-{0.version}'
         )
-        opts = Plumed.plumed_patches[str(self.version)]
-        search = '{0.name}-{0.version}'.format(other)
-        choice = opts[search] + '\n'
-        plumed.stdin.write(choice)
-        plumed.wait()
+        format_strings['espresso'] = 'q{0.name}-{0.version}'
+        format_strings['amber'] = '{0.name}{0.version}'
+
+        get_md = lambda x: format_strings[x.name].format(x)
+
+        # Get available patches
+        plumed_patch = Executable(
+            join_path(self.spec.prefix.bin, 'plumed-patch')
+        )
+
+        out = plumed_patch('-q', '-l', output=str)
+        available = out.split(':')[-1].split()
+
+        # Check that `other` is among the patchable applications
+        if get_md(other) not in available:
+            msg = '{0.name}@{0.version} is not among the MD engine'
+            msg += ' that can be patched by {1.name}@{1.version}.\n'
+            msg += 'Supported engines are:\n'
+            for x in available:
+                msg += x + '\n'
+            raise RuntimeError(msg.format(other, self.spec))
+
+        # Call plumed-patch to patch executables
+        target = format_strings[other.name].format(other)
+        plumed_patch('-p', '-e', target)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Make plumed visible from dependent packages


### PR DESCRIPTION
closes #5506

The application of patches to upstream executables has been reworked according to the suggestions of the main developer in #5506. In particular we are not maintaining a dictionary that maps plumed versions to the versions of patchable executables, and we are using a non-interactive command to patch applications.

All the comments on substituting plumed at run-time do not apply here, since we use RPATH and we want to maintain a 1:1 relationship between the DAG hash and the plumed library used.