### PR TITLE
add environment-awareness to `buildcache create`

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -343,8 +343,9 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
 
     else:
         tty.die("build cache file creation requires at least one" +
-                " installed package argument or else path to a" +
-                " yaml file containing a spec to install")
+                " installed package spec, an activate environment," +
+                " or else a path to a yaml file containing a spec" +
+                " to install")
     pkgs = set(packages)
     specs = set()
     tty.debug("pkgs = ", pkgs)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -338,12 +338,16 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
     elif packages:
         packages = packages
 
+    elif env:
+        packages = env.roots()
+
     else:
         tty.die("build cache file creation requires at least one" +
                 " installed package argument or else path to a" +
                 " yaml file containing a spec to install")
     pkgs = set(packages)
     specs = set()
+    tty.debug("pkgs = ", pkgs)
 
     mirror = spack.mirror.MirrorCollection().lookup(output_location)
     outdir = url_util.format(mirror.push_url)
@@ -356,6 +360,7 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
         signkey = key
 
     matches = find_matching_specs(pkgs, env=env)
+    tty.debug("matches = ", matches)
 
     if matches:
         tty.debug('Found at least one matching spec')

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -348,7 +348,6 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
                 " to install")
     pkgs = set(packages)
     specs = set()
-    tty.debug("pkgs = ", pkgs)
 
     mirror = spack.mirror.MirrorCollection().lookup(output_location)
     outdir = url_util.format(mirror.push_url)
@@ -361,7 +360,6 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
         signkey = key
 
     matches = find_matching_specs(pkgs, env=env)
-    tty.debug("matches = ", matches)
 
     if matches:
         tty.debug('Found at least one matching spec')

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -339,7 +339,7 @@ def _createtarball(env, spec_yaml, packages, add_spec, add_deps,
         packages = packages
 
     elif env:
-        packages = env.roots()
+        packages = env.concretized_user_specs
 
     else:
         tty.die("build cache file creation requires at least one" +

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -5,11 +5,13 @@
 
 import errno
 import platform
+import os
 
 import pytest
 
 import spack.main
 import spack.binary_distribution
+from spack.spec import Spec
 
 buildcache = spack.main.SpackCommand('buildcache')
 install = spack.main.SpackCommand('install')
@@ -46,6 +48,21 @@ def test_buildcache_list_duplicates(mock_get_specs, capsys):
 
 
 def test_buildcache_create_fail_on_perm_denied(
+def tests_buildcache_create(
+    install_mockery, mock_fetch, monkeypatch, tmpdir):
+    """"Ensure that buildcache create creates output files"""
+    pkg = 'trivial-install-test-package'
+    install(pkg)
+
+    buildcache('create', '-d', str(tmpdir), '--unsigned', pkg)
+
+    spec = Spec(pkg).concretized()
+    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
+        spack.binary_distribution.tarball_path_name(spec, '.spack')))
+    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
+        spack.binary_distribution.tarball_name(spec, '.spec.yaml')))
+
+
         install_mockery, mock_fetch, monkeypatch, tmpdir):
     """Ensure that buildcache create fails on permission denied error."""
     install('trivial-install-test-package')

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -89,6 +89,13 @@ def tests_buildcache_create_env(
         os.path.join(str(tmpdir), 'build_cache', tarball))
 
 
+def test_buildcache_create_fails_on_noargs(tmpdir):
+    """Ensure that buildcache create fails when given no args or
+    environment."""
+    with pytest.raises(spack.main.SpackCommandError):
+        buildcache('create', '-d', str(tmpdir), '--unsigned')
+
+
 def test_buildcache_create_fail_on_perm_denied(
         install_mockery, mock_fetch, monkeypatch, tmpdir):
     """Ensure that buildcache create fails on permission denied error."""

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -51,7 +51,7 @@ def test_buildcache_list_duplicates(mock_get_specs, capsys):
 
 
 def tests_buildcache_create(
-    install_mockery, mock_fetch, monkeypatch, tmpdir):
+        install_mockery, mock_fetch, monkeypatch, tmpdir):
     """"Ensure that buildcache create creates output files"""
     pkg = 'trivial-install-test-package'
     install(pkg)
@@ -59,15 +59,15 @@ def tests_buildcache_create(
     buildcache('create', '-d', str(tmpdir), '--unsigned', pkg)
 
     spec = Spec(pkg).concretized()
-    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
-        spack.binary_distribution.tarball_path_name(spec, '.spack')))
-    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
-        spack.binary_distribution.tarball_name(spec, '.spec.yaml')))
+    tarball_path = spack.binary_distribution.tarball_path_name(spec, '.spack')
+    tarball = spack.binary_distribution.tarball_name(spec, '.spec.yaml')
+    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball_path))
+    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball))
 
 
 def tests_buildcache_create_env(
-    install_mockery, mock_fetch, monkeypatch, tmpdir,
-    mutable_mock_env_path):
+        install_mockery, mock_fetch, monkeypatch,
+        tmpdir, mutable_mock_env_path):
     """"Ensure that buildcache create creates output files from env"""
     pkg = 'trivial-install-test-package'
 
@@ -79,10 +79,10 @@ def tests_buildcache_create_env(
         buildcache('create', '-d', str(tmpdir), '--unsigned')
 
     spec = Spec(pkg).concretized()
-    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
-        spack.binary_distribution.tarball_path_name(spec, '.spack')))
-    assert os.path.exists(os.path.join(str(tmpdir), 'build_cache',
-        spack.binary_distribution.tarball_name(spec, '.spec.yaml')))
+    tarball_path = spack.binary_distribution.tarball_path_name(spec, '.spack')
+    tarball = spack.binary_distribution.tarball_name(spec, '.spec.yaml')
+    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball_path))
+    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball))
 
 
 def test_buildcache_create_fail_on_perm_denied(

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -61,8 +61,10 @@ def tests_buildcache_create(
     spec = Spec(pkg).concretized()
     tarball_path = spack.binary_distribution.tarball_path_name(spec, '.spack')
     tarball = spack.binary_distribution.tarball_name(spec, '.spec.yaml')
-    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball_path))
-    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball))
+    assert os.path.exists(
+        os.path.join(str(tmpdir), 'build_cache', tarball_path))
+    assert os.path.exists(
+        os.path.join(str(tmpdir), 'build_cache', tarball))
 
 
 def tests_buildcache_create_env(
@@ -81,8 +83,10 @@ def tests_buildcache_create_env(
     spec = Spec(pkg).concretized()
     tarball_path = spack.binary_distribution.tarball_path_name(spec, '.spack')
     tarball = spack.binary_distribution.tarball_name(spec, '.spec.yaml')
-    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball_path))
-    assert os.path.exists(os.path.join(tmpdir, 'build_cache', tarball))
+    assert os.path.exists(
+        os.path.join(str(tmpdir), 'build_cache', tarball_path))
+    assert os.path.exists(
+        os.path.join(str(tmpdir), 'build_cache', tarball))
 
 
 def test_buildcache_create_fail_on_perm_denied(


### PR DESCRIPTION
A tiny patch so that `buildcache create` in an active environment (with no spec argument) creates a build_cache from the environment roots. 

Also two new tests for buildcache create. 