### PR TITLE
ffmpeg: add @1.0.10, @2.8.15; add '+avresample'; improve variant handling

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -17,6 +17,8 @@ class Ffmpeg(AutotoolsPackage):
     version('4.1.1', sha256='0cb40e3b8acaccd0ecb38aa863f66f0c6e02406246556c2992f67bf650fab058')
     version('4.1',   sha256='b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5')
     version('3.2.4', sha256='c0fa3593a2e9e96ace3c1757900094437ad96d1d6ca19f057c378b5f394496a4')
+    version('2.8.15', sha256='35647f6c1f6d4a1719bc20b76bf4c26e4ccd665f46b5676c0e91c5a04622ee21')
+    version('1.0.10', sha256='1dbde434c3b5c573d3b2ffc1babe3814f781c10c4bc66193a4132a44c9715176')
 
     # Licensing
     variant('gpl', default=True,
@@ -54,6 +56,7 @@ class Ffmpeg(AutotoolsPackage):
     #         description='XML parsing, needed for dash demuxing support')
     variant('libzmq', default=False, description='message passing via libzmq')
     variant('lzma', default=True, description='lzma support')
+    variant('avresample', default=False, description='AV reasmpling component')
     variant('openssl', default=False, description='needed for https support')
     variant('sdl2', default=True, description='sdl2 support')
     variant('shared', default=True, description='build shared libraries')
@@ -83,6 +86,8 @@ class Ffmpeg(AutotoolsPackage):
     depends_on('snappy', when='+libsnappy')
     depends_on('speex', when='+libspeex')
     depends_on('xz', when='+lzma')
+
+    conflicts('+libaom', when='@:3.999') # https://www.ffmpeg.org/index.html#news (search AV1)
 
     def configure_args(self):
         spec = self.spec
@@ -132,6 +137,7 @@ class Ffmpeg(AutotoolsPackage):
             # 'libxml2',
             'libzmq',
             'lzma',
+            'avresample',
             'openssl',
             'sdl2',
             'shared',

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -13,10 +13,10 @@ class Ffmpeg(AutotoolsPackage):
     homepage = "https://ffmpeg.org"
     url      = "http://ffmpeg.org/releases/ffmpeg-4.1.1.tar.bz2"
 
-    version('4.2.2', sha256='b620d187c26f76ca19e74210a0336c3b8380b97730df5cdf45f3e69e89000e5c')
-    version('4.1.1', sha256='0cb40e3b8acaccd0ecb38aa863f66f0c6e02406246556c2992f67bf650fab058')
-    version('4.1',   sha256='b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5')
-    version('3.2.4', sha256='c0fa3593a2e9e96ace3c1757900094437ad96d1d6ca19f057c378b5f394496a4')
+    version('4.2.2',  sha256='b620d187c26f76ca19e74210a0336c3b8380b97730df5cdf45f3e69e89000e5c')
+    version('4.1.1',  sha256='0cb40e3b8acaccd0ecb38aa863f66f0c6e02406246556c2992f67bf650fab058')
+    version('4.1',    sha256='b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5')
+    version('3.2.4',  sha256='c0fa3593a2e9e96ace3c1757900094437ad96d1d6ca19f057c378b5f394496a4')
     version('2.8.15', sha256='35647f6c1f6d4a1719bc20b76bf4c26e4ccd665f46b5676c0e91c5a04622ee21')
     version('1.0.10', sha256='1dbde434c3b5c573d3b2ffc1babe3814f781c10c4bc66193a4132a44c9715176')
 
@@ -55,10 +55,10 @@ class Ffmpeg(AutotoolsPackage):
     # variant('libxml2', default=False,
     #         description='XML parsing, needed for dash demuxing support')
     variant('libzmq', default=False, description='message passing via libzmq')
-    variant('lzma', default=True, description='lzma support')
+    variant('lzma', default=False, description='lzma support')
     variant('avresample', default=False, description='AV reasmpling component')
     variant('openssl', default=False, description='needed for https support')
-    variant('sdl2', default=True, description='sdl2 support')
+    variant('sdl2', default=False, description='sdl2 support')
     variant('shared', default=True, description='build shared libraries')
 
     depends_on('alsa-lib')
@@ -87,61 +87,88 @@ class Ffmpeg(AutotoolsPackage):
     depends_on('speex', when='+libspeex')
     depends_on('xz', when='+lzma')
 
-    conflicts('+libaom', when='@:3.999') # https://www.ffmpeg.org/index.html#news (search AV1)
+    # TODO: enable when libxml2 header issue is resolved
+    # conflicts('+libxml2', when='@:3.999')
+    # See: https://www.ffmpeg.org/index.html#news (search AV1)
+    conflicts('+libaom', when='@:3.999')
+    # All of the following constraints were sourced from the official 'ffmpeg'
+    # change log, which can be found here:
+    # https://raw.githubusercontent.com/FFmpeg/FFmpeg/release/4.0/Changelog
+    conflicts('+sdl2', when='@:3.1.999')
+    conflicts('+libsnappy', when='@:2.7.999')
+    conflicts('+X', when='@:2.4.999')
+    conflicts('+lzma', when='@2.3.999:')
+    conflicts('+libwebp', when='@2.1.999:')
+    conflicts('+libssh', when='@2.0.999:')
+    conflicts('+libzmq', when='@:1.999.999')
+
+    def enable_or_disable_meta(self, variant, options):
+        switch = 'enable' if '+{0}'.format(variant) in self.spec else 'disable'
+        return ['--{0}-{1}'.format(switch, option) for option in options]
 
     def configure_args(self):
         spec = self.spec
         config_args = ['--enable-pic']
 
-        if '+X' in spec:
-            config_args.extend([
-                '--enable-libxcb',
-                '--enable-libxcb-shape',
-                '--enable-libxcb-shm',
-                '--enable-libxcb-xfixes',
-                '--enable-xlib',
-            ])
-        else:
-            config_args.extend([
-                '--disable-libxcb',
-                '--disable-libxcb-shape',
-                '--disable-libxcb-shm',
-                '--disable-libxcb-xfixes',
-                '--disable-xlib',
+        # '+X' meta variant #
+
+        xlib_opts = []
+
+        if spec.satisfies('@2.5:'):
+            xlib_opts.extend([
+                'libxcb',
+                'libxcb-shape',
+                'libxcb-shm',
+                'libxcb-xfixes',
+                'xlib',
             ])
 
-        if '+drawtext' in spec:
-            config_args.extend([
-                '--enable-libfontconfig',
-                '--enable-libfreetype',
-                '--enable-libfribidi',
-            ])
-        else:
-            config_args.extend([
-                '--disable-libfontconfig',
-                '--disable-libfreetype',
-                '--disable-libfribidi',
-            ])
-        for variant in [
+        config_args += self.enable_or_disable_meta('X', xlib_opts)
+
+        # '+drawtext' meta variant #
+
+        drawtext_opts = [
+            '{0}fontconfig'.format('lib' if spec.satisfies('@3:') else ''),
+            'libfreetype',
+        ]
+
+        if spec.satisfies('@2.3:'):
+            drawtext_opts.append('libfribidi')
+
+        config_args += self.enable_or_disable_meta('drawtext', drawtext_opts)
+
+        # other variants #
+
+        variant_opts = [
             'bzlib',
-            'libaom',
             'libmp3lame',
             'libopenjpeg',
             'libopus',
-            'libsnappy',
             'libspeex',
-            'libssh',
             'libvorbis',
-            'libwebp',
-            # TODO: enable when libxml2 header issue is resolved
-            # 'libxml2',
-            'libzmq',
-            'lzma',
             'avresample',
             'openssl',
-            'sdl2',
             'shared',
-        ]:
-            config_args += self.enable_or_disable(variant)
+        ]
+
+        if spec.satisfies('@2.0:'):
+            variant_opts.append('libzmq')
+        if spec.satisfies('@2.1:'):
+            variant_opts.append('libssh')
+        if spec.satisfies('@2.2:'):
+            variant_opts.append('libwebp')
+        if spec.satisfies('@2.4:'):
+            variant_opts.append('lzma')
+        if spec.satisfies('@2.8:'):
+            variant_opts.append('libsnappy')
+        if spec.satisfies('@3.2:'):
+            variant_opts.append('sdl2')
+        if spec.satisfies('@4:'):
+            variant_opts.append('libaom')
+            # TODO: enable when libxml2 header issue is resolved
+            # variant_opts.append('libxml2')
+
+        for variant_opt in variant_opts:
+            config_args += self.enable_or_disable(variant_opt)
 
         return config_args


### PR DESCRIPTION
This pull request makes the following changes to the `ffmpeg` package:

- Adds older versions (i.e. the latest versions of `@1` and `@2`, `@1.0.10` and `@2.8.15`) to enable building older dependents (see `openscenegraph@3.4.0` for details).
- Adds the `+avresample` variant, which allows for conditional building of the `libavresample` component (see `openscenegraph+ffmpeg` for details).
- Overhauls variant handling in order to more accurately constrain variants to their supported versions (e.g. if `+variant` is only available in `@X.Y.Z:`, then a `@conflicts('@:X.Y-1.999', '+variant')` statement is added, etc.).
- Changes package-based variant defaults to `False` for variants that aren't supported by all `ffmpeg` versions (e.g. `+sdl2`, `+lzma`).

I've verified that the following variants of this package build with `gcc@4.9.3` on architecture `linux-rhel7-broadwell`:

- `ffmpeg@1.0.10{+|~}avresample`
- `ffmpeg@2.8.15{+|~}avresample`
- `ffmpeg@4.2.2{+|~}avresample`

Looking at the logs for these builds, I'm fairly confident the per-package variants that were changed will work in enabled states as well as their default disabled states (e.g. `+sdl2`, `+lzma`), but I've not tested these variants as there are quite a few. If there are any important ones I should double check, please let me know and I'll run builds on that subset.

Also, tagging @glennpj as he seems to be the most recent contributor to this package; please let me know if anything looks amiss relative to your changes!