### PR TITLE
r-ggplot2: dependency r-scales version changed to be greater or equal to 0.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-ggplot2/package.py
+++ b/var/spack/repos/builtin/packages/r-ggplot2/package.py
@@ -47,6 +47,6 @@ class RGgplot2(RPackage):
     depends_on('r-mass', type=('build', 'run'))
     depends_on('r-plyr@1.7.1:', type=('build', 'run'))
     depends_on('r-reshape2', type=('build', 'run'))
-    depends_on('r-scales@0.4.1', type=('build', 'run'))
+    depends_on('r-scales@0.4.1:', type=('build', 'run'))
     depends_on('r-tibble', type=('build', 'run'))
     depends_on('r-lazyeval', type=('build', 'run'))


### PR DESCRIPTION
Dependency r-scales version changed to be greater or equal to 0.4.1 according to CRAN web page of ggplot2.