### PR TITLE
Uninstall: tolerate failures when force=true

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1749,8 +1749,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                             " uninstall".format(str(spec)))
                         if isinstance(error, spack.error.SpackError):
                             error_msg += (
-                                "\n\nFull error: {0}".format(str(error)))
-                        tty.debug(error_msg)
+                                "\n\nError message: {0}".format(str(error)))
+                        tty.warn(error_msg)
+                        # Note that if the uninstall succeeds then we won't be
+                        # seeing this error again and won't have another chance
+                        # to run the hook.
                     else:
                         raise
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/16478

@adamjstewart does this work for you (you need to uninstall with `-f` for your uninstall to proceed)?

This allows an uninstall to proceed even when encountering pre-uninstall hook failures if the user chooses the `--force` option for the uninstall.

This also prevents post-uninstall hook failures from raising an exception, which would terminate a sequence of uninstalls. This isn't likely essential for #16478, but I think overall it will improve the user experience: if the post-uninstall hook fails, there isn't much point in terminating a sequence of spec uninstalls because at the point where the post-uninstall hook is run, the spec has already been removed from the database (so it will never have another chance to run).

Notes:

* When doing `spack uninstall -a`, certain pre/post-uninstall hooks aren't important to run, but this isn't easy to track with the current model
* This doesn't handle the uninstallation of specs that are not in the DB, so it may leave "dangling" specs in the installation prefix