### PR TITLE
Boost: fix constraint on patch, avoid 'reversed patch...'

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -158,7 +158,7 @@ class Boost(Package):
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl_r')
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl')
 
-    patch('call_once_variadic.patch', when='@:1.56.0%gcc@5:')
+    patch('call_once_variadic.patch', when='@:1.55.0%gcc@5:')
 
     # Patch fix for PGI compiler
     patch('boost_1.63.0_pgi.patch', when='@1.63.0%pgi')


### PR DESCRIPTION
When I build boost@1.56.0 with gcc@5.4.0 I get a complaint about this patch already having been applied and etc....

Only applying the patch to @:1.55.0 fixes the complaint but I do not know if it is the correct thing to do.

Someone more familiar with Boost should vette this change.