### PR TITLE
netcdf-fortran: fix netcdf-c dependency when ~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -33,7 +33,7 @@ class NetcdfFortran(AutotoolsPackage):
     # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
     depends_on('mpi', when='+mpi')
 
-    depends_on('netcdf-c~mpi', when='~mpi')
+    depends_on('netcdf-c~mpi~parallel-netcdf', when='~mpi')
     depends_on('netcdf-c+mpi', when='+mpi')
     depends_on('doxygen', when='+doc', type='build')
 


### PR DESCRIPTION
Add netcdf-c~parallel-netcdf variant specification to netcdf-fortran~mpi.  

Having `netcdf-c+parallel-netcdf` as the dependency will result in an error when building `netcdf-fortran~mpi` where `netcdf-c` is trying to use MPI symbols that the serial compiler building `netcdf-fortran` can't handle.