### PR TITLE
Fix metis build

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -173,9 +173,8 @@ class Metis(Package):
         source_directory = self.stage.source_path
         build_directory = join_path(source_directory, 'build')
 
-        options = std_cmake_args[:]
+        options = CMakePackage._std_args(self)
         options.append('-DGKLIB_PATH:PATH=%s/GKlib' % source_directory)
-        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
 
         # Normally this is available via the 'CMakePackage' object, but metis
         # IS-A 'Package' (not a 'CMakePackage') to support non-cmake metis@:5.

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -171,7 +171,7 @@ class Metis(Package):
     @when('@5:')
     def install(self, spec, prefix):
         source_directory = self.stage.source_path
-        build_directory = join_path(source_directory, 'build')
+        build_directory = join_path(self.stage.path, 'build')
 
         options = CMakePackage._std_args(self)
         options.append('-DGKLIB_PATH:PATH=%s/GKlib' % source_directory)


### PR DESCRIPTION
fixes a specific problem I noticed where Metis would get CMAKE_INSTALL_PREFIX to the wrong prefix (apparently 'remembered' from a previous build)