### PR TITLE
charmpp: Support for aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -158,6 +158,8 @@ class Charmpp(Package):
             ("linux",   "ppc",      "verbs"):       "verbs-linux-ppc64le",
             ("linux",   "arm",      "netlrts"):     "netlrts-linux-arm7",
             ("linux",   "arm",      "multicore"):   "multicore-arm7",
+            ("linux",   "aarch64",  "netlrts"):     "netlrts-linux-arm8",
+            ("linux",   "aarch64",  "multicore"):   "multicore-arm8",
             ("win",     "x86_64",   "mpi"):         "mpi-win-x86_64",
             ("win",     "x86_64",   "multicore"):   "multicore-win-x86_64",
             ("win",     "x86_64",   "netlrts"):     "netlrts-win-x86_64",


### PR DESCRIPTION
Cham++ supported aarch64 from 6.9.0.
This PR enable to build on aarch64.