### PR TITLE
Even faster concretization

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -113,7 +113,9 @@ class DefaultConcretizer(object):
 
         # Find the nearest spec in the dag that has a compiler.  We'll
         # use that spec to calibrate compiler compatibility.
-        abi_exemplar = find_spec(spec, lambda x: x.compiler, spec.root)
+        abi_exemplar = find_spec(spec, lambda x: x.compiler)
+        if abi_exemplar is None:
+            abi_exemplar = spec.root
 
         # Sort candidates from most to least compatibility.
         #   We reverse because True > False.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -37,7 +37,6 @@ from __future__ import print_function
 from six import iteritems
 from spack.version import *
 from itertools import chain
-from ordereddict_backport import OrderedDict
 from functools_backport import reverse_order
 
 import spack
@@ -80,17 +79,15 @@ class DefaultConcretizer(object):
         # For each candidate package, if it has externals, add those
         # to the usable list.  if it's not buildable, then *only* add
         # the externals.
-        #
-        # Use an OrderedDict to avoid duplicates (use it like a set)
-        usable = OrderedDict()
+        usable = []
         for cspec in candidates:
             if is_spec_buildable(cspec):
-                usable[cspec] = True
+                usable.append(cspec)
 
             externals = spec_externals(cspec)
             for ext in externals:
                 if ext.satisfies(spec):
-                    usable[ext] = True
+                    usable.append(ext)
 
         # If nothing is in the usable list now, it's because we aren't
         # allowed to build anything.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2060,6 +2060,9 @@ class Spec(object):
             index = ProviderIndex([dep], restrict=True)
             items = list(spec_deps.items())
             for name, vspec in items:
+                if not vspec.virtual:
+                    continue
+
                 if index.providers_for(vspec):
                     vspec._replace_with(dep)
                     del spec_deps[vspec.name]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2338,7 +2338,6 @@ class Spec(object):
 
     def common_dependencies(self, other):
         """Return names of dependencies that self an other have in common."""
-        # XXX(deptype): handle deptypes via deptype kwarg.
         common = set(
             s.name for s in self.traverse(root=False))
         common.intersection_update(
@@ -2469,8 +2468,13 @@ class Spec(object):
         """
         other = self._autospec(other)
 
+        # If there are no constraints to satisfy, we're done.
+        if not other._dependencies:
+            return True
+
         if strict:
-            if other._dependencies and not self._dependencies:
+            # if we have no dependencies, we can't satisfy any constraints.
+            if not self._dependencies:
                 return False
 
             selfdeps = self.traverse(root=False)
@@ -2479,9 +2483,9 @@ class Spec(object):
                        for dep in otherdeps):
                 return False
 
-        elif not self._dependencies or not other._dependencies:
-            # if either spec doesn't restrict dependencies then both are
-            # compatible.
+        elif not self._dependencies:
+            # if not strict, this spec *could* eventually satisfy the
+            # constraints on other.
             return True
 
         # Handle first-order constraints directly

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1178,20 +1178,13 @@ class Spec(object):
     @property
     def root(self):
         """Follow dependent links and find the root of this spec's DAG.
-           In spack specs, there should be a single root (the package being
-           installed).  This will throw an assertion error if that is not
-           the case.
+
+        Spack specs have a single root (the package being installed).
         """
         if not self._dependents:
             return self
 
-        # If the spec has multiple dependents, ensure that they all
-        # lead to the same place.  Spack shouldn't deal with any DAGs
-        # with multiple roots, so something's wrong if we find one.
-        depiter = iter(self._dependents.values())
-        first_root = next(depiter).parent.root
-        assert(all(first_root is d.parent.root for d in depiter))
-        return first_root
+        return next(iter(self._dependents.values())).parent.root
 
     @property
     def package(self):


### PR DESCRIPTION
Like #5716, this is still not a rework of the concretizer, but it removes a ton of redundant work from our existing concretization algorithm.

Look at the individual commit messages for details.  But, here are the improvements:

Before:
* `xsdk` (30 nodes): 6s
* `dealii` (44 nodes): 10s
* `r-rminer` (134 nodes): 1m38s

After:
* `xsdk`: 1.7s (3.5x)
* `dealii`: 2.5s (4x)
* `r-rminer`: 5s (19x)

- [x] Cache creation of `Compiler` objects from config data
  - this one also prevents Spack from running `xcrun` zillions of times on macs
- [x] Don't redundantly check for providers of non-virtuals when merging dependencies
- [x] Improve `Spec.traverse` so it doesn't construct superfluous `dicts`
- [x] Don't use an `OrderdDict` where we don't have to -- use a `list` (this is the big win for `r-rminer`
- [x] Remove vestigial assertion in `Spec.root` that would ensure that *all* paths led to the root (oops)
- [x] Add a fast path to `satisfies_dependencies` to avoid a bunch of extra work if there are no constraints to satisfy.

`r-rminer` is kind of the upper bound package so far.  Compared to before #5716, concretizing this package is probably 100x faster.  Sorry for all the wasted time everyone! 😳 

@alalazo @adamjstewart @davydden @scheibelp 
@baberlevi (I know you guys do tons of R stuff)

