### PR TITLE
Fix tarball URL's for htslib

### DIFF
--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -29,13 +29,11 @@ class Htslib(AutotoolsPackage):
     """C library for high-throughput sequencing data formats."""
 
     homepage = "https://github.com/samtools/htslib"
-    url      = "https://github.com/samtools/htslib/releases/download/1.3.1/htslib-1.3.1.tar.bz2"
 
     version('1.6', 'd6fd14e208aca7e08cbe9072233d0af9')
     version('1.4', '2a22ff382654c033c40e4ec3ea880050')
     version('1.3.1', '16d78f90b72f29971b042e8da8be6843')
-    version('1.2', '64026d659c3b062cfb6ddc8a38e9779f',
-      url='https://github.com/samtools/htslib/archive/1.2.tar.gz')
+    version('1.2', '64026d659c3b062cfb6ddc8a38e9779f')
 
     depends_on('zlib')
     depends_on('bzip2', when="@1.4:")
@@ -45,3 +43,12 @@ class Htslib(AutotoolsPackage):
     depends_on('autoconf', when="@1.2")
     depends_on('automake', when="@1.2")
     depends_on('libtool', when="@1.2")
+
+    # v1.2 uses the automagically assembled tarball from .../archive/...
+    # everything else uses the tarballs uploaded to the release
+    def url_for_version(self, version):
+        if version.string == '1.2':
+            return 'https://github.com/samtools/htslib/archive/1.2.tar.gz'
+        else:
+            url = "https://github.com/samtools/htslib/releases/download/{0}/htslib-{0}.tar.bz2"
+            return url.format(version.dotted)


### PR DESCRIPTION
A recent update (#5907) to htslib added a different URL for an old version of htslib.

Now the package is using that URL as the pattern for the newer versions too.

I have a vague memory of running into this before, that it's a known issue.

This fixes it by adding an explicit `url_for_version` routine.