### PR TITLE
Clean up use of stages and os.chdir()

### DIFF
--- a/lib/spack/spack/cmd/clone.py
+++ b/lib/spack/spack/cmd/clone.py
@@ -25,7 +25,7 @@
 import os
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import join_path, mkdirp
+from llnl.util.filesystem import mkdirp, working_dir
 
 import spack
 from spack.util.executable import ProcessError, which
@@ -47,7 +47,7 @@ def setup_parser(subparser):
 
 
 def get_origin_info(remote):
-    git_dir = join_path(spack.prefix, '.git')
+    git_dir = os.path.join(spack.prefix, '.git')
     git = which('git', required=True)
     try:
         branch = git('symbolic-ref', '--short', 'HEAD', output=str)
@@ -81,7 +81,7 @@ def clone(parser, args):
 
     mkdirp(prefix)
 
-    if os.path.exists(join_path(prefix, '.git')):
+    if os.path.exists(os.path.join(prefix, '.git')):
         tty.die("There already seems to be a git repository in %s" % prefix)
 
     files_in_the_way = os.listdir(prefix)
@@ -94,14 +94,14 @@ def clone(parser, args):
             "%s/bin/spack" % prefix,
             "%s/lib/spack/..." % prefix)
 
-    os.chdir(prefix)
-    git = which('git', required=True)
-    git('init', '--shared', '-q')
-    git('remote', 'add', 'origin', origin_url)
-    git('fetch', 'origin', '%s:refs/remotes/origin/%s' % (branch, branch),
-                           '-n', '-q')
-    git('reset', '--hard', 'origin/%s' % branch, '-q')
-    git('checkout', '-B', branch, 'origin/%s' % branch, '-q')
+    with working_dir(prefix):
+        git = which('git', required=True)
+        git('init', '--shared', '-q')
+        git('remote', 'add', 'origin', origin_url)
+        git('fetch', 'origin', '%s:refs/remotes/origin/%s' % (branch, branch),
+            '-n', '-q')
+        git('reset', '--hard', 'origin/%s' % branch, '-q')
+        git('checkout', '-B', branch, 'origin/%s' % branch, '-q')
 
-    tty.msg("Successfully created a new spack in %s" % prefix,
-            "Run %s/bin/spack to use this installation." % prefix)
+        tty.msg("Successfully created a new spack in %s" % prefix,
+                "Run %s/bin/spack to use this installation." % prefix)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -153,16 +153,15 @@ class FetchStrategy(with_metaclass(FSMeta, object)):
 
 @pattern.composite(interface=FetchStrategy)
 class FetchStrategyComposite(object):
+    """Composite for a FetchStrategy object.
 
-    """
-    Composite for a FetchStrategy object. Implements the GoF composite pattern.
+    Implements the GoF composite pattern.
     """
     matches = FetchStrategy.matches
     set_stage = FetchStrategy.set_stage
 
 
 class URLFetchStrategy(FetchStrategy):
-
     """FetchStrategy that pulls source code from a URL for an archive,
        checks the archive against a checksum,and decompresses the archive.
     """
@@ -200,8 +199,6 @@ class URLFetchStrategy(FetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        self.stage.chdir()
-
         if self.archive_file:
             tty.msg("Already downloaded %s" % self.archive_file)
             return
@@ -242,7 +239,8 @@ class URLFetchStrategy(FetchStrategy):
 
         # Run curl but grab the mime type from the http headers
         curl = self.curl
-        headers = curl(*curl_args, output=str, fail_on_error=False)
+        with working_dir(self.stage.path):
+            headers = curl(*curl_args, output=str, fail_on_error=False)
 
         if curl.returncode != 0:
             # clean up archive on failure.
@@ -310,7 +308,6 @@ class URLFetchStrategy(FetchStrategy):
 
         tty.msg("Staging archive: %s" % self.archive_file)
 
-        self.stage.chdir()
         if not self.archive_file:
             raise NoArchiveFileError(
                 "Couldn't find archive file",
@@ -318,15 +315,17 @@ class URLFetchStrategy(FetchStrategy):
 
         if not self.extension:
             self.extension = extension(self.archive_file)
+
         decompress = decompressor_for(self.archive_file, self.extension)
 
         # Expand all tarballs in their own directory to contain
         # exploding tarballs.
         tarball_container = os.path.join(self.stage.path,
                                          "spack-expanded-archive")
+
         mkdirp(tarball_container)
-        os.chdir(tarball_container)
-        decompress(self.archive_file)
+        with working_dir(tarball_container):
+            decompress(self.archive_file)
 
         # Check for an exploding tarball, i.e. one that doesn't expand
         # to a single directory.  If the tarball *didn't* explode,
@@ -345,10 +344,9 @@ class URLFetchStrategy(FetchStrategy):
                     shutil.move(os.path.join(tarball_container, f),
                                 os.path.join(self.stage.path, f))
                 os.rmdir(tarball_container)
+
         if not files:
             os.rmdir(tarball_container)
-        # Set the wd back to the stage when done.
-        self.stage.chdir()
 
     def archive(self, destination):
         """Just moves this archive to the destination."""
@@ -416,8 +414,6 @@ class CacheURLFetchStrategy(URLFetchStrategy):
         if not os.path.isfile(path):
             raise NoCacheError('No cache of %s' % path)
 
-        self.stage.chdir()
-
         # remove old symlink if one is there.
         filename = self.stage.save_filename
         if os.path.exists(filename):
@@ -484,8 +480,8 @@ class VCSFetchStrategy(FetchStrategy):
             for p in patterns:
                 tar.add_default_arg('--exclude=%s' % p)
 
-        self.stage.chdir()
-        tar('-czf', destination, os.path.basename(self.stage.source_path))
+        with working_dir(self.stage.path):
+            tar('-czf', destination, os.path.basename(self.stage.source_path))
 
     def __str__(self):
         return "VCS: %s" % self.url
@@ -495,9 +491,8 @@ class VCSFetchStrategy(FetchStrategy):
 
 
 class GoFetchStrategy(VCSFetchStrategy):
+    """Fetch strategy that employs the `go get` infrastructure.
 
