### PR TITLE
py-plac: remove erroneous argparse dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-plac/package.py
+++ b/var/spack/repos/builtin/packages/py-plac/package.py
@@ -13,4 +13,4 @@ class PyPlac(PythonPackage):
     version('1.1.3', sha256='398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-argparse', type=('build', 'run'))
+    depends_on('py-argparse', when='^python@:2.6', type=('build', 'run'))


### PR DESCRIPTION
This dependency caused argparse to be added to my environment and broke pytest. The `setup.py` first tries to import argparse and only adds the dependency if it isn't found (Python 2.6 and older).