### PR TITLE
Check for namespace-qualified packages in repo_for_pkg

### DIFF
--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -547,10 +547,7 @@ class RepoPath(object):
             name = spec.name
         else:
             # handle strings directly for speed instead of @_autospec'ing
-            try:
-                namespace, name = spec.split('.')
-            except ValueError:
-                name = spec
+            namespace, _, name = spec.rpartition('.')
 
         # If the spec already has a namespace, then return the
         # corresponding repo if we know about it.

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -541,19 +541,24 @@ class RepoPath(object):
         """Given a spec, get the repository for its package."""
         # We don't @_autospec this function b/c it's called very frequently
         # and we want to avoid parsing str's into Specs unnecessarily.
+        namespace = None
         if isinstance(spec, spack.spec.Spec):
-            # If the spec already has a namespace, then return the
-            # corresponding repo if we know about it.
-            if spec.namespace:
-                fullspace = '%s.%s' % (self.super_namespace, spec.namespace)
-                if fullspace not in self.by_namespace:
-                    raise UnknownNamespaceError(spec.namespace)
-                return self.by_namespace[fullspace]
+            namespace = spec.namespace
             name = spec.name
-
         else:
             # handle strings directly for speed instead of @_autospec'ing
-            name = spec
+            try:
+                namespace, name = spec.split('.')
+            except ValueError:
+                name = spec
+
+        # If the spec already has a namespace, then return the
+        # corresponding repo if we know about it.
+        if namespace:
+            fullspace = '%s.%s' % (self.super_namespace, namespace)
+            if fullspace not in self.by_namespace:
+                raise UnknownNamespaceError(spec.namespace)
+            return self.by_namespace[fullspace]
 
         # If there's no namespace, search in the RepoPath.
         for repo in self.repos:

--- a/lib/spack/spack/repository.py
+++ b/lib/spack/spack/repository.py
@@ -819,7 +819,7 @@ class Repo(object):
 
     @_autospec
     def get(self, spec, new=False):
-        if spec.virtual:
+        if not self.exists(spec.name):
             raise UnknownPackageError(spec.name)
 
         if spec.namespace and spec.namespace != self.namespace:

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -64,3 +64,13 @@ def test_repo_multi_getpkgclass(test_repo, extra_repo):
     test_repo.put_first(extra_repo)
     test_repo.get_pkg_class('a')
     test_repo.get_pkg_class('builtin.mock.a')
+
+
+def test_repo_pkg_with_unknown_namespace(test_repo):
+    with pytest.raises(spack.repository.UnknownNamespaceError):
+        test_repo.get('unknown.a')
+
+
+def test_repo_unknown_pkg(test_repo):
+    with pytest.raises(spack.repository.UnknownPackageError):
+        test_repo.get('builtin.mock.nonexistentpackage')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -1,0 +1,48 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+import spack
+
+import pytest
+
+
+def test_repo_getpkg():
+    repopath = spack.repository.RepoPath(spack.mock_packages_path)
+    pkg_a = repopath.get('a')
+
+def test_repo_multi(tmpdir_factory):
+    repopath = spack.repository.RepoPath(spack.mock_packages_path)
+    
+    repo_namespace = 'extra_test_repo'
+    repo_dir = tmpdir_factory.mktemp(repo_namespace)
+    repo_dir.ensure('packages', dir=True)
+    
+    with open(str(repo_dir.join('repo.yaml')), 'w') as F:
+        F.write("""
+repo:
+  namespace: extra_test_repo
+""")
+    extra_repo = spack.repository.Repo(str(repo_dir))
+    repopath.put_first(extra_repo)
+    pkg_a = repopath.get('a')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -30,8 +30,10 @@ import pytest
 def test_repo_getpkg():
     repopath = spack.repository.RepoPath(spack.mock_packages_path)
     pkg_a = repopath.get('a')
+    pkg_a = repopath.get('builtin.mock.a')
 
-def test_repo_multi(tmpdir_factory):
+
+def test_repo_multi_getpkg(tmpdir_factory):
     repopath = spack.repository.RepoPath(spack.mock_packages_path)
     
     repo_namespace = 'extra_test_repo'
@@ -46,3 +48,22 @@ repo:
     extra_repo = spack.repository.Repo(str(repo_dir))
     repopath.put_first(extra_repo)
     pkg_a = repopath.get('a')
