### PR TITLE
warpx: Fixes for building on NERSC

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -74,5 +74,11 @@ class Warpx(MakefilePackage):
                         'TINY_PROFILE = {0}'.format(torf('+tprof')))
         makefile.filter('EBASE .*', 'EBASE = warpx')
 
+    def setup_environment(self, spack_env, run_env):
+        # --- Fool the compiler into using the "unknown" configuration.
+        # --- With this, it will use the spack provided mpi.
+        spack_env.set('HOSTNAME', 'unknown')
+        spack_env.set('NERSC_HOST', 'unknown')
+
     def install(self, spec, prefix):
         make('WarpxBinDir = {0}'.format(prefix.bin), 'all')


### PR DESCRIPTION
These changes are needed for building on NERSC. AMReX has machine specific building configurations that don't play well with how Spack does the configuration. With these changes, the generic, unknown, configuration is used, and queries are done to find any needed libraries (primarily for mpi) instead of using machine specific defaults.