### PR TITLE
Make usage example consistent with current MV variants

### DIFF
--- a/lib/spack/docs/build_systems/cudapackage.rst
+++ b/lib/spack/docs/build_systems/cudapackage.rst
@@ -37,7 +37,7 @@ In order to use it, just add another base class to your package, for example:
             if '+cuda' in spec:
                 options.append('-DWITH_CUDA=ON')
                 cuda_arch = spec.variants['cuda_arch'].value
-                if cuda_arch is not None:
+                if cuda_arch != 'none':
                     options.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch[0]))
             else:
                 options.append('-DWITH_CUDA=OFF')

--- a/var/spack/repos/builtin/packages/amgx/package.py
+++ b/var/spack/repos/builtin/packages/amgx/package.py
@@ -42,7 +42,7 @@ class Amgx(CMakePackage, CudaPackage):
         if '+cuda' in self.spec:
             args.append('-DWITH_CUDA=ON')
             cuda_arch = self.spec.variants['cuda_arch'].value
-            if cuda_arch is not None:
+            if cuda_arch != 'none':
                 args.append('-DCUDA_ARCH={0}'.format(cuda_arch[0]))
         else:
             args.append('-DWITH_CUDA=OFF')

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -150,7 +150,7 @@ class Lammps(CMakePackage, CudaPackage):
             args.append('-DPKG_GPU=ON')
             args.append('-DGPU_API=cuda')
             cuda_arch = spec.variants['cuda_arch'].value
-            if cuda_arch is not None:
+            if cuda_arch != 'none':
                 args.append('-DGPU_ARCH=sm_{0}'.format(cuda_arch[0]))
             args.append('-DCUDA_MPS_SUPPORT={0}'.format(
                 'ON' if '+cuda_mps' in spec else 'OFF'))


### PR DESCRIPTION
Since #9481 Python's None is not permitted as a value for MV variants. The string 'none' is used instead.