### PR TITLE
Configure user for mock Git repository

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -463,6 +463,8 @@ def mock_git_repository(tmpdir_factory):
     # Initialize the repository
     with repodir.as_cwd():
         git('init')
+        git('config', 'user.name', 'Spack')
+        git('config', 'user.email', 'spack@spack.io')
         url = 'file://' + str(repodir)
 
         # r0 is just the first commit


### PR DESCRIPTION
If `user.useConfigOnly` is set globally and no name or e-mail is configured, the git_fetch tests fail.