### PR TITLE
Exodus: skip the -G "Unix Makefiles" part

### DIFF
--- a/var/spack/repos/builtin/packages/exodusii/cmake-exodus.patch
+++ b/var/spack/repos/builtin/packages/exodusii/cmake-exodus.patch
@@ -1,9 +1,0 @@
-diff --git a/cmake-exodus b/cmake-exodus
-index 67ccd34..9b749e3 100755
---- a/cmake-exodus
-+++ b/cmake-exodus
-@@ -1,3 +1,4 @@
-+#!/bin/bash
- EXTRA_ARGS=$@
- 
- ### The following assumes you are building in a subdirectory of ACCESS Root

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -27,9 +27,6 @@ from spack import *
 # TODO: Add support for a C++11 enabled installation that filters out the
 # TODO: "C++11-Disabled" flag (but only if the spec compiler supports C++11).
 
-# TODO: Use variant forwarding to forward the 'mpi' variant to the direct
-# TODO: dependencies 'hdf5' and 'netcdf'.
-
 
 class Exodusii(CMakePackage):
     """Exodus II is a C++/Fortran library developed to store and retrieve
@@ -52,8 +49,10 @@ class Exodusii(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     # https://github.com/gsjaardema/seacas/blob/master/NetCDF-Mapping.md
-    depends_on('netcdf maxdims=65536 maxvars=524288')
-    depends_on('hdf5+shared')
+    depends_on('netcdf+mpi maxdims=65536 maxvars=524288', when='+mpi')
+    depends_on('netcdf~mpi maxdims=65536 maxvars=524288', when='~mpi')
+    depends_on('hdf5+shared+mpi', when='+mpi')
+    depends_on('hdf5+shared~mpi', when='~mpi')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -61,7 +61,7 @@ class Exodusii(Package):
         cc_path = spec['mpi'].mpicc if '+mpi' in spec else self.compiler.cc
         cxx_path = spec['mpi'].mpicxx if '+mpi' in spec else self.compiler.cxx
 
-        config_args = std_cmake_args[:]
+        config_args = std_cmake_args[2:]
         config_args.extend([
             # General Flags #
             '-DSEACASProj_ENABLE_CXX11:BOOL=OFF',


### PR DESCRIPTION
The problem is that spack passes -G "Unix Makefiles" into cmake, which normally
works. But in the Exodus package, it is being passed into a bash wrapper
script. In there, the $@ then loses the information about "Unix Makefiles"
being just one argument, and in effect passes -G Unix Makefiles into the cmake
(without quotes), and so cmake only sees -G Unix, and then fails. This is a
known problem with bash with no simple solutions. As a workaround, this patch
skips the first two arguments, i.e., -G and "Unix Makefiles". This makes it
work.

Fixes #5895.