### PR TITLE
Fix spack build for RAJA: master requires submodules

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -29,6 +29,6 @@ class Raja(CMakePackage):
     """RAJA Parallel Framework."""
     homepage = "http://software.llnl.gov/RAJA/"
 
-    version('git', git='https://github.com/LLNL/RAJA.git', branch="master", submodules="True")
+    version('develop', git='https://github.com/LLNL/RAJA.git', branch="master", submodules="True")
 
     depends_on('cmake@3.3:', type='build')

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -29,6 +29,6 @@ class Raja(CMakePackage):
     """RAJA Parallel Framework."""
     homepage = "http://software.llnl.gov/RAJA/"
 
-    version('git', git='https://github.com/LLNL/RAJA.git', branch="master")
+    version('git', git='https://github.com/LLNL/RAJA.git', branch="master", submodules="True")
 
     depends_on('cmake@3.3:', type='build')


### PR DESCRIPTION
As per subject; it's a trivial change.