+    pkg_a = repopath.get('builtin.mock.a')
+
+
+def test_repo_multi_getpkgclass(tmpdir_factory):
+    repopath = spack.repository.RepoPath(spack.mock_packages_path)
+    
+    repo_namespace = 'extra_test_repo'
+    repo_dir = tmpdir_factory.mktemp(repo_namespace)
+    repo_dir.ensure('packages', dir=True)
+    
+    with open(str(repo_dir.join('repo.yaml')), 'w') as F:
+        F.write("""
+repo:
+  namespace: extra_test_repo
+""")
+    extra_repo = spack.repository.Repo(str(repo_dir))
+    repopath.put_first(extra_repo)
+    pkg_a = repopath.get_pkg_class('a')
+    pkg_a = repopath.get_pkg_class('builtin.mock.a')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -32,7 +32,7 @@ def extra_repo(tmpdir_factory):
     repo_namespace = 'extra_test_repo'
     repo_dir = tmpdir_factory.mktemp(repo_namespace)
     repo_dir.ensure('packages', dir=True)
-    
+
     with open(str(repo_dir.join('repo.yaml')), 'w') as F:
         F.write("""
 repo:
@@ -42,17 +42,17 @@ repo:
 
 
 def test_repo_getpkg(repo_path):
-    pkg_a = repo_path.get('a')
-    pkg_a = repo_path.get('builtin.mock.a')
+    repo_path.get('a')
+    repo_path.get('builtin.mock.a')
 
 
 def test_repo_multi_getpkg(repo_path, extra_repo):
     repo_path.put_first(extra_repo)
-    pkg_a = repo_path.get('a')
-    pkg_a = repo_path.get('builtin.mock.a')
+    repo_path.get('a')
+    repo_path.get('builtin.mock.a')
 
 
 def test_repo_multi_getpkgclass(repo_path, extra_repo):
     repo_path.put_first(extra_repo)
-    pkg_a = repo_path.get_pkg_class('a')
-    pkg_a = repo_path.get_pkg_class('builtin.mock.a')
+    repo_path.get_pkg_class('a')
+    repo_path.get_pkg_class('builtin.mock.a')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -31,7 +31,7 @@ import pytest
 # scope rather than a session level scope, since we want to edit the
 # given RepoPath
 @pytest.fixture()
-def test_repo():
+def repo_for_test():
     return spack.repository.RepoPath(spack.mock_packages_path)
 
 
@@ -49,28 +49,28 @@ repo:
     return spack.repository.Repo(str(repo_dir))
 
 
-def test_repo_getpkg(test_repo):
-    test_repo.get('a')
-    test_repo.get('builtin.mock.a')
+def test_repo_getpkg(repo_for_test):
+    repo_for_test.get('a')
+    repo_for_test.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkg(test_repo, extra_repo):
-    test_repo.put_first(extra_repo)
-    test_repo.get('a')
-    test_repo.get('builtin.mock.a')
+def test_repo_multi_getpkg(repo_for_test, extra_repo):
+    repo_for_test.put_first(extra_repo)
+    repo_for_test.get('a')
+    repo_for_test.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkgclass(test_repo, extra_repo):
-    test_repo.put_first(extra_repo)
-    test_repo.get_pkg_class('a')
-    test_repo.get_pkg_class('builtin.mock.a')
+def test_repo_multi_getpkgclass(repo_for_test, extra_repo):
+    repo_for_test.put_first(extra_repo)
+    repo_for_test.get_pkg_class('a')
+    repo_for_test.get_pkg_class('builtin.mock.a')
 
 
-def test_repo_pkg_with_unknown_namespace(test_repo):
+def test_repo_pkg_with_unknown_namespace(repo_for_test):
     with pytest.raises(spack.repository.UnknownNamespaceError):
-        test_repo.get('unknown.a')
+        repo_for_test.get('unknown.a')
 
 
-def test_repo_unknown_pkg(test_repo):
+def test_repo_unknown_pkg(repo_for_test):
     with pytest.raises(spack.repository.UnknownPackageError):
-        test_repo.get('builtin.mock.nonexistentpackage')
+        repo_for_test.get('builtin.mock.nonexistentpackage')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -27,15 +27,8 @@ import spack
 import pytest
 
 
-def test_repo_getpkg():
-    repopath = spack.repository.RepoPath(spack.mock_packages_path)
-    pkg_a = repopath.get('a')
-    pkg_a = repopath.get('builtin.mock.a')
-
-
-def test_repo_multi_getpkg(tmpdir_factory):
-    repopath = spack.repository.RepoPath(spack.mock_packages_path)
-    
+@pytest.fixture()
+def extra_repo(tmpdir_factory):
     repo_namespace = 'extra_test_repo'
     repo_dir = tmpdir_factory.mktemp(repo_namespace)
     repo_dir.ensure('packages', dir=True)
@@ -45,25 +38,21 @@ def test_repo_multi_getpkg(tmpdir_factory):
 repo:
   namespace: extra_test_repo
 """)
