### PR TITLE
Testing: fix unintended interactions between tests, part 2

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -159,7 +159,19 @@ def compiler_list(args):
     tty.msg("Available compilers")
     index = index_by(spack.compilers.all_compilers(scope=args.scope),
                      lambda c: (c.spec.name, c.operating_system, c.target))
-    ordered_sections = sorted(index.items(), key=lambda item: item[0])
+
+    # For a container, take each element which does not evaluate to false and
+    # convert it to a string. For elements which evaluate to False (e.g. None)
+    # convert them to '' (in which case it still evaluates to False but is a
+    # string type). Tuples produced by this are guaranteed to be comparable in
+    # Python 3
+    convert_str = (
+        lambda tuple_container:
+        tuple(str(x) if x else '' for x in tuple_container))
+
+    index_str_keys = list(
+        (convert_str(x), y) for x, y in index.items())
+    ordered_sections = sorted(index_str_keys, key=lambda item: item[0])
     for i, (key, compilers) in enumerate(ordered_sections):
         if i >= 1:
             print()

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -722,8 +722,8 @@ def test_cdash_auth_token(tmpdir, install_mockery, capfd):
 
 
 def test_compiler_bootstrap(
-        install_mockery_mutable_config, mock_packages, mock_fetch, mock_archive,
-        mutable_config, monkeypatch):
+        install_mockery_mutable_config, mock_packages, mock_fetch,
+        mock_archive, mutable_config, monkeypatch):
     monkeypatch.setattr(spack.concretize.Concretizer,
                         'check_for_compiler_existence', False)
     spack.config.set('config:install_missing_compilers', True)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -547,7 +547,7 @@ def test_cdash_buildstamp_param(tmpdir, mock_fetch, install_mockery, capfd):
 @pytest.mark.disable_clean_stage_check
 def test_cdash_install_from_spec_yaml(tmpdir, mock_fetch, install_mockery,
                                       capfd, mock_packages, mock_archive,
-                                      config):
+                                      mutable_config):
     # capfd interferes with Spack's capturing
     with capfd.disabled():
         with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -547,7 +547,7 @@ def test_cdash_buildstamp_param(tmpdir, mock_fetch, install_mockery, capfd):
 @pytest.mark.disable_clean_stage_check
 def test_cdash_install_from_spec_yaml(tmpdir, mock_fetch, install_mockery,
                                       capfd, mock_packages, mock_archive,
-                                      mutable_config):
+                                      config):
     # capfd interferes with Spack's capturing
     with capfd.disabled():
         with tmpdir.as_cwd():
@@ -722,7 +722,7 @@ def test_cdash_auth_token(tmpdir, install_mockery, capfd):
 
 
 def test_compiler_bootstrap(
-        install_mockery, mock_packages, mock_fetch, mock_archive,
+        install_mockery_mutable_config, mock_packages, mock_fetch, mock_archive,
         mutable_config, monkeypatch):
     monkeypatch.setattr(spack.concretize.Concretizer,
                         'check_for_compiler_existence', False)
@@ -735,8 +735,8 @@ def test_compiler_bootstrap(
 
 @pytest.mark.regression('16221')
 def test_compiler_bootstrap_already_installed(
-        install_mockery, mock_packages, mock_fetch, mock_archive,
-        mutable_config, monkeypatch):
+        install_mockery_mutable_config, mock_packages, mock_fetch,
+        mock_archive, mutable_config, monkeypatch):
     monkeypatch.setattr(spack.concretize.Concretizer,
                         'check_for_compiler_existence', False)
     spack.config.set('config:install_missing_compilers', True)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -12,7 +12,6 @@ import spack.repo
 
 from spack.concretize import find_spec, NoValidVersionError
 from spack.error import SpecError
-from spack.package_prefs import PackagePrefs
 from spack.spec import Spec, CompilerSpec, ConflictsInSpecError
 from spack.version import ver
 from spack.util.mock_package import MockPackageMultiRepo
@@ -103,8 +102,6 @@ def current_host(request, monkeypatch):
         monkeypatch.setattr(spack.platforms.test.Test, 'default', cpu)
         yield target
     else:
-        # There's a cache that needs to be cleared for unit tests
-        PackagePrefs._packages_config_cache = None
         with spack.config.override('packages:all', {'target': [cpu]}):
             yield target
 
