### PR TITLE
Customization of the Paraview module file to its nonstandard directory structure

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -89,6 +89,11 @@ class Paraview(CMakePackage):
         else:
             return self._urlfmt.format(version.up_to(2), version, '')
 
+    def setup_environment(self, spack_env, run_env):
+        paraview_version='paraview-%s' % self.spec.version.up_to(2)
+        run_env.prepend_path('LIBRARY_PATH', join_path(self.prefix.lib, paraview_version))
+        run_env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.lib, paraview_version))
+
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""
         spec = self.spec

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -25,6 +25,7 @@
 from spack import *
 import os
 
+
 class Paraview(CMakePackage):
     """ParaView is an open-source, multi-platform data analysis and
     visualization application."""

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -23,7 +23,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ##############################################################################
 from spack import *
-
+import os
 
 class Paraview(CMakePackage):
     """ParaView is an open-source, multi-platform data analysis and
@@ -90,10 +90,14 @@ class Paraview(CMakePackage):
             return self._urlfmt.format(version.up_to(2), version, '')
 
     def setup_environment(self, spack_env, run_env):
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
         paraview_version = 'paraview-%s' % self.spec.version.up_to(2)
-        run_env.prepend_path('LIBRARY_PATH', join_path(self.prefix.lib,
+        run_env.prepend_path('LIBRARY_PATH', join_path(lib_dir,
                              paraview_version))
-        run_env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.lib,
+        run_env.prepend_path('LD_LIBRARY_PATH', join_path(lib_dir,
                              paraview_version))
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -90,9 +90,11 @@ class Paraview(CMakePackage):
             return self._urlfmt.format(version.up_to(2), version, '')
 
     def setup_environment(self, spack_env, run_env):
-        paraview_version='paraview-%s' % self.spec.version.up_to(2)
-        run_env.prepend_path('LIBRARY_PATH', join_path(self.prefix.lib, paraview_version))
-        run_env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.lib, paraview_version))
+        paraview_version = 'paraview-%s' % self.spec.version.up_to(2)
+        run_env.prepend_path('LIBRARY_PATH', join_path(self.prefix.lib,
+                             paraview_version))
+        run_env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.lib,
+                             paraview_version))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""


### PR DESCRIPTION
Fixing the second half of issue #5735 which involves some customizations to the module file for Paraview where a nonstandard directory structure is added to the library paths.