### PR TITLE
bcl2fastq needs `with working_dir:` after changes in #5776

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -85,16 +85,18 @@ class Bcl2fastq2(Package):
     def unpack_it(self, f):
         def wrap():
             f()                 # call the original expand_archive()
-            if os.path.isdir('bcl2fastq'):
-                tty.msg("The tarball has already been unpacked")
-            else:
-                tty.msg("Unpacking bcl2fastq2 tarball")
-                tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
-                shutil.move(join_path('spack-expanded-archive', tarball), '.')
-                os.rmdir('spack-expanded-archive')
-                tar = which('tar')
-                tar('-xf', tarball)
-                tty.msg("Finished unpacking bcl2fastq2 tarball")
+            with working_dir(self.stage.path):
+                if os.path.isdir('bcl2fastq'):
+                    tty.msg("The tarball has already been unpacked")
+                else:
+                    tty.msg("Unpacking bcl2fastq2 tarball")
+                    tty.msg("cwd sez: {0}".format(os.getcwd()))
+                    tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
+                    shutil.move(join_path('spack-expanded-archive', tarball), '.')
+                    os.rmdir('spack-expanded-archive')
+                    tar = which('tar')
+                    tar('-xf', tarball)
+                    tty.msg("Finished unpacking bcl2fastq2 tarball")
         return wrap
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -91,8 +91,10 @@ class Bcl2fastq2(Package):
                 else:
                     tty.msg("Unpacking bcl2fastq2 tarball")
                     tty.msg("cwd sez: {0}".format(os.getcwd()))
-                    tarball = 'bcl2fastq2-v{0}.tar.gz'.format(self.version.dotted)
-                    shutil.move(join_path('spack-expanded-archive', tarball), '.')
+                    tarball = 'bcl2fastq2-v{0}.tar.gz'.format(
+                        self.version.dotted)
+                    shutil.move(join_path('spack-expanded-archive', tarball),
+                                '.')
                     os.rmdir('spack-expanded-archive')
                     tar = which('tar')
                     tar('-xf', tarball)


### PR DESCRIPTION
(edit, refer to PR, not commit...)

#5776 (commit c14f2dc) cleaned up the way the the current working directory is
managed (less magic state).

bcl2fastq is packaged like a russian doll, rather than an archive file
that contains the source, theirs a zip file that contains a tar.gz
file that contains the source.  The package definition has a bit of
extra code that unpacks the inner tarball.

That extra bit of code now needs to explicitly arrange to be in the
correct directory before it does its work.