### PR TITLE
Fix MacOS tests on develop

### DIFF
--- a/.github/workflows/macos_unit_tests.yaml
+++ b/.github/workflows/macos_unit_tests.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Run unit tests
       run: |
         git --version
-        git fetch origin develop:develop
+        git fetch -u origin develop:develop
         . share/spack/setup-env.sh
         coverage run $(which spack) test
         coverage combine


### PR DESCRIPTION
The -u option allows to update the current head, so tests won't fail if we are on develop