### PR TITLE
Increase coverage of spack.relocate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,25 @@ jobs:
       dist: trusty
       os: linux
       language: python
+      addons:
+        apt:
+          # Everything but patchelf, that is not available for trusty
+          packages:
+            - ccache
+            - cmake
+            - gfortran
+            - graphviz
+            - gnupg2
+            - kcov
+            - mercurial
+            - ninja-build
+            - perl
+            - perl-base
+            - realpath
+            - r-base
+            - r-base-core
+            - r-base-dev
+            - zsh
       env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '2.7'
       os: linux
@@ -84,6 +103,7 @@ addons:
       - kcov
       - mercurial
       - ninja-build
+      - patchelf
       - perl
       - perl-base
       - realpath

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -516,48 +516,6 @@ def _replace_prefix_bin(filename, old_dir, new_dir):
         f.truncate()
 
 
-def _replace_prefix_nullterm(filename, old_dir, new_dir):
-    """Replace all the occurrences of the old install prefix with a
-    new install prefix in binary files.
-
-    The new install prefix is suffixed with enough null termination
-    characters to make it the same length as the old one.
-
-    Does nothing if the old directory is shorter than the new one.
-
-    Args:
-        filename (str): target binary file
-        old_dir (str): directory to be searched in the file
-        new_dir (str): substitute for the old directory
-    """
-    def replace(match):
-        occurances = match.group().count(old_dir.encode('utf-8'))
-        olen = len(old_dir.encode('utf-8'))
-        nlen = len(new_dir.encode('utf-8'))
-        padding = (olen - nlen) * occurances
-        if padding < 0:
-            return data
-        return match.group().replace(old_dir.encode('utf-8'),
-                                     new_dir.encode('utf-8')) + b'\0' * padding
-
-    if len(new_dir) > len(old_dir):
-        raise BinaryTextReplaceError(old_dir, new_dir)
-
-    with open(filename, 'rb+') as f:
-        data = f.read()
-        f.seek(0)
-        original_data_len = len(data)
-        pat = re.compile(re.escape(old_dir).encode('utf-8') + b'([^\0]*?)\0')
-        if not pat.search(data):
-            return
-        ndata = pat.sub(replace, data)
-        if not len(ndata) == original_data_len:
-            raise BinaryStringReplacementError(
-                filename, original_data_len, len(ndata))
-        f.write(ndata)
-        f.truncate()
-
-
 def relocate_macho_binaries(path_names, old_layout_root, new_layout_root,
                             prefix_to_prefix, rel, old_prefix, new_prefix):
     """

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -415,21 +415,28 @@ def _set_elf_rpaths(target, rpaths):
 
 
 def needs_binary_relocation(m_type, m_subtype):
-    """
-    Check whether the given filetype is a binary that may need relocation.
+    """Returns True if the file with MIME type/subtype passed as arguments
+    needs binary relocation, False otherwise.
+
+    Args:
+        m_type (str): MIME type of the file
+        m_subtype (str): MIME subtype of the file
     """
     if m_type == 'application':
-        if (m_subtype == 'x-executable' or m_subtype == 'x-sharedlib' or
-                m_subtype == 'x-mach-binary'):
+        if m_subtype in ('x-executable', 'x-sharedlib', 'x-mach-binary'):
             return True
     return False
 
 
 def needs_text_relocation(m_type, m_subtype):
+    """Returns True if the file with MIME type/subtype passed as arguments
+    needs text relocation, False otherwise.
+
+    Args:
+        m_type (str): MIME type of the file
+        m_subtype (str): MIME subtype of the file
     """
-    Check whether the given filetype is text that may need relocation.
-    """
-    return (m_type == "text")
+    return m_type == 'text'
 
 
 def replace_prefix_text(path_name, old_dir, new_dir):

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -226,7 +226,6 @@ def test_replace_prefix_bin(hello_world):
     # Compile an "Hello world!" executable and set RPATHs
     gcc = spack.util.executable.which('gcc')
     executable = hello_world.dirpath('main.x')
-    os.path.abspath(hello_world)
     opts = [
         '-Wl,--disable-new-dtags',
         '-Wl,-rpath=/usr/lib:/usr/lib64',

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -194,3 +194,16 @@ def test_normalize_relative_paths(start_path, relative_paths, expected):
         start_path, relative_paths
     )
     assert normalized == expected
+
+
+def test_set_elf_rpaths(mock_patchelf):
+    # Try to relocate a mock version of patchelf and check
+    # the call made to patchelf itself
+    patchelf = mock_patchelf('echo $@')
+    rpaths = ['/usr/lib', '/usr/lib64', '/opt/local/lib']
+    output = spack.relocate._set_elf_rpaths(patchelf, rpaths)
+
+    # Assert that the arguments of the call to patchelf are as expected
+    assert '--force-rpath' in output
+    assert '--set-rpath ' + ':'.join(rpaths) in output
+    assert patchelf in output

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -221,6 +221,16 @@ def test_set_elf_rpaths(mock_patchelf):
     assert patchelf in output
 
 
+def test_set_elf_rpaths_warning(mock_patchelf):
+    # Mock a failing patchelf command and ensure it warns users
+    patchelf = mock_patchelf('exit 1')
+    rpaths = ['/usr/lib', '/usr/lib64', '/opt/local/lib']
+    # To avoid using capfd in order to check if the warning was triggered
+    # here we just check that output is not set
+    output = spack.relocate._set_elf_rpaths(patchelf, rpaths)
+    assert output is None
+
+
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 def test_replace_prefix_bin(hello_world):
     # Compile an "Hello world!" executable and set RPATHs


### PR DESCRIPTION
This PR:

- [x] Adds docstrings to a few functions involved in ELF relocation
- [x] Adds unit test to them
- [x] Adds `patchelf` to Travis to trigger tests depending on it

Continuation of #15610
