### PR TITLE
kokkos: cmake dependency needed for generate_makefile.bash

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -142,6 +142,9 @@ class Kokkos(Package):
     depends_on('qthreads', when='+qthreads')
     depends_on('cuda', when='+cuda')
 
+    # generate_makefile.bash calls cmake
+    depends_on('cmake@3.10:', type='build')
+
     def install(self, spec, prefix):
         generate = which(join_path(self.stage.source_path,
                                    'generate_makefile.bash'))


### PR DESCRIPTION
Building kokkos on Summit without the CMake build dependency explicitly specified resulted in the failure listed below. 

This PR adds the cmake build dependency.  CMake 3.10 was specified as that is the minimum version required in the [master](
https://github.com/kokkos/kokkos/blob/785d19f23ed4ba43354f9ecd7ef67cd5976ca4c8/CMakeLists.txt#L67) and [develop](
https://github.com/kokkos/kokkos/blob/3b1fe5c6d92ea6c8325d9f313f809a19d1199592/CMakeLists.txt#L67) versions of kokkos when not building within Trilinos.

I used [packages.yaml](https://github.com/wdmapp/wdmapp-config/blob/d64c9f004f515beaaf10c53c95f9c0e5bc714de9/summit/spack/packages.yaml) and [compilers.yaml](https://github.com/wdmapp/wdmapp-config/blob/d64c9f004f515beaaf10c53c95f9c0e5bc714de9/summit/spack/compilers.yaml) for the build.

```
=> 22086: Installing kokkos
==> Cloning git repository: https://github.com/kokkos/kokkos.git on branch develop
==> No checksum needed when fetching with git
==> Already staged spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt in /gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt
==> No patches needed for kokkos
==> 22086: kokkos: Building kokkos [Package]
==> 22086: kokkos: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 127:
    '/gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt/spack-src/generate_makefile.bash' '--prefix=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt' '--with-hwloc=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/hwloc-1.11.11-viiiqb6v4qru5rbfm4jskc7hl3f6477a' '--with-serial'
See build log for details:
  /gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt/spack-build-out.txt

==> Error: Failed to install kokkos due to ChildError: ProcessError: Command exited with status 127:
    '/gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt/spack-src/generate_makefile.bash' '--prefix=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt' '--with-hwloc=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/hwloc-1.11.11-viiiqb6v4qru5rbfm4jskc7hl3f6477a' '--with-serial'See build log for details:
  /gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt/spack-build-out.txt
Traceback (most recent call last):
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/lib/spack/spack/build_environment.py", line 801, in child_process
    return_value = function()
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/lib/spack/spack/installer.py", line 1034, in build_process
    phase(pkg.spec, pkg.prefix)
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/lib/spack/spack/package.py", line 105, in phase_wrapper
    phase(spec, prefix)
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/var/spack/repos/builtin/packages/kokkos/package.py", line 226, in install
    make()
  File "/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/lib/spack/spack/util/executable.py", line 189, in __call__
    proc.returncode, long_msg)
ProcessError: Command exited with status 127:
    '/gpfs/alpine/fus123/scratch/cwsmith/spack-stage/spack-stage-kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt/spack-src/generate_makefile.bash' '--prefix=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/kokkos-develop-kjlyfthuo3ngfa5mxitzeehks3m7tcgt' '--with-hwloc=/autofs/nccs-svm1_home1/cwsmith/develop/wdmapp/spack/opt/spack/linux-rhel7-power9le/gcc-8.1.1/hwloc-1.11.11-viiiqb6v4qru5rbfm4jskc7hl3f6477a' '--with-serial'

==> Warning: Skipping build of coupler since kokkos failed

```