### PR TITLE
cctools to 7.1.5

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -13,7 +13,7 @@ class Cctools(AutotoolsPackage):
     """
 
     homepage = "https://cctools.readthedocs.io"
-    url      = "http://ccl.cse.nd.edu/software/files/cctools-7.1.5-source.tar.gz"
+    url      = "https://ccl.cse.nd.edu/software/files/cctools-7.1.5-source.tar.gz"
 
     version('7.1.5', sha256='c01415fd47a1d9626b6c556e0dc0a6b0d3cd67224fa060cabd44ff78eede1d8a')
     version('7.1.3', sha256='b937878ab429dda31bc692e5d9ffb402b9eb44bb674c07a934bb769cee4165ba')

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -12,7 +12,7 @@ class Cctools(AutotoolsPackage):
        machines from clusters, clouds, and grids.
     """
 
-    homepage = "https://github.com/cooperative-computing-lab/cctools"
+    homepage = "https://cctools.readthedocs.io"
     url      = "https://github.com/cooperative-computing-lab/cctools/archive/release/7.1.3.tar.gz"
 
     version('7.1.3', sha256='b937878ab429dda31bc692e5d9ffb402b9eb44bb674c07a934bb769cee4165ba')

--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -13,8 +13,9 @@ class Cctools(AutotoolsPackage):
     """
 
     homepage = "https://cctools.readthedocs.io"
-    url      = "https://github.com/cooperative-computing-lab/cctools/archive/release/7.1.3.tar.gz"
+    url      = "http://ccl.cse.nd.edu/software/files/cctools-7.1.5-source.tar.gz"
 
+    version('7.1.5', sha256='c01415fd47a1d9626b6c556e0dc0a6b0d3cd67224fa060cabd44ff78eede1d8a')
     version('7.1.3', sha256='b937878ab429dda31bc692e5d9ffb402b9eb44bb674c07a934bb769cee4165ba')
     version('7.1.2', sha256='ca871e9fe245d047d4c701271cf2b868e6e3a170e8834c1887157ed855985131')
     version('7.1.0', sha256='84748245db10ff26c0c0a7b9fd3ec20fbbb849dd4aadc5e8531fd1671abe7a81')


### PR DESCRIPTION
Updates cctools to version 7.1.5

Updates homepage and source url to match other distribution channels.
