### PR TITLE
Bugfix: install failure perms

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -44,7 +44,7 @@ import spack.compilers
 import spack.error
 import spack.hooks
 import spack.package
-import spack.package_prefs as prefs
+import spack.package_perms as spp
 import spack.repo
 import spack.store
 
@@ -1297,7 +1297,7 @@ class PackageInstaller(object):
             spack.store.layout.create_install_directory(pkg.spec)
         else:
             # Set the proper group for the prefix
-            group = prefs.get_package_group(pkg.spec)
+            group = spp.get_package_group(pkg.spec)
             if group:
                 fs.chgrp(pkg.spec.prefix, group)
 
@@ -1305,7 +1305,7 @@ class PackageInstaller(object):
             # This has to be done after group because changing groups blows
             # away the sticky group bit on the directory
             mode = os.stat(pkg.spec.prefix).st_mode
-            perms = prefs.get_package_dir_permissions(pkg.spec)
+            perms = spp.get_package_dir_permissions(pkg.spec)
             if mode != perms:
                 os.chmod(pkg.spec.prefix, perms)
 

--- a/lib/spack/spack/package_perms.py
+++ b/lib/spack/spack/package_perms.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import stat
+
+import spack.config as scon
+
+
+def get_package_dir_permissions(spec):
+    """Return the permissions configured for the spec.
+
+    Include the GID bit if group permissions are on. This makes the group
+    attribute sticky for the directory. Package-specific settings take
+    precedent over settings for ``all``"""
+    perms = get_package_permissions(spec)
+    if perms & stat.S_IRWXG and scon.get('config:allow_sgid', True):
+        perms |= stat.S_ISGID
+    return perms
+
+
+def get_package_permissions(spec):
+    """Return the permissions configured for the spec.
+
+    Package-specific settings take precedence over settings for ``all``"""
+
+    # Get read permissions level
+    for name in (spec.name, 'all'):
+        try:
+            readable = scon.get('packages:%s:permissions:read' % name, '')
+            if readable:
+                break
+        except AttributeError:
+            readable = 'world'
+
+    # Get write permissions level
+    for name in (spec.name, 'all'):
+        try:
+            writable = scon.get('packages:%s:permissions:write' % name, '')
+            if writable:
+                break
+        except AttributeError:
+            writable = 'user'
+
+    perms = stat.S_IRWXU
+    if readable in ('world', 'group'):  # world includes group
+        perms |= stat.S_IRGRP | stat.S_IXGRP
+    if readable == 'world':
+        perms |= stat.S_IROTH | stat.S_IXOTH
+
+    if writable in ('world', 'group'):
+        if readable == 'user':
+            raise scon.ConfigError('Writable permissions may not be more' +
+                                   ' permissive than readable permissions.\n' +
+                                   '      Violating package is %s' % spec.name)
+        perms |= stat.S_IWGRP
+    if writable == 'world':
+        if readable != 'world':
+            raise scon.ConfigError('Writable permissions may not be more' +
+                                   ' permissive than readable permissions.\n' +
+                                   '      Violating package is %s' % spec.name)
+        perms |= stat.S_IWOTH
+
+    return perms
+
+
+def get_package_group(spec):
+    """Return the unix group associated with the spec.
+
+    Package-specific settings take precedence over settings for ``all``"""
+    for name in (spec.name, 'all'):
+        try:
+            group = scon.get('packages:%s:permissions:group' % name, '')
+            if group:
+                break
+        except AttributeError:
+            group = ''
+    return group

--- a/lib/spack/spack/package_perms.py
+++ b/lib/spack/spack/package_perms.py
@@ -9,11 +9,18 @@ import spack.config as scon
 
 
 def get_package_dir_permissions(spec):
-    """Return the permissions configured for the spec.
+    """Return the permissions configured for the spec or for ``all`` if no spec
 
     Include the GID bit if group permissions are on. This makes the group
     attribute sticky for the directory. Package-specific settings take
-    precedent over settings for ``all``"""
+    precedent over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        perms (int): the appropriate stat permissions or mode
+    """
     perms = get_package_permissions(spec)
     if perms & stat.S_IRWXG and scon.get('config:allow_sgid', True):
         perms |= stat.S_ISGID
