### PR TITLE
Change Omega_h URL

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -11,9 +11,9 @@ class OmegaH(CMakePackage):
     hardware including GPUs.
     """
 
-    homepage = "https://github.com/ibaned/omega_h"
-    url      = "https://github.com/ibaned/omega_h/archive/v9.13.4.tar.gz"
-    git      = "https://github.com/ibaned/omega_h.git"
+    homepage = "https://github.com/SNLComputation/omega_h"
+    url      = "https://github.com/SNLComputation/omega_h/archive/v9.13.4.tar.gz"
+    git      = "https://github.com/SNLComputation/omega_h.git"
 
     version('develop', branch='master')
     version('9.19.1', sha256='60ef65c2957ce03ef9d1b995d842fb65c32c5659d064de002c071effe66b1b1f')


### PR DESCRIPTION
Omega_h will be moving to a new location (GitHub Organization instead of individual account). I'd like to coordinate this move with the merge of this PR, but if the PR takes too long to merge then Spack will simply be broken until its merged.

@balay 