### PR TITLE
votca-*: fix stable deps

### DIFF
--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -32,15 +32,15 @@ class VotcaTools(CMakePackage):
     patch("https://github.com/votca/tools/pull/229.patch", sha256="250d0b679e5d3104e3c8d6adf99751b71386c7ed4cbdae1c75408717ef3f401f", when="@1.6+mkl")
 
     variant('mkl', default=False, description='Build with MKL support')
-    conflicts('+mkl', when='@:1.5.9999')
+    conflicts('+mkl', when='@1.4:1.5.9999')
 
     depends_on("cmake@2.8:", type='build')
     depends_on("expat")
     depends_on("fftw")
-    depends_on("gsl", when="@:1.4.9999")
-    depends_on("eigen@3.3:", when="@1.5:")
+    depends_on("gsl", when="@1.4:1.4.9999")
+    depends_on("eigen@3.3:", when="@stable,1.5:")
     depends_on("boost")
-    depends_on("sqlite", when="@:1.5.9999")
+    depends_on("sqlite", when="@1.4:1.5.9999")
     depends_on('mkl', when='+mkl')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/votca-xtp/package.py
+++ b/var/spack/repos/builtin/packages/votca-xtp/package.py
@@ -31,6 +31,6 @@ class VotcaXtp(CMakePackage):
     for v in ["1.4.1", "1.5", "1.5.1", "1.6", "master", "stable"]:
         depends_on('votca-tools@%s' % v, when="@%s:%s.0" % (v, v))
         depends_on('votca-csg@%s' % v, when="@%s:%s.0" % (v, v))
-    depends_on("libxc", when='@1.5:')
+    depends_on("libxc", when='@stable,1.5:')
     depends_on("ceres-solver", when='@1.5:1.5.9999')
     depends_on("hdf5+cxx~mpi")


### PR DESCRIPTION
Fix up for #16336.

Apparently `stable` < `v1.*` < master, so some deps were wrong. 