### PR TITLE
Bugfix: cray support: fix underscore/dash problems for mic_knl and skylake_avx512

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -21,7 +21,8 @@ _craype_name_to_target_name = {
     'x86-cascadelake': 'cascadelake',
     'x86-naples': 'zen',
     'x86-rome': 'zen',  # Cheating because we have the wrong modules on rzcrayz
-    'x86-skylake': 'skylake-avx512'
+    'x86-skylake': 'skylake_avx512',
+    'mic-knl': 'mic_knl'
 }
 
 


### PR DESCRIPTION
There are two bugs in the dictionary we use to translate cray module names to target names.

1. I wrote `skylake-avx512` instead of `skylake_avx512`. This was noticed by @bvanessen as a bug on Cori GPU nodes
2. There is no entry translating `mic-knl` to `mic_knl`.

This PR fixes both.