### PR TITLE
cmake build system: filter system paths from rpaths

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -615,7 +615,7 @@ def get_rpaths(pkg):
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
         rpaths.append(get_path_from_module(pkg.compiler.modules[1]))
-    return rpaths
+    return list(dedupe(filter_system_paths(rpaths)))
 
 
 def get_std_cmake_args(pkg):


### PR DESCRIPTION
Fixes a bug reported on slack by @khuck 

In all other places we get rpaths, we filter out system paths. We don't do so for the paths going into `CMAKE_INSTALL_RPATH` in `CMakePackage`.

This PR rectifies that oversight.