### PR TITLE
Gaudi: separate variant for building documentation

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -64,7 +64,7 @@ class Gaudi(CMakePackage):
     depends_on('clhep', when='+optional')
     depends_on('cppgsl', when='+optional')
     depends_on('cppunit', when='+optional')
-    depends_on('doxygen +graphviz', when='+optional')
+    depends_on('doxygen +graphviz', when='+docs')
     depends_on('gperftools', when='+optional')
     depends_on('gdb', when='+optional')
     depends_on('gsl', when='+optional')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -26,6 +26,8 @@ class Gaudi(CMakePackage):
 
     variant('optional', default=False,
             description='Build most optional components and tests')
+    variant('docs', default=False,
+            description='Build documentation with Doxygen')
     variant('vtune', default=False,
             description='Build with Intel VTune profiler support')
 
@@ -92,7 +94,7 @@ class Gaudi(CMakePackage):
             self.define_from_variant("GAUDI_USE_CPPUNIT", "optional"),
             self.define_from_variant("GAUDI_USE_UNWIND", "optional"),
             self.define_from_variant("GAUDI_USE_GPERFTOOLS", "optional"),
-            self.define_from_variant("GAUDI_USE_DOXYGEN", "optional"),
+            self.define_from_variant("GAUDI_USE_DOXYGEN", "docs"),
             self.define_from_variant("GAUDI_USE_INTELAMPLIFIER", "optional"),
             self.define_from_variant("GAUDI_USE_JEMALLOC", "optional"),
             # this is not really used in spack builds, but needs to be set


### PR DESCRIPTION
There seems to be a bug in how Gaudi (or CMake) runs doxygen, namely - it ignores LD_LIBRARY_PATH, which is required in my case (external compiler without relocation information):

```
-- Adding directory GaudiRelease/doc/doxygen (22/25)
/workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen)
/workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen)
CMake Warning at /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/cmake-3.14.3-bet5h64ciwfhkxi5gdrpui4vfsgblwru/share/cmake-3.14/Modules/FindDoxygen.cmake:434 (message):
  Unable to determine doxygen version: 1
Call Stack (most recent call first):
  /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/cmake-3.14.3-bet5h64ciwfhkxi5gdrpui4vfsgblwru/share/cmake-3.14/Modules/FindDoxygen.cmake:597 (_Doxygen_find_doxygen)
  GaudiRelease/doc/doxygen/CMakeLists.txt:18 (find_package)


-- Found Doxygen: /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen (found version "") found components:  doxygen dot 
/workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen)
/workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/doxygen-1.8.15-apcnevjpd3wrjlruqzn4a2g6fvusbiu7/bin/doxygen)
CMake Error at /workspace/spack_97/spack/opt/spack/linux-centos7-haswell/gcc-8.3.0/cmake-3.14.3-bet5h64ciwfhkxi5gdrpui4vfsgblwru/share/cmake-3.14/Modules/FindDoxygen.cmake:676 (message):
  Unable to generate Doxyfile template: 1
Call Stack (most recent call first):
  GaudiRelease/doc/doxygen/CMakeLists.txt:18 (find_package)


-- Configuring incomplete, errors occurred!
```

(for the record: [spack-build-out](https://lcgpackages.web.cern.ch/lcgpackages/spack-build-out.txt), [spack-build-env](https://lcgpackages.web.cern.ch/lcgpackages/spack-build-env.txt) ).