### PR TITLE
Libtool: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -47,7 +47,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
         """
         # Possible executable names:
         # * libtool, glibtool, libtoolize, glibtoolize
-        # Take the shortest executable name and hope for the best
+        # Take the first alphabetical executable name and hope for the best
         libtool = Executable(min(exes_in_prefix))
 
         # macOS libtool does not support the `--version` flag

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -56,7 +56,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
         version = ''
         try:
             output = libtool('--version', output=str, error=os.devnull)
-            match = re.match(r'\(GNU libtool\) ([0-9.]+)', output)
+            match = re.search(r'\(GNU libtool\) ([0-9.]+)', output)
             if match:
                 version = '@' + match.group(1)
         except ProcessError:

--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -56,8 +56,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
         version = ''
         try:
             output = libtool('--version', output=str, error=os.devnull)
-            match = re.match(
-                r'g?libtool(?:ize)? \(GNU libtool(?:ize)?\) ([0-9.]+)', output)
+            match = re.match(r'\(GNU libtool\) ([0-9.]+)', output)
             if match:
                 version = '@' + match.group(1)
         except ProcessError:


### PR DESCRIPTION
Correctly finds GNU libtool
```yaml
  libtool:
    externals:
    - spec: libtool@2.4.6
      prefix: /Users/Adam/.spack/darwin/.spack-env/view
```
Unfortunately, we cannot detect macOS libtool because there is no way to detect the version. macOS libtool does not support the `--version` flag. It does support `-V`, but it returns the version of cctools, not the version of libtool