### PR TITLE
Only use XCode clang wrappers for packages that set use_xcode=True

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -125,7 +125,6 @@ class Compiler(object):
         def check(exe):
             if exe is None:
                 return None
-            exe = self._find_full_path(exe)
             _verify_executables(exe)
             return exe
 
@@ -285,17 +284,6 @@ class Compiler(object):
         # does not spoil the intented precedence.
         successful.reverse()
         return dict(((v, p, s), path) for v, p, s, path in successful)
-
-    def _find_full_path(self, path):
-        """Return the actual path for a tool.
-
-        Some toolchains use forwarding executables (particularly Xcode-based
-        toolchains) which can be manipulated by external environment variables.
-        This method should be used to extract the actual path used for a tool
-        by finding out the end executable the forwarding executables end up
-        running.
-        """
-        return path
 
     def setup_custom_environment(self, pkg, env):
         """Set any environment variables necessary to use the compiler."""

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -158,16 +158,6 @@ class Clang(Compiler):
 
         return _version_cache[comp]
 
-    def _find_full_path(self, path):
-        basename = os.path.basename(path)
-
-        if not self.is_apple or basename not in ('clang', 'clang++'):
-            return super(Clang, self)._find_full_path(path)
-
-        xcrun = Executable('xcrun')
-        full_path = xcrun('-f', basename, output=str)
-        return full_path.strip()
-
     @classmethod
     def fc_version(cls, fc):
         # We could map from gcc/gfortran version to clang version, but on macOS
@@ -201,6 +191,14 @@ class Clang(Compiler):
             # with Clang. Those point to Spack's compiler wrappers and
             # consequently render MPI non-functional outside of Spack.
             return
+
+        # Use special XCode versions of compiler wrappers when using XCode
+        # Overwrites build_environment's setting of SPACK_CC and SPACK_CXX
+        xcrun = Executable('xcrun')
+        xcode_clang = xcrun('-f', 'clang', output=str).strip()
+        xcode_clangpp = xcrun('-f', 'clang++', output=str).strip()
+        env.set('SPACK_CC', xcode_clang, force=True)
+        env.set('SPACK_CXX', xcode_clangpp, force=True)
 
         xcode_select = Executable('xcode-select')
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -460,7 +460,9 @@ def set_or_unset_not_first(variable, changes, errstream):
     modifications have already been requested.
     """
     indexes = [ii for ii, item in enumerate(changes)
-               if ii != 0 and type(item) in [SetEnv, UnsetEnv]]
+               if ii != 0 and
+               not item.args.get('force', False) and
+               type(item) in [SetEnv, UnsetEnv]]
     if indexes:
         good = '\t    \t{context} at {filename}:{lineno}'
         nogood = '\t--->\t{context} at {filename}:{lineno}'


### PR DESCRIPTION
Fixes #6051.

This makes Spack builds on OS X faithful to `compilers.yaml` unless they have to be different (e.g. for XCode builds).  Now *only* packages that set `use_xcode=True` will use the XCode compiler wrappers for clang.

@balay: can you see if this fixes your issue?

@mathstuf @davydden 

Ping @alalazo b/c this adds a `force=True` option to `EnvironmentModifications`, in cases where you know you're overwriting an already-set value.