-    """
-    Fetch strategy that employs the `go get` infrastructure
     Use like this in a package:
 
        version('name',
@@ -530,25 +525,24 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        self.stage.chdir()
-
         tty.msg("Trying to get go resource:", self.url)
 
-        try:
-            os.mkdir('go')
-        except OSError:
-            pass
-        env = dict(os.environ)
-        env['GOPATH'] = os.path.join(os.getcwd(), 'go')
-        self.go('get', '-v', '-d', self.url, env=env)
+        with working_dir(self.stage.path):
+            try:
+                os.mkdir('go')
+            except OSError:
+                pass
+            env = dict(os.environ)
+            env['GOPATH'] = os.path.join(os.getcwd(), 'go')
+            self.go('get', '-v', '-d', self.url, env=env)
 
     def archive(self, destination):
         super(GoFetchStrategy, self).archive(destination, exclude='.git')
 
     @_needs_stage
     def reset(self):
-        self.stage.chdir_to_source()
-        self.go('clean')
+        with working_dir(self.stage.source_path):
+            self.go('clean')
 
     def __str__(self):
         return "[go] %s" % self.url
@@ -607,10 +601,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     def cachable(self):
         return bool(self.commit or self.tag)
 
-    @_needs_stage
     def fetch(self):
-        self.stage.chdir()
-
         if self.stage.source_path:
             tty.msg("Already fetched %s" % self.stage.source_path)
             return
@@ -622,20 +613,24 @@ class GitFetchStrategy(VCSFetchStrategy):
             args = 'at tag %s' % self.tag
         elif self.branch:
             args = 'on branch %s' % self.branch
+
         tty.msg("Trying to clone git repository: %s %s" % (self.url, args))
 
+        git = self.git
         if self.commit:
             # Need to do a regular clone and check out everything if
             # they asked for a particular commit.
-            if spack.debug:
-                self.git('clone', self.url)
-            else:
-                self.git('clone', '--quiet', self.url)
-            self.stage.chdir_to_source()
-            if spack.debug:
-                self.git('checkout', self.commit)
-            else:
-                self.git('checkout', '--quiet', self.commit)
+            with working_dir(self.stage.path):
+                if spack.debug:
+                    git('clone', self.url)
+                else:
+                    git('clone', '--quiet', self.url)
+
+            with working_dir(self.stage.source_path):
+                if spack.debug:
+                    git('checkout', self.commit)
+                else:
+                    git('checkout', '--quiet', self.commit)
 
         else:
             # Can be more efficient if not checking out a specific commit.
@@ -654,57 +649,58 @@ class GitFetchStrategy(VCSFetchStrategy):
             if self.git_version > ver('1.7.10'):
                 args.append('--single-branch')
 
-            cloned = False
-            # Yet more efficiency, only download a 1-commit deep tree
-            if self.git_version >= ver('1.7.1'):
-                try:
-                    self.git(*(args + ['--depth', '1', self.url]))
-                    cloned = True
-                except spack.error.SpackError:
-                    # This will fail with the dumb HTTP transport
-                    # continue and try without depth, cleanup first
-                    pass
+            with working_dir(self.stage.path):
+                cloned = False
+                # Yet more efficiency, only download a 1-commit deep tree
+                if self.git_version >= ver('1.7.1'):
+                    try:
+                        git(*(args + ['--depth', '1', self.url]))
+                        cloned = True
+                    except spack.error.SpackError:
+                        # This will fail with the dumb HTTP transport
+                        # continue and try without depth, cleanup first
+                        pass
 
-            if not cloned:
-                args.append(self.url)
-                self.git(*args)
+                if not cloned:
+                    args.append(self.url)
+                    git(*args)
 
-            self.stage.chdir_to_source()
+                with working_dir(self.stage.source_path):
+                    # For tags, be conservative and check them out AFTER
+                    # cloning.  Later git versions can do this with clone
+                    # --branch, but older ones fail.
+                    if self.tag and self.git_version < ver('1.8.5.2'):
+                        # pull --tags returns a "special" error code of 1 in
+                        # older versions that we have to ignore.
+                        # see: https://github.com/git/git/commit/19d122b
+                        if spack.debug:
+                            git('pull', '--tags', ignore_errors=1)
+                            git('checkout', self.tag)
+                        else:
+                            git('pull', '--quiet', '--tags', ignore_errors=1)
+                            git('checkout', '--quiet', self.tag)
 
-            # For tags, be conservative and check them out AFTER
-            # cloning.  Later git versions can do this with clone
-            # --branch, but older ones fail.
-            if self.tag and self.git_version < ver('1.8.5.2'):
-                # pull --tags returns a "special" error code of 1 in
-                # older versions that we have to ignore.
-                # see: https://github.com/git/git/commit/19d122b
+        with working_dir(self.stage.source_path):
+            # Init submodules if the user asked for them.
+            if self.submodules:
                 if spack.debug:
-                    self.git('pull', '--tags', ignore_errors=1)
-                    self.git('checkout', self.tag)
+                    git('submodule', 'update', '--init', '--recursive')
                 else:
-                    self.git('pull', '--quiet', '--tags', ignore_errors=1)
-                    self.git('checkout', '--quiet', self.tag)
-
-        # Init submodules if the user asked for them.
-        if self.submodules:
-            if spack.debug:
-                self.git('submodule', 'update', '--init', '--recursive')
-            else:
-                self.git('submodule', '--quiet', 'update', '--init',
-                         '--recursive')
+                    git('submodule', '--quiet', 'update', '--init',
+                        '--recursive')
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')
 
     @_needs_stage
     def reset(self):
-        self.stage.chdir_to_source()
-        if spack.debug:
-            self.git('checkout', '.')
-            self.git('clean', '-f')
-        else:
-            self.git('checkout', '--quiet', '.')
-            self.git('clean', '--quiet', '-f')
+        with working_dir(self.stage.source_path):
+            if spack.debug:
+                self.git('checkout', '.')
+                self.git('clean', '-f')
+            else:
+                self.git('checkout', '--quiet', '.')
+                self.git('clean', '--quiet', '-f')
 
     def __str__(self):
         return "[git] %s" % self.url
@@ -749,8 +745,6 @@ class SvnFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        self.stage.chdir()
-
         if self.stage.source_path:
             tty.msg("Already fetched %s" % self.stage.source_path)
             return
@@ -762,30 +756,31 @@ class SvnFetchStrategy(VCSFetchStrategy):
             args += ['-r', self.revision]
         args.append(self.url)
 
-        self.svn(*args)
-        self.stage.chdir_to_source()
+        with working_dir(self.stage.path):
+            self.svn(*args)
 
     def _remove_untracked_files(self):
         """Removes untracked files in an svn repository."""
-        status = self.svn('status', '--no-ignore', output=str)
-        self.svn('status', '--no-ignore')
-        for line in status.split('\n'):
-            if not re.match('^[I?]', line):
-                continue
-            path = line[8:].strip()
-            if os.path.isfile(path):
-                os.unlink(path)
-            elif os.path.isdir(path):
-                shutil.rmtree(path, ignore_errors=True)
+        with working_dir(self.stage.source_path):
+            status = self.svn('status', '--no-ignore', output=str)
+            self.svn('status', '--no-ignore')
+            for line in status.split('\n'):
+                if not re.match('^[I?]', line):
+                    continue
+                path = line[8:].strip()
+                if os.path.isfile(path):
+                    os.unlink(path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path, ignore_errors=True)
 
     def archive(self, destination):
         super(SvnFetchStrategy, self).archive(destination, exclude='.svn')
 
     @_needs_stage
     def reset(self):
-        self.stage.chdir_to_source()
         self._remove_untracked_files()
-        self.svn('revert', '.', '-R')
+        with working_dir(self.stage.source_path):
+            self.svn('revert', '.', '-R')
 
     def __str__(self):
         return "[svn] %s" % self.url
@@ -845,8 +840,6 @@ class HgFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        self.stage.chdir()
-
         if self.stage.source_path:
             tty.msg("Already fetched %s" % self.stage.source_path)
             return
@@ -866,27 +859,26 @@ class HgFetchStrategy(VCSFetchStrategy):
         if self.revision:
             args.extend(['-r', self.revision])
 
-        self.hg(*args)
+        with working_dir(self.stage.path):
+            self.hg(*args)
 
     def archive(self, destination):
         super(HgFetchStrategy, self).archive(destination, exclude='.hg')
 
     @_needs_stage
     def reset(self):
-        self.stage.chdir()
+        with working_dir(self.stage.path):
+            source_path = self.stage.source_path
+            scrubbed = "scrubbed-source-tmp"
 
-        source_path = self.stage.source_path
-        scrubbed = "scrubbed-source-tmp"
+            args = ['clone']
+            if self.revision:
+                args += ['-r', self.revision]
+            args += [source_path, scrubbed]
+            self.hg(*args)
 
-        args = ['clone']
-        if self.revision:
-            args += ['-r', self.revision]
-        args += [source_path, scrubbed]
-        self.hg(*args)
-
-        shutil.rmtree(source_path, ignore_errors=True)
-        shutil.move(scrubbed, source_path)
-        self.stage.chdir_to_source()
+            shutil.rmtree(source_path, ignore_errors=True)
+            shutil.move(scrubbed, source_path)
 
     def __str__(self):
         return "[hg] %s" % self.url

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1405,6 +1405,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
 
                     echo = logger.echo
                     self.log()
+
                 # Run post install hooks before build stage is removed.
                 spack.hooks.post_install(self.spec)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -366,18 +366,8 @@ class Stage(object):
                 return p
         return None
 
-    def chdir(self):
-        """Changes directory to the stage path. Or dies if it is not set
-        up."""
-        if os.path.isdir(self.path):
-            os.chdir(self.path)
-        else:
-            raise ChdirError("Setup failed: no such directory: " + self.path)
-
     def fetch(self, mirror_only=False):
         """Downloads an archive or checks out code from a repository."""
-        self.chdir()
-
         fetchers = []
         if not mirror_only:
             fetchers.append(self.default_fetcher)
@@ -477,18 +467,6 @@ class Stage(object):
             tty.msg("Created stage in %s" % self.path)
         else:
             tty.msg("Already staged %s in %s" % (self.name, self.path))
-
-    def chdir_to_source(self):
-        """Changes directory to the expanded archive directory.
-           Dies with an error if there was no expanded archive.
-        """
-        path = self.source_path
-        if not path:
-            raise StageError("Attempt to chdir before expanding archive.")
-        else:
-            os.chdir(path)
-            if not os.listdir(path):
-                raise StageError("Archive was empty for %s" % self.name)
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -613,9 +591,6 @@ class StageComposite:
     def path(self):
         return self[0].path
 
-    def chdir_to_source(self):
-        return self[0].chdir_to_source()
-
     @property
     def archive_file(self):
         return self[0].archive_file
@@ -634,21 +609,12 @@ class DIYStage(object):
         self.source_path = path
         self.created = True
 
-    def chdir(self):
-        if os.path.isdir(self.path):
-            os.chdir(self.path)
-        else:
-            raise ChdirError("Setup failed: no such directory: " + self.path)
-
     # DIY stages do nothing as context managers.
     def __enter__(self):
         pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
-
-    def chdir_to_source(self):
-        self.chdir()
 
     def fetch(self, *args, **kwargs):
         tty.msg("No need to fetch for DIY.")
@@ -699,10 +665,6 @@ class StageError(spack.error.SpackError):
 
 class RestageError(StageError):
     """"Error encountered during restaging."""
