### PR TITLE
arborx: fix kokkos-legacy for +cuda option

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -36,7 +36,7 @@ class Arborx(CMakePackage):
         spec = self.spec
 
         options = [
-            '-DCMAKE_PREFIX_PATH=%s' % spec['kokkos'].prefix,
+            '-DCMAKE_PREFIX_PATH=%s' % spec['kokkos-legacy'].prefix,
             '-DARBORX_ENABLE_TESTS=OFF',
             '-DARBORX_ENABLE_EXAMPLES=OFF',
             '-DARBORX_ENABLE_BENCHMARKS=OFF',

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -44,7 +44,7 @@ class Arborx(CMakePackage):
         ]
 
         if '+cuda' in spec:
-            nvcc_wrapper_path = spec['kokkos'].prefix.bin.nvcc_wrapper
+            nvcc_wrapper_path = spec['kokkos-legacy'].prefix.bin.nvcc_wrapper
             options.append('-DCMAKE_CXX_COMPILER=%s' % nvcc_wrapper_path)
 
         return options


### PR DESCRIPTION
I missed this case in the previous fix, sorry.
Now `spack install arborx+cuda` also works.