### PR TITLE
spack env: activate note

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -208,10 +208,14 @@ def _env_create(name_or_path, init_file=None, dir=False, with_view=None):
         env = ev.Environment(name_or_path, init_file, with_view)
         env.write()
         tty.msg("Created environment in %s" % env.path)
+        tty.msg("You can activate this environment with:")
+        tty.msg("  spack env activate %s" % env.path)
     else:
         env = ev.create(name_or_path, init_file, with_view)
         env.write()
         tty.msg("Created environment '%s' in %s" % (name_or_path, env.path))
+        tty.msg("You can activate this environment with:")
+        tty.msg("  spack env activate %s" % (name_or_path))
     return env
 
 


### PR DESCRIPTION
print a note on how to activate a newly created environment.

Close #16278

```console
$ spack env create test1234
==> Updating view at /home/axel/src/spack/var/spack/environments/test1234/.spack-env/view
==> Created environment 'test1234' in /home/axel/src/spack/var/spack/environments/test1234
==> You can activate this environment with:
==>   spack env activate test1234
```