### PR TITLE
Update for 'hdf5'.

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf/package.py
+++ b/var/spack/repos/builtin/packages/netcdf/package.py
@@ -83,7 +83,7 @@ class Netcdf(AutotoolsPackage):
 
     # Required for NetCDF-4 support
     depends_on("zlib@1.2.5:")
-    depends_on('hdf5')
+    depends_on('hdf5+hl')
 
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250


### PR DESCRIPTION
An update for HDF5:
- some refactoring;
- allows for thread safety and high-level interface at the same time ('hl' becomes a variant);
- returns 'unsupported' variant (see #520) to allow unsupported combinations only when it's specified explicitly;
- additional conflict statement for mpi and cxx.

I would also make \~mpi by default because every time we want to install something that needs just NetCDF we have to write: install A+netcdf ^netcdf\~mpi ^hdf5\~mpi to avoid compilation of MPI library. But I don't know which case is more often.

There will be a discussion probably.
