### PR TITLE
SourceForge: Mirror Mixin

### DIFF
--- a/lib/spack/spack/build_systems/sourceforge.py
+++ b/lib/spack/spack/build_systems/sourceforge.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.util.url
+import spack.package
+
+
+class SourceforgePackage(spack.package.PackageBase):
+    """Mixin that takes care of setting url and mirrors for Sourceforge
+       packages."""
+    #: Path of the package in a Sourceforge mirror
+    sourceforge_mirror_path = None
+
+    #: List of Sourceforge mirrors used by Spack
+    base_mirrors = [
+        'https://prdownloads.sourceforge.net/',
+        'https://freefr.dl.sourceforge.net/',
+        'https://netcologne.dl.sourceforge.net/',
+        'https://pilotfiber.dl.sourceforge.net/',
+        'https://downloads.sourceforge.net/',
+        'http://kent.dl.sourceforge.net/sourceforge/'
+    ]
+
+    @property
+    def urls(self):
+        self._ensure_sourceforge_mirror_path_is_set_or_raise()
+        return [
+            spack.util.url.join(m, self.sourceforge_mirror_path,
+                                resolve_href=True)
+            for m in self.base_mirrors
+        ]
+
+    def _ensure_sourceforge_mirror_path_is_set_or_raise(self):
+        if self.sourceforge_mirror_path is None:
+            cls_name = type(self).__name__
+            msg = ('{0} must define a `sourceforge_mirror_path` attribute'
+                   ' [none defined]')
+            raise AttributeError(msg.format(cls_name))

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -31,6 +31,7 @@ from spack.build_systems.intel import IntelPackage
 from spack.build_systems.meson import MesonPackage
 from spack.build_systems.sip import SIPPackage
 from spack.build_systems.gnu import GNUMirrorPackage
+from spack.build_systems.sourceforge import SourceforgePackage
 from spack.build_systems.sourceware import SourcewarePackage
 from spack.build_systems.xorg import XorgPackage
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -245,6 +245,29 @@ class TestGNUMirrorPackage(object):
 
 
 @pytest.mark.usefixtures('config', 'mock_packages')
+class TestSourceforgePackage(object):
+
+    def test_define(self):
+        s = Spec('mirror-sourceforge')
+        s.concretize()
+        pkg = spack.repo.get(s)
+
+        s = Spec('mirror-sourceforge-broken')
+        s.concretize()
+        pkg_broken = spack.repo.get(s)
+
+        cls_name = type(pkg_broken).__name__
+        with pytest.raises(AttributeError,
+                           match=r'{0} must define a `sourceforge_mirror_path`'
+                                 r' attribute \[none defined\]'
+                                 .format(cls_name)):
+            pkg_broken.urls
+
+        assert pkg.urls[0] == 'https://prdownloads.sourceforge.net/' \
+                              'tcl/tcl8.6.5-src.tar.gz'
+
+
+@pytest.mark.usefixtures('config', 'mock_packages')
 class TestSourcewarePackage(object):
 
     def test_define(self):

--- a/var/spack/repos/builtin.mock/packages/mirror-sourceforge-broken/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-sourceforge-broken/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorSourceforgeBroken(AutotoolsPackage, SourceforgePackage):
+    """Simple sourceforge.net package"""
+
+    homepage = "http://www.tcl.tk"
+    url      = "http://prdownloads.sourceforge.net/tcl/tcl8.6.5-src.tar.gz"
+
+    version('8.6.8', sha256='c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a')

--- a/var/spack/repos/builtin.mock/packages/mirror-sourceforge/package.py
+++ b/var/spack/repos/builtin.mock/packages/mirror-sourceforge/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class MirrorSourceforge(AutotoolsPackage, SourceforgePackage):
+    """Simple sourceforge.net package"""
+
+    homepage = "http://www.tcl.tk"
+    sourceforge_mirror_path = "tcl/tcl8.6.5-src.tar.gz"
+
+    version('8.6.8', sha256='c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a')

