### PR TITLE
Better install output

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -518,7 +518,7 @@ def setup_package(pkg, dirty):
     load_external_modules(pkg)
 
 
-def fork(pkg, function, dirty):
+def fork(pkg, function, dirty, fake):
     """Fork a child process to do part of a spack build.
 
     Args:
@@ -529,6 +529,7 @@ def fork(pkg, function, dirty):
             process.
         dirty (bool): If True, do NOT clean the environment before
             building.
+        fake (bool): If True, skip package setup b/c it's not a real build
 
     Usage::
 
@@ -556,7 +557,8 @@ def fork(pkg, function, dirty):
             sys.stdin = input_stream
 
         try:
-            setup_package(pkg, dirty=dirty)
+            if not fake:
+                setup_package(pkg, dirty=dirty)
             return_value = function()
             child_pipe.send(return_value)
         except StopIteration as e:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -118,8 +118,7 @@ def createtarball(args):
             tty.msg('recursing dependencies')
             for d, node in spec.traverse(order='post',
                                          depth=True,
-                                         deptype=('link', 'run'),
-                                         deptype_query='run'):
+                                         deptype=('link', 'run')):
                 if not node.external:
                     tty.msg('adding dependency %s' % node.format())
                     specs.add(node)

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -57,7 +57,7 @@ def fetch(parser, args):
     specs = spack.cmd.parse_specs(args.packages, concretize=True)
     for spec in specs:
         if args.missing or args.dependencies:
-            for s in spec.traverse(deptype_query=all):
+            for s in spec.traverse():
                 package = spack.repo.get(s)
                 if args.missing and package.installed:
                     continue

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -182,7 +182,7 @@ def mirror_create(args):
         new_specs = set()
         for spec in specs:
             spec.concretize()
-            for s in spec.traverse(deptype_query=all):
+            for s in spec.traverse():
                 new_specs.add(s)
         specs = list(new_specs)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1320,19 +1320,19 @@ class PackageBase(with_metaclass(PackageMeta, object)):
         # First, install dependencies recursively.
         if install_deps:
             tty.debug('Installing {0} dependencies'.format(self.name))
-            for dep in self.spec.dependencies():
+            for dep in self.spec.traverse(order='post', root=False):
                 dep.package.do_install(
+                    install_deps=False,
+                    explicit=False,
                     keep_prefix=keep_prefix,
                     keep_stage=keep_stage,
                     install_source=install_source,
-                    install_deps=install_deps,
                     fake=fake,
                     skip_patch=skip_patch,
                     verbose=verbose,
                     make_jobs=make_jobs,
                     dirty=dirty,
-                    **kwargs
-                )
+                    **kwargs)
 
         tty.msg('Installing %s' % self.name)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1428,7 +1428,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             # Fork a child to do the actual installation
             # we preserve verbosity settings across installs.
             PackageBase._verbose = spack.build_environment.fork(
-                self, build_process, dirty=dirty)
+                self, build_process, dirty=dirty, fake=fake)
 
             # If we installed then we should keep the prefix
             keep_prefix = self.last_phase is None or keep_prefix

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1250,7 +1250,7 @@ class Spec(object):
                 yield get_spec(dspec)
 
     def traverse_edges(self, visited=None, d=0, deptype='all',
-                       deptype_query=default_deptype, dep_spec=None, **kwargs):
+                       dep_spec=None, **kwargs):
         """Generic traversal of the DAG represented by this spec.
            This will yield each node in the spec.  Options:
 
@@ -1301,9 +1301,7 @@ class Spec(object):
         cover = kwargs.get('cover', 'nodes')
         direction = kwargs.get('direction', 'children')
         order = kwargs.get('order', 'pre')
-
         deptype = canonical_deptype(deptype)
-        deptype_query = canonical_deptype(deptype_query)
 
         # Make sure kwargs have legal values; raise ValueError if not.
         def validate(name, val, allowed_values):
@@ -1356,7 +1354,6 @@ class Spec(object):
                     visited,
                     d=(d + 1),
                     deptype=deptype,
-                    deptype_query=deptype_query,
                     dep_spec=dspec,
                     **kwargs)
                 for elt in children:
@@ -1797,7 +1794,7 @@ class Spec(object):
             changed = any(changes)
             force = True
 
-        for s in self.traverse(deptype_query=all):
+        for s in self.traverse():
             # After concretizing, assign namespaces to anything left.
             # Note that this doesn't count as a "change".  The repository
             # configuration is constant throughout a spack run, and
