### PR TITLE
filter_file, don't remove absent backup file

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -135,7 +135,7 @@ def filter_file(regex, repl, *filenames, **kwargs):
             raise
 
         finally:
-            if not backup:
+            if not backup and os.path.exists(backup_filename):
                 os.remove(backup_filename)
 
 


### PR DESCRIPTION
I'm tracking down a problem with the perl package that's been generating this error:

```
OSError: OSError: [Errno 2] No such file or directory: '/blah/blah/blah/lib/5.24.1/x86_64-linux/Config.pm~'
```

The real problem is upstream/elsewhere, but it's being masked by an exception raised in filter_file`s finally block.

In my case, `backup` is `False`.

The backup is created around line 127, the `re.sub()` calls fails (working on that), the `except` block fires and moves the backup file back, then the finally block tries to remove the non-existent backup file.

This change just avoids trying to remove the non-existent file.