### PR TITLE
Add old version to bcftools

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -37,10 +37,12 @@ class Bcftools(Package):
     version('1.6', 'c4dba1e8cb55db0f94b4c47724b4f9fa')
     version('1.4', '50ccf0a073bd70e99cdb3c8be830416e')
     version('1.3.1', '575001e9fca37cab0c7a7287ad4b1cdb')
+    version('1.2', '8044bed8fce62f7072fc6835420f0906')
 
     depends_on('htslib@1.6',   when='@1.6')
     depends_on('htslib@1.4',   when='@1.4')
     depends_on('htslib@1.3.1', when='@1.3.1')
+    depends_on('htslib@1.2', when='@1.2')
 
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "all")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -41,7 +41,7 @@ class Htslib(AutotoolsPackage):
     depends_on('bzip2', when="@1.4:")
     depends_on('xz', when="@1.4:")
 
-    depends_on('m4', when="@1.2:")
-    depends_on('autoconf', when="@1.2:")
-    depends_on('automake', when="@1.2:")
-    depends_on('libtool', when="@1.2:")
+    depends_on('m4', when="@1.2")
+    depends_on('autoconf', when="@1.2")
+    depends_on('automake', when="@1.2")
+    depends_on('libtool', when="@1.2")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -34,7 +34,14 @@ class Htslib(AutotoolsPackage):
     version('1.6', 'd6fd14e208aca7e08cbe9072233d0af9')
     version('1.4', '2a22ff382654c033c40e4ec3ea880050')
     version('1.3.1', '16d78f90b72f29971b042e8da8be6843')
+    version('1.2', '64026d659c3b062cfb6ddc8a38e9779f',
+      url='https://github.com/samtools/htslib/archive/1.2.tar.gz')
 
     depends_on('zlib')
     depends_on('bzip2', when="@1.4:")
     depends_on('xz', when="@1.4:")
+
+    depends_on('m4', when="@1.2:")
+    depends_on('autoconf', when="@1.2:")
+    depends_on('automake', when="@1.2:")
+    depends_on('libtool', when="@1.2:")


### PR DESCRIPTION
I'm forwarding this for an internal user.

@peetsv gets the credit and the blame....

---

Our users need an old version of bcftools.

I requires the matching version of htslib.  That particular version of htslib requires the autotools machinery too.

