### PR TITLE
add hydra/pmix conflict to mpich

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -144,6 +144,7 @@ spack package at this time.''',
     conflicts('netmod=tcp', when='device=ch4')
     conflicts('pmi=pmi2', when='device=ch3 netmod=ofi')
     conflicts('pmi=pmix', when='device=ch3')
+    conflicts('pmi=pmix', when='+hydra')
 
     # MPICH does not require libxml2 and libpciaccess for versions before 3.3
     # when ~hydra is set: prevent users from setting +libxml2 and +pci in this


### PR DESCRIPTION
`MPICH` will silently disable hydra if it is configured to use `PMIx` leading to the `+hydra` and `~hydra` builds being the same in this context. Moreover, Hydra itself does not support `PMIx`. 

Reference : https://lists.mpich.org/pipermail/discuss/2019-December/005841.html

For confirmation of the missing hydra libraries with a `pmi=pmix +hydra` build on develop : 
```
[sas4990@quser10 ~]$ spack find -lv mpich target=ivybridge %gcc@9.3.0
==> 2 installed packages
-- linux-rhel7-ivybridge / gcc@9.3.0 ----------------------------
bt2izlg mpich@develop device=ch4 ~hydra+libxml2 netmod=ucx +pci pmi=pmix +romio+slurm~verbs+wrapperrpath
2votpqi mpich@develop device=ch4 +hydra+libxml2 netmod=ucx +pci pmi=pmix +romio+slurm~verbs+wrapperrpath
[sas4990@quser10 ~]$ ls $(spack location -i /bt2)/bin
mpic++@  mpicc*  mpichversion*  mpicxx*  mpif77@  mpif90@  mpifort*  mpivars*  parkill*
[sas4990@quser10 ~]$ ls $(spack location -i /2vo)/bin
mpic++@  mpicc*  mpichversion*  mpicxx*  mpif77@  mpif90@  mpifort*  mpivars*  parkill*
[sas4990@quser10 ~]$
```
If one sets `pmi=pmi2+hydra`, things work as expected : 
```
[sas4990@quser10 ~]$ spack find -lv mpich pmi=pmi2 %gcc@9.3.0
==> 1 installed package
-- linux-rhel7-haswell / gcc@9.3.0 ------------------------------
apq5h2h mpich@3.3.2 device=ch4 +hydra+libxml2 netmod=ucx +pci pmi=pmi2 +romio+slurm~verbs+wrapperrpath
[sas4990@quser10 ~]$ ls $(spack location -i /apq)/bin
hydra_nameserver*  hydra_pmi_proxy*  mpicc*         mpicxx*   mpiexec.hydra*  mpif90@   mpirun@   parkill*
hydra_persist*     mpic++@           mpichversion*  mpiexec@  mpif77@         mpifort*  mpivars*
[sas4990@quser10 ~]$
``` 