### PR TITLE
openfoam: improve handling of wmake rules, version update

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/common/spack-Allwmake
+++ b/var/spack/repos/builtin/packages/openfoam/common/spack-Allwmake
@@ -7,8 +7,8 @@ export FOAM_INST_DIR=$(cd .. && pwd -L)
 # Prevent influence of user/site config when building
 export FOAM_CONFIG_MODE="o"
 
-. "$PWD/etc/bashrc" ''                              # No arguments
-mkdir -p "$FOAM_APPBIN" "$FOAM_LIBBIN" 2>/dev/null  # Allow build interrupt
+. "$PWD"/etc/bashrc ''                          # No arguments
+mkdir -p "$FOAM_APPBIN" "$FOAM_LIBBIN"          # Allow build interrupt
 
 echo "Build openfoam with SPACK ($@)"
 echo "WM_PROJECT_DIR = $WM_PROJECT_DIR"

--- a/var/spack/repos/builtin/packages/openfoam/common/spack-derived-Allwmake
+++ b/var/spack/repos/builtin/packages/openfoam/common/spack-derived-Allwmake
@@ -10,7 +10,7 @@
 }
 
 export FOAM_INST_DIR=$(cd $FOAM_PROJECT_DIR/.. && pwd -L) # Needed by foam-extend
-. $FOAM_PROJECT_DIR/etc/bashrc ''  # No arguments
+. "$FOAM_PROJECT_DIR"/etc/bashrc ''  # No arguments
 
 # Package-specific adjustments
 [ -f spack-config.sh ] && . ./spack-config.sh ''  # No arguments

--- a/var/spack/repos/builtin/packages/openfoam/common/spack-dummy-Allwmake
+++ b/var/spack/repos/builtin/packages/openfoam/common/spack-dummy-Allwmake
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Build wrapper script for dummy build
+
+# Prevent influence of user/site config when building
+export FOAM_CONFIG_MODE="o"
+. "$PWD"/etc/bashrc ''                          # No arguments
+
+echo "Dummy build openfoam with SPACK ($@)"
+echo "WM_PROJECT_DIR = $WM_PROJECT_DIR"
+
+if [ -f applications/test/00-dummy/Allwmake ]
+then
+    applications/test/00-dummy/Allwmake $@
+else
+    echo "Nothing to make"
+fi
+
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
- add future-proofing for wmake rules locations:
  Accept wmake/rules/{ARCH}{COMP} or wmake/rules/{ARCH}/{COMP}

- compiler option is now '-spack' instead of 'RpathOpt'
  which now seems to be a bit harsh on the eyes.
  Now have compilations such as 'linux64GccDPInt32-spack',
  which is moderately easier to read.

- add OpenFOAM 1912, patch 200506