### PR TITLE
macOS Package Builds (nightly)

### DIFF
--- a/.github/workflows/install_spack.sh
+++ b/.github/workflows/install_spack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+git clone https://github.com/spack/spack.git
+. spack/share/spack/setup-env.sh
+spack compilers

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -1,0 +1,58 @@
+# These are nightly package tests for macOS
+# focus areas:
+# - initial user experience
+# - scientific python stack
+name: macOS builds nightly
+
+on:
+  schedule:
+    # nightly at 1 AM
+    - cron: '0 1 * * *'
+
+# GitHub Action Limits
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+jobs:
+  install_gcc:
+    name: gcc with clang
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: spack install
+      run: |
+        . .github/workflows/install_spack.sh
+        spack install -v gcc
+
+  install_jupyter_clang:
+    name: jupyter
+    runs-on: macos-latest
+    timeout-minutes: 600
+    steps:
+    - uses: actions/checkout@v2
+    - name: spack install
+      run: |
+        . .github/workflows/install_spack.sh
+        spack install -v py-jupyter %clang
+
+  install_scipy_clang:
+    name: scipy, mpl, pd
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: spack install
+      run: |
+        . .github/workflows/install_spack.sh
+        spack install -v py-scipy %clang
+        spack install -v py-matplotlib %clang
+        spack install -v py-pandas %clang
+
+  install_mpi4py_clang:
+    name: mpi4py, petsc4py
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: spack install
+      run: |
+        . .github/workflows/install_spack.sh
+        spack install -v py-mpi4py %clang
+        spack install -v py-petsc4py %clang

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/spack/spack.svg?branch=develop)](https://travis-ci.org/spack/spack)
 [![Linux Builds](https://github.com/spack/spack/workflows/linux%20builds/badge.svg)](https://github.com/spack/spack/actions)
+[![macOS Builds (nightly)](https://github.com/spack/spack/workflows/macOS%20builds%20nightly/badge.svg?branch=develop)](https://github.com/spack/spack/actions?query=workflow%3A%22macOS+builds+nightly%22)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 [![Slack](https://spackpm.herokuapp.com/badge.svg)](https://spackpm.herokuapp.com)


### PR DESCRIPTION
Add nightly builds for popular and commonly used packages on macOS that should improve the onramp user experience if working well.

Previously in https://github.com/spack/macos-nightly