### PR TITLE
Make perl install munging work on NFSv4

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -221,6 +221,6 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def make_briefly_writable(self, path):
         """Temporarily make a file writable, then reset"""
         perm = os.stat(path).st_mode
-        os.chmod(path, perm | 0o222)
+        os.chmod(path, perm | 0o200)
         yield
         os.chmod(path, perm)

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -199,7 +199,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         config_dot_pm = perl('-MModule::Loaded', '-MConfig', '-e',
                              'print is_loaded(Config)', output=str)
 
-        with self.make_tmp_writable(config_dot_pm):
+        with self.make_briefly_writable(config_dot_pm):
             match = 'cc *=>.*'
             substitute = "cc => '{cc}',".format(cc=self.compiler.cc)
             filter_file(match, substitute, config_dot_pm, **kwargs)
@@ -208,7 +208,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         d = os.path.dirname(config_dot_pm)
         config_heavy = join_path(d, 'Config_heavy.pl')
 
-        with self.make_tmp_writable(config_heavy):
+        with self.make_briefly_writable(config_heavy):
             match = '^cc=.*'
             substitute = "cc='{cc}'".format(cc=self.compiler.cc)
             filter_file(match, substitute, config_heavy, **kwargs)
@@ -218,7 +218,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             filter_file(match, substitute, config_heavy, **kwargs)
 
     @contextmanager
-    def make_tmp_writable(self, path):
+    def make_briefly_writable(self, path):
         """Temporarily make a file writable, then reset"""
         perm = os.stat(path).st_mode
         os.chmod(path, perm | 0o222)


### PR DESCRIPTION
(edits for typos, prose)

See #5745 for ~come~ some backstory.

Perl installs a couple of config files that need to be munged so that they don't refer to the spack compiler.  These files are installed by perl read-only.  The munging uses `filter_file`, and behind the scenes `filter_file` moves its file to a safe place, and tries to create a working file that is both O_WRONLY and has the perms of the original file.  On one of my systems with an NFSv4 filesystem, the combination of `r--r--r--` and O_WRONLY throws a permissions error.  Building on a local/`xfs` filesystem on the same host works.

This commit adds a simple context manager that temporarily makes the files writable.  

I'm not sure that `make_tmp_writable`:

1. ~is the best name, will people confuse it with `/tmp`?~
2. should really be a method, but my python-fu wasn't sufficient to make it a simple function.

Tested on CentOS 7 on NFSv4, xfs, gpfs, and NFSv3 filesystems.