### PR TITLE
Minor typos and corrections in `workflows.rst`

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -170,7 +170,7 @@ of usage:
 
 .. code-block:: sh
 
-   #!/bin/sh
+   #!/bin/bash
 
    compilers=(
        %gcc
@@ -355,7 +355,7 @@ Transitive Dependencies
 
 In the script above, each ``spack module loads`` command generates a
 *single* ``module load`` line.  Transitive dependencies do not usually
-need to be loaded, only modules the user needs in in ``$PATH``.  This is
+need to be loaded, only modules the user needs in ``$PATH``.  This is
 because Spack builds binaries with RPATH.  Spack's RPATH policy has
 some nice features:
 


### PR DESCRIPTION
- The shell script uses arrays and hence only works on sophisticated shells and not the default `sh`. For clarity the shebang `#!/bin/bash` has been used instead.
- Duplicated word `in` removed.