### PR TITLE
armadillo: use libs to provide arpack and superlu libraries

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -569,6 +569,9 @@ def _find_recursive(root, search_files):
     # found in a key, and reconstructing the stable order later.
     found_files = collections.defaultdict(list)
 
+    if not os.path.isdir(root):
+        return []
+
     for path, _, list_files in os.walk(root):
         for search_file in search_files:
             for list_file in list_files:
@@ -586,6 +589,9 @@ def _find_non_recursive(root, search_files):
     # The variable here is **on purpose** a defaultdict as os.list_dir
     # can return files in any order (does not preserve stability)
     found_files = collections.defaultdict(list)
+
+    if not os.path.isdir(root):
+        return []
 
     for list_file in os.listdir(root):
         for search_file in search_files:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -569,9 +569,6 @@ def _find_recursive(root, search_files):
     # found in a key, and reconstructing the stable order later.
     found_files = collections.defaultdict(list)
 
-    if not os.path.isdir(root):
-        return []
-
     for path, _, list_files in os.walk(root):
         for search_file in search_files:
             for list_file in list_files:
@@ -589,9 +586,6 @@ def _find_non_recursive(root, search_files):
     # The variable here is **on purpose** a defaultdict as os.list_dir
     # can return files in any order (does not preserve stability)
     found_files = collections.defaultdict(list)
-
-    if not os.path.isdir(root):
-        return []
 
     for list_file in os.listdir(root):
         for search_file in search_files:

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -59,15 +59,8 @@ class Armadillo(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        arpack = find_libraries('libarpack', root=spec[
-                                'arpack-ng'].prefix.lib64, shared=True)
-        if not arpack:
-            arpack = find_libraries("libarpack",
-                                    root=spec["arpack-ng"].prefix.lib,
-                                    shared=True)
-
-        superlu = find_libraries('libsuperlu', root=spec[
-                                 'superlu'].prefix, shared=False, recurse=True)
+        arpack = spec['arpack-ng'].libs
+        superlu = spec['superlu'].libs
         return [
             # ARPACK support
             '-DARPACK_LIBRARY={0}'.format(arpack.joined()),

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -62,7 +62,8 @@ class Armadillo(CMakePackage):
         arpack = find_libraries('libarpack', root=spec[
                                 'arpack-ng'].prefix.lib64, shared=True)
         if not arpack:
-            arpack = find_libraries("libarpack", root=spec["arpack-ng"].prefix.lib,
+            arpack = find_libraries("libarpack",
+                                    root=spec["arpack-ng"].prefix.lib,
                                     shared=True)
 
         superlu = find_libraries('libsuperlu', root=spec[

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -59,18 +59,16 @@ class Armadillo(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        arpack = spec['arpack-ng'].libs
-        superlu = spec['superlu'].libs
         return [
             # ARPACK support
-            '-DARPACK_LIBRARY={0}'.format(arpack.joined()),
+            '-DARPACK_LIBRARY={0}'.format(spec['arpack-ng'].libs.joined()),
             # BLAS support
             '-DBLAS_LIBRARY={0}'.format(spec['blas'].libs.joined()),
             # LAPACK support
             '-DLAPACK_LIBRARY={0}'.format(spec['lapack'].libs.joined()),
             # SuperLU support
             '-DSuperLU_INCLUDE_DIR={0}'.format(spec['superlu'].prefix.include),
-            '-DSuperLU_LIBRARY={0}'.format(superlu.joined()),
+            '-DSuperLU_LIBRARY={0}'.format(spec['superlu'].libs.joined()),
             # HDF5 support
             '-DDETECT_HDF5={0}'.format('ON' if '+hdf5' in spec else 'OFF')
         ]

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -61,14 +61,14 @@ class Armadillo(CMakePackage):
 
         return [
             # ARPACK support
-            '-DARPACK_LIBRARY={0}'.format(spec['arpack-ng'].libs.joined()),
+            '-DARPACK_LIBRARY={0}'.format(spec['arpack-ng'].libs.joined(";")),
             # BLAS support
-            '-DBLAS_LIBRARY={0}'.format(spec['blas'].libs.joined()),
+            '-DBLAS_LIBRARY={0}'.format(spec['blas'].libs.joined(";")),
             # LAPACK support
-            '-DLAPACK_LIBRARY={0}'.format(spec['lapack'].libs.joined()),
+            '-DLAPACK_LIBRARY={0}'.format(spec['lapack'].libs.joined(";")),
             # SuperLU support
             '-DSuperLU_INCLUDE_DIR={0}'.format(spec['superlu'].prefix.include),
-            '-DSuperLU_LIBRARY={0}'.format(spec['superlu'].libs.joined()),
+            '-DSuperLU_LIBRARY={0}'.format(spec['superlu'].libs.joined(";")),
             # HDF5 support
             '-DDETECT_HDF5={0}'.format('ON' if '+hdf5' in spec else 'OFF')
         ]

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -61,6 +61,10 @@ class Armadillo(CMakePackage):
 
         arpack = find_libraries('libarpack', root=spec[
                                 'arpack-ng'].prefix.lib64, shared=True)
+        if not arpack:
+            arpack = find_libraries("libarpack", root=spec["arpack-ng"].prefix.lib,
+                                    shared=True)
+
         superlu = find_libraries('libsuperlu', root=spec[
                                  'superlu'].prefix, shared=False, recurse=True)
         return [


### PR DESCRIPTION
Currently the `find` function and hence `find_libraries` as well as `find_system_libraries` raise an `OSError` if the `root` path of their search does not exist. In my opinion it makes more sense to return an empty dictionary instead.

Note, that this probably affects many packages which use `find`, `find_libraries` or variants thereof. I initially encountered the error while installing `armadillo` on an Ubuntu 14.04 machine, where arpack is placed in a `lib` subfolder and not `lib64` as the `armadillo` Spack package expects it.

I fix that issue in the second commit. My point is, that this requires the extra explicit check whether the returned `LibraryList` is not empty. I am not really happy about this boilerplate, so please point me in a proper direction if you have a better idea how to fix this issue without potentially silently breaking the installation process of other packages.