### PR TITLE
update compiler config with bootstrapped compiler when already installed

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -415,7 +415,7 @@ def _set_variables_for_single_module(pkg, module):
     if getattr(module, marker, False):
         return
 
-    jobs = spack.config.get('config:build_jobs') if pkg.parallel else 1
+    jobs = spack.config.get('config:build_jobs', 16) if pkg.parallel else 1
     jobs = min(jobs, multiprocessing.cpu_count())
     assert jobs is not None, "no default set for config:build_jobs"
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -111,7 +111,7 @@ class SetParallelJobs(argparse.Action):
     def default(self):
         # This default is coded as a property so that look-up
         # of this value is done only on demand
-        return min(spack.config.get('config:build_jobs'),
+        return min(spack.config.get('config:build_jobs', 16),
                    multiprocessing.cpu_count())
 
     @default.setter

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -336,7 +336,7 @@ class URLFetchStrategy(FetchStrategy):
         else:
             curl_args.append('-sS')  # just errors when not.
 
-        connect_timeout = spack.config.get('config:connect_timeout')
+        connect_timeout = spack.config.get('config:connect_timeout', 10)
 
         if self.extra_options:
             cookie = self.extra_options.get('cookie')

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1467,7 +1467,7 @@ class PackageInstaller(object):
                     self._update_installed(task)
                     _print_installed_pkg(pkg.prefix)
 
-                    # If the compiler was already installed, just add it to the config
+                    # It's an already installed compiler, add it to the config
                     if task.compiler:
                         spack.compilers.add_compilers_to_config(
                             spack.compilers.find_compilers([pkg.spec.prefix]))

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1466,6 +1466,12 @@ class PackageInstaller(object):
                 if lock is not None:
                     self._update_installed(task)
                     _print_installed_pkg(pkg.prefix)
+
+                    # If the compiler was already installed, just add it to the config
+                    if task.compiler:
+                        spack.compilers.add_compilers_to_config(
+                            spack.compilers.find_compilers([pkg.spec.prefix]))
+
                 else:
                     # At this point we've failed to get a write or a read
                     # lock, which means another process has taken a write

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -15,11 +15,12 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.config
+import spack.compilers as compilers
 import spack.hash_types as ht
 import spack.package
 import spack.cmd.install
 from spack.error import SpackError
-from spack.spec import Spec
+from spack.spec import Spec, CompilerSpec
 from spack.main import SpackCommand
 import spack.environment as ev
 
@@ -718,3 +719,30 @@ def test_cdash_auth_token(tmpdir, install_mockery, capfd):
                 '--log-format=cdash',
                 'a')
             assert 'Using CDash auth token from environment' in out
+
+
+def test_compiler_bootstrap(
+        install_mockery, mock_packages, mock_fetch, mock_archive,
+        mutable_config, monkeypatch):
+    monkeypatch.setattr(spack.concretize.Concretizer,
+                        'check_for_compiler_existence', False)
+    spack.config.set('config:install_missing_compilers', True)
+    assert CompilerSpec('gcc@2.0') not in compilers.all_compiler_specs()
+
+    # Test succeeds if it does not raise an error
+    install('a%gcc@2.0')
+
+
+@pytest.mark.regression('16221')
+def test_compiler_bootstrap_already_installed(
+        install_mockery, mock_packages, mock_fetch, mock_archive,
+        mutable_config, monkeypatch):
+    monkeypatch.setattr(spack.concretize.Concretizer,
+                        'check_for_compiler_existence', False)
+    spack.config.set('config:install_missing_compilers', True)
+
+    assert CompilerSpec('gcc@2.0') not in compilers.all_compiler_specs()
+
+    # Test succeeds if it does not raise an error
+    install('gcc@2.0')
+    install('a%gcc@2.0')

--- a/var/spack/repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/gcc/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Gcc(Package):
+    """Simple compiler package."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/gcc-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+    version('2.0', '2.0_a_hash')
+
+    def install(self, spec, prefix):
+        # Create the minimal compiler that will fool `spack compiler find`
+        mkdirp(prefix.bin)
+        with open(prefix.bin.gcc, 'w') as f:
+            f.write('#!/bin/bash\necho "%s"' % str(spec.version))
+        set_executable(prefix.bin.gcc)


### PR DESCRIPTION
When `config:install_missing_compilers` is True, `spack install foo %compiler_not_available` works if the compiler is not installed, but fails if the compiler is already installed.

This PR adds logic to update the compiler config upon finding that a needed compiler is already installed, in addition to doing so after installing it if it were not already installed.