### PR TITLE
llvm

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -194,6 +194,7 @@ class Llvm(CMakePackage, CudaPackage):
 
     @run_before("cmake")
     def check_darwin_lldb_codesign_requirement(self):
+        return   # This code signing requires root access :-(
         if not self.spec.satisfies("+lldb platform=darwin"):
             return
         codesign = which("codesign")


### PR DESCRIPTION
A previous PR added code signing to the LLVM install on macOS.  unfortunately, that requires root access and breaks the build for many of us on macOS.  This PR disables it with a sledge hammer.   But we need to be a little more sophisticated about disabling it.  Maybe a variant?  Or check if Spack is running as root before trying to sign code?

One problem with testing / editing this build is LLVM takes (on my laptop) all day to build.  So it's hard to debug or try many things.  I eventually gave up and installed pre-built LLVM binaries.
