### PR TITLE
Fix: Flex Reconfigure

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -43,6 +43,7 @@ class Flex(AutotoolsPackage):
     # - https://github.com/westes/flex/issues/241
     patch('https://github.com/westes/flex/commit/24fd0551333e7eded87b64dd36062da3df2f6380.patch', sha256='09c22e5c6fef327d3e48eb23f0d610dcd3a35ab9207f12e0f875701c677978d3', when='@2.6.4')
 
+    @when('@:2.6.0,2.6.4')
     def autoreconf(self, spec, prefix):
         autogen = Executable('./autogen.sh')
         autogen()

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -43,6 +43,10 @@ class Flex(AutotoolsPackage):
     # - https://github.com/westes/flex/issues/241
     patch('https://github.com/westes/flex/commit/24fd0551333e7eded87b64dd36062da3df2f6380.patch', sha256='09c22e5c6fef327d3e48eb23f0d610dcd3a35ab9207f12e0f875701c677978d3', when='@2.6.4')
 
+    def autoreconf(self, spec, prefix):
+        autogen = Executable('./autogen.sh')
+        autogen()
+
     @property
     def force_autoreconf(self):
         # The patch for 2.6.4 touches configure


### PR DESCRIPTION
Learn the `flex` package how to reconfigure itself when needed.

This is currently the default and crashed builds, see `force_autoreconf` trigger for the latest version.

Kudos to @aweits for spotting this!

Fix #11551