### PR TITLE
spack.relocate: further coverage for ELF related functions

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -514,7 +514,7 @@ def make_package_relative(workdir, spec, allow_root):
             platform.system().lower() == 'linux'):
         relocate.make_elf_binaries_relative(cur_path_names, orig_path_names,
                                             old_layout_root)
-    relocate.check_files_relocatable(cur_path_names, allow_root)
+    relocate.raise_if_not_relocatable(cur_path_names, allow_root)
     orig_path_names = list()
     cur_path_names = list()
     for linkname in buildinfo.get('relocate_links', []):
@@ -532,7 +532,7 @@ def check_package_relocatable(workdir, spec, allow_root):
     cur_path_names = list()
     for filename in buildinfo['relocate_binaries']:
         cur_path_names.append(os.path.join(workdir, filename))
-    relocate.check_files_relocatable(cur_path_names, allow_root)
+    relocate.raise_if_not_relocatable(cur_path_names, allow_root)
 
 
 def relocate_package(spec, allow_root):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -632,7 +632,6 @@ def relocate_package(spec, allow_root):
 
         # relocate the install prefixes in binary files including dependencies
         relocate.relocate_text_bin(files_to_relocate,
-                                   old_layout_root, new_layout_root,
                                    old_prefix, new_prefix,
                                    old_spack_prefix,
                                    new_spack_prefix,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -615,17 +615,13 @@ def relocate_package(spec, allow_root):
                                            prefix_to_prefix, rel,
                                            old_prefix,
                                            new_prefix)
-        # Relocate links to the new install prefix
-            link_names = [linkname
-                          for linkname in buildinfo.get('relocate_links', [])]
-            relocate.relocate_links(link_names,
-                                    old_layout_root,
-                                    new_layout_root,
-                                    old_prefix,
-                                    new_prefix,
-                                    prefix_to_prefix)
+            # Relocate links to the new install prefix
+            links = [link for link in buildinfo.get('relocate_links', [])]
+            relocate.relocate_links(
+                links, old_layout_root, old_prefix, new_prefix
+            )
 
