### PR TITLE
openssl: Be Explicit About perl Usage

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -154,3 +154,6 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
             if os.path.isdir(sys_certs) and not os.path.islink(pkg_certs):
                 os.rmdir(pkg_certs)
                 os.symlink(sys_certs, pkg_certs)
+
+    def setup_build_environment(self, env):
+        env.set('PERL', self.spec['perl'].prefix.bin.perl)


### PR DESCRIPTION
The openssl build process can use the wrong perl for various reasons, including:
* Wrong value in PERL env var
* The build process first looks for `perl5`, which the spack system does not provide, but some other distributions provide it. That way, the build process can end up using the wrong perl.

Stop all of these problems by explicitly setting PERL to the to be used dependency.