### PR TITLE
CPython on macOS: framework issues (scproxy)

### DIFF
--- a/var/spack/repos/builtin/packages/python/objc_macOS.patch
+++ b/var/spack/repos/builtin/packages/python/objc_macOS.patch
@@ -1,0 +1,32 @@
+From e3c0df6cdeac8e7fdc55115aa8b8a39219b9751c Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Wed, 22 Apr 2020 10:04:26 -0700
+Subject: [PATCH] scproxy: ObjC File
+
+This file includes an objective C header from macOS.
+
+See https://github.com/python/cpython/pull/13306
+---
+ Modules/{_scproxy.c => _scproxy.m} | 0
+ setup.py                           | 2 +-
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+ rename Modules/{_scproxy.c => _scproxy.m} (100%)
+
+diff --git a/Modules/_scproxy.c b/Modules/_scproxy.m
+similarity index 100%
+rename from Modules/_scproxy.c
+rename to Modules/_scproxy.m
+diff --git a/setup.py b/setup.py
+index 88cff6164d712..8220e1ccbdf23 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1654,7 +1654,7 @@ class db_found(Exception): pass
+ 
+         if host_platform == 'darwin':
+             exts.append(
+-                       Extension('_scproxy', ['_scproxy.c'],
++                       Extension('_scproxy', ['_scproxy.m'],
+                        extra_link_args=[
+                            '-framework', 'SystemConfiguration',
+                            '-framework', 'CoreFoundation',
+

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -153,6 +153,8 @@ class Python(AutotoolsPackage):
         depends_on('libuuid', when='+uuid')
 
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
+    # patch will only safely apply for 3.7.7 but needed every release
+    patch('objc_macOS.patch', when='%gcc platform=darwin')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
     patch('cray-rpath-2.3.patch', when='@2.3:3.0.1 platform=cray')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -257,7 +257,12 @@ class Python(AutotoolsPackage):
             # fails to build _scproxy
             # https://bugs.python.org/issue26317#msg342055
             # https://github.com/spack/spack/issues/2230
-            config_args.append('--disable-framework')
+            frameworkprefix = self.get_config_var('PYTHONFRAMEWORKPREFIX')
+            if os.path.exists(frameworkprefix):
+                config_args.append('--with-framework={0}'
+                                   .format(frameworkprefix))
+            else:
+                config_args.append('--disable-framework')
 
         if spec.satisfies('%intel', strict=True) and \
                 spec.satisfies('@2.7.12:2.8,3.5.2:', strict=True):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -254,6 +254,10 @@ class Python(AutotoolsPackage):
 
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')
+            # fails to build _scproxy
+            # https://bugs.python.org/issue26317#msg342055
+            # https://github.com/spack/spack/issues/2230
+            config_args.append('--disable-framework')
 
         if spec.satisfies('%intel', strict=True) and \
                 spec.satisfies('@2.7.12:2.8,3.5.2:', strict=True):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -242,6 +242,11 @@ class Python(AutotoolsPackage):
             ldflags = ' '.join(spec[dep.name].libs.search_flags
                                for dep in link_deps)
 
+            # https://github.com/python/cpython/blob/v3.7.7/setup.py#L1655-L1661
+            if spec.satisfies('%gcc platform=darwin'):
+                ldflags += ' -framework SystemConfiguration' \
+                           ' -framework CoreFoundation'
+
             config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
@@ -254,15 +259,6 @@ class Python(AutotoolsPackage):
 
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')
-            # fails to build _scproxy
-            # https://bugs.python.org/issue26317#msg342055
-            # https://github.com/spack/spack/issues/2230
-            frameworkprefix = self.get_config_var('PYTHONFRAMEWORKPREFIX')
-            if os.path.exists(frameworkprefix):
-                config_args.append('--with-framework={0}'
-                                   .format(frameworkprefix))
-            else:
-                config_args.append('--disable-framework')
 
         if spec.satisfies('%intel', strict=True) and \
                 spec.satisfies('@2.7.12:2.8,3.5.2:', strict=True):


### PR DESCRIPTION
When building CPython with GCC, a lot of users report issues with a missing module (`_scproxy`) when using the resulting python interpreter.

[Checking the error message](https://github.com/spack/macos-nightly/actions), which is silently overrun in the build, shows that this module's build is killed while [using functionality](https://github.com/python/cpython/blob/v3.7.7/Modules/_scproxy.c#L6) from the macOS `SystemConfiguration` framework:
```
2020-04-22T07:04:50.2843140Z building '_scproxy' extension
2020-04-22T07:04:50.2846790Z .../spack-src/Modules/_scproxy.o
2020-04-22T07:04:50.6842590Z In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework/Headers/AuthSession.h:32,
2020-04-22T07:04:50.7925720Z                  from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:42,
2020-04-22T07:04:50.7926000Z                  from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/SystemConfiguration.framework/Headers/SCPreferences.h:35,
2020-04-22T07:04:50.7926640Z                  from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/SystemConfiguration.framework/Headers/SystemConfiguration.h:126,
2020-04-22T07:04:50.7928400Z                  from /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/spack-stage/spack-stage-python-3.7.7-unj2vg733v7uv5pqpun3cozwirh2d454/spack-src/Modules/_scproxy.c:6:
2020-04-22T07:04:50.7929300Z /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework/Headers/Authorization.h:193:7: error: variably modified 'bytes' at file scope
2020-04-22T07:04:50.7929590Z   193 |  char bytes[kAuthorizationExternalFormLength];
2020-04-22T07:04:50.7929690Z       |       ^~~~~
```
which causes the subsequent fails when using the package.

Crawling into [CPython's setup.py](https://github.com/python/cpython/blob/v3.7.7/setup.py#L1655-L1661) reveils that one needs to add extra linker flags, `-framework CoreFoundation -framework Security` on Darwin for the `_scproxy` extension.

Update: Found [this CPython PR](https://github.com/python/cpython/pull/13306), the `_scproxy` extension seams to be an objective C file...

Refs.:
- #2230
- https://github.com/spack/spack/issues/2230#issuecomment-617431516
- #16053
- https://bugs.python.org/issue26317#msg342055
- https://github.com/python/cpython/pull/13306
- https://github.com/python/cpython/blob/v3.7.7/setup.py#L1655-L1661
- https://github.com/spack/macos-nightly/runs/606624706?check_suite_focus=true on https://github.com/spack/macos-nightly

Building a framework for python itself is another question, we potentially want to pass `--disable-framework`, too:
- homebrew: with `--enable-framework=...` paths https://github.com/Homebrew/homebrew-core/blob/master/Formula/python.rb#L70
- conda-forge: disables (?) framework: https://github.com/conda-forge/python-feedstock/search?q=framework&unscoped_q=framework and just links `-framework CoreFoundation`?

cc @LDAmorim @hartzell @adamjstewart @citibeth @healther

I am a Linux user, please macOS users, test this extensively :)
In order to test:
- install `py-setuptools %gcc` which reliably triggers the bug and/or
- `spack load -r python %gcc` the python package for extensive testing.

A test with an externally registered python, e.g. from homebrew, is also appreciated.