### PR TITLE
ParaView: conflict ~opengl2 with versions 5.5 and up

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -54,6 +54,9 @@ class Paraview(CMakePackage, CudaPackage):
     conflicts('+python', when='@5.6:')
     conflicts('+python3', when='@:5.5')
     conflicts('+shared', when='+cuda')
+    # Legacy rendering dropped in 5.5
+    # See commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c
+    conflicts('~opengl2', when='@5.5:')
 
     # Workaround for
     # adding the following to your packages.yaml


### PR DESCRIPTION
@utkarshayachit 

This PR adds a conflict for ParaView versions 5.5 and newer for use of legacy rendering, which was removed by this commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c

@chuckatkins @danlipsa Can you review this?