### PR TITLE
Add --fail-first and --fail-fast options to spack test run

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -38,6 +38,14 @@ def setup_parser(subparser):
     run_parser.add_argument('-n', '--name', help=name_help_msg)
 
     run_parser.add_argument(
+        '--fail-fast', action='store_true',
+        help="Stop tests for each package after the first failure."
+    )
+    run_parser.add_argument(
+        '--fail-first', action='store_true',
+        help="Stop after the first failed package."
+    )
+    run_parser.add_argument(
         '--keep-stage',
         action='store_true',
         help='Keep testing directory for debugging'
@@ -112,6 +120,10 @@ environment variables:
         parser.print_help()
         return
 
+    # set config option for fail-fast
+    if args.fail_fast:
+        spack.config.set('config:fail_fast', True, scope='command_line')
+
     # record test time; this will be default test name
     now = datetime.datetime.now()
     test_name = args.name or now.strftime('%Y-%m-%d_%H:%M:%S')
@@ -164,6 +176,8 @@ environment variables:
                 except BaseException:
                     with open(_get_results_file(test_name), 'a') as f:
                         f.write("%s FAILED\n" % spec.format("{name}-{version}-{hash:7}"))
+                    if args.fail_first:
+                        break
         else:
             raise NotImplementedError
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1594,7 +1594,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                         traceback.extract_stack()))
 
             exc = e  # e is deleted after this block
-            self.test_failures.append((exc, m))
+
+            # If we fail fast, raise another error
+            if spack.config.get('config:fail_fast', False):
+                raise TestFailure([(exc, m)])
+            else:
+                self.test_failures.append((exc, m))
 
     def _run_test_helper(self, exe, options, expected, status, installed,
                          purpose):


### PR DESCRIPTION
This adds two options to the `spack test run` command.

`--fail-fast`: Each package will stop testing after the first test failure.
`--fail-first`: Stop after the first package that fails.