### PR TITLE
Travis: change the spec we concretize on MacOS

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -37,7 +37,11 @@ bin/spack -h
 bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  spack -p --lines 20 spec openmpi
+else
+  spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+fi
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage


### PR DESCRIPTION
Since CMake can't build with GCC on MacOS, choose a spec that doesn't have CMake in the DAG.

See #16249 for further information.