### PR TITLE
spack load: add useful user-facing features

### DIFF
--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -55,7 +55,9 @@ the dependencies"""
 
 def load(parser, args):
     env = ev.get_env(args, 'load')
-    specs = [spack.cmd.disambiguate_spec(spec, env, first=args.load_first)
+    specs = [spack.cmd.disambiguate_spec(spec, env, first=args.load_first,
+                                         compatible=True,
+                                         preferred=True)
              for spec in spack.cmd.parse_specs(args.specs)]
 
     if not args.shell:


### PR DESCRIPTION
A number of suggestions came out of conversations with our user-facing
folks regarding how "spack load" should (perhaps) work.

1.) Expressly search for packages that are compatible with
    packages already loaded.
2.) Use information in packages.yaml to help narrow down results.
3.) If no packages are located that are fit for use, calculate
     what one would look like and provide a yaml file that can
     be used to build one.