### PR TITLE
python: add -fwrapv to cflags for python@3.8.0: %intel

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -258,6 +258,15 @@ class Python(AutotoolsPackage):
         env.unset('PYTHONPATH')
         env.unset('PYTHONHOME')
 
+    def flag_handler(self, name, flags):
+        # python 3.8 requires -fwrapv when compiled with intel
+        if self.spec.satisfies('@3.8: %intel'):
+            if name == 'cflags':
+                flags.append('-fwrapv')
+
+        # allow flags to be passed through compiler wrapper
+        return (flags, None, None)
+
     def configure_args(self):
         spec = self.spec
         config_args = []


### PR DESCRIPTION
Fixes #16586

`python@3.8.0: %intel` requires `-fwrapv` in the cflags.

This PR adds the flag using the `flag_handler` interface without changing any other behavior of the package.

This version check should eventually have an upper bound as python plans to incorporate this into their build system. That PR is open.

sources:
https://bugs.python.org/issue40223
https://bugs.python.org/pull_request18905
https://software.intel.com/en-us/forums/intel-c-compiler/topic/849064