### PR TITLE
Make mariadb provide mysql-client...

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -33,6 +33,7 @@ class Mariadb(CMakePackage):
             'operations in the mariadb client library.')
 
     provides('mariadb-client')
+    provides('mysql-client')
 
     depends_on('boost')
     depends_on('cmake@2.6:', type='build')


### PR DESCRIPTION
... as well as mariadb-client. Needed for ROOT.