### PR TITLE
OpenBLAS: Fix LLVM 9.0.0 ICE on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas_appleclang11.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas_appleclang11.patch
@@ -1,0 +1,37 @@
+From 90dba9f71668c0de77b77f32462c78fbbd424db1 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Tue, 5 May 2020 10:44:50 +0200
+Subject: [PATCH] Duplicate earlier Clang 9.0.0 workaround for corresponding
+ Apple Clang version
+
+As discussed on the original PR #2329, the "Apple Clang 11.0.3" that appears to be based the same LLVM release produces the same miscompilation of this file.
+---
+ kernel/x86_64/dsymv_L_microk_skylakex-2.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/x86_64/dsymv_L_microk_skylakex-2.c b/kernel/x86_64/dsymv_L_microk_skylakex-2.c
+index bdcd914fb..f0df5aaa8 100644
+--- a/kernel/x86_64/dsymv_L_microk_skylakex-2.c
++++ b/kernel/x86_64/dsymv_L_microk_skylakex-2.c
+@@ -36,7 +36,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #if defined(__clang_patchlevel__) && __clang_major__ == 9 && __clang_minor__ == 0 && __clang_patchlevel__ == 0
+ #pragma clang optimize off
+ #endif
+-
++#if defined(__apple_build_version__) && __clang_major__ == 11 && __clang_minor__ == 0 && __clang_patchlevel__ == 3
++#pragma clang optimize off
++#endif
+ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FLOAT *y, FLOAT *temp1, FLOAT *temp2)
+ {
+
+@@ -164,6 +166,9 @@ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
+ #if defined(__clang_patchlevel__) && __clang_major__ == 9 && __clang_minor__ == 0 && __clang_patchlevel__ == 0
+ #pragma clang optimize on
+ #endif
++#if defined(__apple_build_version__) && __clang_major__ == 11 && __clang_minor__ == 0 && __clang_patchlevel__ == 3
++#pragma clang optimize on
++#endif
+
+ #else
+ #include "dsymv_L_microk_haswell-2.c"
+

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -92,6 +92,9 @@ class Openblas(MakefilePackage):
     # Fix https://github.com/xianyi/OpenBLAS/issues/2431
     # Patch derived from https://github.com/xianyi/OpenBLAS/pull/2424
     patch('openblas-0.3.8-darwin.patch', when='@0.3.8 platform=darwin')
+    # Fix ICE in LLVM 9.0.0 https://github.com/xianyi/OpenBLAS/pull/2329
+    # Patch as in https://github.com/xianyi/OpenBLAS/pull/2597
+    patch('openblas_appleclang11.patch', when='@0.3.8:0.3.9 %clang@11.0.3-apple')
 
     # Add conditions to f_check to determine the Fujitsu compiler
     patch('openblas_fujitsu.patch', when='%fj')


### PR DESCRIPTION
Recently added patch to port the LLVM 9.0.0 ICE with OpenBLAS and AVX-512 instructions as well to AppleClang (11.0.3).

This fixes the ICE on the latest macOS builds with OpenBLAS which in turn enables building `py-numpy` and the rest of the python stack again.

cc @rubendibattista @s-sajid-ali @LDAmorim 

Refs.:
- https://github.com/xianyi/OpenBLAS/pull/2329#issuecomment-623681496
- https://github.com/xianyi/OpenBLAS/pull/2597