@@ -112,7 +109,10 @@ def current_host(request, monkeypatch):
     spack.architecture.get_platform.cache.clear()
 
 
-@pytest.mark.usefixtures('config', 'mock_packages')
+# This must use the mutable_config fixture because the test
+# adjusting_default_target_based_on_compiler uses the current_host fixture,
+# which changes the config.
+@pytest.mark.usefixtures('mutable_config', 'mock_packages')
 class TestConcretize(object):
     def test_concretize(self, spec):
         check_concretize(spec)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -100,7 +100,7 @@ class TestConcretizePreferences(object):
         # Try the last available compiler
         compiler = str(compiler_list[-1])
         update_packages('mpileaks', 'compiler', [compiler])
-        spec = concretize('mpileaks')
+        spec = concretize('mpileaks os=redhat6 target=x86')
         assert spec.compiler == spack.spec.CompilerSpec(compiler)
 
     def test_preferred_target(self, mutable_mock_repo):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -423,13 +423,13 @@ def config(mock_configuration):
 
 
 @pytest.fixture(scope='function')
-def mutable_config(tmpdir_factory, configuration_dir, monkeypatch):
+def mutable_config(tmpdir_factory, configuration_dir):
     """Like config, but tests can modify the configuration."""
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     configuration_dir.copy(mutable_dir)
 
     cfg = spack.config.Configuration(
-        *[spack.config.ConfigScope(name, str(mutable_dir))
+        *[spack.config.ConfigScope(name, str(mutable_dir.join(name)))
           for name in ['site', 'system', 'user']])
 
     with use_configuration(cfg):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -589,7 +589,7 @@ def disable_compiler_execution(monkeypatch):
 
 
 @pytest.fixture(scope='function')
-def install_mockery(tmpdir, config, mock_packages, monkeypatch):
+def install_mockery(tmpdir, mutable_config, mock_packages, monkeypatch):
     """Hooks a fake install directory, DB, and stage directory into Spack."""
     real_store = spack.store.store
     spack.store.store = spack.store.Store(str(tmpdir.join('opt')))

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -589,7 +589,22 @@ def disable_compiler_execution(monkeypatch):
 
 
 @pytest.fixture(scope='function')
-def install_mockery(tmpdir, mutable_config, mock_packages, monkeypatch):
+def install_mockery(tmpdir, config, mock_packages, monkeypatch):
+    """Hooks a fake install directory, DB, and stage directory into Spack."""
+    real_store = spack.store.store
+    spack.store.store = spack.store.Store(str(tmpdir.join('opt')))
+
+    # We use a fake package, so temporarily disable checksumming
+    with spack.config.override('config:checksum', False):
+        yield
+
+    tmpdir.join('opt').remove()
+    spack.store.store = real_store
+
+
+@pytest.fixture(scope='function')
+def install_mockery_mutable_config(
+        tmpdir, mutable_config, mock_packages, monkeypatch):
     """Hooks a fake install directory, DB, and stage directory into Spack."""
     real_store = spack.store.store
     spack.store.store = spack.store.Store(str(tmpdir.join('opt')))

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -605,7 +605,12 @@ def install_mockery(tmpdir, config, mock_packages, monkeypatch):
 @pytest.fixture(scope='function')
 def install_mockery_mutable_config(
         tmpdir, mutable_config, mock_packages, monkeypatch):
-    """Hooks a fake install directory, DB, and stage directory into Spack."""
+    """Hooks a fake install directory, DB, and stage directory into Spack.
+
+    This is specifically for tests which want to use 'install_mockery' but
+    also need to modify configuration (and hence would want to use
+    'mutable config'): 'install_mockery' does not support this.
+    """
     real_store = spack.store.store
     spack.store.store = spack.store.Store(str(tmpdir.join('opt')))
 

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  all:
+    providers:
+      mpi: [openmpi, mpich]
   externaltool:
     buildable: False
     paths:


### PR DESCRIPTION
https://github.com/spack/spack/pull/16003 addressed some unintended interference between unit tests. It appears that https://github.com/spack/spack/pull/16221 was merged during this time and introduces new unit tests which don't interact well with the fixes. This will reintroduce all changes from #16003 plus whatever is needed to get those changes working with #16221

For now this is just the original changes (and I have marked this WIP). But I think it will be useful to create this thread to track the issue.