### PR TITLE
Add explicit path to upstreams.yaml

### DIFF
--- a/lib/spack/docs/chain.rst
+++ b/lib/spack/docs/chain.rst
@@ -11,7 +11,7 @@ Chaining Spack Installations
 
 You can point your Spack installation to another installation to use any
 packages that are installed there. To register the other Spack instance,
-you can add it as an entry to ``upstreams.yaml``:
+you can add it as an entry to ``etc/spack/upstreams.yaml``:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
I'm not sure is there are other locations for this (e.g. `~/.spack`), but it would have saved me a minute or to if the doc was explicit about where it lived.