### PR TITLE
Updates to Python for macOS

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -84,8 +84,9 @@ class Python(AutotoolsPackage):
     )
 
     # --enable-shared is known to cause problems for some users on macOS
+    # This is a problem for Python 2.7 only, not Python3
     # See http://bugs.python.org/issue29846
-    variant('shared', default=sys.platform != 'darwin',
+    variant('shared', default=True,
             description='Enable shared libraries')
     # From https://docs.python.org/2/c-api/unicode.html: Python's default
     # builds use a 16-bit type for Py_UNICODE and store Unicode values


### PR DESCRIPTION
Defaults back to `shared=True`.  The "fix" for macOS was only needed for Python 2.7, which is now EOL.  And the fix itself caused problems for certain things that depend on Python.  Once I discovered this, I had to rebuild Python itself and then most of my software stack.

If there were a way to default to `shared=False` for macOS but ONLY for `python@2.7`, that would be best.  Otherwise, I think that removing the "fix" (but leaving explanatory comments) is best.