### PR TITLE
Merging netcdf dependency lines in trilinos into one line for better coverage

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -202,8 +202,7 @@ class Trilinos(CMakePackage):
     # MPI related dependencies
     depends_on('mpi')
     depends_on('netcdf+mpi', when="~pnetcdf")
-    depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@master")
-    depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@12.10.2:")
+    depends_on('netcdf+mpi+parallel-netcdf', when="+pnetcdf@master,12.12.1:")
     depends_on('parmetis', when='+metis')
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see


### PR DESCRIPTION
Netcdf was recently updated here. If I did `spack spec nalu`, I would get an unsatisfiable error in concretization. Trilinos was not adding the netcdf dependency correctly when using `trilinos+pnetcdf` after the 12.12.1 version showed up. This consolidates the netcdf dependency lines into one and now the netcdf dependency is correctly put into the spec when using `+pnetcdf` and the current default version 12.12.1 of trilinos.