### PR TITLE
Add new package: stinger

### DIFF
--- a/var/spack/repos/builtin/packages/stinger/package.py
+++ b/var/spack/repos/builtin/packages/stinger/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Stinger(CMakePackage):
+    """The STINGER in-memory graph store and dynamic graph analysis
+    platform. Millions to billions of vertices and edges at thousands
+    to millions of updates per second."""
+
+    homepage = "http://www.stingergraph.com/"
+    git      = "https://github.com/stingergraph/stinger.git"
+
+    version('master', branch='master')
+
+    parallel = False
+
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            install_tree('./bin', prefix.bin)
+            install_tree('./lib', prefix.lib)
+            install_tree('./include', prefix.include)
+            install_tree('./share', prefix.share)


### PR DESCRIPTION
Stinger release package has some build problems(some components are too old), so only master branch can be use now.