### PR TITLE
macOS+GCC: Conflicts CMake, libuv, CPython

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -92,6 +92,13 @@ class Cmake(Package):
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
     variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
+    # Tries to build an Objective-C file from libuv with GCC's C frontend
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/20620
+    # https://github.com/libuv/libuv/issues/2805
+    conflicts('%gcc platform=darwin',
+              msg='CMake does not compile with GCC on macOS yet, use clang. '
+                  'See: https://gitlab.kitware.com/cmake/cmake/-/issues/20620')
+
     # Really this should conflict since it's enabling or disabling openssl for
     # CMake's internal copy of curl.  Ideally we'd want a way to have the
     # openssl variant disabled when ~ownlibs but there's not really a way to

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -19,6 +19,12 @@ class Libuv(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('libtool', type='build')
 
+    # Tries to build an Objective-C file with GCC's C frontend
+    # https://github.com/libuv/libuv/issues/2805
+    conflicts('%gcc platform=darwin',
+              msg='libuv does not compile with GCC on macOS yet, use clang. '
+                  'See: https://github.com/libuv/libuv/issues/2805')
+
     def autoreconf(self, spec, prefix):
         # This is needed because autogen.sh generates on-the-fly
         # an m4 macro needed during configuration

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -166,6 +166,12 @@ class Python(AutotoolsPackage):
     # https://github.com/python/cpython/pull/16717
     patch('intel-3.6.7.patch', when='@3.6.7:3.6.8,3.7.1:3.7.5 %intel')
 
+    # CPython tries to build an Objective-C file with GCC's C frontend
+    # https://github.com/spack/spack/pull/16222
+    # https://github.com/python/cpython/pull/13306
+    conflicts('%gcc platform=darwin',
+              msg='CPython does not compile with GCC on macOS yet, use clang. '
+                  'See: https://github.com/python/cpython/pull/13306')
     # For more information refer to this bug report:
     # https://bugs.python.org/issue29712
     conflicts(


### PR DESCRIPTION
The major building blocks in many software stacks:
- CPython
- CMake (libuv)

do not build on macOS with GCC. The main problem is that some macOS framework includes pull in objective-c code and that code does get misinterpreted as (invalid) C by GCC by default.

Refs.:

* #16222
* https://github.com/python/cpython/pull/13306
* https://gitlab.kitware.com/cmake/cmake/-/issues/20620
* https://github.com/libuv/libuv/issues/2805
