### PR TITLE
gettext: add missing iconv dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -27,6 +27,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     # Optional variants
     variant('libunistring', default=False, description='Use libunistring')
 
+    depends_on('iconv')
     # Recommended dependencies
     depends_on('ncurses',  when='+curses')
     depends_on('libxml2',  when='+libxml2')
@@ -50,7 +51,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
         config_args = [
             '--disable-java',
-            '--disable-csharp',
+            '--disable-icsharp',
+            '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix),
             '--with-included-glib',
             '--with-included-gettext',
             '--with-included-libcroco',


### PR DESCRIPTION
`gettext` will pick up a random `iconv` dependency if not specified, which crashes python and its own builds on macOS.

This should fix #14415 #16075 et al.

I tested building all versions on Ubuntu 18.04 but need someone to confirm this fixes your `gettext` and `python` build issues on macOS.

cc @coreyjadams @LDAmorim @gartung @adamjstewart @sethrj 