### PR TITLE
Python3 not needed for pysqlite

### DIFF
--- a/var/spack/repos/builtin/packages/py-pysqlite/package.py
+++ b/var/spack/repos/builtin/packages/py-pysqlite/package.py
@@ -14,5 +14,6 @@ class PyPysqlite(PythonPackage):
 
     version('2.8.3', '033f17b8644577715aee55e8832ac9fc')
 
+    # pysqlite is built into Python3
     depends_on('python@2.7.0:2.7.999', type=('build', 'run'))
     depends_on('sqlite', type=('build', 'run'))


### PR DESCRIPTION
Add useful comment explaining why this is not needed for Python3.