### PR TITLE
xqilla: Use append instead of extend

### DIFF
--- a/var/spack/repos/builtin/packages/xqilla/package.py
+++ b/var/spack/repos/builtin/packages/xqilla/package.py
@@ -51,6 +51,6 @@ class Xqilla(AutotoolsPackage):
                          '--with-pic'])
 
         if '+debug' in self.spec:
-            args.extend('--enable-debug')
+            args.append('--enable-debug')
 
         return args


### PR DESCRIPTION
This fixes a small typo that causes the configure stage to fail.