### PR TITLE
Add bowtie2@2.3.0, fix dependencies and sbangs

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/bowtie2-2.3.0.patch
+++ b/var/spack/repos/builtin/packages/bowtie2/bowtie2-2.3.0.patch
@@ -1,0 +1,16 @@
+--- Makefile.orig	2017-10-19 16:22:27.589185696 -0700
++++ Makefile	2017-10-19 16:23:26.094227199 -0700
+@@ -25,10 +25,10 @@
+ bindir = $(prefix)/bin
+ 
+ INC =
+-GCC_PREFIX = $(shell dirname `which gcc`)
++GCC_PREFIX =
+ GCC_SUFFIX =
+-CC ?= $(GCC_PREFIX)/gcc$(GCC_SUFFIX)
+-CPP ?= $(GCC_PREFIX)/g++$(GCC_SUFFIX)
++CC = cc
++CPP = c++
+ CXX ?= $(CPP)
+ HEADERS = $(wildcard *.h)
+ BOWTIE_MM = 1

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -37,11 +37,11 @@ class Bowtie2(Package):
     version('2.3.0', '3ab33f30f00f3c30fec1355b4e569ea2')
     version('2.2.5', '51fa97a862d248d7ee660efc1147c75f')
 
-    depends_on('tbb', when='@:2.3.0')
-    depends_on('readline', when='@:2.3.1')
+    depends_on('tbb', when='@2.3.0:')
+    depends_on('readline', when='@2.3.1:')
     depends_on('perl', type='run')
     depends_on('python', type='run')
-    depends_on('zlib', when='@:2.3.1')
+    depends_on('zlib', when='@2.3.1:')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -60,13 +60,13 @@ class Bowtie2(Package):
             kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
 
             match = '^#!/usr/bin/env perl'
-            perl = join_path(self.spec['perl'].prefix.bin, 'perl')
+            perl = self.spec['perl'].command
             substitute = "#!{perl}".format(perl=perl)
             files = ['bowtie2', ]
             filter_file(match, substitute, *files, **kwargs)
 
             match = '^#!/usr/bin/env python'
-            python = join_path(self.spec['python'].prefix.bin, 'perl')
+            python = self.spec['python'].command
             substitute = "#!{python}".format(python=python)
             files = ['bowtie2-build', 'bowtie2-inspect']
             filter_file(match, substitute, *files, **kwargs)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -34,17 +34,42 @@ class Bowtie2(Package):
     url      = "http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.1/bowtie2-2.3.1-source.zip"
 
     version('2.3.1', 'b4efa22612e98e0c23de3d2c9f2f2478')
+    version('2.3.0', '3ab33f30f00f3c30fec1355b4e569ea2')
     version('2.2.5', '51fa97a862d248d7ee660efc1147c75f')
 
-    depends_on('tbb', when='@2.3.1')
-    depends_on('readline')
-    depends_on('zlib')
+    depends_on('tbb', when='@:2.3.0')
+    depends_on('readline', when='@:2.3.1')
+    depends_on('perl', type='run')
+    depends_on('python', type='run')
+    depends_on('zlib', when='@:2.3.1')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)
+    patch('bowtie2-2.3.0.patch', when='@2.3.0', level=0)
 
     # seems to have trouble with 6's -std=gnu++14
     conflicts('%gcc@6:')
+
+    @run_before('install')
+    def filter_sbang(self):
+        """Run before install so that the standard Spack sbang install hook
+           can fix up the path to the perl|python binary.
+        """
+
+        with working_dir(self.stage.source_path):
+            kwargs = {'ignore_absent': True, 'backup': False, 'string': False}
+
+            match = '^#!/usr/bin/env perl'
+            perl = join_path(self.spec['perl'].prefix.bin, 'perl')
+            substitute = "#!{perl}".format(perl=perl)
+            files = ['bowtie2', ]
+            filter_file(match, substitute, *files, **kwargs)
+
+            match = '^#!/usr/bin/env python'
+            python = join_path(self.spec['python'].prefix.bin, 'perl')
+            substitute = "#!{python}".format(python=python)
+            files = ['bowtie2-build', 'bowtie2-inspect']
+            filter_file(match, substitute, *files, **kwargs)
 
     def install(self, spec, prefix):
         make()


### PR DESCRIPTION
Add support for bowtie2@2.3.0

- digest
- a patch for 2.3.0 that parallels the existing package.  Truth be told it builds (for me) without this, but I'm assuming that they're there for a reason...).
- tune up dependencies
  - need tbb
  - don't need readline or zlib

Several things were installed with sbang's that use `/usr/bin/env` to fine perl or python.  Fix the dependency and clean up the sbang lines.