### PR TITLE
colordiff: fix the bad url

### DIFF
--- a/var/spack/repos/builtin/packages/colordiff/package.py
+++ b/var/spack/repos/builtin/packages/colordiff/package.py
@@ -10,7 +10,7 @@ class Colordiff(Package):
     """Colorful diff utility."""
 
     homepage = "https://www.colordiff.org"
-    url      = "https://www.colordiff.org/colordiff-1.0.18.tar.gz"
+    url      = "https://www.colordiff.org/archive/colordiff-1.0.18.tar.gz"
 
     version('1.0.18', sha256='29cfecd8854d6e19c96182ee13706b84622d7b256077df19fbd6a5452c30d6e0')
 


### PR DESCRIPTION
The raw url always changed with the latest release version, 
we should use the archive url to make that url always available.