### PR TITLE
flux: update flux-core to v0.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -42,10 +42,6 @@ class DocbookXml(Package):
             else:
                 install(src, dst)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
-        spack_env.set('XML_CATALOG_FILES', catalog, separator=' ')
-
     def setup_environment(self, spack_env, run_env):
         catalog = os.path.join(self.spec.prefix, 'catalog.xml')
         run_env.set('XML_CATALOG_FILES', catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -44,10 +44,6 @@ class DocbookXsl(Package):
             else:
                 install(src, dst)
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        catalog = os.path.join(self.spec.prefix, 'catalog.xml')
-        spack_env.set('XML_CATALOG_FILES', catalog, separator=' ')
-
     def setup_environment(self, spack_env, run_env):
         catalog = os.path.join(self.spec.prefix, 'catalog.xml')
         run_env.set('XML_CATALOG_FILES', catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -56,7 +56,17 @@ class Flux(AutotoolsPackage):
     depends_on("automake", type='build', when='@master')
     depends_on("libtool", type='build', when='@master')
 
+    def setup():
+        pass
+
+    @when('@master')
+    def setup(self):
+        # Allow git-describe to get last tag so flux-version works:
+        git = which('git')
+        git('pull', '--depth=50', '--tags')
+
     def autoreconf(self, spec, prefix):
+        self.setup()
         if os.path.exists('autogen.sh'):
             # Bootstrap with autotools
             bash = which('bash')

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -62,5 +62,9 @@ class Flux(AutotoolsPackage):
             bash = which('bash')
             bash('./autogen.sh')
 
+    def setup_environment(self, spack_env, run_env):
+        #  Ensure ./fluxometer.lua can be found during flux's make check
+        spack_env.append_path('LUA_PATH', './?.lua', separator=';')
+
     def configure_args(self):
         return ['--disable-docs'] if '+docs' not in self.spec else []

--- a/var/spack/repos/builtin/packages/flux/package.py
+++ b/var/spack/repos/builtin/packages/flux/package.py
@@ -30,28 +30,28 @@ class Flux(AutotoolsPackage):
     """ A next-generation resource manager (pre-alpha) """
 
     homepage = "https://github.com/flux-framework/flux-core"
-    url      = "https://github.com/flux-framework/flux-core/releases/download/v0.6.0/flux-core-0.6.0.tar.gz"
+    url      = "https://github.com/flux-framework/flux-core/releases/download/v0.8.0/flux-core-0.8.0.tar.gz"
 
-    version('0.6.0', md5='d44a0f719744771d168edd205bd8e74e')
+    version('0.8.0', md5='9ee12974a8b2ab9a30533f69826f3bec')
     version('master', branch='master',
             git='https://github.com/flux-framework/flux-core')
 
     variant('docs', default=True, description='Build flux manpages')
 
-    # Also needs autotools, but should use the system version if available
     depends_on("zeromq@4.0.4:")
     depends_on("czmq@2.2:")
     depends_on("hwloc")
     depends_on("lua@5.1:5.1.99")
+    depends_on("lua-luaposix")
     depends_on("munge")
-    depends_on("json-c")
-    depends_on("libxslt")
+    depends_on("libuuid")
     depends_on("python")
     depends_on("py-cffi", type=('build', 'run'))
     depends_on("jansson")
 
     depends_on("asciidoc", type='build', when="+docs")
 
+    # Need autotools when building on master:
     depends_on("autoconf", type='build', when='@master')
     depends_on("automake", type='build', when='@master')
     depends_on("libtool", type='build', when='@master')
@@ -61,7 +61,6 @@ class Flux(AutotoolsPackage):
             # Bootstrap with autotools
             bash = which('bash')
             bash('./autogen.sh')
-            bash('./autogen.sh')  # yes, twice, intentionally
 
     def configure_args(self):
         return ['--disable-docs'] if '+docs' not in self.spec else []


### PR DESCRIPTION
Update the version of flux-core in spack to flux-core v0.8.0, along with required dependency fixes and general spec updates.

In order to get a2x working to build the docs, the docbook-xml and docbook-xsl packages had to be updated to remove the set of XML_CATALOG_FILES in the dependent environment. I'm not exactly sure why, but this caused this environment variable to not be set at all, or set incorrectly, and thus causing errors in xmllint during manpage builds.