### PR TITLE
fix vim build

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -58,6 +58,7 @@ class Vim(AutotoolsPackage):
 
     depends_on('ncurses', when="@7.4:")
     depends_on('findutils', type='build')
+    depends_on('fontconfig', when="+gui")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
add fontconfig as vim dependency

otherwise, with packages in current develop on rhel7 system, the vim build fails with:

```
  >> 801    //usr/lib64/libfontconfig.so.1: undefined reference to `uuid_copy@@UUID_1.0'
  >> 802    //usr/lib64/libfontconfig.so.1: undefined reference to `uuid_parse@@UUID_1.0'
  >> 803    //usr/lib64/libfontconfig.so.1: undefined reference to `uuid_unparse@@UUID_1.0'
  >> 804    //usr/lib64/libfontconfig.so.1: undefined reference to `uuid_generate_random@@UUID_1.0'
  >> 805    collect2: error: ld returned 1 exit status
```

