### PR TITLE
grpc: Allow Building Shared Libraries

### DIFF
--- a/var/spack/repos/builtin/packages/grpc/package.py
+++ b/var/spack/repos/builtin/packages/grpc/package.py
@@ -19,6 +19,8 @@ class Grpc(CMakePackage):
     version('1.24.3', sha256='c84b3fa140fcd6cce79b3f9de6357c5733a0071e04ca4e65ba5f8d306f10f033')
     version('1.23.1', sha256='dd7da002b15641e4841f20a1f3eb1e359edb69d5ccf8ac64c362823b05f523d9')
 
+    variant('shared', default=False,
+            description='Build shared instead of static libraries')
     variant('codegen', default=True,
             description='Builds code generation plugins for protobuf '
                         'compiler (protoc)')
@@ -31,6 +33,8 @@ class Grpc(CMakePackage):
 
     def cmake_args(self):
         args = [
+            '-DBUILD_SHARED_LIBS:Bool={0}'.format(
+                'ON' if '+shared' in self.spec else 'OFF'),
             '-DgRPC_BUILD_CODEGEN:Bool={0}'.format(
                 'ON' if '+codegen' in self.spec else 'OFF'),
             '-DgRPC_BUILD_CSHARP_EXT:Bool=OFF',


### PR DESCRIPTION
Added a shared variant, that switches between shared and static library building, like with most cmake packages.