### PR TITLE
openscenegraph: add @3.4.0, @3.4.1; add '+ffmpeg'

### DIFF
--- a/var/spack/repos/builtin/packages/openscenegraph/glibc-jasper.patch
+++ b/var/spack/repos/builtin/packages/openscenegraph/glibc-jasper.patch
@@ -1,0 +1,15 @@
+diff --git a/src/osgPlugins/jp2/ReaderWriterJP2.cpp b/src/osgPlugins/jp2/ReaderWriterJP2.cpp
+index 7b3c6cc..d949c2c 100644
+--- a/src/osgPlugins/jp2/ReaderWriterJP2.cpp
++++ b/src/osgPlugins/jp2/ReaderWriterJP2.cpp
+@@ -15,6 +15,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
++#ifndef SIZE_MAX
++#define SIZE_MAX ((size_t)(-1))
++#endif
++
+ extern "C"
+ {
+     #include <jasper/jasper.h>

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
 
 
@@ -22,20 +21,22 @@ class Openscenegraph(CMakePackage):
     version('3.1.5', git=git_url, tag='OpenSceneGraph-3.1.5')
 
     variant('shared', default=True, description='Builds a shared version of the library')
+    variant('ffmpeg', default=False, description='Builds ffmpeg plugin for audio encoding/decoding')
 
     depends_on('cmake@2.8.7:', type='build')
     depends_on('qt+opengl')
     depends_on('qt@4:', when='@3.2:')
     depends_on('qt@:4', when='@:3.1')
-    # TODO: Since 'ffmpeg' constantly changes its API and OSG must change in response,
-    # the version of the dependency here matters greatly on the version and patch of
-    # the release of OSG that's being used.
-    depends_on('ffmpeg@1:2+avresample')
-    depends_on('zlib')
     depends_on('libxinerama')
     depends_on('libxrandr')
+    depends_on('jasper')
+    depends_on('zlib')
 
-    patch('glibc-jasper.patch', when='@3.4.0:3.4.999%gcc')
+    depends_on('ffmpeg+avresample', when='+ffmpeg')
+    # https://github.com/openscenegraph/OpenSceneGraph/issues/167
+    depends_on('ffmpeg@:2', when='@:3.4.0+ffmpeg')
+
+    patch('glibc-jasper.patch', when='@3.4%gcc')
 
     def cmake_args(self):
         spec = self.spec
@@ -44,35 +45,25 @@ class Openscenegraph(CMakePackage):
         opengl_profile = 'GL{0}'.format(spec['gl'].version.up_to(1))
 
         args = [
-            # Library Options #
-            '-DZLIB_INCLUDE_DIR={0}'.format(spec['zlib'].prefix.include),
-            '-DZLIB_LIBRARY={0}/libz.{1}'.format(spec['zlib'].prefix.lib,
-                                                 dso_suffix),
-            '-DFFMPEG_ROOT={0}'.format(spec['ffmpeg'].prefix),
             # Variant Options #
             '-DDYNAMIC_OPENSCENEGRAPH={0}'.format(shared_status),
             '-DDYNAMIC_OPENTHREADS={0}'.format(shared_status),
             '-DOPENGL_PROFILE={0}'.format(opengl_profile),
+
             # General Options #
             '-DBUILD_OSG_APPLICATIONS=OFF',
             '-DOSG_NOTIFY_DISABLED=ON',
             '-DLIB_POSTFIX=',
             '-DCMAKE_RELWITHDEBINFO_POSTFIX=',
+            '-DCMAKE_MINSIZEREL_POSTFIX='
         ]
-        if spec.satisfies('@:3.2'):
-            args.extend([
-                '-DZLIB_INCLUDE_DIR={0}'.format(spec['zlib'].prefix.include),
-                '-DZLIB_LIBRARY={0}/libz.{1}'.format(spec['zlib'].prefix.lib,
-                                                     dso_suffix),
-            ])
 
-        # NOTE: Specifying only the root seems to be sufficient, and specifying
-        # the locations explicity causes OSG to be buggy.
-        for ffmpeg_lib in ['libavcodec', 'libavformat', 'libavutil']:
-            args.extend([
-                '-DFFMPEG_{0}_INCLUDE_DIRS='.format(ffmpeg_lib.upper()),
-                '-DFFMPEG_{0}_LIBRARIES='.format(ffmpeg_lib.upper()),
-            ])
+        if spec.satisfies('~ffmpeg'):
+            for ffmpeg_lib in ['libavcodec', 'libavformat', 'libavutil']:
+                args.extend([
+                    '-DFFMPEG_{0}_INCLUDE_DIRS='.format(ffmpeg_lib.upper()),
+                    '-DFFMPEG_{0}_LIBRARIES='.format(ffmpeg_lib.upper()),
+                ])
 
         # NOTE: This is necessary in order to allow OpenSceneGraph to compile
         # despite containing a number of implicit bool to int conversions.
@@ -81,8 +72,5 @@ class Openscenegraph(CMakePackage):
                 '-DCMAKE_C_FLAGS=-fpermissive',
                 '-DCMAKE_CXX_FLAGS=-fpermissive',
             ])
