### PR TITLE
samtools: add version 1.6 + some fixes

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -34,13 +34,13 @@ class Bcftools(Package):
     homepage = "http://samtools.github.io/bcftools/"
     url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
 
+    version('1.6', 'c4dba1e8cb55db0f94b4c47724b4f9fa')
     version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
     version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
 
-    depends_on('zlib')
-    depends_on('bzip2', when="@1.4:")
-    # build fails without xz
-    depends_on('xz', when="@1.4")
+    depends_on('htslib@1.6',   when='@1.6')
+    depends_on('htslib@1.4',   when='@1.4')
+    depends_on('htslib@1.3.1', when='@1.3.1')
 
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "all")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -31,9 +31,10 @@ class Htslib(AutotoolsPackage):
     homepage = "https://github.com/samtools/htslib"
     url      = "https://github.com/samtools/htslib/releases/download/1.3.1/htslib-1.3.1.tar.bz2"
 
+    version('1.6', 'd6fd14e208aca7e08cbe9072233d0af9')
     version('1.4', '2a22ff382654c033c40e4ec3ea880050')
     version('1.3.1', '16d78f90b72f29971b042e8da8be6843')
 
     depends_on('zlib')
     depends_on('bzip2', when="@1.4:")
-    depends_on('xz')
+    depends_on('xz', when="@1.4:")

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -33,15 +33,16 @@ class Samtools(Package):
     homepage = "www.htslib.org"
     url = "https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2"
 
+    version('1.6', 'b756f05fd5d1a7042074417edb8c9aea')
     version('1.4', '8cbd7d2a0ec16d834babcd6c6d85d691')
     version('1.3.1', 'a7471aa5a1eb7fc9cc4c6491d73c2d88')
     version('1.2', '988ec4c3058a6ceda36503eebecd4122')
 
-    depends_on("ncurses")
+    depends_on('ncurses')
     # htslib became standalone @1.3.1, must use corresponding version
-    depends_on("htslib@1.4",   when='@1.4')
-    depends_on("htslib@1.3.1", when='@1.3.1')
-    depends_on('zlib', when='@1.2')       # needed for builtin htslib
+    depends_on('htslib@1.6',   when='@1.6')
+    depends_on('htslib@1.4',   when='@1.4')
+    depends_on('htslib@1.3.1', when='@1.3.1')
 
     def install(self, spec, prefix):
         if self.spec.version >= Version('1.3.1'):


### PR DESCRIPTION
Adding checksums for samtools suite 1.6. (htslib, samtools, bcftools)
bcftools built its own htslib instead of depending on it like samtools does, so I fixed that and some library dependencies too.