### PR TITLE
votca-csg: Block gromacs@2020 and newer

### DIFF
--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -30,5 +30,5 @@ class VotcaCsg(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "master"]:
         depends_on('votca-tools@%s' % v, when="@%s:%s.0" % (v, v))
     depends_on("boost")
-    depends_on("gromacs~mpi@5.1:")
+    depends_on("gromacs~mpi@5.1:2019.9999")
     depends_on("hdf5~mpi")


### PR DESCRIPTION
A feature that votca-csg needs is missing in gromacs-2020, see https://gitlab.com/gromacs/gromacs/-/issues/1347