### PR TITLE
Use spack built tool as external for spack builds.

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -124,7 +124,8 @@ class DirectoryLayout(object):
         _check_concrete(spec)
 
         path = self.relative_path_for_spec(spec)
-        assert(not path.startswith(self.root))
+        if not spec.external:
+            assert(not path.startswith(self.root))
         return os.path.join(self.root, path)
 
     def remove_install_directory(self, spec):


### PR DESCRIPTION
When you compile a tool, eg cmake, with the system compiler you would like to use that tool with other compilers, eg gcc compiled with the system compiler. Skipping this assert if the package is declared external allows this.

For example, I want to be able to use cmake build with the system compiler in spack builds using gcc-7.2.0. I add this to spack/etc/spack/packages.yaml

  cmake:
    paths:
      cmake: /home/gartung/spack/opt/spack/linux-rhel7-x86_64/gcc-4.8.5/cmake-3.9.4-irpcf7frtiwi5fviqqvqcjbb77ustdvy
    buildable: False