### PR TITLE
override Spglib libs attribute

### DIFF
--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -18,3 +18,8 @@ class Spglib(CMakePackage):
 
     version('1.10.3', sha256='43776b5fb220b746d53c1aa39d0230f304687ec05984671392bccaf850d9d696')
     version('1.10.0', sha256='117fff308731784bea2ddaf3d076f0ecbf3981b31ea1c1bfd5ce4f057a5325b1')
+
+    @property
+    def libs(self):
+        return find_libraries(['libsymspg'], root=self.prefix.lib,
+                              recursive=False)


### PR DESCRIPTION
override the libs attribute in the spglib package since the library name is different from the package name.