### PR TITLE
helics: Allow building with (or without) boost libraries

### DIFF
--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -42,7 +42,7 @@ class Helics(CMakePackage):
     # Build dependency
     depends_on('git', type='build', when='@master:')
     depends_on('cmake@3.4:', type='build')
-    depends_on('boost@1.70', type='build', when='+boost')
+    depends_on('boost@1.70:', type='build', when='+boost')
     depends_on('swig@3.0:', type='build', when='+swig')
 
     depends_on('libzmq@4.3:', when='+zmq')

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -42,7 +42,7 @@ class Helics(CMakePackage):
     # Build dependency
     depends_on('git', type='build', when='@master:')
     depends_on('cmake@3.4:', type='build')
-    depends_on('boost@1.70: ~atomic ~chrono ~date_time ~exception ~filesystem ~graph ~iostreams ~locale ~log ~math ~program_options ~random ~regex ~serialization ~signals ~system ~test ~thread ~timer ~wave', type='build', when='+boost')
+    depends_on('boost@1.70', type='build', when='+boost')
     depends_on('swig@3.0:', type='build', when='+swig')
 
     depends_on('libzmq@4.3:', when='+zmq')


### PR DESCRIPTION
HELICS only uses the Boost headers, but having the libraries installed won't break anything. Having them disabled caused a conflict with another library that actually needs the libraries (I thought disabling building the libraries would be more along the lines of setting a preferred default).