### PR TITLE
LAPACKC++: Shared Control

### DIFF
--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -16,8 +16,16 @@ class Lapackpp(CMakePackage):
 
     version('develop', hg=hg, revision="7ffa486")
 
+    variant('shared', default=True,
+            description='Build a shared version of the library')
+
     depends_on('blaspp')
 
     def cmake_args(self):
-        return ['-DBUILD_LAPACKPP_TESTS:BOOL={0}'.format(
-            'ON' if self.run_tests else 'OFF')]
+        spec = self.spec
+        return [
+            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
+                'ON' if '+shared' in spec else 'OFF'),
+            '-DBUILD_LAPACKPP_TESTS:BOOL={0}'.format(
+                'ON' if self.run_tests else 'OFF')
+        ]


### PR DESCRIPTION
We can control the shared/static build of CMake and [by convention in Spack](https://spack.readthedocs.io/en/latest/packaging_guide.html#style-guidelines-for-packages) one builds shared libraries by default. The old, uncontrolled default of this package is a static build (CMake default).

Ping @teonnik @Sely85 for review :)

Side note: the static build leads to the following linker error when using `lapackpp` downstream (not addressed with this PR):
```
  >> 871    /usr/bin/ld: opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/lapackpp-develop-i67yw6xhv4m6tqm6bqcsqqsqxnquskd5/lib/liblapackpp.a(gesvd.cc.o): undefined reference to symbol 
            'cgesvd_'
  >> 872    opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/openblas-0.3.9-ai3wimvj7brav75ug24n52e3fojn3awy/lib/libopenblas.so.0: error adding symbols: DSO missing from command line
  >> 873    collect2: error: ld returned 1 exit status
```