### PR TITLE
preCICE: Fix conflict with Boost 1.73.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -42,6 +42,7 @@ class Precice(CMakePackage):
     depends_on('cmake@3.10.2:', type='build', when='@1.4:')
     depends_on('boost@1.60.0:')
     depends_on('boost@1.65.1:', when='@1.4:')
+    depends_on('boost@:1.72.99', when='@:2.0.2')
     depends_on('eigen@3.2:')
     depends_on('eigen@:3.3.7', type='build', when='@:1.5')  # bug in prettyprint
     depends_on('libxml2')


### PR DESCRIPTION
This PR fixes a conflict with the version 1.73.0 of boost.

A fix is in review and will make it into develop soon, so the next version will be compatible again.

**To the reviewer(s)**
Can you please check if I got the version notation right?