### PR TITLE
Python: add spack external find support

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4308,8 +4308,8 @@ follows:
                return
            # This implementation is lazy and only checks the first candidate
            exe_path = candidates[0]
-           exe = spack.util.executable.Executable(exe_path)
-           output = exe('--version')
+           exe = Executable(exe_path)
+           output = exe('--version', output=str, error=str)
            version_str = ...  # parse output for version string
            return Spec.from_detection(
                'foo-package@{0}'.format(version_str)

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4309,7 +4309,7 @@ follows:
            # This implementation is lazy and only checks the first candidate
            exe_path = candidates[0]
            exe = spack.util.executable.Executable(exe_path)
-           output = exe('--version', output=str, error=str)
+           output = exe('--version')
            version_str = ...  # parse output for version string
            return Spec.from_detection(
                'foo-package@{0}'.format(version_str)

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4308,7 +4308,7 @@ follows:
                return
            # This implementation is lazy and only checks the first candidate
            exe_path = candidates[0]
-           exe = Executable(exe_path)
+           exe = spack.util.executable.Executable(exe_path)
            output = exe('--version', output=str, error=str)
            version_str = ...  # parse output for version string
            return Spec.from_detection(

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -242,7 +242,7 @@ class Python(AutotoolsPackage):
         # Possible red herrings:
         # * python-config, python3-config, python3.7-config
         # * spack-python
-        # Take the shortest executable name and hope for the best
+        # Take the first alphabetical executable name and hope for the best
         python = Executable(min(exes_in_prefix))
         if python.name.startswith('spack-') or python.name.endswith('-config'):
             return None


### PR DESCRIPTION
Produces the following entries in `packages.yaml`:
```yaml
  python:
    externals:
    - spec: python@2.7.16+bz2+ctypes+dbm~lzma+nis+pyexpat+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
      prefix: /usr
    - spec: python@3.7.3+bz2+ctypes+dbm+lzma+nis+pyexpat+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
      prefix: /usr
    - spec: python@3.7.7+bz2+ctypes+dbm+lzma+nis+pyexpat+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
      prefix: /Users/Adam/.spack/darwin/.spack-env/view
```