### PR TITLE
all_urls: add urls[0] for versions

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2011,6 +2011,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if hasattr(self, 'url') and self.url:
             urls.append(self.url)
 
+        # fetch from first entry in urls to save time
+        if hasattr(self, 'urls') and self.urls:
+            urls.append(self.urls[0])
+
         for args in self.versions.values():
             if 'url' in args:
                 urls.append(args['url'])


### PR DESCRIPTION
This adds the `url` alternative `urls` to `package.all_urls`. With this addition, one can find again new versions with `spack versions <package>` for packages that are populated with from mixin mirror `urls`.

Example: `util-macros` from x.org mixin.