### PR TITLE
hwloc: Add libudev variant.

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -50,6 +50,7 @@ class Hwloc(AutotoolsPackage):
     variant('gl', default=False, description="Support GL device discovery")
     variant('cuda', default=False, description="Support CUDA devices")
     variant('libxml2', default=True, description="Build with libxml2")
+    variant('libudev', default=False, description="Build with libhudev")
     variant('pci', default=(sys.platform != 'darwin'),
             description="Support analyzing devices on PCI bus")
     variant('shared', default=True, description="Build shared libraries")
@@ -66,6 +67,9 @@ class Hwloc(AutotoolsPackage):
 
     # netloc isn't available until version 2.0.0
     conflicts('+netloc', when="@:1.99.99")
+
+    # libudev isn't available until version 1.11.1
+    conflicts('+libudev', when="@:1.10.0")
 
     depends_on('pkgconfig', type='build')
     depends_on('m4', type='build', when='@master')
@@ -102,6 +106,7 @@ class Hwloc(AutotoolsPackage):
         args.extend(self.enable_or_disable('gl'))
         args.extend(self.enable_or_disable('cuda'))
         args.extend(self.enable_or_disable('libxml2'))
+        args.extend(self.enable_or_disable('libudev'))
         args.extend(self.enable_or_disable('pci'))
         args.extend(self.enable_or_disable('shared'))
 

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -27,6 +27,8 @@ class Hwloc(AutotoolsPackage):
     list_depth = 2
     git = 'https://github.com/open-mpi/hwloc.git'
 
+    maintainers = ['bgoglin']
+
     version('master', branch='master')
     version('2.2.0', sha256='2defba03ddd91761b858cbbdc2e3a6e27b44e94696dbfa21380191328485a433')
     version('2.1.0',  sha256='1fb8cc1438de548e16ec3bb9e4b2abb9f7ce5656f71c0906583819fcfa8c2031')

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -68,8 +68,8 @@ class Hwloc(AutotoolsPackage):
     # netloc isn't available until version 2.0.0
     conflicts('+netloc', when="@:1.99.99")
 
-    # libudev isn't available until version 1.11.1
-    conflicts('+libudev', when="@:1.10.0")
+    # libudev isn't available until version 1.11.0
+    conflicts('+libudev', when="@:1.10")
 
     depends_on('pkgconfig', type='build')
     depends_on('m4', type='build', when='@master')

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -50,7 +50,7 @@ class Hwloc(AutotoolsPackage):
     variant('gl', default=False, description="Support GL device discovery")
     variant('cuda', default=False, description="Support CUDA devices")
     variant('libxml2', default=True, description="Build with libxml2")
-    variant('libudev', default=False, description="Build with libhudev")
+    variant('libudev', default=False, description="Build with libudev")
     variant('pci', default=(sys.platform != 'darwin'),
             description="Support analyzing devices on PCI bus")
     variant('shared', default=True, description="Build shared libraries")


### PR DESCRIPTION
This PR add libudev variant in hwloc.
On rhel8, libudev dose not link with spack build libuuid.
So I want to libudev default to False.

libudev.so depend libblkid.so:
<pre>
$ ldd  /lib64/libudev.so
        linux-vdso.so.1 (0x0000ffffad450000)
        libmount.so.1 => /lib64/libmount.so.1 (0x0000ffffad360000)
        libgcc_s.so.1 => /opt/arm/reports-20.0.3/lib/libgcc_s.so.1 (0x0000ffffad320000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x0000ffffad2e0000)
        libc.so.6 => /lib64/libc.so.6 (0x0000ffffad160000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffad460000)
        libblkid.so.1 => /lib64/libblkid.so.1 (0x0000ffffad0f0000)
        libuuid.so.1 => /lib64/libuuid.so.1 (0x0000ffffad0c0000)
        libselinux.so.1 => /lib64/libselinux.so.1 (0x0000ffffad070000)
        librt.so.1 => /lib64/librt.so.1 (0x0000ffffad040000)
        libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x0000ffffacfa0000)
        libdl.so.2 => /lib64/libdl.so.2 (0x0000ffffacf70000)
</pre>
libblkid need uuid_unparse@UUID_1.0.
But uuid_unparse@UUID_1.0 is not found in spack provided libuuid.
So the package depends hwloc and libuuid is faild to build.
<pre>
/bin/ld: /lib64/libblkid.so.1: undefined reference to `uuid_unparse@UUID_1.0
</pre>