### PR TITLE
arborx: fix build with new kokkos-legacy

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -36,7 +36,7 @@ class Arborx(CMakePackage):
         spec = self.spec
 
         options = [
-            '-DCMAKE_PREFIX_PATH=%s' % spec['kokkos'].prefix,
+            '-DCMAKE_PREFIX_PATH=%s' % spec['kokkos-legacy'].prefix,
             '-DARBORX_ENABLE_TESTS=OFF',
             '-DARBORX_ENABLE_EXAMPLES=OFF',
             '-DARBORX_ENABLE_BENCHMARKS=OFF',


### PR DESCRIPTION
Fix commit [598c233](https://github.com/spack/spack/commit/598c233f78d23329c0cc6c7bc86b7117dca7bacd)

After this fix, `spack install arborx` builds and installs successfully.