### PR TITLE
py-netcdf4: a couple of improvements

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/check_hdf5version.patch
+++ b/var/spack/repos/builtin/packages/py-netcdf4/check_hdf5version.patch
@@ -1,0 +1,20 @@
+--- a/setup.py
++++ b/setup.py
+@@ -275,7 +275,7 @@ HDF5_DIR environment variable not set, checking some standard locations ..\n""")
+         for direc in dirstosearch:
+             sys.stdout.write('checking %s ...\n' % direc)
+             hdf5_version = check_hdf5version(os.path.join(direc, 'include'))
+-            if hdf5_version is None or hdf5_version[1:6] < '1.8.0':
++            if hdf5_version is None or [int(c) for c in hdf5_version[1:-1].split('.')] < [1, 8, 0]:
+                 continue
+             else:
+                 HDF5_dir = direc
+@@ -290,7 +290,7 @@ HDF5_DIR environment variable not set, checking some standard locations ..\n""")
+         hdf5_version = check_hdf5version(HDF5_incdir)
+         if hdf5_version is None:
+             raise ValueError('did not find HDF5 headers in %s' % HDF5_incdir)
+-        elif hdf5_version[1:6] < '1.8.0':
++        elif [int(c) for c in hdf5_version[1:-1].split('.')] < [1, 8, 0]:
+             raise ValueError('HDF5 version >= 1.8.0 is required')
+ 
+     if netCDF4_incdir is None and netCDF4_dir is None:

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -32,6 +32,13 @@ class PyNetcdf4(PythonPackage):
     # following patch disables the usage of pkg-config at all.
     patch('disable_pkgconf.patch')
 
+    # Older versions of the package get a false negative result when checking
+    # the version of HDF5.
+    patch('check_hdf5version.patch', when='@:1.2.9 ^hdf5@1.10:')
+
+    # We can skip the 'build' phase to avoid recompilation of the library.
+    phases = ['install']
+
     def setup_build_environment(self, env):
         """Ensure installed netcdf and hdf5 libraries are used"""
         # Explicitly set these variables so setup.py won't erroneously pick up

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -12,6 +12,9 @@ class PyNetcdf4(PythonPackage):
     homepage = "https://github.com/Unidata/netcdf4-python"
     url      = "https://pypi.io/packages/source/n/netCDF4/netCDF4-1.2.7.tar.gz"
 
+    maintainers = ['skosukhin']
+
+    version('1.5.3',   sha256='2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be')
     version('1.4.2',   sha256='b934af350459cf9041bcdf5472e2aa56ed7321c018d918e9f325ec9a1f9d1a30')
     version('1.2.7',   sha256='0c449b60183ee06238a8f9a75de7b0eed3acaa7a374952ff9f1ff06beb8f94ba')
     version('1.2.3.1', sha256='55edd74ef9aabb1f7d1ea3ffbab9c555da2a95632a97f91c0242281dc5eb919f')


### PR DESCRIPTION
- avoid recompilation
- make the older versions to work with `hdf5@1.10:`