### PR TITLE
libxml2: pass location for libiconv to build system

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -47,7 +47,8 @@ class Libxml2(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        args = ['--with-lzma={0}'.format(spec['xz'].prefix)]
+        args = ['--with-lzma={0}'.format(spec['xz'].prefix),
+                '--with-iconv={0}'.format(spec['libiconv'].prefix)]
 
         if '+python' in spec:
             args.extend([


### PR DESCRIPTION
Fixes #12304 (awaiting confirmation from @bartlettroscoe)

Previously, `libxml2` declared a dependency on `libiconv` but did not tell its build system where to find the Spack-built `libiconv`. This caused the build system to find a system `libiconv`, and caused `libtool` to put a bare `-liconv` option into the `libxml2.la` file. This was then propagated to the link lines of other libraries depending on `libxml2`, and caused build failures. I believe the exact failure mode related to how MPI implementations use libtool to generate flags for their compiler wrappers.

With this PR, the `libxml2.la` file has a fully qualified path to `libiconv.la`, and I believe this should fix all related issues.