### PR TITLE
qt : new version (@5.12.7), new variant (+debug), changed constraints (+opengl)

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -28,6 +28,7 @@ class Qt(Package):
     version('5.14.1', sha256='6f17f488f512b39c2feb57d83a5e0a13dcef32999bea2e2a8f832f54a29badb8')
     version('5.14.0', sha256='be9a77cd4e1f9d70b58621d0753be19ea498e6b0da0398753e5038426f76a8ba')
     version('5.13.1', sha256='adf00266dc38352a166a9739f1a24a1e36f1be9c04bf72e16e142a256436974e')
+    version('5.12.7', sha256='873783a0302129d98a8f63de9afe4520fb5f8d5316be8ad7b760c59875cd8a8d')
     version('5.12.5', sha256='a2299e21db7767caf98242767bffb18a2a88a42fee2d6a393bedd234f8c91298')
     version('5.12.2', sha256='59b8cb4e728450b21224dcaaa40eb25bafc5196b6988f2225c394c6b7f881ff5')
     version('5.11.3', sha256='859417642713cee2493ee3646a7fee782c9f1db39e41d7bb1322bba0c5f0ff4d')
@@ -48,6 +49,8 @@ class Qt(Package):
     version('4.8.5',  sha256='eb728f8268831dc4373be6403b7dd5d5dde03c169ad6882f9a8cb560df6aa138')
     version('3.3.8b', sha256='1b7a1ff62ec5a9cb7a388e2ba28fda6f960b27f27999482ebeceeadb72ac9f6e')
 
+    variant('debug',      default=False,
+            description="Build debug version.")
     variant('gtk',        default=False,
             description="Build with gtkplus.")
     variant('webkit',     default=False,
@@ -111,6 +114,8 @@ class Qt(Package):
     # https://github.com/spack/spack/issues/14400
     patch('qt5-11-intel-overflow.patch', when='@5.11 %intel')
     patch('qt5-12-intel-overflow.patch', when='@5.12:5.14.0 %intel')
+    # https://bugreports.qt.io/browse/QTBUG-78937
+    patch('qt5-12-configure.patch', when='@5.12')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')
@@ -140,7 +145,7 @@ class Qt(Package):
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')
     depends_on("dbus", when='@4:+dbus')
-    depends_on("gl@3.2:", when='@4:+opengl')
+    depends_on("gl", when='@4:+opengl')
 
     depends_on("harfbuzz", when='@5:')
     depends_on("double-conversion", when='@5.7:')
@@ -358,7 +363,7 @@ class Qt(Package):
             '-v',
             '-opensource',
             '-{0}opengl'.format('' if '+opengl' in self.spec else 'no-'),
-            '-release',
+            '-{0}'.format('debug' if '+debug' in self.spec else 'release'),
             '-confirm-license',
             '-optimized-qmake',
             '-no-pch',

--- a/var/spack/repos/builtin/packages/qt/qt5-12-configure.patch
+++ b/var/spack/repos/builtin/packages/qt/qt5-12-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/qtbase/src/corelib/tools/qsimd_p.h b/qtbase/src/corelib/tools/qsimd_p.h
+index 2130a1f..3a14715 100644
+--- a/qtbase/src/corelib/tools/qsimd_p.h
++++ b/qtbase/src/corelib/tools/qsimd_p.h
+@@ -346,7 +346,7 @@ extern Q_CORE_EXPORT QBasicAtomicInteger<unsigned> qt_cpu_features[2];
+ #endif
+ Q_CORE_EXPORT void qDetectCpuFeatures();
+ 
+-#if defined(Q_PROCESSOR_X86) && QT_COMPILER_SUPPORTS_HERE(RDRND)
++#if defined(Q_PROCESSOR_X86) && QT_COMPILER_SUPPORTS_HERE(RDRND) && !defined(QT_BOOTSTRAPPED)
+ Q_CORE_EXPORT qsizetype qRandomCpu(void *, qsizetype) Q_DECL_NOTHROW;
+ #else
+ static inline qsizetype qRandomCpu(void *, qsizetype) Q_DECL_NOTHROW


### PR DESCRIPTION
The changes in this pull request modify the `qt` package in the following ways:

- Add support for `@5.12.7`, which requires the new `qt5-12-configure` patch.
- Add the `+debug` variant to allow for the export of debugging symbols.
- Modify the `+opengl` variant to require any version of the `gl` package instead of only `gl@3.2:`.

I've verified that the `qt@5.12.7{+/~}debug+opengl ^gl@1.4` variants work in the `gcc%4.9.3 arch=linux-rhel7-broadwell` build environment. In terms of more complete testing, I'm fairly confident that `+debug` variant will work for `qt@4` since I was using it in a local branch some time ago, but I'm unsure whether or not it will work for `qt@3`; I can test that version as well if needed.