### PR TITLE
unifyfs: update gotcha dependency version

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -36,9 +36,8 @@ class Unifyfs(AutotoolsPackage):
 
     # Required dependencies
     depends_on('flatcc')
-    # Latest version of GOTCHA has API changes that break UnifyFS.
-    # Updates to UnifyFS are coming in order to fix this.
-    depends_on('gotcha@0.0.2')
+    depends_on('gotcha@0.0.2', when='@:0.9.0')
+    depends_on('gotcha@1.0.3:', when='@0.9.1:')
     depends_on('leveldb')
     depends_on('margo')
     depends_on('mercury+bmi+sm')


### PR DESCRIPTION
The dev branch of UnifyFS now depends on the latest release of GOTCHA, as will future releases.

This updates our spackage to depend on the correct version of GOTCHA depending on the version of UnifyFS being installed.