### PR TITLE
fio: Add 3.19

### DIFF
--- a/var/spack/repos/builtin/packages/fio/package.py
+++ b/var/spack/repos/builtin/packages/fio/package.py
@@ -16,6 +16,7 @@ class Fio(AutotoolsPackage):
     homepage = "https://github.com/axboe/fio"
     url = "https://github.com/axboe/fio/archive/fio-2.19.tar.gz"
 
+    version('3.19', sha256='809963b1d023dbc9ac7065557af8129aee17b6895e0e8c5ca671b0b14285f404')
     version('3.16', sha256='c7731a9e831581bab7104da9ea60c9f44e594438dbe95dff26726ca0285e7b93')
     version('2.19', sha256='61fb03a18703269b781aaf195cb0d7931493bbb5bfcc8eb746d5d66d04ed77f7')
 
@@ -31,6 +32,9 @@ class Fio(AutotoolsPackage):
 
     conflicts('+libaio', when='platform=darwin',
               msg='libaio does not support Darwin')
+
+    conflicts('@:3.18', when='%gcc@10:',
+              msg='gcc@10: sets -fno-common by default')
 
     def configure_args(self):
         config_args = []


### PR DESCRIPTION
Earlier versions are not compatible with gcc@10:.