### PR TITLE
Specify base branch for flake8 comparison

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -98,9 +98,11 @@ def changed_files(args):
 
     git = which('git', required=True)
 
+    range = "{0}...".format(args.base)
+
     git_args = [
         # Add changed files committed since branching off of develop
-        ['diff', '--name-only', '--diff-filter=ACMR', 'develop...'],
+        ['diff', '--name-only', '--diff-filter=ACMR', range],
         # Add changed files that have been staged but not yet committed
         ['diff', '--name-only', '--diff-filter=ACMR', '--cached'],
         # Add changed files that are unstaged
@@ -166,6 +168,9 @@ def filter_file(source, dest, output=False):
 
 
 def setup_parser(subparser):
+    subparser.add_argument(
+        '-b', '--base', action='store', default='develop',
+        help="select base branch for collecting list of modified files")
     subparser.add_argument(
         '-k', '--keep-temp', action='store_true',
         help="do not delete temporary directory where flake8 runs. "


### PR DESCRIPTION
I've found this handy.  It might be useful in the outside world also...

---

Internally we work against a branch named 'llnl/develop', which mirrors the public repository's `develop` branch.

It's useful to be able to run flake8 on our changes, using `llnl/develop` as the base branch instead of `develop`.

Internally the flake8 subcommand generates the list of changes files using a hardcoded range of `develop...`.

This makes the base of that range a command line option, with a default of `develop`.

That lets us do this:

```
spack flake8 --base llnl/develop
```

which uses a range of `llnl/develop...`.