### PR TITLE
PyTorch: add conflict for Apple Clang 11.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -52,7 +52,6 @@ class PyTorch(PythonPackage, CudaPackage):
     version('master', branch='master', submodules=True)
     version('1.5.0', tag='v1.5.0', submodules=True)
     version('1.4.1', tag='v1.4.1', submodules=True)
-    # see https://github.com/pytorch/pytorch/issues/35149
     version('1.4.0', tag='v1.4.0', submodules=True,
             submodules_delete=['third_party/fbgemm'])
     version('1.3.1', tag='v1.3.1', submodules=True)
@@ -104,8 +103,12 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('+redis', when='@:1.0')
     conflicts('+zstd', when='@:1.0')
     conflicts('+tbb', when='@:1.1')
-    # see https://github.com/pytorch/pytorch/issues/35149
+    # https://github.com/pytorch/pytorch/issues/35149
     conflicts('+fbgemm', when='@1.4.0')
+    # https://github.com/pytorch/pytorch/issues/35478
+    conflicts('%clang@11.0.3-apple',
+              msg='Apple Clang 11.0.3 segfaults at build-time')
+
 
     conflicts('cuda_arch=none', when='+cuda',
               msg='Must specify CUDA compute capabilities of your GPU, see '

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -109,7 +109,6 @@ class PyTorch(PythonPackage, CudaPackage):
     conflicts('%clang@11.0.3-apple',
               msg='Apple Clang 11.0.3 segfaults at build-time')
 
-
     conflicts('cuda_arch=none', when='+cuda',
               msg='Must specify CUDA compute capabilities of your GPU, see '
               'https://developer.nvidia.com/cuda-gpus')


### PR DESCRIPTION
This compiler bug has prevented me from building PyTorch on my laptop, so I figured I would let others know with a conflict. I reported the bug to Apple but still haven't gotten any response.