-
-
-class ChdirError(StageError):
-    """Raised when Spack can't change directories."""
 
 
 # Keep this in namespace for convenience

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -57,8 +57,8 @@ def test_install_package_and_dependency(
         tmpdir, builtin_mock, mock_archive, mock_fetch, config,
         install_mockery):
 
-    tmpdir.chdir()
-    install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
+    with tmpdir.as_cwd():
+        install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
 
     files = tmpdir.listdir()
     filename = tmpdir.join('test.xml')
@@ -104,9 +104,9 @@ def test_install_package_already_installed(
         tmpdir, builtin_mock, mock_archive, mock_fetch, config,
         install_mockery):
 
-    tmpdir.chdir()
-    install('libdwarf')
-    install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
+    with tmpdir.as_cwd():
+        install('libdwarf')
+        install('--log-format=junit', '--log-file=test.xml', 'libdwarf')
 
     files = tmpdir.listdir()
     filename = tmpdir.join('test.xml')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -150,6 +150,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
     assert "'install'\nAFTER INSTALL" in out
 
 
+@pytest.mark.disable_clean_stage_check
 def test_install_output_on_build_error(builtin_mock, mock_archive, mock_fetch,
                                        config, install_mockery, capfd):
     # capfd interferes with Spack's capturing
@@ -161,6 +162,7 @@ def test_install_output_on_build_error(builtin_mock, mock_archive, mock_fetch,
     assert 'configure: error: cannot run C compiled programs.' in out
 
 
+@pytest.mark.disable_clean_stage_check
 def test_install_output_on_python_error(builtin_mock, mock_archive, mock_fetch,
                                         config, install_mockery):
     out = install('failing-build', fail_on_error=False)
@@ -169,6 +171,7 @@ def test_install_output_on_python_error(builtin_mock, mock_archive, mock_fetch,
     assert 'raise InstallError("Expected failure.")' in out
 
 
+@pytest.mark.disable_clean_stage_check
 def test_install_with_source(
         builtin_mock, mock_archive, mock_fetch, config, install_mockery):
     """Verify that source has been copied into place."""
@@ -180,6 +183,7 @@ def test_install_with_source(
                        os.path.join(src, 'configure'))
 
 
+@pytest.mark.disable_clean_stage_check
 def test_show_log_on_error(builtin_mock, mock_archive, mock_fetch,
                            config, install_mockery, capfd):
     """Make sure --show-log-on-error works."""

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -47,7 +47,6 @@ def test_inspect_path(tmpdir):
         '': ['CMAKE_PREFIX_PATH']
     }
 
-    tmpdir.chdir()
     tmpdir.mkdir('bin')
     tmpdir.mkdir('lib')
     tmpdir.mkdir('include')

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -72,22 +72,23 @@ def test_fetch(
         finally:
             spack.insecure = False
 
-        assert h('HEAD') == h(t.revision)
+        with working_dir(pkg.stage.source_path):
+            assert h('HEAD') == h(t.revision)
 
-        file_path = join_path(pkg.stage.source_path, t.file)
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            file_path = join_path(pkg.stage.source_path, t.file)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        os.unlink(file_path)
-        assert not os.path.isfile(file_path)
+            os.unlink(file_path)
+            assert not os.path.isfile(file_path)
 
-        untracked_file = 'foobarbaz'
-        touch(untracked_file)
-        assert os.path.isfile(untracked_file)
-        pkg.do_restage()
-        assert not os.path.isfile(untracked_file)
+            untracked_file = 'foobarbaz'
+            touch(untracked_file)
+            assert os.path.isfile(untracked_file)
+            pkg.do_restage()
+            assert not os.path.isfile(untracked_file)
 
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        assert h('HEAD') == h(t.revision)
+            assert h('HEAD') == h(t.revision)

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -29,6 +29,7 @@ import spack
 from llnl.util.filesystem import *
 from spack.spec import Spec
 from spack.version import ver
+from spack.fetch_strategy import GitFetchStrategy
 from spack.util.executable import which
 
 
@@ -36,15 +37,42 @@ pytestmark = pytest.mark.skipif(
     not which('git'), reason='requires git to be installed')
 
 
+@pytest.fixture(params=[None, '1.8.5.2', '1.8.5.1', '1.7.10', '1.7.0'])
+def git_version(request):
+    """Tests GitFetchStrategy behavior for different git versions.
+
+    GitFetchStrategy tries to optimize using features of newer git
+    versions, but needs to work with older git versions.  To ensure code
+    paths for old versions still work, we fake it out here and make it
+    use the backward-compatibility code paths with newer git versions.
+    """
+    git = which('git', required=True)
+    real_git_version = ver(git('--version', output=str).lstrip('git version '))
+
+    if request.param is None:
+        yield    # don't patch; run with the real git_version method.
+    else:
+        test_git_version = ver(request.param)
+        if test_git_version > real_git_version:
+            pytest.skip("Can't test clone logic for newer version of git.")
+
+        # patch the fetch strategy to think it's using a lower git version.
+        # we use this to test what we'd need to do with older git versions
+        # using a newer git installation.
+        git_version_method = GitFetchStrategy.git_version
+        GitFetchStrategy.git_version = test_git_version
+        yield
+        GitFetchStrategy.git_version = git_version_method
+
+
 @pytest.mark.parametrize("type_of_test", ['master', 'branch', 'tag', 'commit'])
 @pytest.mark.parametrize("secure", [True, False])
-def test_fetch(
-        type_of_test,
-        secure,
-        mock_git_repository,
-        config,
-        refresh_builtin_mock
-):
+def test_fetch(type_of_test,
+               secure,
+               mock_git_repository,
+               config,
+               refresh_builtin_mock,
+               git_version):
     """Tries to:
 
     1. Fetch the repo using a fetch strategy constructed with

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -72,22 +72,23 @@ def test_fetch(
         finally:
             spack.insecure = False
 
-        assert h() == t.revision
+        with working_dir(pkg.stage.source_path):
+            assert h() == t.revision
 
-        file_path = join_path(pkg.stage.source_path, t.file)
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            file_path = join_path(pkg.stage.source_path, t.file)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        os.unlink(file_path)
-        assert not os.path.isfile(file_path)
+            os.unlink(file_path)
+            assert not os.path.isfile(file_path)
 
-        untracked_file = 'foobarbaz'
-        touch(untracked_file)
-        assert os.path.isfile(untracked_file)
-        pkg.do_restage()
-        assert not os.path.isfile(untracked_file)
+            untracked_file = 'foobarbaz'
+            touch(untracked_file)
+            assert os.path.isfile(untracked_file)
+            pkg.do_restage()
+            assert not os.path.isfile(untracked_file)
 
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        assert h() == t.revision
+            assert h() == t.revision

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -69,46 +69,49 @@ class MockStage(object):
         self.test_destroyed = False
 
     def __enter__(self):
+        self.create()
         return self
 
-    def __exit__(self, *exc):
-        return True
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.destroy()
 
     def destroy(self):
         self.test_destroyed = True
         self.wrapped_stage.destroy()
+
+    def create(self):
+        self.wrapped_stage.create()
 
     def __getattr__(self, attr):
         return getattr(self.wrapped_stage, attr)
 
 
 def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
-    spec = Spec('canfail')
-    spec.concretize()
+    spec = Spec('canfail').concretized()
     pkg = spack.repo.get(spec)
     remove_prefix = spack.package.Package.remove_prefix
     instance_rm_prefix = pkg.remove_prefix
 
     try:
+        pkg.succeed = False
         spack.package.Package.remove_prefix = mock_remove_prefix
         with pytest.raises(MockInstallError):
             pkg.do_install()
         assert os.path.isdir(pkg.prefix)
         rm_prefix_checker = RemovePrefixChecker(instance_rm_prefix)
         spack.package.Package.remove_prefix = rm_prefix_checker.remove_prefix
-        setattr(pkg, 'succeed', True)
+
+        pkg.succeed = True
         pkg.stage = MockStage(pkg.stage)
+
         pkg.do_install(restage=True)
         assert rm_prefix_checker.removed
         assert pkg.stage.test_destroyed
         assert pkg.installed
+
     finally:
         spack.package.Package.remove_prefix = remove_prefix
-        pkg._stage = None
-        try:
-            delattr(pkg, 'succeed')
-        except AttributeError:
-            pass
 
 
 def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
@@ -141,53 +144,50 @@ def test_installed_dependency_request_conflicts(
         dependent.concretize()
 
 
+@pytest.mark.disable_clean_stage_check
 def test_partial_install_keep_prefix(install_mockery, mock_fetch):
-    spec = Spec('canfail')
-    spec.concretize()
+    spec = Spec('canfail').concretized()
     pkg = spack.repo.get(spec)
+
     # Normally the stage should start unset, but other tests set it
     pkg._stage = None
     remove_prefix = spack.package.Package.remove_prefix
     try:
         # If remove_prefix is called at any point in this test, that is an
         # error
+        pkg.succeed = False  # make the build fail
         spack.package.Package.remove_prefix = mock_remove_prefix
         with pytest.raises(spack.build_environment.ChildError):
             pkg.do_install(keep_prefix=True)
         assert os.path.exists(pkg.prefix)
-        setattr(pkg, 'succeed', True)
+
+        pkg.succeed = True   # make the build succeed
         pkg.stage = MockStage(pkg.stage)
         pkg.do_install(keep_prefix=True)
         assert pkg.installed
         assert not pkg.stage.test_destroyed
+
     finally:
         spack.package.Package.remove_prefix = remove_prefix
-        pkg._stage = None
-        try:
-            delattr(pkg, 'succeed')
-        except AttributeError:
-            pass
 
 
 def test_second_install_no_overwrite_first(install_mockery, mock_fetch):
-    spec = Spec('canfail')
-    spec.concretize()
+    spec = Spec('canfail').concretized()
     pkg = spack.repo.get(spec)
     remove_prefix = spack.package.Package.remove_prefix
     try:
         spack.package.Package.remove_prefix = mock_remove_prefix
-        setattr(pkg, 'succeed', True)
+
+        pkg.succeed = True
         pkg.do_install()
         assert pkg.installed
+
         # If Package.install is called after this point, it will fail
-        delattr(pkg, 'succeed')
+        pkg.succeed = False
         pkg.do_install()
+
     finally:
         spack.package.Package.remove_prefix = remove_prefix
-        try:
-            delattr(pkg, 'succeed')
-        except AttributeError:
-            pass
 
 
 def test_store(install_mockery, mock_fetch):
@@ -196,9 +196,11 @@ def test_store(install_mockery, mock_fetch):
     pkg.do_install()
 
 
+@pytest.mark.disable_clean_stage_check
 def test_failing_build(install_mockery, mock_fetch):
     spec = Spec('failing-build').concretized()
     pkg = spec.package
+
     with pytest.raises(spack.build_environment.ChildError):
         pkg.do_install()
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -70,11 +70,7 @@ def check_mirror():
         # register mirror with spack config
         mirrors = {'spack-mirror-test': 'file://' + mirror_root}
         spack.config.update_config('mirrors', mirrors)
-
-        os.chdir(stage.path)
-        spack.mirror.create(
-            mirror_root, repos, no_checksum=True
-        )
+        spack.mirror.create(mirror_root, repos, no_checksum=True)
 
         # Stage directory exists
         assert os.path.isdir(mirror_root)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -25,20 +25,22 @@
 """
 This test checks the binary packaging infrastructure
 """
-import pytest
-import spack
-import spack.store
-from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
-from spack.spec import Spec
-import spack.binary_distribution as bindist
-from llnl.util.filesystem import join_path, mkdirp
-import argparse
-import spack.cmd.buildcache as buildcache
-from spack.relocate import *
 import os
 import stat
 import sys
 import shutil
+import pytest
+import argparse
+
+from llnl.util.filesystem import mkdirp
+
+import spack
+import spack.store
+import spack.binary_distribution as bindist
+import spack.cmd.buildcache as buildcache
+from spack.spec import Spec
+from spack.fetch_strategy import URLFetchStrategy, FetchStrategyComposite
+from spack.relocate import *
 from spack.util.executable import ProcessError
 
 
@@ -72,8 +74,8 @@ def test_packaging(mock_archive, tmpdir):
     spec.concretize()
     pkg = spack.repo.get(spec)
     fake_fetchify(pkg.fetcher, pkg)
-    mkdirp(join_path(pkg.prefix, "bin"))
-    patchelfscr = join_path(pkg.prefix, "bin", "patchelf")
+    mkdirp(os.path.join(pkg.prefix, "bin"))
+    patchelfscr = os.path.join(pkg.prefix, "bin", "patchelf")
     f = open(patchelfscr, 'w')
     body = """#!/bin/bash
 echo $PATH"""
@@ -91,14 +93,14 @@ echo $PATH"""
     pkg.do_install()
 
     # Put some non-relocatable file in there
-    filename = join_path(spec.prefix, "dummy.txt")
+    filename = os.path.join(spec.prefix, "dummy.txt")
     with open(filename, "w") as script:
         script.write(spec.prefix)
 
     # Create the build cache  and
     # put it directly into the mirror
 
-    mirror_path = join_path(tmpdir, 'test-mirror')
+    mirror_path = os.path.join(str(tmpdir), 'test-mirror')
     specs = [spec]
     spack.mirror.create(
         mirror_path, specs, no_checksum=True
@@ -286,18 +288,25 @@ def test_relocate():
 
 @pytest.mark.skipif(sys.platform != 'darwin',
                     reason="only works with Mach-o objects")
-def test_relocate_macho():
-    get_patchelf()
-    assert (needs_binary_relocation('Mach-O') is True)
-    macho_get_paths('/bin/bash')
-    shutil.copyfile('/bin/bash', 'bash')
-    modify_macho_object('bash', '/bin/bash', '/usr', '/opt', False)
-    modify_macho_object('bash', '/bin/bash', '/usr', '/opt', True)
-    shutil.copyfile('/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
-    modify_macho_object('libncurses.5.4.dylib',
-                        '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', False)
-    modify_macho_object('libncurses.5.4.dylib',
-                        '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', True)
+def test_relocate_macho(tmpdir):
+    with tmpdir.as_cwd():
+        get_patchelf()
+        assert (needs_binary_relocation('Mach-O') is True)
+
+        macho_get_paths('/bin/bash')
+        shutil.copyfile('/bin/bash', 'bash')
+
+        modify_macho_object('bash', '/bin/bash', '/usr', '/opt', False)
+        modify_macho_object('bash', '/bin/bash', '/usr', '/opt', True)
+
+        shutil.copyfile(
+            '/usr/lib/libncurses.5.4.dylib', 'libncurses.5.4.dylib')
+        modify_macho_object(
+            'libncurses.5.4.dylib',
+            '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', False)
+        modify_macho_object(
+            'libncurses.5.4.dylib',
+            '/usr/lib/libncurses.5.4.dylib', '/usr', '/opt', True)
 
 
 @pytest.mark.skipif(sys.platform != 'linux2',

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -30,16 +30,8 @@ import pytest
 import spack
 import spack.stage
 import spack.util.executable
-from llnl.util.filesystem import join_path
+from llnl.util.filesystem import join_path, working_dir
 from spack.stage import Stage
-
-
-def check_chdir_to_source(stage, stage_name):
-    stage_path = get_stage_path(stage, stage_name)
-    archive_dir = 'test-files'
-    assert join_path(
-        os.path.realpath(stage_path), archive_dir
-    ) == os.getcwd()
 
 
 def check_expand_archive(stage, stage_name, mock_archive):
@@ -62,11 +54,6 @@ def check_fetch(stage, stage_name):
     stage_path = get_stage_path(stage, stage_name)
     assert archive_name in os.listdir(stage_path)
     assert join_path(stage_path, archive_name) == stage.fetcher.archive_file
-
-
-def check_chdir(stage, stage_name):
-    stage_path = get_stage_path(stage, stage_name)
-    assert os.path.realpath(stage_path) == os.getcwd()
 
 
 def check_destroy(stage, stage_name):
@@ -162,10 +149,9 @@ def mock_archive(tmpdir, monkeypatch):
     test_tmp_path.ensure(dir=True)
     test_readme.write('hello world!\n')
 
-    current = tmpdir.chdir()
-    tar = spack.util.executable.which('tar', required=True)
-    tar('czf', str(archive_name), 'test-files')
-    current.chdir()
+    with tmpdir.as_cwd():
+        tar = spack.util.executable.which('tar', required=True)
+        tar('czf', str(archive_name), 'test-files')
 
     # Make spack use the test environment for tmp stuff.
     monkeypatch.setattr(spack.stage, '_tmp_root', None)
@@ -180,9 +166,6 @@ def mock_archive(tmpdir, monkeypatch):
         test_tmp_dir=test_tmp_path,
         archive_dir=archive_dir
     )
-    # record this since this test changes to directories that will
-    # be removed.
-    current.chdir()
 
 
 @pytest.fixture()
@@ -245,18 +228,10 @@ class TestStage(object):
             check_setup(stage, None, mock_archive)
         check_destroy(stage, None)
 
-    def test_chdir(self, mock_archive):
-        with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.chdir()
-            check_setup(stage, self.stage_name, mock_archive)
-            check_chdir(stage, self.stage_name)
-        check_destroy(stage, self.stage_name)
-
     def test_fetch(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
             stage.fetch()
             check_setup(stage, self.stage_name, mock_archive)
-            check_chdir(stage, self.stage_name)
             check_fetch(stage, self.stage_name)
         check_destroy(stage, self.stage_name)
 
@@ -307,37 +282,23 @@ class TestStage(object):
             check_expand_archive(stage, self.stage_name, mock_archive)
         check_destroy(stage, self.stage_name)
 
-    def test_expand_archive_with_chdir(self, mock_archive):
-        with Stage(mock_archive.url, name=self.stage_name) as stage:
-            stage.fetch()
-            check_setup(stage, self.stage_name, mock_archive)
-            check_fetch(stage, self.stage_name)
-            stage.expand_archive()
-            stage.chdir_to_source()
-            check_expand_archive(stage, self.stage_name, mock_archive)
-            check_chdir_to_source(stage, self.stage_name)
-        check_destroy(stage, self.stage_name)
-
     def test_restage(self, mock_archive):
         with Stage(mock_archive.url, name=self.stage_name) as stage:
             stage.fetch()
             stage.expand_archive()
-            stage.chdir_to_source()
-            check_expand_archive(stage, self.stage_name, mock_archive)
-            check_chdir_to_source(stage, self.stage_name)
 
-            # Try to make a file in the old archive dir
-            with open('foobar', 'w') as file:
-                file.write("this file is to be destroyed.")
+            with working_dir(stage.source_path):
+                check_expand_archive(stage, self.stage_name, mock_archive)
+
+                # Try to make a file in the old archive dir
+                with open('foobar', 'w') as file:
+                    file.write("this file is to be destroyed.")
 
             assert 'foobar' in os.listdir(stage.source_path)
 
             # Make sure the file is not there after restage.
             stage.restage()
-            check_chdir(stage, self.stage_name)
             check_fetch(stage, self.stage_name)
-            stage.chdir_to_source()
-            check_chdir_to_source(stage, self.stage_name)
             assert 'foobar' not in os.listdir(stage.source_path)
         check_destroy(stage, self.stage_name)
 

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -72,22 +72,23 @@ def test_fetch(
         finally:
             spack.insecure = False
 
-        assert h() == t.revision
+        with working_dir(pkg.stage.source_path):
+            assert h() == t.revision
 
-        file_path = join_path(pkg.stage.source_path, t.file)
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            file_path = join_path(pkg.stage.source_path, t.file)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        os.unlink(file_path)
-        assert not os.path.isfile(file_path)
+            os.unlink(file_path)
+            assert not os.path.isfile(file_path)
 
-        untracked_file = 'foobarbaz'
-        touch(untracked_file)
-        assert os.path.isfile(untracked_file)
-        pkg.do_restage()
-        assert not os.path.isfile(untracked_file)
+            untracked_file = 'foobarbaz'
+            touch(untracked_file)
+            assert os.path.isfile(untracked_file)
+            pkg.do_restage()
+            assert not os.path.isfile(untracked_file)
 
-        assert os.path.isdir(pkg.stage.source_path)
-        assert os.path.isfile(file_path)
+            assert os.path.isdir(pkg.stage.source_path)
+            assert os.path.isfile(file_path)
 
-        assert h() == t.revision
+            assert h() == t.revision

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -72,13 +72,14 @@ def test_fetch(
         finally:
             spack.insecure = False
 
-        assert os.path.exists('configure')
-        assert is_exe('configure')
+        with working_dir(pkg.stage.source_path):
+            assert os.path.exists('configure')
+            assert is_exe('configure')
 
-        with open('configure') as f:
-            contents = f.read()
-        assert contents.startswith('#!/bin/sh')
-        assert 'echo Building...' in contents
+            with open('configure') as f:
+                contents = f.read()
+            assert contents.startswith('#!/bin/sh')
+            assert 'echo Building...' in contents
 
 
 def test_hash_detection(checksum_type):

--- a/var/spack/repos/builtin.mock/packages/canfail/package.py
+++ b/var/spack/repos/builtin.mock/packages/canfail/package.py
@@ -33,11 +33,9 @@ class Canfail(Package):
 
     version('1.0', '0123456789abcdef0123456789abcdef')
 
+    succeed = False
+
     def install(self, spec, prefix):
-        try:
-            succeed = getattr(self, 'succeed')
-            if not succeed:
-                raise InstallError("'succeed' was false")
-            touch(join_path(prefix, 'an_installation_file'))
-        except AttributeError:
-            raise InstallError("'succeed' attribute was not set")
+        if not self.succeed:
+            raise InstallError("'succeed' was false")
+        touch(join_path(prefix, 'an_installation_file'))


### PR DESCRIPTION
This PR does a few things:

- [x] Add an `autouse` fixture that verifies that tests don't change the working directory.

- [x] Tests no longer drop extra stuff in Spack's staging area (`var/spack/stage`).  They're executed with a mock stage.

- [x] Another `autouse` fixture ensures that no test clutters the stage directory.

- [x] Spack doesn't use `os.chdir()` directly anymore -- it only uses context managers like `working_dir` and `py.path.as_cwd()` so that no function ends up actually changing the working directory for its caller.
    - This cleans up some of the nastiness where reordering would cause tests to fail.
    - This also makes Spack functions (e.g., `do_stage()`) nicer to work with.

- [x] Getting the `stage` property from a package no longer creates the stage directory automatically.  You have to call `pkg.stage.create()` for that, and Spack now calls it right before fetching.

@hartzell: The last bullet above caused empty stages to be erroneously created for already-installed dependencies.  I wonder if that has to do with the problem you saw in #4977.  The stages for dependencies would be re-created by recursive calls to `do_install()`, even when `do_install()` decided nothing to bail b/c the dependency was already installed.  I am curious whether this, and to a lesser extent  #5714, help with #4977.