### PR TITLE
adjust petsc to build cuda only when requested explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -296,7 +296,7 @@ class Petsc(Package):
             ])
 
         # Activates library support if needed
-        for library in ('cuda', 'metis', 'hdf5', 'hypre', 'parmetis',
+        for library in ('metis', 'hdf5', 'hypre', 'parmetis',
                         'mumps', 'trilinos', 'fftw', 'valgrind'):
             options.append(
                 '--with-{library}={value}'.format(
@@ -307,6 +307,16 @@ class Petsc(Package):
                     '--with-{library}-dir={path}'.format(
                         library=library, path=spec[library].prefix)
                 )
+
+        # Add cuda if explicitly requested
+        if '+cuda' in spec:
+            options.append('--with-cuda=1')
+            options.append(
+                '--with-cuda-dir={path}'.format(
+                    path=spec['cuda'].prefix))
+        else:
+            options.append('--with-cuda=0')
+
         # PETSc does not pick up SuperluDist from the dir as they look for
         # superlu_dist_4.1.a
         if 'superlu-dist' in spec:

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -296,26 +296,17 @@ class Petsc(Package):
             ])
 
         # Activates library support if needed
-        for library in ('metis', 'hdf5', 'hypre', 'parmetis',
+        for library in ('cuda', 'metis', 'hdf5', 'hypre', 'parmetis',
                         'mumps', 'trilinos', 'fftw', 'valgrind'):
             options.append(
                 '--with-{library}={value}'.format(
-                    library=library, value=('1' if library in spec else '0'))
+                    library=library, value=('1' if '+'+library in spec else '0'))
             )
-            if library in spec:
+            if '+'+library in spec:
                 options.append(
                     '--with-{library}-dir={path}'.format(
                         library=library, path=spec[library].prefix)
                 )
-
-        # Add cuda if explicitly requested
-        if '+cuda' in spec:
-            options.append('--with-cuda=1')
-            options.append(
-                '--with-cuda-dir={path}'.format(
-                    path=spec['cuda'].prefix))
-        else:
-            options.append('--with-cuda=0')
 
         # PETSc does not pick up SuperluDist from the dir as they look for
         # superlu_dist_4.1.a

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -300,9 +300,10 @@ class Petsc(Package):
                         'mumps', 'trilinos', 'fftw', 'valgrind'):
             options.append(
                 '--with-{library}={value}'.format(
-                    library=library, value=('1' if '+'+library in spec else '0'))
+                    library=library,
+                    value=('1' if '+' + library in spec else '0'))
             )
-            if '+'+library in spec:
+            if '+' + library in spec:
                 options.append(
                     '--with-{library}-dir={path}'.format(
                         library=library, path=spec[library].prefix)


### PR DESCRIPTION
Currently petsc package activates cuda support when cuda is anywhere in the spec (i.e. `'cuda' in spec`). This is perhaps a bit surprising as it means cuda support will be built if you ask for `petsc~cuda ^openmpi+cuda`. 

This patch changes the PETSc package to only build with cuda support when `petsc+cuda` is specified. 