### PR TITLE
Extend packages.yaml to allow custom attributes

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -25,15 +25,10 @@ packages:
       - libelf
       unwind:
       - apple-libunwind
-    version: []
-    target: []
-    buildable: true
   apple-libunwind:
     buildable: false
     externals:
+    # Apple bundles libunwind version 35.3 with macOS 10.9 and later,
+    # although the version number used here isn't critical
     - spec: apple-libunwind@35.3
       prefix: /usr
-    version: []
-    target: []
-    compiler: []
-    providers: {}

--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -21,11 +21,19 @@ packages:
     - gcc
     - intel
     providers:
-      elf: [libelf]
-      unwind: [apple-libunwind]
+      elf:
+      - libelf
+      unwind:
+      - apple-libunwind
+    version: []
+    target: []
+    buildable: true
   apple-libunwind:
-    paths:
-    # Apple bundles libunwind version 35.3 with macOS 10.9 and later,
-    # although the version number used here isn't critical
-      apple-libunwind@35.3: /usr
-    buildable: False
+    buildable: false
+    externals:
+    - spec: apple-libunwind@35.3
+      prefix: /usr
+    version: []
+    target: []
+    compiler: []
+    providers: {}

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -85,7 +85,7 @@ of the installation prefixes.  The following example says that module
        - CMake/3.7.2
 
 Each ``packages.yaml`` begins with a ``packages:`` attribute, followed
-by a list of package names.  To specify externals, add an ``externals``
+by a list of package names.  To specify externals, add an ``externals:``
 attribute under the package name, which lists externals.
 Each external should specify a ``spec:`` string that should be as
 well-defined as reasonably possible.  If a

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -81,12 +81,13 @@ of the installation prefixes.  The following example says that module
    cmake:
      externals:
      - spec: cmake@3.7.2
-       module: CMake/3.7.2
+       modules:
+       - CMake/3.7.2
 
-Each ``packages.yaml`` begins with a ``packages:`` token, followed
-by a list of package names.  To specify externals, add a ``paths`` or ``modules``
-token under the package name, which lists externals in a
-``spec: /path`` or ``spec: module-name`` format.  Each spec should be as
+Each ``packages.yaml`` begins with a ``packages:`` attribute, followed
+by a list of package names.  To specify externals, add an ``externals``
+attribute under the package name, which lists externals.
+Each external should specify a ``spec:`` string that should be as
 well-defined as reasonably possible.  If a
 package lacks a spec component, such as missing a compiler or
 package version, then Spack will guess the missing component based

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -57,10 +57,13 @@ directory. Here's an example of an external configuration:
 
    packages:
      openmpi:
-       paths:
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64: /opt/openmpi-1.4.3
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug: /opt/openmpi-1.4.3-debug
-         openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64: /opt/openmpi-1.6.5-intel
+       externals:
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.4.3
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+         prefix: /opt/openmpi-1.4.3-debug
+       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.6.5-intel
 
 This example lists three installations of OpenMPI, one built with GCC,
 one built with GCC and debug information, and another built with Intel.
@@ -76,8 +79,9 @@ of the installation prefixes.  The following example says that module
 .. code-block:: yaml
 
    cmake:
-     modules:
-       cmake@3.7.2: CMake/3.7.2
+     externals:
+     - spec: cmake@3.7.2
+       module: CMake/3.7.2
 
 Each ``packages.yaml`` begins with a ``packages:`` token, followed
 by a list of package names.  To specify externals, add a ``paths`` or ``modules``
@@ -106,10 +110,13 @@ be:
 
    packages:
      openmpi:
-       paths:
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64: /opt/openmpi-1.4.3
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug: /opt/openmpi-1.4.3-debug
-         openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64: /opt/openmpi-1.6.5-intel
+       externals:
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.4.3
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+         prefix: /opt/openmpi-1.4.3-debug
+       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.6.5-intel
        buildable: False
 
 The addition of the ``buildable`` flag tells Spack that it should never build
@@ -137,10 +144,13 @@ but more conveniently:
      mpi:
        buildable: False
      openmpi:
-       paths:
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64: /opt/openmpi-1.4.3
-         openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug: /opt/openmpi-1.4.3-debug
-         openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64: /opt/openmpi-1.6.5-intel
+       externals:
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.4.3
+       - spec: "openmpi@1.4.3%gcc@4.4.7 arch=linux-debian7-x86_64+debug"
+         prefix: /opt/openmpi-1.4.3-debug
+       - spec: "openmpi@1.6.5%intel@10.1 arch=linux-debian7-x86_64"
+         prefix: /opt/openmpi-1.6.5-intel
 
 Implementations can also be listed immediately under the virtual they provide:
 
@@ -172,8 +182,9 @@ After running this command your ``packages.yaml`` may include new entries:
 
    packages:
      cmake:
-       paths:
-         cmake@3.17.2: /usr
+       externals:
+       - spec: cmake@3.17.2
+         prefix: /usr
 
 Generally this is useful for detecting a small set of commonly-used packages;
 for now this is generally limited to finding build-only dependencies.

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -420,9 +420,11 @@ Adapt the following example. Be sure to maintain the indentation:
      intel-mkl:
        externals:
        - spec: "intel-mkl@2018.2.199  arch=linux-centos6-x86_64"
-         module:  intel-mkl/18/18.0.2
+         modules:
+         -  intel-mkl/18/18.0.2
        - spec: "intel-mkl@2018.3.222  arch=linux-centos6-x86_64"
-         module:  intel-mkl/18/18.0.3
+         modules:
+         -  intel-mkl/18/18.0.3
 
 The version numbers for the ``intel-mkl`` specs defined here correspond to file
 and directory names that Intel uses for its products because they were adopted
@@ -455,9 +457,11 @@ mechanism.
      intel-parallel-studio:
        externals:
        - spec: "intel-parallel-studio@cluster.2018.2.199 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64"
-         module:  intel/18/18.0.2
+         modules:
+         -  intel/18/18.0.2
        - spec: "intel-parallel-studio@cluster.2018.3.222 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64"
-         module:  intel/18/18.0.3
+         modules:
+         -  intel/18/18.0.3
        buildable: False
 
 One additional example illustrates the use of ``prefix:`` instead of

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -460,7 +460,7 @@ mechanism.
          module:  intel/18/18.0.3
        buildable: False
 
-One additional example illustrates the use of ``paths:`` instead of
+One additional example illustrates the use of ``prefix:`` instead of
 ``modules:``, useful when external modulefiles are not available or not
 suitable:
 
@@ -476,7 +476,7 @@ suitable:
        buildable: False
 
 Note that for the Intel packages discussed here, the directory values in the
-``paths:`` entries must be the high-level and typically version-less
+``prefix:`` entries must be the high-level and typically version-less
 "installation directory" that has been used by Intel's product installer.
 Such a directory will typically accumulate various product versions.  Amongst
 them, Spack will select the correct version-specific product directory based on

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -418,9 +418,11 @@ Adapt the following example. Be sure to maintain the indentation:
    # other content ...
 
      intel-mkl:
-       modules:
-         intel-mkl@2018.2.199  arch=linux-centos6-x86_64:  intel-mkl/18/18.0.2
-         intel-mkl@2018.3.222  arch=linux-centos6-x86_64:  intel-mkl/18/18.0.3
+       externals:
+       - spec: "intel-mkl@2018.2.199  arch=linux-centos6-x86_64"
+         module:  intel-mkl/18/18.0.2
+       - spec: "intel-mkl@2018.3.222  arch=linux-centos6-x86_64"
+         module:  intel-mkl/18/18.0.3
 
 The version numbers for the ``intel-mkl`` specs defined here correspond to file
 and directory names that Intel uses for its products because they were adopted
@@ -451,9 +453,11 @@ mechanism.
 
    packages:
      intel-parallel-studio:
-       modules:
-         intel-parallel-studio@cluster.2018.2.199 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64:  intel/18/18.0.2
-         intel-parallel-studio@cluster.2018.3.222 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64:  intel/18/18.0.3
+       externals:
+       - spec: "intel-parallel-studio@cluster.2018.2.199 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64"
+         module:  intel/18/18.0.2
+       - spec: "intel-parallel-studio@cluster.2018.3.222 +mkl+mpi+ipp+tbb+daal  arch=linux-centos6-x86_64"
+         module:  intel/18/18.0.3
        buildable: False
 
 One additional example illustrates the use of ``paths:`` instead of
@@ -464,9 +468,11 @@ suitable:
 
    packages:
      intel-parallel-studio:
-       paths:
-         intel-parallel-studio@cluster.2018.2.199 +mkl+mpi+ipp+tbb+daal: /opt/intel
-         intel-parallel-studio@cluster.2018.3.222 +mkl+mpi+ipp+tbb+daal: /opt/intel
+       externals:
+       - spec: "intel-parallel-studio@cluster.2018.2.199 +mkl+mpi+ipp+tbb+daal"
+         prefix: /opt/intel
+       - spec: "intel-parallel-studio@cluster.2018.3.222 +mkl+mpi+ipp+tbb+daal"
+         prefix: /opt/intel
        buildable: False
 
 Note that for the Intel packages discussed here, the directory values in the

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -712,8 +712,9 @@ an OpenMPI installed in /opt/local, one would use:
 
     packages:
         openmpi:
-            paths:
-                openmpi@1.10.1: /opt/local
+            externals:
+            - spec: openmpi@1.10.1
+              prefix: /opt/local
             buildable: False
 
 In general, Spack is easier to use and more reliable if it builds all of
@@ -775,8 +776,9 @@ Then add the following to ``~/.spack/packages.yaml``:
 
     packages:
         openssl:
-            paths:
-                openssl@1.0.2g: /usr
+            externals:
+            - spec: openssl@1.0.2g
+              prefix: /usr
             buildable: False
 
 
@@ -791,8 +793,9 @@ to add the following to ``packages.yaml``:
 
     packages:
         netlib-lapack:
-            paths:
-                netlib-lapack@3.6.1: /usr
+            externals:
+            - spec: netlib-lapack@3.6.1
+              prefix: /usr
             buildable: False
         all:
             providers:
@@ -1181,9 +1184,11 @@ Here's an example of an external configuration for cray modules:
 
    packages:
      mpich:
-       modules:
-         mpich@7.3.1%gcc@5.2.0 arch=cray_xc-haswell-CNL10: cray-mpich
-         mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-haswell-CNL10: cray-mpich
+       externals:
+       - spec: "mpich@7.3.1%gcc@5.2.0 arch=cray_xc-haswell-CNL10"
+         module: cray-mpich
+       - spec: "mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-haswell-CNL10"
+         module: cray-mpich
      all:
        providers:
          mpi: [mpich]
@@ -1211,19 +1216,25 @@ Here is an example of a full packages.yaml used at NERSC
 
    packages:
      mpich:
-       modules:
-         mpich@7.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge: cray-mpich
-         mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-SuSE11-ivybridge: cray-mpich
+       externals:
+       - spec: "mpich@7.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
+         module: cray-mpich
+       - spec: "mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-SuSE11-ivybridge"
+         module: cray-mpich
        buildable: False
      netcdf:
-       modules:
-         netcdf@4.3.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge: cray-netcdf
-         netcdf@4.3.3.1%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge: cray-netcdf
+       externals:
+       - spec: "netcdf@4.3.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
+         module: cray-netcdf
+       - spec: "netcdf@4.3.3.1%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge"
+         module: cray-netcdf
        buildable: False
      hdf5:
-       modules:
-         hdf5@1.8.14%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge: cray-hdf5
-         hdf5@1.8.14%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge: cray-hdf5
+       externals:
+       - spec: "hdf5@1.8.14%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
+         module: cray-hdf5
+       - spec: "hdf5@1.8.14%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge"
+         module: cray-hdf5
        buildable: False
      all:
        compiler: [gcc@5.2.0, intel@16.0.0.109]

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1186,9 +1186,11 @@ Here's an example of an external configuration for cray modules:
      mpich:
        externals:
        - spec: "mpich@7.3.1%gcc@5.2.0 arch=cray_xc-haswell-CNL10"
-         module: cray-mpich
+         modules:
+         - cray-mpich
        - spec: "mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-haswell-CNL10"
-         module: cray-mpich
+         modules:
+         - cray-mpich
      all:
        providers:
          mpi: [mpich]
@@ -1218,23 +1220,29 @@ Here is an example of a full packages.yaml used at NERSC
      mpich:
        externals:
        - spec: "mpich@7.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
-         module: cray-mpich
+         modules:
+         - cray-mpich
        - spec: "mpich@7.3.1%intel@16.0.0.109 arch=cray_xc-SuSE11-ivybridge"
-         module: cray-mpich
+         modules:
+         - cray-mpich
        buildable: False
      netcdf:
        externals:
        - spec: "netcdf@4.3.3.1%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
-         module: cray-netcdf
+         modules:
+         - cray-netcdf
        - spec: "netcdf@4.3.3.1%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge"
-         module: cray-netcdf
+         modules:
+         - cray-netcdf
        buildable: False
      hdf5:
        externals:
        - spec: "hdf5@1.8.14%gcc@5.2.0 arch=cray_xc-CNL10-ivybridge"
-         module: cray-hdf5
+         modules:
+         - cray-hdf5
        - spec: "hdf5@1.8.14%intel@16.0.0.109 arch=cray_xc-CNL10-ivybridge"
-         module: cray-hdf5
+         modules:
+         - cray-hdf5
        buildable: False
      all:
        compiler: [gcc@5.2.0, intel@16.0.0.109]

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1200,7 +1200,7 @@ via module load.
 
 .. note::
 
-    For Cray-provided packages, it is best to use ``modules:`` instead of ``paths:``
+    For Cray-provided packages, it is best to use ``modules:`` instead of ``prefix:``
     in ``packages.yaml``, because the Cray Programming Environment heavily relies on
     modules (e.g., loading the ``cray-mpich`` module adds MPI libraries to the
     compiler wrapper link line).

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4057,21 +4057,18 @@ Making a package discoverable with ``spack external find``
 The simplest way to make a package discoverable with
 :ref:`spack external find <cmd-spack-external-find>` is to:
 
-1. Mark the Package with the ``detectable`` decorator
-2. Define the executables associated with the package
-3. Implement a method to determine the versions of these executables
+1. Define the executables associated with the package
+2. Implement a method to determine the versions of these executables
 
 ^^^^^^^^^^^^^^^^^
 Minimal detection
 ^^^^^^^^^^^^^^^^^
 
-The first two steps are fairly simple, as they require only to
-decorate the package being defined and specify a package level
-``executables`` attribute:
+The first step is fairly simple, as it requires only to
+specify a package level ``executables`` attribute:
 
 .. code-block:: python
 
