### PR TITLE
Use fetch_remote_versions instead of fetch_remote_package_versions

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -960,7 +960,7 @@ def from_list_url(pkg):
        the specified package's version."""
     if pkg.list_url:
         try:
-            versions = pkg.fetch_remote_package_versions()
+            versions = pkg.fetch_remote_versions()
             try:
                 url_from_list = versions[pkg.version]
                 digest = None


### PR DESCRIPTION
cdo failed to download newer versions for me because `from_list_url` could not determine the correct URL. I tracked it down to commit 94d85d842c15f373377a790664e81706b171a411, which seems to have introduced a typo (`fetch_remote_package_versions` instead of `fetch_remote_versions`, which is used everywhere else).

With this tiny fix, cdo downloads work again.