### PR TITLE
Phist int64 variant

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -49,7 +49,7 @@ class Phist(CMakePackage):
 
     variant(name='outlev', default='2', values=['0', '1', '2', '3', '4', '5'],
             description='verbosity. 0: errors 1: +warnings 2: +info '
-                        '3: +verbose 4: +extreme 5; +debug')
+                        '3: +verbose 4: +extreme 5: +debug')
 
     variant('host', default=True,
             description='allow PHIST to use compiler flags that lead to host-'
@@ -93,6 +93,10 @@ class Phist(CMakePackage):
     conflicts('~int64', when='kernel_lib=builtin')
     conflicts('+int64', when='kernel_lib=eigen')
 
+    # ###################### Patches ##########################
+
+    patch('update_tpetra_gotypes.patch', when='@:1.9.0')
+
     # ###################### Dependencies ##########################
 
     depends_on('cmake@3.8:', type='build')
@@ -104,7 +108,7 @@ class Phist(CMakePackage):
     depends_on('python@3:', when='@1.7: +fortran', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('trilinos@12:+tpetra gotype=long_long', when='kernel_lib=tpetra +int64')
-    depends_on('trilinos@12:+tpetra gotype=long', when='kernel_lib=tpetra ~int64')
+    depends_on('trilinos@12:+tpetra gotype=int', when='kernel_lib=tpetra ~int64')
     # Epetra backend also works with older Trilinos versions
     depends_on('trilinos+epetra', when='kernel_lib=epetra')
     depends_on('petsc +int64', when='kernel_lib=petsc +int64')

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -26,6 +26,7 @@ class Phist(CMakePackage):
 
     version('develop', branch='devel')
     version('master', branch='master')
+    version('1.9.0', sha256='c0f5b403051f161ac85a309a2a11ace5ea63d7e82eaf1d14a6d9f69ac585c008')
     version('1.8.0', sha256='ee42946bce187e126452053b5f5c200b57b6e40ee3f5bcf0751f3ced585adeb0')
     version('1.7.5', sha256='f11fe27f2aa13d69eb285cc0f32c33c1603fa1286b84e54c81856c6f2bdef500')
     version('1.7.4', sha256='ef0c97fda9984f53011020aff3e61523833320f5f5719af2f2ed84463cccb98b')

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -26,7 +26,7 @@ class Phist(CMakePackage):
 
     version('develop', branch='devel')
     version('master', branch='master')
-    version('1.9.0', sha256='c0f5b403051f161ac85a309a2a11ace5ea63d7e82eaf1d14a6d9f69ac585c008')
+    version('1.9.0', sha256='990d3308fc0083ed0f9f565d00c649ee70c3df74d44cbe5f19dfe05263d06559')
     version('1.8.0', sha256='ee42946bce187e126452053b5f5c200b57b6e40ee3f5bcf0751f3ced585adeb0')
     version('1.7.5', sha256='f11fe27f2aa13d69eb285cc0f32c33c1603fa1286b84e54c81856c6f2bdef500')
     version('1.7.4', sha256='ef0c97fda9984f53011020aff3e61523833320f5f5719af2f2ed84463cccb98b')

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -103,7 +103,6 @@ class Phist(CMakePackage):
     # the feature (e.g. use the '~fortran' variant)
     depends_on('python@3:', when='@1.7: +fortran', type='build')
     depends_on('mpi', when='+mpi')
-    depends_on('trilinos+anasazi+belos+teuchos', when='+trilinos')
     depends_on('trilinos@12:+tpetra gotype=long_long', when='kernel_lib=tpetra +int64')
     depends_on('trilinos@12:+tpetra gotype=long', when='kernel_lib=tpetra ~int64')
     # Epetra backend also works with older Trilinos versions
@@ -113,7 +112,7 @@ class Phist(CMakePackage):
     depends_on('eigen', when='kernel_lib=eigen')
     depends_on('ghost', when='kernel_lib=ghost')
 
-    depends_on('trilinos', when='+trilinos')
+    depends_on('trilinos+anasazi+belos+teuchos', when='+trilinos')
     depends_on('parmetis ^metis+int64', when='+parmetis +int64')
     depends_on('parmetis ^metis~int64', when='+parmetis ~int64')
 
@@ -148,11 +147,11 @@ class Phist(CMakePackage):
                 '-DPHIST_ENABLE_SCAMAC:BOOL=%s'
                 % ('ON' if '+scamac' in spec else 'OFF'),
                 '-DPHIST_USE_TRILINOS_TPLS:BOOL=%s'
-                % ('ON' if '+trilinos' in spec else 'OFF'),
+                % ('ON' if '^trilinos' in spec else 'OFF'),
                 '-DPHIST_USE_SOLVER_TPLS:BOOL=%s'
-                % ('ON' if '+trilinos' in spec else 'OFF'),
+                % ('ON' if '^trilinos+belos+anasazi' in spec else 'OFF'),
                 '-DPHIST_USE_PRECON_TPLS:BOOL=%s'
-                % ('ON' if '+trilinos' in spec else 'OFF'),
+                % ('ON' if '^trilinos' in spec else 'OFF'),
                 '-DXSDK_ENABLE_Fortran:BOOL=%s'
                 % ('ON' if '+fortran' in spec else 'OFF'),
                 '-DXSDK_INDEX_SIZE=%s'

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -45,7 +45,7 @@ class Phist(CMakePackage):
                     'eigen',
                     'ghost'])
 
-    variant(name='int64', default=True, 
+    variant(name='int64', default=True,
             description='Use 64-bit global indices.')
 
     variant(name='outlev', default='2', values=['0', '1', '2', '3', '4', '5'],

--- a/var/spack/repos/builtin/packages/phist/update_tpetra_gotypes.patch
+++ b/var/spack/repos/builtin/packages/phist/update_tpetra_gotypes.patch
@@ -1,0 +1,35 @@
+commit 8df8ad0e56e3bbd3d0c133fcdb7d2af6ab4dd229
+Author: Jonas Thies <Jonas.Thies@DLR.de>
+Date:   Tue Apr 21 18:24:53 2020 +0200
+
+    tpetra: use 'int' and 'long long' as gidx type for 32 and 64-bit compilations, respectively
+    because Trilinos allows to instantiate those variants (before I had 'int'/'ptrdiff_t')
+
+diff --git a/src/kernels/tpetra/phist_typedefs.h b/src/kernels/tpetra/phist_typedefs.h
+index 1f6b6c6c..3a351c27 100644
+--- a/src/kernels/tpetra/phist_typedefs.h
++++ b/src/kernels/tpetra/phist_typedefs.h
+@@ -34,19 +34,18 @@
+ using phist_s_complex = std::complex<float>;
+ //! double precision complex type
+ using phist_d_complex = std::complex<double>;
+-//! type of global indices
+-using phist_gidx = std::ptrdiff_t;
+ #else
+ typedef float complex phist_s_complex;
+ typedef double complex phist_d_complex;
++#endif
++
+ //! type of global indices
+ #ifdef PHIST_FORCE_32BIT_GIDX
+ typedef int phist_gidx;
+ #define PRgidx "d"
+ #else
+-typedef ptrdiff_t phist_gidx;
+-#define PRgidx "ld"
+-#endif
++typedef long long phist_gidx;
++#define PRgidx "lld"
+ #endif
+ 
+ // we want ptrdiff_t (aka long long int on 64 bit systems) as local index,


### PR DESCRIPTION
these updates are required to correctly build with Trilinos kernel libraries or optional packages (since Trilinos introuced the 'gotype' variant recently)