### PR TITLE
bugfix: use flags when computing implicit rpaths

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -297,8 +297,10 @@ class Compiler(object):
         if self.enable_implicit_rpaths is False:
             return []
 
+        # Put CXX first since it has the most linking issues
+        # And because it has flags that affect linking
         exe_paths = [
-            x for x in [self.cc, self.cxx, self.fc, self.f77] if x]
+            x for x in [self.cxx, self.cc, self.fc, self.f77] if x]
         link_dirs = self._get_compiler_link_paths(exe_paths)
 
         all_required_libs = (
@@ -322,6 +324,16 @@ class Compiler(object):
             # In this case there is no mechanism to learn what link directories
             # are used by the compiler
             return []
+        
+        flags = ['cppflags', 'ldflags']
+        if cls.flags:
+            # cls is an instance not a class
+            if first_compiler == cls.cc:
+                flags = ['cflags'] + flags
+            elif first_compiler == cls.cxx:
+                flags = ['cxxflgs'] + flags
+            else:
+                flags.append('fflags')
 
         try:
             tmpdir = tempfile.mkdtemp(prefix='spack-implicit-link-info')
@@ -333,6 +345,9 @@ class Compiler(object):
                     'int main(int argc, char* argv[]) { '
                     '(void)argc; (void)argv; return 0; }\n')
             compiler_exe = spack.util.executable.Executable(first_compiler)
+            for flag_type in flags:
+                for flag in cls.flags[flag_type]:
+                    compiler_exe.add_default_arg(flag)
             output = str(compiler_exe(cls.verbose_flag(), fin, '-o', fout,
                                       output=str, error=str))  # str for py2
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -331,7 +331,7 @@ class Compiler(object):
             if first_compiler == cls.cc:
                 flags = ['cflags'] + flags
             elif first_compiler == cls.cxx:
-                flags = ['cxxflgs'] + flags
+                flags = ['cxxflags'] + flags
             else:
                 flags.append('fflags')
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -319,7 +319,7 @@ class Compiler(object):
         first_compiler = next((c for c in paths if c), None)
         if not first_compiler:
             return []
-        if not self.verbose_flag():
+        if not self.verbose_flag:
             # In this case there is no mechanism to learn what link directories
             # are used by the compiler
             return []
@@ -346,7 +346,7 @@ class Compiler(object):
             for flag_type in flags:
                 for flag in self.flags.get(flag_type, []):
                     compiler_exe.add_default_arg(flag)
