### PR TITLE
z3: update python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -21,8 +21,9 @@ class Z3(MakefilePackage):
 
     phases = ['bootstrap', 'build', 'install']
 
-    variant('python', default=False, description='Enable python binding')
+    variant('python', default=True, description='Enable python binding')
     depends_on('python', type=('build', 'run'))
+    depends_on('py-setuptools', type=('run'), when='+python')
     extends('python', when='+python')
 
     # Referenced: https://github.com/Z3Prover/z3/issues/1016


### PR DESCRIPTION
- [x] `z3` needs a dependency on `py-setuptools`
- [x] `z3` has a run dependency on `python`, so we might as well make building with the python bindings default