@@ -21,12 +28,20 @@ def get_package_dir_permissions(spec):
 
 
 def get_package_permissions(spec):
-    """Return the permissions configured for the spec.
+    """Return the permissions configured for the spec or for ``all`` if no spec
 
-    Package-specific settings take precedence over settings for ``all``"""
+    Package-specific settings take precedence over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        perms (int): the appropriate stat permissions or mode
+    """
+    names = ['all'] if spec is None else [spec.name, 'all']
 
     # Get read permissions level
-    for name in (spec.name, 'all'):
+    for name in names:
         try:
             readable = scon.get('packages:%s:permissions:read' % name, '')
             if readable:
@@ -35,7 +50,7 @@ def get_package_permissions(spec):
             readable = 'world'
 
     # Get write permissions level
-    for name in (spec.name, 'all'):
+    for name in names:
         try:
             writable = scon.get('packages:%s:permissions:write' % name, '')
             if writable:
@@ -66,10 +81,19 @@ def get_package_permissions(spec):
 
 
 def get_package_group(spec):
-    """Return the unix group associated with the spec.
+    """Return the unix group associated with the spec or for ``all`` if no spec
 
-    Package-specific settings take precedence over settings for ``all``"""
-    for name in (spec.name, 'all'):
+    Package-specific settings take precedence over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        group (str): the appropriate group name
+    """
+    names = ['all'] if spec is None else [spec.name, 'all']
+
+    for name in names:
         try:
             group = scon.get('packages:%s:permissions:group' % name, '')
             if group:

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -6,8 +6,8 @@
 import pytest
 import stat
 
-import spack.package_prefs
 import spack.repo
+import spack.package_perms as spp
 import spack.util.spack_yaml as syaml
 from spack.config import ConfigScope, ConfigError
 from spack.spec import Spec
@@ -246,42 +246,42 @@ mpi:
 
         # Test inheriting from 'all'
         spec = Spec('zmpi')
-        perms = spack.package_prefs.get_package_permissions(spec)
+        perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU | stat.S_IRWXG
 
-        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        dir_perms = spp.get_package_dir_permissions(spec)
         assert dir_perms == stat.S_IRWXU | stat.S_IRWXG | stat.S_ISGID
 
-        group = spack.package_prefs.get_package_group(spec)
+        group = spp.get_package_group(spec)
         assert group == 'all'
 
     def test_config_permissions_from_package(self, configure_permissions):
         # Test overriding 'all'
         spec = Spec('mpich')
-        perms = spack.package_prefs.get_package_permissions(spec)
+        perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU
 
-        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        dir_perms = spp.get_package_dir_permissions(spec)
         assert dir_perms == stat.S_IRWXU
 
-        group = spack.package_prefs.get_package_group(spec)
+        group = spp.get_package_group(spec)
         assert group == 'all'
 
     def test_config_permissions_differ_read_write(self, configure_permissions):
         # Test overriding group from 'all' and different readable/writable
         spec = Spec('mpileaks')
-        perms = spack.package_prefs.get_package_permissions(spec)
+        perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
 
-        dir_perms = spack.package_prefs.get_package_dir_permissions(spec)
+        dir_perms = spp.get_package_dir_permissions(spec)
         expected = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_ISGID
         assert dir_perms == expected
 
-        group = spack.package_prefs.get_package_group(spec)
+        group = spp.get_package_group(spec)
         assert group == 'mpileaks'
 
     def test_config_perms_fail_write_gt_read(self, configure_permissions):
         # Test failure for writable more permissive than readable
         spec = Spec('callpath')
         with pytest.raises(ConfigError):
-            spack.package_prefs.get_package_permissions(spec)
+            spp.get_package_permissions(spec)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -7,11 +7,12 @@ import pytest
 import stat
 
 import spack.repo
+import spack.spec
+import spack.version
+
+import spack.config as scon
 import spack.package_perms as spp
 import spack.util.spack_yaml as syaml
-from spack.config import ConfigScope, ConfigError
-from spack.spec import Spec
-from spack.version import Version
 
 
 @pytest.fixture()
