### PR TITLE
scalasca: add 2.4

### DIFF
--- a/var/spack/repos/builtin/packages/scalasca/package.py
+++ b/var/spack/repos/builtin/packages/scalasca/package.py
@@ -38,14 +38,18 @@ class Scalasca(AutotoolsPackage):
     homepage = "http://www.scalasca.org"
     url = "http://apps.fz-juelich.de/scalasca/releases/scalasca/2.1/dist/scalasca-2.1.tar.gz"
 
+    version('2.4',   '4a895868258030f700a635eac93d36764f60c8c63673c7db419ea4bcc6b0b760')
     version('2.3.1', 'a83ced912b9d2330004cb6b9cefa7585')
     version('2.2.2', '2bafce988b0522d18072f7771e491ab9')
     version('2.1',   'bab9c2b021e51e2ba187feec442b96e6')
 
     depends_on("mpi")
 
+    # version 2.4
+    depends_on('cubew@4.4:', when='@2.4:')
+
     # version 2.3
-    depends_on('cube@4.3:', when='@2.3:')
+    depends_on('cube@4.3', when='@2.3:2.3.99')
     depends_on('otf2@2:', when='@2.3:')
 
     # version 2.1+
@@ -60,7 +64,11 @@ class Scalasca(AutotoolsPackage):
 
         config_args = ["--enable-shared"]
 
-        config_args.append("--with-cube=%s" % spec['cube'].prefix.bin)
+        if spec.satisfies('@2.4:'):
+            config_args.append("--with-cube=%s" % spec['cubew'].prefix.bin)
+        else:
+            config_args.append("--with-cube=%s" % spec['cube'].prefix.bin)
+
         config_args.append("--with-otf2=%s" % spec['otf2'].prefix.bin)
 
         if self.spec['mpi'].name == 'openmpi':


### PR DESCRIPTION
scalasca actually requires cubew, not the full cube bundle. However, cubew@4.4 causes the build of previous versions to fail because there is no cube-config script anymore.