### PR TITLE
py-spacy: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-spacy/package.py
+++ b/var/spack/repos/builtin/packages/py-spacy/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PySpacy(PythonPackage):
+    """spaCy is a library for advanced Natural Language Processing in
+    Python and Cython."""
+
+    homepage = "https://spacy.io/"
+    url      = "https://pypi.io/packages/source/s/spacy/spacy-2.2.4.tar.gz"
+
+    version('2.2.4', sha256='f0f3a67c5841e6e35d62c98f40ebb3d132587d3aba4f4dccac5056c4e90ff5b9')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-wheel', type='build')
+    depends_on('py-cython@0.25:', type='build')
+    depends_on('py-murmurhash@0.28:1.0', type=('build', 'run'))
+    depends_on('py-cymem@2.0.2:2.0.999', type=('build', 'run'))
+    depends_on('py-preshed@3.0.2:3.0.999', type=('build', 'run'))
+    depends_on('py-thinc@7.4.0', type=('build', 'run'))
+    depends_on('py-blis@0.4.0:0.4.999', type=('build', 'run'))
+    depends_on('py-srsly@1.0.2:1.0.999', type=('build', 'run'))
+    depends_on('py-catalogue@0.0.7:1.0', type=('build', 'run'))
+    depends_on('py-tqdm@4.38:4.999', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-numpy@1.15:', type=('build', 'run'))
+    depends_on('py-plac@0.9.6:1.1', type=('build', 'run'))
+    depends_on('py-requests@2.13:2.999', type=('build', 'run'))
+    depends_on('py-pathlib@1.0.1', when='^python@:3.3', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.4 with Python 3.7.7 and Clang 11.0.3.