### PR TITLE
Add info for go@1.9.2

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -56,6 +56,7 @@ class Go(Package):
 
     extendable = True
 
+    version('1.9.2', '44105c865a1a810464df79233a05a568')
     version('1.9.1', '27bce1ffb05f4f6bd90d90081e5d4169')
     version('1.9',   'da2d44ea384076efec43ee1f8b7d45d2')
     version('1.8.3', '64e9380e07bba907e26a00cf5fcbe77e')


### PR DESCRIPTION
The go team released 1.9.2 which includes fixes for some things that 1.9.1 broke:

> ... include fixes to the compiler, linker, runtime, documentation, go command, and the crypto/x509, database/sql, log, and net/smtp packages. They include a fix to a bug introduced in Go 1.9.1 and Go 1.8.4 that broke "go get" of non-Git repositories under certain conditions.