### PR TITLE
emacs: libxml2 deps

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -36,6 +36,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on('ncurses')
     depends_on('pcre')
     depends_on('zlib')
+    depends_on('libxml2')
     depends_on('libtiff', when='+X')
     depends_on('libpng', when='+X')
     depends_on('libxpm', when='+X')


### PR DESCRIPTION
emacs depends on libxml2.

independent of the issue in #16098, we saw at emacs configures and links against `libxml2` by default, as this is often present from the OS.

This does not fix the linker issue we see with `ncurses`, but avoids at least to pick up a system library for `libxml2`.