### PR TITLE
module-type argument defaults to 'tcl' instead of every known type

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -107,7 +107,7 @@ _arguments['module_type'] = Args(
     '-m', '--module-type',
     choices=spack.modules.module_types.keys(),
     action='append',
-    help='type of module file. More than one choice is allowed [default: all available module types]')  # NOQA: ignore=E501
+    help='type of module file. More than one choice is allowed [default: tcl]')  # NOQA: ignore=E501
 
 _arguments['yes_to_all'] = Args(
     '-y', '--yes-to-all', action='store_true', dest='yes_to_all',

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -332,7 +332,9 @@ def module(parser, args):
     module_types = args.module_type
     if module_types is None:
         # If no selection has been made select all of them
-        module_types = list(spack.modules.module_types.keys())
+        module_types = ['tcl']
+
+    module_types = list(set(module_types))
 
     try:
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -54,7 +54,8 @@ def parser():
         ['rm', 'doesnotexist'],  # Try to remove a non existing module
         ['find', 'mpileaks'],  # Try to find a module with multiple matches
         ['find', 'doesnotexist'],  # Try to find a module with no matches
-        ['find', 'libelf'],  # Try to find a module wo specifying the type
+        # Try to find a module specifying more than one type
+        ['find', '-m', 'tcl', '-m', 'lmod', 'libelf'],
     ]
 )
 def failure_args(request):


### PR DESCRIPTION
fixes #5721

This is to solve the fact that lmod needs to be configured by the user (to specify a core compiler).