### PR TITLE
julia: Fix LLVM build failing with newer versions of CMake

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -46,7 +46,8 @@ class Julia(Package):
     # Python only needed to build LLVM?
     depends_on('python@2.7:2.8', type='build', when='@:1.1')
     depends_on('python@2.7:', type='build', when='@1.2:')
-    depends_on('cmake @2.8:', type='build', when='@1.0:')
+    depends_on('cmake@2.8:', type='build', when='@1.0:')
+    depends_on('cmake@:3.11', type='build', when='@:1.4')
     depends_on('git', type='build', when='@master')
 
     # Combined build-time and run-time dependencies:


### PR DESCRIPTION
julia fails to build with CMake >= 3.12 because its built-in LLVM 8.0.1 uses FindPythonInterp, which has been deprecated. (similar to #11579)
This PR limits CMake to <= 3.11 when building Julia <= 1.4.x. Julia master branch uses LLVM 10 which has fixed this problem so the fix shouldn't be needed in future releases.