### PR TITLE
autotools: remove FORCE_UNSAFE_CONFIGURE from docs, commands, code

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -284,9 +284,9 @@ have some drawbacks:
    The ``spack load`` and ``spack module tcl loads`` commands, on the
    other hand, are not very smart: if the user-supplied spec matches
    more than one installed package, then ``spack module tcl loads`` will
-   fail. This default behavior may change in the future.  For now, 
-   the workaround is to either be more specific on any failing ``spack load`` 
-   commands or to use ``spack load --first`` to allow spack to load the 
+   fail. This default behavior may change in the future.  For now,
+   the workaround is to either be more specific on any failing ``spack load``
+   commands or to use ``spack load --first`` to allow spack to load the
    first matching spec.
 
 
@@ -1432,10 +1432,6 @@ The following functionality is prepared:
 
 #. Base image: the example starts from a minimal ubuntu.
 
-#. Installing as root: docker images are usually set up as root.
-   Since some autotools scripts might complain about this being unsafe, we set
-   ``FORCE_UNSAFE_CONFIGURE=1`` to avoid configure errors.
-
 #. Pre-install the spack dependencies, including modules from the packages.
    This avoids needing to build those from scratch via ``spack bootstrap``.
    Package installs are followed by a clean-up of the system package index,
@@ -1466,8 +1462,7 @@ In order to build and run the image, execute:
 
    # general environment for docker
    ENV        DEBIAN_FRONTEND=noninteractive \
-              SPACK_ROOT=/usr/local \
-              FORCE_UNSAFE_CONFIGURE=1
+              SPACK_ROOT=/usr/local
 
    # install minimal spack dependencies
    RUN        apt-get update \

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -283,8 +283,6 @@ def ci_rebuild(args):
 
     spack_cmd = exe.which('spack')
 
-    os.environ['FORCE_UNSAFE_CONFIGURE'] = '1'
-
     cdash_report_dir = os.path.join(ci_artifact_dir, 'cdash_report')
     temp_dir = os.path.join(ci_artifact_dir, 'jobs_scratch_dir')
     job_log_dir = os.path.join(temp_dir, 'logs')

--- a/share/spack/docker/centos-6.dockerfile
+++ b/share/spack/docker/centos-6.dockerfile
@@ -5,7 +5,6 @@ ENV DOCKERFILE_BASE=centos            \
     DOCKERFILE_DISTRO=centos          \
     DOCKERFILE_DISTRO_VERSION=6       \
     SPACK_ROOT=/opt/spack             \
-    FORCE_UNSAFE_CONFIGURE=1          \
     DEBIAN_FRONTEND=noninteractive    \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker

--- a/share/spack/docker/centos-7.dockerfile
+++ b/share/spack/docker/centos-7.dockerfile
@@ -5,7 +5,6 @@ ENV DOCKERFILE_BASE=centos            \
     DOCKERFILE_DISTRO=centos          \
     DOCKERFILE_DISTRO_VERSION=7       \
     SPACK_ROOT=/opt/spack             \
-    FORCE_UNSAFE_CONFIGURE=1          \
     DEBIAN_FRONTEND=noninteractive    \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -5,7 +5,6 @@ ENV DOCKERFILE_BASE=ubuntu:16.04      \
     DOCKERFILE_DISTRO=ubuntu          \
     DOCKERFILE_DISTRO_VERSION=16.04   \
     SPACK_ROOT=/opt/spack             \
-    FORCE_UNSAFE_CONFIGURE=1          \
     DEBIAN_FRONTEND=noninteractive    \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
@@ -90,4 +89,3 @@ RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["docker-shell"]
-

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -5,7 +5,6 @@ ENV DOCKERFILE_BASE=ubuntu            \
     DOCKERFILE_DISTRO=ubuntu          \
     DOCKERFILE_DISTRO_VERSION=18.04   \
     SPACK_ROOT=/opt/spack             \
-    FORCE_UNSAFE_CONFIGURE=1          \
     DEBIAN_FRONTEND=noninteractive    \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker

--- a/share/spack/docs/docker/module-file-tutorial/Dockerfile
+++ b/share/spack/docs/docker/module-file-tutorial/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:16.04
 
 # General environment for docker
 ENV DEBIAN_FRONTEND=noninteractive \
-    SPACK_ROOT=/usr/local \
-    FORCE_UNSAFE_CONFIGURE=1
+    SPACK_ROOT=/usr/local
 
 # Install system packages
 RUN apt-get update \
@@ -18,20 +17,20 @@ RUN apt-get update \
        openmpi-bin openmpi-common libopenmpi-dev \
        python \
        unzip \
-    &&  rm -rf /var/lib/apt/lists/*      
+    &&  rm -rf /var/lib/apt/lists/*
 
 # Load spack environment on login
 COPY spack.sh /etc/profile
 
 # Install spack
 RUN curl -s -L https://api.github.com/repos/spack/spack/tarball/develop \
-    | tar xzC $SPACK_ROOT --strip 1 
+    | tar xzC $SPACK_ROOT --strip 1
 
 # Copy configuration for external packages
 COPY packages.yaml $SPACK_ROOT/etc/spack/
 
 # Build lmod
-RUN spack install lmod && spack clean -a 
+RUN spack install lmod && spack clean -a
 
 # Build a compiler
 RUN spack install gcc@7.2.0 && spack clean -a
@@ -48,4 +47,3 @@ RUN spack install netlib-scalapack ^openmpi ^openblas %gcc@7.2.0 \
 
 # image run hook: the -l will make sure /etc/profile environments are loaded
 CMD /bin/bash -l
-

--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -34,6 +34,5 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
                 configure_args.append('--program-prefix=g')
             configure_args.append('--without-gmp')
             configure_args.append('gl_cv_func_ftello_works=yes')
-            configure_args.append('FORCE_UNSAFE_CONFIGURE=1')
 
             return configure_args


### PR DESCRIPTION
Since #16132, we've consolidated the setting of FORCE_UNSAFE_CONFIGURE to `autotools.py`, so we don't need to use it in packages like `coreutils`, in our commands, or in our container recipes.

- [x] Remove FORCE_UNSAFE_CONFIGURE from packages
- [x] Remove FORCE_UNSAFE_CONFIGURE from container recipes
- [x] Remove FORCE_UNSAFE_CONFIGURE from `spack ci` command

@DiegoMagdaleno FYI.