### PR TITLE
Ensure that FileList makes it into the documentation

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -42,6 +42,7 @@ from llnl.util.lang import dedupe
 
 __all__ = [
     'FileFilter',
+    'FileList',
     'HeaderList',
     'LibraryList',
     'ancestor',


### PR DESCRIPTION
Fixes #5727.

According to [Sphinx Autodoc](http://www.sphinx-doc.org/en/stable/ext/autodoc.html):

> For modules, `__all__` will be respected when looking for members