### PR TITLE
Added alias and bash completion for spacktivate

### DIFF
--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -304,6 +304,14 @@ _pretty_print() {
 
 complete -o bashdefault -o default -F _bash_completion_spack spack
 
+# Alias and completion for spacktivate
+alias spacktivate="spack env activate"
+complete -o bashdefault -o default -F _bash_completion_spack spacktivate
+
+_spacktivate() {
+  _spack_env_activate
+}
+
 # Spack commands
 #
 # Everything below here is auto-generated.

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -18,6 +18,7 @@ if ($?SPACK_ROOT) then
 
     # Command aliases point at separate source files
     alias spack          'set _sp_args = (\!*); source $_spack_share_dir/csh/spack.csh'
+    alias spacktivate    'spack env activate'
     alias _spack_pathadd 'set _pa_args = (\!*) && source $_spack_share_dir/csh/pathadd.csh'
 
     # Set variables needed by this script


### PR DESCRIPTION
This PR adds support for a `spacktivate` alias with bash completion that is interpreted as `spack env activate`. I put it in the bash completion file because it is a *first-class* action, i.e., it needs to be recognized without spack, and it is always active (unlike `despacktivate`, which is only defined when an environment is active). If there is a better location, or implementation, I'm happy to update this PR. The csh version is a simple alias.

@junghans @tgamblin