### PR TITLE
autotools: Set FORCE_UNSAFE_CONFIGURE to 1 in autotools.py

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -404,6 +404,11 @@ def set_build_environment_variables(pkg, env, dirty):
             if os.path.isdir(pcdir):
                 env.prepend_path('PKG_CONFIG_PATH', pcdir)
 
+    # We force "unsafe build" for packages that require it
+    # when spack is running as root
+    if os.getgid() == 0:
+        env.set("FORCE_UNSAFE_CONFIGURE", "1")
+
     return env
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -404,11 +404,6 @@ def set_build_environment_variables(pkg, env, dirty):
             if os.path.isdir(pcdir):
                 env.prepend_path('PKG_CONFIG_PATH', pcdir)
 
-    # We force "unsafe build" for packages that require it
-    # when spack is running as root
-    if os.getgid() == 0:
-        env.set("FORCE_UNSAFE_CONFIGURE", "1")
-
     return env
 
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -153,6 +153,21 @@ class AutotoolsPackage(PackageBase):
 
         raise RuntimeError('Failed to find suitable config.guess')
 
+    @run_before('configure')
+    def _set_autotools_environment_varoables(self):
+        """Many autotools builds use a version of mknod.m4 that fails when
+        running as root unless FORCE_UNSAFE_CONFIGURE is set to 1.
+
+        We set this to 1 and expect the user to take responsibiltiy if
+        they are running as root. They have to anyway, as this variable
+        doesn't actually prevent configure from doing bad things as root.
+        Without it, configure just fails halfway through, but it can
+        still run things *before* this check. Forcing this just removes a
+        nuisance -- this is not circumventing any real protection.
+
+        """
+        os.environ["FORCE_UNSAFE_CONFIGURE"] = "1"
+
     @run_after('configure')
     def _do_patch_libtool(self):
         """If configure generates a "libtool" script that does not correctly


### PR DESCRIPTION
Allow us running unsafe configure automatically,
when we are running as root.

This is done by appending the proper
enviroment variable in spack env if our
UID is equal to 0 (root on most systems)