-    extra_repo = spack.repository.Repo(str(repo_dir))
-    repopath.put_first(extra_repo)
-    pkg_a = repopath.get('a')
-    pkg_a = repopath.get('builtin.mock.a')
+    return spack.repository.Repo(str(repo_dir))
 
 
-def test_repo_multi_getpkgclass(tmpdir_factory):
-    repopath = spack.repository.RepoPath(spack.mock_packages_path)
-    
-    repo_namespace = 'extra_test_repo'
-    repo_dir = tmpdir_factory.mktemp(repo_namespace)
-    repo_dir.ensure('packages', dir=True)
-    
-    with open(str(repo_dir.join('repo.yaml')), 'w') as F:
-        F.write("""
-repo:
-  namespace: extra_test_repo
-""")
-    extra_repo = spack.repository.Repo(str(repo_dir))
-    repopath.put_first(extra_repo)
-    pkg_a = repopath.get_pkg_class('a')
-    pkg_a = repopath.get_pkg_class('builtin.mock.a')
+def test_repo_getpkg(repo_path):
+    pkg_a = repo_path.get('a')
+    pkg_a = repo_path.get('builtin.mock.a')
+
+
+def test_repo_multi_getpkg(repo_path, extra_repo):
+    repo_path.put_first(extra_repo)
+    pkg_a = repo_path.get('a')
+    pkg_a = repo_path.get('builtin.mock.a')
+
+
+def test_repo_multi_getpkgclass(repo_path, extra_repo):
+    repo_path.put_first(extra_repo)
+    pkg_a = repo_path.get_pkg_class('a')
+    pkg_a = repo_path.get_pkg_class('builtin.mock.a')

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -27,6 +27,14 @@ import spack
 import pytest
 
 
+# Unlike the repo_path fixture defined in conftest, this has a test-level
+# scope rather than a session level scope, since we want to edit the
+# given RepoPath
+@pytest.fixture()
+def test_repo():
+    return spack.repository.RepoPath(spack.mock_packages_path)
+
+
 @pytest.fixture()
 def extra_repo(tmpdir_factory):
     repo_namespace = 'extra_test_repo'
@@ -41,18 +49,18 @@ repo:
     return spack.repository.Repo(str(repo_dir))
 
 
-def test_repo_getpkg(repo_path):
-    repo_path.get('a')
-    repo_path.get('builtin.mock.a')
+def test_repo_getpkg(test_repo):
+    test_repo.get('a')
+    test_repo.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkg(repo_path, extra_repo):
-    repo_path.put_first(extra_repo)
-    repo_path.get('a')
-    repo_path.get('builtin.mock.a')
+def test_repo_multi_getpkg(test_repo, extra_repo):
+    test_repo.put_first(extra_repo)
+    test_repo.get('a')
+    test_repo.get('builtin.mock.a')
 
 
-def test_repo_multi_getpkgclass(repo_path, extra_repo):
-    repo_path.put_first(extra_repo)
-    repo_path.get_pkg_class('a')
-    repo_path.get_pkg_class('builtin.mock.a')
+def test_repo_multi_getpkgclass(test_repo, extra_repo):
+    test_repo.put_first(extra_repo)
+    test_repo.get_pkg_class('a')
+    test_repo.get_pkg_class('builtin.mock.a')


### PR DESCRIPTION
Fixes #5754

Previously when RepoPath.repo_for_pkg was invoked with a string,
it did not check if the string included a namespace. Any
namespace-qualified package provided as a string would not be found
(at which point the behavior was to return the highest-precedence
repository).