### PR TITLE
the-silver-searcher: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/the-silver-searcher/package.py
+++ b/var/spack/repos/builtin/packages/the-silver-searcher/package.py
@@ -37,4 +37,5 @@ class TheSilverSearcher(AutotoolsPackage):
 
     depends_on('pcre')
     depends_on('xz')
+    depends_on('zlib')
     depends_on('pkg-config', type='build')


### PR DESCRIPTION
otherwise failed to build on almost fresh Ubuntu 16.04 with gcc 5.4.0