### PR TITLE
macOS: Fix emacs Linking

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -47,6 +47,13 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on('gnutls', when='+tls')
     depends_on('jpeg')
 
+    @when('platform=darwin')
+    def setup_build_environment(self, env):
+        # on macOS, emacs' config does search hard enough for ncurses'
+        # termlib `-ltinfo` lib, which results in linker errors
+        if '+termlib' in spec['ncurses']:
+            env.append_flags('LDFLAGS', '-ltinfo')
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -28,7 +28,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
     variant('termlib', default=True,
-            description='Enables termlib needs for gnutls in emacs.')
+            description='Enables termlib features. This is an extra '
+                        'lib and optional internal dependency.')
 
     depends_on('pkgconfig', type='build')
 


### PR DESCRIPTION
Fix linking issue of emacs on macOS (clang and gcc).

Applies the same work-around as conda-forge:
  https://github.com/conda-forge/emacs-feedstock/blob/b051f6c928d8b99fed3fabd9a8d67be993f94494/recipe/build.sh

Homebrew avoids this by linking against the system ncurses lib:
  https://github.com/Homebrew/homebrew-core/blob/master/Formula/emacs.rb

I tried this on Linux and there `tinfo` is always found properly inside spack, so the work-around is not needed.

Thanks to @maxthevenet for macOS testing!

Fix #16098