### PR TITLE
Argobots: mark 1.0 as preferred

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -21,7 +21,8 @@ class Argobots(AutotoolsPackage):
     maintainers = ['shintaro-iwasaki']
 
     version("master", branch="master")
-    version("1.0", sha256="36a0815f7bf99900a9c9c1eef61ef9b3b76aa2cfc4594a304f6c8c3296da8def")
+    version("1.0", sha256="36a0815f7bf99900a9c9c1eef61ef9b3b76aa2cfc4594a304f6c8c3296da8def",
+            preferred=True)
     version("1.0rc2", sha256="7496b8bd39930a548b01aa3b1fe8f8b582c272600ef6a05ddc4398cf21dc12a2")
     version("1.0rc1", sha256="2dc4487556dce602655a6535f501136f0edc3575708029c80b1af6dccd069ce7")
     version("1.0b1", sha256="480b85b0e8db288400088a57c2dc5639f556843b06b0492841920c38348a2a3e")


### PR DESCRIPTION
Spack by default chooses `1.0rc2` instead of `1.0` though `1.0` is a stable and newer release.  We manually mark the version `1.0` as preferred.

Note that we want to avoid removing unstable versions (e.g., `rc2` ...) as suggested in https://github.com/spack/spack/pull/15786#discussion_r401788921 since `margo` package points to an old unstable version. I have contacted one of maintainers but it would require more time. We believe these unstable versions can be removed in the next update. 