### PR TITLE
macOS nightly: two cores

### DIFF
--- a/.github/workflows/install_spack.sh
+++ b/.github/workflows/install_spack.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 git clone https://github.com/spack/spack.git
+echo -e "config:\n  build_jobs: 2" > spack/etc/spack/config.yaml
 . spack/share/spack/setup-env.sh
 spack compilers

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -26,7 +26,7 @@ jobs:
   install_jupyter_clang:
     name: jupyter
     runs-on: macos-latest
-    timeout-minutes: 600
+    timeout-minutes: 700
     steps:
     - uses: actions/checkout@v2
     - name: spack install


### PR DESCRIPTION
All GitHub actions provide two cores. Just make sure this does not get oversubscribed with potentially visible additional physical cores.

+1hr py-jupyter: in order to observe if failures ares actually a real timeout or an error that just causes a `spack install` hang.