-
-        if spec.satisfies('@3.4:'):
-            args.extend(['-DBUILD_OSG_FRAMEWORKS=OFF'])
 
         return args

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -12,30 +12,48 @@ class Openscenegraph(CMakePackage):
        that's used in a variety of visual simulation applications."""
 
     homepage = "http://www.openscenegraph.org"
-    url      = "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.4.tar.gz"
+    git_url  = "https://github.com/openscenegraph/OpenSceneGraph.git"
 
-    version('3.6.5', sha256='aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12')
-    version('3.6.4', sha256='81394d1b484c631028b85d21c5535280c21bbd911cb058e8746c87e93e7b9d33')
-    version('3.2.3', sha256='a1ecc6524197024834e1277916922b32f30246cb583e27ed19bf3bf889534362')
-    version('3.1.5', sha256='dddecf2b33302076712100af59b880e7647bc595a9a7cc99186e98d6e0eaeb5c')
+    version('3.6.5', git=git_url, tag='OpenSceneGraph-3.6.5')
+    version('3.6.4', git=git_url, tag='OpenSceneGraph-3.6.4')
+    version('3.4.1', git=git_url, tag='OpenSceneGraph-3.4.1')
+    version('3.4.0', git=git_url, tag='OpenSceneGraph-3.4.0')
+    version('3.2.3', git=git_url, tag='OpenSceneGraph-3.2.3')
+    version('3.1.5', git=git_url, tag='OpenSceneGraph-3.1.5')
 
     variant('shared', default=True, description='Builds a shared version of the library')
 
     depends_on('cmake@2.8.7:', type='build')
+    depends_on('qt+opengl')
     depends_on('qt@4:', when='@3.2:')
     depends_on('qt@:4', when='@:3.1')
+    # TODO: Since 'ffmpeg' constantly changes its API and OSG must change in response,
+    # the version of the dependency here matters greatly on the version and patch of
+    # the release of OSG that's being used.
+    depends_on('ffmpeg@1:2+avresample')
     depends_on('zlib')
     depends_on('libxinerama')
     depends_on('libxrandr')
+
+    patch('glibc-jasper.patch', when='@3.4.0:3.4.999%gcc')
 
     def cmake_args(self):
         spec = self.spec
 
         shared_status = 'ON' if '+shared' in spec else 'OFF'
+        opengl_profile = 'GL{0}'.format(spec['gl'].version.up_to(1))
 
         args = [
+            # Library Options #
+            '-DZLIB_INCLUDE_DIR={0}'.format(spec['zlib'].prefix.include),
+            '-DZLIB_LIBRARY={0}/libz.{1}'.format(spec['zlib'].prefix.lib,
+                                                 dso_suffix),
+            '-DFFMPEG_ROOT={0}'.format(spec['ffmpeg'].prefix),
+            # Variant Options #
             '-DDYNAMIC_OPENSCENEGRAPH={0}'.format(shared_status),
             '-DDYNAMIC_OPENTHREADS={0}'.format(shared_status),
+            '-DOPENGL_PROFILE={0}'.format(opengl_profile),
+            # General Options #
             '-DBUILD_OSG_APPLICATIONS=OFF',
             '-DOSG_NOTIFY_DISABLED=ON',
             '-DLIB_POSTFIX=',
@@ -48,6 +66,14 @@ class Openscenegraph(CMakePackage):
                                                      dso_suffix),
             ])
 
