### PR TITLE
py-cartopy: update package, fix PROJ.6 support

### DIFF
--- a/var/spack/repos/builtin/packages/py-cartopy/package.py
+++ b/var/spack/repos/builtin/packages/py-cartopy/package.py
@@ -9,12 +9,20 @@ from spack import *
 class PyCartopy(PythonPackage):
     """Cartopy - a cartographic python library with matplotlib support."""
 
-    homepage = "http://scitools.org.uk/cartopy/"
-    url      = "https://github.com/SciTools/cartopy/archive/v0.16.0.tar.gz"
+    homepage = "https://scitools.org.uk/cartopy/docs/latest/"
+    url      = "https://github.com/SciTools/cartopy/archive/v0.17.0.tar.gz"
+
+    maintainers = ['adamjstewart']
+    import_modules = [
+        'cartopy', 'cartopy.sphinxext', 'cartopy.io', 'cartopy.geodesic',
+        'cartopy.examples', 'cartopy.mpl', 'cartopy.feature',
+    ]
 
     version('0.17.0', sha256='137642e63952404ec0841fa0333ad14c58fbbf19cca2a5ac6a38498c4b4998fb')
     version('0.16.0', sha256='cadf62434492c965220b37f0548bc58180466ad6894a1db57dbc51cd43467e5c')
 
+    # https://scitools.org.uk/cartopy/docs/latest/installing.html#installing
+    depends_on('python@2.7:', type=('build', 'run'))
     depends_on('py-setuptools@0.7.2:', type='build')
     depends_on('py-cython@0.15.1:',    type='build')
     depends_on('py-numpy@1.10.0:',  type=('build', 'run'))
@@ -25,11 +33,11 @@ class PyCartopy(PythonPackage):
     depends_on('proj@4.9.0:5', when='@0.16.0')
     depends_on('proj@4.9:',    when='@0.17.0')
 
-    variant('epsg', default=True, description='Add support for epsg.io')
-    variant('ows', default=True, description='Add support for Open Geospatial Consortium (OGC) web service')
-    variant('plotting', default=True, description='Add plotting functionality')
+    variant('epsg', default=False, description='Add support for epsg.io')
+    variant('ows', default=False, description='Add support for Open Geospatial Consortium (OGC) web service')
+    variant('plotting', default=False, description='Add plotting functionality')
 
-    # optional dependecies
+    # Optional dependecies
     depends_on('py-matplotlib@1.5.1:', type=('build', 'run'), when='+plotting')
     depends_on('gdal@1.10.0:+python',  type=('build', 'run'), when='+plotting')
     depends_on('py-pillow@1.7.8:',     type=('build', 'run'), when='+ows')
@@ -38,19 +46,34 @@ class PyCartopy(PythonPackage):
     depends_on('py-scipy@0.10:',       type=('build', 'run'), when='+plotting')
     depends_on('py-owslib@0.8.11:',    type=('build', 'run'), when='+ows')
 
-    # testing dependencies
+    # Testing dependencies
     depends_on('py-filelock',      type='test')
-    depends_on('py-mock@1.0.1',    type='test')
+    depends_on('py-mock@1.0.1:',   type='test')
     depends_on('py-pytest@3.0.0:', type='test')
