### PR TITLE
prefix gets removed when adding additional configure options

### DIFF
--- a/lib/spack/docs/build_systems/wafpackage.rst
+++ b/lib/spack/docs/build_systems/wafpackage.rst
@@ -47,8 +47,9 @@ Each phase provides a ``<phase>`` function that runs:
 
 where ``<jobs>`` is the number of parallel jobs to build with. Each phase
 also has a ``<phase_args>`` function that can pass arguments to this call.
-All of these functions are empty except for the ``configure_args``
-function, which passes ``--prefix=/path/to/installation/prefix``.
+All of these functions are empty. The ``configure`` phase
+automatically adds  ``--prefix=/path/to/installation/prefix``, so you
+don't need to add that in the ``configure_args``.
 
 ^^^^^^^
 Testing

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -75,13 +75,14 @@ class WafPackage(PackageBase):
 
     def configure(self, spec, prefix):
         """Configures the project."""
-        args = self.configure_args()
+        args = ['--prefix={0}'.format(self.prefix)]
+        args += self.configure_args()
 
         self.waf('configure', *args)
 
     def configure_args(self):
         """Arguments to pass to configure."""
-        return ['--prefix={0}'.format(self.prefix)]
+        return []
 
     def build(self, spec, prefix):
         """Executes the build."""


### PR DESCRIPTION
WafPackage configure step does not include prefix if you add additional arguments to the configure line. Changing so that we just append that additional arguments.