### PR TITLE
ppopen-appl-fdm: Added 'iargc' definition.

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-fdm/iargc_definition.patch
+++ b/var/spack/repos/builtin/packages/ppopen-appl-fdm/iargc_definition.patch
@@ -1,0 +1,13 @@
+--- spack-src/tools/seismic_2D-tools/m_getopt.f90.org	2020-05-13 10:14:41.822006522 +0900
++++ spack-src/tools/seismic_2D-tools/m_getopt.f90	2020-05-13 10:17:01.102690012 +0900
+@@ -80,7 +80,9 @@
+     character(256), allocatable :: argv(:)
+     integer :: i
+     character(256) :: optkey
+-    
++
++    integer, external :: iargc
++
+     narg = iargc()
+     allocate( argv(1:narg) )
+     

--- a/var/spack/repos/builtin/packages/ppopen-appl-fdm/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-fdm/package.py
@@ -24,7 +24,10 @@ class PpopenApplFdm(MakefilePackage):
     patch('unused.patch')
     # remove iargc external definition
     # iargc is intrinsic in gfortran
-    patch('gfortran_iargc.patch')
+    patch('gfortran_iargc.patch', when='%gcc')
+
+    # Fixed a problem that 'iargc' was not declared in advance
+    patch('iargc_definition.patch', when='%fj')
 
     depends_on('ppopen-math-vis', type='link')
     depends_on('mpi')


### PR DESCRIPTION
Fujitsu compiler needs the definition in advance when using 'iargc' function.
So, the range of applying 'gfortran_iargc.patch' was narrowed, and Added 'iargc_definition.patch'.