### PR TITLE
Install RMPISNOW wrapper in prefix.bin for r-snow

### DIFF
--- a/var/spack/repos/builtin/packages/r-snow/package.py
+++ b/var/spack/repos/builtin/packages/r-snow/package.py
@@ -17,3 +17,8 @@ class RSnow(RPackage):
     version('0.4-2', sha256='ee070187aea3607c9ca6235399b3db3e181348692405d038e962e06aefccabd7')
 
     depends_on('r@2.13.1:', type=('build', 'run'))
+
+    @run_after('install')
+    def install_wrapper(self):
+        mkdir(self.prefix.bin)
+        install('inst/RMPISNOW', self.prefix.bin)


### PR DESCRIPTION
If using mpirun, the R sessions can be started with a wrapper script
that helps set up the R session cluster. Put this wrapper in the PATH so
it is easily accessible.