### PR TITLE
Added unit tests to Github Actions

### DIFF
--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -26,26 +26,39 @@ jobs:
     - name: Install System packages
       run: |
           sudo apt-get -y update
-          sudo apt-get install -y ccache coreutils gfortran graphviz gnupg2 mercurial ninja-build patchelf
+          sudo apt-get install -y coreutils gfortran graphviz gnupg2 mercurial ninja-build patchelf
+          # Needed for kcov
+          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
           pip install --upgrade codecov coverage==4.5.4
     - name: Setup git configuration
       run: |
-        # Need this for the git tests to succeed.
-        git --version
-        git config --global user.email "spack@example.com"
-        git config --global user.name "Test User"
-        git fetch -u origin develop:develop
-    - name: Run unit tests
+          # Need this for the git tests to succeed.
+          git --version
+          git config --global user.email "spack@example.com"
+          git config --global user.name "Test User"
+          git fetch -u origin develop:develop
+    - name: Install kcov for bash script coverage
+      env:
+          KCOV_VERSION: 34
       run: |
-        . share/spack/setup-env.sh
-        coverage run $(which spack) test
-        coverage combine
-        coverage xml
+          KCOV_ROOT=$(mktemp -d)
+          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
+          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
+          mkdir -p ${KCOV_ROOT}/build
+          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
+          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
+    - name: Run unit tests
+      env:
+          COVERAGE: true
+      run: |
+          share/spack/qa/run-unit-tests
+          coverage combine
+          coverage xml
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
-        flags: unittests,linux
+        flags: unittests,linux,${{ matrix.python-version }}

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -1,0 +1,46 @@
+name: linux tests
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  unittests:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install System packages
+      run: |
+          sudo apt-get -y update
+          sudo apt-get install -y ccache coreutils gfortran graphviz gnupg2 mercurial ninja-build patchelf
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip six setuptools
+          pip install --upgrade codecov coverage==4.5.4
+    - name: Run unit tests
+      run: |
+        git --version
+        git fetch -u origin develop:develop
+        . share/spack/setup-env.sh
+        coverage run $(which spack) test
+        coverage combine
+        coverage xml
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests,linux

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -11,7 +11,6 @@ on:
       - develop
 jobs:
   unittests:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,8 +30,7 @@ jobs:
           sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools
-          pip install --upgrade codecov coverage==4.5.4
+          pip install --upgrade pip six setuptools codecov coverage==4.5.4
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -60,5 +58,4 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage.xml
         flags: unittests,linux

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools codecov coverage==4.5.4
+          pip install --upgrade pip six setuptools codecov coverage
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -31,10 +31,15 @@ jobs:
       run: |
           pip install --upgrade pip six setuptools
           pip install --upgrade codecov coverage==4.5.4
+    - name: Setup git configuration
+      run: |
+        # Need this for the git tests to succeed.
+        git --version
+        git config --global user.email "spack@example.com"
+        git config --global user.name "Test User"
+        git fetch -u origin develop:develop
     - name: Run unit tests
       run: |
-        git --version
-        git fetch -u origin develop:develop
         . share/spack/setup-env.sh
         coverage run $(which spack) test
         coverage combine

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -61,4 +61,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
-        flags: unittests,linux,${{ matrix.python-version }}
+        flags: unittests,linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,27 +41,6 @@ jobs:
             - realpath
             - zsh
       env: [ TEST_SUITE=unit, COVERAGE=true ]
-    - python: '2.7'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=unit, COVERAGE=true, KCOV_VERSION=34 ]
-    - python: '3.5'
-      os: linux
-      dist: xenial
-      language: python
-      env: TEST_SUITE=unit
-    - python: '3.6'
-      os: linux
-      language: python
-      env: TEST_SUITE=unit
-    - python: '3.7'
-      os: linux
-      language: python
-      env: TEST_SUITE=unit
-    - python: '3.8'
-      os: linux
-      language: python
-      env: [ TEST_SUITE=unit, COVERAGE=true, KCOV_VERSION=34 ]
     - python: '3.8'
       os: linux
       language: python

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # <img src="https://cdn.rawgit.com/spack/spack/develop/share/spack/logo/spack-logo.svg" width="64" valign="middle" alt="Spack"/> Spack
 
-[![](https://github.com/spack/spack/workflows/macos%20tests/badge.svg)](https://github.com/spack/spack/actions)
-[![Build Status](https://travis-ci.com/spack/spack.svg?branch=develop)](https://travis-ci.com/spack/spack)
+[![MacOS Tests](https://github.com/spack/spack/workflows/macos%20tests/badge.svg)](https://github.com/spack/spack/actions)
+[![Linux Tests](https://github.com/spack/spack/workflows/linux%20tests/badge.svg)](https://github.com/spack/spack/actions)
 [![Linux Builds](https://github.com/spack/spack/workflows/linux%20builds/badge.svg)](https://github.com/spack/spack/actions)
 [![macOS Builds (nightly)](https://github.com/spack/spack/workflows/macOS%20builds%20nightly/badge.svg?branch=develop)](https://github.com/spack/spack/actions?query=workflow%3A%22macOS+builds+nightly%22)
+[![Build Status](https://travis-ci.com/spack/spack.svg?branch=develop)](https://travis-ci.com/spack/spack)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 [![Slack](https://spackpm.herokuapp.com/badge.svg)](https://spackpm.herokuapp.com)

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -20,24 +20,15 @@ export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 coverage=""
 coverage_run=""
 
-# bash coverage depends on some other factors -- there are issues with
-# kcov for Python 2.6, unit tests, and build tests.
-if [[ $TEST_SUITE == unit &&   # kcov segfaults for the MPICH build test
-      $TRAVIS_OS_NAME == linux &&
-      $TRAVIS_PYTHON_VERSION != 2.6 ]];
-then
-    BASH_COVERAGE="true"
-else
-    BASH_COVERAGE="false"
-fi
-
 # Set up some variables for running coverage tests.
 if [[ "$COVERAGE" == "true" ]]; then
     # these set up coverage for Python
     coverage=coverage
     coverage_run="coverage run"
 
-    if [ "$BASH_COVERAGE" = true ]; then
+    # bash coverage depends on some other factors -- there are issues with
+    # kcov for Python 2.6, unit tests, and build tests.
+    if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then
         mkdir -p coverage
         cc_script="$SPACK_ROOT/lib/spack/env/cc"
         bashcov=$(realpath ${QA_DIR}/bashcov)


### PR DESCRIPTION
Modifications:
- [x] Added Python (>=2.7) unit tests to Github Actions and removed them from Travis
- [x] Simplified the logic to enable coverage from `setup.sh`

At the moment all the jobs in Github Actions run with coverage. The timing is comparable to the same jobs in Travis. A caveat is that Github Actions doesn't support Python 2.6 - so Travis is necessary at least as long as we provide support for it.