### PR TITLE
Map the spack skylake arch to Kokkos BDW, rather than SKX

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -120,7 +120,12 @@ class Kokkos(CMakePackage, CudaPackage):
         "core2": None,
         "ivybridge": "SNB",
         "broadwell": "BDW",
-        "skylake": "SKX",
+        # @AndrewGaspar: Kokkos does not have an arch for plain-skylake - only
+        # for Skylake-X (i.e. Xeon). For now, I'm mapping this to Broadwell
+        # until Kokkos learns to optimize for SkyLake without the AVX-512
+        # extensions. SkyLake with AVX-512 will still be optimized using the
+        # separate `skylake_avx512` arch.
+        "skylake": "BDW",
         "icelake": "SKX",
         "skylake_avx512": "SKX",
     }


### PR DESCRIPTION
SKX includes AVX-512 extensions that consumer Skylake processors do
not have. Therefore, map Skylake to the prior arch to work on
these systems. Skylake-X processors will still map as the
skylake_avx512 spack arch and get the correct optimzations.

cc @crtrott @jjwilke 