### PR TITLE
update filename used for cc wrapper invocation debug log

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -45,6 +45,7 @@ parameters=(
     SPACK_PREFIX
     SPACK_ENV_PATH
     SPACK_DEBUG_LOG_DIR
+    SPACK_DEBUG_LOG_ID
     SPACK_COMPILER_SPEC
     SPACK_CC_RPATH_ARG
     SPACK_CXX_RPATH_ARG
@@ -355,8 +356,8 @@ fi
 # Write the input and output commands to debug logs if it's asked for.
 #
 if [[ $SPACK_DEBUG == TRUE ]]; then
-    input_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_SHORT_SPEC.in.log"
-    output_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_SHORT_SPEC.out.log"
+    input_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.in.log"
+    output_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.out.log"
     echo "[$mode] $command $input_command" >> "$input_log"
     echo "[$mode] ${full_command[@]}" >> "$output_log"
 fi

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -91,6 +91,7 @@ SPACK_PREFIX = 'SPACK_PREFIX'
 SPACK_INSTALL = 'SPACK_INSTALL'
 SPACK_DEBUG = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC = 'SPACK_SHORT_SPEC'
+SPACK_DEBUG_LOG_ID = 'SPACK_DEBUG_LOG_ID'
 SPACK_DEBUG_LOG_DIR = 'SPACK_DEBUG_LOG_DIR'
 
 
@@ -296,7 +297,8 @@ def set_build_environment_variables(pkg, env, dirty):
     # Working directory for the spack command itself, for debug logs.
     if spack.debug:
         env.set(SPACK_DEBUG, 'TRUE')
-    env.set(SPACK_SHORT_SPEC, pkg.spec.format('${PACKAGE}-${HASH:7}'))
+    env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
+    env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format('${PACKAGE}-${HASH:7}'))
     env.set(SPACK_DEBUG_LOG_DIR, spack.spack_working_dir)
 
     # Add any pkgconfig directories to PKG_CONFIG_PATH

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -296,7 +296,7 @@ def set_build_environment_variables(pkg, env, dirty):
     # Working directory for the spack command itself, for debug logs.
     if spack.debug:
         env.set(SPACK_DEBUG, 'TRUE')
-    env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
+    env.set(SPACK_SHORT_SPEC, pkg.spec.format('${PACKAGE}-${HASH:7}'))
     env.set(SPACK_DEBUG_LOG_DIR, spack.spack_working_dir)
 
     # Add any pkgconfig directories to PKG_CONFIG_PATH

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -70,8 +70,10 @@ class CompilerWrapperTest(unittest.TestCase):
         os.environ['SPACK_PREFIX'] = self.prefix
         os.environ['SPACK_ENV_PATH'] = "test"
         os.environ['SPACK_DEBUG_LOG_DIR'] = "."
+        os.environ['SPACK_DEBUG_LOG_ID'] = "foo-hashabc"
         os.environ['SPACK_COMPILER_SPEC'] = "gcc@4.4.7"
-        os.environ['SPACK_SHORT_SPEC'] = "foo@1.2"
+        os.environ['SPACK_SHORT_SPEC'] = (
+            "foo@1.2 arch=linux-rhel6-x86_64 /hashabc")
 
         os.environ['SPACK_CC_RPATH_ARG']  = "-Wl,-rpath,"
         os.environ['SPACK_CXX_RPATH_ARG'] = "-Wl,-rpath,"


### PR DESCRIPTION
The name of the debug log written by the cc compiler wrapper is given by `Spec.short_spec`, which includes the architecture. Somewhere along the line `Spec.format` started adding spaces around the architecture property so the filename started including spaces; the cc wrapper script appears to ignore this, so files like `spack-cc-bzip2-....in.log` (which record the wrapped compiler invocations) were not being generated. This updates the value of `SPACK_SHORT_SPEC` to a value without spaces (just includes the name and hash).