### PR TITLE
bugfix: reorder variants in Spec strings

### DIFF
--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -177,7 +177,7 @@ class TestSpecSyntax(object):
             " ^stackwalker@8.1_1e")
         self.check_parse(
             "mvapich_foo"
-            " ^_openmpi@1.2:1.4,1.6%intel@12.1 debug=2 ~qt_4"
+            " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2"
             " ^stackwalker@8.1_1e")
         self.check_parse(
             'mvapich_foo'
@@ -185,7 +185,7 @@ class TestSpecSyntax(object):
             ' ^stackwalker@8.1_1e')
         self.check_parse(
             "mvapich_foo"
-            " ^_openmpi@1.2:1.4,1.6%intel@12.1 debug=2 ~qt_4"
+            " ^_openmpi@1.2:1.4,1.6%intel@12.1~qt_4 debug=2"
             " ^stackwalker@8.1_1e arch=test-redhat6-x86")
 
     def test_canonicalize(self):

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -694,7 +694,7 @@ class TestVariantMapTest(object):
         c['foobar'] = SingleValuedVariant('foobar', 'fee')
         c['feebar'] = SingleValuedVariant('feebar', 'foo')
         c['shared'] = BoolValuedVariant('shared', True)
-        assert str(c) == ' feebar=foo foo=bar,baz foobar=fee +shared'
+        assert str(c) == '+shared feebar=foo foo=bar,baz foobar=fee'
 
 
 def test_disjoint_set_initialization_errors():

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -570,7 +570,7 @@ class VariantMap(lang.HashableMap):
         # Separate boolean variants from key-value pairs as they print
         # differently. All booleans go first to avoid ' ~foo' strings that
         # break spec reuse in zsh.
-        bool_keys= []
+        bool_keys = []
         kv_keys = []
         for key in sorted_keys:
             bool_keys.append(key) if isinstance(self[key].value, bool) \

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -567,25 +567,24 @@ class VariantMap(lang.HashableMap):
         # print keys in order
         sorted_keys = sorted(self.keys())
 
+        # Separate boolean variants from key-value pairs as they print
+        # differently. All booleans go first to avoid ' ~foo' strings that
+        # break spec reuse in zsh.
+        bool_keys= []
+        kv_keys = []
+        for key in sorted_keys:
+            bool_keys.append(key) if isinstance(self[key].value, bool) \
+                else kv_keys.append(key)
+
         # add spaces before and after key/value variants.
         string = StringIO()
 
-        kv = False
-        for key in sorted_keys:
-            vspec = self[key]
+        for key in bool_keys:
+            string.write(str(self[key]))
 
-            if not isinstance(vspec.value, bool):
-                # add space before all kv pairs.
-                string.write(' ')
-                kv = True
-            else:
-                # not a kv pair this time
-                if kv:
-                    # if it was LAST time, then pad after.
-                    string.write(' ')
-                kv = False
-
-            string.write(str(vspec))
+        for key in kv_keys:
+            string.write(' ')
+            string.write(str(self[key]))
 
         return string.getvalue()
 


### PR DESCRIPTION
Fixes #15362

Reorder variant strings so that ` ~foo` can never be printed in a spec. This avoids bugs in zsh when users try to reuse Specs. See #15362 for details.