### PR TITLE
spack dev-build: Do not mark -u builds in database

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -873,7 +873,9 @@ def fork(pkg, function, dirty, fake):
     # allows exception handling output to be logged from within Spack.
     # see spack.main.SpackCommand.
     if isinstance(child_result, ChildError):
-        child_result.print_context()
+        # Stop Iteration is used to control partial builds, and will be caught
+        if child_result.name != "StopIteration":
+            child_result.print_context()
         raise child_result
 
     return child_result

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -812,11 +812,6 @@ def fork(pkg, function, dirty, fake):
                 setup_package(pkg, dirty=dirty)
             return_value = function()
             child_pipe.send(return_value)
-        except StopIteration as e:
-            # StopIteration is used to stop installations
-            # before the final stage, mainly for debug purposes
-            tty.msg(e)
-            child_pipe.send(None)
 
         except BaseException:
             # catch ANYTHING that goes wrong in the child process

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1072,11 +1072,11 @@ def _make_child_error(msg, module, name, traceback, build_log, context):
     return ChildError(msg, module, name, traceback, build_log, context)
 
 
-class StopPhase(Exception):
+class StopPhase(spack.error.SpackError):
     """Pickle-able exception to control stopped builds."""
     def __reduce__(self):
-        return _make_stop_phase, (self.message,)
+        return _make_stop_phase, (self.message, self.long_message)
 
 
-def _make_stop_phase(msg):
-    return StopPhase(msg)
+def _make_stop_phase(msg, long_msg):
+    return StopPhase(msg, long_msg)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -813,6 +813,10 @@ def fork(pkg, function, dirty, fake):
             return_value = function()
             child_pipe.send(return_value)
 
+        except StopPhase as e:
+            # Do not create a full ChildError from this, it's not an error
+            # it's a control statement.
+            child_pipe.send(e)
         except BaseException:
             # catch ANYTHING that goes wrong in the child process
             exc_type, exc, tb = sys.exc_info()
@@ -864,18 +868,21 @@ def fork(pkg, function, dirty, fake):
     child_result = parent_pipe.recv()
     p.join()
 
+    # If returns a StopPhase, raise it
+    if isinstance(child_result, StopPhase):
+        # do not print
+        raise child_result
+
     # let the caller know which package went wrong.
     if isinstance(child_result, InstallError):
         child_result.pkg = pkg
 
-    # If the child process raised an error, print its output here rather
-    # than waiting until the call to SpackError.die() in main(). This
-    # allows exception handling output to be logged from within Spack.
-    # see spack.main.SpackCommand.
     if isinstance(child_result, ChildError):
-        # Stop Iteration is used to control partial builds, and will be caught
-        if child_result.name != "StopIteration":
-            child_result.print_context()
+        # If the child process raised an error, print its output here rather
+        # than waiting until the call to SpackError.die() in main(). This
+        # allows exception handling output to be logged from within Spack.
+        # see spack.main.SpackCommand.
+        child_result.print_context()
         raise child_result
 
     return child_result
@@ -1063,3 +1070,13 @@ class ChildError(InstallError):
 def _make_child_error(msg, module, name, traceback, build_log, context):
     """Used by __reduce__ in ChildError to reconstruct pickled errors."""
     return ChildError(msg, module, name, traceback, build_log, context)
+
+
+class StopPhase(Exception):
+    """Pickle-able exception to control stopped builds."""
+    def __reduce__(self):
+        return _make_stop_phase, (self.message,)
+
+
+def _make_stop_phase(msg):
+    return StopPhase(msg)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -808,7 +808,6 @@ class PackageInstaller(object):
                 self.pkg.last_phase == self.pkg.phases[-1]:
             self.pkg.last_phase = None
 
-
     def _cleanup_all_tasks(self):
         """Cleanup all build tasks to include releasing their locks."""
         for pkg_id in self.locks:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1171,16 +1171,14 @@ class PackageInstaller(object):
             if task.compiler:
                 spack.compilers.add_compilers_to_config(
                     spack.compilers.find_compilers([pkg.spec.prefix]))