-    # For all buildcaches
+        # For all buildcaches
         # relocate the install prefixes in text files including dependencies
         relocate.relocate_text(text_names,
                                old_layout_root, new_layout_root,

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -709,17 +709,23 @@ def make_macho_binaries_relative(cur_path_names, orig_path_names,
                                 paths_to_paths)
 
 
-def make_elf_binaries_relative(cur_path_names, orig_path_names,
-                               old_layout_root):
+def make_elf_binaries_relative(new_binaries, orig_binaries, orig_layout_root):
+    """Replace the original RPATHs in the new binaries making them
+    relative to the original layout root.
+    
+    Args:
+        new_binaries (list): new binaries whose RPATHs is to be made relative
+        orig_binaries (list): original binaries
+        orig_layout_root (str): path to be used as a base for making
+            RPATHs relative
     """
-    Replace old RPATHs with paths relative to old_dir in binary files
-    """
-    for cur_path, orig_path in zip(cur_path_names, orig_path_names):
-        orig_rpaths = _elf_rpaths_for(cur_path)
+    for new_binary, orig_binary in zip(new_binaries, orig_binaries):
+        orig_rpaths = _elf_rpaths_for(new_binary)
         if orig_rpaths:
-            new_rpaths = _make_relative(orig_path, old_layout_root,
-                                        orig_rpaths)
-            _set_elf_rpaths(cur_path, new_rpaths)
+            new_rpaths = _make_relative(
+                orig_binary, orig_layout_root, orig_rpaths
+            )
+            _set_elf_rpaths(new_binary, new_rpaths)
 
 
 def check_files_relocatable(cur_path_names, allow_root):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -675,16 +675,19 @@ def relocate_elf_binaries(binaries, orig_root, new_root,
             _set_elf_rpaths(new_binary, new_rpaths)
 
 
-def make_link_relative(cur_path_names, orig_path_names):
-    """
-    Change absolute links to relative links.
-    """
-    for cur_path, orig_path in zip(cur_path_names, orig_path_names):
-        target = os.readlink(orig_path)
-        relative_target = os.path.relpath(target, os.path.dirname(orig_path))
+def make_link_relative(new_links, orig_links):
+    """Compute the relative target from the original link and
+    make the new link relative.
 
-        os.unlink(cur_path)
-        os.symlink(relative_target, cur_path)
+    Args:
+        new_links (list): new links to be made relative
+        orig_links (list): original links
+    """
+    for new_link, orig_link in zip(new_links, orig_links):
+        target = os.readlink(orig_link)
+        relative_target = os.path.relpath(target, os.path.dirname(orig_link))
+        os.unlink(new_link)
+        os.symlink(relative_target, new_link)
 
 
 def make_macho_binaries_relative(cur_path_names, orig_path_names,

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -458,6 +458,7 @@ def _replace_prefix_text(filename, old_dir, new_dir):
         old_dir (str): directory to be searched in the file
         new_dir (str): substitute for the old directory
     """
+    # TODO: cache regexes globally to speedup computation
     with open(filename, 'rb+') as f:
         data = f.read()
         f.seek(0)
@@ -782,23 +783,36 @@ def relocate_links(links, orig_layout_root,
             tty.warn(msg.format(link_target, abs_link, new_install_prefix))
 
 
-def relocate_text(path_names, old_layout_root, new_layout_root,
-                  old_install_prefix, new_install_prefix,
-                  old_spack_prefix, new_spack_prefix,
-                  prefix_to_prefix):
-    """
-    Replace old paths with new paths in text files
-    including the path the the spack sbang script
-    """
-    sbangre = '#!/bin/bash %s/bin/sbang' % old_spack_prefix
-    sbangnew = '#!/bin/bash %s/bin/sbang' % new_spack_prefix
+def relocate_text(
+        files, orig_layout_root, new_layout_root, orig_install_prefix,
+        new_install_prefix, orig_spack, new_spack, new_prefixes
+):
+    """Relocate text file from the original installation prefix to the
+    new prefix.
 
-    for path_name in path_names:
-        _replace_prefix_text(path_name, old_install_prefix, new_install_prefix)
-        for orig_dep_prefix, new_dep_prefix in prefix_to_prefix.items():
-            _replace_prefix_text(path_name, orig_dep_prefix, new_dep_prefix)
-        _replace_prefix_text(path_name, old_layout_root, new_layout_root)
-        _replace_prefix_text(path_name, sbangre, sbangnew)
+    Relocation also affects the the path in Spack's sbang script.
+
+    Args:
+        files (list): text files to be relocated
+        orig_layout_root (str): original layout root
+        new_layout_root (str): new layout root
+        orig_install_prefix (str): install prefix of the original installation
+        new_install_prefix (str): install prefix where we want to relocate
+        orig_spack (str): path to the original Spack
+        new_spack (str): path to the new Spack
+        new_prefixes (dict): dictionary that maps the original prefixes to
+            where they should be relocated
+    """
+    # TODO: reduce the number of arguments (8 seems too much)
+    sbang_regex = r'#!/bin/bash {0}/bin/sbang'.format(orig_spack)
+    new_sbang = r'#!/bin/bash {0}/bin/sbang'.format(new_spack)
+
+    for file in files:
+        _replace_prefix_text(file, orig_install_prefix, new_install_prefix)
+        for orig_dep_prefix, new_dep_prefix in new_prefixes.items():
+            _replace_prefix_text(file, orig_dep_prefix, new_dep_prefix)
+        _replace_prefix_text(file, orig_layout_root, new_layout_root)
+        _replace_prefix_text(file, sbang_regex, new_sbang)
 
 
 def relocate_text_bin(path_names, old_layout_root, new_layout_root,

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -712,7 +712,7 @@ def make_macho_binaries_relative(cur_path_names, orig_path_names,
 def make_elf_binaries_relative(new_binaries, orig_binaries, orig_layout_root):
     """Replace the original RPATHs in the new binaries making them
     relative to the original layout root.
-    
+
     Args:
         new_binaries (list): new binaries whose RPATHs is to be made relative
         orig_binaries (list): original binaries

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -728,15 +728,19 @@ def make_elf_binaries_relative(new_binaries, orig_binaries, orig_layout_root):
             _set_elf_rpaths(new_binary, new_rpaths)
 
 
-def check_files_relocatable(cur_path_names, allow_root):
+def raise_if_not_relocatable(binaries, allow_root):
+    """Raise an error if any binary in the list is not relocatable.
+
+    Args:
+        binaries (list): list of binaries to check
+        allow_root (bool): whether root dir is allowed or not in a binary
+
+    Raises:
+        InstallRootStringError: if the file is not relocatable
     """
-    Check binary files for the current install root
-    """
-    for cur_path in cur_path_names:
-        if (not allow_root and
-                not file_is_relocatable(cur_path)):
-            raise InstallRootStringError(
-                cur_path, spack.store.layout.root)
+    for binary in binaries:
+        if not (allow_root or file_is_relocatable(binary)):
+            raise InstallRootStringError(binary, spack.store.layout.root)
 
 
 def relocate_links(linknames, old_layout_root, new_layout_root,

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -979,4 +979,4 @@ def mime_type(file):
     if '/' not in output:
         output += '/'
     split_by_slash = output.strip().split('/')
-    return (split_by_slash[0], "/".join(split_by_slash[1:]))
+    return split_by_slash[0], "/".join(split_by_slash[1:])

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -242,9 +242,8 @@ def test_relocate_links(tmpdir):
         os.utime(new_binname, None)
         os.symlink(old_binname, new_linkname)
         os.symlink('/usr/lib/libc.so', new_linkname2)
-        relocate_links(filenames, old_layout_root, new_layout_root,
-                       old_install_prefix, new_install_prefix,
-                       {old_install_prefix: new_install_prefix})
+        relocate_links(filenames, old_layout_root,
+                       old_install_prefix, new_install_prefix)
         assert os.readlink(new_linkname) == new_binname
         assert os.readlink(new_linkname2) == '/usr/lib/libc.so'
 

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -344,3 +344,28 @@ def test_raise_if_not_relocatable(monkeypatch):
         spack.relocate.raise_if_not_relocatable(
             ['an_executable'], allow_root=False
         )
+
+
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
+def test_relocate_text_bin(hello_world, copy_binary, tmpdir):
+    orig_binary = hello_world(rpaths=[
+        str(tmpdir.mkdir('lib')), str(tmpdir.mkdir('lib64')), '/opt/local/lib'
+    ])
+    new_binary = copy_binary(orig_binary)
+
+    # Check this call succeed
+    spack.relocate.relocate_text_bin(
+        [str(new_binary)],
+        str(orig_binary.dirpath()), str(new_binary.dirpath()),
+        spack.paths.spack_root, spack.paths.spack_root,
+        {str(orig_binary.dirpath()): str(new_binary.dirpath())}
+    )
+
+
+def test_relocate_text_bin_raise_if_new_prefix_is_longer():
+    short_prefix = '/short'
+    long_prefix = '/much/longer'
+    with pytest.raises(spack.relocate.BinaryTextReplaceError):
+        spack.relocate.relocate_text_bin(
+            ['item'], short_prefix, long_prefix, None, None, None
+        )

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -336,3 +336,11 @@ def test_make_elf_binaries_relative(hello_world, copy_binary, tmpdir):
     )
 
     assert rpaths_for(new_binary) == '$ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib'
+
+
+def test_raise_if_not_relocatable(monkeypatch):
+    monkeypatch.setattr(spack.relocate, 'file_is_relocatable', lambda x: False)
+    with pytest.raises(spack.relocate.InstallRootStringError):
+        spack.relocate.raise_if_not_relocatable(
+            ['an_executable'], allow_root=False
+        )


### PR DESCRIPTION
This PR:

- [x] Increase coverage for all the remaining ELF related functions in `spack.relocate`
- [x] Improve docstrings and naming for the same functions