### PR TITLE
py-murmurhash: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-murmurhash/package.py
+++ b/var/spack/repos/builtin/packages/py-murmurhash/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyMurmurhash(PythonPackage):
+    """Cython bindings for MurmurHash."""
+
+    homepage = "https://github.com/explosion/murmurhash"
+    url      = "https://pypi.io/packages/source/m/murmurhash/murmurhash-1.0.2.tar.gz"
+
+    version('1.0.2', sha256='c7a646f6b07b033642b4f52ae2e45efd8b80780b3b90e8092a0cec935fbf81e2')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-wheel@0.32.0:0.32.999', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.4 with Python 3.7.7 and Clang 11.0.3.