### PR TITLE
py-pyyaml: Specify libyaml location explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -30,6 +30,9 @@ class PyPyyaml(PythonPackage):
 
         if '+libyaml' in self.spec:
             args.insert(0, '--with-libyaml')
+            args.append('build_ext')
+            args.append('-I{0}'.format(self.spec['libyaml'].prefix.include))
+            args.append('-L{0}'.format(self.spec['libyaml'].prefix.lib))
         else:
             args.insert(0, '--without-libyaml')
 


### PR DESCRIPTION
Depending on the compiler, the library of `libyaml` could not be found and an error occurred.
So, I fixed to specify the path of `libyaml` installed with Spack explicitly.