### PR TITLE
sundials+hypre depends on hypre

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -183,8 +183,10 @@ class Sundials(CMakePackage):
     depends_on('petsc+double~complex', when='+petsc precision=double')
 
     # Require that external libraries built with the same index type
+    depends_on('hypre', when='+hypre')
     depends_on('hypre~int64', when='+hypre ~int64')
     depends_on('hypre+int64', when='+hypre +int64')
+    depends_on('petsc', when='+petsc')
     depends_on('petsc~int64', when='+petsc ~int64')
     depends_on('petsc+int64', when='+petsc +int64')
 


### PR DESCRIPTION
### Before
```
$ spack spec sundials +hypre ^hypre@2.12.1
Input spec
--------------------------------
sundials+hypre
    ^hypre@2.12.1

Normalized
--------------------------------
==> Error: sundials does not depend on hypre
```

### After

Works as expected.

This bug was reported by Julian Andrej over Slack. The problem is that previously, `sundials+hypre` didn't depend on `hypre`, `sundials+hypre+int64` and `sundials+hypre~int64` depended on `hypre`. Spack's concretizer isn't currently smart enough to realize that this represents the entire space of possibilities, and tries to decide whether or not the package actually depends on `hypre` before it makes a final decision as to the value of `+int64`. By specifying that `sundials+hypre` _always_ depends on `hypre`, we can get around this problem.