+
+    patch('proj6.patch', when='@0.17.0')
 
     phases = ['build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
-        args = ['-I{0}'.format(spec['proj'].prefix.include),
-                '-L{0}'.format(spec['proj'].prefix.lib)
-                ]
+        args = [
+            spec['geos'].headers.include_flags,
+            spec['geos'].libs.search_flags,
+            spec['proj'].headers.include_flags,
+            spec['proj'].libs.search_flags,
+        ]
 
-        if spec.satisfies('@0.17.0 ^proj@6'):
-            args.append('-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H')
+        if '+plotting' in spec:
+            args.extend([
+                spec['gdal'].headers.include_flags,
+                spec['gdal'].libs.search_flags,
+            ])
 
         return args
+
+    # Tests need to be re-added since `phases` was overridden
+    run_after('build_ext')(
+        PythonPackage._run_default_build_time_test_callbacks)
+    run_after('install')(
+        PythonPackage._run_default_install_time_test_callbacks)
+    run_after('install')(PythonPackage.sanity_check_prefix)

--- a/var/spack/repos/builtin/packages/py-cartopy/proj6.patch
+++ b/var/spack/repos/builtin/packages/py-cartopy/proj6.patch
@@ -1,0 +1,109 @@
+# Fix PROJ.6 support
+# Adapted from https://github.com/SciTools/cartopy/pull/1289
+--- a/setup.py	2020-05-02 17:50:37.000000000 -0500
++++ b/setup.py	2020-05-02 18:02:04.000000000 -0500
+@@ -16,25 +16,25 @@
+ # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+ from __future__ import print_function
+ 
+-"""
+-Distribution definition for Cartopy.
+-
+-"""
+-
+-import setuptools
+-from setuptools import setup, Extension
+-from setuptools import Command
+-from setuptools import convert_path
+-from distutils.spawn import find_executable
+-from distutils.sysconfig import get_config_var
+ import fnmatch
+ import os
+ import subprocess
+ import sys
+ import warnings
++from collections import defaultdict
++from distutils.spawn import find_executable
++from distutils.sysconfig import get_config_var
++
++from setuptools import Command, Extension, convert_path, setup
+ 
+ import versioneer
+ 
++"""
++Distribution definition for Cartopy.
++"""
++
++
++
+ 
+ try:
+     from Cython.Distutils import build_ext
+@@ -230,6 +230,18 @@
+     return proj_version
+ 
+ 
++def get_proj_libraries():
++    """
++    This function gets the PROJ libraries to cythonize with
++    """
++    proj_libraries = ["proj"]
++    if os.name == "nt" and proj_version >= (6, 0, 0):
++        proj_libraries = [
++            "proj_{}_{}".format(proj_version[0], proj_version[1])
++        ]
++    return proj_libraries
++
++
+ conda = os.getenv('CONDA_DEFAULT_ENV')
+ if conda is not None and conda in sys.prefix:
+     # Conda does not provide pkg-config compatibility, but the search paths
+@@ -245,7 +257,7 @@
+         exit(1)
+ 
+     proj_includes = []
+-    proj_libraries = ['proj']
++    proj_libraries = get_proj_libraries()
+     proj_library_dirs = []
+ 
+ else:
+@@ -268,7 +280,7 @@
+             exit(1)
+ 
+         proj_includes = []
+-        proj_libraries = ['proj']
++        proj_libraries = get_proj_libraries()
+         proj_library_dirs = []
+     else:
+         if proj_version < PROJ_MIN_VERSION:
+@@ -284,7 +296,7 @@
+             proj_clibs = proj_clibs.decode()
+ 
+         proj_includes = [proj_include[2:] if proj_include.startswith('-I') else
+-                         proj_include for proj_include in proj_includes.split()]      
++                         proj_include for proj_include in proj_includes.split()]
+ 
+         proj_libraries = []
+         proj_library_dirs = []
+@@ -316,11 +328,16 @@
+         return '.'
+ include_dir = get_config_var('INCLUDEDIR')
+ library_dir = get_config_var('LIBDIR')
+-if sys.platform.startswith('win'):
+-    extra_extension_args = {}
+-else:
+-    extra_extension_args = dict(
+-        runtime_library_dirs=[get_config_var('LIBDIR')])
++extra_extension_args = defaultdict(list)
++if not sys.platform.startswith('win'):
++    extra_extension_args["runtime_library_dirs"].append(
++        get_config_var('LIBDIR')
++    )
++
++if proj_version >= (6, 0, 0):
++    extra_extension_args["define_macros"].append(
++        ('ACCEPT_USE_OF_DEPRECATED_PROJ_API_H', '1')
++    )
+ 
+ # Description
+ # ===========


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.15.4 with Python 3.7.7, PROJ 6.3.1, GEOS 3.7.2, and Clang 11.0.3.

Contains the following changes:

- [x] Add myself as a maintainer
- [x] Add import modules test
- [x] Specify supported versions of Python
- [x] Disable all variants by default, minimize unnecessary deps
- [x] Change required mock version to 1.0.1+
- [x] Add patch for PROJ.6 support, previous logic did not work
- [x] Use Spack to query proj/geos library/header directories
- [x] Ensure unit tests are actually run

Correctly RPATHs to Spack-installed libraries:
```console
$ otool -L $(find . -name '*.so') | sort | uniq
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/geos-3.7.2-ai26sz7duiqfarqfkgx3fglcvpcki2on/lib/libgeos_c.1.dylib (compatibility version 13.0.0, current version 13.2.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/proj-6.3.1-kfr7fwzmklwhqbnq7u5cxxgsti5wuhol/lib/libproj.15.dylib (compatibility version 19.0.0, current version 19.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 902.1.0)
```

@citibeth may be interested in this.