### PR TITLE
disable openblas intel openmp patch for versions > 0.2.20

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -78,7 +78,7 @@ class Openblas(MakefilePackage):
     #  https://github.com/xianyi/OpenBLAS/pull/915
     #  UPD: the patch has been merged starting version 0.2.20
     patch('openblas_icc.patch', when='@:0.2.19%intel')
-    patch('openblas_icc_openmp.patch', when='%intel@16.0:')
+    patch('openblas_icc_openmp.patch', when='@:0.2.20%intel@16.0:')
     patch('openblas_icc_fortran.patch', when='%intel@16.0:')
     patch('openblas_icc_fortran2.patch', when='%intel@18.0:')
 


### PR DESCRIPTION
Fixed upstream, patch no longer necessary for newer versions.

Patch previously fixed openmp flag error in openblas build system for intel compilers `intel@16.0.0:`

As of `openblas@0.3.0` it is fixed. `0.2.20` is the last openblas version before `0.3.0`.