### PR TITLE
compilers: add opt_flags and debug_flags properties

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -245,6 +245,14 @@ class Compiler(object):
             return ''
         return '--enable-new-dtags'
 
+    @property
+    def debug_flags(self):
+        return ['-g']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3']
+
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv = None
     # Name of module used to switch versions of this compiler

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -56,6 +56,10 @@ class Arm(spack.compiler.Compiler):
         return "-v"
 
     @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-Ofast']
+
+    @property
     def openmp_flag(self):
         return "-fopenmp"
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -45,6 +45,10 @@ class Cce(Compiler):
         return "-v"
 
     @property
+    def debug_flags(self):
+        return ['-g', '-G0', '-G1', '-G2', '-Gfast']
+
+    @property
     def openmp_flag(self):
         if self.version >= ver('9.0'):
             return '-fopenmp'

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -57,8 +57,8 @@ class Clang(Compiler):
 
     @property
     def opt_flags(self):
-        return ['-O0', '-O1', '-O2', '-O3', '-Ofast','-Os', '-Oz', '-Og', '-O',
-                '-O4']
+        return ['-O0', '-O1', '-O2', '-O3', '-Ofast', '-Os', '-Oz', '-Og',
+                '-O', '-O4']
 
     # Clang has support for using different fortran compilers with the
     # clang executable.

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -50,6 +50,16 @@ class Clang(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['flang', 'gfortran', 'xlf90_r']
 
+    @property
+    def debug_flags(self):
+        return ['-gcodeview', '-gdwarf-2', '-gdwarf-3', '-gdwarf-4',
+                '-gdwarf-5', '-gline-tables-only', '-gmodules', '-gz', '-g']
+
+    @property
+    def opt_flags(self):
+        return ['-O0', '-O1', '-O2', '-O3', '-Ofast','-Os', '-Oz', '-Og', '-O',
+                '-O4']
+
     # Clang has support for using different fortran compilers with the
     # clang executable.
     @property

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -35,6 +35,10 @@ class Fj(spack.compiler.Compiler):
         return "-v"
 
     @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-O4']
+
+    @property
     def openmp_flag(self):
         return "-Kopenmp"
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -43,6 +43,14 @@ class Gcc(Compiler):
         return "-v"
 
     @property
+    def debug_flags(self):
+        return ['-g', '-gstabs+', '-gstabs', '-gxcoff+', '-gxcoff', '-gvms']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-Os', '-Ofast', '-Og']
+
+    @property
     def openmp_flag(self):
         return "-fopenmp"
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -39,6 +39,14 @@ class Intel(Compiler):
     required_libs = ['libirc', 'libifcore', 'libifcoremt', 'libirng']
 
     @property
+    def debug_flags(self):
+        return ['-debug', '-g', '-g0', '-g1', '-g2', '-g3']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-Ofast', '-Os']
+
+    @property
     def openmp_flag(self):
         if self.version < ver('16.0'):
             return "-openmp"

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -35,6 +35,14 @@ class Nag(spack.compiler.Compiler):
         return "-openmp"
 
     @property
+    def debug_flags(self):
+        return ['-g', '-gline', '-g90']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-O4']
+
+    @property
     def cxx11_flag(self):
         # NAG does not have a C++ compiler
         # However, it can be mixed with a compiler that does support it

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -38,6 +38,14 @@ class Pgi(Compiler):
         return "-v"
 
     @property
+    def debug_flags(self):
+        return ['-g', '-gopt']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-O4']
+
+    @property
     def openmp_flag(self):
         return "-mp"
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -34,6 +34,14 @@ class Xl(Compiler):
         return "-V"
 
     @property
+    def debug_flags(self):
+        return ['-g', '-g0', '-g1', '-g2', '-g8', '-g9']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-O4', '-O5', '-Ofast']
+
+    @property
     def openmp_flag(self):
         return "-qsmp=omp"
 

--- a/lib/spack/spack/test/compilers.py
+++ b/lib/spack/spack/test/compilers.py
@@ -316,6 +316,8 @@ def test_default_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC")
     supported_flag_test("f77_pic_flag", "-fPIC")
     supported_flag_test("fc_pic_flag",  "-fPIC")
+    supported_flag_test("debug_flags", ["-g"])
+    supported_flag_test("opt_flags", ["-O", "-O0", "-O1", "-O2", "-O3"])
 
 
 # Verify behavior of particular compiler definitions.
@@ -330,6 +332,9 @@ def test_arm_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC", "arm@1.0")
     supported_flag_test("f77_pic_flag", "-fPIC", "arm@1.0")
     supported_flag_test("fc_pic_flag",  "-fPIC", "arm@1.0")
+    supported_flag_test("opt_flags",
+                        ['-O', '-O0', '-O1', '-O2', '-O3', '-Ofast'],
+                        'arm@1.0')
 
 
 def test_cce_flags():
@@ -344,6 +349,8 @@ def test_cce_flags():
     supported_flag_test("cxx_pic_flag", "-h PIC", "cce@1.0")
     supported_flag_test("f77_pic_flag", "-h PIC", "cce@1.0")
     supported_flag_test("fc_pic_flag",  "-h PIC", "cce@1.0")
+    supported_flag_test("debug_flags", ['-g', '-G0', '-G1', '-G2', '-Gfast'],
+                        'cce@1.0')
 
 
 def test_clang_flags():
@@ -382,6 +389,15 @@ def test_clang_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC", "clang@3.3")
     supported_flag_test("f77_pic_flag", "-fPIC", "clang@3.3")
     supported_flag_test("fc_pic_flag",  "-fPIC", "clang@3.3")
+    supported_flag_test("debug_flags",
+                        ['-gcodeview', '-gdwarf-2', '-gdwarf-3', '-gdwarf-4',
+                         '-gdwarf-5', '-gline-tables-only', '-gmodules', '-gz',
+                         '-g'],
+                        'clang@3.3')
+    supported_flag_test("opt_flags",
+                        ['-O0', '-O1', '-O2', '-O3', '-Ofast', '-Os', '-Oz',
+                         '-Og', '-O', '-O4'],
+                        'clang@3.3')
 
 
 def test_fj_flags():
@@ -395,6 +411,8 @@ def test_fj_flags():
     supported_flag_test("cxx_pic_flag", "-KPIC", "fj@4.0.0")
     supported_flag_test("f77_pic_flag", "-KPIC", "fj@4.0.0")
     supported_flag_test("fc_pic_flag",  "-KPIC", "fj@4.0.0")
+    supported_flag_test("opt_flags", ['-O', '-O0', '-O1', '-O2', '-O3', '-O4'],
+                        'fj@4.0.0')
 
 
 def test_gcc_flags():
@@ -420,6 +438,14 @@ def test_gcc_flags():
     supported_flag_test("f77_pic_flag", "-fPIC", "gcc@4.0")
     supported_flag_test("fc_pic_flag",  "-fPIC", "gcc@4.0")
     supported_flag_test("stdcxx_libs", ("-lstdc++",), "gcc@4.1")
+    supported_flag_test("debug_flags",
+                        ['-g', '-gstabs+', '-gstabs', '-gxcoff+', '-gxcoff',
+                         '-gvms'],
+                        'gcc@4.0')
+    supported_flag_test("opt_flags",
+                        ['-O', '-O0', '-O1', '-O2', '-O3', '-Os', '-Ofast',
+                         '-Og'],
+                        'gcc@4.0')
 
 
 def test_intel_flags():
@@ -440,6 +466,12 @@ def test_intel_flags():
     supported_flag_test("f77_pic_flag", "-fPIC", "intel@1.0")
     supported_flag_test("fc_pic_flag",  "-fPIC", "intel@1.0")
     supported_flag_test("stdcxx_libs", ("-cxxlib",), "intel@1.0")
+    supported_flag_test("debug_flags",
+                        ['-debug', '-g', '-g0', '-g1', '-g2', '-g3'],
+                        'intel@1.0')
+    supported_flag_test("opt_flags",
+                        ['-O', '-O0', '-O1', '-O2', '-O3', '-Ofast', '-Os'],
+                        'intel@1.0')
 
 
 def test_nag_flags():
@@ -454,6 +486,9 @@ def test_nag_flags():
     supported_flag_test("f77_rpath_arg", "-Wl,-Wl,,-rpath,,", "nag@1.0")
     supported_flag_test("fc_rpath_arg",  "-Wl,-Wl,,-rpath,,", "nag@1.0")
     supported_flag_test("linker_arg", "-Wl,-Wl,,", "nag@1.0")
+    supported_flag_test("debug_flags", ['-g', '-gline', '-g90'], 'nag@1.0')
+    supported_flag_test("opt_flags", ['-O', '-O0', '-O1', '-O2', '-O3', '-O4'],
+                        'nag@1.0')
 
 
 def test_pgi_flags():
@@ -467,6 +502,9 @@ def test_pgi_flags():
     supported_flag_test("cxx_pic_flag", "-fpic", "pgi@1.0")
     supported_flag_test("f77_pic_flag", "-fpic", "pgi@1.0")
     supported_flag_test("fc_pic_flag",  "-fpic", "pgi@1.0")
+    supported_flag_test("debug_flags", ['-g', '-gopt'], 'pgi@1.0')
+    supported_flag_test("opt_flags", ['-O', '-O0', '-O1', '-O2', '-O3', '-O4'],
+                        'pgi@1.0')
 
 
 def test_xl_flags():
@@ -484,6 +522,13 @@ def test_xl_flags():
     supported_flag_test("f77_pic_flag", "-qpic", "xl@1.0")
     supported_flag_test("fc_pic_flag",  "-qpic", "xl@1.0")
     supported_flag_test("fflags", "-qzerosize", "xl@1.0")
+    supported_flag_test("debug_flags",
+                        ['-g', '-g0', '-g1', '-g2', '-g8', '-g9'],
+                        'xl@1.0')
+    supported_flag_test("opt_flags",
+                        ['-O', '-O0', '-O1', '-O2', '-O3', '-O4', '-O5',
+                         '-Ofast'],
+                        'xl@1.0')
 
 
 def test_xl_r_flags():
@@ -501,6 +546,13 @@ def test_xl_r_flags():
     supported_flag_test("f77_pic_flag", "-qpic", "xl_r@1.0")
     supported_flag_test("fc_pic_flag",  "-qpic", "xl_r@1.0")
     supported_flag_test("fflags", "-qzerosize", "xl_r@1.0")
+    supported_flag_test("debug_flags",
+                        ['-g', '-g0', '-g1', '-g2', '-g8', '-g9'],
+                        'xl@1.0')
+    supported_flag_test("opt_flags",
+                        ['-O', '-O0', '-O1', '-O2', '-O3', '-O4', '-O5',
+                         '-Ofast'],
+                        'xl@1.0')
 
 
 @pytest.mark.parametrize('version_str,expected_version', [


### PR DESCRIPTION
Allow packages to query the optimization and debug flags for a compiler.

For example:

```
def flag_handler(self, name, flags):
    if name == 'cxxflags':
        opt_flag_found = any(f in self.compiler.opt_flags for f in flags)
        debug_flag_found = any(f in self.compiler.debug_flags for f in flags)

        if '+debug' in self.spec:
            debug_flag_found or flags.append('-g')
            opt_flag_found or flags.append('-O0')
        else:
            opt_flag_found or flags.append('-O2')

    return (flags, None, None)
```