### PR TITLE
PyTorch/Torchvision: fix deptype

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -124,7 +124,7 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('py-future', when='@1.1: ^python@:2', type='build')
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-typing', when='@0.4: ^python@:3.4', type=('build', 'run'))
-    depends_on('py-pybind11', when='@0.4:', type=('build', 'run'))
+    depends_on('py-pybind11', when='@0.4:', type=('build', 'link', 'run'))
     depends_on('blas')
     depends_on('lapack')
     depends_on('protobuf', when='@0.4:')

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -32,9 +32,9 @@ class PyTorchvision(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-six', when='@:0.5', type=('build', 'run'))
-    depends_on('py-torch@1.4:', when='@0.6:', type=('build', 'run'))
-    depends_on('py-torch@1.2:', when='@0.4:', type=('build', 'run'))
-    depends_on('py-torch@1.1:', type=('build', 'run'))
+    depends_on('py-torch@1.4:', when='@0.6:', type=('build', 'link', 'run'))
+    depends_on('py-torch@1.2:', when='@0.4:', type=('build', 'link', 'run'))
+    depends_on('py-torch@1.1:', type=('build', 'link', 'run'))
     # https://github.com/pytorch/vision/issues/1712
     depends_on('py-pillow@4.1.1:6', when='@:0.4', type=('build', 'run'))  # or py-pillow-simd
     depends_on('py-pillow@4.1.1:',  when='@0.5:', type=('build', 'run'))  # or py-pillow-simd


### PR DESCRIPTION
The torchvision headers link to PyTorch headers, which link to pybind11 headers, so these should all be connected via link-type dependencies (unless we add include-types someday).

Without this, I see the following build failure:
```
In file included from /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/Adam/spack-stage/spack-stage-py-torchvision-0.6.0-regfy53rf4x4ucc6yj4iakpiuywleetv/spack-src/torchvision/csrc/vision.cpp:11:
In file included from /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/Adam/spack-stage/spack-stage-py-torchvision-0.6.0-regfy53rf4x4ucc6yj4iakpiuywleetv/spack-src/torchvision/csrc/DeformConv.h:3:
In file included from /private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/Adam/spack-stage/spack-stage-py-torchvision-0.6.0-regfy53rf4x4ucc6yj4iakpiuywleetv/spack-src/torchvision/csrc/cpu/vision_cpu.h:2:
In file included from /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/py-torch-1.5.0-ktctoccu4qvf6e4jkzstkw7d7ff56eyq/lib/python3.7/site-packages/torch/include/torch/extension.h:6:
In file included from /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/py-torch-1.5.0-ktctoccu4qvf6e4jkzstkw7d7ff56eyq/lib/python3.7/site-packages/torch/include/torch/csrc/api/include/torch/python.h:12:
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/clang-11.0.3-apple/py-torch-1.5.0-ktctoccu4qvf6e4jkzstkw7d7ff56eyq/lib/python3.7/site-packages/torch/include/torch/csrc/utils/pybind.h:6:10: fatal error: 'pybind11/pybind11.h' file not found
#include <pybind11/pybind11.h>
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```