### PR TITLE
Make source mirrors unique w.r.t. git options.

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -766,11 +766,14 @@ class GitFetchStrategy(VCSFetchStrategy):
         return self.commit or self.tag
 
     def mirror_id(self):
-        repo_ref = self.commit or self.tag or self.branch
-        if repo_ref:
-            repo_path = url_util.parse(self.url).path
-            result = os.path.sep.join(['git', repo_path, repo_ref])
-            return result
+        repo_ref = self.commit or self.tag or self.branch or 'HEAD'
+        if self.submodules:
+            repo_ref += '_submodules'
+        if self.get_full_repo:
+            repo_ref += '_full'
+        repo_path = url_util.parse(self.url).path
+        result = os.path.sep.join(['git', repo_path, repo_ref])
+        return result
 
     def _repo_info(self):
         args = ''

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -783,6 +783,21 @@ def mock_git_repository(tmpdir_factory):
             git('commit', '-m', 'mock-git-repo r0 {0}'.format(submodule_count))
 
     tmpdir = tmpdir_factory.mktemp('mock-git-repo-dir')
+    tmpdir.ensure("submodule", dir=True)
+    moddir = tmpdir.join("submodule")
+    with moddir.as_cwd():
+        git('init')
+        git('config', 'user.name', 'Spack')
+        git('config', 'user.email', 'spack@spack.io')
+
+        # s0 is just the first commit
+        s0_file = 's0_file'
+        moddir.ensure(s0_file)
+        git('add', s0_file)
+        git('commit', '-m', 'mock-git-submodule-repo s0')
+
+        url = 'file://' + str(moddir)
+
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
     repodir = tmpdir.join(spack.stage._source_path_subdir)
 
@@ -791,6 +806,10 @@ def mock_git_repository(tmpdir_factory):
         git('init')
         git('config', 'user.name', 'Spack')
         git('config', 'user.email', 'spack@spack.io')
+        git('submodule', 'add', url, 'submodule')
+        git('submodule', 'update', '--init', '--recursive')
+        git('add', '.gitmodules', 'submodule')
+        git('commit', '-m', 'add submodule')
         url = 'file://' + str(repodir)
         for number, suburl in suburls:
             git('submodule', 'add', suburl,

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -212,7 +212,7 @@ def test_get_full_repo(get_full_repo, git_version, mock_git_repository,
 
         if get_full_repo:
             assert(nbranches == 5)
-            assert(ncommits == 2)
+            assert(ncommits == 3)
         else:
             assert(nbranches == 2)
             assert(ncommits == 1)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -71,33 +71,35 @@ def check_mirror():
                     mirror_root, mirror_paths.storage_path)
                 assert os.path.exists(expected_path)
 
+            def compare(left, right):
+                dcmp = filecmp.dircmp(left, right)
+
+                # make sure there are no new files in the expanded
+                # tarball
+                assert not dcmp.right_only
+                # and that all original files are present.
+                assert all(l in exclude for l in dcmp.left_only)
+
+                for subdir in dcmp.common_dirs:
+                    compare(os.path.join(left, subdir),
+                            os.path.join(right, subdir))
+
             # Now try to fetch each package.
             for name, mock_repo in repos.items():
                 spec = Spec(name).concretized()
                 pkg = spec.package
 
                 with spack.config.override('config:checksum', False):
-                    with pkg.stage:
-                        pkg.do_stage(mirror_only=True)
+                    with Stage('baseline') as baseline:
+                        fetcher = pkg.fetcher[0]
+                        fetcher.set_stage(baseline)
+                        fetcher.fetch()
+                        fetcher.expand()
+                        original_path = baseline.source_path
 
-                        # Compare the original repo with the expanded archive
-                        original_path = mock_repo.path
-                        if 'svn' in name:
-                            # have to check out the svn repo to compare.
-                            original_path = os.path.join(
-                                mock_repo.path, 'checked_out')
-
-                            svn = which('svn', required=True)
-                            svn('checkout', mock_repo.url, original_path)
-
-                        dcmp = filecmp.dircmp(
-                            original_path, pkg.stage.source_path)
-
-                        # make sure there are no new files in the expanded
-                        # tarball
-                        assert not dcmp.right_only
-                        # and that all original files are present.
-                        assert all(l in exclude for l in dcmp.left_only)
+                        with pkg.stage:
+                            pkg.do_stage(mirror_only=True)
+                            compare(original_path, pkg.stage.source_path)
 
 
 def test_url_mirror(mock_archive):
@@ -110,6 +112,7 @@ def test_url_mirror(mock_archive):
     not which('git'), reason='requires git to be installed')
 def test_git_mirror(mock_git_repository):
     set_up_package('git-test', mock_git_repository, 'git')
+    set_up_package('git-test-full', mock_git_repository, 'git')
     check_mirror()
     repos.clear()
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -92,7 +92,7 @@ def check_mirror():
                 with spack.config.override('config:checksum', False):
                     with Stage('baseline') as baseline:
                         fetcher = pkg.fetcher[0]
-                        fetcher.set_stage(baseline)
+                        fetcher.stage = baseline
                         fetcher.fetch()
                         fetcher.expand()
                         original_path = baseline.source_path

--- a/var/spack/repos/builtin.mock/packages/git-test-full/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-test-full/package.py
@@ -6,8 +6,11 @@
 from spack import *
 
 
-class GitTest(Package):
+class GitTestFull(Package):
     """Mock package that uses git for fetching."""
     homepage = "http://www.git-fetch-example.com"
 
-    version('git', branch='master', git='to-be-filled-in-by-test')
+    version('git', branch='master', git='to-be-filled-in-by-test', submodules=True)
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
Packages using the same git repository but specifying different values
to the options `submodules` or `get_full_repo` in multiple packages,
source mirrors would be populated with one cache tarball only,
potentially missing part of the required source tree.

Augment the `mirror_id` for `GitFetchStrategy` to reflect option values.