-   @detectable
    class Foo(Package):
        # Each string provided here is treated as a regular expression, and
        # would match for example 'foo', 'foobar', and 'bazfoo'.

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4092,9 +4092,10 @@ method must be implemented:
        """
 
 This method receives as input the path to a single executable and must return
-as output its version as a string, or ``None`` if the version cannot be determined
-or the executable is not related to the package.
-Implementing the three steps above is mandatory, and gives the package the
+as output its version as a string; if the user cannot determine the version
+or determines that the executable is not an instance of the package, they can
+return None and the exe will be discarded as a candidate.
+Implementing the two steps above is mandatory, and gives the package the
 basic ability to detect if a spec is present on the system at a given version.
 
 .. note::
@@ -4105,7 +4106,7 @@ basic ability to detect if a spec is present on the system at a given version.
 Additional functionality
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Besides the three mandatory steps described above, there are also optional
+Besides the two mandatory steps described above, there are also optional
 methods that can be implemented to either increase the amount of details
 being detected or improve the robustness of the detection logic in a package.
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4145,14 +4145,20 @@ would look like:
        externals:
        - spec: 'gcc@9.0.1 languages=c,c++,fortran'
          prefix: /usr
-         compilers:
-           c: /usr/bin/x86_64-linux-gnu-gcc-9
-           c++: /usr/bin/x86_64-linux-gnu-g++-9
-           fortran: /usr/bin/x86_64-linux-gnu-gfortran-9
+         extra_attributes:
+           compilers:
+             c: /usr/bin/x86_64-linux-gnu-gcc-9
+             c++: /usr/bin/x86_64-linux-gnu-g++-9
+             fortran: /usr/bin/x86_64-linux-gnu-gfortran-9
 
 This permits, for instance, to keep track of executables that would be named
 differently if built by Spack (e.g. ``x86_64-linux-gnu-gcc-9``
 instead of just ``gcc``).
+
+.. TODO: we need to gather some more experience on overriding 'prefix'
+   and other special keywords in extra attributes, but as soon as we are
+   confident that this is the way to go we should document the process.
+   See https://github.com/spack/spack/pull/16526#issuecomment-653783204
 
 """""""""""""""""""""""""""
 Filter matching executables

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4077,7 +4077,7 @@ decorate the package being defined and specify a package level
        # would match for example 'foo', 'foobar', and 'bazfoo'.
        executables = ['foo']
 
-This attribute must be a list of strings. Each string is treated as a regular
+This attribute must be a list of strings. Each string is a regular
 expression (e.g. 'gcc' would match 'gcc', 'gcc-8.3', 'my-weird-gcc', etc.) to
 determine a set of system executables that might be part or this package. Note
 that to match only executables named 'gcc' the regular expression ``r'^gcc$'``

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4205,9 +4205,9 @@ to validate the detected Spec objects:
        """Validate a detected spec. Raise an exception if validation fails."""
 
 This method receives a detected spec along with its extra attributes and must
-raise an exception if the spec is considered invalid. In that case the spec
-will be discarded from the list of the ones detected and the exception message
-will be logged as the reason for discarding it.
+raise an exception of any type if the spec is considered invalid. In that case
+the spec will be discarded and the exception message will be logged as the reason
+for discarding it.
 
 .. _determine_spec_details:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4079,7 +4079,9 @@ decorate the package being defined and specify a package level
 
 This attribute must be a list of strings. Each string is treated as a regular
 expression (e.g. 'gcc' would match 'gcc', 'gcc-8.3', 'my-weird-gcc', etc.) to
-determine a set of system executables that might be part or this package.
+determine a set of system executables that might be part or this package. Note
+that to match only executables named 'gcc' the regular expression ``r'^gcc$'``
+must be used.
 
 Finally to determine the version of each executable the ``determine_version``
 method must be implemented:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4077,7 +4077,7 @@ specify a package level ``executables`` attribute:
 This attribute must be a list of strings. Each string is a regular
 expression (e.g. 'gcc' would match 'gcc', 'gcc-8.3', 'my-weird-gcc', etc.) to
 determine a set of system executables that might be part or this package. Note
-that to match only executables named 'gcc' the regular expression ``r'^gcc$'``
+that to match only executables named 'gcc' the regular expression ``'^gcc$'``
 must be used.
 
 Finally to determine the version of each executable the ``determine_version``
@@ -4088,7 +4088,10 @@ method must be implemented:
    @classmethod
    def determine_version(cls, exe):
        """Return either the version of the executable passed as argument
-       or ``None`` if the version cannot be determined
+       or ``None`` if the version cannot be determined.
+
+       Args:
+           exe (str): absolute path to the executable being examined
        """
 
 This method receives as input the path to a single executable and must return
@@ -4124,6 +4127,12 @@ to detect additional details of the spec:
        """Return either a variant string, a tuple of a variant string
        and a dictionary of extra attributes that will be recorded in
        packages.yaml or a list of those items.
+
+       Args:
+           exes (list of str): list of executables (absolute paths) that
+               live in the same prefix and share the same version
+           version_str (str): version associated with the list of
+               executables, as detected by ``determine_version``
        """
 
 This method takes as input a list of executables that live in the same prefix and
@@ -4131,7 +4140,7 @@ share the same version string, and returns either:
 
 1. A variant string
 2. A tuple of a variant string and a dictionary of extra attributes
-3. A list of items matching either 1. or 2. (if multiple specs are detected
+3. A list of items matching either 1 or 2 (if multiple specs are detected
    from the set of executables)
 
 If extra attributes are returned, they will be recorded in ``packages.yaml``
@@ -4152,7 +4161,7 @@ would look like:
              c++: /usr/bin/x86_64-linux-gnu-g++-9
              fortran: /usr/bin/x86_64-linux-gnu-gfortran-9
 
-This permits, for instance, to keep track of executables that would be named
+This allows us, for instance, to keep track of executables that would be named
 differently if built by Spack (e.g. ``x86_64-linux-gnu-gcc-9``
 instead of just ``gcc``).
 
@@ -4242,9 +4251,9 @@ or like this:
    def validate_detected_spec(cls, spec, extra_attributes):
        """Check that 'compilers' is in the extra attributes."""
        if 'compilers' not in extra_attributes:
-         msg = ('the extra attribute "compilers" must be set for '
-                 'the detected spec "{0}"'.format(spec))
-         raise InvalidSpecDetected(msg)
+           msg = ('the extra attribute "compilers" must be set for '
+                  'the detected spec "{0}"'.format(spec))
+           raise InvalidSpecDetected(msg)
 
 .. _determine_spec_details:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4095,9 +4095,14 @@ method must be implemented:
        """
 
 This method receives as input the path to a single executable and must return
-as output its version as a string, or ``None`` is the version cannot be determined.
+as output its version as a string, or ``None`` if the version cannot be determined
+or the executable is not related to the package.
 Implementing the three steps above is mandatory, and gives the package the
 basic ability to detect if a spec is present on the system at a given version.
+
+.. note::
+   Any executable for which the ``determine_version`` method returns ``None``
+   will be discarded and won't appear in later stages of the workflow described below.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Additional functionality

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4209,11 +4209,13 @@ to validate the detected Spec objects:
        """Validate a detected spec. Raise an exception if validation fails."""
 
 This method receives a detected spec along with its extra attributes and can be
-used to assert that certain conditions are met by the spec. In case the assertions
-are not honored the spec will be discarded and any assertion message will be logged
-as the reason for discarding it.
+used to check that certain conditions are met by the spec. Packagers can either
+use assertions or raise an ``InvalidSpecDetected`` exception when the check fails.
+In case the conditions are not honored the spec will be discarded and any message
+associated with the assertion or the exception will be logged as the reason for
+discarding it.
 
-As an example, a package that wants to assert that the ``compilers`` attribute is
+As an example, a package that wants to check that the ``compilers`` attribute is
 in the extra attributes can implement this method like this:
 
 .. code-block:: python
@@ -4224,6 +4226,18 @@ in the extra attributes can implement this method like this:
        msg = ('the extra attribute "compilers" must be set for '
               'the detected spec "{0}"'.format(spec))
        assert 'compilers' in extra_attributes, msg
+
+or like this:
+
+.. code-block:: python
+
+   @classmethod
+   def validate_detected_spec(cls, spec, extra_attributes):
+       """Check that 'compilers' is in the extra attributes."""
+       if 'compilers' not in extra_attributes:
+         msg = ('the extra attribute "compilers" must be set for '
+                 'the detected spec "{0}"'.format(spec))
+         raise InvalidSpecDetected(msg)
 
 .. _determine_spec_details:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4211,10 +4211,22 @@ to validate the detected Spec objects:
    def validate_detected_spec(cls, spec, extra_attributes):
        """Validate a detected spec. Raise an exception if validation fails."""
 
-This method receives a detected spec along with its extra attributes and must
-raise an exception of any type if the spec is considered invalid. In that case
-the spec will be discarded and the exception message will be logged as the reason
-for discarding it.
+This method receives a detected spec along with its extra attributes and can be
+used to assert that certain conditions are met by the spec. In case the assertions
+are not honored the spec will be discarded and any assertion message will be logged
+as the reason for discarding it.
+
+As an example, a package that wants to assert that the ``compilers`` attribute is
+in the extra attributes can implement this method like this:
+
+.. code-block:: python
+
+   @classmethod
+   def validate_detected_spec(cls, spec, extra_attributes):
+       """Check that 'compilers' is in the extra attributes."""
+       msg = ('the extra attribute "compilers" must be set for '
+              'the detected spec "{0}"'.format(spec))
+       assert 'compilers' in extra_attributes, msg
 
 .. _determine_spec_details:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4094,8 +4094,8 @@ method must be implemented:
        or ``None`` if the version cannot be determined
        """
 
-This method receives as input a single executable and must return as output
-its version as a string, or ``None`` is the version cannot be determined.
+This method receives as input the path to a single executable and must return
+as output its version as a string, or ``None`` is the version cannot be determined.
 Implementing the three steps above is mandatory, and gives the package the
 basic ability to detect if a spec is present on the system at a given version.
 
@@ -4236,7 +4236,7 @@ the definition of the ``executables`` attribute is still required):
 
 This method takes as input a set of discovered executables (which match
 those specified by the user) as well as a common prefix shared by all
-of those executables. The function must return one or more Specs associated
+of those executables. The function must return one or more :py:class:`spack.spec.Spec` associated
 with the executables (it can also return ``None`` to indicate that no
 provided executables are associated with the package).
 

--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -1545,8 +1545,9 @@ Avoid double-installing CUDA by adding, e.g.
 
    packages:
      cuda:
-       paths:
-         cuda@9.0.176%gcc@5.4.0 arch=linux-ubuntu16-x86_64: /usr/local/cuda
+       externals:
+       - spec: "cuda@9.0.176%gcc@5.4.0 arch=linux-ubuntu16-x86_64"
+         prefix: /usr/local/cuda
        buildable: False
 
 to your ``packages.yaml``.

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import collections
 import errno
 import hashlib
@@ -377,17 +376,17 @@ def install(src, dest):
     copy(src, dest, _permissions=True)
 
 
-def resolve_link_target_relative_to_the_link(l):
+def resolve_link_target_relative_to_the_link(link):
     """
     os.path.isdir uses os.path.exists, which for links will check
     the existence of the link target. If the link target is relative to
     the link, we need to construct a pathname that is valid from
     our cwd (which may not be the same as the link's directory)
     """
-    target = os.readlink(l)
+    target = os.readlink(link)
     if os.path.isabs(target):
         return target
-    link_dir = os.path.dirname(os.path.abspath(l))
+    link_dir = os.path.dirname(os.path.abspath(link))
     return os.path.join(link_dir, target)
 
 
@@ -1683,3 +1682,18 @@ def prefixes(path):
         pass
 
     return paths
+
+
+def md5sum(file):
+    """Compute the MD5 sum of a file.
+
+    Args:
+        file (str): file to be checksummed
+
+    Returns:
+        MD5 sum of the file's content
+    """
+    md5 = hashlib.md5()
+    with open(file, "rb") as f:
+        md5.update(f.read())
+    return md5.digest()

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1570,6 +1570,19 @@ def can_access_dir(path):
 
 
 @memoized
+def can_write_to_dir(path):
+    """Return True if the argument is a directory in which we can write.
+
+    Args:
+        path: path to be tested
+
+    Returns:
+        True if ``path`` is an writeable directory, else False
+    """
+    return os.path.isdir(path) and os.access(path, os.R_OK | os.X_OK | os.W_OK)
+
+
+@memoized
 def files_in(*search_paths):
     """Returns all the files in paths passed as arguments.
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -62,7 +62,7 @@ from spack.util.environment import (
 from spack.util.environment import system_dirs
 from spack.error import NoLibrariesError, NoHeadersError
 from spack.util.executable import Executable
-from spack.util.module_cmd import load_module, get_path_from_module, module
+from spack.util.module_cmd import load_module, path_from_modules, module
 from spack.util.log_parse import parse_log_events, make_log_context
 
 
@@ -642,7 +642,7 @@ def get_rpaths(pkg):
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
-        rpaths.append(get_path_from_module(pkg.compiler.modules[1]))
+        rpaths.append(path_from_modules(pkg.compiler.modules[1]))
     return list(dedupe(filter_system_paths(rpaths)))
 
 
@@ -706,8 +706,9 @@ def load_external_modules(pkg):
         pkg (PackageBase): package to load deps for
     """
     for dep in list(pkg.spec.traverse()):
-        if dep.external_module:
-            load_module(dep.external_module)
+        external_modules = dep.external_modules or []
+        for external_module in external_modules:
+            load_module(external_module)
 
 
 def setup_package(pkg, dirty):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -87,13 +87,13 @@ def setup_parser(subparser):
     )
     update.add_argument('section', help='section to update')
 