-            output = str(compiler_exe(self.verbose_flag(), fin, '-o', fout,
+            output = str(compiler_exe(self.verbose_flag, fin, '-o', fout,
                                       output=str, error=str))  # str for py2
 
             return _parse_non_system_link_dirs(output)
@@ -357,8 +357,8 @@ class Compiler(object):
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         """
         This property should be overridden in the compiler subclass if a
         verbose flag is available.

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -315,22 +315,21 @@ class Compiler(object):
         # By default every compiler returns the empty list
         return []
 
-    @classmethod
-    def _get_compiler_link_paths(cls, paths):
+    def _get_compiler_link_paths(self, paths):
         first_compiler = next((c for c in paths if c), None)
         if not first_compiler:
             return []
-        if not cls.verbose_flag():
+        if not self.verbose_flag():
             # In this case there is no mechanism to learn what link directories
             # are used by the compiler
             return []
 
         flags = ['cppflags', 'ldflags']
-        if cls.flags:
+        if self.flags:
             # cls is an instance not a class
-            if first_compiler == cls.cc:
+            if first_compiler == self.cc:
                 flags = ['cflags'] + flags
-            elif first_compiler == cls.cxx:
+            elif first_compiler == self.cxx:
                 flags = ['cxxflags'] + flags
             else:
                 flags.append('fflags')
@@ -346,9 +345,9 @@ class Compiler(object):
                     '(void)argc; (void)argv; return 0; }\n')
             compiler_exe = spack.util.executable.Executable(first_compiler)
             for flag_type in flags:
-                for flag in cls.flags[flag_type]:
+                for flag in self.flags.get(flag_type, []):
                     compiler_exe.add_default_arg(flag)
-            output = str(compiler_exe(cls.verbose_flag(), fin, '-o', fout,
+            output = str(compiler_exe(self.verbose_flag(), fin, '-o', fout,
                                       output=str, error=str))  # str for py2
 
             return _parse_non_system_link_dirs(output)

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -324,15 +324,14 @@ class Compiler(object):
             # are used by the compiler
             return []
 
+        # What flag types apply to first_compiler, in what order
         flags = ['cppflags', 'ldflags']
-        if self.flags:
-            # cls is an instance not a class
-            if first_compiler == self.cc:
-                flags = ['cflags'] + flags
-            elif first_compiler == self.cxx:
-                flags = ['cxxflags'] + flags
-            else:
-                flags.append('fflags')
+        if first_compiler == self.cc:
+            flags = ['cflags'] + flags
+        elif first_compiler == self.cxx:
+            flags = ['cxxflags'] + flags
+        else:
+            flags.append('fflags')
 
         try:
             tmpdir = tempfile.mkdtemp(prefix='spack-implicit-link-info')

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -324,7 +324,7 @@ class Compiler(object):
             # In this case there is no mechanism to learn what link directories
             # are used by the compiler
             return []
-        
+
         flags = ['cppflags', 'ldflags']
         if cls.flags:
             # cls is an instance not a class

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -51,8 +51,8 @@ class Arm(spack.compiler.Compiler):
                 temp = match.group(1) + "." + match.group(2)
         return temp
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -40,7 +40,7 @@ class Cce(Compiler):
 
     version_regex = r'[Vv]ersion.*?(\d+(\.\d+)+)'
 
-    #property
+    @property
     def verbose_flag(self):
         return "-v"
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -40,8 +40,8 @@ class Cce(Compiler):
 
     version_regex = r'[Vv]ersion.*?(\d+(\.\d+)+)'
 
-    @classmethod
-    def verbose_flag(cls):
+    #property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -81,8 +81,8 @@ class Clang(Compiler):
         ver_string = str(self.version)
         return ver_string.endswith('-apple')
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -30,8 +30,8 @@ class Fj(spack.compiler.Compiler):
 
     required_libs = ['libfj90i', 'libfj90f', 'libfjsrcinfo']
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -38,8 +38,8 @@ class Gcc(Compiler):
     PrgEnv = 'PrgEnv-gnu'
     PrgEnv_compiler = 'gcc'
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -32,8 +32,8 @@ class Intel(Compiler):
     version_argument = '--version'
     version_regex = r'\((?:IFORT|ICC)\) ([^ ]+)'
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     required_libs = ['libirc', 'libifcore', 'libifcoremt', 'libirng']

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -33,8 +33,8 @@ class Pgi(Compiler):
     ignore_version_errors = [2]  # `pgcc -V` on PowerPC annoyingly returns 2
     version_regex = r'pg[^ ]* ([0-9.]+)-[0-9]+ (LLVM )?[^ ]+ target on '
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-v"
 
     @property

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -29,8 +29,8 @@ class Xl(Compiler):
     version_argument = '-qversion'
     version_regex = r'([0-9]?[0-9]\.[0-9])'
 
-    @classmethod
-    def verbose_flag(cls):
+    @property
+    def verbose_flag(self):
         return "-V"
 
     @property

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -201,6 +201,7 @@ def test_get_compiler_link_paths(tmpdir, monkeypatch):
     # Mock compiler call
     test_dirs = ['/path/to/first/lib', '/path/to/second/lib64']
     test_output = 'ld -L%s -L%s' % tuple(test_dirs)
+
     def call_compiler(*args, **kwargs):
         return test_output
     monkeypatch.setattr(
@@ -216,6 +217,7 @@ def test_get_compiler_link_paths_with_flags(tmpdir, monkeypatch):
     # Mock compiler call
     test_dirs = ['/path/to/first/lib', '/path/to/second/lib64']
     test_output = 'ld -L%s -L%s' % tuple(test_dirs)
+
     def call_compiler(exe, *args, **kwargs):
         if '--correct-flag' in exe.exe:
             return test_output

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -175,6 +175,7 @@ class MockCompiler(Compiler):
     def version(self):
         return "1.0.0"
 
+    @property
     def verbose_flag(self):
         return "--verbose"
 

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -175,9 +175,11 @@ class MockCompiler(Compiler):
     def version(self):
         return "1.0.0"
 
+    _verbose_flag = "--verbose"
+
     @property
     def verbose_flag(self):
-        return "--verbose"
+        return self._verbose_flag
 
     required_libs = ['libgfortran']
 
@@ -259,7 +261,7 @@ def test_get_compiler_link_paths_no_path():
 
 def test_get_compiler_link_paths_no_verbose_flag():
     compiler = MockCompiler()
-    compiler.verbose_flag = lambda: None
+    compiler._verbose_flag = None
 
     dirs = compiler._get_compiler_link_paths([compiler.cxx])
     assert dirs == []

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -213,17 +213,17 @@ def call_compiler(exe, *args, **kwargs):
 
 
 @pytest.mark.parametrize('exe,flagname', [
-        ('cxx', ''),
-        ('cxx', 'cxxflags'),
-        ('cxx', 'cppflags'),
-        ('cxx', 'ldflags'),
-        ('cc', ''),
-        ('cc', 'cflags'),
-        ('cc', 'cppflags'),
-        ('fc', ''),
-        ('fc', 'fflags'),
-        ('f77', 'fflags'),
-        ('f77', 'cppflags'),
+    ('cxx', ''),
+    ('cxx', 'cxxflags'),
+    ('cxx', 'cppflags'),
+    ('cxx', 'ldflags'),
+    ('cc', ''),
+    ('cc', 'cflags'),
+    ('cc', 'cppflags'),
+    ('fc', ''),
+    ('fc', 'fflags'),
+    ('f77', 'fflags'),
+    ('f77', 'cppflags'),
 ])
 def test_get_compiler_link_paths(monkeypatch, exe, flagname):
     # create fake compiler that emits mock verbose output

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -216,6 +216,7 @@ def fake_compiler_verbose_output(monkeypatch):
         spack.util.executable.Executable, '__call__', call_compiler)
     yield MockCompiler()
 
+
 def test_get_compiler_link_paths(fake_compiler_verbose_output):
     compiler = fake_compiler_verbose_output
     dirs = compiler._get_compiler_link_paths([compiler.cc])


### PR DESCRIPTION
Some compilers (intel, pgi, clang) can dynamically change their language directories depending on what GCC they are instructed to look for, which can often be changed by a compiler flag.

This PR ensures that we use the compiler flags for the spec when computing implicit rpaths. That allows us to account for those changes in the generated library and rpath flags.

Fixes a bug reported via LLNL internal chat.