### PR TITLE
[dd4hep] fix runtime environment

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -41,7 +41,7 @@ class Dd4hep(CMakePackage):
     depends_on('cmake @3.12:', type='build')
     depends_on('boost @1.49:')
     depends_on('root @6.08: +gdml +math +opengl +python +x')
-    depends_on('python')
+    extends('python')
     depends_on('xerces-c', when='+xercesc')
     depends_on('geant4@10.2.2:', when='+geant4')
 


### PR DESCRIPTION
DD4hep  comes with some python modules that are installed under, p.ex `<prefix>/lib/python3.7/site-packages/`. This adds the runtime setup so that they can be used with `spack load dd4hep`