+        # NOTE: Specifying only the root seems to be sufficient, and specifying
+        # the locations explicity causes OSG to be buggy.
+        for ffmpeg_lib in ['libavcodec', 'libavformat', 'libavutil']:
+            args.extend([
+                '-DFFMPEG_{0}_INCLUDE_DIRS='.format(ffmpeg_lib.upper()),
+                '-DFFMPEG_{0}_LIBRARIES='.format(ffmpeg_lib.upper()),
+            ])
+
         # NOTE: This is necessary in order to allow OpenSceneGraph to compile
         # despite containing a number of implicit bool to int conversions.
         if spec.satisfies('%gcc'):
@@ -55,5 +81,8 @@ class Openscenegraph(CMakePackage):
                 '-DCMAKE_C_FLAGS=-fpermissive',
                 '-DCMAKE_CXX_FLAGS=-fpermissive',
             ])
+
+        if spec.satisfies('@3.4:'):
+            args.extend(['-DBUILD_OSG_FRAMEWORKS=OFF'])
 
         return args

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -30,7 +30,10 @@ class Openscenegraph(CMakePackage):
     depends_on('qt@:4', when='@:3.1')
     depends_on('libxinerama')
     depends_on('libxrandr')
+    depends_on('libpng')
     depends_on('jasper')
+    depends_on('libtiff')
+    depends_on('glib')
     depends_on('zlib')
 
     depends_on('ffmpeg+avresample', when='+ffmpeg')

--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -11,14 +11,15 @@ class Openscenegraph(CMakePackage):
        that's used in a variety of visual simulation applications."""
 
     homepage = "http://www.openscenegraph.org"
-    git_url  = "https://github.com/openscenegraph/OpenSceneGraph.git"
+    git      = "https://github.com/openscenegraph/OpenSceneGraph.git"
+    url      = "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.4.tar.gz"
 
-    version('3.6.5', git=git_url, tag='OpenSceneGraph-3.6.5')
-    version('3.6.4', git=git_url, tag='OpenSceneGraph-3.6.4')
-    version('3.4.1', git=git_url, tag='OpenSceneGraph-3.4.1')
-    version('3.4.0', git=git_url, tag='OpenSceneGraph-3.4.0')
-    version('3.2.3', git=git_url, tag='OpenSceneGraph-3.2.3')
-    version('3.1.5', git=git_url, tag='OpenSceneGraph-3.1.5')
+    version('3.6.5', sha256='aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12')
+    version('3.6.4', sha256='81394d1b484c631028b85d21c5535280c21bbd911cb058e8746c87e93e7b9d33')
+    version('3.4.1', sha256='930eb46f05781a76883ec16c5f49cfb29a059421db131005d75bec4d78401fd5')
+    version('3.4.0', sha256='0d5efe12b923130d14a6fce5866675d7625fcfb1c004c9f9b10034b9feb61ac2')
+    version('3.2.3', sha256='a1ecc6524197024834e1277916922b32f30246cb583e27ed19bf3bf889534362')
+    version('3.1.5', sha256='dddecf2b33302076712100af59b880e7647bc595a9a7cc99186e98d6e0eaeb5c')
 
     variant('shared', default=True, description='Builds a shared version of the library')
     variant('ffmpeg', default=False, description='Builds ffmpeg plugin for audio encoding/decoding')


### PR DESCRIPTION
This pull request makes the following changes to the `openscenegraph` package:

- Adds older versions `@3.4.0` and `@3.4.1`.
- Adds the `+ffmpeg` variant to enable conditionally building with OpenSceneGraph's `ffmpeg` plugin.
- Adds the previously missing `jasper` dependency to this package.

I've verified that the following variants of this package build with `gcc@4.9.3` on architecture `linux-rhel7-broadwell` using  `qt@5.12.7+shared+opengl+webkit+dbus` as a `qt` base:

- `openscenegraph@3.4.0+ffmpeg ^ffmpeg@4.4` (verified that this **doesn't** work)
- `openscenegraph@3.4.0{+|~}ffmpeg ^ffmpeg@2.8.15` (verified that this **does** work)
- `openscenegraph@3.4.1{+|~}ffmpeg ^ffmpeg@4.4`
- `openscenegraph@3.6.4{+|~}ffmpeg ^ffmpeg@4.4`

In order to build `openscenegraph@3.4.0` the latest `ffmpeg` changes are required (see #16359).

Also, tagging @glennpj again as he's the most recent contributor to this package!