### PR TITLE
charliecloud: add more checksummed versions

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -24,10 +24,10 @@ class Charliecloud(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
 
-    # Use legacy build system up to version 0.13
-    depends_on('skopeo',         type='run', when='@:0.13')
-    depends_on('umoci',          type='run', when='@:0.13')
-    depends_on('python+libxml2', type='run', when='@:0.13')
+    # Use skopeo and umoci for older ch-grow version dependencies
+    depends_on('skopeo',         type='run', when='@0.10:0.13')
+    depends_on('umoci',          type='run', when='@0.10:0.13')
+    depends_on('python+libxml2', type='run', when='@0.10:0.13')
 
     # Charliecloud@0.14 and up use python for building
     depends_on('python@3.5:',    type='run', when='@0.14:')
@@ -44,6 +44,7 @@ class Charliecloud(AutotoolsPackage):
 
     # bash automated testing harness (bats)
     depends_on('bats@0.4.0', type='test')
+    depends_on('python@3.5:', type='test')
 
     def configure_args(self):
 

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -24,9 +24,15 @@ class Charliecloud(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
 
-    depends_on('python@3.5:',    type='run')
-    depends_on('py-lark-parser', type='run')
-    depends_on('py-requests',    type='run')
+    # Use legacy build system up to version 0.13
+    depends_on('skopeo',         type='run', when='@:0.13')
+    depends_on('umoci',          type='run', when='@:0.13')
+    depends_on('python+libxml2', type='run', when='@:0.13')
+
+    # Charliecloud@0.14 and up use python for building
+    depends_on('python@3.5:',    type='run', when='@0.14:')
+    depends_on('py-lark-parser', type='run', when='@0.14:')
+    depends_on('py-requests',    type='run', when='@0.14:')
 
     # man pages and html docs variant
     variant('docs', default=False, description='Build man pages and html docs')

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -17,6 +17,13 @@ class Charliecloud(AutotoolsPackage):
     version('master', branch='master')
     version('0.15',   sha256='2163420d43c934151c4f44a188313bdb7f79e576d5a86ba64b9ea45f784b9921')
     version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
+    version('0.13',   sha256='5740bff6e410ca99484c1bdf3dbe834c0f753c846d55c19d6162967a3e2718e0')
+    version('0.12',   sha256='8a90f33406905cee935b5673a1159232b0b71845f4b6a26d28ca88f5d3f55891')
+    version('0.11',   sha256='942d3c7a74c978fd7420cb2b255e618f4f0acaafb6025160bc3a4deeb687ef3c')
+    version('0.10',   sha256='5cf00b170e7568750ca0b828c43c0857c39674860b480d757057450d69f1a21e')
+    version('0.9.10', sha256='44e821b62f9c447749d3ed0d2b2e44d374153058814704a5543e83f42db2a45a')
+    version('0.9.9',  sha256='7f83d25dd77b90232f8529c83c689e565117414b7be996dbd2dd4bf3220b2166')
+    version('0.9.8',  sha256='330071ef9e597df75278b8c870af3cd1acfdf6d702ceae25071c7cb8cd5d84b5')
 
     depends_on('m4',       type='build')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -18,12 +18,6 @@ class Charliecloud(AutotoolsPackage):
     version('0.15',   sha256='2163420d43c934151c4f44a188313bdb7f79e576d5a86ba64b9ea45f784b9921')
     version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
     version('0.13',   sha256='5740bff6e410ca99484c1bdf3dbe834c0f753c846d55c19d6162967a3e2718e0')
-    version('0.12',   sha256='8a90f33406905cee935b5673a1159232b0b71845f4b6a26d28ca88f5d3f55891')
-    version('0.11',   sha256='942d3c7a74c978fd7420cb2b255e618f4f0acaafb6025160bc3a4deeb687ef3c')
-    version('0.10',   sha256='5cf00b170e7568750ca0b828c43c0857c39674860b480d757057450d69f1a21e')
-    version('0.9.10', sha256='44e821b62f9c447749d3ed0d2b2e44d374153058814704a5543e83f42db2a45a')
-    version('0.9.9',  sha256='7f83d25dd77b90232f8529c83c689e565117414b7be996dbd2dd4bf3220b2166')
-    version('0.9.8',  sha256='330071ef9e597df75278b8c870af3cd1acfdf6d702ceae25071c7cb8cd5d84b5')
 
     depends_on('m4',       type='build')
     depends_on('autoconf', type='build')


### PR DESCRIPTION
This PR adds version 0.13 and the associated checksum to the charliecloud package. 