### PR TITLE
buildcache command updates

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -447,6 +447,7 @@ def get_specs():
                     stage.fetch()
                 except fs.FetchError:
                     continue
+                stage.cache_local()
                 with open(stage.save_filename, 'r') as f:
                     # read the spec from the build cache file. All specs
                     # in build caches are concrete (as they aer built) so
@@ -499,3 +500,4 @@ def get_keys(install=False, yes_to_all=False):
                 else:
                     tty.msg('Will not add this key to trusted keys.'
                             'Use -y to override')
+

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -412,7 +412,7 @@ def extract_tarball(spec, filename, yes_to_all=False, force=False):
     relocate_package(installpath)
 
 
-def get_specs():
+def get_specs(force=False):
     """
     Get spec.yaml's for build caches available on mirror
     """
@@ -443,11 +443,13 @@ def get_specs():
                     urls.add(link)
         for link in urls:
             with Stage(link, name="build_cache", keep=True) as stage:
-                try:
-                    stage.fetch()
-                except fs.FetchError:
-                    continue
-                stage.cache_local()
+                if force and os.path.exists(stage.save_filename):
+                    os.remove(stage.save_filename)
+                if not os.path.exists(stage.save_filename):
+                    try:
+                        stage.fetch()
+                    except fs.FetchError:
+                        continue
                 with open(stage.save_filename, 'r') as f:
                     # read the spec from the build cache file. All specs
                     # in build caches are concrete (as they aer built) so
@@ -460,7 +462,7 @@ def get_specs():
     return specs, durls
 
 
-def get_keys(install=False, yes_to_all=False):
+def get_keys(install=False, yes_to_all=False, force=False):
     """
     Get pgp public keys available on mirror
     """
@@ -488,10 +490,13 @@ def get_keys(install=False, yes_to_all=False):
                     keys.add(link)
         for link in keys:
             with Stage(link, name="build_cache", keep=True) as stage:
-                try:
-                    stage.fetch()
-                except fs.FetchError:
-                    continue
+                if os.path.exists(stage.save_filename) and force:
+                    os.remove(stage.save_filename)
+                if not os.path.exists(stage.save_filename):
+                    try:
+                        stage.fetch()
+                    except fs.FetchError:
+                        continue
             tty.msg('Found key %s' % link)
             if install:
                 if yes_to_all:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -505,4 +505,3 @@ def get_keys(install=False, yes_to_all=False, force=False):
                 else:
                     tty.msg('Will not add this key to trusted keys.'
                             'Use -y to override')
-

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -25,7 +25,6 @@
 import argparse
 
 import os
-import re
 import llnl.util.tty as tty
 
 import spack
@@ -47,9 +46,10 @@ display_args = {
 }
 
 error_message = """You can either:
-    a) use a more specific spec, or 
+    a) use a more specific spec, or
     b) use the package hash with a leading /
 """
+
 
 def setup_parser(subparser):
     setup_parser.parser = subparser
@@ -88,7 +88,7 @@ def setup_parser(subparser):
 
     listcache = subparsers.add_parser('list')
     listcache.add_argument('-f', '--force', action='store_true',
-                         help="force new download of specs")
+                           help="force new download of specs")
     listcache.add_argument(
         'packages', nargs=argparse.REMAINDER,
         help="specs of packages to search for")
@@ -102,8 +102,9 @@ def setup_parser(subparser):
         '-y', '--yes-to-all', action='store_true',
         help="answer yes to all trust questions")
     dlkeys.add_argument('-f', '--force', action='store_true',
-                         help="force new download of keys")
+                        help="force new download of keys")
     dlkeys.set_defaults(func=getkeys)
+
 
 def find_matching_specs(specs, allow_multiple_matches=False, force=False):
     """Returns a list of specs matching the not necessarily
@@ -142,6 +143,7 @@ def find_matching_specs(specs, allow_multiple_matches=False, force=False):
 
     return specs_from_cli
 
+
 def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
     """Returns a list of specs matching the not necessarily
        concretized specs given from cli
@@ -173,7 +175,7 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
             has_errors = True
 
         # No downloaded package matches the query
-        if len(matches) == 0 :
+        if len(matches) == 0:
             tty.error('%s does not match any downloaded packages.' % pkg)
             has_errors = True
 
@@ -182,6 +184,7 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False):
         tty.die(error_message)
 
     return specs_from_cli
+
 
 def createtarball(args):
     if not args.packages:
@@ -205,16 +208,17 @@ def createtarball(args):
     if args.rel:
         relative = True
 
-    matches=find_matching_specs(pkgs,False,False)
+    matches = find_matching_specs(pkgs, False, False)
     for match in matches:
         tty.msg('adding matching spec %s' % match.format())
         specs.add(match)
         tty.msg('recursing dependencies')
         for d, node in match.traverse(order='post',
-                                     depth=True,
-                                     deptype=('link', 'run')):
-            if node.external or node.virtual :
-                tty.msg('Skipping external or virtual dependency %s' % node.format())
+                                      depth=True,
+                                      deptype=('link', 'run')):
+            if node.external or node.virtual:
+                tty.msg('Skipping external or virtual dependency %s' %
+                        node.format())
             else:
                 tty.msg('adding dependency %s' % node.format())
                 specs.add(node)
@@ -259,7 +263,7 @@ def installtarball(args):
 def install_tarball(spec, args):
     s = spack.spec.Spec(spec)
     if s.external or s.virtual:
-        tty.warn("Skipping external or virtual package %s" %spec.format())
+        tty.warn("Skipping external or virtual package %s" % spec.format())
         return
     yes_to_all = False
     if args.yes_to_all:
@@ -307,7 +311,7 @@ def listspecs(args):
             for spec in sorted(specs):
                 if spec.satisfies(pkg):
                     tty.msg('spack buildcache install /%s\n' %
-                            spec.dag_hash(7) + 
+                            spec.dag_hash(7) +
                             '   to install %s' %
                             spec.format())
     else:

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -189,6 +189,9 @@ echo $PATH"""
     args = parser.parse_args(['list'])
     buildcache.buildcache(parser, args)
 
+    args = parser.parse_args(['list', '-f'])
+    buildcache.buildcache(parser, args)
+
     args = parser.parse_args(['list', 'trivial'])
     buildcache.buildcache(parser, args)
 
@@ -197,6 +200,9 @@ echo $PATH"""
                     mirror_path + '/external.key')
 
     args = parser.parse_args(['keys'])
+    buildcache.buildcache(parser, args)
+
+    args = parser.parse_args(['keys', '-f'])
     buildcache.buildcache(parser, args)
 
     # unregister mirror with spack config


### PR DESCRIPTION
Added better matching of partial specs passed to spack buildcache create,list,install.
Skip virtual and external packages that are dependencies when installing buildcaches.
Skip downloading of spec.yaml and gpg2 keys if they exist in the stage directory unless -f is used.