@@ -19,7 +20,7 @@ def concretize_scope(mutable_config, tmpdir):
     """Adds a scope for concretization preferences"""
     tmpdir.ensure_dir('concretize')
     mutable_config.push_scope(
-        ConfigScope('concretize', str(tmpdir.join('concretize'))))
+        scon.ConfigScope('concretize', str(tmpdir.join('concretize'))))
 
     yield
 
@@ -53,7 +54,7 @@ callpath:
 
 
 def concretize(abstract_spec):
-    return Spec(abstract_spec).concretized()
+    return spack.spec.Spec(abstract_spec).concretized()
 
 
 def update_packages(pkgname, section, value):
@@ -128,16 +129,16 @@ class TestConcretizePreferences(object):
         """
         update_packages('mpileaks', 'version', ['2.3'])
         spec = concretize('mpileaks')
-        assert spec.version == Version('2.3')
+        assert spec.version == spack.version.Version('2.3')
 
         update_packages('mpileaks', 'version', ['2.2'])
         spec = concretize('mpileaks')
-        assert spec.version == Version('2.2')
+        assert spec.version == spack.version.Version('2.2')
 
     def test_preferred_versions_mixed_version_types(self):
         update_packages('mixedversions', 'version', ['2.0'])
         spec = concretize('mixedversions')
-        assert spec.version == Version('2.0')
+        assert spec.version == spack.version.Version('2.0')
 
     def test_preferred_providers(self):
         """Test preferred providers of virtual packages are
@@ -153,41 +154,41 @@ class TestConcretizePreferences(object):
 
     def test_preferred(self):
         """"Test packages with some version marked as preferred=True"""
-        spec = Spec('preferred-test')
+        spec = spack.spec.Spec('preferred-test')
         spec.concretize()
-        assert spec.version == Version('0.2.15')
+        assert spec.version == spack.version.Version('0.2.15')
 
         # now add packages.yaml with versions other than preferred
         # ensure that once config is in place, non-preferred version is used
         update_packages('preferred-test', 'version', ['0.2.16'])
-        spec = Spec('preferred-test')
+        spec = spack.spec.Spec('preferred-test')
         spec.concretize()
-        assert spec.version == Version('0.2.16')
+        assert spec.version == spack.version.Version('0.2.16')
 
     def test_develop(self):
         """Test concretization with develop-like versions"""
-        spec = Spec('develop-test')
+        spec = spack.spec.Spec('develop-test')
         spec.concretize()
-        assert spec.version == Version('0.2.15')
-        spec = Spec('develop-test2')
+        assert spec.version == spack.version.Version('0.2.15')
+        spec = spack.spec.Spec('develop-test2')
         spec.concretize()
-        assert spec.version == Version('0.2.15')
+        assert spec.version == spack.version.Version('0.2.15')
 
         # now add packages.yaml with develop-like versions
         # ensure that once config is in place, develop-like version is used
         update_packages('develop-test', 'version', ['develop'])
-        spec = Spec('develop-test')
+        spec = spack.spec.Spec('develop-test')
         spec.concretize()
-        assert spec.version == Version('develop')
+        assert spec.version == spack.version.Version('develop')
 
         update_packages('develop-test2', 'version', ['0.2.15.develop'])
-        spec = Spec('develop-test2')
+        spec = spack.spec.Spec('develop-test2')
         spec.concretize()
-        assert spec.version == Version('0.2.15.develop')
+        assert spec.version == spack.version.Version('0.2.15.develop')
 
     def test_external_mpi(self):
         # make sure this doesn't give us an external first.
-        spec = Spec('mpi')
+        spec = spack.spec.Spec('mpi')
         spec.concretize()
         assert not spec['mpi'].external
 
@@ -204,7 +205,7 @@ mpich:
         spack.config.set('packages', conf, scope='concretize')
 
         # ensure that once config is in place, external is used
-        spec = Spec('mpi')
+        spec = spack.spec.Spec('mpi')
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
 
@@ -218,7 +219,7 @@ mpich:
             return 'prepend-path PATH /dummy/path'
         monkeypatch.setattr(spack.util.module_cmd, 'module', mock_module)
 
