### PR TITLE
Fix user specs which include already-installed packages

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2225,10 +2225,10 @@ class Spec(object):
             if not spec.virtual:
                 pkg_cls = spec.package_class
                 pkg_variants = pkg_cls.variants
-                # 'patches' is a variant that may be set on any package but is
-                # not necessarily recorded by the package's class
+                # reserved names are variants that may be set on any package
+                # but are not necessarily recorded by the package's class
                 not_existing = set(spec.variants) - (
-                    set(pkg_variants) | set(['patches']))
+                    set(pkg_variants) | set(spack.directives.reserved_names))
                 if not_existing:
                     raise UnknownVariantError(spec.name, not_existing)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2225,7 +2225,10 @@ class Spec(object):
             if not spec.virtual:
                 pkg_cls = spec.package_class
                 pkg_variants = pkg_cls.variants
-                not_existing = set(spec.variants) - set(pkg_variants)
+                # 'patches' is a variant that may be set on any package but is
+                # not necessarily recorded by the package's class
+                not_existing = set(spec.variants) - (
+                    set(pkg_variants) | set(['patches']))
                 if not_existing:
                     raise UnknownVariantError(spec.name, not_existing)
 

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -592,6 +592,8 @@ def substitute_abstract_variants(spec):
         spec: spec on which to operate the substitution
     """
     for name, v in spec.variants.items():
+        if name == 'patches':
+            continue
         pkg_variant = spec.package_class.variants[name]
         new_variant = pkg_variant.make_variant(v._original_value)
         pkg_variant.validate_or_raise(new_variant, spec.package_class)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -31,6 +31,7 @@ import inspect
 import re
 
 import llnl.util.lang as lang
+import spack
 import spack.error as error
 from six import StringIO
 
@@ -592,7 +593,7 @@ def substitute_abstract_variants(spec):
         spec: spec on which to operate the substitution
     """
     for name, v in spec.variants.items():
-        if name == 'patches':
+        if name in spack.directives.reserved_names:
             continue
         pkg_variant = spec.package_class.variants[name]
         new_variant = pkg_variant.make_variant(v._original_value)


### PR DESCRIPTION
Fixes https://github.com/LLNL/spack/issues/5913

When a user-provided spec refers to an already-installed package, packages with patches applied were causing validation errors based on the recorded variants in the package's class. This specifically avoids validation related to the `patches` variant managed by the concretizer.