### PR TITLE
ncurses: forward termlib libs

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -105,5 +105,9 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def libs(self):
-        return find_libraries(
+        nc_libs = find_libraries(
             ['libncurses', 'libncursesw'], root=self.prefix, recursive=True)
+        if '+termlib' in self.spec:
+            nc_libs.extend(find_libraries(
+                ['libtinfo', 'libtinfow'], root=self.prefix, recursive=True))
+        return nc_libs


### PR DESCRIPTION
These libs need to be forwarded, as in ncurses `pkg-config` file.

This patch does **not** address #16098, but still looks wrong in the `nurses` package and several packages, e.g. `samtools`, seam to work-around this downstream. `libncurses` has an rpath to `ltinfo` set in Spack, but maybe some downstream libs need other `ncurses` lib artifacts directly as well...

```
ldd [...]/opt/spack/linux-ubuntu18.04-skylake/gcc-8.3.0/ncurses-6.2-xgtgxgzhrvlpslxomko63jqbqgmshyah/lib/libncursesw.so
	linux-vdso.so.1 (0x00007ffcb23f3000)
	libtinfow.so.6 => [...]/opt/spack/linux-ubuntu18.04-skylake/gcc-8.3.0/ncurses-6.2-xgtgxgzhrvlpslxomko63jqbqgmshyah/lib/libtinfow.so.6 (0x00007f68557c1000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f68553d0000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6855c37000)
```

There are even more libs build by `ncurses` but that `ncurses` does not link to directly. For example, I see on Ubuntu in Spacks install prefix`/lib`:
```
libcurses.a   libform.so.6.2   libmenu.a       libmenuw_g.a     libncurses_g.a     libncurses.so.6.2    libncurses++w.so      libpanel.a       libpanelw_g.a     libtinfo.so      libtinfow.so.6
libcurses.so  libformw.a       libmenu_g.a     libmenuw.so      libncurses++_g.a   libncurses++.so.6.2  libncursesw.so        libpanel_g.a     libpanelw.so      libtinfo.so.6    libtinfow.so.6.2
libform.a     libformw_g.a     libmenu.so      libmenuw.so.6    libncurses.so      libncurses++w.a      libncurses++w.so.6    libpanel.so      libpanelw.so.6    libtinfo.so.6.2  pkgconfig
libform_g.a   libformw.so      libmenu.so.6    libmenuw.so.6.2  libncurses++.so    libncursesw.a        libncursesw.so.6      libpanel.so.6    libpanelw.so.6.2  libtinfow.a      terminfo
libform.so    libformw.so.6    libmenu.so.6.2  libncurses.a     libncurses.so.6    libncurses++w_g.a    libncurses++w.so.6.2  libpanel.so.6.2  libtinfo.a        libtinfow_g.a
libform.so.6  libformw.so.6.2  libmenuw.a      libncurses++.a   libncurses++.so.6  libncursesw_g.a      libncursesw.so.6.2    libpanelw.a      libtinfo_g.a      libtinfow.so
```

Maybe relying more on the `pkg-config/` scripts inside `lib/` could help as well.

Refs.:
- https://github.com/conda-forge/ncurses-feedstock/issues/36
- https://github.com/conda-forge/emacs-feedstock/pull/16