### PR TITLE
Travis use bionic as default for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,10 +118,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
         KCOV_ROOT=$(mktemp -d);
-        wget --output-document=${KCOV_ROOT}/38.tar.gz https://github.com/SimonKagstrom/kcov/archive/38.tar.gz;
-        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/38.tar.gz;
+        wget --output-document=${KCOV_ROOT}/34.tar.gz https://github.com/SimonKagstrom/kcov/archive/v34.tar.gz;
+        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/34.tar.gz;
         mkdir -p ${KCOV_ROOT}/build;
-        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-38 && cd - ;
+        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-34 && cd - ;
         make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,11 +96,6 @@ addons:
       - mercurial
       - ninja-build
       - patchelf
-      - perl
-      - perl-base
-      - r-base
-      - r-base-core
-      - r-base-dev
       - zsh
     update: true
 
@@ -115,7 +110,7 @@ cache:
 before_install:
   - ccache -M 2G && ccache -z
   # Install kcov manually, since it's not packaged for bionic beaver
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$COVERAGE" == "true" ]]; then
         sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
         KCOV_ROOT=$(mktemp -d);
         wget --output-document=${KCOV_ROOT}/34.tar.gz https://github.com/SimonKagstrom/kcov/archive/v34.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 # Build matrix
 #=============================================================================
 
-dist: xenial
+dist: bionic
 
 jobs:
   fast_finish: true
@@ -53,6 +53,7 @@ jobs:
       env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '3.5'
       os: linux
+      dist: xenial
       language: python
       env: TEST_SUITE=unit
     - python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,17 +88,16 @@ addons:
   apt:
     packages:
       - ccache
+      - coreutils
       - cmake
       - gfortran
       - graphviz
       - gnupg2
-      - kcov
       - mercurial
       - ninja-build
       - patchelf
       - perl
       - perl-base
-      - realpath
       - r-base
       - r-base-core
       - r-base-dev
@@ -115,6 +114,16 @@ cache:
 
 before_install:
   - ccache -M 2G && ccache -z
+  # Install kcov manually, since it's not packaged for bionic beaver
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
+        KCOV_ROOT=$(mktemp -d);
+        wget --output-document=${KCOV_ROOT}/38.tar.gz https://github.com/SimonKagstrom/kcov/archive/38.tar.gz;
+        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/38.tar.gz;
+        mkdir -p ${KCOV_ROOT}/build;
+        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-38 && cd - ;
+        make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install;
+    fi
 
 # Install various dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ jobs:
     - python: '3.8'
       os: linux
       language: python
+      env: [ TEST_SUITE=shell, COVERAGE=true ]
+    - python: '3.8'
+      os: linux
+      language: python
       env: TEST_SUITE=doc
 
 stages:
@@ -156,6 +160,10 @@ after_success:
                         --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
             fi
             ;;
+        shell)
+            codecov --env PYTHON_VERSION
+            --required
+            --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
     esac
 
 #=============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - python: '2.7'
       os: linux
       language: python
-      env: [ TEST_SUITE=unit, COVERAGE=true ]
+      env: [ TEST_SUITE=unit, COVERAGE=true, KCOV_VERSION=34 ]
     - python: '3.5'
       os: linux
       dist: xenial
@@ -64,11 +64,11 @@ jobs:
     - python: '3.8'
       os: linux
       language: python
-      env: [ TEST_SUITE=unit, COVERAGE=true ]
+      env: [ TEST_SUITE=unit, COVERAGE=true, KCOV_VERSION=34 ]
     - python: '3.8'
       os: linux
       language: python
-      env: [ TEST_SUITE=shell, COVERAGE=true ]
+      env: [ TEST_SUITE=shell, COVERAGE=true, KCOV_VERSION=38 ]
     - python: '3.8'
       os: linux
       language: python
@@ -111,13 +111,13 @@ cache:
 before_install:
   - ccache -M 2G && ccache -z
   # Install kcov manually, since it's not packaged for bionic beaver
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$COVERAGE" == "true" ]]; then
+  - if [[ "$KCOV_VERSION" ]]; then
         sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
         KCOV_ROOT=$(mktemp -d);
-        wget --output-document=${KCOV_ROOT}/34.tar.gz https://github.com/SimonKagstrom/kcov/archive/v34.tar.gz;
-        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/34.tar.gz;
+        wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz;
+        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz;
         mkdir -p ${KCOV_ROOT}/build;
-        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-34 && cd - ;
+        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd - ;
         make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,6 @@ jobs:
             - perl
             - perl-base
             - realpath