-        spec = Spec('mpi')
+        spec = spack.spec.Spec('mpi')
         spec.concretize()
         assert not spec['mpi'].external
 
@@ -235,7 +236,7 @@ mpi:
         spack.config.set('packages', conf, scope='concretize')
 
         # ensure that once config is in place, external is used
-        spec = Spec('mpi')
+        spec = spack.spec.Spec('mpi')
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
 
@@ -245,7 +246,7 @@ mpi:
         # Make sure we can configure readable and writable
 
         # Test inheriting from 'all'
-        spec = Spec('zmpi')
+        spec = spack.spec.Spec('zmpi')
         perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU | stat.S_IRWXG
 
@@ -257,7 +258,7 @@ mpi:
 
     def test_config_permissions_from_package(self, configure_permissions):
         # Test overriding 'all'
-        spec = Spec('mpich')
+        spec = spack.spec.Spec('mpich')
         perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU
 
@@ -269,7 +270,7 @@ mpi:
 
     def test_config_permissions_differ_read_write(self, configure_permissions):
         # Test overriding group from 'all' and different readable/writable
-        spec = Spec('mpileaks')
+        spec = spack.spec.Spec('mpileaks')
         perms = spp.get_package_permissions(spec)
         assert perms == stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
 
@@ -282,6 +283,18 @@ mpi:
 
     def test_config_perms_fail_write_gt_read(self, configure_permissions):
         # Test failure for writable more permissive than readable
-        spec = Spec('callpath')
-        with pytest.raises(ConfigError):
+        spec = spack.spec.Spec('callpath')
+        with pytest.raises(scon.ConfigError):
             spp.get_package_permissions(spec)
+
+    def test_config_all_perms(self, configure_permissions):
+        # Test all permissions only
+        group = spp.get_package_group(None)
+        assert group == 'all'
+
+        ug_rwx = stat.S_IRWXU | stat.S_IRWXG
+        perms = spp.get_package_permissions(None)
+        assert perms == ug_rwx
+
+        dir_perms = spp.get_package_dir_permissions(None)
+        assert dir_perms == ug_rwx | stat.S_ISGID

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -15,7 +15,7 @@ import spack.binary_distribution
 import spack.compilers
 import spack.directory_layout as dl
 import spack.installer as inst
-import spack.package_prefs as prefs
+import spack.package_perms as spp
 import spack.repo
 import spack.spec
 import spack.store
@@ -635,7 +635,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     def _chgrp(path, group):
         tty.msg(mock_chgrp_msg.format(path, group))
 
-    monkeypatch.setattr(prefs, 'get_package_group', _get_group)
+    monkeypatch.setattr(spp, 'get_package_group', _get_group)
     monkeypatch.setattr(fs, 'chgrp', _chgrp)
 
     spec, installer = create_installer('trivial-install-test-package')

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -56,7 +56,7 @@ def mock_module_filename(monkeypatch, tmpdir):
 @pytest.fixture()
 def mock_package_perms(monkeypatch):
     perms = stat.S_IRGRP | stat.S_IWGRP
-    monkeypatch.setattr(spack.package_prefs,
+    monkeypatch.setattr(spack.package_perms,
                         'get_package_permissions',
                         lambda spec: perms)
 

--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -6,17 +6,17 @@
 import os
 import stat as st
 import llnl.util.filesystem as fs
-import spack.package_prefs as pp
+import spack.package_perms as spp
 from spack.error import SpackError
 
 
 def set_permissions_by_spec(path, spec):
     # Get permissions for spec
     if os.path.isdir(path):
-        perms = pp.get_package_dir_permissions(spec)
+        perms = spp.get_package_dir_permissions(spec)
     else:
-        perms = pp.get_package_permissions(spec)
-    group = pp.get_package_group(spec)
+        perms = spp.get_package_permissions(spec)
+    group = spp.get_package_group(spec)
 
     set_permissions(path, perms, group)
 


### PR DESCRIPTION
Fixes #16283 

The goal of this PR is to ensure `all` permissions (and groups) specified in `packages.yaml` are used for the Spack database and as the basis for failure directories/files.

TODO:
- [ ] Review and address 'failures' subdir permissions