### PR TITLE
bioconductor update

### DIFF
--- a/var/spack/repos/builtin/packages/r-a4/package.py
+++ b/var/spack/repos/builtin/packages/r-a4/package.py
@@ -29,10 +29,11 @@ class RA4(RPackage):
     """Automated Affymetrix Array Analysis Umbrella Package."""
 
     homepage = "https://www.bioconductor.org/packages/a4/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4_1.24.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/a4"
     list_url = homepage
-    version('1.24.0', 'dfa17ec5b1914300360ff11f43955fdd')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4', commit='79b5143652176787c85a0d587b3bbfad6b4a19f4')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-a4base', type=('build', 'run'))
     depends_on('r-a4preproc', type=('build', 'run'))
     depends_on('r-a4classif', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-a4base/package.py
+++ b/var/spack/repos/builtin/packages/r-a4base/package.py
@@ -29,10 +29,11 @@ class RA4base(RPackage):
     """Automated Affymetrix Array Analysis."""
 
     homepage = "https://www.bioconductor.org/packages/a4Base/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4Base_1.24.0.tar.gz"
+    url      = "'https://git.bioconductor.org/packages/a4Base'"
     list_url = homepage
-    version('1.24.0', '98f53cb437f1b8bb7ba8c2628c0f44c6')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4Base', commit='f674afe424a508df2c8ee6c87a06fbd4aa410ef6')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-annotationdbi', type=('build', 'run'))
     depends_on('r-annaffy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-a4classif/package.py
+++ b/var/spack/repos/builtin/packages/r-a4classif/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class RA4classif(RPackage)
+class RA4classif(RPackage):
     """Automated Affymetrix Array Analysis Classification Package."""
 
     homepage = "https://www.bioconductor.org/packages/a4Classif/"

--- a/var/spack/repos/builtin/packages/r-a4classif/package.py
+++ b/var/spack/repos/builtin/packages/r-a4classif/package.py
@@ -25,15 +25,16 @@
 from spack import *
 
 
-class RA4classif(RPackage):
+class RA4classif(RPackage)
     """Automated Affymetrix Array Analysis Classification Package."""
 
-    homepage = "https://www.bioconductor.org"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4Classif_1.24.0.tar.gz"
+    homepage = "https://www.bioconductor.org/packages/a4Classif/"
+    url      = "https://git.bioconductor.org/packages/a4Classif"
     list_url = homepage
 
-    version('1.24.0', 'b3367ba63a5d5a38d94e671d027098ff')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4Classif', commit='ca06bf274c87a73fc12c29a6eea4b90289fe30b1')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-a4core', type=('build', 'run'))
     depends_on('r-a4preproc', type=('build', 'run'))
     depends_on('r-mlinterfaces', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-a4core/package.py
+++ b/var/spack/repos/builtin/packages/r-a4core/package.py
@@ -28,10 +28,11 @@ from spack import *
 class RA4core(RPackage):
     """Automated Affymetrix Array Analysis Core Package."""
 
-    homepage = "https://www.bioconductor.org"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4Core_1.24.0.tar.gz"
+    homepage = "https://www.bioconductor.org/packages/a4Core/"
+    url      = "https://git.bioconductor.org/packages/a4Core"
 
-    version('1.24.0', 'd7f79c350ae0a6175f2ecc9a337ca61f')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4Core', commit='c871faa3e1ab6be38a9ea3018816cf31b58b0ed3')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-glmnet', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-a4preproc/package.py
+++ b/var/spack/repos/builtin/packages/r-a4preproc/package.py
@@ -29,8 +29,9 @@ class RA4preproc(RPackage):
     """Automated Affymetrix Array Analysis Preprocessing Package."""
 
     homepage = "https://www.bioconductor.org/packages/a4Preproc/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4Preproc_1.24.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/a4Preproc"
 
-    version('1.24.0', '8de73ad20a28155f34a4636c3f7c6539')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4Preproc', commit='651014b8102807aea4f1274e34e083e70b5e7ee7')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-annotationdbi', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-a4reporting/package.py
+++ b/var/spack/repos/builtin/packages/r-a4reporting/package.py
@@ -28,10 +28,11 @@ from spack import *
 class RA4reporting(RPackage):
     """Automated Affymetrix Array Analysis Reporting Package."""
 
-    homepage = "https://www.bioconductor.org"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/a4Reporting_1.24.0.tar.gz"
+    homepage = "https://www.bioconductor.org/packages/a4Reporting"
+    url      = "https://git.bioconductor.org/packages/a4Reporting"
     list_url = homepage
-    version('1.24.0', '0d69505cae81da94e77b69184ae30abd')
+    version('1.24.0', git='https://git.bioconductor.org/packages/a4Reporting', commit='bf22c4d50daf40fc9eaf8c476385bf4a24a5b5ce')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.24.0')
     depends_on('r-annaffy', type=('build', 'run'))
     depends_on('r-xtable', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-abaenrichment/package.py
+++ b/var/spack/repos/builtin/packages/r-abaenrichment/package.py
@@ -42,10 +42,11 @@ class RAbaenrichment(RPackage):
     user-defined brain regions."""
 
     homepage = "https://bioconductor.org/packages/ABAEnrichment/"
-    url      = "https://bioconductor.org/packages/release/bioc/src/contrib/ABAEnrichment_1.6.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/ABAEnrichment"
 
-    version('1.6.0', '810eb4ee9ce2a5049babbb174dc8d588')
+    version('1.6.0', git='https://git.bioconductor.org/packages/ABAEnrichment', commit='d2a0467dcb7aa6e103e3b83dccd6510b0e142ac1')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.6.0')
     depends_on('r-rcpp', type=('build', 'run'))
     depends_on('r-gplots', type=('build', 'run'))
     depends_on('r-gtools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-absseq/package.py
+++ b/var/spack/repos/builtin/packages/r-absseq/package.py
@@ -32,9 +32,10 @@ class RAbsseq(RPackage):
     of dispersion across expression level."""
 
     homepage = "https://www.bioconductor.org/packages/ABSSeq/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/ABSSeq_1.22.8.tar.gz"
+    url      = "https://git.bioconductor.org/packages/ABSSeq"
 
-    version('1.22.8', 'bfdb1800f2e7c60dfa7f6b43026ec8f9')
+    version('1.22.8', git='https://git.bioconductor.org/packages/ABSSeq', commit='a67ba49bc156a4522092519644f3ec83d58ebd6a')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.22.8')
     depends_on('r-locfit', type=('build', 'run'))
     depends_on('r-limma', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-acgh/package.py
+++ b/var/spack/repos/builtin/packages/r-acgh/package.py
@@ -32,10 +32,11 @@ class RAcgh(RPackage):
     printing and plotting aCGH objects."""
 
     homepage = "https://www.bioconductor.org/packages/aCGH/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/aCGH_1.54.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/aCGH"
 
-    version('1.54.0', '8e5bd1800b2760e46fcab4179c2e920c')
+    version('1.54.0', git='https://git.bioconductor.org/packages/aCGH', commit='be2ed339449f55c8d218e10c435e4ad356683693')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.54.0')
     depends_on('r-cluster', type=('build', 'run'))
     depends_on('r-survival', type=('build', 'run'))
     depends_on('r-multtest', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-acme/package.py
+++ b/var/spack/repos/builtin/packages/r-acme/package.py
@@ -37,9 +37,10 @@ class RAcme(RPackage):
     experiments quite easily with enough memory."""
 
     homepage = "https://www.bioconductor.org/packages/ACME/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/ACME_2.32.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/ACME"
 
-    version('2.32.0', 'f99ea6b94399fd7a10f55ac7e7ec04fa')
+    version('2.32.0', git='https://git.bioconductor.org/packages/ACME', commit='76372255d7714a0c8128a11c028bf70214dac407')
 
+    depends_on('r@3.4.0:3.4.9', when='@2.32.0')
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-biocgenerics', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-adsplit/package.py
+++ b/var/spack/repos/builtin/packages/r-adsplit/package.py
@@ -32,10 +32,11 @@ class RAdsplit(RPackage):
     significance of the supporting gene set is determined."""
 
     homepage = "https://www.bioconductor.org/packages/adSplit/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/adSplit_1.46.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/adSplit"
 
-    version('1.46.0', '7638432c734c1fe458acbb9b29384f57')
+    version('1.46.0', git='https://git.bioconductor.org/packages/adSplit', commit='7e81a83f34d371447f491b3a146bf6851e260c7c')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.46.0')
     depends_on('r-annotationdbi', type=('build', 'run'))
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-cluster', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-affxparser/package.py
+++ b/var/spack/repos/builtin/packages/r-affxparser/package.py
@@ -36,7 +36,9 @@ class RAffxparser(RPackage):
     from a set of CEL files into a convenient list structure."""
 
     homepage = "https://www.bioconductor.org/packages/affxparser/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/affxparser_1.48.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/affxparser"
     list_url = homepage
 
-    version('1.48.0', '20ae3f61e3ea25c3baeabf949b1f1165')
+    version('1.48.0', git='https://git.bioconductor.org/packages/affxparser', commit='2461ea88f310b59c4a9a997a4b3dadedbd65a4aa')
+
+    depends_on('r@3.4.0:3.4.9', when='@1.48.0')

--- a/var/spack/repos/builtin/packages/r-affycomp/package.py
+++ b/var/spack/repos/builtin/packages/r-affycomp/package.py
@@ -30,8 +30,9 @@ class RAffycomp(RPackage):
     expression measures for Affymetrix Oligonucleotide Arrays."""
 
     homepage = "https://www.bioconductor.org/packages/affycomp/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/affycomp_1.52.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/affycomp"
 
-    version('1.52.0', 'efa67e67701f2083fadbed99bf7d60b9')
+    version('1.52.0', git='https://git.bioconductor.org/packages/affycomp', commit='1b97a1cb21ec93bf1e5c88d5d55b988059612790')
 
+    depends_on('r@3.4.0:3.4.9', when='1.52.0')
     depends_on('r-biobase', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-affycomp/package.py
+++ b/var/spack/repos/builtin/packages/r-affycomp/package.py
@@ -34,5 +34,5 @@ class RAffycomp(RPackage):
 
     version('1.52.0', git='https://git.bioconductor.org/packages/affycomp', commit='1b97a1cb21ec93bf1e5c88d5d55b988059612790')
 
-    depends_on('r@3.4.0:3.4.9', when='1.52.0')
+    depends_on('r@3.4.0:3.4.9', when='@1.52.0')
     depends_on('r-biobase', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-affycompatible/package.py
+++ b/var/spack/repos/builtin/packages/r-affycompatible/package.py
@@ -34,9 +34,9 @@ class RAffycompatible(RPackage):
     (AGCC)-compatible sample annotation files."""
 
     homepage = "https://www.bioconductor.org/packages/AffyCompatible/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/AffyCompatible_1.36.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/AffyCompatible"
 
-    version('1.36.0', '0e30d7f20308d7c48beb4a03b5ea20c6')
+    version('1.36.0', 'https://git.bioconductor.org/packages/AffyCompatible', commit='dbbfd43a54ae1de6173336683a9461084ebf38c3')
 
     depends_on('r@3.4.0:3.4.9', when=('@1.36.0'))
     depends_on('r-xml', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-affycontam/package.py
+++ b/var/spack/repos/builtin/packages/r-affycontam/package.py
@@ -30,9 +30,9 @@ class RAffycontam(RPackage):
     effectiveness."""
 
     homepage = "https://www.bioconductor.org/packages/affyContam/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/affyContam_1.34.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/affyContam"
 
-    version('1.34.0', '19e4452b65701482e8ee65aa8ce54fb9')
+    version('1.34.0', git='https://git.bioconductor.org/packages/affyContam', commit='03529f26d059c19e069cdda358dbf7789b6d4c40')
 
     depends_on('r@3.4.0:3.4.9', when=('@1.34.0'))
     depends_on('r-biobase', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-annaffy/package.py
+++ b/var/spack/repos/builtin/packages/r-annaffy/package.py
@@ -35,10 +35,11 @@ class RAnnaffy(RPackage):
     using various criteria."""
 
     homepage = "https://www.bioconductor.org/packages/annaffy/"
-    url = "https://www.bioconductor.org/packages/release/bioc/src/contrib/annaffy_1.48.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/annaffy"
 
-    version('1.48.0', 'c51219a222b377403fe4bc08a6c57e7f')
+    version('1.48.0', git='https://git.bioconductor.org/packages/annaffy', commit='89a03c64ac9df5d963ed60b87893a3fffa6798a0')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.48.0')
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-go-db', type=('build', 'run'))
     depends_on('r-kegg-db', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-annotate/package.py
+++ b/var/spack/repos/builtin/packages/r-annotate/package.py
@@ -31,7 +31,6 @@ class RAnnotate(RPackage):
     homepage = "https://www.bioconductor.org/packages/annotate/"
     url      = "https://git.bioconductor.org/packages/annotate"
     list_url = homepage
-
     version('1.54.0', git='https://git.bioconductor.org/packages/annotate', commit='860cc5b696795a31b18beaf4869f9c418d74549e')
 
     depends_on('r@3.4.0:3.4.9', when='@1.54.0')

--- a/var/spack/repos/builtin/packages/r-annotate/package.py
+++ b/var/spack/repos/builtin/packages/r-annotate/package.py
@@ -29,10 +29,12 @@ class RAnnotate(RPackage):
     """Using R enviroments for annotation."""
 
     homepage = "https://www.bioconductor.org/packages/annotate/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/annotate_1.54.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/annotate"
     list_url = homepage
-    version('1.54.0', '01a4961ef28fc88943e168f946592d44')
 
+    version('1.54.0', git='https://git.bioconductor.org/packages/annotate', commit='860cc5b696795a31b18beaf4869f9c418d74549e')
+
+    depends_on('r@3.4.0:3.4.9', when='@1.54.0')
     depends_on('r-annotationdbi', type=('build', 'run'))
     depends_on('r-xml', type=('build', 'run'))
     depends_on('r-rcurl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-annotationdbi/package.py
+++ b/var/spack/repos/builtin/packages/r-annotationdbi/package.py
@@ -32,10 +32,11 @@ class RAnnotationdbi(RPackage):
     annotation data packages using SQLite data storage."""
 
     homepage = "https://www.bioconductor.org/packages/AnnotationDbi/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/AnnotationDbi_1.38.2.tar.gz"
+    url      = "https://git.bioconductor.org/packages/AnnotationDbi"
     list_url = homepage
-    version('1.38.2', 'aea4a5cd1f752b59cb9f4a8dcca05734')
+    version('1.38.2', git='https://git.bioconductor.org/packages/AnnotationDbi', commit='67d46facba8c15fa5f0eb47c4e39b53dbdc67c36')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.38.2')
     depends_on('r-biocgenerics', type=('build', 'run'))
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-iranges', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-genefilter/package.py
+++ b/var/spack/repos/builtin/packages/r-genefilter/package.py
@@ -29,9 +29,11 @@ class RGenefilter(RPackage):
     """Some basic functions for filtering genes"""
 
     homepage = "https://bioconductor.org/packages/genefilter/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/genefilter_1.58.1.tar.gz"
+    url      = "https://git.bioconductor.org/packages/genefilter"
     list_url = homepage
-    version('1.58.1', 'bc1a90bdf93d8db994220545cd80f438')
+    version('1.58.1', git='https://git.bioconductor.org/packages/genefilter', commit='ace2556049677f60882adfe91f8cc96791556fc2')
+
+    depends_on('r@3.4.0:3.4.9', when='@1.58.1')
     depends_on('r-s4vectors', type=('build', 'run'))
     depends_on('r-annotationdbi', type=('build', 'run'))
     depends_on('r-annotate', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-limma/package.py
+++ b/var/spack/repos/builtin/packages/r-limma/package.py
@@ -30,8 +30,10 @@ class RLimma(RPackage):
     for microarray data."""
 
     homepage = "https://www.bioconductor.org/packages/limma/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/limma_3.32.6.tar.gz"
+    url      = "https://git.bioconductor.org/packages/limma"
     list_url = homepage
 
-    version('3.32.7', '9fb616ba50b4758307b0e89dbe3143d9')
+    version('3.32.10', git='https://git.bioconductor.org/packages/limma', commit='593edf28e21fe054d64137ae271b8a52ab05bc60')
     version('3.32.6', 'df5dc2b85189a24e939efa3a8e6abc41')
+
+    depends_on('r@3.4.0:3.4.9', when='@3.32.10')

--- a/var/spack/repos/builtin/packages/r-mlinterfaces/package.py
+++ b/var/spack/repos/builtin/packages/r-mlinterfaces/package.py
@@ -30,10 +30,11 @@ class RMlinterfaces(RPackage):
     code for data in R and Bioconductor containers."""
 
     homepage = "https://www.bioconductor.org/packages/MLInterfaces/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/MLInterfaces_1.56.0.tar.gz"
+    url      = "https://git.bioconductor.org/packages/MLInterfaces"
 
-    version('1.56.0', '14245ac510304af211734079a81e3b4a')
+    version('1.56.0', git='https://git.bioconductor.org/packages/MLInterfaces', commit='31fe6fb20d859fcb01d5552f42bca6bab16cc67f')
 
+    depends_on('r@3.4.0:3.4.9', when='@1.56.0')
     depends_on('r-biocgenerics', type=('build', 'run'))
     depends_on('r-biobase', type=('build', 'run'))
     depends_on('r-gdata', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-multtest/package.py
+++ b/var/spack/repos/builtin/packages/r-multtest/package.py
@@ -29,8 +29,10 @@ class RMulttest(RPackage):
     """Resampling-based multiple hypothesis testing"""
 
     homepage = "https://www.bioconductor.org/packages/multtest/"
-    url      = "https://www.bioconductor.org/packages/release/bioc/src/contrib/multtest_2.32.0.tar.gz"
-    version('2.32.0', 'edfa82ac11e4f86c438609e9d2128e5c')
+    url      = "https://git.bioconductor.org/packages/multtest"
 
+    version('2.32.0', git='https://git.bioconductor.org/packages/multtest', commit='c5e890dfbffcc3a3f107303a24b6085614312f4a')
+
+    depends_on('r@3.4.0:3.4.9', when='@2.32.0')
     depends_on('r-biocgenerics', type=('build', 'run'))
     depends_on('r-biobase', type=('build', 'run'))


### PR DESCRIPTION
Update url and add r dependency for bioconductor packages r-a4, r-a4base, r-a4classif, r-a4core, r-a4preproc, r-a4reporting. Through these changes, when bioconductor update their packages, spack can refer to the old version and don't need to update each time.