### PR TITLE
Colorize "Installing pkg_name"

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -66,6 +66,7 @@ from llnl.util.filesystem import working_dir, install_tree, install
 from llnl.util.lang import memoized
 from llnl.util.link_tree import LinkTree
 from llnl.util.tty.log import log_output
+from llnl.util.tty.color import colorize
 from spack import directory_layout
 from spack.util.executable import which
 from spack.stage import Stage, ResourceStage, StageComposite
@@ -1337,7 +1338,7 @@ class PackageBase(with_metaclass(PackageMeta, object)):
                     dirty=dirty,
                     **kwargs)
 
-        tty.msg('Installing %s' % self.name)
+        tty.msg(colorize('@*{Installing} @*g{%s}' % self.name))
 
         # Set run_tests flag before starting build.
         self.run_tests = spack.package_testing.check(self.name)


### PR DESCRIPTION
Now one can quickly visually see in the terminal which packages are installed
and where each package begins and ends in the log.

Here is how it looks like now:

![terminal_colors](https://user-images.githubusercontent.com/20568/32008916-c92cb240-b96a-11e7-847d-672a4cbc8435.png)

The line
```
==> Installing openmpi
```
now becomes redundant, but I left it there, since the colorized output is produced by a different mechanism than the `tty.message` output, and I don't know if you want to perhaps keep the `tty` output.

I can also change the colors etc. But it's now much more usable to see what package is being built.