### PR TITLE
clingo: update package

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -18,13 +18,32 @@ class Clingo(CMakePackage):
 
     homepage = "https://potassco.org/clingo/"
     url      = "https://github.com/potassco/clingo/archive/v5.2.2.tar.gz"
+    git      = 'https://github.com/potassco/clingo.git'
 
+    maintainers = ["tgamblin"]
+
+    version('develop', branch='wip', submodules=True)
     version('5.4.0', sha256='e2de331ee0a6d254193aab5995338a621372517adcf91568092be8ac511c18f3')
     version('5.3.0', sha256='b0d406d2809352caef7fccf69e8864d55e81ee84f4888b0744894977f703f976')
     version('5.2.2', sha256='da1ef8142e75c5a6f23c9403b90d4f40b9f862969ba71e2aaee9a257d058bfcf')
 
-    depends_on('doxygen', type=('build'))
-    depends_on('python')
+    variant("docs", default=False, description="build documentation with Doxyegen")
+    variant("python", default=True, description="build with python bindings")
+
+    depends_on('doxygen', type="build", when="+docs")
+    depends_on('re2c@0.13:', type="build")
+    depends_on('bison@2.5:', type="build")
+
+    depends_on('python', type=("build", "link", "run"), when="+python")
+
+    def patch(self):
+        # Doxygen is optional but can't be disabled with a -D, so patch
+        # it out if it's really supposed to be disabled
+        if '+docs' not in self.spec:
+            filter_file(r'find_package\(Doxygen\)',
+                        'message("Doxygen disabled for Spack build.")',
+                        'clasp/CMakeLists.txt',
+                        'clasp/libpotassco/CMakeLists.txt')
 
     def cmake_args(self):
         try:
@@ -32,8 +51,11 @@ class Clingo(CMakePackage):
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
-        args = ['-DCLINGO_BUILD_WITH_PYTHON=ON',
-                '-DCLING_BUILD_PY_SHARED=ON',
-                '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
-                '-DCLINGO_BUILD_WITH_LUA=OFF']
-        return args
+        return [
+            '-DCLINGO_REQUIRE_PYTHON=ON',
+            '-DCLINGO_BUILD_WITH_PYTHON=ON',
+            '-DCLINGO_BUILD_PY_SHARED=ON',
+            '-DPYCLINGO_USER_INSTALL=OFF',
+            '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
+            '-DCLINGO_BUILD_WITH_LUA=OFF'
+        ]


### PR DESCRIPTION
`clingo` has some undocumented dependencies:
- `bison`, for which the default macos version is too old
- `re2c`, which isn't always available

Also, the python installation was not set up properly. Clingo by default
does an install in `~/.local`, so we need to disable that and add a few
other options to get things right.

- [x] add `bison` dependency
- [x] add `re2c` dependency
- [x] make `doxygen` dependency optional (and patch if needed)
- [x] add options to fix `python` build
- [x] make python build optional but on by default