### PR TITLE
libsecret

### DIFF
--- a/var/spack/repos/builtin/packages/libsecret/package.py
+++ b/var/spack/repos/builtin/packages/libsecret/package.py
@@ -25,7 +25,7 @@ class Libsecret(AutotoolsPackage):
     # Optional Vala support is not implemented yet
     # variant('vala', default=False, descript='Build with Vala support')
 
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')
 #    depends_on('mesa')
     # https://gitlab.gnome.org/GNOME/libsecret/blob/master/meson.build
     depends_on('glib@2.44:')

--- a/var/spack/repos/builtin/packages/libsecret/package.py
+++ b/var/spack/repos/builtin/packages/libsecret/package.py
@@ -25,6 +25,8 @@ class Libsecret(AutotoolsPackage):
     # Optional Vala support is not implemented yet
     # variant('vala', default=False, descript='Build with Vala support')
 
+    depends_on('pkg-config', type='build')
+#    depends_on('mesa')
     # https://gitlab.gnome.org/GNOME/libsecret/blob/master/meson.build
     depends_on('glib@2.44:')
     depends_on('libgcrypt@1.2.2:', when='+gcrypt')


### PR DESCRIPTION
Add missing dependency.

I believe this also depends on OpenGL?  I could not get `mesa` (OpenGL) building on my macOS Catalina.  I tried using the System built-in OpenGL instead, also to no avail (for other reasons).  Finally I just used the pre-built downloaded Qt distort for macOS and punted on OpenGL / Qt build issues.

In any case, I believe `libsecret` does need `pig-config`.