### PR TITLE
Bugfix/tests: Check presence not equality for rpath changes

### DIFF
--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -253,7 +253,7 @@ def test_replace_prefix_bin(hello_world):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(executable), output=str)
-    assert output.strip() == '/foo/lib:/foo/lib64'
+    assert '/foo/lib:/foo/lib64' in output
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
@@ -280,7 +280,7 @@ def test_relocate_elf_binaries_absolute_paths(hello_world, tmpdir):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(new_binary), output=str)
-    assert output.strip() == '/foo/lib:/usr/lib64'
+    assert '/foo/lib:/usr/lib64' in output
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
@@ -307,4 +307,4 @@ def test_relocate_elf_binaries_relative_paths(hello_world, tmpdir):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(new_binary), output=str)
-    assert output.strip() == '/foo/lib:/foo/lib64:/opt/local/lib'
+    assert '/foo/lib:/foo/lib64:/opt/local/lib' in output

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -253,6 +253,8 @@ def test_replace_prefix_bin(hello_world):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(executable), output=str)
+
+    # Some compilers add rpaths so ensure changes included in final result
     assert '/foo/lib:/foo/lib64' in output
 
 
@@ -280,6 +282,8 @@ def test_relocate_elf_binaries_absolute_paths(hello_world, tmpdir):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(new_binary), output=str)
+
+    # Some compilers add rpaths so ensure changes included in final result
     assert '/foo/lib:/usr/lib64' in output
 
 
@@ -307,4 +311,6 @@ def test_relocate_elf_binaries_relative_paths(hello_world, tmpdir):
     # Check that the RPATHs changed
     patchelf = spack.util.executable.which('patchelf')
     output = patchelf('--print-rpath', str(new_binary), output=str)
+
+    # Some compilers add rpaths so ensure changes included in final result
     assert '/foo/lib:/foo/lib64:/opt/local/lib' in output


### PR DESCRIPTION
Fixes #16636 

The tests currently expect equality, which is a problem if there are other libraries in the `rpath`.  This PR instead checks for presence of the changed lib paths in the output since some compilers add rpaths.