-
-        except spack.build_environment.ChildError as e:
-            # A StopIteration exception means that do_install was asked to
+        except spack.build_environment.StopPhase as e:
+            # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
-            if e.name == "StopIteration":
-                tty.debug('{0} {1}'.format(self.pid, str(e)))
-                tty.debug('Package stage directory : {0}'
-                          .format(pkg.stage.source_path))
-            else:
-                raise
+            tty.debug('{0} {1}'.format(self.pid, str(e)))
+            tty.debug('Package stage directory : {0}'
+                      .format(pkg.stage.source_path))
+#        except spack.build_environment.ChildError as e:
+#            raise
 
     _install_task.__doc__ += install_args_docstring
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1176,7 +1176,7 @@ class PackageInstaller(object):
             if e.name == "StopIteration":
                 tty.debug('{0} {1}'.format(self.pid, str(e)))
                 tty.debug('Package stage directory : {0}'
-                        .format(pkg.stage.source_path))
+                          .format(pkg.stage.source_path))
             else:
                 raise
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1169,8 +1169,8 @@ class PackageInstaller(object):
             # A StopIteration exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
             if e.name == "StopIteration":
-                tty.msg('{0} {1}'.format(self.pid, str(e)))
-                tty.msg('Package stage directory : {0}'
+                tty.debug('{0} {1}'.format(self.pid, str(e)))
+                tty.debug('Package stage directory : {0}'
                         .format(pkg.stage.source_path))
             else:
                 raise

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1177,8 +1177,6 @@ class PackageInstaller(object):
             tty.debug('{0} {1}'.format(self.pid, str(e)))
             tty.debug('Package stage directory : {0}'
                       .format(pkg.stage.source_path))
-#        except spack.build_environment.ChildError as e:
-#            raise
 
     _install_task.__doc__ += install_args_docstring
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -784,6 +784,9 @@ class PackageInstaller(object):
         The ``stop_before`` or ``stop_at`` arguments are removed from the
         installation arguments.
 
+        The last phase is also set to None if it is the last phase of the
+        package already
+
         Args:
             kwargs:
               ``stop_before``': stop before execution of this phase (or None)
@@ -796,6 +799,8 @@ class PackageInstaller(object):
                     .format(self.pkg.stop_before_phase, self.pkg.name))
 
         self.pkg.last_phase = kwargs.pop('stop_at', None)
+        if self.pkg.last_phase == self.pkg.phases[-1]:
+            self.pkg.last_phase = None
         if self.pkg.last_phase is not None and \
                 self.pkg.last_phase not in self.pkg.phases:
             tty.die('\'{0}\' is not an allowed phase for package {1}'

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1165,12 +1165,15 @@ class PackageInstaller(object):
                 spack.compilers.add_compilers_to_config(
                     spack.compilers.find_compilers([pkg.spec.prefix]))
 
-        except StopIteration as e:
+        except spack.build_environment.ChildError as e:
             # A StopIteration exception means that do_install was asked to
-            # stop early from clients.
-            tty.msg('{0} {1}'.format(self.pid, str(e)))
-            tty.msg('Package stage directory : {0}'
-                    .format(pkg.stage.source_path))
+            # stop early from clients, and is not an error at this point
+            if e.name == "StopIteration":
+                tty.msg('{0} {1}'.format(self.pid, str(e)))
+                tty.msg('Package stage directory : {0}'
+                        .format(pkg.stage.source_path))
+            else:
+                raise
 
     _install_task.__doc__ += install_args_docstring
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -799,12 +799,15 @@ class PackageInstaller(object):
                     .format(self.pkg.stop_before_phase, self.pkg.name))
 
         self.pkg.last_phase = kwargs.pop('stop_at', None)
-        if self.pkg.last_phase == self.pkg.phases[-1]:
-            self.pkg.last_phase = None
         if self.pkg.last_phase is not None and \
                 self.pkg.last_phase not in self.pkg.phases:
             tty.die('\'{0}\' is not an allowed phase for package {1}'
                     .format(self.pkg.last_phase, self.pkg.name))
