### PR TITLE
py-pandas: add 1.0.X release

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -7,17 +7,12 @@ from spack import *
 
 
 class PyPandas(PythonPackage):
-    """pandas is a Python package providing fast, flexible, and expressive
-       data structures designed to make working with relational or
-       labeled data both easy and intuitive. It aims to be the
-       fundamental high-level building block for doing practical, real
-       world data analysis in Python. Additionally, it has the broader
-       goal of becoming the most powerful and flexible open source data
-       analysis / manipulation tool available in any language.
+    """pandas is a fast, powerful, flexible and easy to use open source
+    data analysis and manipulation tool, built on top of the Python
+    programming language."""
 
-    """
-    homepage = "http://pandas.pydata.org/"
-    url = "https://pypi.io/packages/source/p/pandas/pandas-0.25.1.tar.gz"
+    homepage = "https://pandas.pydata.org/"
+    url = "https://pypi.io/packages/source/p/pandas/pandas-1.0.3.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = [
@@ -34,6 +29,12 @@ class PyPandas(PythonPackage):
         'pandas.api.extensions'
     ]
 
+    version('1.0.3',  sha256='32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586')
+    version('1.0.2',  sha256='76334ba36aa42f93b6b47b79cbc32187d3a178a4ab1c3a478c8f4198bcd93a73')
+    version('1.0.1',  sha256='3c07765308f091d81b6735d4f2242bb43c332cc3461cae60543df6b10967fe27')
+    version('1.0.0',  sha256='3ea6cc86931f57f18b1240572216f09922d91b19ab8a01cf24734394a3db3bec')
+    version('0.25.3', sha256='52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4')
+    version('0.25.2', sha256='ca91a19d1f0a280874a24dca44aadce42da7f3a7edb7e9ab7c7baad8febee2be')
     version('0.25.1', sha256='cb2e197b7b0687becb026b84d3c242482f20cbb29a9981e43604eb67576da9f6')
     version('0.25.0', sha256='914341ad2d5b1ea522798efa4016430b66107d05781dbfe7cf05eba8f37df995')
     version('0.24.2', sha256='4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2')
@@ -47,9 +48,12 @@ class PyPandas(PythonPackage):
     version('0.16.1', sha256='570d243f8cb068bf780461b9225d2e7bef7c90aa10d43cf908fe541fc92df8b6')
     version('0.16.0', sha256='4013de6f8796ca9d2871218861823bd9878a8dfacd26e08ccf9afdd01bbad9f1')
 
-    # https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies
     # Required dependencies
+    # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#dependencies
+    depends_on('python@3.6.1:', type=('build', 'run'), when='@1:')
     depends_on('python@3.5.3:', type=('build', 'run'), when='@0.25:')
+    # https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#build-changes
+    depends_on('py-cython@0.29.13:', type='build', when='@1:')
     depends_on('py-setuptools@24.2.0:', type='build')
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-numpy@1.13.3:', type=('build', 'run'), when='@0.25:')
@@ -58,16 +62,18 @@ class PyPandas(PythonPackage):
     depends_on('py-pytz@2017.2:', type=('build', 'run'))
 
     # Recommended dependencies
+    # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#recommended-dependencies
     depends_on('py-numexpr', type=('build', 'run'))
     depends_on('py-numexpr@2.6.2:', type=('build', 'run'), when='@0.25:')
     depends_on('py-bottleneck', type=('build', 'run'))
     depends_on('py-bottleneck@1.2.1:', type=('build', 'run'), when='@0.25:')
 
     # Optional dependencies
-    # https://pandas.pydata.org/pandas-docs/stable/install.html#optional-dependencies
+    # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#optional-dependencies
 
     # Test dependencies
     # https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#running-the-test-suite
     depends_on('py-pytest@4.0.2:', type='test')
+    depends_on('py-pytest-xdist', type='test')
     depends_on('py-hypothesis@3.58:', type='test')
     depends_on('py-pyarrow@0.10.0:', type='test')


### PR DESCRIPTION
Pandas finally came out with a stable 1.0 release! Among other things, they plan on actually using SemVer from now on. See https://pandas.pydata.org/docs/whatsnew/v1.0.0.html for more changes.

Successfully installs on macOS 10.15.4 with Python 3.7.7 and Clang 11.0.3.