### PR TITLE
Fix for source-highlight package to detect installed boost lib

### DIFF
--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -21,5 +21,5 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
     depends_on('boost')
 
     def configure_args(self):
-        args = ["--with-boost=" + format(self.spec['boost'].prefix)]
+        args = ["--with-boost={0}".format(self.spec['boost'].prefix)]
         return args

--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -19,3 +19,7 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
     version('3.1.8', sha256='01336a7ea1d1ccc374201f7b81ffa94d0aecb33afc7d6903ebf9fbf33a55ada3')
 
     depends_on('boost')
+
+    def configure_args(self):
+        args = ["--with-boost=" + format(self.spec['boost'].prefix)]
+        return args


### PR DESCRIPTION
Source highlight configure script doesn't detect the boost regex library installed through Spack. So as suggested https://www.gnu.org/software/src-highlite/source-highlight.html#Tips-on-installing-Boost-Regex-library I added a fix for configure script that resolves the issue.