### PR TITLE
Add info for bedtools2@2.23.0

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -36,6 +36,7 @@ class Bedtools2(Package):
 
     version('2.26.0', '52227e7efa6627f0f95d7d734973233d')
     version('2.25.0', '534fb4a7bf0d0c3f05be52a0160d8e3d')
+    version('2.23.0', '4fa3671b3a3891eefd969ad3509222e3')
 
     depends_on('zlib')
 


### PR DESCRIPTION
[edit, give credit/blame to @peetsv]

I'm just throwing this over the wall.

Credit/blame goes to @peetsv.

---

Our users need an older version of bedtools.