### PR TITLE
qt +opengl: fix macOS w/ AppleClang (mesa libs)

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -13,6 +13,7 @@ class Mesa(AutotoolsPackage):
      - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
+    maintainers = ['v-dobrev']
 
     # Note that we always want to build from the git repo instead of a
     # tarball since the tarball has pre-generated files for certain versions
@@ -180,7 +181,8 @@ class Mesa(AutotoolsPackage):
     @property
     def libs(self):
         for dir in ['lib64', 'lib']:
-            libs = find_libraries('libGL', join_path(self.prefix, dir),
+            libs = find_libraries(['libGL', 'libOSMesa'],
+                                  join_path(self.prefix, dir),
                                   shared=True, recursive=False)
             if libs:
                 return libs


### PR DESCRIPTION
Building the `py-jupyter` stack on macOS with AppleClang breaks on the `py-qtconsole` -> `py-qtconsole` -> `qt +opengl` package build environment setup with
```
 ==> Error: AttributeError: Query of package 'mesa' for 'libs' failed
    prefix : /Users/runner/runners/2.169.1/work/macos-nightly/macos-nightly/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.0-apple/mesa-18.3.6-uu5cyvrzka5g2xfjguuf2tngqsgkgfvf
    spec : mesa@18.3.6%clang@11.0.0-apple~glx+llvm+opengl~opengles+osmesa patches=55a5611ca9fcbe8324c4d68a07b338134954ff12c5b122dc78ff376f012a1414 swr=none arch=darwin-catalina-x86_64 ^autoconf@2.69%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^automake@1.16.2%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^bison@3.4.2%clang@11.0.0-apple patches=89aa362716d898edd0b5c6ae4208dc1b6992887774848a09e8021afd676f7d61 arch=darwin-catalina-x86_64 ^bzip2@1.0.8%clang@11.0.0-apple+shared arch=darwin-catalina-x86_64 ^cmake@3.17.0%clang@11.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-catalina-x86_64 ^diffutils@3.7%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^expat@2.2.9%clang@11.0.0-apple~libbsd arch=darwin-catalina-x86_64 ^findutils@4.6.0%clang@11.0.0-apple patches=84b916c0bf8c51b7e7b28417692f0ad3e7030d1f3c248ba77c42ede5c1c5d11e,bd9e4e5cc280f9753ae14956c4e4aa17fe7a210f55dd6c84aa60b12d106d47a2 arch=darwin-catalina-x86_64 ^flex@2.6.4%clang@11.0.0-apple+lex patches=09c22e5c6fef327d3e48eb23f0d610dcd3a35ab9207f12e0f875701c677978d3 arch=darwin-catalina-x86_64 ^gdbm@1.18.1%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^gettext@0.20.1%clang@11.0.0-apple+bzip2+curses+git~libunistring+libxml2+tar+xz arch=darwin-catalina-x86_64 ^help2man@1.47.11%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^hwloc@2.1.0%clang@11.0.0-apple~cairo~cuda~gl+libxml2~netloc~nvml~pci+shared arch=darwin-catalina-x86_64 ^libedit@3.1-20191231%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^libffi@3.2.1%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^libiconv@1.16%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^libsigsegv@2.12%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^libtool@2.4.6%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^libxml2@2.9.9%clang@11.0.0-apple~python arch=darwin-catalina-x86_64 ^llvm@10.0.0%clang@11.0.0-apple~all_targets build_type=Release +clang~code_signing+compiler-rt~cuda cuda_arch=none ~gold+internal_unwind+libcxx+lld+lldb~mlir~omp_debug~omp_tsan patches=332fe65f78b2b4a242045ec2394eee8db631fbcbe27b0016d5e5c859e34f47af +polly~python~shared_libs~split_dwarf arch=darwin-catalina-x86_64 ^m4@1.4.18%clang@11.0.0-apple patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=darwin-catalina-x86_64 ^ncurses@6.2%clang@11.0.0-apple~symlinks+termlib arch=darwin-catalina-x86_64 ^openssl@1.1.1g%clang@11.0.0-apple+systemcerts arch=darwin-catalina-x86_64 ^pcre@8.43%clang@11.0.0-apple~jit+multibyte+utf arch=darwin-catalina-x86_64 ^perl@5.30.1%clang@11.0.0-apple+cpanm+shared+threads arch=darwin-catalina-x86_64 ^perl-data-dumper@2.173%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^pkgconf@1.6.3%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^py-mako@1.0.4%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^py-markupsafe@1.1.1%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^py-setuptools@46.1.3%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^python@3.7.7%clang@11.0.0-apple+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations patches=210df3f28cde02a8135b58cc4168e70ab91dbf9097359d05938f1e2843875e57 +pic+pyexpat+pythoncmd+readline~shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib arch=darwin-catalina-x86_64 ^readline@8.0%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^sqlite@3.30.1%clang@11.0.0-apple+column_metadata+fts~functions~rtree arch=darwin-catalina-x86_64 ^swig@4.0.1%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^tar@1.32%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^texinfo@6.5%clang@11.0.0-apple patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=darwin-catalina-x86_64 ^xz@5.2.5%clang@11.0.0-apple arch=darwin-catalina-x86_64 ^z3@4.8.7%clang@11.0.0-apple~python arch=darwin-catalina-x86_64 ^zlib@1.2.11%clang@11.0.0-apple+optimize+pic+shared arch=darwin-catalina-x86_64
    queried as : mesa
    extra parameters : []

 /Users/runner/runners/2.169.1/work/macos-nightly/macos-nightly/spack/lib/spack/spack/build_environment.py:819, in child_process:
         816            tb_string = traceback.format_exc()
         817
         818            # build up some context from the offending package so we can
   >>    819            # show that, too.
         820            package_context = get_package_context(tb)
         821
         822            build_log = None


 ==> Error: Failed to install qt due to ChildError: AttributeError: Query of package 'mesa' for 'libs' failed
```

This tries to add more library targets build by `mesa` to avoid this.

Refs.:
- see #16215
- https://github.com/spack/macos-nightly
- https://github.com/spack/macos-nightly/actions/runs/87856259 (`develop`)
- https://github.com/spack/macos-nightly/actions/runs/88017004 (this PR)