### PR TITLE
LLVM libomptarget fixes

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -237,6 +237,7 @@ class Llvm(CMakePackage, CudaPackage):
             "-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp",
             "-DPYTHON_EXECUTABLE:PATH={0}".format(spec["python"].command.path),
             "-DLIBOMP_USE_HWLOC:BOOL=ON",
+            "-DLIBOMP_HWLOC_INSTALL_DIR={0}".format(spec["hwloc"].prefix),
         ]
 
         projects = []
@@ -397,9 +398,8 @@ class Llvm(CMakePackage, CudaPackage):
 
                 # work around bad libelf detection in libomptarget
                 cmake_args.append(
-                    "-DCMAKE_CXX_FLAGS:String=-I{0} -I{1}".format(
-                        spec["libelf"].prefix.include,
-                        spec["hwloc"].prefix.include,
+                    "-DLIBOMPTARGET_DEP_LIBELF_INCLUDE_DIR:String={0}".format(
+                        spec["libelf"].prefix.include
                     )
                 )
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -236,7 +236,7 @@ class Llvm(CMakePackage, CudaPackage):
             "-DLLVM_ENABLE_EH:BOOL=ON",
             "-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp",
             "-DPYTHON_EXECUTABLE:PATH={0}".format(spec["python"].command.path),
-            "-DLIBOMP_USE_HWLOC=On",
+            "-DLIBOMP_USE_HWLOC:BOOL=ON",
         ]
 
         projects = []
@@ -391,7 +391,9 @@ class Llvm(CMakePackage, CudaPackage):
                     "-DCMAKE_INSTALL_PREFIX:PATH={0}".format(spec.prefix),
                 ]
                 cmake_args.extend(self.cmake_args())
-                cmake_args.append('-DLIBOMPTARGET_NVPTX_ENABLE_BCLIB=true')
+                cmake_args.append(
+                    "-DLIBOMPTARGET_NVPTX_ENABLE_BCLIB:BOOL=TRUE"
+                )
 
                 # work around bad libelf detection in libomptarget
                 cmake_args.append(

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -170,6 +170,9 @@ class Llvm(CMakePackage, CudaPackage):
     # OMP TSAN exists in > 5.x
     conflicts("+omp_tsan", when="@:5.99")
 
+    # cuda_arch value must be specified
+    conflicts("cuda_arch=none", msg="A value for cuda_arch must be specified.")
+
     # MLIR exists in > 10.x
     conflicts("+mlir", when="@:9")
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -171,7 +171,7 @@ class Llvm(CMakePackage, CudaPackage):
     conflicts("+omp_tsan", when="@:5.99")
 
     # cuda_arch value must be specified
-    conflicts("cuda_arch=none", msg="A value for cuda_arch must be specified.")
+    conflicts("cuda_arch=none", when="+cuda", msg="A value for cuda_arch must be specified.")
 
     # MLIR exists in > 10.x
     conflicts("+mlir", when="@:9")


### PR DESCRIPTION
@trws 

Changes include:
- cuda_arch value must be specified with +cuda
- minor clean-up
- hwloc and libelf directories are no longer injected throw CMAKE_CXX_FLAGS.

Keeping fingers crossed that it will resolve this issue:
https://github.com/spack/spack/issues/16033
