### PR TITLE
BOLT: add 1.0

### DIFF
--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -23,10 +23,7 @@ class Bolt(CMakePackage):
     maintainers = ['shintaro-iwasaki']
 
     version("master", branch="master")
-    version("1.0rc3", sha256="beec522d26e74f0a562762ea5ae7805486a17b40013090ea1472f0c34c3379c8")
-    version("1.0rc2", sha256="662ab0bb9583e8d733e8af62a97b41828e8bfe4bd65902f1195b986901775a45")
-    version("1.0rc1", sha256="c08cde0695b9d1252ab152425be96eb29c70d764e3083e276c013804883a15a4")
-    version("1.0b1", sha256="fedba46ad2f8835dd1cec1a9a52bcc9d8923071dc40045d0360517d09cd1a57d")
+    version("1.0", sha256="1c0d2f75597485ca36335d313a73736594e75c8a36123c5a6f54d01b5ba5c384")
 
     depends_on('argobots')
     depends_on('autoconf', type='build')
@@ -36,7 +33,6 @@ class Bolt(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         options = [
-            '-DLIBOMP_USE_ITT_NOTIFY=off',
             '-DLIBOMP_USE_ARGOBOTS=on',
             '-DLIBOMP_ARGOBOTS_INSTALL_DIR=' + spec['argobots'].prefix
         ]


### PR DESCRIPTION
This PR adds a new version 1.0 of the BOLT package.
- We remove the old unstable versions since this 1.0 is the first stable release.
- We remove `-DLIBOMP_USE_ITT_NOTIFY=off` because it becomes unnecessary in the version 1.0.