### PR TITLE
dealii: blacklist boost 1.64 and 1.65

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -98,19 +98,19 @@ class Dealii(CMakePackage):
     # depends_on("boost@1.59.0+thread+system+serialization+iostreams")
     # depends_on("boost+mpi", when='+mpi')
     # depends_on("boost+python", when='+python')
-    depends_on("boost@1.59.0:+thread+system+serialization+iostreams",
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams",
                when='@:8.4.2~mpi')
-    depends_on("boost@1.59.0:+thread+system+serialization+iostreams+mpi",
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+mpi",
                when='@:8.4.2+mpi')
     # since @8.5.0: (and @develop) python bindings are introduced:
-    depends_on("boost@1.59.0:+thread+system+serialization+iostreams",
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams",
                when='@8.5.0:~mpi~python')
-    depends_on("boost@1.59.0:+thread+system+serialization+iostreams+mpi",
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+mpi",
                when='@8.5.0:+mpi~python')
-    depends_on("boost@1.59.0:+thread+system+serialization+iostreams+python",
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+python",
                when='@8.5.0:~mpi+python')
     depends_on(
-        "boost@1.59.0:+thread+system+serialization+iostreams+mpi+python",
+        "boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+mpi+python",
         when='@8.5.0:+mpi+python')
     depends_on("bzip2")
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -109,9 +109,8 @@ class Dealii(CMakePackage):
                when='@8.5.0:+mpi~python')
     depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+python",
                when='@8.5.0:~mpi+python')
-    depends_on(
-        "boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+mpi+python",
-        when='@8.5.0:+mpi+python')
+    depends_on("boost@1.59.0:1.63,1.66:+thread+system+serialization+iostreams+mpi+python",
+               when='@8.5.0:+mpi+python')
     depends_on("bzip2")
     depends_on("lapack")
     depends_on("muparser")


### PR DESCRIPTION
dealii has couple of failing tests with serialization in `1.65.1` https://github.com/dealii/dealii/issues/5262, probably related to this issue in boost https://svn.boost.org/trac10/ticket/13186 . `1.66` is not out yet, but I wanted to make sure that I can specify two version ranges.

p.s. Let me know If I shall put back `preferred` to `1.63` and revert https://github.com/LLNL/spack/pull/5770 

 