### PR TITLE
ISAAC 1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -35,6 +35,7 @@ class IsaacServer(CMakePackage):
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('1.3.2', 'c557daa74de52fd79e734c9758fca38b')
     version('1.3.1', '7fe075f9af68d05355eaba0e224f20ca')
     version('1.3.0', 'c8a794da9bb998ef0e75449bfece1a12')
 
@@ -44,11 +45,11 @@ class IsaacServer(CMakePackage):
     depends_on('cmake@3.3:', type='build')
     depends_on('jpeg', type='link')
     depends_on('jansson', type='link')
-    depends_on('boost@1.56:', type='link')
+    depends_on('boost@1.56.0:', type='link')
     depends_on('libwebsockets@2.1.1:', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')
 
     # Until the pull request is merged: https://github.com/ComputationalRadiationPhysics/isaac/pull/70
-    patch('jpeg.patch')
+    patch('jpeg.patch', when='@:1.3.1')
 
     root_cmakelists_dir = 'server'

--- a/var/spack/repos/builtin/packages/isaac/package.py
+++ b/var/spack/repos/builtin/packages/isaac/package.py
@@ -35,6 +35,7 @@ class Isaac(CMakePackage):
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
     version('master', branch='master',
             git='https://github.com/ComputationalRadiationPhysics/isaac.git')
+    version('1.3.2', 'c557daa74de52fd79e734c9758fca38b')
     version('1.3.1', '7fe075f9af68d05355eaba0e224f20ca')
     version('1.3.0', 'c8a794da9bb998ef0e75449bfece1a12')
 
@@ -46,7 +47,8 @@ class Isaac(CMakePackage):
     depends_on('cmake@3.3:', type='build')
     depends_on('jpeg', type='link')
     depends_on('jansson', type='link')
-    depends_on('boost@1.56:', type='link')
+    depends_on('boost@1.56.0:', type='link')
+    depends_on('boost@1.65.1:', type='link', when='^cuda@9:')
     depends_on('cuda@7.0:', type='link', when='+cuda')
     # depends_on('alpaka', when='+alpaka')
     depends_on('icet', type='link')


### PR DESCRIPTION
Add a new release of ISAAC.

Other changes:
- jpeg patch only needed before release 1.3.2
- adjust boost dependency as soon as CUDA9 support is needed