--- a/var/spack/repos/builtin/packages/bbmap/package.py
+++ b/var/spack/repos/builtin/packages/bbmap/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Bbmap(Package):
+class Bbmap(Package, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 
     homepage = "http://sourceforge.net/projects/bbmap/"
-    url      = "https://downloads.sourceforge.net/project/bbmap/BBMap_38.63.tar.gz"
+    sourceforge_mirror_path = "bbmap/BBMap_38.63.tar.gz"
 
     version('38.63', sha256='089064104526c8d696164aefa067f935b888bc71ef95527c72a98c17ee90a01f')
     version('37.36', sha256='befe76d7d6f3d0f0cd79b8a01004a2283bdc0b5ab21b0743e9dbde7c7d79e8a9')

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -7,12 +7,12 @@ from spack import *
 from os import symlink
 
 
-class Bridger(MakefilePackage):
+class Bridger(MakefilePackage, SourceforgePackage):
     """Bridger : An Efficient De novo Transcriptome Assembler For
        RNA-Seq Data"""
 
     homepage = "https://sourceforge.net/projects/rnaseqassembly/"
-    url      = "https://downloads.sourceforge.net/project/rnaseqassembly/Bridger_r2014-12-01.tar.gz"
+    sourceforge_mirror_path = "rnaseqassembly/Bridger_r2014-12-01.tar.gz"
 
     version('2014-12-01', sha256='8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737')
 

--- a/var/spack/repos/builtin/packages/freeglut/package.py
+++ b/var/spack/repos/builtin/packages/freeglut/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Freeglut(CMakePackage):
+class Freeglut(CMakePackage, SourceforgePackage):
     """FreeGLUT is a free-software/open-source alternative to the OpenGL
        Utility Toolkit (GLUT) library"""
 
     homepage = "http://freeglut.sourceforge.net/"
-    url      = "http://prdownloads.sourceforge.net/freeglut/freeglut-3.0.0.tar.gz"
+    sourceforge_mirror_path = "freeglut/freeglut-3.0.0.tar.gz"
 
     version('3.0.0', sha256='2a43be8515b01ea82bcfa17d29ae0d40bd128342f0930cd1f375f1ff999f76a2')
 

--- a/var/spack/repos/builtin/packages/giflib/package.py
+++ b/var/spack/repos/builtin/packages/giflib/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Giflib(AutotoolsPackage):
+class Giflib(AutotoolsPackage, SourceforgePackage):
     """The GIFLIB project maintains the giflib service library, which has
     been pulling images out of GIFs since 1989."""
 
     homepage = "http://giflib.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/giflib/giflib-5.1.4.tar.bz2"
+    sourceforge_mirror_path = "giflib/giflib-5.1.4.tar.bz2"
 
     version('5.1.4', sha256='df27ec3ff24671f80b29e6ab1c4971059c14ac3db95406884fc26574631ba8d5')
 

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -5,14 +5,14 @@
 from spack import *
 
 
-class Imlib2(AutotoolsPackage):
+class Imlib2(AutotoolsPackage, SourceforgePackage):
     """
     Library that does image file loading and saving as well as rendering,
     manipulation, arbitrary polygon support
     """
 
     homepage = "http://sourceforge.net/projects/enlightenment/"
-    url      = "http://downloads.sourceforge.net/enlightenment/imlib2-1.5.1.tar.bz2"
+    sourceforge_mirror_path = "enlightenment/imlib2-1.5.1.tar.bz2"
 
     maintainers = ['TheQueasle']
 

--- a/var/spack/repos/builtin/packages/iperf2/package.py
+++ b/var/spack/repos/builtin/packages/iperf2/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Iperf2(AutotoolsPackage):
+class Iperf2(AutotoolsPackage, SourceforgePackage):
     """This code is a continuation based from the no longer maintained iperf
     2.0.5 code base. Iperf 2.0.5 is still widely deployed and used by many for
     testing networks and for qualifying networking products."""
 
     homepage = "https://sourceforge.net/projects/iperf2"
-    url      = "https://downloads.sourceforge.net/project/iperf2/iperf-2.0.12.tar.gz"
+    sourceforge_mirror_path = "iperf2/iperf-2.0.12.tar.gz"
 
     version('2.0.12', sha256='367f651fb1264b13f6518e41b8a7e08ce3e41b2a1c80e99ff0347561eed32646')

--- a/var/spack/repos/builtin/packages/kaks-calculator/package.py
+++ b/var/spack/repos/builtin/packages/kaks-calculator/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class KaksCalculator(MakefilePackage):
+class KaksCalculator(MakefilePackage, SourceforgePackage):
     """KaKs_Calculator adopts model selection and model averaging to calculate
        nonsynonymous (Ka) and synonymous (Ks) substitution rates, attempting to
        include as many features as needed for accurately capturing evolutionary
        information in protein-coding sequences."""
 
     homepage = "https://sourceforge.net/projects/kakscalculator2"
-    url      = "https://downloads.sourceforge.net/project/kakscalculator2/KaKs_Calculator2.0.tar.gz"
+    sourceforge_mirror_path = "kakscalculator2/KaKs_Calculator2.0.tar.gz"
 
     version('2.0', sha256='e2df719a2fecc549d8ddc4e6d8f5cfa4b248282dca319c1928eaf886d68ec3c5')
 

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -7,14 +7,14 @@
 from spack import *
 
 
-class Libcerf(AutotoolsPackage):
+class Libcerf(AutotoolsPackage, SourceforgePackage):
     """A self-contained C library providing complex error functions, based
        on Faddeeva's plasma dispersion function w(z). Also provides Dawson's
        integral and Voigt's convolution of a Gaussian and a Lorentzian
 
     """
     homepage = "http://sourceforge.net/projects/libcerf"
-    url      = "http://downloads.sourceforge.net/project/libcerf/libcerf-1.3.tgz"
+    sourceforge_mirror_path = "libcerf/libcerf-1.3.tgz"
 
     version('1.3', sha256='d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859')
 

--- a/var/spack/repos/builtin/packages/libexif/package.py
+++ b/var/spack/repos/builtin/packages/libexif/package.py
@@ -5,11 +5,11 @@
 from spack import *
 
 
-class Libexif(AutotoolsPackage):
+class Libexif(AutotoolsPackage, SourceforgePackage):
     """A library to parse an EXIF file and read the data from those tags"""
 
     homepage = "https://sourceforge.net/projects/libexif"
-    url      = "https://downloads.sourceforge.net/sourceforge/libexif/libexif-0.6.21.tar.bz2"
+    sourceforge_mirror_path = "libexif/libexif-0.6.21.tar.bz2"
 
     maintainers = ['TheQueasle']
 

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Libuuid(AutotoolsPackage):
+class Libuuid(AutotoolsPackage, SourceforgePackage):
     """Portable uuid C library"""
 
     homepage = "http://sourceforge.net/projects/libuuid/"
-    url      = "http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Flibuuid%2F&ts=1433881396&use_mirror=iweb"
+    sourceforge_mirror_path = "libuuid/libuuid-1.0.3.tar.gz"
 
     version('1.0.3', sha256='46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644')

--- a/var/spack/repos/builtin/packages/meraculous/package.py
+++ b/var/spack/repos/builtin/packages/meraculous/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Meraculous(CMakePackage):
+class Meraculous(CMakePackage, SourceforgePackage):
     """Meraculous is a while genome assembler for Next Generation Sequencing
        data geared for large genomes."""
 
     homepage = "http://jgi.doe.gov/data-and-tools/meraculous/"
-    url      = "https://downloads.sourceforge.net/project/meraculous20/Meraculous-v2.2.4.tar.gz"
+    sourceforge_mirror_path = "meraculous20/Meraculous-v2.2.4.tar.gz"
     git      = "https://bitbucket.org/berkeleylab/genomics-meraculous2.git"
 
     version('2.2.5.1', branch='release-2.2.5.1')

--- a/var/spack/repos/builtin/packages/microbiomeutil/package.py
+++ b/var/spack/repos/builtin/packages/microbiomeutil/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Microbiomeutil(MakefilePackage):
+class Microbiomeutil(MakefilePackage, SourceforgePackage):
     """Microbiome analysis utilities"""
 
     homepage = "http://microbiomeutil.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/microbiomeutil/microbiomeutil-r20110519.tgz"
+    sourceforge_mirror_path = "microbiomeutil/microbiomeutil-r20110519.tgz"
 
     version('20110519', sha256='9233de80ea57bfb9e9371cbe7e3bfad2d4a51168fddaf60fa144c4046c80d823')
 

--- a/var/spack/repos/builtin/packages/nccmp/package.py
+++ b/var/spack/repos/builtin/packages/nccmp/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Nccmp(Package):
+class Nccmp(Package, SourceforgePackage):
     """Compare NetCDF Files"""
     homepage = "http://nccmp.sourceforge.net/"
-    url      = "http://downloads.sourceforge.net/project/nccmp/nccmp-1.8.2.0.tar.gz"
+    sourceforge_mirror_path = "nccmp/nccmp-1.8.2.0.tar.gz"
 
     version('1.8.2.0', sha256='7f5dad4e8670568a71f79d2bcebb08d95b875506d3d5faefafe1a8b3afa14f18')
 

--- a/var/spack/repos/builtin/packages/nicstat/package.py
+++ b/var/spack/repos/builtin/packages/nicstat/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Nicstat(MakefilePackage):
+class Nicstat(MakefilePackage, SourceforgePackage):
     """
     Nicstat is a Solaris and Linux command-line that prints out network
     statistics for all network interface cards (NICs), including packets,
@@ -14,7 +14,7 @@ class Nicstat(MakefilePackage):
     """
 
     homepage = "https://github.com/scotte/nicstat"
-    url      = "https://jaist.dl.sourceforge.net/project/nicstat/nicstat-1.95.tar.gz"
+    sourceforge_mirror_path = "nicstat/nicstat-1.95.tar.gz"
 
     version('1.95', sha256='c4cc33f8838f4523f27c3d7584eedbe59f4c587f0821612f5ac2201adc18b367')
 

--- a/var/spack/repos/builtin/packages/octave-optim/package.py
+++ b/var/spack/repos/builtin/packages/octave-optim/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class OctaveOptim(OctavePackage):
+class OctaveOptim(OctavePackage, SourceforgePackage):
     """Non-linear optimization toolkit for Octave."""
 
     homepage = "https://octave.sourceforge.io/optim/"
-    url      = "https://downloads.sourceforge.net/octave/optim-1.5.2.tar.gz"
+    sourceforge_mirror_path = "octave/optim-1.5.2.tar.gz"
 
     version('1.5.2', sha256='7b36033c5581559dc3e7616f97d402bc44dde0dfd74c0e3afdf47d452a76dddf')
 

--- a/var/spack/repos/builtin/packages/octave-splines/package.py
+++ b/var/spack/repos/builtin/packages/octave-splines/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class OctaveSplines(OctavePackage):
+class OctaveSplines(OctavePackage, SourceforgePackage):
     """Additional spline functions."""
 
     homepage = "http://octave.sourceforge.net/splines/index.html"
-    url      = "http://downloads.sourceforge.net/octave/splines-1.3.1.tar.gz"
+    sourceforge_mirror_path = "octave/splines-1.3.1.tar.gz"
 
     version('1.3.1', sha256='f9665d780c37aa6a6e17d1f424c49bdeedb89d1192319a4e39c08784122d18f9')
     extends('octave@3.6.0:')

--- a/var/spack/repos/builtin/packages/octave-struct/package.py
+++ b/var/spack/repos/builtin/packages/octave-struct/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class OctaveStruct(OctavePackage):
+class OctaveStruct(OctavePackage, SourceforgePackage):
     """Additional structure manipulation functions for Octave."""
 
     homepage = "https://octave.sourceforge.io/struct/"
-    url      = "https://downloads.sourceforge.net/octave/struct-1.0.14.tar.gz"
+    sourceforge_mirror_path = "octave/struct-1.0.14.tar.gz"
 
     version('1.0.14', sha256='ad4e17687bc24650f032757271b20b70fe32c35513d4dd9ab1e549919df36b47')
     extends('octave@2.9.7:')

--- a/var/spack/repos/builtin/packages/optipng/package.py
+++ b/var/spack/repos/builtin/packages/optipng/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Optipng(AutotoolsPackage):
+class Optipng(AutotoolsPackage, SourceforgePackage):
     """
     OptiPNG is a PNG optimizer that recompresses image files to a smaller
     size, without losing any information. This program also converts external
@@ -15,6 +15,6 @@ class Optipng(AutotoolsPackage):
     """
 
     homepage = "http://optipng.sourceforge.net/"
-    url      = "http://prdownloads.sourceforge.net/optipng/optipng-0.7.7.tar.gz"
+    sourceforge_mirror_path = "optipng/optipng-0.7.7.tar.gz"
 
     version('0.7.7', sha256='4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452')

--- a/var/spack/repos/builtin/packages/pbsuite/package.py
+++ b/var/spack/repos/builtin/packages/pbsuite/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Pbsuite(Package):
+class Pbsuite(Package, SourceforgePackage):
     """PBJelly is a highly automated pipeline that aligns long sequencing
        reads (such as PacBio RS reads or long 454 reads in fasta format)
        to high-confidence draft assembles."""
 
     homepage = "https://sourceforge.net/p/pb-jelly/wiki/Home/"
-    url      = "https://downloads.sourceforge.net/project/pb-jelly/PBSuite_15.8.24.tgz"
+    sourceforge_mirror_path = "pb-jelly/PBSuite_15.8.24.tgz"
 
     version('15.8.24', sha256='1be082faa62cb3f701c78498db8544c844c3d6d3e3524fecf00a12e82a97e12b')
 

--- a/var/spack/repos/builtin/packages/py-crossmap/package.py
+++ b/var/spack/repos/builtin/packages/py-crossmap/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class PyCrossmap(PythonPackage):
+class PyCrossmap(PythonPackage, SourceforgePackage):
     """CrossMap is a program for convenient conversion of genome coordinates
        (or annotation files) between different assemblies"""
 
     homepage = "http://crossmap.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/crossmap/CrossMap-0.3.3.tar.gz"
+    sourceforge_mirror_path = "crossmap/CrossMap-0.3.3.tar.gz"
 
     version('0.3.3', sha256='56d99fd606e13e399b83438953d0d89fc281df1c1e8e47eed7d773e7ec9c88f8')
     version('0.2.9', sha256='57243ee5051352c93088874c797ceac0426f249704ba897360fb628b3365d0af')

--- a/var/spack/repos/builtin/packages/qrupdate/package.py
+++ b/var/spack/repos/builtin/packages/qrupdate/package.py
@@ -8,12 +8,12 @@ import sys
 from spack import *
 
 
-class Qrupdate(MakefilePackage):
+class Qrupdate(MakefilePackage, SourceforgePackage):
     """qrupdate is a Fortran library for fast updates of QR and
     Cholesky decompositions."""
 
     homepage = "http://sourceforge.net/projects/qrupdate/"
-    url      = "https://downloads.sourceforge.net/qrupdate/qrupdate-1.1.2.tar.gz"
+    sourceforge_mirror_path = "qrupdate/qrupdate-1.1.2.tar.gz"
 
     version('1.1.2', sha256='e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08')
 

--- a/var/spack/repos/builtin/packages/ray/package.py
+++ b/var/spack/repos/builtin/packages/ray/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Ray(CMakePackage):
+class Ray(CMakePackage, SourceforgePackage):
     """Parallel genome assemblies for parallel DNA sequencing"""
 
     homepage = "http://denovoassembler.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/denovoassembler/Ray-2.3.1.tar.bz2"
+    sourceforge_mirror_path = "denovoassembler/Ray-2.3.1.tar.bz2"
 
     version('2.3.1', sha256='3122edcdf97272af3014f959eab9a0f0e5a02c8ffc897d842b06b06ccd748036')
 

--- a/var/spack/repos/builtin/packages/rdp-classifier/package.py
+++ b/var/spack/repos/builtin/packages/rdp-classifier/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class RdpClassifier(Package):
+class RdpClassifier(Package, SourceforgePackage):
     """The RDP Classifier is a naive Bayesian classifier that can rapidly and
        accurately provides taxonomic assignments from domain to genus, with
        confidence estimates for each assignment. """
 
     homepage = "http://rdp.cme.msu.edu/"
-    url      = "https://downloads.sourceforge.net/project/rdp-classifier/rdp-classifier/rdp_classifier_2.12.zip"
+    sourceforge_mirror_path = "rdp-classifier/rdp_classifier_2.12.zip"
 
     version('2.12', sha256='977896248189a1ce2146dd3a61d203c3c6bc9aa3982c60332d463832922f7d0a')
 

--- a/var/spack/repos/builtin/packages/saga-gis/package.py
+++ b/var/spack/repos/builtin/packages/saga-gis/package.py
@@ -5,7 +5,7 @@
 from spack import *
 
 
-class SagaGis(AutotoolsPackage):
+class SagaGis(AutotoolsPackage, SourceforgePackage):
     """
     SAGA is a GIS for Automated Geoscientific Analyses and has been designed
     for an easy and effective implementation of spatial algorithms. It offers
@@ -13,7 +13,7 @@ class SagaGis(AutotoolsPackage):
     easily approachable user interface with many visualisation options
     """
     homepage    = "http://saga-gis.org/"
-    url         = "https://sourceforge.net/projects/saga-gis/files/SAGA%20-%205/SAGA%20-%205.0.0/saga-5.0.0.tar.gz"
+    sourceforge_mirror_path = "SAGA%20-%205.0.0/saga-5.0.0.tar.gz"
     git         = "git://git.code.sf.net/p/saga-gis/code"
 
     version('develop',  branch='master')

--- a/var/spack/repos/builtin/packages/scalpel/package.py
+++ b/var/spack/repos/builtin/packages/scalpel/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Scalpel(MakefilePackage):
+class Scalpel(MakefilePackage, SourceforgePackage):
     """Scalpel is a software package for detecting INDELs (INsertions and
        DELetions) mutations in a reference genome which has been sequenced
        with next-generation sequencing technology.
     """
 
     homepage = "http://scalpel.sourceforge.net/index.html"
-    url      = "https://downloads.sourceforge.net/project/scalpel/scalpel-0.5.4.tar.gz"
+    sourceforge_mirror_path = "scalpel/scalpel-0.5.4.tar.gz"
 
     version('0.5.4', sha256='506f731b3886def158c15fd8b74fa98390f304a507d2040972e6b09ddefac8f0')
     version('0.5.3', sha256='d45b569fe3aa5934883bc7216c243d53168351c23e020d96a46fa77a1563b65e')

--- a/var/spack/repos/builtin/packages/smalt/package.py
+++ b/var/spack/repos/builtin/packages/smalt/package.py
@@ -6,10 +6,10 @@
 from spack import *
 
 
-class Smalt(AutotoolsPackage):
+class Smalt(AutotoolsPackage, SourceforgePackage):
     """SMALT aligns DNA sequencing reads with a reference genome."""
 
     homepage = "http://www.sanger.ac.uk/science/tools/smalt-0"
-    url      = "https://downloads.sourceforge.net/project/smalt/smalt-0.7.6.tar.gz"
+    sourceforge_mirror_path = "smalt/smalt-0.7.6.tar.gz"
 
     version('0.7.6', sha256='89ccdfe471edba3577b43de9ebfdaedb5cd6e26b02bf4000c554253433796b31')

--- a/var/spack/repos/builtin/packages/snpeff/package.py
+++ b/var/spack/repos/builtin/packages/snpeff/package.py
@@ -7,13 +7,13 @@ from spack import *
 import os.path
 
 
-class Snpeff(Package):
+class Snpeff(Package, SourceforgePackage):
     """SnpEff is a variant annotation and effect prediction tool. It
     annotates and predicts the effects of genetic variants (such as
     amino acid changes)."""
 
     homepage = "http://snpeff.sourceforge.net/"
-    url      = "https://downloads.sourceforge.net/project/snpeff/snpEff_latest_core.zip"
+    sourceforge_mirror_path = "snpeff/snpEff_latest_core.zip"
 
     version('2017-11-24', sha256='d55a7389a78312947c1e7dadf5e6897b42d3c6e942e7c1b8ec68bb35d2ae2244')
 

--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -9,7 +9,7 @@ import os
 from spack import *
 
 
-class Swig(AutotoolsPackage):
+class Swig(AutotoolsPackage, SourceforgePackage):
     """SWIG is an interface compiler that connects programs written in
        C and C++ with scripting languages such as Perl, Python, Ruby,
        and Tcl. It works by taking the declarations found in C/C++
@@ -20,7 +20,7 @@ class Swig(AutotoolsPackage):
        application."""
 
     homepage = "http://www.swig.org"
-    url      = "http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz"
+    sourceforge_mirror_path = "swig/swig-3.0.12.tar.gz"
 
     version('master', git='https://github.com/swig/swig.git')
     version('4.0.1', sha256='7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -9,7 +9,7 @@ from spack.util.environment import is_system_path
 from spack import *
 
 
-class Tcl(AutotoolsPackage):
+class Tcl(AutotoolsPackage, SourceforgePackage):
     """Tcl (Tool Command Language) is a very powerful but easy to
        learn dynamic programming language, suitable for a very wide
        range of uses, including web and desktop applications,
@@ -18,7 +18,7 @@ class Tcl(AutotoolsPackage):
        that is truly cross platform, easily deployed and highly
        extensible."""
     homepage = "http://www.tcl.tk"
-    url      = "http://prdownloads.sourceforge.net/tcl/tcl8.6.5-src.tar.gz"
+    sourceforge_mirror_path = "tcl/tcl8.6.5-src.tar.gz"
 
     version('8.6.8', sha256='c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a')
     version('8.6.6', sha256='a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07')

--- a/var/spack/repos/builtin/packages/tclap/package.py
+++ b/var/spack/repos/builtin/packages/tclap/package.py
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class Tclap(AutotoolsPackage):
+class Tclap(AutotoolsPackage, SourceforgePackage):
     """Templatized C++ Command Line Parser"""
 
     homepage = "http://tclap.sourceforge.net"
-    url      = "https://downloads.sourceforge.net/project/tclap/tclap-1.2.2.tar.gz"
+    sourceforge_mirror_path = "tclap/tclap-1.2.2.tar.gz"
 
     version('1.2.2', sha256='f5013be7fcaafc69ba0ce2d1710f693f61e9c336b6292ae4f57554f59fde5837')
     version('1.2.1', sha256='9f9f0fe3719e8a89d79b6ca30cf2d16620fba3db5b9610f9b51dd2cd033deebb')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -7,7 +7,7 @@ from spack import *
 import os
 
 
-class Tk(AutotoolsPackage):
+class Tk(AutotoolsPackage, SourceforgePackage):
     """Tk is a graphical user interface toolkit that takes developing
        desktop applications to a higher level than conventional
        approaches. Tk is the standard GUI not only for Tcl, but for
@@ -15,7 +15,7 @@ class Tk(AutotoolsPackage):
        applications that run unchanged across Windows, Mac OS X, Linux
        and more."""
     homepage = "http://www.tcl.tk"
-    url      = "http://prdownloads.sourceforge.net/tcl/tk8.6.5-src.tar.gz"
+    sourceforge_mirror_path = "tcl/tk8.6.5-src.tar.gz"
 
     version('8.6.8', sha256='49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33')
     version('8.6.6', sha256='d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d')

--- a/var/spack/repos/builtin/packages/wxpropgrid/package.py
+++ b/var/spack/repos/builtin/packages/wxpropgrid/package.py
@@ -6,13 +6,13 @@
 from spack import *
 
 
-class Wxpropgrid(Package):
+class Wxpropgrid(Package, SourceforgePackage):
     """wxPropertyGrid is a property sheet control for wxWidgets. In
        other words, it is a specialized two-column grid for editing
        properties such as strings, numbers, flagsets, string arrays,
        and colours."""
     homepage = "http://wxpropgrid.sourceforge.net/"
-    url      = "http://prdownloads.sourceforge.net/wxpropgrid/wxpropgrid-1.4.15-src.tar.gz"
+    sourceforge_mirror_path = "wxpropgrid/wxpropgrid-1.4.15-src.tar.gz"
 
     version('1.4.15', sha256='f0c9a86656828f592c8e57d2c89401f07f0af6a45b17bbca3990e8d29121c2b8')
 

--- a/var/spack/repos/builtin/packages/xqilla/package.py
+++ b/var/spack/repos/builtin/packages/xqilla/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Xqilla(AutotoolsPackage):
+class Xqilla(AutotoolsPackage, SourceforgePackage):
     """XQilla is an XQuery and XPath 2 library and command line utility
     written in C++, implemented on top of the Xerces-C library."""
 
     homepage = "http://xqilla.sourceforge.net/HomePage"
-    url      = "https://downloads.sourceforge.net/project/xqilla/XQilla-2.3.3.tar.gz"
+    sourceforge_mirror_path = "xqilla/XQilla-2.3.3.tar.gz"
 
     version('2.3.3', sha256='8f76b9b4f966f315acc2a8e104e426d8a76ba4ea3441b0ecfdd1e39195674fd6')
 

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Xz(AutotoolsPackage):
+class Xz(AutotoolsPackage, SourceforgePackage):
     """XZ Utils is free general-purpose data compression software with
     high compression ratio. XZ Utils were written for POSIX-like systems,
     but also work on some not-so-POSIX systems. XZ Utils are the successor
     to LZMA Utils."""
 
     homepage = "http://tukaani.org/xz/"
-    url      = "http://tukaani.org/xz/xz-5.2.5.tar.bz2"
+    sourceforge_mirror_path = "lzmautils/files/xz-5.2.5.tar.bz2"
     list_url = "http://tukaani.org/xz/old.html"
 
     version('5.2.5', sha256='5117f930900b341493827d63aa910ff5e011e0b994197c3b71c08a20228a42df')


### PR DESCRIPTION
Add a mixing class for direct `CNAME`s to sourceforge mirrors. Since the main gateway servers are often down, this could reduce timeouts and fetch errors for sourceforge.net hosted software.

I only added about half of the sourceforge.net powered packages, since others had more complex URLs or did not pass my fetch-and-checksum tests without further manual intervention.