### PR TITLE
Update libsm deps by adding libuuid.

### DIFF
--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -20,3 +20,4 @@ class Libsm(AutotoolsPackage, XorgPackage):
     depends_on('xtrans', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+    depends_on('libuuid')


### PR DESCRIPTION
* While building _visit_, I ran into an undefined symbol at link time. I tracked the missing dependency to _libsm_ needing to know about _libuuid_ at link time.
* Related to #15082.