-            - r-base
-            - r-base-core
-            - r-base-dev
             - zsh
       env: [ TEST_SUITE=unit, COVERAGE=true ]
     - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,12 @@ jobs:
           # Everything but patchelf, that is not available for trusty
           packages:
             - ccache
-            - cmake
             - gfortran
             - graphviz
             - gnupg2
             - kcov
             - mercurial
             - ninja-build
-            - perl
-            - perl-base
             - realpath
             - zsh
       env: [ TEST_SUITE=unit, COVERAGE=true ]
@@ -90,7 +87,6 @@ addons:
     packages:
       - ccache
       - coreutils
-      - cmake
       - gfortran
       - graphviz
       - gnupg2
@@ -112,7 +108,7 @@ before_install:
   - ccache -M 2G && ccache -z
   # Install kcov manually, since it's not packaged for bionic beaver
   - if [[ "$KCOV_VERSION" ]]; then
-        sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
+        sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
         KCOV_ROOT=$(mktemp -d);
         wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz;
         tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz;

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+#
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# Description:
+#     Runs Spack shell tests.
+#
+# Usage:
+#     run-shell-tests
+
+#-----------------------------------------------------------
+# Run a few initial commands and set up test environment
+#-----------------------------------------------------------
+ORIGINAL_PATH="$PATH"
+
+. "$(dirname $0)/setup.sh"
+check_dependencies $coverage git hg svn
+
+# Clean the environment by removing Spack from the path and getting rid of
+# the spack shell function
+export PATH="$ORIGINAL_PATH"
+unset spack
+
+# Start in the spack root directory
+cd "$SPACK_ROOT"
+
+# Run bash tests with coverage enabled, but pipe output to /dev/null
+# because it seems that kcov seems to undo the script's redirection
+if [ "$BASH_COVERAGE" = true ]; then
+    "$QA_DIR/bashcov" "$QA_DIR/setup-env-test.sh" &> /dev/null
+    "$QA_DIR/bashcov" "$QA_DIR/completion-test.sh" &> /dev/null
+else
+    bash "$QA_DIR/setup-env-test.sh"
+    bash "$QA_DIR/completion-test.sh"
+fi
+
+# Run the test scripts for their output (these will print nicely)
+zsh  "$QA_DIR/setup-env-test.sh"
+dash "$QA_DIR/setup-env-test.sh"

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -30,7 +30,7 @@ cd "$SPACK_ROOT"
 
 # Run bash tests with coverage enabled, but pipe output to /dev/null
 # because it seems that kcov seems to undo the script's redirection
-if [ "$BASH_COVERAGE" = true ]; then
+if [ "$COVERAGE" = true ]; then
     "$QA_DIR/bashcov" "$QA_DIR/setup-env-test.sh" &> /dev/null
     "$QA_DIR/bashcov" "$QA_DIR/completion-test.sh" &> /dev/null
 else

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -47,28 +47,3 @@ fi
 # Run unit tests with code coverage
 #-----------------------------------------------------------
 $coverage_run $(which spack) test -x --verbose
-
-#-----------------------------------------------------------
-# Run tests for setup-env.sh
-#-----------------------------------------------------------
-# Clean the environment by removing Spack from the path and getting rid of
-# the spack shell function
-export PATH="$ORIGINAL_PATH"
-unset spack
-
-# start in the spack root directory
-cd "$SPACK_ROOT"
-
-# Run bash tests with coverage enabled, but pipe output to /dev/null
-# because it seems that kcov seems to undo the script's redirection
-if [ "$BASH_COVERAGE" = true ]; then
-    "$QA_DIR/bashcov" "$QA_DIR/setup-env-test.sh" &> /dev/null
-    "$QA_DIR/bashcov" "$QA_DIR/completion-test.sh" &> /dev/null
-fi
-
-# run the test scripts for their output (these will print nicely)
-bash "$QA_DIR/setup-env-test.sh"
-zsh  "$QA_DIR/setup-env-test.sh"
-dash "$QA_DIR/setup-env-test.sh"
-
-bash "$QA_DIR/completion-test.sh"


### PR DESCRIPTION
Modifications:

- [x] Travis now uses `bionic` as a default (`xenial` used for Python 3.5, `trusty` for Python 2.6)
- [x] Shell unit tests have been factored into their own run
- [x] `kcov` is built only for tests that upload coverage results

Overall with this we shave 3-4 mins. on each run and add an additional run of about 3 min. For some reason `kcov` 38 fails forwarding output when used with Python unit tests, so I used v34 for that and v38 (latest) for shell testing. Previously we were using v25.