### PR TITLE
Forcing Paraview to avoid using git describe to determine its own version number

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -141,7 +141,7 @@ class Paraview(CMakePackage):
                 '-DMPIEXEC:FILEPATH=%s/bin/mpiexec' % spec['mpi'].prefix
             ])
 
-        if 'darwin' in self.spec.architecture:
+        if 'darwin' in spec.architecture:
             cmake_args.extend([
                 '-DVTK_USE_X:BOOL=OFF',
                 '-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON',
@@ -149,7 +149,7 @@ class Paraview(CMakePackage):
 
         # Hide git from Paraview so it will not use `git describe`
         # to find its own version number
-        if self.spec.satisfies('@5.4.0:5.4.1'):
+        if spec.satisfies('@5.4.0:5.4.1'):
             cmake_args.extend([
                 '-DGIT_EXECUTABLE=FALSE'
             ])

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -147,4 +147,11 @@ class Paraview(CMakePackage):
                 '-DPARAVIEW_DO_UNIX_STYLE_INSTALLS:BOOL=ON',
             ])
 
+        # Hide git from Paraview so it will not use `git describe`
+        # to find its own version number
+        if self.spec.satisfies('@5.4.0:5.4.1'):
+            cmake_args.extend([
+                '-DGIT_EXECUTABLE=FALSE'
+            ])
+
         return cmake_args


### PR DESCRIPTION
In replacement of #5744 and related to issue #5735 . This sets `GIT_EXECUTABLE=FALSE` to avoid Paraview using `git describe` to determine its own version number. I have tested that it avoids finding the `git` executable:

```
-- Could NOT find Git (missing:  GIT_EXECUTABLE) 
-- Could not use git to determine source version, using version 5.4.1
```