### PR TITLE
oce: fix Glibc 2.26 does not provide xlocale.h

### DIFF
--- a/var/spack/repos/builtin/packages/oce/package.py
+++ b/var/spack/repos/builtin/packages/oce/package.py
@@ -60,6 +60,10 @@ class Oce(Package):
     # https://github.com/tpaviot/oce/commit/61cb965b9ffeca419005bc15e635e67589c421dd.patch
     patch('null.patch', when='@0.16:0.17.1')
 
+    # OCE depends on xlocale.h from glibc-headers but it was removed in 2.26,
+    # see https://github.com/tpaviot/oce/issues/675
+    patch('xlocale.patch', level=0, when='@0.18.1:')
+
     # fix build with Xcode 8 "previous definition of CLOCK_REALTIME"
     # reported 27 Sep 2016 https://github.com/tpaviot/oce/issues/643
     if (platform.system() == "Darwin") and (

--- a/var/spack/repos/builtin/packages/oce/xlocale.patch
+++ b/var/spack/repos/builtin/packages/oce/xlocale.patch
@@ -1,0 +1,13 @@
+--- src/Standard/Standard_CLocaleSentry.hxx.ORIG	2017-08-11 07:51:11.000000000 +0200
++++ src/Standard/Standard_CLocaleSentry.hxx	2017-08-18 01:07:11.639206272 +0200
+@@ -30,7 +30,9 @@
+   #endif
+ 
+   //! We check _GNU_SOURCE for glibc extensions here and it is always defined by g++ compiler.
+-  #if defined(_GNU_SOURCE) && !defined(__ANDROID__)
++  //! Musl libc does not provide xlocale.h
++  //! glibc 2.26+ does not provide xlocale.h (anymore)
++  #if defined(_GNU_SOURCE) && defined(__GLIBC__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ < 26 && !defined(__ANDROID__)
+     #define HAVE_XLOCALE_H
+   #endif
+ #endif // ifndef HAVE_LOCALE_H


### PR DESCRIPTION
Patch to handle missing xlocale.h, based on https://github.com/tpaviot/oce/issues/675

fixes https://github.com/LLNL/spack/issues/5713