### PR TITLE
bugfix: Update run-time dependencies of py-xenv

### DIFF
--- a/var/spack/repos/builtin/packages/py-xenv/package.py
+++ b/var/spack/repos/builtin/packages/py-xenv/package.py
@@ -18,4 +18,4 @@ class PyXenv(PythonPackage):
     version('develop',            branch='master')
     version('develop_2018-12-20', commit='ddc3bf5e65e1689da499f639af7a27c5c4242841')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Otherwise, if I run `xenv` after `spack load py-xenv` it fails with:
```
Traceback (most recent call last):
  File "/home/vavolkl/spack/opt/spack/linux-centos7-broadwell/gcc-8.3.0/py-xenv-develop_2018-12-20-lqbxakapsepqo5w3sjhhokj5o7c5jei2/bin/xenv", line 6, in <module>
    from pkg_resources import load_entry_point
ModuleNotFoundError: No module named 'pkg_resources'
```