### PR TITLE
cuDNN home not set on power for spack environment

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -194,6 +194,8 @@ class Cudnn(Package):
         if 'target=ppc64le: platform=linux' in self.spec:
             env.set('cuDNN_ROOT', os.path.join(
                 self.prefix, 'targets', 'ppc64le-linux'))
+            env.set('CUDNN_ROOT', os.path.join(
+                self.prefix, 'targets', 'ppc64le-linux'))
 
     def install(self, spec, prefix):
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -194,8 +194,6 @@ class Cudnn(Package):
         if 'target=ppc64le: platform=linux' in self.spec:
             env.set('cuDNN_ROOT', os.path.join(
                 self.prefix, 'targets', 'ppc64le-linux'))
-            env.set('CUDNN_ROOT', os.path.join(
-                self.prefix, 'targets', 'ppc64le-linux'))
 
     def install(self, spec, prefix):
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -192,7 +192,7 @@ class Cudnn(Package):
 
     def setup_run_environment(self, env):
         if 'target=ppc64le: platform=linux' in self.spec:
-            env.set('CUDNN_DIR', os.path.join(
+            env.set('cuDNN_ROOT', os.path.join(
                 self.prefix, 'targets', 'ppc64le-linux'))
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -192,7 +192,8 @@ class Cudnn(Package):
 
     def setup_run_environment(self, env):
         if 'target=ppc64le: platform=linux' in self.spec:
-            env.set('CUDNN_DIR', os.path.join(self.prefix, 'targets', 'ppc64le-linux'))
+            env.set('CUDNN_DIR', os.path.join(
+                self.prefix, 'targets', 'ppc64le-linux'))
 
     def install(self, spec, prefix):
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -190,6 +190,10 @@ class Cudnn(Package):
 
         return url.format(directory, cuda, ver)
 
+    def setup_run_environment(self, env):
+        if 'target=ppc64le: platform=linux' in self.spec:
+            env.set('CUDNN_DIR', os.path.join(self.prefix, 'targets', 'ppc64le-linux'))
+
     def install(self, spec, prefix):
         install_tree('.', prefix)
 


### PR DESCRIPTION
On Power architectures cuDNN will install in a target directory.  This
was not getting exported properly into environments.  This PR will set
CUDNN_HOME properly when the environment is setup.