### PR TITLE
Better singularity info re post-install step

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -17,7 +17,10 @@ class Singularity(MakefilePackage):
        which has a different install base (Autotools).
 
        Needs post-install chmod/chown steps to enable full functionality.
-       See package definition or `spack-build-out.txt` build log for details.
+       See package definition or `spack-build-out.txt` build log for details,
+       e.g.
+       
+       tail -15 $(spack location -i singularity)/.spack/spack-build-out.txt
     '''
 
     homepage = "https://www.sylabs.io/singularity/"

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -19,7 +19,7 @@ class Singularity(MakefilePackage):
        Needs post-install chmod/chown steps to enable full functionality.
        See package definition or `spack-build-out.txt` build log for details,
        e.g.
-       
+
        tail -15 $(spack location -i singularity)/.spack/spack-build-out.txt
     '''
 


### PR DESCRIPTION
The singularity info should actually suggest where you might find the info about the post-install steps.