### PR TITLE
boost: remove preferred 1.63

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -50,16 +50,12 @@ class Boost(Package):
             url='https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2')
     version('1.65.0', '5512d3809801b0a1b9dd58447b70915d',
             url='https://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.bz2')
-
     # NOTE: 1.64.0 seems fine for *most* applications, but if you need
     #       +python and +mpi, there seem to be errors with out-of-date
     #       API calls from mpi/python.
     #       See: https://github.com/LLNL/spack/issues/3963
     version('1.64.0', '93eecce2abed9d2442c9676914709349')
-
-    # Set previous release to preferred for now, can be removed
-    # once boost+python+mpi is fixed.
-    version('1.63.0', '1c837ecd990bb022d07e7aab32b09847', preferred=True)
+    version('1.63.0', '1c837ecd990bb022d07e7aab32b09847')
     version('1.62.0', '5fb94629535c19e48703bdb2b2e9490f')
     version('1.61.0', '6095876341956f65f9d35939ccea1a9f')
     version('1.60.0', '65a840e1a0b13a558ff19eeb2c4f0cbe')


### PR DESCRIPTION
`1.64` had issues with serialization (`make_array` and others) when built with
`+mpi+python`. see https://github.com/LLNL/spack/issues/3963
It appears that those issues are fixed in `1.65.1` so we can remove preferred tag from `1.63`.
At the very least I don't have issues with `1.65.1` reported here https://github.com/LLNL/spack/issues/3963#issuecomment-296554280 .

