### PR TITLE
lib/spack : expand spack config vars in 'include' section

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -37,6 +37,7 @@ from spack.spec import Spec
 from spack.spec_list import SpecList, InvalidSpecConstraintError
 from spack.variant import UnknownVariantError
 import spack.util.lock as lk
+from spack.util.path import canonicalize_path
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'
@@ -776,8 +777,8 @@ class Environment(object):
         # highest-precedence scopes are last.
         includes = config_dict(self.yaml).get('include', [])
         for i, config_path in enumerate(reversed(includes)):
-            # allow paths to contain environment variables
-            config_path = config_path.format(**os.environ)
+            # allow paths to contain spack config/environment variables, etc.
+            config_path = canonicalize_path(config_path)
 
             # treat relative paths as relative to the environment
             if not os.path.isabs(config_path):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -37,7 +37,7 @@ from spack.spec import Spec
 from spack.spec_list import SpecList, InvalidSpecConstraintError
 from spack.variant import UnknownVariantError
 import spack.util.lock as lk
-from spack.util.path import canonicalize_path
+from spack.util.path import substitute_path_variables
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'
@@ -778,7 +778,7 @@ class Environment(object):
         includes = config_dict(self.yaml).get('include', [])
         for i, config_path in enumerate(reversed(includes)):
             # allow paths to contain spack config/environment variables, etc.
-            config_path = canonicalize_path(config_path)
+            config_path = substitute_path_variables(config_path)
 
             # treat relative paths as relative to the environment
             if not os.path.isabs(config_path):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -22,6 +22,7 @@ from spack.stage import stage_prefix
 from spack.spec_list import SpecListError
 from spack.test.conftest import MockPackage, MockPackageMultiRepo
 import spack.util.spack_json as sjson
+from spack.util.path import substitute_path_variables
 
 
 # everything here uses the mock_env_path
@@ -504,6 +505,35 @@ env:
 
     fs.mkdirp(config_scope_path)
     with open(os.path.join(config_scope_path, 'packages.yaml'), 'w') as f:
+        f.write("""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+
+    with e:
+        e.concretize()
+
+    assert any(x.satisfies('mpileaks@2.2')
+               for x in e._get_environment_specs())
+
+
+def test_env_with_included_config_var_path():
+    config_var_path = os.path.join('$tempdir', 'included-config.yaml')
+    test_config = """\
+env:
+  include:
+  - %s
+  specs:
+  - mpileaks
+""" % config_var_path
+
+    _env_create('test', StringIO(test_config))
+    e = ev.read('test')
+
+    config_real_path = substitute_path_variables(config_var_path)
+    fs.mkdirp(os.path.dirname(config_real_path))
+    with open(config_real_path, 'w') as f:
         f.write("""\
 packages:
   mpileaks:


### PR DESCRIPTION
The changes in this pull request modify the [`include` section](https://spack.readthedocs.io/en/latest/environments.html#included-configurations) of the Spack environment configuration to support Spack's [configuration file variables](https://spack.readthedocs.io/en/latest/configuration.html#config-file-variables). These changes make it much simpler to share and refer to local Spack configuration files, e.g.:

#### Environment File 1 ####
```
spack:
  include:
  - $spack/env/repos.yaml

  specs:
  - builtin_package1
  - local_package1
```
#### Environment File 2 ####
```
spack:
  include:
  - $spack/env/repos.yaml

  specs:
  - builtin_package2
  - local_package1
```