-    update = sp.add_parser(
+    revert = sp.add_parser(
         'revert',
         help='revert configuration files to their state before update'
     )
-    update.add_argument('--force', action='store_true',
+    revert.add_argument('--force', action='store_true',
                         help='force removal of configuration file')
-    update.add_argument('section', help='section to update')
+    revert.add_argument('section', help='section to update')
 
 
 def _get_scope_and_section(args):
@@ -321,7 +321,7 @@ def config_update(args):
         # Make a backup copy and rewrite the file
         bkp_file = cfg_file + '.bkp'
         if os.path.exists(bkp_file):
-            msg = ('backup file "{0}" exists on disk. Check its content '
+            msg = ('backup file "{0}" exists on disk.\n\nCheck its content '
                    'and remove it before trying to update again.')
             tty.die(msg.format(bkp_file))
         shutil.copy(cfg_file, bkp_file)
@@ -339,7 +339,7 @@ def config_revert(args):
             continue
 
         if os.path.exists(cfg_file) and not args.force:
-            msg = ('configuration file "{0}" exists on disk. Check '
+            msg = ('configuration file "{0}" exists on disk.\n\nCheck '
                    'its content and remove it before trying to revert '
                    'again. use the --force option to overwrite existing '
                    'files')

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -360,7 +360,9 @@ def config_update(args):
 
 
 def config_revert(args):
-    scopes = [args.scope] if args.scope else spack.config.file_scopes()
+    scopes = [args.scope] if args.scope else [
+        x.name for x in spack.config.config.file_scopes
+    ]
 
     # Search for backup files in the configuration scopes
     Entry = collections.namedtuple('Entry', ['scope', 'cfg', 'bkp'])

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -341,7 +341,10 @@ def config_update(args):
                 scope.name, args.section
             )
             msg += '\t[scope={0}, file={1}]\n'.format(scope.name, cfg_file)
-        msg += '\nThis operation is not forward-compatible.'
+        msg += ('\nIf the configuration files are updated, versions of Spack '
+                'that are older than this version may not be able to read '
+                'them. Spack stores backups of the updated files which can '
+                'be retrieved with "spack config revert"')
         tty.msg(msg)
         proceed = tty.get_yes_or_no('Do you want to proceed?', default=False)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -418,9 +418,10 @@ def env_update(args):
     proceed = True
     if not args.yes_to_all:
         msg = ('The environment "{0}" is going to be updated to the latest '
-               'schema format.\nThis operation is not forward-compatible i.e. '
-               'old versions of Spack will not be able to use this environment'
-               ' anymore.')
+               'schema format.\nIf the environment is updated, versions of '
+               'Spack that are older than this version may not be able to '
+               'read it. Spack stores backups of the updated environment '
+               'which can be retrieved with "spack env revert"')
         tty.msg(msg.format(args.env))
         proceed = tty.get_yes_or_no('Do you want to proceed?', default=False)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -409,7 +409,7 @@ def env_update_setup_parser(subparser):
 def env_update(args):
     manifest_file = ev.manifest_file(args.env)
     backup_file = manifest_file + ".bkp"
-    needs_update = ev.is_latest_format(manifest_file)
+    needs_update = not ev.is_latest_format(manifest_file)
 
     if not needs_update:
         tty.msg('No update needed for the environment "{0}"'.format(args.env))

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -418,7 +418,7 @@ def env_update(args):
     proceed = True
     if not args.yes_to_all:
         msg = ('The environment "{0}" is going to be updated to the latest '
-               'schema format. This operation is not forward-compatible i.e.'
+               'schema format.\nThis operation is not forward-compatible i.e. '
                'old versions of Spack will not be able to use this environment'
                ' anymore.')
         tty.msg(msg.format(args.env))

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -399,6 +399,7 @@ def env_loads(args):
 
 
 def env_update_setup_parser(subparser):
+    """update environments to the latest format"""
     subparser.add_argument(
         metavar='env', dest='env',
         help='name or directory of the environment to activate'
@@ -434,6 +435,7 @@ def env_update(args):
 
 
 def env_revert_setup_parser(subparser):
+    """restore environments to their state before update"""
     subparser.add_argument(
         metavar='env', dest='env',
         help='name or directory of the environment to activate'

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -464,7 +464,7 @@ def env_revert(args):
         tty.die('Operation aborted.')
 
     shutil.copy(backup_file, manifest_file)
-    os.unlink(backup_file)
+    os.remove(backup_file)
     msg = 'Environment "{0}" reverted to old state'
     tty.msg(msg.format(manifest_file))
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -259,6 +259,14 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
                 else:
                     resolved_specs[spec] = prefix
 
+                try:
+                    spec.validate_detection()
+                except Exception as e:
+                    msg = ('"{0}" has been detected on the system but will '
+                           'not be added to packages.yaml [{1}]')
+                    tty.warn(msg.format(spec, str(e)))
+                    continue
+
                 pkg_to_entries[pkg.name].append(
                     ExternalPackageEntry(spec=spec, base_dir=pkg_prefix))
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -280,7 +280,7 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
                     spec.validate_detection()
                 except Exception as e:
                     msg = ('"{0}" has been detected on the system but will '
-                           'not be added to packages.yaml [{1}]')
+                           'not be added to packages.yaml [reason={1}]')
                     tty.warn(msg.format(spec, str(e)))
                     continue
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -19,7 +19,7 @@ import spack.error
 import spack.util.environment
 import spack.util.spack_yaml as syaml
 
-description = "Manage external packages in Spack configuration"
+description = "manage external packages in Spack configuration"
 section = "config"
 level = "short"
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -36,7 +36,7 @@ def setup_parser(subparser):
         help="packages with detected externals won't be built with Spack")
     find_parser.add_argument('packages', nargs=argparse.REMAINDER)
 
-    _ = sp.add_parser(
+    sp.add_parser(
         'list', help='list detectable packages, by repository and name'
     )
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -100,7 +100,16 @@ def _generate_pkg_config(external_pkg_entries):
             continue
 
         external_items = [('spec', str(e.spec)), ('prefix', e.base_dir)]
-        external_items.extend(e.spec.extra_attributes.items())
+        if e.spec.external_modules:
+            external_items.append(('modules', e.spec.external_modules))
+
+        if e.spec.extra_attributes:
+            external_items.append(
+                ('extra_attributes',
+                 syaml.syaml_dict(e.spec.extra_attributes.items()))
+            )
+
+        # external_items.extend(e.spec.extra_attributes.items())
         pkg_dict['externals'].append(
             syaml.syaml_dict(external_items)
         )
@@ -283,6 +292,9 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
                            'not be added to packages.yaml [reason={1}]')
                     tty.warn(msg.format(spec, str(e)))
                     continue
+
+                if spec.external_path:
+                    pkg_prefix = spec.external_path
 
                 pkg_to_entries[pkg.name].append(
                     ExternalPackageEntry(spec=spec, base_dir=pkg_prefix))

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -74,19 +74,28 @@ def _generate_pkg_config(external_pkg_entries):
     This does not generate the entire packages.yaml. For example, given some
     external entries for the CMake package, this could return::
 
-       { 'paths': {
-             'cmake@3.17.1': '/opt/cmake-3.17.1/',
-             'cmake@3.16.5': '/opt/cmake-3.16.5/'
-         }
+        {
+            'externals': [{
+                'spec': 'cmake@3.17.1',
+                'prefix': '/opt/cmake-3.17.1/'
+            }, {
+                'spec': 'cmake@3.16.5',
+                'prefix': '/opt/cmake-3.16.5/'
+            }]
        }
     """
-    paths_dict = syaml.syaml_dict()
+
+    pkg_dict = syaml.syaml_dict()
+    pkg_dict['externals'] = []
     for e in external_pkg_entries:
         if not _spec_is_valid(e.spec):
             continue
-        paths_dict[str(e.spec)] = e.base_dir
-    pkg_dict = syaml.syaml_dict()
-    pkg_dict['paths'] = paths_dict
+
+        external_items = [('spec', str(e.spec)), ('prefix', e.base_dir)]
+        external_items.extend(e.spec._extra_attributes.items())
+        pkg_dict['externals'].append(
+            syaml.syaml_dict(external_items)
+        )
 
     return pkg_dict
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -92,7 +92,7 @@ def _generate_pkg_config(external_pkg_entries):
             continue
 
         external_items = [('spec', str(e.spec)), ('prefix', e.base_dir)]
-        external_items.extend(e.spec._extra_attributes.items())
+        external_items.extend(e.spec.extra_attributes.items())
         pkg_dict['externals'].append(
             syaml.syaml_dict(external_items)
         )

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1056,8 +1056,9 @@ def ensure_latest_format_fn(section):
         section (str): section of the configuration e.g. "packages",
             "config", etc.
     """
-    section_module_name = 'spack.schema.' + section
-    section_module = __import__(section_module_name, fromlist=['update'])
+    # The line below is based on the fact that every module we need
+    # is already imported at the top level
+    section_module = getattr(spack.schema, section)
     update_fn = getattr(section_module, 'update', lambda x: False)
     return update_fn
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -735,6 +735,11 @@ def scopes():
     return config.scopes
 
 
+def file_scopes():
+    """Return the list of scopes associated with a file."""
+    return [s for s, k in config.scopes.items() if type(k) == ConfigScope]
+
+
 def _validate_section_name(section):
     """Exit if the section is not a valid section."""
     if section not in section_schemas:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -466,7 +466,7 @@ class Configuration(object):
                    ' to disk, but is currently using a deprecated format. '
                    'Please update it using:\n\n'
                    '\tspack config [--scope=<scope] update {0}\n\n'
-                   'Not that any update will not be forward-compatible.')
+                   'Note that any update will not be forward-compatible.')
             msg = msg.format(section)
             raise RuntimeError(msg)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -764,11 +764,6 @@ def scopes():
     return config.scopes
 
 
-def file_scopes():
-    """Return the list of scopes associated with a file."""
-    return [s for s, k in config.scopes.items() if type(k) == ConfigScope]
-
-
 def _validate_section_name(section):
     """Exit if the section is not a valid section."""
     if section not in section_schemas:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -30,6 +30,7 @@ schemas are in submodules of :py:mod:`spack.schema`.
 
 """
 
+import collections
 import copy
 import os
 import re
@@ -352,6 +353,7 @@ class Configuration(object):
         self.scopes = OrderedDict()
         for scope in scopes:
             self.push_scope(scope)
+        self.format_updates = collections.defaultdict(list)
 
     def push_scope(self, scope):
         """Add a higher precedence scope to the Configuration."""
@@ -440,7 +442,7 @@ class Configuration(object):
         for scope in self.scopes.values():
             scope.clear()
 
-    def update_config(self, section, update_data, scope=None):
+    def update_config(self, section, update_data, scope=None, force=False):
         """Update the configuration file for a particular scope.
 
         Overwrites contents of a section in a scope with update_data,
@@ -449,7 +451,25 @@ class Configuration(object):
         update_data should have the top-level section name stripped off
         (it will be re-added).  Data itself can be a list, dict, or any
         other yaml-ish structure.
+
+        Configuration scopes that are still written in an old schema
+        format will fail to update unless ``force`` is True.
+
+        Args:
+            section (str): section of the configuration to be updated
+            update_data (dict): data to be used for the update
+            scope (str): scope to be updated
+            force (str): force the update
         """
+        if self.format_updates.get(section) and not force:
+            msg = ('The "{0}" section of the configuration needs to be written'
+                   ' to disk, but is currently using a deprecated format. '
+                   'Please update it using:\n\n'
+                   '\tspack config [--scope=<scope] update {0}\n\n'
+                   'Not that any update will not be forward-compatible.')
+            msg = msg.format(section)
+            raise RuntimeError(msg)
+
         _validate_section_name(section)  # validate section name
         scope = self._validate_scope(scope)  # get ConfigScope object
 
@@ -513,6 +533,15 @@ class Configuration(object):
 
             if section not in data:
                 continue
+
+            # We might be reading configuration files in an old format,
+            # thus read data and update it in memory if need be.
+            changed = _update_in_memory(data, section)
+            if changed:
+                self.format_updates[section].append(scope)
+                msg = ('OUTDATED CONFIGURATION FILE '
+                       '[section={0}, scope={1}, dir={2}]')
+                tty.debug(msg.format(section, scope.name, scope.path))
 
             merged_section = merge_yaml(merged_section, data)
 
@@ -723,7 +752,7 @@ def get(path, default=None, scope=None):
 
 
 def set(path, value, scope=None):
-    """Convenience function for getting single values in config files.
+    """Convenience function for setting single values in config files.
 
     Accepts the path syntax described in ``get()``.
     """
@@ -1002,6 +1031,38 @@ def default_list_scope():
     Commands that list configuration list *all* scopes (merged) by default.
     """
     return None
+
+
+def _update_in_memory(data, section):
+    """Update the format of the configuration data in memory.
+
+    This function assumes the section is valid (i.e. validation
+    is responsibility of the caller)
+
+    Args:
+        data (dict): configuration data
+        section (str): section of the configuration to update
+
+    Returns:
+        True if the data was changed, False otherwise
+    """
+    update_fn = ensure_latest_format_fn(section)
+    changed = update_fn(data[section])
+    return changed
+
+
+def ensure_latest_format_fn(section):
+    """Return a functions that takes as input a dictionary read from
+    a configuration file and update it to the latest format.
+
+    Args:
+        section (str): section of the configuration e.g. "packages",
+            "config", etc.
+    """
+    section_module_name = 'spack.schema.' + section
+    section_module = __import__(section_module_name, fromlist=['update'])
+    update_fn = getattr(section_module, 'update', lambda x: False)
+    return update_fn
 
 
 class ConfigError(SpackError):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -466,7 +466,8 @@ class Configuration(object):
                    ' to disk, but is currently using a deprecated format. '
                    'Please update it using:\n\n'
                    '\tspack config [--scope=<scope] update {0}\n\n'
-                   'Note that any update will not be forward-compatible.')
+                   'Note that previous versions of Spack will not be able to '
+                   'use the updated configuration.')
             msg = msg.format(section)
             raise RuntimeError(msg)
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1052,8 +1052,10 @@ def _update_in_memory(data, section):
 
 
 def ensure_latest_format_fn(section):
-    """Return a functions that takes as input a dictionary read from
+    """Return a function that takes as input a dictionary read from
     a configuration file and update it to the latest format.
+
+    The function returns True if there was any update, False otherwise.
 
     Args:
         section (str): section of the configuration e.g. "packages",

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1481,7 +1481,8 @@ class Environment(object):
                    'is currently using a deprecated format. Please update it '
                    'using:\n\n'
                    '\tspack env update {0}\n\n'
-                   'Note that any update will not be forward-compatible')
+                   'Note that previous versions of Spack will not be able to '
+                   'use the updated configuration.')
             raise RuntimeError(msg.format(self.name))
 
         # ensure path in var/spack/environments

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1761,7 +1761,8 @@ def update_yaml(manifest, backup_file):
     with open(manifest) as f:
         data = syaml.load(f)
 
-    needs_update = spack.schema.env.update(list(data.values()).pop())
+    top_level_key = _top_level_key(data)
+    needs_update = spack.schema.env.update(data[top_level_key])
     if not needs_update:
         msg = "No update needed [manifest={0}]".format(manifest)
         tty.debug(msg)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1768,7 +1768,7 @@ def update_yaml(manifest, backup_file):
         return False
 
     # Copy environment to a backup file and update it
-    msg = ('backup file "{0}" exists on disk. Check its content '
+    msg = ('backup file "{0}" already exists on disk. Check its content '
            'and remove it before trying to update again.')
     assert not os.path.exists(backup_file), msg.format(backup_file)
 
@@ -1776,6 +1776,18 @@ def update_yaml(manifest, backup_file):
     with open(manifest, 'w') as f:
         _write_yaml(data, f)
     return True
+
+
+def is_latest_format(manifest):
+    """Return True if the manifest file is at the latest schema format,
+    False otherwise.
+
+    Args:
+        manifest (str): manifest file to be analyzed
+    """
+    with open(manifest) as f:
+        data = syaml.load(f)
+    return spack.schema.env.update(list(data.values()).pop())
 
 
 class SpackEnvironmentError(spack.error.SpackError):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1473,6 +1473,17 @@ class Environment(object):
                 writing if True.
 
         """
+        # Intercept environment not using the latest schema format and prevent
+        # them from being modified
+        manifest_exists = os.path.exists(self.manifest_path)
+        if manifest_exists and not is_latest_format(self.manifest_path):
+            msg = ('The environment "{0}" needs to be written to disk, but '
+                   'is currently using a deprecated format. Please update it '
+                   'using:\n\n'
+                   '\tspack env update {0}\n\n'
+                   'Note that any update will not be forward-compatible')
+            raise RuntimeError(msg.format(self.name))
+
         # ensure path in var/spack/environments
         fs.mkdirp(self.path)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1778,6 +1778,23 @@ def update_yaml(manifest, backup_file):
     return True
 
 
+def _top_level_key(data):
+    """Return the top level key used in this environment
+
+    Args:
+        data (dict): raw yaml data of the environment
+
+    Returns:
+        Either 'spack' or 'env'
+    """
+    msg = ('cannot find top level attribute "spack" or "env"'
+           'in the environment')
+    assert any(x in data for x in ('spack', 'env')), msg
+    if 'spack' in data:
+        return 'spack'
+    return 'env'
+
+
 def is_latest_format(manifest):
     """Return True if the manifest file is at the latest schema format,
     False otherwise.
@@ -1787,7 +1804,9 @@ def is_latest_format(manifest):
     """
     with open(manifest) as f:
         data = syaml.load(f)
-    return spack.schema.env.update(list(data.values()).pop())
+    top_level_key = _top_level_key(data)
+    changed = spack.schema.env.update(data[top_level_key])
+    return not changed
 
 
 class SpackEnvironmentError(spack.error.SpackError):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -272,9 +272,9 @@ def _process_external_package(pkg, explicit):
     pre = '{s.name}@{s.version} :'.format(s=pkg.spec)
     spec = pkg.spec
 
-    if spec.external_module:
+    if spec.external_modules:
         tty.msg('{0} has external module in {1}'
-                .format(pre, spec.external_module))
+                .format(pre, spec.external_modules))
         tty.debug('{0} is actually installed in {1}'
                   .format(pre, spec.external_path))
     else:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -195,8 +195,20 @@ class DetectablePackageMeta(object):
                         spec_str = '{0}@{1} {2}'.format(
                             cls.name, version_str, variant_str
                         )
