### PR TITLE
smoke tests:  grab and run build examples (openmpi)

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1112,14 +1112,6 @@ class PackageInstaller(object):
                                 phase = getattr(pkg, phase_attr)
                                 phase(pkg.spec, pkg.prefix)
 
-                        # cache install testing source files
-                        install_dir = pkg.install_test_root
-                        for pkg_dir in pkg.test_pkg_dirs:
-                            test_dir = os.path.join(source_path, pkg_dir)
-                            dest_dir = os.path.join(install_dir, pkg_dir)
-                            if os.path.isdir(test_dir):
-                                shutil.copytree(test_dir, dest_dir)
-
                     echo = logger.echo
                     log(pkg)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1072,10 +1072,10 @@ class PackageInstaller(object):
                                                   pkg.name, 'src')
                         tty.msg('{0} Copying source to {1}'
                                 .format(pre, src_target))
-                        fs.install_tree(pkg.stage.source_path, src_target)
+                        fs.install_tree(source_path, src_target)
 
                     # Do the real install in the source directory.
-                    with fs.working_dir(pkg.stage.source_path):
+                    with fs.working_dir(source_path):
                         # Save the build environment in a file before building.
                         dump_environment(pkg.env_path)
 
@@ -1111,6 +1111,14 @@ class PackageInstaller(object):
                                 # Redirect stdout and stderr to daemon pipe
                                 phase = getattr(pkg, phase_attr)
                                 phase(pkg.spec, pkg.prefix)
+
+                        # cache install testing source files
+                        install_dir = pkg.install_test_root
+                        for pkg_dir in pkg.test_pkg_dirs:
+                            test_dir = os.path.join(source_path, pkg_dir)
+                            dest_dir = os.path.join(install_dir, pkg_dir)
+                            if os.path.isdir(test_dir):
+                                shutil.copytree(test_dir, dest_dir)
 
                     echo = logger.echo
                     log(pkg)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1474,11 +1474,24 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         return self.test_stage.join(
             self.spec.format('{name}-{version}-{hash}'))
 
+    def copy_src_to_install(self, src_subdir, install_subdir):
+        """Copy the source subdirectory to the install test subdirectory.
+
+        Args:
+            src_subdir (str): name of the subdirectory under staged source
+                that is to be copied to the install test directory
+            install_subdir (str): name of the target subdirectory under the
+                install test directory 
+        """
+        test_dir = os.path.join(self.stage.source_path, src_subdir)
+        dest_dir = os.path.join(self.install_test_root, install_subdir)
+        if os.path.isdir(test_dir):
+            shutil.copytree(test_dir, dest_dir)
+
     test_requires_compiler = False
     test_failures = None
     test_log_file = None
     test_stage = None
-    test_pkg_dirs = []
 
     def do_test(self, name, remove_directory=False, dirty=False):
         if self.test_requires_compiler:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -918,7 +918,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     @property
     def install_test_root(self):
         """Return the install test root directory."""
-        return self.metadata_dir
+        return os.path.join(self.metadata_dir, 'test')
 
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least
@@ -1490,9 +1490,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         paths = [srcs] if isinstance(srcs, string_types) else srcs
 
-        def skip_file(path):
-            return path not in paths
-
+        skip_file = lambda p: p not in paths
         for path in paths:
             src_path = os.path.join(self.stage.source_path, path)
             dest_path = os.path.join(self.install_test_root, path)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1475,8 +1475,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         return self.test_stage.join(
             self.spec.format('{name}-{version}-{hash}'))
 
