### PR TITLE
Skip rebuilding installed packages

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -679,13 +679,8 @@ class PackageInstaller(object):
             installed_in_db = False
         return rec, installed_in_db
 
-    def _check_deps_status(self, install_compilers):
-        """Check the install status of the explicit spec's dependencies
-
-        Args:
-            install_compilers (bool): ``True`` if compilers to be added to
-                the queue; otherwise ``False``
-        """
+    def _check_deps_status(self):
+        """Check the install status of the explicit spec's dependencies"""
 
         err = 'Cannot proceed with {0}: {1}'
         for dep in self.spec.traverse(order='post', root=False):
@@ -1029,7 +1024,7 @@ class PackageInstaller(object):
             # If not installing dependencies, then determine their
             # installation status before proceeding.
             if not install_deps:
-                self._check_deps_status(install_compilers)
+                self._check_deps_status()
                 return
 
         if install_deps:
@@ -1534,7 +1529,6 @@ class PackageInstaller(object):
                 continue
 
             # Determine state of installation artifacts and adjust accordingly.
-            # Possession of a read lock is required/assumed.
             self._prepare_for_install(task, keep_prefix, keep_stage, restage)
 
             # Flag an already installed package

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1253,6 +1253,9 @@ class Spec(object):
                If 'children', does a traversal of this spec's children.  If
                'parents', traverses upwards in the DAG towards the root.
 
+           predicate [=None]
+               Optional truth function applied to the spec so that only specs
+               evaluating to ``True`` are traversed
         """
         # get initial values for kwargs
         depth = kwargs.get('depth', False)
@@ -1264,6 +1267,7 @@ class Spec(object):
         direction = kwargs.get('direction', 'children')
         order = kwargs.get('order', 'pre')
         deptype = dp.canonical_deptype(deptype)
+        predicate = kwargs.get('predicate', None)
 
         # Make sure kwargs have legal values; raise ValueError if not.
         def validate(name, val, allowed_values):
@@ -1297,8 +1301,10 @@ class Spec(object):
         if yield_me and order == 'pre':
             yield return_val(dep_spec)
 
-        # Edge traversal yields but skips children of visited nodes
-        if not (key in visited and cover == 'edges'):
+        # Edge traversal yields but skips children/parents of visited nodes
+        # and those that do not satisfy the predicate.
+        do_traversal = not predicate or predicate(self)
+        if not (key in visited and cover == 'edges') and do_traversal:
             visited.add(key)
 
             # This code determines direction and yields the children/parents

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -469,7 +469,7 @@ def test_check_deps_status_install_failure(install_mockery, monkeypatch):
     monkeypatch.setattr(spack.database.Database, 'prefix_failed', _true)
 
     with pytest.raises(inst.InstallError, match='install failure'):
-        installer._check_deps_status(False)
+        installer._check_deps_status()
 
 
 def test_check_deps_status_write_locked(install_mockery, monkeypatch):
@@ -479,7 +479,7 @@ def test_check_deps_status_write_locked(install_mockery, monkeypatch):
     monkeypatch.setattr(inst.PackageInstaller, '_ensure_locked', _not_locked)
 
     with pytest.raises(inst.InstallError, match='write locked by another'):
-        installer._check_deps_status(False)
+        installer._check_deps_status()
 
 
 def test_check_deps_status_external(install_mockery, monkeypatch):
@@ -487,7 +487,7 @@ def test_check_deps_status_external(install_mockery, monkeypatch):
 
     # Mock the known dependent, b, as external so assumed to be installed
     monkeypatch.setattr(spack.spec.Spec, 'external', True)
-    installer._check_deps_status(False)
+    installer._check_deps_status()
     assert 'b' in installer.installed
 
 
@@ -496,7 +496,7 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
 
     # Mock the known dependent, b, as installed upstream
     monkeypatch.setattr(spack.package.PackageBase, 'installed_upstream', True)
-    installer._check_deps_status(False)
+    installer._check_deps_status()
     assert 'b' in installer.installed
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -469,7 +469,7 @@ def test_check_deps_status_install_failure(install_mockery, monkeypatch):
     monkeypatch.setattr(spack.database.Database, 'prefix_failed', _true)
 
     with pytest.raises(inst.InstallError, match='install failure'):
-        installer._check_deps_status()
+        installer._check_deps_status(False)
 
 
 def test_check_deps_status_write_locked(install_mockery, monkeypatch):
@@ -479,7 +479,7 @@ def test_check_deps_status_write_locked(install_mockery, monkeypatch):
     monkeypatch.setattr(inst.PackageInstaller, '_ensure_locked', _not_locked)
 
     with pytest.raises(inst.InstallError, match='write locked by another'):
-        installer._check_deps_status()
+        installer._check_deps_status(False)
 
 
 def test_check_deps_status_external(install_mockery, monkeypatch):
@@ -487,7 +487,7 @@ def test_check_deps_status_external(install_mockery, monkeypatch):
 
     # Mock the known dependent, b, as external so assumed to be installed
     monkeypatch.setattr(spack.spec.Spec, 'external', True)
-    installer._check_deps_status()
+    installer._check_deps_status(False)
     assert 'b' in installer.installed
 
 
@@ -496,7 +496,7 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
 
     # Mock the known dependent, b, as installed upstream
     monkeypatch.setattr(spack.package.PackageBase, 'installed_upstream', True)
-    installer._check_deps_status()
+    installer._check_deps_status(False)
     assert 'b' in installer.installed
 
 


### PR DESCRIPTION
(UPDATE: Was #16654 but renamed to fix typo in the branch name.)

This PR addresses an issue raised in `slack` where a package that is already installed but has uninstalled dependencies was having its dependencies re-installed even when those dependencies were not needed to use the package.

Todd recommended using pre- (versus post-) order traversals to prune installed dependencies when initializing the build queue so that has been included.

There is a third commit to replace `try-finally` blocks with attribute assignments that attempt to do the equivalent of `monkeypatch` but does not always work as expected.  For example, at one point tests using `canfail` with initial installs with `succeed` set to `False` then run after setting `succeed` to `True` would fail with complaints that `succeed` was [still] `False`.  Using the testing framework's `monkeypatch` seemed to solve this problem.