### PR TITLE
Use cflags instead of the args variable

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -48,11 +48,13 @@ class M4(AutotoolsPackage):
         spec = self.spec
         args = ['--enable-c++']
 
+        # CFLAGS handling
+        cflags = copy.deepcopy(optflags[self.spec.compiler.name])
         if spec.satisfies('%clang') and not spec.satisfies('platform=darwin'):
-            args.append('CFLAGS=-rtlib=compiler-rt')
-
+            cflags.append('-rtlib=compiler-rt')
         if spec.satisfies('%intel'):
-            args.append('CFLAGS=-no-gcc')
+            cflags.append('-no-gcc')
+        args.append('CFLAGS = {0}'.format(' '.join(cflags)))
 
         if '+sigsegv' in spec:
             args.append('--with-libsigsegv-prefix={0}'.format(


### PR DESCRIPTION
That way the user can still append things to CFLAGS.

This PR is a result of the discussion at #5728.