### PR TITLE
macos: use DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -145,6 +145,7 @@ def clean_environment():
     env.unset('CPATH')
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
+    env.unset('DYLD_FALLBACK_LIBRARY_PATH')
 
     build_lang = spack.config.get('config:build_language')
     if build_lang:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -692,7 +692,10 @@ def main(argv=None):
     # Spack clears these variables before building and installing packages,
     # but needs to know the prior state for commands like `spack load` and
     # `spack env activate that modify the user environment.
-    for var in ('LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH'):
+    recovered_vars = (
+        'LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH'
+    )
+    for var in recovered_vars:
         stored_var_name = 'SPACK_%s' % var
         if stored_var_name in os.environ:
             os.environ[var] = os.environ[stored_var_name]

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -40,7 +40,7 @@ def prefix_inspections(platform):
 
     if platform == 'darwin':
         for subdir in ('lib', 'lib64'):
-            inspections[subdir].append('DYLD_LIBRARY_PATH')
+            inspections[subdir].append('DYLD_FALLBACK_LIBRARY_PATH')
 
     return inspections
 

--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -29,12 +29,15 @@
 ########################################################################
 # Store LD_LIBRARY_PATH variables from spack shell function
 # This is necessary because MacOS System Integrity Protection clears
-# (DY?)LD_LIBRARY_PATH variables on process start.
+# variables that affect dyld on process start.
 if ( ${?LD_LIBRARY_PATH} ) then
     setenv SPACK_LD_LIBRARY_PATH $LD_LIBRARY_PATH
 endif
 if ( ${?DYLD_LIBRARY_PATH} ) then
     setenv SPACK_DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH
+endif
+if ( ${?DYLD_FALLBACK_LIBRARY_PATH} ) then
+    setenv SPACK_DYLD_FALLBACK_LIBRARY_PATH $DYLD_FALLBACK_LIBRARY_PATH
 endif
 
 # accumulate initial flags for main spack command

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -42,13 +42,10 @@
 spack() {
     # Store LD_LIBRARY_PATH variables from spack shell function
     # This is necessary because MacOS System Integrity Protection clears
-    # (DY?)LD_LIBRARY_PATH variables on process start.
-    if [ -n "${LD_LIBRARY_PATH-}" ]; then
-        export SPACK_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-    fi
-    if [ -n "${DYLD_LIBRARY_PATH-}" ]; then
-        export SPACK_DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH
-    fi
+    # variables that affect dyld on process start.
+    for var in LD_LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH; do
+        eval "if [ -n \"\${${var}-}\" ]; then export SPACK_$var=\${${var}}; fi"
+    done
 
     # Zsh does not do word splitting by default, this enables it for this
     # function only


### PR DESCRIPTION
Closes #9221. (or should we just merge that first?) 
Fixes #16084. @DiegoMagdaleno 

`DYLD_LIBRARY_PATH` can frequently break builtin macOS software when pointed at Spack libraries.  This is because it takes *higher* precedence than the default library search paths, which are used by system software.

`DYLD_FALLBACK_LIBRARY_PATH`, on the other hand, takes lower precedence. At first glance, this might seem bad, because the software installed by Spack in an environment needs to find *its* libraries, and it should not use the defaults.  However, Spack's isntallations are always `RPATH`'d, so they do not have this problem.

`DYLD_FALLBACK_LIBRARY_PATH` is thus useful for things built in an environment that need to use Spack's libraries, that don't set *their* RPATHs correctly for whatever reason. We now prefer it to `DYLD_LIBRARY_PATH` in modules and in environments because it helps a little bit, and it is much less intrusive.

I think we should probably also do this for `LD_LIBRARY_PATH` on Linux, as it can interfere in siilar ways.  People *do* want to build against their environments, though, and it's much more common to use `LD_LIBRARY_PATH` there, so I'm torn.  Thoughts?

@goxberry @adamjstewart @sethrj @gartung