### PR TITLE
py-mypy: setuptools needed at run-time

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -15,7 +15,7 @@ class PyMypy(PythonPackage):
     version('0.740', sha256='48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d')
 
     depends_on('python@3.5:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-typed-ast@1.4.0:1.4.999', type=('build', 'run'))
     depends_on('py-typing-extensions@3.7.4:', type=('build', 'run'))
     depends_on('py-mypy-extensions@0.4.0:0.4.999', type=('build', 'run'))


### PR DESCRIPTION
Without this, I get:
```console
$ mypy
Traceback (most recent call last):
  File "/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/py-mypy-0.740-zcq2gsthloz6nkcyjjptlga23mvvm7j4/bin/mypy", line 7, in <module>
    from pkg_resources import load_entry_point
ModuleNotFoundError: No module named 'pkg_resources'
```