### PR TITLE
py-plac: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-plac/package.py
+++ b/var/spack/repos/builtin/packages/py-plac/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyPlac(PythonPackage):
+    """The smartest command line arguments parser in the world."""
+
+    homepage = "https://github.com/micheles/plac"
+    url      = "https://pypi.io/packages/source/p/plac/plac-1.1.3.tar.gz"
+
+    version('1.1.3', sha256='398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-argparse', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.4 with Python 3.7.7 and Clang 11.0.3.