### PR TITLE
root: New Version, Better Variant Handling

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -26,6 +26,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version('6.20.04', sha256='1f8c76ccdb550e64e6ddb092b4a7e9d0a10655ef80044828cba12d5e7c874472')
     version('6.20.02', sha256='0997586bf097c0afbc6f08edbffcebf5eb6a4237262216114ba3f5c8087dcba6')
     version('6.20.00', sha256='68421eb0434b38b66346fa8ea6053a0fdc9a6d254e4a72019f4e3633ae118bf0')
     version('6.18.04', sha256='315a85fc8363f8eb1bffa0decbf126121258f79bd273513ed64795675485cfa4',
@@ -213,10 +214,10 @@ class Root(CMakePackage):
     depends_on('python@2.7:', when='+python', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'), when='+tmva')
     # This numpy dependency was not intended and will hopefully
-    # be fixed in 6.20.04.
+    # be fixed in 6.20.06.
     # See: https://sft.its.cern.ch/jira/browse/ROOT-10626
     depends_on('py-numpy', type=('build', 'run'),
-               when='@6.20.00:6.20.03 +python')
+               when='@6.20.00:6.20.05 +python')
 
     # Optional dependencies
     depends_on('davix @0.7.1:', when='+davix')
@@ -378,7 +379,6 @@ class Root(CMakePackage):
                 ['pgsql', 'postgres'],
                 ['pythia6'],
                 ['pythia8'],
-                ['python'],
                 ['qt', 'qt4'],  # See conflicts
                 ['qtgsi', 'qt4'],  # See conflicts
                 ['r', 'R'],
@@ -408,6 +408,12 @@ class Root(CMakePackage):
             ]
 
         options = self._process_opts(control_opts, builtin_opts, feature_opts)
+
+        # Some special features
+        if self.spec.satisfies('@6.20:'):
+            options.append(self.define_from_variant('pyroot', 'python'))
+        else:
+            options.append(self.define_from_variant('python'))
 
         # #################### Compiler options ####################
 


### PR DESCRIPTION
* Add version 6.20.04
* This version still requires numpy for +python
* ROOT 6.20 renamed the define from `python` to `pyroot`: Add appropiate handling

Maintainer-Ping: @chissg @HadrienG2 @drbenmorgan
