### PR TITLE
prrte uses libev data structues, not libevent

### DIFF
--- a/var/spack/repos/builtin/packages/prrte/package.py
+++ b/var/spack/repos/builtin/packages/prrte/package.py
@@ -18,6 +18,7 @@ class Prrte(AutotoolsPackage):
     homepage = "https://pmix.org"
     url      = "https://github.com/pmix/prrte/releases/download/v1.0.0/prrte-1.0.0.tar.bz2"
     git      = "https://github.com/pmix/prrte.git"
+    maintainers = ['rhc54']
 
     version('develop', branch='master')
     version('1.0.0', sha256='a9b3715e059c10ed091bd6e3a0d8896f7752e43ee731abcc95fb962e67132a2d')

--- a/var/spack/repos/builtin/packages/prrte/package.py
+++ b/var/spack/repos/builtin/packages/prrte/package.py
@@ -50,7 +50,7 @@ class Prrte(AutotoolsPackage):
 
         # libevent
         config_args.append(
-            '--with-libev={0}'.format(spec['libevent'].prefix))
+            '--with-libevent={0}'.format(spec['libevent'].prefix))
         # hwloc
         config_args.append('--with-hwloc={0}'.format(spec['hwloc'].prefix))
         # pmix


### PR DESCRIPTION
the 'libev' package provides data structures prrte needs such as
`ev_async`.  libevent does not offer such an interface.  Was it a mistake to depend on `libevent` instead of `libev`?  

Without this change prrte fails to build, giving errors:

```==> Error: ProcessError: Command exited with status 2:
    'make' '-j4'

4 errors found in build log:
     1645      CC       runtime/opal_init.lo
     1646      CC       runtime/opal_params.lo
     1647      CC       runtime/opal_info_support.lo
     1648      CC       runtime/opal_progress_threads.lo
     1649      CC       threads/condition.lo
     1650      CC       threads/mutex.lo
  >> 1651    runtime/opal_progress_threads.c:50:5: error: unknown type name 'ev_async'
     1652       50 |     ev_async async;
     1653          |     ^~~~~~~~
  >> 1654    runtime/opal_progress_threads.c:116:37: error: unknown type name 'EV_P_'
     1655      116 | static void opal_libev_ev_async_cb (EV_P_ ev_async *w, int revents)
     1656          |                                     ^~~~~  
     1657    runtime/opal_progress_threads.c: In function 'opal_event_add':
     1658    runtime/opal_progress_threads.c:150:9: warning: implicit declaration of function 'ev_async_send' [-Wimplicit-function-declaration]
     1659      150 |         ev_async_send ((struct ev_loop *)trk->ev_base, &trk->async);
     1660          |         ^~~~~~~~~~~~~
     1661    runtime/opal_progress_threads.c: In function 'opal_progress_thread_init':
     1662    runtime/opal_progress_threads.c:320:5: warning: implicit declaration of function 'ev_async_init'; did you mean 'evtag_init'? [-Wimplicit-function-declaration]
     1663      320 |     ev_async_init (&trk->async, opal_libev_ev_async_cb);
     1664          |     ^~~~~~~~~~~~~
     1665          |     evtag_init
  >> 1666    runtime/opal_progress_threads.c:320:33: error: 'opal_libev_ev_async_cb' undeclared (first use in this function)
     1667      320 |     ev_async_init (&trk->async, opal_libev_ev_async_cb);
     1668          |                                 ^~~~~~~~~~~~~~~~~~~~~~
     1669    runtime/opal_progress_threads.c:320:33: note: each undeclared identifier is reported only once for each function it appears in
     1670    runtime/opal_progress_threads.c:321:5: warning: implicit declaration of function 'ev_async_start' [-Wimplicit-function-declaration]
     1671      321 |     ev_async_start((struct ev_loop *)trk->ev_base, &trk->async);
     1672          |     ^~~~~~~~~~~~~~
     1673    runtime/opal_progress_threads.c: In function 'opal_progress_thread_attach':
  >> 1674    runtime/opal_progress_threads.c:382:33: error: 'opal_libev_ev_async_cb' undeclared (first use in this function)
     1675      382 |     ev_async_init (&trk->async, opal_libev_ev_async_cb);
     1676          |                                 ^~~~~~~~~~~~~~~~~~~~~~
     1677    make[2]: *** [Makefile:1448: runtime/opal_progress_threads.lo] Error 1
     1678    make[2]: *** Waiting for unfinished jobs....
     1679    make[2]: Leaving directory '/tmp/robl/spack-stage/spack-stage-prrte-1.0.0-wvg7qdwqtcsxyuqq7jpqqg45dtngh3xl/spack-src/opal'
     1680    make[1]: *** [Makefile:1520: all-recursive] Error 1
```