### PR TITLE
remove url function, it seems the pypi version of the package somehow…

### DIFF
--- a/var/spack/repos/builtin/packages/py-configobj/package.py
+++ b/var/spack/repos/builtin/packages/py-configobj/package.py
@@ -16,7 +16,5 @@ class PyConfigobj(PythonPackage):
     version('5.0.6', sha256='a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902')
     version('4.7.2', sha256='515ff923462592e8321df8b48c47e3428f8d406ee22b8de77bef969d1af11171')
 
-    # The version on PyPi seems to be outdated (2014) although confusingly
-    # enough version number is the same as the latest release on github.
     depends_on('py-six', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-configobj/package.py
+++ b/var/spack/repos/builtin/packages/py-configobj/package.py
@@ -20,11 +20,3 @@ class PyConfigobj(PythonPackage):
     # enough version number is the same as the latest release on github.
     depends_on('py-six', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-
-    def url_for_version(self, version):
-        if version <= Version('5.0.0'):
-            url = "https://pypi.io/packages/source/c/configobj/configobj-{0}.tar.gz"
-        else:
-            url = "https://github.com/DiffSK/configobj/archive/v{0}.tar.gz"
-
-        return url.format(version)


### PR DESCRIPTION
… compiles just fine

Checked that both versions compile just fine without the url function.

fixes #16407 