### PR TITLE
stata: add libpng dependency

### DIFF
--- a/var/spack/repos/builtin/packages/stata/package.py
+++ b/var/spack/repos/builtin/packages/stata/package.py
@@ -30,8 +30,8 @@ class Stata(Package):
     version('16', 'a13a6a92558eeb3c6cb3013c458a6777e54c21af43599df6b0a924f5f5c2d5d2')
     version('15', '2486f4c7db1e7b453004c7bd3f8da40ba1e30be150613065c7b82b1915259016')
 
-    # V15 depends on libpng v12 and fails with other versions of libpng
-    depends_on('libpng@1.2.57')
+    depends_on('libpng@1.2.57', when='@15', type='run')
+    depends_on('libpng@1.6:1.6.99', when='@16', type='run')
 
     # STATA is downloaded from user/pass protected ftp as Stata15Linux64.tar.gz
     def url_for_version(self, version):


### PR DESCRIPTION
Here the dependency needs to be of 'run' type as stata is distributed as a prebuilt binary.