### PR TITLE
adios: Fix hdf5 and sz dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -90,10 +90,10 @@ class Adios(AutotoolsPackage):
     depends_on('zlib', when='+zlib')
     depends_on('bzip2', when='+bzip2')
     depends_on('szip', when='+szip')
-    depends_on('sz', when='+sz')
+    depends_on('sz@:1.4.10', when='+sz')
     depends_on('zfp@:0.5.0', when='+zfp')
     # optional transports & file converters
-    depends_on('hdf5@1.8:+mpi', when='+hdf5')
+    depends_on('hdf5@1.8:+hl+mpi', when='+hdf5')
     depends_on('netcdf', when='+netcdf')
     depends_on('libevpath', when='staging=flexpath')
     depends_on('dataspaces+mpi', when='staging=dataspaces')


### PR DESCRIPTION
- hdf5's +hl variant is required because the build uses libhdf5_hl.
- sz is only compatible up to version 1.4.10 because the library has been renamed to libSZ in 1.4.11.