### PR TITLE
coreutils: add variant for g prefix

### DIFF
--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -22,13 +22,16 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
     version('8.26', sha256='155e94d748f8e2bc327c66e0cbebdb8d6ab265d2f37c3c928f7bf6c3beba9a8e')
     version('8.23', sha256='ec43ca5bcfc62242accb46b7f121f6b684ee21ecd7d075059bf650ff9e37b82d')
 
+    variant("gprefix", default=False, description="prefix commands with 'g', to avoid conflicts with OS utilities")
+
     build_directory = 'spack-build'
 
     def configure_args(self):
         spec = self.spec
         configure_args = []
         if spec.satisfies('platform=darwin'):
-            configure_args.append('--program-prefix=g')
+            if "+gprefix" in self.spec:
+                configure_args.append('--program-prefix=g')
             configure_args.append('--without-gmp')
             configure_args.append('gl_cv_func_ftello_works=yes')
             configure_args.append('FORCE_UNSAFE_CONFIGURE=1')


### PR DESCRIPTION
This bit me because `coreutils` all of a sudden didn't "work" -- the commands all had a `g` prefix.  This PR makes that optional, for those of us who *want* them to override other things on `$PATH`.

- [x] Add a `gprefix` variant to coreutils, so that the 'g' prefix on binaries is optional.
- [x] Make un-prefixed binaries the default again

@DiegoMagdaleno this reverts the default behavior  added in #15883.  If we merge this, you'll need to use `coreutils+gprefix`