### PR TITLE
NetCDF: fix constraints 2

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -96,26 +96,15 @@ class NetcdfC(AutotoolsPackage):
 
     # High-level API of HDF5 1.8.9 or later is required for netCDF-4 support:
     # http://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html
-    depends_on('hdf5@1.8.9:+hl~mpi', when='~mpi')
-    depends_on('hdf5@1.8.9:+hl+mpi', when='+mpi')
+    depends_on('hdf5@1.8.9:+hl')
 
     # Starting version 4.4.0, it became possible to disable parallel I/O even
     # if HDF5 supports it. For previous versions of the library we need
-    # HDF5 without mpi support to disable parallel I/O.
-    # The following doesn't work if hdf5+mpi by default and netcdf-c~mpi is
-    # specified in packages.yaml
-    # depends_on('hdf5~mpi', when='@:4.3~mpi')
-    # Thus, we have to introduce a conflict
-    conflicts('~mpi', when='@:4.3^hdf5+mpi',
-              msg='netcdf-c@:4.3~mpi requires hdf5~mpi')
+    # HDF5 without mpi support to disable parallel I/O:
+    depends_on('hdf5~mpi', when='@:4.3~mpi')
 
     # We need HDF5 with mpi support to enable parallel I/O.
-    # The following doesn't work if hdf5~mpi by default and netcdf-c+mpi is
-    # specified in packages.yaml
-    # depends_on('hdf5+mpi', when='+mpi')
-    # Thus, we have to introduce a conflict
-    conflicts('+mpi', when='^hdf5~mpi',
-              msg='netcdf-c+mpi requires hdf5+mpi')
+    depends_on('hdf5+mpi', when='+mpi')
 
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250


### PR DESCRIPTION
This PR ~is mainly for the discussion in #16671 and~ is an extension of #15950.

The advantage of merging this is that we can install all valid configurations of `netcdf-c`:
1. It is possible to build `netcdf-c` without parallel I/O even when `hdf5` is built with `+mpi`:
    ```console
    $ spack install netcdf-c~mpi ^hdf5+mpi
    ```
    but not for versions before `4.4.0` as it should be:
    ```console
    $ spack install netcdf-c@4.3.3.1~mpi ^hdf5+mpi
    ==> Error: An unsatisfiable variant constraint has been detected for spec:
    
    hdf5+mpi
    
    
    while trying to concretize the partial spec:
    
        netcdf-c@4.3.3.1~mpi
            ^zlib@1.2.5:
    ```

2. It is possible to build `netcdf-fortran` when `netcdf-c` is built without NetCDF4 parallel features (i.e. `~mpi`) but with parallel features for NetCDF3 (i.e. `+parallel-netcdf`):
    ```console
    $ spack install netcdf-fortran ^netcdf-c~mpi+parallel-netcdf
    ```

The main disadvantage of this is that in order to build `netcdf-c` without MPI dependencies at all, one has to run:
```console
$ spack spec -I netcdf-fortran ^netcdf-c~mpi ^hdf5~mpi`
```

But this can be handled in `packages.yaml`:
```yaml
  netcdf-c:
    variants: ~mpi
  hdf5:
    variants: ~mpi
```

With this configuration, one can install `netcdf-fortran` without MPI dependencies by calling:
```console
$ spack install netcdf-fortran
```
and enable MPI by calling:
```console
$ spack install netcdf-fortran ^netcdf-c+mpi
```