### PR TITLE
CMake: Cray XC40 system errors bootstrapping CMake

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/ignore_crayxc_warnings.patch
+++ b/var/spack/repos/builtin/packages/cmake/ignore_crayxc_warnings.patch
@@ -1,0 +1,11 @@
+diff --git a/Source/Checks/cm_cxx_features.cmake b/Source/Checks/cm_cxx_features.cmake
+index fb68ed78c9..c6c1ba667f 100644
+--- a/Source/Checks/cm_cxx_features.cmake
++++ b/Source/Checks/cm_cxx_features.cmake
+@@ -17,2 +17,6 @@ function(cm_check_cxx_feature name)
+     set(check_output "${OUTPUT}")
++    # Filter out libhugetlbfs warnings
++    string(REGEX REPLACE "[^\n]*libhugetlbfs [^\n]*: WARNING[^\n]*" "" check_output "${check_output}")
++    # Filter out icpc warnings
++    string(REGEX REPLACE "[^\n]*icpc: command line warning #10121: overriding [^\n]*" "" check_output "${check_output}")
+     # Filter out MSBuild output that looks like a warning.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -135,7 +135,7 @@ class Cmake(Package):
     # Cray libhugetlbfs and icpc warnings failing CXX tests
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4698
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4681
-    patch('ignore_crayxc_warnings.patch', when='@3.7:3.17')
+    patch('ignore_crayxc_warnings.patch', when='@3.7:3.17.2')
 
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -132,6 +132,11 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/issues/18232
     patch('nag-response-files.patch', when='@3.7:3.12')
 
+    # Cray libhugetlbfs and icpc warnings failing CXX tests
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4698
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4681
+    patch('ignore_crayxc_warnings.patch', when='@3.7:3.17')
+
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166


### PR DESCRIPTION
Patch to CMake builtin package to Closes #16453  

Cray libhugetlbfs and icpc warnings failing CXX tests in CMake bootstrap for versions between v3.7 and v3.17 CMake;  The changes implement the modifications merged into release-3.17.3 of https://gitlab.kitware.com/cmake/cmake:
  https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4698
  https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4681

@chuckatkins 
