### PR TITLE
cdo: Update for use with proj@6

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -73,8 +73,9 @@ class Cdo(AutotoolsPackage):
 
     # PROJ.6 supported starting 1.9.8.1
     # https://launchpad.net/ubuntu/+source/cdo/+changelog
-    depends_on('proj@:5', when='@:1.9.8+proj')
-    depends_on('proj@6:', when='@1.9.9:+proj')
+    depends_on('proj@:5', when='@:1.9.6+proj')
+    depends_on('proj@:7', when='@1.9.7+proj')
+    depends_on('proj@5:', when='@1.9.8:+proj')
     depends_on('curl', when='+curl')
     depends_on('fftw@3:', when='+fftw3')
     depends_on('magics', when='+magics')

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -17,6 +17,8 @@ class Cdo(AutotoolsPackage):
 
     maintainers = ['skosukhin']
 
+    version('1.9.9.rc2', sha256='2328299c43ecd10f8283056b6a65e6f205fb64e988ce360fc2b30672e7491e66',
+            url='https://code.mpimet.mpg.de/attachments/download/21529/cdo-1.9.9rc2.tar.gz')
     version('1.9.8', sha256='f2660ac6f8bf3fa071cf2a3a196b3ec75ad007deb3a782455e80f28680c5252a', url='https://code.mpimet.mpg.de/attachments/download/20286/cdo-1.9.8.tar.gz')
     version('1.9.7.1', sha256='3771952e065bcf935d43e492707370ed2a0ecb59a06bea24f9ab69d77943962c',
             url='https://code.mpimet.mpg.de/attachments/download/20124/cdo-1.9.7.1.tar.gz')
@@ -42,6 +44,8 @@ class Cdo(AutotoolsPackage):
 
     variant('udunits2', default=True, description='Enable UDUNITS2 support')
     variant('libxml2', default=True, description='Enable libxml2 support')
+    # PROJ.6 supported starting 1.9.8.1
+    # https://launchpad.net/ubuntu/+source/cdo/+changelog
     variant('proj', default=True,
             description='Enable PROJ library for cartographic projections')
     variant('curl', default=False, description='Enable curl support')
@@ -66,7 +70,8 @@ class Cdo(AutotoolsPackage):
 
     depends_on('udunits', when='+udunits2')
     depends_on('libxml2', when='+libxml2')
-    depends_on('proj@:5', when='+proj')
+    depends_on('proj@:5', when='@:1.9.8+proj')
+    depends_on('proj@6:', when='@1.9.9:+proj')
     depends_on('curl', when='+curl')
     depends_on('fftw@3:', when='+fftw3')
     depends_on('magics', when='+magics')

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -19,7 +19,9 @@ class Cdo(AutotoolsPackage):
 
     version('1.9.9.rc2', sha256='2328299c43ecd10f8283056b6a65e6f205fb64e988ce360fc2b30672e7491e66',
             url='https://code.mpimet.mpg.de/attachments/download/21529/cdo-1.9.9rc2.tar.gz')
-    version('1.9.8', sha256='f2660ac6f8bf3fa071cf2a3a196b3ec75ad007deb3a782455e80f28680c5252a', url='https://code.mpimet.mpg.de/attachments/download/20286/cdo-1.9.8.tar.gz')
+    version('1.9.8', sha256='f2660ac6f8bf3fa071cf2a3a196b3ec75ad007deb3a782455e80f28680c5252a',
+            url='https://code.mpimet.mpg.de/attachments/download/20286/cdo-1.9.8.tar.gz',
+           preferred=True)
     version('1.9.7.1', sha256='3771952e065bcf935d43e492707370ed2a0ecb59a06bea24f9ab69d77943962c',
             url='https://code.mpimet.mpg.de/attachments/download/20124/cdo-1.9.7.1.tar.gz')
     version('1.9.6', sha256='b31474c94548d21393758caa33f35cf7f423d5dfc84562ad80a2bdcb725b5585', url='https://code.mpimet.mpg.de/attachments/download/19299/cdo-1.9.6.tar.gz')
@@ -44,8 +46,6 @@ class Cdo(AutotoolsPackage):
 
     variant('udunits2', default=True, description='Enable UDUNITS2 support')
     variant('libxml2', default=True, description='Enable libxml2 support')
-    # PROJ.6 supported starting 1.9.8.1
-    # https://launchpad.net/ubuntu/+source/cdo/+changelog
     variant('proj', default=True,
             description='Enable PROJ library for cartographic projections')
     variant('curl', default=False, description='Enable curl support')
@@ -70,6 +70,9 @@ class Cdo(AutotoolsPackage):
 
     depends_on('udunits', when='+udunits2')
     depends_on('libxml2', when='+libxml2')
+
+    # PROJ.6 supported starting 1.9.8.1
+    # https://launchpad.net/ubuntu/+source/cdo/+changelog
     depends_on('proj@:5', when='@:1.9.8+proj')
     depends_on('proj@6:', when='@1.9.9:+proj')
     depends_on('curl', when='+curl')


### PR DESCRIPTION
Added new version to work with `proj@6`.  No official releases work with `proj@6` yet, but the RC2 version is pretty close.  When there is an official release, we should replace the RC2 version with it.