+        # If we got a last_phase, make sure it's not already last
+        if self.pkg.last_phase and \
+                self.pkg.last_phase == self.pkg.phases[-1]:
+            self.pkg.last_phase = None
+
 
     def _cleanup_all_tasks(self):
         """Cleanup all build tasks to include releasing their locks."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -119,8 +119,7 @@ class InstallPhase(object):
         # stop the installation process raising a StopPhase
         if getattr(instance, 'stop_before_phase', None) == self.name:
             from spack.build_environment import StopPhase
-            raise StopPhase('Stopping before \'{0}\' phase'
-                                .format(self.name))
+            raise StopPhase('Stopping before \'{0}\' phase'.format(self.name))
 
     def _on_phase_exit(self, instance):
         # If a phase has a matching last_phase attribute,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -116,16 +116,18 @@ class InstallPhase(object):
 
     def _on_phase_start(self, instance):
         # If a phase has a matching stop_before_phase attribute,
-        # stop the installation process raising a StopIteration
+        # stop the installation process raising a StopPhase
         if getattr(instance, 'stop_before_phase', None) == self.name:
-            raise StopIteration('Stopping before \'{0}\' phase'
+            from spack.build_environment import StopPhase
+            raise StopPhase('Stopping before \'{0}\' phase'
                                 .format(self.name))
 
     def _on_phase_exit(self, instance):
         # If a phase has a matching last_phase attribute,
-        # stop the installation process raising a StopIteration
+        # stop the installation process raising a StopPhase
         if getattr(instance, 'last_phase', None) == self.name:
-            raise StopIteration('Stopping at \'{0}\' phase'.format(self.name))
+            from spack.build_environment import StopPhase
+            raise StopPhase('Stopping at \'{0}\' phase'.format(self.name))
 
     def copy(self):
         try:

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -57,6 +57,24 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     assert not spack.store.db.query(spec, installed=True)
 
 
+def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
+    # Test that we ignore the last_phase argument if it is already last
+    spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
+
+    with tmpdir.as_cwd():
+        with open(spec.package.filename, 'w') as f:
+            f.write(spec.package.original_string)
+
+        dev_build('-u', 'install', 'dev-build-test-install@0.0.0')
+
+        assert spec.package.filename in os.listdir(os.getcwd())
+        with open(spec.package.filename, 'r') as f:
+            assert f.read() == spec.package.replacement_string
+
+    assert os.path.exists(spec.prefix)
+    assert spack.store.db.query(spec, installed=True)
+
+
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
 
@@ -128,15 +146,3 @@ def test_dev_build_fails_nonexistent_package_name(mock_packages):
 def test_dev_build_fails_no_version(mock_packages):
     output = dev_build('dev-build-test-install', fail_on_error=False)
     assert 'dev-build spec must have a single, concrete version' in output
-
-
-def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
-    # Test that we ignore the last_phase argument if it is already last
-        dev_build('-u', 'install', 'dev-build-test-install@0.0.0')
-
-        assert spec.package.filename in os.listdir(os.getcwd())
-        with open(spec.package.filename, 'r') as f:
-            assert f.read() == spec.package.replacement_string
-
-    assert os.path.exists(spec.prefix)
-    assert spack.store.db.query(spec, installed=True)

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -54,6 +54,7 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
             assert f.read() == spec.package.replacement_string
 
     assert not os.path.exists(spec.prefix)
+    assert not spack.store.db.query(spec, installed=True)
 
 
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -57,6 +57,7 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     assert not spack.store.db.query(spec, installed=True)
 
 
+<<<<<<< HEAD
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
 
@@ -128,3 +129,15 @@ def test_dev_build_fails_nonexistent_package_name(mock_packages):
 def test_dev_build_fails_no_version(mock_packages):
     output = dev_build('dev-build-test-install', fail_on_error=False)
     assert 'dev-build spec must have a single, concrete version' in output
+
+
+def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
+    # Test that we ignore the last_phase argument if it is already last
+        dev_build('-u', 'install', 'dev-build-test-install@0.0.0')
+
+        assert spec.package.filename in os.listdir(os.getcwd())
+        with open(spec.package.filename, 'r') as f:
+            assert f.read() == spec.package.replacement_string
+
+    assert os.path.exists(spec.prefix)
+    assert spack.store.db.query(spec, installed=True)

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -57,7 +57,6 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
     assert not spack.store.db.query(spec, installed=True)
 
 
-<<<<<<< HEAD
 def test_dev_build_before_until(tmpdir, mock_packages, install_mockery):
     spec = spack.spec.Spec('dev-build-test-install@0.0.0').concretized()
 


### PR DESCRIPTION
Fixes #16329 

Builds can be stopped before the final install phase due to user requests. Those builds should not be registered as installed in the database.

We had code intended to handle this but:

1. It caught the wrong type of exception
2. We were catching these exceptions to suppress them at a lower level in the stack

This PR allows the StopIteration to propagate through a ChildError, and catches it properly. Also added to an existing test to prevent regression.