### PR TITLE
pkgconfig: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -27,32 +27,19 @@ class PkgConfig(AutotoolsPackage):
 
     parallel = False
 
-    executables = ['pkg-config']
+    executables = ['^pkg-config$']
 
     @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        """Allow ``spack external find pkg-config`` to locate
-        pkg-config installations.
-
-        Parameters:
-            prefix (str): the directory containing the executables
-            exes_in_prefix (set): the executables that match the regex
-
-        Returns:
-            spack.spec.Spec: the spec of this pkg-config installation
-        """
-        # Possible executable names:
-        # * pkg-config
-        # Take the first alphabetical executable name and hope for the best
-        pkgconfig = Executable(min(exes_in_prefix))
+    def determine_version(cls, exe):
+        exe = Executable(exe)
 
         # Make sure this is actually pkg-config, not pkgconf
-        if 'usage: pkgconf' in pkgconfig('--help', output=str):
+        if 'usage: pkgconf' in exe('--help', output=str):
             return None
 
-        version = pkgconfig('--version', output=str).rstrip()
+        version = exe('--version', output=str).rstrip()
 
-        return Spec(cls.name + '@' + version)
+        return version
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -27,6 +27,33 @@ class PkgConfig(AutotoolsPackage):
 
     parallel = False
 
+    executables = ['pkg-config']
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        """Allow ``spack external find pkg-config`` to locate
+        pkg-config installations.
+
+        Parameters:
+            prefix (str): the directory containing the executables
+            exes_in_prefix (set): the executables that match the regex
+
+        Returns:
+            spack.spec.Spec: the spec of this pkg-config installation
+        """
+        # Possible executable names:
+        # * pkg-config
+        # Take the shortest executable name and hope for the best
+        pkgconfig = Executable(min(exes_in_prefix))
+
+        # Make sure this is actually pkg-config, not pkgconf
+        if 'usage: pkgconf' in pkgconfig('--help', output=str):
+            return None
+
+        version = pkgconfig('--version', output=str).rstrip()
+
+        return (cls.name + '@' + version)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""
         env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -43,7 +43,7 @@ class PkgConfig(AutotoolsPackage):
         """
         # Possible executable names:
         # * pkg-config
-        # Take the shortest executable name and hope for the best
+        # Take the first alphabetical executable name and hope for the best
         pkgconfig = Executable(min(exes_in_prefix))
 
         # Make sure this is actually pkg-config, not pkgconf

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -52,7 +52,7 @@ class PkgConfig(AutotoolsPackage):
 
         version = pkgconfig('--version', output=str).rstrip()
 
-        return (cls.name + '@' + version)
+        return Spec(cls.name + '@' + version)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -34,10 +34,10 @@ class PkgConfig(AutotoolsPackage):
         exe = Executable(exe)
 
         # Make sure this is actually pkg-config, not pkgconf
-        if 'usage: pkgconf' in exe('--help', output=str):
+        if 'usage: pkgconf' in exe('--help', output=str, error=str):
             return None
 
-        version = exe('--version', output=str).rstrip()
+        version = exe('--version', output=str, error=str).rstrip()
 
         return version
 

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -31,6 +31,33 @@ class Pkgconf(AutotoolsPackage):
     # TODO: Add a package for the kyua testing framework
     # depends_on('kyua', type='test')
 
+    executables = ['pkgconf', 'pkg-config']
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        """Allow ``spack external find pkgconf`` to locate
+        pkgconf installations.
+
+        Parameters:
+            prefix (str): the directory containing the executables
+            exes_in_prefix (set): the executables that match the regex
+
+        Returns:
+            spack.spec.Spec: the spec of this pkgconf installation
+        """
+        # Possible executable names:
+        # * pkgconf, pkg-config
+        # Take the shortest executable name and hope for the best
+        pkgconf = Executable(min(exes_in_prefix))
+
+        # Make sure this is actually pkgconf, not pkg-config
+        if 'usage: pkgconf' not in pkgconf('--help', output=str):
+            return None
+
+        version = pkgconf('--version', output=str).rstrip()
+
+        return (cls.name + '@' + version)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""
         env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -56,7 +56,7 @@ class Pkgconf(AutotoolsPackage):
 
         version = pkgconf('--version', output=str).rstrip()
 
-        return (cls.name + '@' + version)
+        return Spec(cls.name + '@' + version)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -38,10 +38,10 @@ class Pkgconf(AutotoolsPackage):
         exe = Executable(exe)
 
         # Make sure this is actually pkgconf, not pkg-config
-        if 'usage: pkgconf' not in exe('--help', output=str):
+        if 'usage: pkgconf' not in exe('--help', output=str, error=str):
             return None
 
-        version = exe('--version', output=str).rstrip()
+        version = exe('--version', output=str, error=str).rstrip()
 
         return version
 

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -31,32 +31,19 @@ class Pkgconf(AutotoolsPackage):
     # TODO: Add a package for the kyua testing framework
     # depends_on('kyua', type='test')
 
-    executables = ['pkgconf', 'pkg-config']
+    executables = ['^pkgconf$', '^pkg-config$']
 
     @classmethod
-    def determine_spec_details(cls, prefix, exes_in_prefix):
-        """Allow ``spack external find pkgconf`` to locate
-        pkgconf installations.
-
-        Parameters:
-            prefix (str): the directory containing the executables
-            exes_in_prefix (set): the executables that match the regex
-
-        Returns:
-            spack.spec.Spec: the spec of this pkgconf installation
-        """
-        # Possible executable names:
-        # * pkgconf, pkg-config
-        # Take the first alphabetical executable name and hope for the best
-        pkgconf = Executable(min(exes_in_prefix))
+    def determine_version(cls, exe):
+        exe = Executable(exe)
 
         # Make sure this is actually pkgconf, not pkg-config
-        if 'usage: pkgconf' not in pkgconf('--help', output=str):
+        if 'usage: pkgconf' not in exe('--help', output=str):
             return None
 
-        version = pkgconf('--version', output=str).rstrip()
+        version = exe('--version', output=str).rstrip()
 
-        return Spec(cls.name + '@' + version)
+        return version
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""

--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -47,7 +47,7 @@ class Pkgconf(AutotoolsPackage):
         """
         # Possible executable names:
         # * pkgconf, pkg-config
-        # Take the shortest executable name and hope for the best
+        # Take the first alphabetical executable name and hope for the best
         pkgconf = Executable(min(exes_in_prefix))
 
         # Make sure this is actually pkgconf, not pkg-config


### PR DESCRIPTION
Works even when both packages are in the `PATH`, and correctly distinguishes between the two.
```yaml
  pkg-config:
    externals:
    - spec: pkg-config@0.29.2
      prefix: /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/pkg-config-0.29.2-azgq6iz2pne3aqck7wrxat5bbtnthv6l
  pkgconf:
    externals:
    - spec: pkgconf@1.7.3
      prefix: /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/pkgconf-1.7.3-52kfpvjixcntquvt67sltjuajdhq73od
```
Unfortunately, `spack external find` doesn't work for virtual dependencies like `pkgconfig`.