### PR TITLE
cloc: URLs are now consistent

### DIFF
--- a/var/spack/repos/builtin/packages/cloc/package.py
+++ b/var/spack/repos/builtin/packages/cloc/package.py
@@ -13,9 +13,7 @@ class Cloc(Package):
     homepage = "https://github.com/AlDanial/cloc/"
     url      = "https://github.com/AlDanial/cloc/releases/download/1.74/cloc-1.74.tar.gz"
 
-    # cloc versions have an inconsistent URL scheme
-    version('1.80', sha256='082f53530eee3f9ee84ec449eca59a77ff114250cd7daf9519679537b5b21d67',
-            url="https://github.com/AlDanial/cloc/releases/download/v1.80/cloc-1.80.tar.gz")
+    version('1.80', sha256='082f53530eee3f9ee84ec449eca59a77ff114250cd7daf9519679537b5b21d67')
     version('1.74', '1372da13a83862c186aa0b6b0c9b86f5')
 
     depends_on('perl')


### PR DESCRIPTION
Fixed in upstream:
https://github.com/AlDanial/cloc/issues/352