### PR TITLE
jansson: enable shared library

### DIFF
--- a/var/spack/repos/builtin/packages/jansson/package.py
+++ b/var/spack/repos/builtin/packages/jansson/package.py
@@ -33,3 +33,12 @@ class Jansson(CMakePackage):
     url      = "https://github.com/akheron/jansson/archive/v2.9.tar.gz"
 
     version('2.9', 'd2db25c437b359fc5a065ed938962237')
+
+    variant('shared', default=True,
+            description='Enables the build of shared libraries')
+
+    def cmake_args(self):
+        return [
+            '-DJANSSON_BUILD_SHARED_LIBS:BOOL=%s' % (
+                'ON' if '+shared' in self.spec else 'OFF'),
+        ]


### PR DESCRIPTION
Jansson builds only a static library by default, which is probably
not what most users want. Add Cmake args to enable shared libraries
for the jansson spack package.