### PR TITLE
LLVM lldb 10.0: Python Link Dependency

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -287,8 +287,9 @@ class Llvm(CMakePackage, CudaPackage):
         if "+python" in spec and "+lldb" in spec and spec.satisfies("@5.0.0:"):
             cmake_args.append("-DLLDB_USE_SYSTEM_SIX:Bool=TRUE")
 
-        if "~python" in spec and "+lldb" in spec:
-            cmake_args.append("-DLLDB_DISABLE_PYTHON:Bool=TRUE")
+        if "+lldb" in spec and spec.satisfies("@:9.9.9"):
+            cmake_args.append("-DLLDB_DISABLE_PYTHON:Bool={0}".format(
+                'ON' if '~python' in spec else 'OFF'))
         if "+lldb" in spec and spec.satisfies("@10.0.0:"):
             cmake_args.append("-DLLDB_ENABLE_PYTHON:Bool={0}".format(
                 'ON' if '+python' in spec else 'OFF'))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -289,6 +289,9 @@ class Llvm(CMakePackage, CudaPackage):
 
         if "~python" in spec and "+lldb" in spec:
             cmake_args.append("-DLLDB_DISABLE_PYTHON:Bool=TRUE")
+        if "+lldb" in spec and spec.satisfies("@10.0.0:"):
+            cmake_args.append("-DLLDB_ENABLE_PYTHON:Bool={0}".format(
+                'ON' if '+python' in spec else 'OFF'))
 
         if "+gold" in spec:
             cmake_args.append(


### PR DESCRIPTION
A CMake option changed in LLVM 10 that controls the LLDB python bindings. This fixes a linker issue on Darwin with AppleClang, but was generally a missing dependency control.

cc @trws @naromero77 @adamjstewart 

Refs.:
- fix #16246
- see #16215
- https://github.com/spack/macos-nightly
- https://github.com/spack/macos-nightly/actions/runs/87264792 (`develop`)
- [x] https://github.com/spack/macos-nightly/actions/runs/87484420 (this PR)
- https://github.com/llvm/llvm-project/blob/release/10.x/lldb/include/lldb/Host/Config.h.cmake
- https://lldb.llvm.org/resources/build.html#optional-dependencies