### PR TITLE
Fix staging of resources for failed patches

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -548,8 +548,18 @@ class ResourceStage(Stage):
         self.root_stage = root
         self.resource = resource
 
+    def restage(self):
+        super(ResourceStage, self).restage()
+        self._add_to_root_stage()
+
     def expand_archive(self):
         super(ResourceStage, self).expand_archive()
+        self._add_to_root_stage()
+
+    def _add_to_root_stage(self):
+        """
+        Move the extracted resource to the root stage (according to placement).
+        """
         root_stage = self.root_stage
         resource = self.resource
         placement = os.path.basename(self.source_path) \
@@ -557,23 +567,23 @@ class ResourceStage(Stage):
             else resource.placement
         if not isinstance(placement, dict):
             placement = {'': placement}
-        # Make the paths in the dictionary absolute and link
+
+        target_path = join_path(
+            root_stage.source_path, resource.destination)
+
+        try:
+            os.makedirs(target_path)
+        except OSError as err:
+            if err.errno == errno.EEXIST and os.path.isdir(target_path):
+                pass
+            else:
+                raise
+
         for key, value in iteritems(placement):
-            target_path = join_path(
-                root_stage.source_path, resource.destination)
             destination_path = join_path(target_path, value)
             source_path = join_path(self.source_path, key)
 
-            try:
-                os.makedirs(target_path)
-            except OSError as err:
-                if err.errno == errno.EEXIST and os.path.isdir(target_path):
-                    pass
-                else:
-                    raise
-
             if not os.path.exists(destination_path):
-                # Create a symlink
                 tty.info('Moving resource stage\n\tsource : '
                          '{stage}\n\tdestination : {destination}'.format(
                              stage=source_path, destination=destination_path


### PR DESCRIPTION
When a failed patch was detected, the resource stage was asked to re-expand by calling `fetcher.reset()`.
This however caused the root package to be extracted again, removing the nested copies/symbolic links of the resources.  As ResourceStage did not handle `restage` explicitly, it would only unpack the resources to their respective stage folder and not also put them in the root stage.

For example when attempting to apply patches to `llvm/tools/clang` (which is in the cfe resource):
```
==> Already staged llvm-5.0.0-4wbencqbmejbxkcpmeztwvkf6koy7jlm in .../stage/llvm-5.0.0-4wbencqbmejbxkcpmeztwvkf6koy7jlm
...
==> Already staged resource-cfe-4wbencqbmejbxkcpmeztwvkf6koy7jlm in .../stage/resource-cfe-4wbencqbmejbxkcpmeztwvkf6koy7jlm
==> Moving resource stage
        source : .../stage/resource-cfe-4wbencqbmejbxkcpmeztwvkf6koy7jlm/cfe-5.0.0.src/
        destination : .../stage/llvm-5.0.0-4wbencqbmejbxkcpmeztwvkf6koy7jlm/llvm-5.0.0.src/tools/clang
==> Already staged resource-lldb-4wbencqbmejbxkcpmeztwvkf6koy7jlm in .../stage/resource-lldb-4wbencqbmejbxkcpmeztwvkf6koy7jlm
==> Moving resource stage
        source : .../stage/resource-lldb-4wbencqbmejbxkcpmeztwvkf6koy7jlm/lldb-5.0.0.src/
        destination : .../stage/llvm-5.0.0-4wbencqbmejbxkcpmeztwvkf6koy7jlm/llvm-5.0.0.src/tools/lldb
...
==> Patching failed last time. Restaging.
==> Staging archive: .../stage/llvm-5.0.0-4wbencqbmejbxkcpmeztwvkf6koy7jlm/llvm-5.0.0.src.tar.xz
...
==> Staging archive: .../stage/resource-cfe-4wbencqbmejbxkcpmeztwvkf6koy7jlm/cfe-5.0.0.src.tar.xz
==> Staging archive: .../stage/resource-lldb-4wbencqbmejbxkcpmeztwvkf6koy7jlm/lldb-5.0.0.src.tar.xz
...
```

Note the missing "moving resource stage" message above.