### PR TITLE
Cray: fix Blue Waters support and user-built MPIs on Cray

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -53,6 +53,7 @@ import spack.main
 import spack.paths
 import spack.schema.environment
 import spack.store
+import spack.architecture as arch
 from spack.util.string import plural
 from spack.util.environment import (
     env_flag, filter_system_paths, get_path, is_system_path,
@@ -146,6 +147,16 @@ def clean_environment():
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
     env.unset('DYLD_FALLBACK_LIBRARY_PATH')
+
+    # Test the host architecture because old cray systems (i.e. Blue Waters)
+    # do not work when we clean aspects of the cray environment.
+    # Cleaning these is necessary on cray "cluster" systems.
+    hostarch = arch.Arch(arch.platform(), 'default_os', 'default_target')
+    if str(hostarch.platform) == 'cray' and str(hostarch.os) != 'cnl5':
+        env.unset('CRAY_LD_LIBRARY_PATH')
+        for varname in os.environ.keys():
+            if 'PKGCONF' in varname:
+                env.unset(varname)
 
     build_lang = spack.config.get('config:build_language')
     if build_lang:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -147,11 +147,6 @@ def clean_environment():
     env.unset('DYLD_LIBRARY_PATH')
     env.unset('DYLD_FALLBACK_LIBRARY_PATH')
 
-    # Remove all pkgconfig stuff from craype
-    for varname in os.environ.keys():
-        if 'PKGCONF' in varname:
-            env.unset(varname)
-
     build_lang = spack.config.get('config:build_language')
     if build_lang:
         # Override language-related variables. This can be used to force

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -725,7 +725,8 @@ def setup_package(pkg, dirty):
 
     implicit_rpaths = pkg.compiler.implicit_rpaths()
     if implicit_rpaths:
-        build_env.set('SPACK_COMPILER_IMPLICIT_RPATHS', ':'.join(implicit_rpaths))
+        build_env.set('SPACK_COMPILER_IMPLICIT_RPATHS',
+                      ':'.join(implicit_rpaths))
 
     # Make sure nothing's strange about the Spack environment.
     validate(build_env, tty.warn)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -141,7 +141,6 @@ def clean_environment():
     # can affect how some packages find libraries.  We want to make
     # sure that builds never pull in unintended external dependencies.
     env.unset('LD_LIBRARY_PATH')
-    env.unset('CRAY_LD_LIBRARY_PATH')
     env.unset('LIBRARY_PATH')
     env.unset('CPATH')
     env.unset('LD_RUN_PATH')
@@ -354,10 +353,6 @@ def set_build_environment_variables(pkg, env, dirty):
     if compiler.extra_rpaths:
         extra_rpaths = ':'.join(compiler.extra_rpaths)
         env.set('SPACK_COMPILER_EXTRA_RPATHS', extra_rpaths)
-
-    implicit_rpaths = compiler.implicit_rpaths()
-    if implicit_rpaths:
-        env.set('SPACK_COMPILER_IMPLICIT_RPATHS', ':'.join(implicit_rpaths))
 
     # Add bin directories from dependencies to the PATH for the build.
     for prefix in build_prefixes:
@@ -732,6 +727,10 @@ def setup_package(pkg, dirty):
             load_module(pkg.architecture.target.module_name)
 
         load_external_modules(pkg)
+
+    implicit_rpaths = pkg.compiler.implicit_rpaths()
+    if implicit_rpaths:
+        env.set('SPACK_COMPILER_IMPLICIT_RPATHS', ':'.join(implicit_rpaths))
 
     # Make sure nothing's strange about the Spack environment.
     validate(build_env, tty.warn)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -148,9 +148,9 @@ def clean_environment():
     env.unset('DYLD_LIBRARY_PATH')
     env.unset('DYLD_FALLBACK_LIBRARY_PATH')
 
-    # Test the host architecture because old cray systems (i.e. Blue Waters)
-    # do not work when we clean aspects of the cray environment.
-    # Cleaning these is necessary on cray "cluster" systems.
+    # On Cray systems newer than CNL5, unset CRAY_LD_LIBRARY_PATH to avoid
+    # interference with Spack dependencies. CNL5 (e.g. Blue Waters) requires
+    # these variables to be set.
     hostarch = arch.Arch(arch.platform(), 'default_os', 'default_target')
     if str(hostarch.platform) == 'cray' and str(hostarch.os) != 'cnl5':
         env.unset('CRAY_LD_LIBRARY_PATH')

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -730,7 +730,7 @@ def setup_package(pkg, dirty):
 
     implicit_rpaths = pkg.compiler.implicit_rpaths()
     if implicit_rpaths:
-        env.set('SPACK_COMPILER_IMPLICIT_RPATHS', ':'.join(implicit_rpaths))
+        build_env.set('SPACK_COMPILER_IMPLICIT_RPATHS', ':'.join(implicit_rpaths))
 
     # Make sure nothing's strange about the Spack environment.
     validate(build_env, tty.warn)

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -22,7 +22,9 @@ _craype_name_to_target_name = {
     'x86-naples': 'zen',
     'x86-rome': 'zen',  # Cheating because we have the wrong modules on rzcrayz
     'x86-skylake': 'skylake_avx512',
-    'mic-knl': 'mic_knl'
+    'mic-knl': 'mic_knl',
+    'interlagos': 'bulldozer',
+    'abudhabi': 'piledriver',
 }
 
 
@@ -176,7 +178,7 @@ class Cray(Platform):
             craype_default_path = '/opt/cray/pe/craype/default/modulefiles'
             if os.path.isdir(craype_default_path):
                 return os.listdir(craype_default_path)
-            return None
+            return []
 
         if getattr(self, '_craype_targets', None) is None:
             strategies = [

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -161,8 +161,8 @@ spack package at this time.''',
             env.set('FFLAGS', '-fallow-argument-mismatch')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        # On Cray, the regular compiler wrappers *are* the MPI wrappers.
-        if 'platform=cray' in self.spec:
+        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        if self.spec.external_module and 'cray' in self.spec.external_module:
             env.set('MPICC', spack_cc)
             env.set('MPICXX', spack_cxx)
             env.set('MPIF77', spack_fc)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -162,6 +162,7 @@ spack package at this time.''',
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
         if self.spec.external_module and 'cray' in self.spec.external_module:
             env.set('MPICC', spack_cc)
             env.set('MPICXX', spack_cxx)
@@ -180,6 +181,8 @@ spack package at this time.''',
         env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
+        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
         if self.spec.external_module and 'cray' in self.spec.external_module:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -180,7 +180,7 @@ spack package at this time.''',
         env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
-        if 'platform=cray' in self.spec:
+        if self.spec.external_module and 'cray' in self.spec.external_module:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx
             self.spec.mpifc = spack_fc

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -208,8 +208,8 @@ class Mvapich2(AutotoolsPackage):
             env.set('SLURM_MPI_TYPE', 'pmi2')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        # On Cray, the regular compiler wrappers *are* the MPI wrappers.
-        if 'platform=cray' in self.spec:
+        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        if self.spec.external_module and 'cray' in self.spec.external_module:
             env.set('MPICC',  spack_cc)
             env.set('MPICXX', spack_cxx)
             env.set('MPIF77', spack_fc)

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -209,6 +209,7 @@ class Mvapich2(AutotoolsPackage):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
         if self.spec.external_module and 'cray' in self.spec.external_module:
             env.set('MPICC',  spack_cc)
             env.set('MPICXX', spack_cxx)
@@ -227,6 +228,8 @@ class Mvapich2(AutotoolsPackage):
         env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
+        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
+        # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
         if self.spec.external_module and 'cray' in self.spec.external_module:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -227,7 +227,7 @@ class Mvapich2(AutotoolsPackage):
         env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
-        if 'platform=cray' in self.spec:
+        if self.spec.external_module and 'cray' in self.spec.external_module:
             self.spec.mpicc = spack_cc
             self.spec.mpicxx = spack_cxx
             self.spec.mpifc = spack_fc


### PR DESCRIPTION
Fixes some of the bugs that were introduced by #12989. See the bottom of #12989 for the specific error messages.

In particular:

- [x] `module load PrgEnv-gnu` fails when `CRAY_LD_LIBRARY_PATH` is unset
- [x] Implicit RPATH detection shouldn't be run until after compiler modules are loaded
- [x] Add some older Cray PE names
- [x] None can't be executed 
- [x] PrgEnv compiler fails to find mpich when `PKGCONFIG` env vars are unset