+
+                        # Pop a few reserved keys from extra attributes, since
+                        # they have a different semantics
+                        external_path = extra_attributes.pop('prefix', None)
+                        external_modules = extra_attributes.pop(
+                            'modules', None
+                        )
+                        spec = spack.spec.Spec(
+                            spec_str,
+                            external_path=external_path,
+                            external_modules=external_modules
+                        )
                         specs.append(spack.spec.Spec.from_detection(
-                            spec_str, extra_attributes=extra_attributes
+                            spec, extra_attributes=extra_attributes
                         ))
 
                 return sorted(specs)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2268,9 +2268,19 @@ def detectable(decorated_cls):
 
         return sorted(specs)
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        spec_str = '{0}@{1}'.format(cls.name, version_str)
+        return [spack.spec.Spec.from_detection(spec_str)]
+
     detectable_packages[decorated_cls.namespace].append(decorated_cls.name)
+    default = False
     if not hasattr(decorated_cls, 'determine_spec_details'):
+        default = True
         decorated_cls.determine_spec_details = determine_spec_details
+
+    if default and not hasattr(decorated_cls, 'determine_variants'):
+        decorated_cls.determine_variants = determine_variants
 
     return decorated_cls
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -141,7 +141,92 @@ class InstallPhase(object):
             return other
 
 
+#: Registers which are the detectable packages, by repo and package name
+#: Need a pass of package repositories to be filled.
+detectable_packages = collections.defaultdict(list)
+
+
+class DetectablePackageMeta(object):
+    """Check if a package is detectable and add default implementations
+    for the detection function.
+    """
+    def __init__(cls, name, bases, attr_dict):
+        # If a package has the executables attribute then it's
+        # assumed to be detectable
+        if hasattr(cls, 'executables'):
+            @classmethod
+            def determine_spec_details(cls, prefix, exes_in_prefix):
+                """Allow ``spack external find ...`` to locate installations.
+
+                Args:
+                    prefix (str): the directory containing the executables
+                    exes_in_prefix (set): the executables that match the regex
+
+                Returns:
+                    The list of detected specs for this package
+                """
+                exes_by_version = collections.defaultdict(list)
+                # The default filter function is the identity function for the
+                # list of executables
+                filter_fn = getattr(cls, 'filter_detected_exes',
+                                    lambda x, exes: exes)
+                exes_in_prefix = filter_fn(prefix, exes_in_prefix)
+                for exe in exes_in_prefix:
+                    try:
+                        version_str = cls.determine_version(exe)
+                        if version_str:
+                            exes_by_version[version_str].append(exe)
+                    except Exception as e:
+                        msg = ('An error occurred when trying to detect '
+                               'the version of "{0}" [{1}]')
+                        tty.debug(msg.format(exe, str(e)))
+
+                specs = []
+                for version_str, exes in exes_by_version.items():
+                    variants = cls.determine_variants(exes, version_str)
+                    # Normalize output to list
+                    if not isinstance(variants, list):
+                        variants = [variants]
+
+                    for variant in variants:
+                        if isinstance(variant, six.string_types):
+                            variant = (variant, {})
+                        variant_str, extra_attributes = variant
+                        spec_str = '{0}@{1} {2}'.format(
+                            cls.name, version_str, variant_str
+                        )
+                        specs.append(spack.spec.Spec.from_detection(
+                            spec_str, extra_attributes=extra_attributes
+                        ))
+
+                return sorted(specs)
+
+            @classmethod
+            def determine_variants(cls, exes, version_str):
+                return ''
+
+            # Register the class as a detectable package
+            detectable_packages[cls.namespace].append(cls.name)
+
+            # Attach function implementations to the detectable class
+            default = False
+            if not hasattr(cls, 'determine_spec_details'):
+                default = True
+                cls.determine_spec_details = determine_spec_details
+
+            if default and not hasattr(cls, 'determine_version'):
+                msg = ('the package "{0}" in the "{1}" repo needs to define'
+                       ' the "determine_version" method to be detectable')
+                NotImplementedError(msg.format(cls.name, cls.namespace))
+
+            if default and not hasattr(cls, 'determine_variants'):
+                cls.determine_variants = determine_variants
+
+        super(DetectablePackageMeta, cls).__init__(name, bases, attr_dict)
+
+
 class PackageMeta(
+    DetectablePackageMeta,
     spack.directives.DirectiveMeta,
     spack.mixins.PackageMixinsMeta,
     spack.multimethod.MultiMethodMeta
@@ -2233,85 +2318,6 @@ def possible_dependencies(*pkg_or_spec, **kwargs):
         pkg.possible_dependencies(visited=visited, **kwargs)
 
     return visited
-
-
-#: Registers which are the detectable packages, by repo and package name
-detectable_packages = collections.defaultdict(list)
-
-
-def detectable(decorated_cls):
-    """Mark a package class as detectable and add a default implementation
-    for detection logic.
-
-    The decorator registers the class as detectable and attaches to it a
-    default implementation of ``determine_spec_details``.
-
-    Args:
-        decorated_cls: class to be decorated
-
-    Returns:
-        Decorated class
-    """
-    @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        """Allow ``spack external find ...`` to locate installations.
-
-        Args:
-            prefix (str): the directory containing the executables
-            exes_in_prefix (set): the executables that match the regex
-
-        Returns:
-            The list of detected specs for this package
-        """
-        exes_by_version = collections.defaultdict(list)
-        # The default filter function is the identity function for the
-        # list of executables
-        filter_fn = getattr(cls, 'filter_detected_exes', lambda x, exes: exes)
-        exes_in_prefix = filter_fn(prefix, exes_in_prefix)
-        for exe in exes_in_prefix:
-            try:
-                version_str = cls.determine_version(exe)
-                if version_str:
-                    exes_by_version[version_str].append(exe)
-            except Exception as e:
-                msg = ('An error occurred when trying to detect the version '
-                       'of "{0}" [{1}]')
-                tty.debug(msg.format(exe, str(e)))
-
-        specs = []
-        for version_str, exes in exes_by_version.items():
-            variants = cls.determine_variants(exes, version_str)
-            # Normalize output to list
-            if not isinstance(variants, list):
-                variants = [variants]
-
-            for variant in variants:
-                if isinstance(variant, six.string_types):
-                    variant = (variant, {})
-                variant_str, extra_attributes = variant
-                spec_str = '{0}@{1} {2}'.format(
-                    cls.name, version_str, variant_str
-                )
-                specs.append(spack.spec.Spec.from_detection(
-                    spec_str, extra_attributes=extra_attributes
-                ))
-
-        return sorted(specs)
-
-    @classmethod
-    def determine_variants(cls, exes, version_str):
-        return ''
-
-    detectable_packages[decorated_cls.namespace].append(decorated_cls.name)
-    default = False
-    if not hasattr(decorated_cls, 'determine_spec_details'):
-        default = True
-        decorated_cls.determine_spec_details = determine_spec_details
-
-    if default and not hasattr(decorated_cls, 'determine_variants'):
-        decorated_cls.determine_variants = determine_variants
-
-    return decorated_cls
 
 
 class FetchError(spack.error.SpackError):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2254,6 +2254,15 @@ def detectable(decorated_cls):
     """
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
+        """Allow ``spack external find ...`` to locate installations.
+
+        Args:
+            prefix (str): the directory containing the executables
+            exes_in_prefix (set): the executables that match the regex
+
+        Returns:
+            The list of detected specs for this package
+        """
         exes_by_version = collections.defaultdict(list)
         # The default filter function is the identity function for the
         # list of executables

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import copy
 import stat
 
 from six import string_types
@@ -169,16 +169,20 @@ def spec_externals(spec):
         pkg_config = allpkgs.get(name, {})
         pkg_externals = pkg_config.get('externals', [])
         for entry in pkg_externals:
-            # FIXME: Copy and pop?
-            spec_str = entry['spec']
-            external_path = entry.get('prefix', None)
+            # This copy makes it safe to pop out of entry without
+            # Modifying the object in config
+            entry = copy.deepcopy(entry)
+            spec_str = entry.pop('spec')
+            external_path = entry.pop('prefix', None)
             if external_path:
                 external_path = canonicalize_path(external_path)
-            external_module = entry.get('module', None)
-            external_spec = spack.spec.Spec(
-                spec_str,
-                external_path=external_path,
-                external_module=external_module
+            external_module = entry.pop('module', None)
+            external_spec = spack.spec.Spec.from_detection(
+                spack.spec.Spec(
+                    spec_str,
+                    external_path=external_path,
+                    external_module=external_module
+                ), extra_attributes=entry
             )
             if external_spec.satisfies(spec):
                 external_specs.append(external_spec)

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -167,24 +167,23 @@ def spec_externals(spec):
     external_specs = []
     for name in names:
         pkg_config = allpkgs.get(name, {})
-        pkg_paths = pkg_config.get('paths', {})
-        pkg_modules = pkg_config.get('modules', {})
-        if (not pkg_paths) and (not pkg_modules):
-            continue
-
-        for external_spec, path in pkg_paths.items():
+        pkg_externals = pkg_config.get('externals', [])
+        for entry in pkg_externals:
+            # FIXME: Copy and pop?
+            spec_str = entry['spec']
+            external_path = entry.get('prefix', None)
+            if external_path:
+                external_path = canonicalize_path(external_path)
+            external_module = entry.get('module', None)
             external_spec = spack.spec.Spec(
-                external_spec, external_path=canonicalize_path(path))
+                spec_str,
+                external_path=external_path,
+                external_module=external_module
+            )
             if external_spec.satisfies(spec):
                 external_specs.append(external_spec)
 
-        for external_spec, module in pkg_modules.items():
-            external_spec = spack.spec.Spec(
-                external_spec, external_module=module)
-            if external_spec.satisfies(spec):
-                external_specs.append(external_spec)
-
-    # defensively copy returned specs
+    # Defensively copy returned specs
     return [s.copy() for s in external_specs]
 
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -171,7 +171,7 @@ def spec_externals(spec):
         for entry in pkg_externals:
             # This copy makes it safe to pop out of entry without
             # modifying the object in config
-            entry = copy.deepcopy(entry)
+            entry = copy.copy(entry)
             spec_str = entry.pop('spec')
             external_path = entry.pop('prefix', None)
             if external_path:

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -158,7 +158,7 @@ def spec_externals(spec):
     """Return a list of external specs (w/external directory path filled in),
        one for each known external installation."""
     # break circular import.
-    from spack.util.module_cmd import get_path_from_module # NOQA: ignore=F401
+    from spack.util.module_cmd import path_from_modules # NOQA: ignore=F401
 
     allpkgs = spack.config.get('packages')
     names = set([spec.name])
@@ -176,12 +176,12 @@ def spec_externals(spec):
             external_path = entry.pop('prefix', None)
             if external_path:
                 external_path = canonicalize_path(external_path)
-            external_module = entry.pop('module', None)
+            external_modules = entry.pop('modules', None)
             external_spec = spack.spec.Spec.from_detection(
                 spack.spec.Spec(
                     spec_str,
                     external_path=external_path,
-                    external_module=external_module
+                    external_modules=external_modules
                 ), extra_attributes=entry
             )
             if external_spec.satisfies(spec):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -170,7 +170,7 @@ def spec_externals(spec):
         pkg_externals = pkg_config.get('externals', [])
         for entry in pkg_externals:
             # This copy makes it safe to pop out of entry without
-            # Modifying the object in config
+            # modifying the object in config
             entry = copy.deepcopy(entry)
             spec_str = entry.pop('spec')
             external_path = entry.pop('prefix', None)

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import copy
 import stat
 
 from six import string_types
@@ -169,20 +168,17 @@ def spec_externals(spec):
         pkg_config = allpkgs.get(name, {})
         pkg_externals = pkg_config.get('externals', [])
         for entry in pkg_externals:
-            # This copy makes it safe to pop out of entry without
-            # modifying the object in config
-            entry = copy.copy(entry)
-            spec_str = entry.pop('spec')
-            external_path = entry.pop('prefix', None)
+            spec_str = entry['spec']
+            external_path = entry.get('prefix', None)
             if external_path:
                 external_path = canonicalize_path(external_path)
-            external_modules = entry.pop('modules', None)
+            external_modules = entry.get('modules', None)
             external_spec = spack.spec.Spec.from_detection(
                 spack.spec.Spec(
                     spec_str,
                     external_path=external_path,
                     external_modules=external_modules
-                ), extra_attributes=entry
+                ), extra_attributes=entry.get('extra_attributes', {})
             )
             if external_spec.satisfies(spec):
                 external_specs.append(external_spec)

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -39,7 +39,7 @@ from spack.mixins import filter_compiler_wrappers
 
 from spack.version import Version, ver
 
-from spack.spec import Spec
+from spack.spec import Spec, InvalidSpecDetected
 
 from spack.dependency import all_deptypes
 

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -13,7 +13,7 @@ from llnl.util.filesystem import *
 
 from spack.package import \
     Package, BundlePackage, \
-    run_before, run_after, on_package_attributes
+    run_before, run_after, on_package_attributes, detectable
 from spack.package import inject_flags, env_flags, build_system_flags
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.aspell_dict import AspellDictPackage

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -13,7 +13,7 @@ from llnl.util.filesystem import *
 
 from spack.package import \
     Package, BundlePackage, \
-    run_before, run_after, on_package_attributes, detectable
+    run_before, run_after, on_package_attributes
 from spack.package import inject_flags, env_flags, build_system_flags
 from spack.build_systems.makefile import MakefilePackage
 from spack.build_systems.aspell_dict import AspellDictPackage

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -90,11 +90,15 @@ def _make_validator():
         is_error = deprecated['error']
         if not is_error:
             for entry in deprecated_properties:
-                llnl.util.tty.warn(msg.format(property=entry))
+                llnl.util.tty.warn(
+                    msg.format(property=entry, entry=instance[entry])
+                )
         else:
             import jsonschema
             for entry in deprecated_properties:
-                yield jsonschema.ValidationError(msg.format(property=entry))
+                yield jsonschema.ValidationError(
+                    msg.format(property=entry, entry=instance[entry])
+                )
 
     return jsonschema.validators.extend(
         jsonschema.Draft4Validator, {

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -8,9 +8,12 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/env.py
    :lines: 36-
 """
+import warnings
+
 from llnl.util.lang import union_dicts
 
 import spack.schema.merged
+import spack.schema.packages
 import spack.schema.projections
 
 #: legal first keys in the schema
@@ -133,3 +136,22 @@ schema = {
         }
     }
 }
