### PR TITLE
tcl modulefiles: added prefixes for organizing

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -420,6 +420,19 @@ class BaseConfiguration(object):
         return spack.schema.environment.parse(self.conf.get('environment', {}))
 
     @property
+    def mprefixes(self):
+        """List of prefixes that should be prepended to the module
+        file name. 'm' is added to prefix variables to avoid ambiguity.
+        """
+        mprefixes = []
+        for mprefix, packages in self.conf.get('prefixes', {}).items():
+            for package in packages:
+                if package in self.spec.name:
+                    mprefixes.append(mprefix)
+        mprefixes = sorted(set(mprefixes))
+        return mprefixes
+
+    @property
     def suffixes(self):
         """List of suffixes that should be appended to the module
         file name.
@@ -556,7 +569,8 @@ class BaseFileLayout(object):
         parts = name.split('/')
         name = os.path.join(*parts)
         # Add optional suffixes based on constraints
-        path_elements = [name] + self.conf.suffixes
+        path_prefixes = ['/'.join(self.conf.mprefixes + [name])]
+        path_elements = path_prefixes + self.conf.suffixes
         return '-'.join(path_elements)
 
     @property

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -59,6 +59,15 @@ module_file_configuration = {
         'prerequisites': dependency_selection,
         'conflict': array_of_strings,
         'load': array_of_strings,
+        'prefixes': {
+            'type': 'object',
+            'validate_spec': True,
+            'patternProperties': {
+                r'\w[\w-]*': {  # key
+                    'type': 'array'
+                }
+            }
+        },
         'suffixes': {
             'type': 'object',
             'validate_spec': True,


### PR DESCRIPTION
A prefix for Tcl modulefiles allows for easy organization by category, use-case, topic, etc. The prefixes can be added to `modules.yaml` like this:

```
modules:
  tcl:
    all:
      prefixes:
        'applications': [abinit, quantum-espresso, cp2k, namd, vmd]
        'compilers': [gcc, intel]
        'mpi': 
          - openmpi
          - mpich
          - mvapich2
          - intel-mpi
          - mpileaks
        'langs': [perl, python]
        'toolchain': 
          - autoconf
          - automake
          - gdbm
          - libsigsegv
          - libtool
```

where each prefix key is followed by a list of package names that fall under it. Installed packages that have no prefix specified will simply follow whatever naming convention is currently being used.

While this approach is not "programmatic" (unlike the suffixes), most sites will only need to do this once in order to maintain a well organized collection of modulefiles. A package can be specified within several prefixes, and they will be prepended in order of appearance.