### PR TITLE
PyTorch: fix master and mkldnn builds

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -247,7 +247,7 @@ class PyTorch(PythonPackage, CudaPackage):
 
         enable_or_disable('mkldnn')
         if '@0.4:0.4.1+mkldnn' in self.spec:
-            env.set('MKLDNN_HOME', self.spec['intel-mkl-dnn'].prefix)
+            env.set('MKLDNN_HOME', self.spec['onednn'].prefix)
 
         enable_or_disable('nnpack')
         enable_or_disable('qnnpack')
@@ -270,8 +270,9 @@ class PyTorch(PythonPackage, CudaPackage):
         enable_or_disable('lmdb', newer=True)
         enable_or_disable('binary', keyword='BUILD', newer=True)
 
-        env.set('PYTORCH_BUILD_VERSION', self.version)
-        env.set('PYTORCH_BUILD_NUMBER', 0)
+        if not self.spec.satisfies('@master'):
+            env.set('PYTORCH_BUILD_VERSION', self.version)
+            env.set('PYTORCH_BUILD_NUMBER', 0)
 
         # BLAS to be used by Caffe2
         if '^mkl' in self.spec:


### PR DESCRIPTION
We can't set `PYTORCH_BUILD_VERSION` to `master`, otherwise the build crashes with:
```
     2051    In file included from ../caffe2/core/common.h:27:0,
     2052                     from ../caffe2/perfkernels/common_avx2.cc:5:
  >> 2053    ./caffe2/core/macros.h:12:30: error: 'master' was not declared in this scope
     2054     #define CAFFE2_VERSION_MINOR master
     2055                                  ^
     2056    ./caffe2/core/macros.h:16:5: note: in expansion of macro 'CAFFE2_VERSION_MINOR'
     2057         CAFFE2_VERSION_MINOR < 100,
     2058         ^
  >> 2059    ./caffe2/core/macros.h:13:30: error: 'master' was not declared in this scope
     2060     #define CAFFE2_VERSION_PATCH master
     2061                                  ^
     2062    ./caffe2/core/macros.h:19:5: note: in expansion of macro 'CAFFE2_VERSION_PATCH'
     2063         CAFFE2_VERSION_PATCH < 100,
     2064         ^
     2065    [1035/2226] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/fused_8bit_rowwise_conversion_avx2.cc.o
```
Also, the `intel-mkl-dnn` package was renamed to `dnnl`, and then renamed again to `onednn`. Update `py-torch` to use the right dependency name.

@tgamblin why didn't your package sanity dependency checks catch the missing `intel-mkl-dnn` package?

EDIT: Oh, that test only looks at `depends_on`, the spec of non-existing package bug can only be caught at run-time.