@@ -1887,7 +1884,7 @@ class Spec(object):
         Only for internal use -- client code should use "concretize"
         unless there is a need to force a spec to be concrete.
         """
-        for s in self.traverse(deptype_query=all):
+        for s in self.traverse():
             if (not value) and s.concrete and s.package.installed:
                 continue
             s._normal = value
@@ -1912,11 +1909,10 @@ class Spec(object):
            returns them.
         """
         copy = kwargs.get('copy', True)
-        deptype_query = kwargs.get('deptype_query', 'all')
 
         flat_deps = {}
         try:
-            deptree = self.traverse(root=False, deptype_query=deptype_query)
+            deptree = self.traverse(root=False)
             for spec in deptree:
 
                 if spec.name not in flat_deps:
@@ -2175,7 +2171,7 @@ class Spec(object):
         # Ensure first that all packages & compilers in the DAG exist.
         self.validate_or_raise()
         # Get all the dependencies into one DependencyMap
-        spec_deps = self.flat_dependencies(copy=False, deptype_query=all)
+        spec_deps = self.flat_dependencies(copy=False)
 
         # Initialize index of virtual dependency providers if
         # concretize didn't pass us one already


### PR DESCRIPTION
This is actually 3 fixes.  The main fix in this PR beautifies `spack install` output:

- `do_install()` was originally depth-first recursive, and printed `<pkg> already installed in ...` multiple times for packages as recursive calls encountered them.
- For much cleaner output, use `spec.traverse(order='post')` to install dependencies instead.
- Now info about each install is printed only once.

We can probably make things cleaner still, but this gets rid of the largest current source of noise in `install()` output.

All tasks:
- [x] `spack install` prints out much less output, especially for large DAGs.
- [x] Get rid of vestigial `deptype_query` argument to `spec.traverse()`
- [x] Fix a bug with `--fake` installs

The install fix turns 197 lines of `spack install xsdk` output into 152 lines, by getting rid of stuff like this:

```
$ spack install --fake xsdk
...

==> Successfully installed trilinos
  Fetch: .  Build: 4.30s.  Total: 4.30s.
[+] /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/trilinos-xsdk-0.2.0-d5wjl6o4fceno7w7dlv4cvi7wwmgoozb
==> hypre is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/hypre-xsdk-0.2.0-nlrcck7w2bckbnfeivvie7ecoheoryed
==> metis is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/metis-5.1.0-msxayllqzgji6se66iucactn6zd2g3kq
==> superlu-dist is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/superlu-dist-xsdk-0.2.0-pl63z4w5rlusg36yfptkv6coaz7lhixr
==> bzip2 is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/bzip2-1.0.6-hp626dwtuiakdmsgazw7xd6ymyijxjyn
==> ncurses is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/ncurses-6.0-ny2iyrd374kkzwc2bam5xqvbbkxgmxgv
==> zlib is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/zlib-1.2.11-fn323gjmbkegonjedtppmyua7xfkxy7t
==> openssl is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/openssl-1.0.2k-nxao5denc343bgfsvio6q22jwmxl62m2
==> ncurses is already installed in /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/ncurses-6.0-ny2iyrd374kkzwc2bam5xqvbbkxgmxgv
==> Installing readline

...
```

The new output is much more organized:

```
$ spack install --fake xsdk
==> Installing pkg-config
==> Building pkg-config [AutotoolsPackage]
==> Successfully installed pkg-config
  Fetch: .  Build: 0.26s.  Total: 0.26s.
[+] /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/pkg-config-0.29.2-x67y3tjvezfvj6odssyblthsbzk7f6ca
==> Installing ncurses
==> Building ncurses [AutotoolsPackage]
==> Successfully installed ncurses
  Fetch: .  Build: 0.26s.  Total: 0.26s.
[+] /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/ncurses-6.0-ny2iyrd374kkzwc2bam5xqvbbkxgmxgv
==> Installing zlib
...
==> Installing xsdk
==> Building xsdk [Package]
==> Successfully installed xsdk
  Fetch: .  Build: 5.20s.  Total: 5.20s.
[+] /Users/gamblin2/src/spack/db/test-tree/darwin-sierra-x86_64/clang-7.0.2-apple/xsdk-xsdk-0.2.0-z6kbxwa7zhza6qhd4jai6q7ggb3jbm43
```