### PR TITLE
Revert "Use cflags instead of the args variable (#5756)"

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -48,13 +48,11 @@ class M4(AutotoolsPackage):
         spec = self.spec
         args = ['--enable-c++']
 
-        # CFLAGS handling
-        cflags = copy.deepcopy(optflags[self.spec.compiler.name])
         if spec.satisfies('%clang') and not spec.satisfies('platform=darwin'):
-            cflags.append('-rtlib=compiler-rt')
+            args.append('CFLAGS=-rtlib=compiler-rt')
+
         if spec.satisfies('%intel'):
-            cflags.append('-no-gcc')
-        args.append('CFLAGS = {0}'.format(' '.join(cflags)))
+            args.append('CFLAGS=-no-gcc')
 
         if '+sigsegv' in spec:
             args.append('--with-libsigsegv-prefix={0}'.format(


### PR DESCRIPTION
This reverts commit 6c3184820aa1052016d92f7ff0419b8085d8ad14.