### PR TITLE
CMakePackage: use cmake_root_listdir as last argument to cmake

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -331,9 +331,9 @@ class CMakePackage(PackageBase):
 
     def cmake(self, spec, prefix):
         """Runs ``cmake`` in the build directory"""
-        options = [os.path.abspath(self.root_cmakelists_dir)]
-        options += self.std_cmake_args
+        options = self.std_cmake_args
         options += self.cmake_args()
+        options.append(os.path.abspath(self.root_cmakelists_dir))
         with working_dir(self.build_directory, create=True):
             inspect.getmodule(self).cmake(*options)
 


### PR DESCRIPTION
@white238 reported a bug that a user of his has a package that fails when the cmake source dir is the first (rather than the last) argument as Spack has been doing it.

This matches up with CMake's documentation, to have options come before the source directory:
https://cmake.org/cmake/help/latest/manual/cmake.1.html

This PR brings us in line with CMake documentation.