+
+
+def update(data):
+    """Update the data in place to remove deprecated properties.
+
+    Args:
+        data (dict): dictionary to be updated
+
+    Returns:
+        True if data was changed, False otherwise
+    """
+    if 'include' in data:
+        msg = ("included configuration files should be updated manually"
+               " [files={0}]")
+        warnings.warn(msg.format(', '.join(data['include'])))
+
+    if 'packages' in data:
+        return spack.schema.packages.update(data['packages'])
+    return False

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -81,7 +81,8 @@ properties = {
                                 'spec': {'type': 'string'},
                                 'prefix': {'type': 'string'},
                                 'modules': {'type': 'array',
-                                            'items': {'type': 'string'}}
+                                            'items': {'type': 'string'}},
+                                'extra_attributes': {'type': 'object'}
                             },
                             'additionalProperties': True,
                             'required': ['spec']

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -114,7 +114,7 @@ schema = {
 
 
 def update(data):
-    """Update in-place the data to remove deprecated properties.
+    """Update the data in place to remove deprecated properties.
 
     Args:
         data (dict): dictionary to be updated

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -79,6 +79,9 @@ properties = {
                             'type': 'object',
                             'properties': {
                                 'spec': {'type': 'string'},
+                                'prefix': {'type': 'string'},
+                                'modules': {'type': 'array',
+                                            'items': {'type': 'string'}}
                             },
                             'additionalProperties': True,
                             'required': ['spec']
@@ -135,7 +138,7 @@ def update(data):
         for spec, module in modules.items():
             externals.append({
                 'spec': str(spec),
-                'module': str(module)
+                'modules': [str(module)]
             })
         if externals:
             changed = True

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -94,10 +94,11 @@ properties = {
                 },
                 'deprecatedProperties': {
                     'properties': ['modules', 'paths'],
-                    'message': 'the attributes "modules" and "paths" in '
-                               'packages.yaml have been deprecated. Run '
-                               '"spack config update packages" to update '
-                               'your configuration',
+                    'message': 'the attributes "modules" and "paths" in the '
+                               '"packages" section of the configuration have '
+                               'been deprecated.\n\n'
+                               'Run "spack config update packages" or "spack '
+                               'env update" to update your configuration',
                     'error': True
                 }
             },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -94,12 +94,10 @@ properties = {
                 },
                 'deprecatedProperties': {
                     'properties': ['modules', 'paths'],
-                    'message': 'the attributes "modules" and "paths" in the '
-                               '"packages" section of the configuration have '
-                               'been deprecated.\n\n'
-                               'Run "spack config update packages" or "spack '
-                               'env update" to update your configuration',
-                    'error': True
+                    'message': 'the attribute "{property}" in the "packages" '
+                               'section of the configuration has been '
+                               'deprecated [entry={entry}]',
+                    'error': False
                 }
             },
         },

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4575,3 +4575,7 @@ class SpecDependencyNotFoundError(spack.error.SpecError):
 
 class SpecDeprecatedError(spack.error.SpecError):
     """Raised when a spec concretizes to a deprecated spec or dependency."""
+
+
+class InvalidSpecDetected(spack.error.SpecError):
+    """Raised when a detected spec doesn't pass validation checks."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1014,8 +1014,8 @@ class Spec(object):
         self._full_hash = full_hash
 
         # This attribute is used to store custom information for
-        # external specs
-        self._extra_attributes = None
+        # external specs. None signal that it was not set yet.
+        self.extra_attributes = None
 
         if isinstance(spec_like, six.string_types):
             spec_list = SpecParser(self).parse(spec_like)
@@ -1987,11 +1987,11 @@ class Spec(object):
             Spec object (external spec)
         """
         s = Spec(spec_str)
-        extra_attributes = extra_attributes or {}
+        extra_attributes = syaml.sorted_dict(extra_attributes or {})
         # This is needed to be able to validate multi-valued variants,
         # otherwise they'll still be abstract in the context of detection.
         vt.substitute_abstract_variants(s)
-        s._extra_attributes = extra_attributes
+        s.extra_attributes = extra_attributes
         s._mark_concrete()
         return s
 
@@ -2005,13 +2005,13 @@ class Spec(object):
         # which likely means the spec was created with Spec.from_detection
         msg = ('cannot validate "{0}" since it was not created '
                'using Spec.from_detection'.format(self))
-        assert isinstance(self._extra_attributes, collections.Mapping), msg
+        assert isinstance(self.extra_attributes, collections.Mapping), msg
 
         # Validate the spec calling a package specific method
         validate_fn = getattr(
             self.package, 'validate_detected_spec', lambda x, y: None
         )
-        validate_fn(self, self._extra_attributes)
+        validate_fn(self, self.extra_attributes)
 
     def _concretize_helper(self, concretizer, presets=None, visited=None):
         """Recursive helper function for concretize().

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -988,8 +988,6 @@ class Spec(object):
         self.variants = vt.VariantMap(self)
         self.architecture = None
         self.compiler = None
-        self.external_path = None
-        self.external_modules = None
         self.compiler_flags = FlagMap(self)
         self._dependents = DependencyMap()
         self._dependencies = DependencyMap()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1985,7 +1985,7 @@ class Spec(object):
             extra_attributes (dict): dictionary containing extra attributes
 
         Returns:
-            Spec object (external spec)
+            spack.spec.Spec: external spec
         """
         s = Spec(spec_str)
         extra_attributes = syaml.sorted_dict(extra_attributes or {})

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1531,6 +1531,7 @@ class Spec(object):
             d['external'] = syaml.syaml_dict([
                 ('path', self.external_path),
                 ('module', self.external_module),
+                ('extra_attributes', self.extra_attributes)
             ])
 
         if not self._concrete:
@@ -1699,9 +1700,9 @@ class Spec(object):
             for name in FlagMap.valid_compiler_flags():
                 spec.compiler_flags[name] = []
 
+        spec.external_path = None
+        spec.external_module = None
         if 'external' in node:
-            spec.external_path = None
-            spec.external_module = None
             # This conditional is needed because sometimes this function is
             # called with a node already constructed that contains a 'versions'
             # and 'external' field. Related to virtual packages provider
@@ -1711,9 +1712,9 @@ class Spec(object):
                 spec.external_module = node['external']['module']
                 if spec.external_module is False:
                     spec.external_module = None
-        else:
-            spec.external_path = None
-            spec.external_module = None
+                spec.extra_attributes = node['external'].get(
+                    'extra_attributes', syaml.syaml_dict()
+                )
 
         # specs read in are concrete unless marked abstract
         spec._concrete = node.get('concrete', True)
@@ -1992,7 +1993,6 @@ class Spec(object):
         # otherwise they'll still be abstract in the context of detection.
         vt.substitute_abstract_variants(s)
         s.extra_attributes = extra_attributes
-        s._mark_concrete()
         return s
 
     def validate_detection(self):
@@ -3118,6 +3118,7 @@ class Spec(object):
         self.variants.spec = self
         self.external_path = other.external_path
         self.external_module = other.external_module
+        self.extra_attributes = other.extra_attributes
         self.namespace = other.namespace
 
         # Cached fields are results of expensive operations.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -959,7 +959,7 @@ class Spec(object):
 
     def __init__(self, spec_like=None,
                  normal=False, concrete=False, external_path=None,
-                 external_module=None, full_hash=None):
+                 external_modules=None, full_hash=None):
         """Create a new Spec.
 
         Arguments:
@@ -989,7 +989,7 @@ class Spec(object):
         self.architecture = None
         self.compiler = None
         self.external_path = None
-        self.external_module = None
+        self.external_modules = None
         self.compiler_flags = FlagMap(self)
         self._dependents = DependencyMap()
         self._dependencies = DependencyMap()
@@ -1010,7 +1010,7 @@ class Spec(object):
         self._normal = normal
         self._concrete = concrete
         self.external_path = external_path
-        self.external_module = external_module
+        self.external_modules = external_modules
         self._full_hash = full_hash
 
         # This attribute is used to store custom information for
@@ -1029,7 +1029,7 @@ class Spec(object):
 
     @property
     def external(self):
-        return bool(self.external_path) or bool(self.external_module)
+        return bool(self.external_path) or bool(self.external_modules)
 
     def get_dependency(self, name):
         dep = self._dependencies.get(name)
@@ -1530,7 +1530,7 @@ class Spec(object):
         if self.external:
             d['external'] = syaml.syaml_dict([
                 ('path', self.external_path),
-                ('module', self.external_module),
+                ('module', self.external_modules),
                 ('extra_attributes', self.extra_attributes)
             ])
 
@@ -1701,7 +1701,7 @@ class Spec(object):
                 spec.compiler_flags[name] = []
 
         spec.external_path = None
-        spec.external_module = None
+        spec.external_modules = None
         if 'external' in node:
             # This conditional is needed because sometimes this function is
             # called with a node already constructed that contains a 'versions'
@@ -1709,9 +1709,9 @@ class Spec(object):
             # indexes.
             if node['external']:
                 spec.external_path = node['external']['path']
-                spec.external_module = node['external']['module']
-                if spec.external_module is False:
-                    spec.external_module = None
+                spec.external_modules = node['external']['module']
+                if spec.external_modules is False:
+                    spec.external_modules = None
                 spec.extra_attributes = node['external'].get(
                     'extra_attributes', syaml.syaml_dict()
                 )
@@ -2158,8 +2158,8 @@ class Spec(object):
                         feq(replacement.variants, spec.variants) and
                         feq(replacement.external_path,
                             spec.external_path) and
-                        feq(replacement.external_module,
-                            spec.external_module)):
+                        feq(replacement.external_modules,
+                            spec.external_modules)):
                     continue
                 # Refine this spec to the candidate. This uses
                 # replace_with AND dup so that it can work in
@@ -2293,7 +2293,7 @@ class Spec(object):
                 t[-1] for t in ordered_hashes)
 
         for s in self.traverse():
-            if s.external_module and not s.external_path:
+            if s.external_modules and not s.external_path:
                 compiler = spack.compilers.compiler_for_spec(
                     s.compiler, s.architecture)
                 for mod in compiler.modules:
@@ -2302,8 +2302,8 @@ class Spec(object):
                 # get the path from the module
                 # the package can override the default
                 s.external_path = getattr(s.package, 'external_prefix',
-                                          md.get_path_from_module(
-                                              s.external_module))
+                                          md.path_from_modules(
+                                              s.external_modules))
 
         # Mark everything in the spec as concrete, as well.
         self._mark_concrete()
@@ -3089,7 +3089,7 @@ class Spec(object):
                        self._normal != other._normal and
                        self.concrete != other.concrete and
                        self.external_path != other.external_path and
-                       self.external_module != other.external_module and
+                       self.external_modules != other.external_modules and
                        self.compiler_flags != other.compiler_flags)
 
         self._package = None
@@ -3117,7 +3117,7 @@ class Spec(object):
 
         self.variants.spec = self
         self.external_path = other.external_path
-        self.external_module = other.external_module
+        self.external_modules = other.external_modules
         self.extra_attributes = other.extra_attributes
         self.namespace = other.namespace
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -527,14 +527,10 @@ spack:
             ci_cmd('generate', '--output-file', outputfile)
 
         with open(outputfile) as f:
-            contents = f.read()
-            print('generated contents: ')
-            print(contents)
-            yaml_contents = syaml.load(contents)
-            for ci_key in yaml_contents.keys():
-                if 'externaltool' in ci_key:
-                    print('Erroneously staged "externaltool" pkg')
-                    assert(False)
+            yaml_contents = syaml.load(f)
+
+        # Check that the "externaltool package was not erroneously staged
+        assert not any('externaltool' in key for key in yaml_contents)
 
 
 def test_ci_generate_debug_with_custom_spack(tmpdir, mutable_mock_env_path,

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -529,7 +529,7 @@ spack:
         with open(outputfile) as f:
             yaml_contents = syaml.load(f)
 
-        # Check that the "externaltool package was not erroneously staged
+        # Check that the "externaltool" package was not erroneously staged
         assert not any('externaltool' in key for key in yaml_contents)
 
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -25,7 +25,7 @@ def md5sum(file):
 
 
 @pytest.fixture()
-def packages_yaml(mutable_config):
+def old_format_packages_yaml(mutable_config):
     """Create a packages.yaml in the old format"""
     def _create():
         old_data = {'packages': {'cmake': {'paths': {'cmake@3.14.0': '/usr'}}}}
@@ -430,8 +430,8 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
     assert output == expected
 
 
-def test_config_update(packages_yaml):
-    packages_yaml()
+def test_config_update(old_format_packages_yaml):
+    old_format_packages_yaml()
     config('update', 'packages')
 
     # Check the entries have been transformed
@@ -451,19 +451,19 @@ def test_config_update_not_needed(mutable_config):
     assert data_before == data_after
 
 
-def test_config_update_fail_if_bkp_is_there(packages_yaml):
+def test_config_update_fail_if_bkp_is_there(old_format_packages_yaml):
     # The first time it will update and create the backup file
-    packages_yaml()
+    old_format_packages_yaml()
     config('update', 'packages')
     # The second time it will stop because a backup file
     # is already present
-    packages_yaml()
+    old_format_packages_yaml()
     with pytest.raises(spack.main.SpackCommandError):
         config('update', 'packages')
 
 
-def test_config_revert(packages_yaml):
-    cfg_file = packages_yaml()
+def test_config_revert(old_format_packages_yaml):
+    cfg_file = old_format_packages_yaml()
     bkp_file = cfg_file + '.bkp'
 
     config('update', 'packages')
@@ -481,8 +481,8 @@ def test_config_revert(packages_yaml):
     assert md5bkp == md5sum(cfg_file)
 
 
-def test_config_revert_raise_if_not_force(packages_yaml):
-    packages_yaml()
+def test_config_revert_raise_if_not_force(old_format_packages_yaml):
+    old_format_packages_yaml()
     config('update', 'packages')
     # The command raises with an helpful error if a configuration
     # file is to be deleted and the user didn't specify --force

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -422,7 +422,11 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
     assert output == expected
 
 
-def test_config_update(old_format_packages_yaml):
+def test_config_update_packages(old_format_packages_yaml):
+    """Test Spack updating old packages.yaml format for externals
+    to new format. Ensure that data is preserved and converted
+    properly.
+    """
     old_format_packages_yaml()
     config('update', 'packages')
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -17,7 +17,7 @@ env = spack.main.SpackCommand('env')
 
 
 @pytest.fixture()
-def old_format_packages_yaml(mutable_config):
+def packages_yaml_v015(mutable_config):
     """Create a packages.yaml in the old format"""
     def _create(scope=None):
         old_data = {
@@ -428,12 +428,12 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
     assert output == expected
 
 
-def test_config_update_packages(old_format_packages_yaml):
+def test_config_update_packages(packages_yaml_v015):
     """Test Spack updating old packages.yaml format for externals
     to new format. Ensure that data is preserved and converted
     properly.
     """
-    old_format_packages_yaml()
+    packages_yaml_v015()
     config('update', '-y', 'packages')
 
     # Check the entries have been transformed
@@ -448,16 +448,16 @@ def test_config_update_not_needed(mutable_config):
     assert data_before == data_after
 
 
-def test_config_update_fail_on_permission_issue(old_format_packages_yaml):
+def test_config_update_fail_on_permission_issue(packages_yaml_v015):
     # The first time it will update and create the backup file
-    cfg_file = old_format_packages_yaml()
+    cfg_file = packages_yaml_v015()
     os.chmod(cfg_file, 0o555)
     with pytest.raises(spack.main.SpackCommandError):
         config('update', '-y', 'packages')
 
 
-def test_config_revert(old_format_packages_yaml):
-    cfg_file = old_format_packages_yaml()
+def test_config_revert(packages_yaml_v015):
+    cfg_file = packages_yaml_v015()
     bkp_file = cfg_file + '.bkp'
 
     config('update', '-y', 'packages')
@@ -475,8 +475,8 @@ def test_config_revert(old_format_packages_yaml):
     assert md5bkp == fs.md5sum(cfg_file)
 
 
-def test_config_revert_raise_if_cant_write(old_format_packages_yaml):
-    cfg_file = old_format_packages_yaml()
+def test_config_revert_raise_if_cant_write(packages_yaml_v015):
+    cfg_file = packages_yaml_v015()
     config('update', '-y', 'packages')
 
     # Mock a global scope where we cannot write
@@ -487,20 +487,20 @@ def test_config_revert_raise_if_cant_write(old_format_packages_yaml):
         config('revert', '-y', 'packages')
 
 
-def test_updating_config_implicitly_raises(old_format_packages_yaml):
+def test_updating_config_implicitly_raises(packages_yaml_v015):
     # Trying to write implicitly to a scope with a configuration file
     # in the old format raises an exception
-    old_format_packages_yaml()
+    packages_yaml_v015()
     with pytest.raises(RuntimeError):
         config('add', 'packages:cmake:buildable:false')
 
 
-def test_updating_multiple_scopes_at_once(old_format_packages_yaml):
+def test_updating_multiple_scopes_at_once(packages_yaml_v015):
     # Create 2 config files in the old format
-    old_format_packages_yaml(scope='user')
-    old_format_packages_yaml(scope='site')
+    packages_yaml_v015(scope='user')
+    packages_yaml_v015(scope='site')
 
-    # Update them at once
+    # Update both of them at once
     config('update', '-y', 'packages')
 
     for scope in ('user', 'site'):
@@ -509,7 +509,7 @@ def test_updating_multiple_scopes_at_once(old_format_packages_yaml):
 
 
 def check_update(data):
-    """Check that the data from the old_format_packages_yaml
+    """Check that the data from the packages_yaml_v015
     has been updated.
     """
     assert 'externals' in data['cmake']

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -20,10 +20,16 @@ env = spack.main.SpackCommand('env')
 def old_format_packages_yaml(mutable_config):
     """Create a packages.yaml in the old format"""
     def _create():
