### PR TITLE
[py-xenv] Introduce version 1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -50,7 +50,7 @@ class Gaudi(CMakePackage):
     depends_on('python@:2.99.99', when='@:32.1', type=('build', 'run'))
     depends_on('py-setuptools@:45.99.99', when='^python@:2.7.99', type='build')
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-xenv@develop_2018-12-20:', type=('build', 'run'))
+    depends_on('py-xenv@1:', type=('build', 'run'))
     depends_on('range-v3')
     depends_on('root +python +root7 +ssl +tbb +threads')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/py-xenv/package.py
+++ b/var/spack/repos/builtin/packages/py-xenv/package.py
@@ -10,12 +10,10 @@ class PyXenv(PythonPackage):
     """Helpers to work with the environment in a platform independent way."""
 
     homepage = "https://gitlab.cern.ch/gaudi/xenv"
+    url      = "https://pypi.io/packages/source/x/xenv/xenv-1.0.0.tar.gz"
     git      = "https://gitlab.cern.ch/gaudi/xenv.git"
 
-    # As of 0.0.4, all released versions of xenv corrupt the system environment
-    # in a manner which breaks Spack's compiler wrappers. Therefore, we must
-    # package an un-released development version of xenv.
     version('develop',            branch='master')
-    version('develop_2018-12-20', commit='ddc3bf5e65e1689da499f639af7a27c5c4242841')
+    version('1.0.0', sha256='cea9547295f0bd07c87e68353bb9eb1c2f2d1c09a840e3196c19cbc807ee4558')
 
     depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Initially when splitting `py-xenv` from `gaudi`, there were some problems with the then most up-to-date version of `py-xenv`, which have since been fixed. Since version 1.0.0 has also been released on PyPI, we make use of it here as well.

Also updating `gaudi` to use a newer version of `py-xenv`.