### PR TITLE
qscintilla

### DIFF
--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -43,6 +43,8 @@ class Qscintilla(QMakePackage):
     # giving 'Nothing Installed Error'
     def setup_build_environment(self, env):
         env.set('INSTALL_ROOT', self.prefix)
+        # https://riverbankcomputing.com/pipermail/qscintilla/2015-January/001012.html
+        env.set('QMAKEFEATURES', join_path(self.stage.source_path, 'Qt4Qt5', 'features'))
 
     def setup_run_environment(self, env):
         env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -43,8 +43,6 @@ class Qscintilla(QMakePackage):
     # giving 'Nothing Installed Error'
     def setup_build_environment(self, env):
         env.set('INSTALL_ROOT', self.prefix)
-        # https://riverbankcomputing.com/pipermail/qscintilla/2015-January/001012.html
-        env.set('QMAKEFEATURES', join_path(self.stage.source_path, 'Qt4Qt5', 'features'))
 
     def setup_run_environment(self, env):
         env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -218,7 +218,8 @@ class Qt(Package):
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('QTDIR', self.prefix)
         # https://riverbankcomputing.com/pipermail/qscintilla/2015-January/001012.html
-        env.set('QMAKEFEATURES', join_path(dependent_spec.stage.source_path, 'Qt4Qt5', 'features'))
+        env.set('QMAKEFEATURES', join_path(
+            dependent_spec.stage.source_path, 'Qt4Qt5', 'features'))
 
     def setup_dependent_package(self, module, dependent_spec):
         module.qmake = Executable(join_path(self.spec.prefix.bin, 'qmake'))

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -217,6 +217,8 @@ class Qt(Package):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('QTDIR', self.prefix)
+        # https://riverbankcomputing.com/pipermail/qscintilla/2015-January/001012.html
+        env.set('QMAKEFEATURES', join_path(dependent_spec.stage.source_path, 'Qt4Qt5', 'features'))
 
     def setup_dependent_package(self, module, dependent_spec):
         module.qmake = Executable(join_path(self.spec.prefix.bin, 'qmake'))


### PR DESCRIPTION
In order for Qt packages to find their dependencies, the `QMAKEFEATURE` env var must be set appropriately at build time.  This PR adds that necessary step.
