### PR TITLE
Patch Paraview to avoid using git describe to find its own version number

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/get_version_without_git.patch
+++ b/var/spack/repos/builtin/packages/paraview/get_version_without_git.patch
@@ -1,0 +1,29 @@
+--- ParaView-v5.4.1.orig/CMake/ParaViewDetermineVersion.cmake	2017-10-12 14:36:02.000000000 -0600
++++ ParaView-v5.4.1/CMake/ParaViewDetermineVersion.cmake	2017-10-12 14:39:39.000000000 -0600
+@@ -36,16 +36,16 @@
+     # this function.
+     return ()
+   elseif (NOT PARAVIEW_GIT_DESCRIBE)
+-    if(EXISTS ${git_command})
+-      execute_process(
+-        COMMAND ${git_command} describe
+-        WORKING_DIRECTORY ${source_dir}
+-        RESULT_VARIABLE result
+-        OUTPUT_VARIABLE output
+-        ERROR_QUIET
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-        ERROR_STRIP_TRAILING_WHITESPACE)
+-    endif()
++    #if(EXISTS ${git_command})
++    #  execute_process(
++    #    COMMAND ${git_command} describe
++    #    WORKING_DIRECTORY ${source_dir}
++    #    RESULT_VARIABLE result
++    #    OUTPUT_VARIABLE output
++    #    ERROR_QUIET
++    #    OUTPUT_STRIP_TRAILING_WHITESPACE
++    #    ERROR_STRIP_TRAILING_WHITESPACE)
++    #endif()
+   else()
+     set(result 0)
+     set(output ${PARAVIEW_GIT_DESCRIBE})

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -77,8 +77,9 @@ class Paraview(CMakePackage):
     patch('stl-reader-pv440.patch', when='@4.4.0')
 
     # Paraview defaults to using 'git describe' to find its own
-    # version number which can easily produce the wrong version for itself.
-    # This stops paraview from finding git and using its own version.txt file.
+    # version number which can easily produce the wrong version
+    # for itself. This stops paraview from finding git and will
+    # then use its own version.txt file.
     patch('get_version_without_git.patch', when='@5.4.0:5.4.1')
 
     # Broken gcc-detection - improved in 5.1.0, redundant later

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -76,6 +76,11 @@ class Paraview(CMakePackage):
 
     patch('stl-reader-pv440.patch', when='@4.4.0')
 
+    # Paraview defaults to using 'git describe' to find its own
+    # version number which can easily produce the wrong version for itself.
+    # This stops paraview from finding git and using its own version.txt file.
+    patch('get_version_without_git.patch', when='@5.4.0:5.4.1')
+
     # Broken gcc-detection - improved in 5.1.0, redundant later
     patch('gcc-compiler-pv501.patch', when='@:5.0.1')
 


### PR DESCRIPTION
In regards to #5735 . This patches Paraview to avoid using `git describe` to find its own version number and to use its own shipped version number instead.

I have not fixed the Paraview module file to point the library paths to `lib/paraview-5.4` where Paraview actually installs the libraries rather than just `lib`. 