### PR TITLE
Zlib gets a 50-60% performance win when compiled with -O2

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -45,6 +45,8 @@ class Zlib(Package):
             description='Produce position-independent code (for shared libs)')
     variant('shared', default=True,
             description='Enables the build of shared libraries.')
+    variant('optimize', default=True,
+            description='Enable -O2 for a more optimized lib')
 
     patch('w_patch.patch', when="@1.2.11%cce")
 
@@ -58,6 +60,8 @@ class Zlib(Package):
     def setup_environment(self, spack_env, run_env):
         if '+pic' in self.spec:
             spack_env.append_flags('CFLAGS', self.compiler.pic_flag)
+        if '+optimize' in self.spec:
+            spack_env.append_flags('CFLAGS', '-O2')
 
     def install(self, spec, prefix):
         config_args = []


### PR DESCRIPTION
Chasing a performance regression has lead me to this change, going from default optimization gives a significant performance win. The sweet spot for zlib is apparently `-O2`, both `-Ofast` and `-O3` are slightly worse (regression is about 3% compared with `-O2`) in my testing. 

Happy to share my methodology with people so we can benchmark on a wider variety of systems.