### PR TITLE
PyTorch: remove CUDA conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -6,7 +6,6 @@
 from spack import *
 
 
-# TODO: try switching to CMakePackage for more control over build
 class PyTorch(PythonPackage, CudaPackage):
     """Tensors and Dynamic neural networks in Python
     with strong GPU acceleration."""
@@ -107,26 +106,9 @@ class PyTorch(PythonPackage, CudaPackage):
     # see https://github.com/pytorch/pytorch/issues/35149
     conflicts('+fbgemm', when='@1.4.0')
 
-    cuda_arch_conflict = ('This version of Torch/Caffe2 only supports compute '
-                          'capabilities ')
-
     conflicts('cuda_arch=none', when='+cuda',
               msg='Must specify CUDA compute capabilities of your GPU, see '
               'https://developer.nvidia.com/cuda-gpus')
-    conflicts('cuda_arch=52', when='@1.3.0:+cuda',
-              msg=cuda_arch_conflict + '>=5.3')
-    conflicts('cuda_arch=50', when='@1.3.0:+cuda',
-              msg=cuda_arch_conflict + '>=5.3')
-    conflicts('cuda_arch=35', when='@1.3.0:+cuda',
-              msg=cuda_arch_conflict + '>=5.3')
-    conflicts('cuda_arch=32', when='@1.3.0:+cuda',
-              msg=cuda_arch_conflict + '>=5.3')
-    conflicts('cuda_arch=30', when='@1.3.0:+cuda',
-              msg=cuda_arch_conflict + '>=5.3')
-    conflicts('cuda_arch=30', when='@1.2.0:+cuda',
-              msg=cuda_arch_conflict + '>=3.2')
-    conflicts('cuda_arch=20', when='@1.0.0:+cuda',
-              msg=cuda_arch_conflict + '>=3.0')
 
     # Required dependencies
     depends_on('cmake@3.5:', type='build')


### PR DESCRIPTION
These conflicts were added by @glennpj in #14619, but I don't see where they come from. In #15548, @darthsuogles mentioned that the official Docker image still builds with old versions of CUDA. I've also personally built PyTorch 1.4.0 with CUDA 9 and `cuda_arch=35`, so I think these conflicts are incorrect. @glennpj if you can chime in with where these conflicts came from, that would be great. Note that I modified the conflicts slightly in #15548, so maybe I got something wrong during the conversion.