-    def copy_src_to_install(self, src_subdir, install_subdir):
+    def cache_extra_test_source(self, src_subdir, install_subdir):
         """Copy the source subdirectory to the install test subdirectory.
+
+        This method is intended as an optional test set up helper for use
+        during the install process when the goal is to leverage existing
+        package source files (e.g., tests, examples) for package installation
+        testing.
 
         Args:
             src_subdir (str): name of the subdirectory under staged source

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -45,7 +45,6 @@ import spack.multimethod
 import spack.repo
 import spack.url
 import spack.util.environment
-import spack.util.path as sup
 import spack.util.web
 import spack.multimethod
 
@@ -1523,7 +1522,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                         for pdir in self.test_pkg_dirs:
                             extradir = os.path.join(self.stage.source_path,
                                                     pdir)
-                            destdir = os.path.join(testdir.data, pdir)
+                            destdir = os.path.join(testdir, pdir)
                             if os.path.isdir(extradir):
                                 shutil.copytree(extradir, destdir)
                     self.do_clean()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -864,19 +864,22 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             return os.path.join(self.stage.path, _spack_build_envfile)
 
     @property
+    def metadata_dir(self):
+        """Return the install metadata directory."""
+        return spack.store.layout.metadata_path(self.spec)
+
+    @property
     def install_env_path(self):
         """
         Return the build environment file path on successful installation.
         """
-        install_path = spack.store.layout.metadata_path(self.spec)
-
         # Backward compatibility: Return the name of an existing log path;
         # otherwise, return the current install env path name.
-        old_filename = os.path.join(install_path, 'build.env')
+        old_filename = os.path.join(self.metadata_dir, 'build.env')
         if os.path.exists(old_filename):
             return old_filename
         else:
-            return os.path.join(install_path, _spack_build_envfile)
+            return os.path.join(self.metadata_dir, _spack_build_envfile)
 
     @property
     def log_path(self):
@@ -893,16 +896,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     @property
     def install_log_path(self):
         """Return the build log file path on successful installation."""
-        install_path = spack.store.layout.metadata_path(self.spec)
-
         # Backward compatibility: Return the name of an existing install log.
         for filename in ['build.out', 'build.txt']:
-            old_log = os.path.join(install_path, filename)
+            old_log = os.path.join(self.metadata_dir, filename)
             if os.path.exists(old_log):
                 return old_log
 
         # Otherwise, return the current install log path name.
-        return os.path.join(install_path, _spack_build_logfile)
+        return os.path.join(self.metadata_dir, _spack_build_logfile)
 
     @property
     def configure_args_path(self):
@@ -912,14 +913,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     @property
     def install_configure_args_path(self):
         """Return the configure args file path on successful installation."""
-        install_path = spack.store.layout.metadata_path(self.spec)
-
-        return os.path.join(install_path, _spack_configure_argsfile)
+        return os.path.join(self.metadata_dir, _spack_configure_argsfile)
 
     @property
     def install_test_root(self):
         """Return the install test root directory."""
-        return spack.store.layout.metadata_path(self.spec)
+        return self.metadata_dir
 
     def _make_fetcher(self):
         # Construct a composite fetcher that always contains at least

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1467,7 +1467,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def test_log_name(self):
-        return 'test-%s-out.txt' % self.spec.format('{name}-{version}-{hash:7}')
+        return 'test-{0}-out.txt' \
+            .format(self.spec.format('{name}-{version}-{hash:7}'))
 
     @property
     def test_dir(self):
@@ -1481,7 +1482,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             src_subdir (str): name of the subdirectory under staged source
                 that is to be copied to the install test directory
             install_subdir (str): name of the target subdirectory under the
-                install test directory 
+                install test directory
         """
         test_dir = os.path.join(self.stage.source_path, src_subdir)
         dest_dir = os.path.join(self.install_test_root, install_subdir)
@@ -1618,12 +1619,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                         out, 'test', self.test_log_file, last=1)
                     m = out.getvalue()
                 else:
