### PR TITLE
Spacktivate

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -304,6 +304,9 @@ _pretty_print() {
 
 complete -o bashdefault -o default -F _bash_completion_spack spack
 
+alias spacktivate="spack env activate"
+complete -o bashdefault -o default -F _bash_completion_spack spacktivate
+
 # Spack commands
 #
 # Everything below here is auto-generated.
@@ -314,6 +317,15 @@ _spack() {
         SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add arch blame bootstrap build build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config configure containerize create deactivate debug dependencies dependents deprecate dev-build diy docs edit env extensions fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test uninstall unload upload-s3 url verify versions view"
+    fi
+}
+
+_spacktivate() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --sh --csh -v --with-view -V --without-view -d --dir -p --prompt"
+    else
+        _environments
     fi
 }
 

--- a/var/spack/repos/builtin/packages/gdbm/gdbm_gcc_10.patch
+++ b/var/spack/repos/builtin/packages/gdbm/gdbm_gcc_10.patch
@@ -1,0 +1,11 @@
+--- gdbm-1.18.1/src/parseopt.c	2018-05-30 03:39:15.000000000 -0600
++++ gdbm-1.18.1_new/src/parseopt.c	2020-04-30 10:29:52.869582500 -0600
+@@ -255,8 +255,6 @@
+ }
+ 
+ char *parseopt_program_name;
+-char *parseopt_program_doc;
+-char *parseopt_program_args;
+ const char *program_bug_address = "<" PACKAGE_BUGREPORT ">";
+ void (*parseopt_help_hook) (FILE *stream);
+ 

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -26,6 +26,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     version('1.9',   sha256='f85324d7de3777db167581fd5d3493d2daa3e85e195a8ae9afc05b34551b6e57')
 
     depends_on("readline")
+    patch('gdbm_gcc_10.patch', when='%gcc@10:')
 
     def configure_args(self):
 


### PR DESCRIPTION
This PR adds support for a *spacktivate* alias with bash completion that is interpreted as *spack env activate*. I put it in the bash completion file because it is a *first-class* action, i.e., it needs to be recognized without *spack*, and it is always active (unlike *despacktivate*, which is only defined when an environment is active. If there is a better location, I'm happy to move it. @junghans @tgamblin 