### PR TITLE
gnuplot: add 5.2.0 and 5.0.7

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -45,6 +45,8 @@ class Gnuplot(AutotoolsPackage):
     # dependency of readline. Fix it with a small patch
     patch('term_include.patch')
 
+    version('5.2.0', '0bd8f9af84c0ad2fa9de16772c366416')
+    version('5.0.7', '8eaafddb0b12795f82ed6dd2a6ebbe80')
     version('5.0.6', '8ec46520a86a61163a701b00404faf1a')
     version('5.0.5', 'c5e96fca73afbee4f57cbc1bfce6b3b8')
     version('5.0.1', '79b4f9e203728f76b60b28bcd402d3c7')


### PR DESCRIPTION
`5.2.0` lightly tested on macOS High Sierra