### PR TITLE
IntelPackage: Use 'version_yearlike' in check for libfabrics RPATH.

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1089,7 +1089,7 @@ class IntelPackage(PackageBase):
                 # Intel MPI since 2019 depends on libfabric which is not in the
                 # lib directory but in a directory of its own which should be
                 # included in the rpath
-                if self.version >= ver('2019'):
+                if self.version_yearlike >= ver('2019'):
                     d = ancestor(self.component_lib_dir('mpi'))
                     libfabrics_path = os.path.join(d, 'libfabric', 'lib')
                     env.append_path('SPACK_COMPILER_EXTRA_RPATHS',


### PR DESCRIPTION
In #15214, the `SPACK_COMPILER_EXTRA_RPATHS` is set to include the `libfabrics` built with Intel MPI.

When using this with `intel-parallel-studio` however, the version check

```python
if self.version >= ver('2019'):
```

is always ``False``, because ``self.version`` contains the "edition" prefix, e.g. ``cluster.2019.3``. The IntelPackage already has the `version_yearlike` property to deal with this. As such, this can be fixed by simply replacing ``self.version`` with ``self.version_yearlike``.