-        old_data = {'packages': {'cmake': {'paths': {'cmake@3.14.0': '/usr'}}}}
-        old_data['packages'].update(
-            {'gcc': {'modules': {'gcc@8.3.0': 'gcc-8'}}}
-        )
+        old_data = {
+            'packages': {
+                'cmake': {
+                    'paths': {'cmake@3.14.0': '/usr'}
+                },
+                'gcc': {
+                    'modules': {'gcc@8.3.0': 'gcc-8'}
+                }
+            }
+        }
         scope = spack.config.default_modify_scope()
         cfg_file = spack.config.config.get_config_filename(scope, 'packages')
         with open(cfg_file, 'w') as f:

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -2,26 +2,18 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import hashlib
 import os
 
 import pytest
 
+import llnl.util.filesystem as fs
 import spack.config
 import spack.environment as ev
+import spack.main
 import spack.util.spack_yaml as syaml
-from llnl.util.filesystem import mkdirp
-from spack.main import SpackCommand
 
-config = SpackCommand('config')
-env = SpackCommand('env')
-
-
-def md5sum(file):
-    md5 = hashlib.md5()
-    with open(file, "rb") as f:
-        md5.update(f.read())
-    return md5.digest()
+config = spack.main.SpackCommand('config')
+env = spack.main.SpackCommand('env')
 
 
 @pytest.fixture()
@@ -48,8 +40,8 @@ def test_get_config_scope_merged(mock_low_high_config):
     low_path = mock_low_high_config.scopes['low'].path
     high_path = mock_low_high_config.scopes['high'].path
 
