### PR TITLE
gcc: Fix several issues

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -19,11 +19,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = 'https://gcc.gnu.org'
     gnu_mirror_path = 'gcc/gcc-9.2.0/gcc-9.2.0.tar.xz'
-    svn      = 'svn://gcc.gnu.org/svn/gcc/'
+    git      = 'git://gcc.gnu.org/git/gcc.git'
     list_url = 'http://ftp.gnu.org/gnu/gcc/'
     list_depth = 1
 
-    version('develop', svn=svn + 'trunk')
+    maintainers = ['michaelkuhn']
+
+    version('master', branch='master')
 
     version('10.1.0', sha256='b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2')
 
@@ -89,6 +91,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('nvptx',
             default=False,
             description='Target nvptx offloading to NVIDIA GPUs')
+
+    depends_on('flex', type='build', when='@master')
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -121,14 +121,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     # The server is sometimes a bit slow to respond
     timeout = {'timeout': 60}
 
-    resource(
-             name='newlib',
+    resource(name='newlib',
              url='ftp://sourceware.org/pub/newlib/newlib-3.0.0.20180831.tar.gz',
              sha256='3ad3664f227357df15ff34e954bfd9f501009a647667cd307bf0658aefd6eb5b',
              destination='newlibsource',
              when='+nvptx',
-             fetch_options=timeout
-            )
+             fetch_options=timeout)
 
     # nvptx-tools does not seem to work as a dependency,
     # but does fine when the source is inside the gcc build directory
@@ -271,7 +269,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # mirrors are tried. It takes care of modifying the suffix of gnu
         # mirror path so that Spack will also look for the correct file in
         # the mirrors
-        if (version < Version('6.4.0')and version != Version('5.5.0')) \
+        if (version < Version('6.4.0') and version != Version('5.5.0')) \
                 or version == Version('7.1.0'):
             self.gnu_mirror_path = self.gnu_mirror_path.replace('xz', 'bz2')
         return super(Gcc, self).url_for_version(version)

--- a/var/spack/repos/builtin/packages/gcc/zstd.patch
+++ b/var/spack/repos/builtin/packages/gcc/zstd.patch
@@ -1,23 +1,43 @@
---- a/gcc/Makefile.in	2020-05-08 11:50:17.962838228 +0200
-+++ b/gcc/Makefile.in	2020-05-08 11:50:58.220960817 +0200
-@@ -1075,6 +1075,11 @@
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -1075,7 +1075,8 @@ GNATMAKE = @GNATMAKE@
  # Libs needed (at present) just for jcf-dump.
  LDEXP_LIB = @LDEXP_LIB@
  
-+ifneq (@ZSTD_INCLUDE@,)
-+ZSTD_INCLUDE = -I@ZSTD_INCLUDE@
-+else
-+ZSTD_INCLUDE =
-+endif
- ZSTD_LIB = @ZSTD_LIB@
+-ZSTD_LIB = @ZSTD_LIB@
++ZSTD_INC = @ZSTD_CPPFLAGS@
++ZSTD_LIB = @ZSTD_LDFLAGS@ @ZSTD_LIB@
  
  # Likewise, for use in the tools that must run on this machine
-@@ -2275,7 +2280,7 @@
+ # even if we are cross-building GCC.
+@@ -2275,7 +2276,7 @@ CFLAGS-version.o += -DBASEVER=$(BASEVER_s) -DDATESTAMP=$(DATESTAMP_s) \
  version.o: $(REVISION) $(DATESTAMP) $(BASEVER) $(DEVPHASE)
  
  # lto-compress.o needs $(ZLIBINC) added to the include flags.
 -CFLAGS-lto-compress.o += $(ZLIBINC)
-+CFLAGS-lto-compress.o += $(ZLIBINC) $(ZSTD_INCLUDE)
++CFLAGS-lto-compress.o += $(ZLIBINC) $(ZSTD_INC)
  
  CFLAGS-lto-streamer-in.o += -DTARGET_MACHINE=\"$(target_noncanonical)\"
  
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -786,6 +786,8 @@ LTLIBICONV
+ LIBICONV
+ ZSTD_LIB
+ ZSTD_INCLUDE
++ZSTD_LDFLAGS
++ZSTD_CPPFLAGS
+ DL_LIB
+ LDEXP_LIB
+ EXTRA_GCC_LIBS
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -1339,6 +1339,8 @@ AC_SUBST(ZSTD_INCLUDE)
+ AC_SUBST(ZSTD_LIB)
+ ZSTD_CPPFLAGS=
+ ZSTD_LDFLAGS=
++AC_SUBST(ZSTD_CPPFLAGS)
++AC_SUBST(ZSTD_LDFLAGS)
+ AC_ARG_WITH(zstd,
+ 	[AS_HELP_STRING([--with-zstd=PATH],
+ 		[specify prefix directory for installed zstd library.


### PR DESCRIPTION
This PR updates several things:
- GCC has moved to Git
- The develop/master version requires flex
- Add myself as a maintainer
- Set the library path in the zstd patch