### PR TITLE
gettext: Fix typo

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -51,7 +51,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
         config_args = [
             '--disable-java',
-            '--disable-icsharp',
+            '--disable-csharp',
             '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix),
             '--with-included-glib',
             '--with-included-gettext',


### PR DESCRIPTION
It seems that #16193 introduced a typo (`icsharp` instead of `csharp`). @ax3l 