-    mkdirp(low_path)
-    mkdirp(high_path)
+    fs.mkdirp(low_path)
+    fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, 'repos.yaml'), 'w') as f:
         f.write('''\
@@ -470,7 +462,7 @@ def test_config_revert(old_format_packages_yaml):
 
     # Check that the backup file exists, compute its md5 sum
     assert os.path.exists(bkp_file)
-    md5bkp = md5sum(bkp_file)
+    md5bkp = fs.md5sum(bkp_file)
 
     config('revert', '--force', 'packages')
 
@@ -478,7 +470,7 @@ def test_config_revert(old_format_packages_yaml):
     # that the md5 sum of the configuration file is the same
     # as that of the old backup file
     assert not os.path.exists(bkp_file)
-    assert md5bkp == md5sum(cfg_file)
+    assert md5bkp == fs.md5sum(cfg_file)
 
 
 def test_config_revert_raise_if_not_force(old_format_packages_yaml):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -437,7 +437,7 @@ def test_config_update_packages(old_format_packages_yaml):
     assert {'spec': 'cmake@3.14.0', 'prefix': '/usr'} in externals
     assert 'externals' in data['gcc']
     externals = data['gcc']['externals']
-    assert {'spec': 'gcc@8.3.0', 'module': 'gcc-8'} in externals
+    assert {'spec': 'gcc@8.3.0', 'modules': ['gcc-8']} in externals
 
 
 def test_config_update_not_needed(mutable_config):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2057,7 +2057,7 @@ spack:
     manifest = tmpdir.ensure('spack.yaml')
     backup_file = tmpdir.join('spack.yaml.bkp')
     manifest.write(raw_yaml)
-    env('update', str(manifest.dirname))
+    env('update', '-y', str(manifest.dirname))
 
     # Check if the backup file has been created
     assert os.path.exists(str(backup_file))
@@ -2066,16 +2066,12 @@ spack:
 
     # Retrying another update does nothing since the
     # manifest is up-to-date
-    env('update', str(manifest.dirname))
-
-    # An update on an old manifest fails in presence of a backup file
-    manifest.write(raw_yaml)
-    with pytest.raises(AssertionError):
-        env('update', str(manifest.dirname))
+    env('update', '-y', str(manifest.dirname))
 
     # Try an update followed by a revert
     os.unlink(str(backup_file))
-    env('update', str(manifest.dirname))
+    manifest.write(raw_yaml)
+    env('update', '-y', str(manifest.dirname))
     assert os.path.exists(str(backup_file))
-    env('revert', '--force', str(manifest.dirname))
+    env('revert', '-y', str(manifest.dirname))
     assert not os.path.exists(str(backup_file))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -448,8 +448,9 @@ env:
     external_config = StringIO("""\
 packages:
   a:
-    paths:
-      a: {a_prefix}
+    externals:
+    - spec: a
+      prefix: {a_prefix}
     buildable: false
 """.format(a_prefix=str(fake_prefix)))
     external_config_dict = spack.util.spack_yaml.load_config(external_config)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2105,3 +2105,10 @@ def test_update_and_revert(packages_yaml_v015):
     env('revert', '-y', str(manifest.dirname))
     assert not os.path.exists(str(backup_file))
     assert not ev.is_latest_format(str(manifest))
+
+
+def test_old_format_cant_be_updated_implicitly(packages_yaml_v015):
+    manifest, backup_file = packages_yaml_v015
+    env('activate', str(manifest.dirname))
+    with pytest.raises(spack.main.SpackCommandError):
+        add('hdf5')

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -182,3 +182,8 @@ def test_find_external_merge(mutable_config, mutable_mock_repo):
             'prefix': '/preexisting-prefix/'} in pkg_externals
     assert {'spec': 'find-externals1@1.2',
             'prefix': '/x/y2/'} in pkg_externals
+
+
+def test_list_detectable_packages(mutable_config, mutable_mock_repo):
+    external("list")
+    assert external.returncode == 0

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -2,10 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import pytest
 import os
-import stat
+import os.path
 
 import spack
 from spack.spec import Spec
@@ -13,30 +11,10 @@ from spack.cmd.external import ExternalPackageEntry
 from spack.main import SpackCommand
 
 
-@pytest.fixture()
-def create_exe(tmpdir_factory):
-    def _create_exe(exe_name, content):
-        base_prefix = tmpdir_factory.mktemp('base-prefix')
-        base_prefix.ensure('bin', dir=True)
-        exe_path = str(base_prefix.join('bin', exe_name))
-        with open(exe_path, 'w') as f:
-            f.write("""\
-#!/bin/bash
-
-echo "{0}"
-""".format(content))
-
-        st = os.stat(exe_path)
-        os.chmod(exe_path, st.st_mode | stat.S_IEXEC)
-        return exe_path
-
-    yield _create_exe
-
-
-def test_find_external_single_package(create_exe):
+def test_find_external_single_package(mock_executable):
     pkgs_to_check = [spack.repo.get('cmake')]
 
-    cmake_path = create_exe("cmake", "cmake version 1.foo")
+    cmake_path = mock_executable("cmake", output='echo "cmake version 1.foo"')
     system_path_to_exe = {cmake_path: 'cmake'}
 
     pkg_to_entries = spack.cmd.external._get_external_packages(
@@ -48,12 +26,16 @@ def test_find_external_single_package(create_exe):
     assert single_entry.spec == Spec('cmake@1.foo')
 
 
-def test_find_external_two_instances_same_package(create_exe):
+def test_find_external_two_instances_same_package(mock_executable):
     pkgs_to_check = [spack.repo.get('cmake')]
 
     # Each of these cmake instances is created in a different prefix
-    cmake_path1 = create_exe("cmake", "cmake version 1.foo")
-    cmake_path2 = create_exe("cmake", "cmake version 3.17.2")
+    cmake_path1 = mock_executable(
+        "cmake", output='echo "cmake version 1.foo"', subdir=('base1', 'bin')
+    )
+    cmake_path2 = mock_executable(
+        "cmake", output='echo "cmake version 3.17.2"', subdir=('base2', 'bin')
+    )
     system_path_to_exe = {
         cmake_path1: 'cmake',
         cmake_path2: 'cmake'}
@@ -86,8 +68,8 @@ def test_find_external_update_config(mutable_config):
     assert {'spec': 'cmake@3.17.2', 'prefix': '/x/y2/'} in cmake_externals
 
 
-def test_get_executables(working_env, create_exe):
-    cmake_path1 = create_exe("cmake", "cmake version 1.foo")
+def test_get_executables(working_env, mock_executable):
+    cmake_path1 = mock_executable("cmake", output="echo cmake version 1.foo")
 
     os.environ['PATH'] = ':'.join([os.path.dirname(cmake_path1)])
     path_to_exe = spack.cmd.external._get_system_executables()
@@ -97,11 +79,11 @@ def test_get_executables(working_env, create_exe):
 external = SpackCommand('external')
 
 
-def test_find_external_cmd(mutable_config, working_env, create_exe):
+def test_find_external_cmd(mutable_config, working_env, mock_executable):
     """Test invoking 'spack external find' with additional package arguments,
     which restricts the set of packages that Spack looks for.
     """
-    cmake_path1 = create_exe("cmake", "cmake version 1.foo")
+    cmake_path1 = mock_executable("cmake", output="echo cmake version 1.foo")
     prefix = os.path.dirname(os.path.dirname(cmake_path1))
 
     os.environ['PATH'] = ':'.join([os.path.dirname(cmake_path1)])
@@ -115,12 +97,12 @@ def test_find_external_cmd(mutable_config, working_env, create_exe):
 
 
 def test_find_external_cmd_not_buildable(
-        mutable_config, working_env, create_exe):
+        mutable_config, working_env, mock_executable):
     """When the user invokes 'spack external find --not-buildable', the config
     for any package where Spack finds an external version should be marked as
     not buildable.
     """
-    cmake_path1 = create_exe("cmake", "cmake version 1.foo")
+    cmake_path1 = mock_executable("cmake", output="echo cmake version 1.foo")
     os.environ['PATH'] = ':'.join([os.path.dirname(cmake_path1)])
     external('find', '--not-buildable', 'cmake')
     pkgs_cfg = spack.config.get('packages')
@@ -128,13 +110,13 @@ def test_find_external_cmd_not_buildable(
 
 
 def test_find_external_cmd_full_repo(
-        mutable_config, working_env, create_exe, mutable_mock_repo):
+        mutable_config, working_env, mock_executable, mutable_mock_repo):
     """Test invoking 'spack external find' with no additional arguments, which
     iterates through each package in the repository.
     """
 
-    exe_path1 = create_exe(
-        "find-externals1-exe", "find-externals1 version 1.foo"
+    exe_path1 = mock_executable(
+        "find-externals1-exe", output="echo find-externals1 version 1.foo"
     )
     prefix = os.path.dirname(os.path.dirname(exe_path1))
 
@@ -187,3 +169,27 @@ def test_find_external_merge(mutable_config, mutable_mock_repo):
 def test_list_detectable_packages(mutable_config, mutable_mock_repo):
     external("list")
     assert external.returncode == 0
+
+
+def test_packages_yaml_format(mock_executable, mutable_config, monkeypatch):
+    # Prepare an environment to detect a fake gcc
+    gcc_exe = mock_executable('gcc', output="echo 4.2.1")
+    prefix = os.path.dirname(gcc_exe)
+    monkeypatch.setenv('PATH', prefix)
+
+    # Find the external spec
+    external('find', 'gcc')
+
+    # Check entries in 'packages.yaml'
+    packages_yaml = spack.config.get('packages')
+    assert 'gcc' in packages_yaml
+    assert 'externals' in packages_yaml['gcc']
+    externals = packages_yaml['gcc']['externals']
+    assert len(externals) == 1
+    external_gcc = externals[0]
+    assert external_gcc['spec'] == 'gcc@4.2.1 languages=c'
+    assert external_gcc['prefix'] == os.path.dirname(prefix)
+    assert 'extra_attributes' in external_gcc
+    extra_attributes = external_gcc['extra_attributes']
+    assert 'prefix' not in extra_attributes
+    assert extra_attributes['compilers']['c'] == gcc_exe

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -373,7 +373,7 @@ class TestConcretize(object):
 
         spec = Spec('externalmodule')
         spec.concretize()
-        assert spec['externalmodule'].external_module == 'external-module'
+        assert spec['externalmodule'].external_modules == ['external-module']
         assert 'externalprereq' not in spec
         assert spec['externalmodule'].compiler.satisfies('gcc')
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -198,8 +198,9 @@ all:
         mpi: [mpich]
 mpich:
     buildable: false
-    paths:
-        mpich@3.0.4: /dummy/path
+    externals:
+    - spec: mpich@3.0.4
+      prefix: /dummy/path
 """)
         spack.config.set('packages', conf, scope='concretize')
 
@@ -229,8 +230,9 @@ all:
         mpi: [mpich]
 mpi:
     buildable: false
-    modules:
-        mpich@3.0.4: dummy
+    externals:
+    - spec: mpich@3.0.4
+      module: dummy
 """)
         spack.config.set('packages', conf, scope='concretize')
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -232,7 +232,7 @@ mpi:
     buildable: false
     externals:
     - spec: mpich@3.0.4
-      module: dummy
+      modules: [dummy]
 """)
         spack.config.set('packages', conf, scope='concretize')
 

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -20,4 +20,5 @@ packages:
     buildable: False
     externals:
     - spec: externalmodule@1.0%gcc@4.5.0
-      module: external-module
+      modules:
+      - external-module

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -4,15 +4,20 @@ packages:
       mpi: [openmpi, mpich]
   externaltool:
     buildable: False
-    paths:
-      externaltool@1.0%gcc@4.5.0: /path/to/external_tool
-      externaltool@0.9%gcc@4.5.0: /usr
+    externals:
+    - spec: externaltool@1.0%gcc@4.5.0
+      prefix: /path/to/external_tool
+    - spec: externaltool@0.9%gcc@4.5.0
+      prefix: /usr
   externalvirtual:
     buildable: False
-    paths:
-      externalvirtual@2.0%clang@3.3: /path/to/external_virtual_clang
-      externalvirtual@1.0%gcc@4.5.0: /path/to/external_virtual_gcc
+    externals:
+    - spec: externalvirtual@2.0%clang@3.3
+      prefix: /path/to/external_virtual_clang
+    - spec: externalvirtual@1.0%gcc@4.5.0
+      prefix: /path/to/external_virtual_gcc
   externalmodule:
     buildable: False
-    modules:
-      externalmodule@1.0%gcc@4.5.0: external-module
+    externals:
+    - spec: externalmodule@1.0%gcc@4.5.0
+      module: external-module

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -689,17 +689,17 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database):
 def test_external_entries_in_db(mutable_database):
     rec = mutable_database.get_record('mpileaks ^zmpi')
     assert rec.spec.external_path is None
-    assert rec.spec.external_modules is None
+    assert not rec.spec.external_modules
 
     rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_modules is None
+    assert not rec.spec.external_modules
     assert rec.explicit is False
 
     rec.spec.package.do_install(fake=True, explicit=True)
     rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_modules is None
+    assert not rec.spec.external_modules
     assert rec.explicit is True
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -689,17 +689,17 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database):
 def test_external_entries_in_db(mutable_database):
     rec = mutable_database.get_record('mpileaks ^zmpi')
     assert rec.spec.external_path is None
-    assert rec.spec.external_module is None
+    assert rec.spec.external_modules is None
 
     rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_module is None
+    assert rec.spec.external_modules is None
     assert rec.explicit is False
 
     rec.spec.package.do_install(fake=True, explicit=True)
     rec = mutable_database.get_record('externaltool')
     assert rec.spec.external_path == '/path/to/external_tool'
-    assert rec.spec.external_module is None
+    assert rec.spec.external_modules is None
     assert rec.explicit is True
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -157,7 +157,7 @@ def test_process_external_package_module(install_mockery, monkeypatch, capfd):
     monkeypatch.setattr(spack.database.Database, 'get_record', _none)
 
     spec.external_path = '/actual/external/path/not/checked'
-    spec.external_modules = 'unchecked_module'
+    spec.external_modules = ['unchecked_module']
     inst._process_external_package(spec.package, False)
 
     out = capfd.readouterr()[0]
@@ -257,15 +257,15 @@ def test_installer_ensure_ready_errors(install_mockery):
 
     fmt = r'cannot be installed locally.*{0}'
     # Force an external package error
-    path, module = spec.external_path, spec.external_modules
+    path, modules = spec.external_path, spec.external_modules
     spec.external_path = '/actual/external/path/not/checked'
-    spec.external_modules = 'unchecked_module'
+    spec.external_modules = ['unchecked_module']
     msg = fmt.format('is external')
     with pytest.raises(inst.ExternalPackageError, match=msg):
         installer._ensure_install_ready(spec.package)
 
     # Force an upstream package error
-    spec.external_path, spec.external_modules = path, module
+    spec.external_path, spec.external_modules = path, modules
     spec.package._installed_upstream = True
     msg = fmt.format('is upstream')
     with pytest.raises(inst.UpstreamPackageError, match=msg):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -157,11 +157,11 @@ def test_process_external_package_module(install_mockery, monkeypatch, capfd):
     monkeypatch.setattr(spack.database.Database, 'get_record', _none)
 
     spec.external_path = '/actual/external/path/not/checked'
-    spec.external_module = 'unchecked_module'
+    spec.external_modules = 'unchecked_module'
     inst._process_external_package(spec.package, False)
 
     out = capfd.readouterr()[0]
-    assert 'has external module in {0}'.format(spec.external_module) in out
+    assert 'has external module in {0}'.format(spec.external_modules) in out
 
 
 def test_process_binary_cache_tarball_none(install_mockery, monkeypatch,
@@ -257,15 +257,15 @@ def test_installer_ensure_ready_errors(install_mockery):
 
     fmt = r'cannot be installed locally.*{0}'
     # Force an external package error
-    path, module = spec.external_path, spec.external_module
+    path, module = spec.external_path, spec.external_modules
     spec.external_path = '/actual/external/path/not/checked'
-    spec.external_module = 'unchecked_module'
+    spec.external_modules = 'unchecked_module'
     msg = fmt.format('is external')
     with pytest.raises(inst.ExternalPackageError, match=msg):
         installer._ensure_install_ready(spec.package)
 
     # Force an upstream package error
-    spec.external_path, spec.external_module = path, module
+    spec.external_path, spec.external_modules = path, module
     spec.package._installed_upstream = True
     msg = fmt.format('is upstream')
     with pytest.raises(inst.UpstreamPackageError, match=msg):

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -9,7 +9,7 @@ import spack
 
 from spack.util.module_cmd import (
     module,
-    get_path_from_module,
+    path_from_modules,
     get_path_args_from_module_line,
     get_path_from_module_contents
 )
@@ -55,7 +55,7 @@ def test_get_path_from_module_faked(monkeypatch):
             return line
         monkeypatch.setattr(spack.util.module_cmd, 'module', fake_module)
 
-        path = get_path_from_module('mod')
+        path = path_from_modules(['mod'])
         assert path == '/path/to'
 
 
@@ -116,10 +116,10 @@ def test_get_argument_from_module_line():
     bad_lines = ['prepend_path(PATH,/lib/path)',
                  'prepend-path (LD_LIBRARY_PATH) /lib/path']
 
-    assert all(get_path_args_from_module_line(l) == ['/lib/path']
-               for l in simple_lines)
-    assert all(get_path_args_from_module_line(l) == ['/lib/path', '/pkg/path']
-               for l in complex_lines)
+    assert all(get_path_args_from_module_line(x) == ['/lib/path']
+               for x in simple_lines)
+    assert all(get_path_args_from_module_line(x) == ['/lib/path', '/pkg/path']
+               for x in complex_lines)
     for bl in bad_lines:
         with pytest.raises(ValueError):
             get_path_args_from_module_line(bl)

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -135,18 +135,32 @@ def get_path_args_from_module_line(line):
     return paths
 
 
-def get_path_from_module(mod):
-    """Inspects a TCL module for entries that indicate the absolute path
-    at which the library supported by said module can be found.
-    """
-    # Read the module
-    text = module('show', mod).split('\n')
+def path_from_modules(modules):
+    """Inspect a list of TCL modules for entries that indicate the absolute
+    path at which the library supported by said module can be found.
 
-    p = get_path_from_module_contents(text, mod)
-    if p and not os.path.exists(p):
-        tty.warn("Extracted path from module does not exist:"
-                 "\n\tExtracted path: " + p)
-    return p
+    Args:
+        modules (list): module files to be loaded to get an external package
+
+    Returns:
+        Guess of the prefix path where the package
+    """
+    best_choice = None
+    for module_name in modules:
+        # Read the current module and return a candidate path
+        text = module('show', module_name).split('\n')
+        candidate_path = get_path_from_module_contents(text, module_name)
+
+        if candidate_path and not os.path.exists(candidate_path):
+            msg = ("Extracted path from module does not exist "
+                   "[module={0}, path={0}]")
+            tty.warn(msg.format(module_name, candidate_path))
+
+        # If anything is found, then it's the best choice. This means
+        # that we give preference to the last module to be loaded
+        # for packages requiring to load multiple modules in sequence
+        best_choice = candidate_path or best_choice
+    return best_choice
 
 
 def get_path_from_module_contents(text, module_name):

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -13,7 +13,7 @@
 
 """
 import ctypes
-
+import collections
 
 from ordereddict_backport import OrderedDict
 from six import string_types, StringIO
@@ -330,6 +330,22 @@ def dump_annotated(data, stream=None, *args, **kwargs):
 
     if getvalue:
         return getvalue()
+
+
+def sorted_dict(dict_like):
+    """Return an ordered dict with all the fields sorted recursively.
+
+    Args:
+        dict_like (dict): dictionary to be sorted
+
+    Returns:
+        dictionary sorted recursively
+    """
+    result = syaml_dict(sorted(dict_like.items()))
+    for key, value in result.items():
+        if isinstance(value, collections.Mapping):
+            result[key] = sorted_dict(value)
+    return result
 
 
 class SpackYAMLError(spack.error.SpackError):

--- a/share/spack/qa/configuration/packages.yaml
+++ b/share/spack/qa/configuration/packages.yaml
@@ -1,26 +1,32 @@
 packages:
   cmake:
     buildable: False
-    paths:
-      cmake@3.12.4: /usr
+    externals:
+    - spec: cmake@3.12.4
+      prefix: /usr
   r:
     buildable: False
-    paths:
-      r@3.4.4: /usr
+    externals:
+    - spec: r@3.4.4
+      prefix: /usr
   perl:
     buildable: False
-    paths:
-      perl@5.26.1: /usr
+    externals:
+    - spec: perl@5.26.1
+      prefix: /usr
   findutils:
     buildable: False
-    paths:
-      findutils@4.6.0: /usr
+    externals:
+    - spec: findutils@4.6.0
+      prefix: /usr
   openssl:
     buildable: False
-    paths:
-      openssl@1.1.1: /usr
+    externals:
+    - spec: openssl@1.1.1
+      prefix: /usr
   libpciaccess:
     buildable: False
-    paths:
-      libpciaccess@0.13.5: /usr
+    externals:
+    - spec: libpciaccess@0.13.5
+      prefix: /usr
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -835,7 +835,7 @@ _spack_external() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find"
+        SPACK_COMPREPLY="find list"
     fi
 }
 
@@ -846,6 +846,10 @@ _spack_external_find() {
     else
         _all_packages
     fi
+}
+
+_spack_external_list() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_fetch() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -635,7 +635,7 @@ _spack_config_rm() {
 _spack_config_update() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --list-only"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         _config_sections
     fi
@@ -644,7 +644,7 @@ _spack_config_update() {
 _spack_config_revert() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --force"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         _config_sections
     fi
@@ -824,7 +824,7 @@ _spack_env_view() {
 _spack_env_update() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         _environments
     fi
@@ -833,7 +833,7 @@ _spack_env_update() {
 _spack_env_revert() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --force"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         _environments
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -570,7 +570,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list add remove rm"
+        SPACK_COMPREPLY="get blame edit list add remove rm update"
     fi
 }
 
@@ -629,6 +629,24 @@ _spack_config_rm() {
         SPACK_COMPREPLY="-h --help"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_config_update() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _config_sections
+    fi
+}
+
+_spack_configure() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -v --verbose"
+    else
+        _all_packages
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -570,7 +570,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list add remove rm update"
+        SPACK_COMPREPLY="get blame edit list add remove rm update revert"
     fi
 }
 
@@ -641,12 +641,12 @@ _spack_config_update() {
     fi
 }
 
-_spack_configure() {
+_spack_config_revert() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -v --verbose"
+        SPACK_COMPREPLY="-h --help --force"
     else
-        _all_packages
+        _config_sections
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -635,7 +635,7 @@ _spack_config_rm() {
 _spack_config_update() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --list-only"
     else
         _config_sections
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -743,7 +743,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view"
+        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert"
     fi
 }
 
@@ -818,6 +818,24 @@ _spack_env_view() {
         SPACK_COMPREPLY="-h --help"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_env_update() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _environments
+    fi
+}
+
+_spack_env_revert() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --force"
+    else
+        _environments
     fi
 }
 

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -31,4 +31,6 @@ class FindExternals1(AutotoolsPackage):
             match = re.search(r'find-externals1.*version\s+(\S+)', output)
             if match:
                 version_str = match.group(1)
-                return Spec('find-externals1@{0}'.format(version_str))
+                return Spec.from_detection(
+                    'find-externals1@{0}'.format(version_str)
+                )

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -8,7 +8,6 @@ import re
 import spack.package
 
 
-@spack.package.detectable
 class FindExternals1(AutotoolsPackage):
     executables = ['find-externals1-exe']
 

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -2,13 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
-
 import os
 import re
 
+import spack.package
 
+
+@spack.package.detectable
 class FindExternals1(AutotoolsPackage):
     executables = ['find-externals1-exe']
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -2,13 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
-
 import os
 import re
 
+import spack.package
 
+
+@spack.package.detectable
 class Automake(AutotoolsPackage, GNUMirrorPackage):
     """Automake -- make file builder part of autotools"""
 
@@ -31,20 +31,13 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     executables = ['automake']
 
     @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        exe_to_path = dict(
-            (os.path.basename(p), p) for p in exes_in_prefix
-        )
-        if 'automake' not in exe_to_path:
+    def determine_version(cls, exe):
+        if os.path.basename(exe) != 'automake':
             return None
 
-        exe = spack.util.executable.Executable(exe_to_path['automake'])
-        output = exe('--version', output=str)
-        if output:
-            match = re.search(r'GNU automake\)\s+(\S+)', output)
-            if match:
-                version_str = match.group(1)
-                return Spec.from_detection('automake@{0}'.format(version_str))
+        output = spack.util.executable.Executable(exe)('--version', output=str)
+        match = re.search(r'GNU automake\)\s+(\S+)', output)
+        return match.group(1) if match else None
 
     def patch(self):
         # The full perl shebang might be too long

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
 
-import spack.package
 
-
-@spack.package.detectable
+@detectable
 class Automake(AutotoolsPackage, GNUMirrorPackage):
     """Automake -- make file builder part of autotools"""
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 import re
 
 import spack.package
@@ -28,14 +27,11 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
 
     build_directory = 'spack-build'
 
-    executables = ['automake']
+    executables = ['^automake$']
 
     @classmethod
     def determine_version(cls, exe):
-        if os.path.basename(exe) != 'automake':
-            return None
-
-        output = spack.util.executable.Executable(exe)('--version', output=str)
+        output = Executable(exe)('--version', output=str)
         match = re.search(r'GNU automake\)\s+(\S+)', output)
         return match.group(1) if match else None
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -44,7 +44,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
             match = re.search(r'GNU automake\)\s+(\S+)', output)
             if match:
                 version_str = match.group(1)
-                return Spec('automake@{0}'.format(version_str))
+                return Spec.from_detection('automake@{0}'.format(version_str))
 
     def patch(self):
         # The full perl shebang might be too long

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -5,7 +5,6 @@
 import re
 
 
-@detectable
 class Automake(AutotoolsPackage, GNUMirrorPackage):
     """Automake -- make file builder part of autotools"""
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -5,7 +5,6 @@
 import re
 
 
-@detectable
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
     tools designed to build, test and package software.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -175,7 +175,7 @@ class Cmake(Package):
             match = re.search(r'cmake.*version\s+(\S+)', output)
             if match:
                 version_str = match.group(1)
-                return Spec('cmake@{0}'.format(version_str))
+                return Spec.from_detection('cmake@{0}'.format(version_str))
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags' and self.compiler.name == 'fj':

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -2,18 +2,19 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
-
 import re
 import os
 
+import spack.package
 
+
+@spack.package.detectable
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
-       tools designed to build, test and package software."""
+    tools designed to build, test and package software.
+    """
     homepage = 'https://www.cmake.org'
-    url      = 'https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5.tar.gz'
+    url = 'https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5.tar.gz'
     maintainers = ['chuckatkins']
 
     executables = ['cmake']
@@ -162,20 +163,14 @@ class Cmake(Package):
     phases = ['bootstrap', 'build', 'install']
 
     @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        exe_to_path = dict(
-            (os.path.basename(p), p) for p in exes_in_prefix
-        )
-        if 'cmake' not in exe_to_path:
+    def determine_version(cls, exe):
+        if os.path.basename(exe) != 'cmake':
             return None
 
-        cmake = spack.util.executable.Executable(exe_to_path['cmake'])
+        cmake = spack.util.executable.Executable(exe)
         output = cmake('--version', output=str)
-        if output:
-            match = re.search(r'cmake.*version\s+(\S+)', output)
-            if match:
-                version_str = match.group(1)
-                return Spec.from_detection('cmake@{0}'.format(version_str))
+        match = re.search(r'cmake.*version\s+(\S+)', output)
+        return match.group(1) if match else None
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags' and self.compiler.name == 'fj':

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
-import os
 
 import spack.package
 
@@ -17,7 +16,7 @@ class Cmake(Package):
     url = 'https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5.tar.gz'
     maintainers = ['chuckatkins']
 
-    executables = ['cmake']
+    executables = ['^cmake$']
 
     version('3.18.0',   sha256='83b4ffcb9482a73961521d2bafe4a16df0168f03f56e6624c419c461e5317e29')
     version('3.17.3',   sha256='0bd60d512275dc9f6ef2a2865426a184642ceb3761794e6b65bff233b91d8c40')
@@ -164,11 +163,7 @@ class Cmake(Package):
 
     @classmethod
     def determine_version(cls, exe):
-        if os.path.basename(exe) != 'cmake':
-            return None
-
-        cmake = spack.util.executable.Executable(exe)
-        output = cmake('--version', output=str)
+        output = Executable(exe)('--version', output=str)
         match = re.search(r'cmake.*version\s+(\S+)', output)
         return match.group(1) if match else None
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
 
-import spack.package
 
-
-@spack.package.detectable
+@detectable
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
     tools designed to build, test and package software.

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -358,6 +358,36 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                 msg = '{0} not in {1}'
                 assert key in compilers, msg.format(key, spec)
 
+    @property
+    def cc(self):
+        msg = "cannot retrieve C compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('c', None)
+        return self.spec.prefix.bin.gcc if 'languages=c' in self.spec else None
+
+    @property
+    def cxx(self):
+        msg = "cannot retrieve C++ compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('cxx', None)
+        result = None
+        if 'languages=c++' in self.spec:
+            result = os.path.join(self.spec.prefix.bin, 'g++')
+        return result
+
+    @property
+    def fortran(self):
+        msg = "cannot retrieve Fortran compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('fortran', None)
+        result = None
+        if 'languages=fortran' in self.spec:
+            result = self.spec.prefix.bin.gfortran
+        return result
+
     def url_for_version(self, version):
         # This function will be called when trying to fetch from url, before
         # mirrors are tried. It takes care of modifying the suffix of gnu

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -340,18 +340,18 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def cc(self):
-        if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('c', None)
         msg = "cannot retrieve C compiler [spec is not concrete]"
         assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('c', None)
         return self.spec.prefix.bin.gcc if 'languages=c' in self.spec else None
 
     @property
     def cxx(self):
-        if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('cxx', None)
         msg = "cannot retrieve C++ compiler [spec is not concrete]"
         assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('cxx', None)
         result = None
         if 'languages=c++' in self.spec:
             result = os.path.join(self.spec.prefix.bin, 'g++')
@@ -359,10 +359,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def fortran(self):
-        if self.spec.external:
-            return self.spec.extra_attributes['compilers'].get('fortran', None)
         msg = "cannot retrieve Fortran compiler [spec is not concrete]"
         assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('fortran', None)
         result = None
         if 'languages=fortran' in self.spec:
             result = self.spec.prefix.bin.gfortran

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -348,7 +348,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                'the detected spec "{0}"'.format(spec))
         assert 'compilers' in extra_attributes, msg
 
-        #
         compilers = extra_attributes['compilers']
         for constraint, key in {
             'languages=c': 'c',
@@ -356,7 +355,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             'languages=fortran': 'fortran'
         }.items():
             if spec.satisfies(constraint, strict=True):
-                # TODO: Here the variants are still abstract
                 msg = '{0} not in {1}'
                 assert key in compilers, msg.format(key, spec)
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -9,13 +9,12 @@ import re
 import sys
 
 import llnl.util.tty as tty
-import spack.package
 import spack.util.executable
 
 from spack.operating_systems.mac_os import macos_version, macos_sdk_path
 
 
-@spack.package.detectable
+@detectable
 class Gcc(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
     Fortran, Ada, and Go, as well as libraries for these languages."""

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -14,7 +14,6 @@ import spack.util.executable
 from spack.operating_systems.mac_os import macos_version, macos_sdk_path
 
 
-@detectable
 class Gcc(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
     Fortran, Ada, and Go, as well as libraries for these languages."""

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -309,7 +309,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        spec_str = 'gcc@{0} languages={1}'
         languages, compilers = set(), {}
         for exe in exes:
             if 'gcc' in exe:
@@ -321,11 +320,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             if 'gfortran' in exe:
                 languages.add('fortran')
                 compilers['fortran'] = exe
-
-        spec_str = spec_str.format(version_str, ','.join(languages))
-        return [Spec.from_detection(
-            spec_str, extra_attributes={'compilers': compilers}
-        )]
+        variant_str = 'languages={0}'.format(','.join(languages))
+        return variant_str, {'compilers': compilers}
 
     @classmethod
     def validate_detected_spec(cls, spec, extra_attributes):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -274,7 +274,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     @property
     def executables(self):
         names = [r'gcc', r'[^\w]?g\+\+', r'gfortran']
-        suffixes = [r'-mp-\d\.\d', r'-\d\.\d', r'-\d', r'\d\d']
+        suffixes = [r'', r'-mp-\d+\.\d', r'-\d+\.\d', r'-\d+', r'\d\d']
         return [r''.join(x) for x in itertools.product(names, suffixes)]
 
     @classmethod
@@ -282,7 +282,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         result = []
         for exe in exes_in_prefix:
             # clang++ matches g++ -> clan[g++]
-            if 'clang' in exe:
+            if any(x in exe for x in ('clang', 'ranlib')):
                 continue
             # Filter out links in favor of real executables
             if os.path.islink(exe):
@@ -292,7 +292,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        version_regex = re.compile(r'(.*)')
+        version_regex = re.compile(r'([\d\.]+)')
         for vargs in ('-dumpfullversion', '-dumpversion'):
             try:
                 output = spack.compiler.get_compiler_version_output(exe, vargs)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -309,13 +309,14 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     def determine_variants(cls, exes, version_str):
         languages, compilers = set(), {}
         for exe in exes:
-            if 'gcc' in exe:
+            basename = os.path.basename(exe)
+            if 'gcc' in basename:
                 languages.add('c')
                 compilers['c'] = exe
-            if 'g++' in exe:
+            elif 'g++' in basename:
                 languages.add('c++')
                 compilers['cxx'] = exe
-            if 'gfortran' in exe:
+            elif 'gfortran' in basename:
                 languages.add('fortran')
                 compilers['fortran'] = exe
         variant_str = 'languages={0}'.format(','.join(languages))

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -340,18 +340,18 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def cc(self):
-        msg = "cannot retrieve C compiler [spec is not concrete]"
-        assert self.spec.concrete, msg
         if self.spec.external:
             return self.spec.extra_attributes['compilers'].get('c', None)
+        msg = "cannot retrieve C compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
         return self.spec.prefix.bin.gcc if 'languages=c' in self.spec else None
 
     @property
     def cxx(self):
-        msg = "cannot retrieve C++ compiler [spec is not concrete]"
-        assert self.spec.concrete, msg
         if self.spec.external:
             return self.spec.extra_attributes['compilers'].get('cxx', None)
+        msg = "cannot retrieve C++ compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
         result = None
         if 'languages=c++' in self.spec:
             result = os.path.join(self.spec.prefix.bin, 'g++')
@@ -359,10 +359,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def fortran(self):
-        msg = "cannot retrieve Fortran compiler [spec is not concrete]"
-        assert self.spec.concrete, msg
         if self.spec.external:
             return self.spec.extra_attributes['compilers'].get('fortran', None)
+        msg = "cannot retrieve Fortran compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
         result = None
         if 'languages=fortran' in self.spec:
             result = self.spec.prefix.bin.gfortran

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -2,19 +2,20 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import collections
 import glob
 import itertools
 import os
 import re
 import sys
 
+import llnl.util.tty as tty
+import spack.package
 import spack.util.executable
-from llnl.util import tty
+
 from spack.operating_systems.mac_os import macos_version, macos_sdk_path
 
 
+@spack.package.detectable
 class Gcc(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
     Fortran, Ada, and Go, as well as libraries for these languages."""
@@ -276,21 +277,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         names = [r'gcc', r'[^\w]?g\+\+', r'gfortran']
         suffixes = [r'-mp-\d\.\d', r'-\d\.\d', r'-\d', r'\d\d']
         return [r''.join(x) for x in itertools.product(names, suffixes)]
-
-    @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        exes_by_version = collections.defaultdict(list)
-        exes_in_prefix = cls.filter_detected_exes(prefix, exes_in_prefix)
-        for exe in exes_in_prefix:
-            version_str = cls.determine_version(exe)
-            if version_str:
-                exes_by_version[version_str].append(exe)
-
-        specs = []
-        for version_str, exes in exes_by_version.items():
-            specs.extend(cls.determine_variants(exes, version_str))
-
-        return specs
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -187,7 +187,7 @@ spack package at this time.''',
         # their run environments the code to make the compilers available.
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
-        if self.spec.external_module and 'cray' in self.spec.external_module:
+        if self.spec.external_modules and 'cray' in self.spec.external_modules:
             env.set('MPICC', spack_cc)
             env.set('MPICXX', spack_cxx)
             env.set('MPIF77', spack_fc)
@@ -210,7 +210,7 @@ spack package at this time.''',
     def setup_dependent_package(self, module, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
-        if self.spec.external_module and 'cray' in self.spec.external_module:
+        if self.spec.external_modules and 'cray' in self.spec.external_modules:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx
             self.spec.mpifc = spack_fc

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -235,7 +235,7 @@ class Mvapich2(AutotoolsPackage):
     def setup_compiler_environment(self, env):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
-        if self.spec.external_module and 'cray' in self.spec.external_module:
+        if self.spec.external_modules and 'cray' in self.spec.external_modules:
             env.set('MPICC',  spack_cc)
             env.set('MPICXX', spack_cxx)
             env.set('MPIF77', spack_fc)
@@ -249,7 +249,7 @@ class Mvapich2(AutotoolsPackage):
     def setup_dependent_package(self, module, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
-        if self.spec.external_module and 'cray' in self.spec.external_module:
+        if self.spec.external_modules and 'cray' in self.spec.external_modules:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx
             self.spec.mpifc = spack_fc


### PR DESCRIPTION
fixes #3181 (either that or this issue was already fixed by #15158)

Modifications:
- [x] The schema for `packages.yaml` has been updated. Old configuration files are not allowed anymore and Spack will error out in their presence. The new schema permits to store arbitrary  attributes for each external detected.
- [x] The detection mechanism has been extended to account for these custom attributes. A validation step is now in place to ensure the detected specs are in a proper state before writing them to `packages.yaml`. All specs that are detected must be created with `Spec.from_detection`.
- [x] The GCC package can now be detected automatically
- [x] A command to update existing configuration files to the new format has been added
- [x] A command to revert configuration updates has been added too
- [x] All the occurences of `packages.yaml` displayed in the docs have been updated
- [x] Added a decorator to mark detectable packages and a command to list them
- [x] Documentation for external spec detection has been extended