### PR TITLE
Feature: add option to create view by copying/relocating files

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -33,8 +33,6 @@ All operations on views are performed via proxy objects such as
 YamlFilesystemView.
 
 '''
-import os
-
 import llnl.util.tty as tty
 from llnl.util.link_tree import MergeConflictError
 from llnl.util.tty.color import colorize
@@ -191,7 +189,7 @@ def view(parser, args):
         link_fn = view_copy
     else:
         link_fn = view_symlink
-        
+
     view = YamlFilesystemView(
         path, spack.store.layout,
         projections=ordered_projections,

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -45,13 +45,15 @@ import spack.store
 import spack.schema.projections
 from spack.config import validate
 from spack.filesystem_view import YamlFilesystemView
+from spack.filesystem_view import view_symlink, view_hardlink, view_copy
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."
 section = "environments"
 level = "short"
 
-actions_link = ["symlink", "add", "soft", "hardlink", "hard"]
+actions_link = ["symlink", "add", "soft", "hardlink", "hard", "copy",
+                "relocate"]
 actions_remove = ["remove", "rm"]
 actions_status = ["statlink", "status", "check"]
 
@@ -112,6 +114,9 @@ def setup_parser(sp):
         "hardlink": ssp.add_parser(
             'hardlink', aliases=['hard'],
             help='add packages files to a filesystem view via hard links'),
+        "copy": ssp.add_parser(
+            'copy', aliases=['relocate'],
+            help='add package files to a filesystem view via copy/relocate'),
         "remove": ssp.add_parser(
             'remove', aliases=['rm'],
             help='remove packages from a filesystem view'),
@@ -125,7 +130,7 @@ def setup_parser(sp):
         act.add_argument('path', nargs=1,
                          help="path to file system view directory")
 
-        if cmd in ("symlink", "hardlink"):
+        if cmd in ("symlink", "hardlink", "copy"):
             # invalid for remove/statlink, for those commands the view needs to
             # already know its own projections.
             help_msg = "Initialize view using projections from file."
@@ -157,7 +162,7 @@ def setup_parser(sp):
             so["nargs"] = "+"
             act.add_argument('specs', **so)
 
-    for cmd in ["symlink", "hardlink"]:
+    for cmd in ["symlink", "hardlink", "copy"]:
         act = file_system_view_actions[cmd]
         act.add_argument("-i", "--ignore-conflicts", action='store_true')
 
@@ -179,11 +184,19 @@ def view(parser, args):
     else:
         ordered_projections = {}
 
+    # What method are we using for this view
+    if args.action in ("hardlink", "hard"):
+        link_fn = view_hardlink
+    elif args.action in ("copy", "relocate"):
+        link_fn = view_copy
+    else:
+        link_fn = view_symlink
+        
     view = YamlFilesystemView(
         path, spack.store.layout,
         projections=ordered_projections,
         ignore_conflicts=getattr(args, "ignore_conflicts", False),
-        link=os.link if args.action in ["hardlink", "hard"] else os.symlink,
+        link=link_fn,
         verbose=args.verbose)
 
     # Process common args and specs

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -54,14 +54,12 @@ def view_hardlink(src, dst, **kwargs):
     os.link(src, dst)
 
 
-def view_copy(src, dst, **kwargs):
+def view_copy(src, dst, view, spec=None):
     """
     Copy a file from src to dst.
 
-    Use spec and view from kwargs to generate relocations
+    Use spec and view to generate relocations
     """
-    spec = kwargs.get(spec, None)
-    view = kwargs.get(view)  # functools assures this is present
     shutil.copyfile(src, dst)
     if spec:
         # Not metadata, we have to relocate it
@@ -115,8 +113,12 @@ class FilesystemView(object):
         self.projections = kwargs.get('projections', {})
 
         self.ignore_conflicts = kwargs.get("ignore_conflicts", False)
-        self.link = ft.partial(kwargs.get("link", view_symlink), view=self)
         self.verbose = kwargs.get("verbose", False)
+
+        # Setup link function to include view
+        link_func = kwargs.get("link", view_symlink)
+        self.link = ft.partial(link_func, view=self)
+
 
     def add_specs(self, *specs, **kwargs):
         """

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -71,16 +71,21 @@ def view_copy(src, dst, **kwargs):
             if spack.relocate.is_binary(dst) else spack.relocate.relocate_text
 
         # Get information on where to relocate from/to
-        prefix_to_prefix = dict(
+        prefix_to_projection = dict(
             (dep.prefix, view.get_projection_for_spec(dep))
             for dep in spec.traverse()
         )
 
         # Call actual relocation method
         relocate_method(
-            [dst], spack.store.layout.root, view._root,
-            spec.prefix, view.get_projection_for_spec(spec),
-            spack.paths.spack_root, view._root, prefix_to_prefix
+            path_names=[dst],
+            old_layout_root=spack.store.layout.root,
+            new_layout_root=view._root,
+            old_install_prefix=spec.prefix,
+            new_install_prefix=view.get_projection_for_spec(spec),
+            old_spack_prefix=spack.paths.spack_root,
+            new_spack_prefix=view._root,
+            prefix_to_prefix=prefix_to_projection
         )
 
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -57,14 +57,13 @@ def view_copy(src, dst, view, spec):
 
         # What type of file are we relocating
         relocate_method = spack.relocate.relocate_text_bin \
-                          if spack.relocate.is_binary(dst) \
-                          else spack.relocate.relocate_text
+            if spack.relocate.is_binary(dst) else spack.relocate.relocate_text
 
         # Get information on where to relocate from/to
         prefix_to_prefix = dict(
-                (dep.prefix, view.get_projection_for_spec(dep))
-                for dep in spec.traverse()
-            )
+            (dep.prefix, view.get_projection_for_spec(dep))
+            for dep in spec.traverse()
+        )
 
         # Call actual relocation method
         relocate_method(
@@ -80,7 +79,7 @@ def view_link_wrapper(view, link_method):
 
     return view_link
 
-    
+
 class FilesystemView(object):
     """
         Governs a filesystem view that is located at certain root-directory.

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -119,7 +119,6 @@ class FilesystemView(object):
         link_func = kwargs.get("link", view_symlink)
         self.link = ft.partial(link_func, view=self)
 
-
     def add_specs(self, *specs, **kwargs):
         """
             Add given specs to view.

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -394,9 +394,6 @@ class YamlFilesystemView(FilesystemView):
         if not os.path.lexists(dest):
             tty.warn("Tried to remove %s which does not exist" % dest)
             return
-        # TODO: Can I remove this?
-        if not os.path.islink(dest):
-            raise ValueError("%s is not a link tree!" % dest)
         # remove if dest is a hardlink/symlink to src; this will only
         # be false if two packages are merged into a prefix and have a
         # conflicting file

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -64,27 +64,34 @@ def view_copy(src, dst, view, spec=None):
     if spec:
         # Not metadata, we have to relocate it
 
-        # What type of file are we relocating
-        relocate_method = spack.relocate.relocate_text_bin \
-            if spack.relocate.is_binary(dst) else spack.relocate.relocate_text
-
         # Get information on where to relocate from/to
         prefix_to_projection = dict(
             (dep.prefix, view.get_projection_for_spec(dep))
             for dep in spec.traverse()
         )
 
-        # Call actual relocation method
-        relocate_method(
-            path_names=[dst],
-            old_layout_root=spack.store.layout.root,
-            new_layout_root=view._root,
-            old_install_prefix=spec.prefix,
-            new_install_prefix=view.get_projection_for_spec(spec),
-            old_spack_prefix=spack.paths.spack_root,
-            new_spack_prefix=view._root,
-            prefix_to_prefix=prefix_to_projection
-        )
+        if spack.relocate.is_binary(dst):
+            # relocate binaries
+            spack.relocate.relocate_text_bin(
+                binaries=[dst],
+                orig_install_prefix=spec.prefix,
+                new_install_prefix=view.get_projection_for_spec(spec),
+                orig_spack=spack.paths.spack_root,
+                new_spack=view._root,
+                new_prefixes=prefix_to_projection
+            )
+        else:
+            # relocate text
+            spack.relocate.relocate_text(
+                files=[dst],
+                orig_layout_root=spack.store.layout.root,
+                new_layout_root=view._root,
+                orig_install_prefix=spec.prefix,
+                new_install_prefix=view.get_projection_for_spec(spec),
+                orig_spack=spack.paths.spack_root,
+                new_spack=view._root,
+                new_prefixes=prefix_to_projection
+            )
 
 
 class FilesystemView(object):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -332,7 +332,7 @@ class PackageViewMixin(object):
         """
         for src, dst in merge_map.items():
             if not os.path.exists(dst):
-                view.link(src, dst)
+                view.link(src, dst, self.spec)
 
     def remove_files_from_view(self, view, merge_map):
         """Given a map of package files to files currently linked in the view,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -332,7 +332,7 @@ class PackageViewMixin(object):
         """
         for src, dst in merge_map.items():
             if not os.path.exists(dst):
-                view.link(src, dst, self.spec)
+                view.link(src, dst, spec=self.spec)
 
     def remove_files_from_view(self, view, merge_map):
         """Given a map of package files to files currently linked in the view,

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -24,7 +24,8 @@ def create_projection_file(tmpdir, projection):
     return projection_file
 
 
-@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
+@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add',
+                                 'copy', 'relocate'])
 def test_view_link_type(
         tmpdir, mock_packages, mock_archive, mock_fetch, config,
         install_mockery, cmd):
@@ -33,10 +34,11 @@ def test_view_link_type(
     view(cmd, viewpath, 'libdwarf')
     package_prefix = os.path.join(viewpath, 'libdwarf')
     assert os.path.exists(package_prefix)
-    assert os.path.islink(package_prefix) == (not cmd.startswith('hard'))
+    assert os.path.islink(package_prefix) == (cmd in ('symlink', 'add'))
 
 
-@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add'])
+@pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add',
+                                 'copy', 'relocate'])
 def test_view_projections(
         tmpdir, mock_packages, mock_archive, mock_fetch, config,
         install_mockery, cmd):
@@ -54,7 +56,7 @@ def test_view_projections(
 
     package_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
     assert os.path.exists(package_prefix)
-    assert os.path.islink(package_prefix) == (not cmd.startswith('hard'))
+    assert os.path.islink(package_prefix) == (cmd in ('symlink', 'add'))
 
 
 def test_view_multiple_projections(

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -34,7 +34,10 @@ def test_view_link_type(
     view(cmd, viewpath, 'libdwarf')
     package_prefix = os.path.join(viewpath, 'libdwarf')
     assert os.path.exists(package_prefix)
-    assert os.path.islink(package_prefix) == (cmd in ('symlink', 'add'))
+
+    # Check that we use symlinks for and only for the appropriate subcommands
+    is_link_cmd = cmd in ('symlink', 'add')
+    assert os.path.islink(package_prefix) == is_link_cmd
 
 
 @pytest.mark.parametrize('cmd', ['hardlink', 'symlink', 'hard', 'add',
@@ -56,7 +59,10 @@ def test_view_projections(
 
     package_prefix = os.path.join(viewpath, 'libdwarf-20130207/libdwarf')
     assert os.path.exists(package_prefix)
-    assert os.path.islink(package_prefix) == (cmd in ('symlink', 'add'))
+
+    # Check that we use symlinks for and only for the appropriate subcommands
+    is_symlink_cmd = cmd in ('symlink', 'add')
+    assert os.path.islink(package_prefix) == is_symlink_cmd
 
 
 def test_view_multiple_projections(

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1521,7 +1521,7 @@ _spack_view() {
     then
         SPACK_COMPREPLY="-h --help -v --verbose -e --exclude -d --dependencies"
     else
-        SPACK_COMPREPLY="symlink add soft hardlink hard remove rm statlink status check"
+        SPACK_COMPREPLY="symlink add soft hardlink hard copy relocate remove rm statlink status check"
     fi
 }
 
@@ -1562,6 +1562,24 @@ _spack_view_hardlink() {
 }
 
 _spack_view_hard() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --projection-file -i --ignore-conflicts"
+    else
+        _all_packages
+    fi
+}
+
+_spack_view_copy() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --projection-file -i --ignore-conflicts"
+    else
+        _all_packages
+    fi
+}
+
+_spack_view_relocate() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --projection-file -i --ignore-conflicts"

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -962,7 +962,7 @@ class Python(AutotoolsPackage):
         bin_dir = self.spec.prefix.bin
         for src, dst in merge_map.items():
             if not path_contains_subdirectory(src, bin_dir):
-                view.link(src, dst, self.spec)
+                view.link(src, dst, spec=self.spec)
             elif not os.path.islink(src):
                 copy(src, dst)
                 if 'script' in get_filetype(src):
@@ -988,7 +988,7 @@ class Python(AutotoolsPackage):
                 orig_link_target = os.path.join(self.spec.prefix, realpath_rel)
 
                 new_link_target = os.path.abspath(merge_map[orig_link_target])
-                view.link(new_link_target, dst, self.spec)
+                view.link(new_link_target, dst, spec=self.spec)
 
     def remove_files_from_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -962,7 +962,7 @@ class Python(AutotoolsPackage):
         bin_dir = self.spec.prefix.bin
         for src, dst in merge_map.items():
             if not path_contains_subdirectory(src, bin_dir):
-                view.link(src, dst)
+                view.link(src, dst, self.spec)
             elif not os.path.islink(src):
                 copy(src, dst)
                 if 'script' in get_filetype(src):
@@ -988,7 +988,7 @@ class Python(AutotoolsPackage):
                 orig_link_target = os.path.join(self.spec.prefix, realpath_rel)
 
                 new_link_target = os.path.abspath(merge_map[orig_link_target])
-                view.link(new_link_target, dst)
+                view.link(new_link_target, dst, self.spec)
 
     def remove_files_from_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin


### PR DESCRIPTION
Views can currently be created by symlinks or hardlinks. In both cases, dependencies are silently used from the original location.

In deployment contexts, this can cause permissions problems if one user installs a package and creates a public view for other users.

The `spack view copy` subcommand is an alternative that copies files into place, using logic from `lib/spack/spack/relocate.py` to edit the files in the new location to point to each other.

TODO:
- [x] tests