### PR TITLE
bdftopcf: require xproto and fontsproto at build time

### DIFF
--- a/var/spack/repos/builtin/packages/bdftopcf/package.py
+++ b/var/spack/repos/builtin/packages/bdftopcf/package.py
@@ -41,4 +41,6 @@ class Bdftopcf(AutotoolsPackage):
     depends_on('libxfont')
 
     depends_on('pkg-config@0.9.0:', type='build')
+    depends_on('xproto', type='build')
+    depends_on('fontsproto', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
These are technically "link" depends of libxfont, but they have no
actual libraries.

Fixes #5936.

---
This is the easy fix. The proper fix may be to make these `link` depends of `libxfont` and deal with the extra prefixes required.

Cc: @luigi-calori 