-                    # We're below the package context, so get context from stack
-                    # instead of from traceback.
+                    # We're below the package context, so get context from
+                    # stack instead of from traceback.
                     # The traceback is truncated here, so we can't use it to
                     # traverse the stack.
                     m = '\n'.join(spack.build_environment.get_package_context(
-                            traceback.extract_stack()))
+                        traceback.extract_stack()))
 
                 exc = e  # e is deleted after this block
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -10,7 +10,12 @@ etc.).  Only methods like ``possible_dependencies()`` that deal with the
 static DSL metadata for packages.
 """
 
+import os
 import pytest
+import shutil
+
+import llnl.util.filesystem as fs
+
 import spack.package
 import spack.repo
 
@@ -119,3 +124,54 @@ def test_possible_dependencies_with_multiple_classes(
     })
 
     assert expected == spack.package.possible_dependencies(*pkgs)
+
+
+def setup_install_test(source_paths, install_test_root):
+    """Set up the install test by creating sources and install test roots."""
+    fs.mkdirp(install_test_root)
+    for path in source_paths:
+        fs.mkdirp(os.path.dirname(path))
+        if os.path.splitext(path)[1]:
+            fs.touch(path)
+
+
+@pytest.mark.parametrize('spec,sources,extras,exists', [
+    ('a',
+     ['example/a.c'],   # Source(s)
+     ['example/a.c'],   # Extra test source
+     ['example/a.c']),  # Test install dir source(s)
+    ('b',
+     ['test/b.cpp', 'test/b.hpp', 'example/b.txt'],   # Source(s)
+     ['test'],                                        # Extra test source
+     ['test/b.cpp', 'test/b.hpp']),                   # Test install dir source
+    ('c',
+     ['examples/a.py', 'examples/b.py', 'examples/c.py', 'tests/d.py'],
+     ['examples/b.py', 'tests'],
+     ['examples/b.py', 'tests/d.py']),
+])
+def test_cache_extra_sources(install_mockery, spec, sources, extras, exists):
+    """Test the package's cache extra test sources helper function."""
+
+    pkg = spack.repo.get(spec)
+    pkg.spec.concretize()
+    source_path = pkg.stage.source_path
+
+    srcs = [fs.join_path(source_path, s) for s in sources]
+    setup_install_test(srcs, pkg.install_test_root)
+    for s in srcs:
+        assert os.path.exists(s), 'Expected {0} to exist'.format(s)
+
+    pkg.cache_extra_test_sources(extras)
+
+    poss_dests = [fs.join_path(pkg.install_test_root, s) for s in sources]
+    expected = [fs.join_path(pkg.install_test_root, e) for e in exists]
+
+    msg = 'Expected {0} to{1} exist'
+    for pd in poss_dests:
+        if pd in expected:
+            assert os.path.exists(pd), msg.format(pd, '')
+        else:
+            assert not os.path.exists(pd), msg.format(pd, ' not')
+
+    # Perform a little cleanup
+    shutil.rmtree(os.path.dirname(source_path))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -571,8 +571,7 @@ class Openmpi(AutotoolsPackage):
         Copy the example files after the package is installed to an
         install test subdirectory for use during `spack test run`.
         """
-        self.cache_extra_test_source(self.extra_install_tests,
-                                     self.extra_install_tests)
+        self.cache_extra_test_sources(self.extra_install_tests)
 
     def _test_bin_ops(self):
         info = ([], ['Ident string: {0}'.format(self.spec.version), 'MCA'],

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -625,12 +625,12 @@ class Openmpi(AutotoolsPackage):
             'Expected only one package directory'
 
         # First build the examples
-        work_dir = os.path.join(self.test_dir.data, self.test_pkg_dirs[0])
+        work_dir = os.path.join(self.test_dir, self.test_pkg_dirs[0])
         self.run_test('make', ['all'], [], None, False,
                       purpose='test build the examples', work_dir=work_dir)
 
         # Now run those with known results
-        have_spml = self.spec.version in spack.version.ver('2.0.0:3.1.5')
+        have_spml = self.spec.version in spack.version.ver('2.0.0:2.1.6')
 
         hello_world = (['Hello, world', 'I am', '0 of', '1'], None)
 
@@ -640,12 +640,7 @@ class Openmpi(AutotoolsPackage):
 
         no_out = ([''], None)
 
-        ring_out = (['Process 0 sending 10', '1 processes in ring',
-                     'Process 0 sent to', 'Process 0 decremented value:',
-                     'exiting'], None)
-
-        shift_out = (['Process 0 gets message from', '1 processes in ring'],
-                      'exiting'], None)
+        ring_out = (['1 processes in ring', '0 exiting'], None)
 
         strided = (['not in valid range'], 255)
 
@@ -658,7 +653,7 @@ class Openmpi(AutotoolsPackage):
             'hello_oshmemfh': hello_world if have_spml else missing_spml,
             'hello_usempi': hello_world,
             'hello_usempif08': hello_world,
-            'oshmem_circular_shift': shift_out if have_spml else missing_spml,
+            'oshmem_circular_shift': ring_out if have_spml else missing_spml,
             'oshmem_max_reduction': max_red if have_spml else missing_spml,
             'oshmem_shmalloc': no_out if have_spml else missing_spml,
             'oshmem_strided_puts': strided if have_spml else missing_spml,
@@ -666,8 +661,8 @@ class Openmpi(AutotoolsPackage):
             'ring_c': ring_out,
             'ring_cxx': ring_out,
             'ring_mpifh': ring_out,
-            'ring_oshmem': shift_out if have_spml else missing_spml,
-            'ring_oshmemfh': shift_out if have_spml else missing_spml,
+            'ring_oshmem': ring_out if have_spml else missing_spml,
+            'ring_oshmemfh': ring_out if have_spml else missing_spml,
             'ring_usempi': ring_out,
             'ring_usempif08': ring_out,
         }

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -633,12 +633,12 @@ class Openmpi(AutotoolsPackage):
             'Expected only one package directory'
 
         # First build the examples
-        work_dir = os.path.join(self.test_dir, self.test_pkg_dirs[0])
+        work_dir = os.path.join(self.install_test_root, self.test_pkg_dirs[0])
         self.run_test('make', ['all'], [], None, False,
                       purpose='test build the examples', work_dir=work_dir)
 
         # Now run those with known results
-        have_spml = self.spec.version in spack.version.ver('2.0.0:2.1.6')
+        have_spml = self.spec.satisfies('@2.0.0:2.1.6')
 
         hello_world = (['Hello, world', 'I am', '0 of', '1'], None)
 
@@ -683,7 +683,9 @@ class Openmpi(AutotoolsPackage):
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        if self.spec.version not in spack.version.ver('2.0.0:4.0.3'):
+        tty.warn('Expected results currently based on simple openmpi builds')
+
+        if not self.spec.satisfies('@2.0.0:4.0.3'):
             tty.warn('Expected results have not been confirmed for {0} {1}'
                      .format(self.name, self.spec.version))
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -565,6 +565,27 @@ class Openmpi(AutotoolsPackage):
                 else:
                     copy(script_stub, exe)
 
+    def _test_bin_ops(self):
+        info = ([], ['Ident string: {0}'.format(self.spec.version), 'MCA'],
+                None)
+
+        ls = (['-n', '1', 'ls', '..'],
+              ['openmpi-{0}'.format(self.spec.version)], None)
+
+        checks = {
+            'mpirun': ls,
+            'ompi_info': info,
+            'oshmem_info': info,
+            'oshrun': ls,
+            'shmemrun': ls,
+        }
+
+        for exe in checks:
+            options, expected, status = checks[exe]
+            reason = 'test {0} output'.format(exe)
+            self.run_test(exe, options, expected, status, installed=True,
+                          purpose=reason, skip_missing=True)
+
     def _test_check_versions(self):
         comp_vers = str(self.spec.compiler.version)
         spec_vers = str(self.spec.version)
@@ -692,5 +713,8 @@ class Openmpi(AutotoolsPackage):
         # Simple version check tests on known packages
         self._test_check_versions()
 
-        # Test example programs pulled from the source
+        # Test the operation of selected executables
+        self._test_bin_ops()
+
+        # Test example programs pulled from the build
         self._test_examples()

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -567,8 +567,12 @@ class Openmpi(AutotoolsPackage):
 
     @run_after('install')
     def setup_install_tests(self):
-        self.copy_src_to_install(self.extra_install_tests,
-                                 self.extra_install_tests)
+        """
+        Copy the example files after the package is installed to an
+        install test subdirectory for use during `spack test run`.
+        """
+        self.cache_extra_test_source(self.extra_install_tests,
+                                     self.extra_install_tests)
 
     def _test_bin_ops(self):
         info = ([], ['Ident string: {0}'.format(self.spec.version), 'MCA'],

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -79,8 +79,6 @@ class Openmpi(AutotoolsPackage):
 
     version('develop', branch='master')
 
-    test_pkg_dirs = ['examples']
-
     # Current
     version('4.0.3', sha256='1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03')  # libmpi.so.40.20.3
 
@@ -565,6 +563,13 @@ class Openmpi(AutotoolsPackage):
                 else:
                     copy(script_stub, exe)
 
+    extra_install_tests = 'examples'
+
+    @run_after('install')
+    def setup_install_tests(self):
+        self.copy_src_to_install(self.extra_install_tests,
+                                 self.extra_install_tests)
+
     def _test_bin_ops(self):
         info = ([], ['Ident string: {0}'.format(self.spec.version), 'MCA'],
                 None)
@@ -650,11 +655,9 @@ class Openmpi(AutotoolsPackage):
                           purpose=purpose, skip_missing=True)
 
     def _test_examples(self):
-        assert len(self.test_pkg_dirs) == 1, \
-            'Expected only one package directory'
-
         # First build the examples
-        work_dir = os.path.join(self.install_test_root, self.test_pkg_dirs[0])
+        work_dir = os.path.join(self.install_test_root,
+                                self.extra_install_tests)
         self.run_test('make', ['all'], [], None, False,
                       purpose='test build the examples', work_dir=work_dir)
 


### PR DESCRIPTION
This PR supports grabbing one or more paths relative to the stage source directory during the installation process, caching them so available to run the tests as part of the smoke (or install)n test process.

TODO

- [x] Determine why test stage directories are no longer being retained
- [x] Determine why the tests are failing (requires at least the test output above be retained)
- [x] Finish testing examples against different version of openmpi
- [x] Move copying build files for testing from install testing to install
- [x] Change copying from `build_process` to a package-provided, after-phase function
- [x] Add `shmemrun ls` install test case
- [x] Rename `copy_src_to_install` to `cache_extra_test_source`
- [x] Add explanation of `cache_extra_test_source` to its docstring and an explanation in `openmpi/package.py` for its use of the method
- [x] Create `metadata_dir` for spec's `metadata_path`
- [x] Change `cache_extra_test_source` to accept a file ==> changed to accept a list of relative source paths
- [x] Change `cache_extra_test_source` to use `filesystem`'s `install_tree` instead of `shutil.copytree`
- [x] Add unit test of `cache_extra_test_source`
- [x] Add `test` subdirectory to the (test) metadata directory for the `install_test_root`
- [x] Replace function def with lambda for `skip_files`