### PR TITLE
petsc: update to latest 3.8 version [and include 3.7.7]

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -23,8 +23,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 
-import sys
 import os
+import sys
 from spack import *
 
 
@@ -40,6 +40,8 @@ class Petsc(Package):
     version('develop', git='https://bitbucket.org/petsc/petsc.git', tag='master')
     version('xsdk-0.2.0', git='https://bitbucket.org/petsc/petsc.git', tag='xsdk-0.2.0')
 
+    version('3.8.0', '02680f1f78a0d4c5a9de80a366793eb8')
+    version('3.7.7', 'c2cfb76677d32839810c4cf51a2f9cf5')
     version('3.7.6', '977aa84b85aa3146c695592cd0a11057')
     version('3.7.5', 'f00f6e6a3bac39052350dd47194b58a3')
     version('3.7.4', 'aaf94fa54ef83022c14091f10866eedf')


### PR DESCRIPTION
Also fix flake8 warning "import os should be before import sys"