### PR TITLE
opengl : add all older versions

### DIFF
--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -20,6 +20,17 @@ class Opengl(Package):
     provides('gl@:4.2', when='@4.2:')
     provides('gl@:4.1', when='@4.1:')
     provides('gl@:3.3', when='@3.3:')
+    provides('gl@:3.2', when='@3.2:')
+    provides('gl@:3.1', when='@3.1:')
+    provides('gl@:3.0', when='@3.0:')
+    provides('gl@:2.1', when='@2.1:')
+    provides('gl@:2.0', when='@2.0:')
+    provides('gl@:1.5', when='@1.5:')
+    provides('gl@:1.4', when='@1.4:')
+    provides('gl@:1.3', when='@1.3:')
+    provides('gl@:1.2', when='@1.2:')
+    provides('gl@:1.1', when='@1.1:')
+    provides('gl@:1.0', when='@1.0:')
 
     if sys.platform != 'darwin':
         provides('glx@1.4')


### PR DESCRIPTION
The changes in this pull request revise the `opengl` package so that all older versions of the library are included (see [the OpenGL wiki](https://www.khronos.org/opengl/wiki/History_of_OpenGL) for more information). These changes are important for older systems, which tend to only support versions of OpenGL up through `@1.4`.