### PR TITLE
MPark.Variant: GCC 7.3.1 Conflict

### DIFF
--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -19,7 +19,7 @@ class MparkVariant(CMakePackage):
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')
 
-    cxx11_msg = 'MPark.Variant needs at a C++11-capable compiler. ' \
+    cxx11_msg = 'MPark.Variant needs a C++11-capable compiler. ' \
                 'See https://github.com/mpark/variant#requirements'
     conflicts('%gcc@:4.7', msg=cxx11_msg)
     conflicts('%clang@:3.5', msg=cxx11_msg)

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -19,5 +19,14 @@ class MparkVariant(CMakePackage):
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')
 
-    conflicts('%gcc@:4.7')
-    conflicts('%clang@:3.5')
+    cxx11_msg = 'MPark.Variant needs at a C++11-capable compiler. ' \
+                'See https://github.com/mpark/variant#requirements'
+    conflicts('%gcc@:4.7', msg=cxx11_msg)
+    conflicts('%clang@:3.5', msg=cxx11_msg)
+
+    conflicts('%gcc@7.3.1',
+              msg='GCC 7.3.1 has a bug that prevents using MPark.Variant. '
+                  'See https://github.com/mpark/variant/issues/43 and '
+                  '    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84785 '
+                  'Please use a different compiler version or another '
+                  'compiler.')

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -27,6 +27,6 @@ class MparkVariant(CMakePackage):
     conflicts('%gcc@7.3.1',
               msg='GCC 7.3.1 has a bug that prevents using MPark.Variant. '
                   'See https://github.com/mpark/variant/issues/43 and '
-                  '    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84785 '
+                  'https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84785 '
                   'Please use a different compiler version or another '
                   'compiler.')


### PR DESCRIPTION
Due to an ICE in this specific patch-release of GCC, compile errors in downstream packages can be avoided with a clean conflict.