### PR TITLE
singularity: Add more Dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -40,9 +40,12 @@ class Singularity(MakefilePackage):
 
     variant('suid', default=True, description='install SUID binary')
     variant('network', default=True, description='install network plugins')
+
+    depends_on('pkgconfig', type='build')
     depends_on('go')
     depends_on('libuuid')
     depends_on('libgpg-error')
+    depends_on('libseccomp')
     depends_on('squashfs', type='run')
     depends_on('git', when='@develop')  # mconfig uses it for version info
     depends_on('shadow', type='run', when='@3.3:')


### PR DESCRIPTION
Without `pkgconfig` and `libseccomp` the build fails on one of my systems.

Maintainer-ping: @alalazo