### PR TITLE
Add new package: trident

### DIFF
--- a/var/spack/repos/builtin/packages/trident/package.py
+++ b/var/spack/repos/builtin/packages/trident/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Trident(Package):
+    """Trident is a fully supported open source project maintained by
+    NetApp. It has been designed from the ground up to help you meet
+    the sophisticated persistence demands of your containerized
+    applications."""
+
+    homepage = "https://netapp-trident.readthedocs.io"
+    url      = "https://github.com/NetApp/trident/archive/v20.01.1.tar.gz"
+
+    version('20.01.1', sha256='02ba92e569916b98fb1b563c5ef03a94fd7981c3ac1ecb47e69ebb45471dc976')
+    version('20.01.0', sha256='5de190579acf62f5e9945dfd45aeb21989272c4972e85cb10256b7ec605c29c7')
+
+    depends_on('go', type='build')
+
+    def install(self, spec, prefix):
+        install_tree('.', prefix)
+        mkdirp(prefix.bin)
+        go = which('go')
+        go('build', '-o', prefix.bin)

--- a/var/spack/repos/builtin/packages/trident/package.py
+++ b/var/spack/repos/builtin/packages/trident/package.py
@@ -21,7 +21,8 @@ class Trident(Package):
     depends_on('go', type='build')
 
     def install(self, spec, prefix):
-        install_tree('.', prefix)
         mkdirp(prefix.bin)
         go = which('go')
         go('build', '-o', prefix.bin)
+        with working_dir('cli'):
+            go('build', '-o', prefix.bin.tridentctl)


### PR DESCRIPTION
`trident` binary can be build by go, but it looks there are some config files for it in source code, so I copyed all src file to the installed dir.