### PR TITLE
spack fetch --dependencies should not fetch externals.

### DIFF
--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -40,7 +40,7 @@ def setup_parser(subparser):
         help="do not check packages against checksum")
     subparser.add_argument(
         '-m', '--missing', action='store_true',
-        help="also fetch all missing dependencies")
+        help="fetch only missing (not yet installed) dependencies")
     subparser.add_argument(
         '-D', '--dependencies', action='store_true',
         help="also fetch all dependencies")
@@ -61,8 +61,15 @@ def fetch(parser, args):
         if args.missing or args.dependencies:
             for s in spec.traverse():
                 package = spack.repo.get(s)
+
+                # Skip already-installed packages with --missing
                 if args.missing and package.installed:
                     continue
+
+                # Do not attempt to fetch externals (they're local)
+                if package.spec.external:
+                    continue
+
                 package.do_fetch()
 
         package = spack.repo.get(spec)


### PR DESCRIPTION
Fixes #6123.

`spack fetch` shouldn't attempt to fetch external deps when invoked with `--dependencies`.