### PR TITLE
externals: allow package prefs to configure default not buildable

### DIFF
--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -190,11 +190,17 @@ def spec_externals(spec):
 
 def is_spec_buildable(spec):
     """Return true if the spec pkgspec is configured as buildable"""
+
     allpkgs = spack.config.get('packages')
-    do_not_build = [name for name, entry in allpkgs.items()
-                    if not entry.get('buildable', True)]
-    return not (spec.name in do_not_build or
-                any(spec.package.provides(name) for name in do_not_build))
+    all_buildable = allpkgs.get('all', {}).get('buildable', True)
+
+    # Get the list of names for which all_buildable is overridden
+    reverse = [name for name, entry in allpkgs.items()
+               if entry.get('buildable', all_buildable) != all_buildable]
+    # Does this spec override all_buildable
+    spec_reversed = (spec.name in reverse or
+                     any(spec.package.provides(name) for name in reverse))
+    return not all_buildable if spec_reversed else all_buildable
 
 
 def get_package_dir_permissions(spec):

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -239,6 +239,70 @@ mpi:
         spec.concretize()
         assert spec['mpich'].external_path == '/dummy/path'
 
+    def test_buildable_false(self):
+        conf = syaml.load_config("""\
+libelf:
+  buildable: false
+""")
+        spack.config.set('packages', conf, scope='concretize')
+        spec = Spec('libelf')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert spack.package_prefs.is_spec_buildable(spec)
+
+    def test_buildable_false_virtual(self):
+        conf = syaml.load_config("""\
+mpi:
+  buildable: false
+""")
+        spack.config.set('packages', conf, scope='concretize')
+        spec = Spec('libelf')
+        assert spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+    def test_buildable_false_all(self):
+        conf = syaml.load_config("""\
+all:
+  buildable: false
+""")
+        spack.config.set('packages', conf, scope='concretize')
+        spec = Spec('libelf')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+    def test_buildable_false_all_true_package(self):
+        conf = syaml.load_config("""\
+all:
+  buildable: false
+libelf:
+  buildable: true
+""")
+        spack.config.set('packages', conf, scope='concretize')
+        spec = Spec('libelf')
+        assert spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+    def test_buildable_false_all_true_virtual(self):
+        conf = syaml.load_config("""\
+all:
+  buildable: false
+mpi:
+  buildable: true
+""")
+        spack.config.set('packages', conf, scope='concretize')
+        spec = Spec('libelf')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert spack.package_prefs.is_spec_buildable(spec)
+
     def test_config_permissions_from_all(self, configure_permissions):
         # Although these aren't strictly about concretization, they are
         # configured in the same file and therefore convenient to test here.


### PR DESCRIPTION
Fixes #16734

Allows `all` to be configured non-buildable in packages.yaml.

The following config would only allow zlib to be built by Spack, all other packages would have to be found as externals.

```
packages:
  all:
    buildable: False
  zlib:
    buildable: True
```

includes
- [x] code changes
- [x] tests