### PR TITLE
blis: FIX threads option, HPL: enable opemp variant for 2.3

### DIFF
--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -104,8 +104,9 @@ class BlisBase(Package):
 
     @property
     def libs(self):
-        return find_libraries(['libblis', 'libblis-mt'], root=self.prefix, recursive=True)
-
+        return find_libraries(
+            ["libblis", "libblis-mt"], root=self.prefix, recursive=True
+        )
 
 class Blis(BlisBase):
     """BLIS is a portable software framework for instantiating high-performance

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -104,7 +104,7 @@ class BlisBase(Package):
 
     @property
     def libs(self):
-        return find_libraries(['libblis'], root=self.prefix, recursive=True)
+        return find_libraries(['libblis', 'libblis-mt'], root=self.prefix, recursive=True)
 
 
 class Blis(BlisBase):

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -108,6 +108,7 @@ class BlisBase(Package):
             ["libblis", "libblis-mt"], root=self.prefix, recursive=True
         )
 
+
 class Blis(BlisBase):
     """BLIS is a portable software framework for instantiating high-performance
     BLAS-like dense linear algebra libraries.

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -102,7 +102,8 @@ class Hpl(AutotoolsPackage):
     @when('@2.3:')
     def configure_args(self):
         filter_file(
-            r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure"
+            r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags,
+            "configure"
         )
 
         if '+openmp' in self.spec:

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -101,9 +101,10 @@ class Hpl(AutotoolsPackage):
 
     @when('@2.3:')
     def configure_args(self):
-        config = [
-            'CFLAGS=-O3'
-        ]
+        if '+openmp' in spec:
+            config = ['CFLAGS=-O3 -fopenmp']
+        else:
+            config = ['CFLAGS=-O3']
 
         if (self.spec.satisfies('^intel-mkl') or
             self.spec.satisfies('^intel-parallel-studio+mkl')):

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -102,7 +102,7 @@ class Hpl(AutotoolsPackage):
     @when('@2.3:')
     def configure_args(self):
         if '+openmp' in spec:
-            config = ['CFLAGS=-O3 -fopenmp']
+            config = ['CFLAGS=-O3 ' + self.compiler.openmp_flag]
         else:
             config = ['CFLAGS=-O3']
 

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -101,7 +101,9 @@ class Hpl(AutotoolsPackage):
 
     @when('@2.3:')
     def configure_args(self):
-        filter_file(r'^libs10=.*', "libs10=%s" % self.spec['blas'].libs.ld_flags,  'configure')
+        filter_file(
+            r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure"
+        )
 
         if '+openmp' in self.spec:
             config = ['CFLAGS=-O3 ' + self.compiler.openmp_flag]

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -101,7 +101,9 @@ class Hpl(AutotoolsPackage):
 
     @when('@2.3:')
     def configure_args(self):
-        if '+openmp' in spec:
+        filter_file(r'^libs10=.*', "libs10=%s" % self.spec['blas'].libs.ld_flags,  'configure')
+
+        if '+openmp' in self.spec:
             config = ['CFLAGS=-O3 ' + self.compiler.openmp_flag]
         else:
             config = ['CFLAGS=-O3']


### PR DESCRIPTION
Patch blis package to look for the libblis-mt.so library
Thanks to jlow2016 for the hint

Patch HPL package to use openmp variant on 2.3 version, now is skipped.
