### PR TITLE
Use a single ThreadPool for "spack versions"

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -22,7 +22,7 @@ def setup_parser(subparser):
     subparser.add_argument('-s', '--safe-only', action='store_true',
                            help='only list safe versions of the package')
     subparser.add_argument(
-        '-c', '--concurrency', default=128, type=int,
+        '-c', '--concurrency', default=32, type=int,
         help='number of concurrent requests'
     )
     arguments.add_common_arguments(subparser, ['package'])

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -21,6 +21,10 @@ level = "long"
 def setup_parser(subparser):
     subparser.add_argument('-s', '--safe-only', action='store_true',
                            help='only list safe versions of the package')
+    subparser.add_argument(
+        '-c', '--concurrency', default=128,
+        help='number of concurrent requests'
+    )
     arguments.add_common_arguments(subparser, ['package'])
 
 
@@ -45,7 +49,7 @@ def versions(parser, args):
     if sys.stdout.isatty():
         tty.msg('Remote versions (not yet checksummed):')
 
-    fetched_versions = pkg.fetch_remote_versions()
+    fetched_versions = pkg.fetch_remote_versions(int(args.concurrency))
     remote_versions = set(fetched_versions).difference(safe_versions)
 
     if not remote_versions:

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -22,7 +22,7 @@ def setup_parser(subparser):
     subparser.add_argument('-s', '--safe-only', action='store_true',
                            help='only list safe versions of the package')
     subparser.add_argument(
-        '-c', '--concurrency', default=128,
+        '-c', '--concurrency', default=128, type=int,
         help='number of concurrent requests'
     )
     arguments.add_common_arguments(subparser, ['package'])
@@ -49,7 +49,7 @@ def versions(parser, args):
     if sys.stdout.isatty():
         tty.msg('Remote versions (not yet checksummed):')
 
-    fetched_versions = pkg.fetch_remote_versions(int(args.concurrency))
+    fetched_versions = pkg.fetch_remote_versions(args.concurrency)
     remote_versions = set(fetched_versions).difference(safe_versions)
 
     if not remote_versions:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2020,7 +2020,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 urls.append(args['url'])
         return urls
 
-    def fetch_remote_versions(self):
+    def fetch_remote_versions(self, concurrency=128):
         """Find remote versions of this package.
 
         Uses ``list_url`` and any other URLs listed in the package file.
@@ -2033,7 +2033,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         try:
             return spack.util.web.find_versions_of_archive(
-                self.all_urls, self.list_url, self.list_depth)
+                self.all_urls, self.list_url, self.list_depth, concurrency
+            )
         except spack.util.web.NoNetworkConnectionError as e:
             tty.die("Package.fetch_versions couldn't connect to:", e.url,
                     e.message)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -21,85 +21,53 @@ page_3 = 'file://' + os.path.join(web_data_path, '3.html')
 page_4 = 'file://' + os.path.join(web_data_path, '4.html')
 
 
-def test_spider_0():
-    pages, links = spack.util.web.spider(root, depth=0)
+@pytest.mark.parametrize(
+    'depth,expected_found,expected_not_found,expected_text', [
+        (0,
+         {'pages': [root], 'links': [page_1]},
+         {'pages': [page_1, page_2, page_3, page_4],
+          'links': [root, page_2, page_3, page_4]},
+         {root: "This is the root page."}),
+        (1,
+         {'pages': [root, page_1], 'links': [page_1, page_2]},
+         {'pages': [page_2, page_3, page_4],
+          'links': [root, page_3, page_4]},
+         {root: "This is the root page.",
+          page_1: "This is page 1."}),
+        (2,
+         {'pages': [root, page_1, page_2],
+          'links': [page_1, page_2, page_3, page_4]},
+         {'pages': [page_3, page_4], 'links': [root]},
+         {root: "This is the root page.",
+          page_1: "This is page 1.",
+          page_2: "This is page 2."}),
+        (3,
+         {'pages': [root, page_1, page_2, page_3, page_4],
+          'links': [root, page_1, page_2, page_3, page_4]},
+         {'pages': [], 'links': []},
+         {root: "This is the root page.",
+          page_1: "This is page 1.",
+          page_2: "This is page 2.",
+          page_3: "This is page 3.",
+          page_4: "This is page 4."}),
+    ])
+def test_spider(depth, expected_found, expected_not_found, expected_text):
+    pages, links = spack.util.web.spider(root, depth=depth)
 
-    assert root in pages
-    assert page_1 not in pages
-    assert page_2 not in pages
-    assert page_3 not in pages
-    assert page_4 not in pages
+    for page in expected_found['pages']:
+        assert page in pages
 
-    assert "This is the root page." in pages[root]
+    for page in expected_not_found['pages']:
+        assert page not in pages
 
-    assert root not in links
-    assert page_1 in links
-    assert page_2 not in links
-    assert page_3 not in links
-    assert page_4 not in links
+    for link in expected_found['links']:
+        assert link in links
 
+    for link in expected_not_found['links']:
+        assert link not in links
 
-def test_spider_1():
-    pages, links = spack.util.web.spider(root, depth=1)
-
-    assert root in pages
-    assert page_1 in pages
-    assert page_2 not in pages
-    assert page_3 not in pages
-    assert page_4 not in pages
-
-    assert "This is the root page." in pages[root]
-    assert "This is page 1." in pages[page_1]
-
-    assert root not in links
-    assert page_1 in links
-    assert page_2 in links
-    assert page_3 not in links
-    assert page_4 not in links
-
-
-def test_spider_2():
-    pages, links = spack.util.web.spider(root, depth=2)
-
-    assert root in pages
-    assert page_1 in pages
-    assert page_2 in pages
-    assert page_3 not in pages
-    assert page_4 not in pages
-
-    assert "This is the root page." in pages[root]
-    assert "This is page 1." in pages[page_1]
-    assert "This is page 2." in pages[page_2]
-
-    assert root not in links
-    assert page_1 in links
-    assert page_1 in links
-    assert page_2 in links
-    assert page_3 in links
-    assert page_4 in links
-
-
-def test_spider_3():
-    pages, links = spack.util.web.spider(root, depth=3)
-
-    assert root in pages
-    assert page_1 in pages
-    assert page_2 in pages
-    assert page_3 in pages
-    assert page_4 in pages
-
-    assert "This is the root page." in pages[root]
-    assert "This is page 1." in pages[page_1]
-    assert "This is page 2." in pages[page_2]
-    assert "This is page 3." in pages[page_3]
-    assert "This is page 4." in pages[page_4]
-
-    assert root in links  # circular link on page 3
-    assert page_1 in links
-    assert page_1 in links
-    assert page_2 in links
-    assert page_3 in links
-    assert page_4 in links
+    for page, text in expected_text.items():
+        assert text in pages[page]
 
 
 def test_find_versions_of_archive_0():

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -10,15 +10,18 @@ import spack.paths
 import spack.util.web
 from spack.version import ver
 
-web_data_path = os.path.join(spack.paths.test_path, 'data', 'web')
 
-root = 'file://' + web_data_path + '/index.html'
-root_tarball = 'file://' + web_data_path + '/foo-0.0.0.tar.gz'
+def _create_url(relative_url):
+    web_data_path = os.path.join(spack.paths.test_path, 'data', 'web')
+    return 'file://' + os.path.join(web_data_path, relative_url)
 
-page_1 = 'file://' + os.path.join(web_data_path, '1.html')
-page_2 = 'file://' + os.path.join(web_data_path, '2.html')
-page_3 = 'file://' + os.path.join(web_data_path, '3.html')
-page_4 = 'file://' + os.path.join(web_data_path, '4.html')
+
+root = _create_url('index.html')
+root_tarball = _create_url('foo-0.0.0.tar.gz')
+page_1 = _create_url('1.html')
+page_2 = _create_url('2.html')
+page_3 = _create_url('3.html')
+page_4 = _create_url('4.html')
 
 
 @pytest.mark.parametrize(
@@ -68,6 +71,15 @@ def test_spider(depth, expected_found, expected_not_found, expected_text):
 
     for page, text in expected_text.items():
         assert text in pages[page]
+
+
+def test_spider_no_response(monkeypatch):
+    # Mock the absence of a response
+    monkeypatch.setattr(
+        spack.util.web, 'read_from_url', lambda x, y: (None, None, None)
+    )
+    pages, links = spack.util.web.spider(root, depth=0)
+    assert not pages and not links
 
 
 def test_find_versions_of_archive_0():

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -2,17 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-"""Tests for web.py."""
 import os
+
+import ordereddict_backport
 import pytest
-
-from ordereddict_backport import OrderedDict
-
 import spack.paths
-import spack.util.web as web_util
+import spack.util.web
 from spack.version import ver
-
 
 web_data_path = os.path.join(spack.paths.test_path, 'data', 'web')
 
@@ -26,7 +22,7 @@ page_4 = 'file://' + os.path.join(web_data_path, '4.html')
 
 
 def test_spider_0():
-    pages, links = web_util.spider(root, depth=0)
+    pages, links = spack.util.web.spider(root, depth=0)
 
     assert root in pages
     assert page_1 not in pages
@@ -44,7 +40,7 @@ def test_spider_0():
 
 
 def test_spider_1():
-    pages, links = web_util.spider(root, depth=1)
+    pages, links = spack.util.web.spider(root, depth=1)
 
     assert root in pages
     assert page_1 in pages
@@ -63,7 +59,7 @@ def test_spider_1():
 
 
 def test_spider_2():
-    pages, links = web_util.spider(root, depth=2)
+    pages, links = spack.util.web.spider(root, depth=2)
 
     assert root in pages
     assert page_1 in pages
@@ -84,7 +80,7 @@ def test_spider_2():
 
 
 def test_spider_3():
-    pages, links = web_util.spider(root, depth=3)
+    pages, links = spack.util.web.spider(root, depth=3)
 
     assert root in pages
     assert page_1 in pages
@@ -107,20 +103,20 @@ def test_spider_3():
 
 
 def test_find_versions_of_archive_0():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=0)
     assert ver('0.0.0') in versions
 
 
 def test_find_versions_of_archive_1():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=1)
     assert ver('0.0.0') in versions
     assert ver('1.0.0') in versions
 
 
 def test_find_versions_of_archive_2():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=2)
     assert ver('0.0.0') in versions
     assert ver('1.0.0') in versions
@@ -128,14 +124,14 @@ def test_find_versions_of_archive_2():
 
 
 def test_find_exotic_versions_of_archive_2():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=2)
     # up for grabs to make this better.
     assert ver('2.0.0b2') in versions
 
 
 def test_find_versions_of_archive_3():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=3)
     assert ver('0.0.0') in versions
     assert ver('1.0.0') in versions
@@ -145,7 +141,7 @@ def test_find_versions_of_archive_3():
 
 
 def test_find_exotic_versions_of_archive_3():
-    versions = web_util.find_versions_of_archive(
+    versions = spack.util.web.find_versions_of_archive(
         root_tarball, root, list_depth=3)
     assert ver('2.0.0b2') in versions
     assert ver('3.0a1') in versions
@@ -159,35 +155,35 @@ def test_get_header():
 
     # looking up headers should just work like a plain dict
     # lookup when there is an entry with the right key
-    assert(web_util.get_header(headers, 'Content-type') == 'text/plain')
+    assert(spack.util.web.get_header(headers, 'Content-type') == 'text/plain')
 
     # looking up headers should still work if there is a fuzzy match
-    assert(web_util.get_header(headers, 'contentType') == 'text/plain')
+    assert(spack.util.web.get_header(headers, 'contentType') == 'text/plain')
 
     # ...unless there is an exact match for the "fuzzy" spelling.
     headers['contentType'] = 'text/html'
-    assert(web_util.get_header(headers, 'contentType') == 'text/html')
+    assert(spack.util.web.get_header(headers, 'contentType') == 'text/html')
 
     # If lookup has to fallback to fuzzy matching and there are more than one
     # fuzzy match, the result depends on the internal ordering of the given
     # mapping
-    headers = OrderedDict()
+    headers = ordereddict_backport.OrderedDict()
     headers['Content-type'] = 'text/plain'
     headers['contentType'] = 'text/html'
 
-    assert(web_util.get_header(headers, 'CONTENT_TYPE') == 'text/plain')
+    assert(spack.util.web.get_header(headers, 'CONTENT_TYPE') == 'text/plain')
     del headers['Content-type']
-    assert(web_util.get_header(headers, 'CONTENT_TYPE') == 'text/html')
+    assert(spack.util.web.get_header(headers, 'CONTENT_TYPE') == 'text/html')
 
     # Same as above, but different ordering
-    headers = OrderedDict()
+    headers = ordereddict_backport.OrderedDict()
     headers['contentType'] = 'text/html'
     headers['Content-type'] = 'text/plain'
 
-    assert(web_util.get_header(headers, 'CONTENT_TYPE') == 'text/html')
+    assert(spack.util.web.get_header(headers, 'CONTENT_TYPE') == 'text/html')
     del headers['contentType']
-    assert(web_util.get_header(headers, 'CONTENT_TYPE') == 'text/plain')
+    assert(spack.util.web.get_header(headers, 'CONTENT_TYPE') == 'text/plain')
 
     # If there isn't even a fuzzy match, raise KeyError
     with pytest.raises(KeyError):
-        web_util.get_header(headers, 'ContentLength')
+        spack.util.web.get_header(headers, 'ContentLength')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -330,15 +330,17 @@ def _urlopen(req, *args, **kwargs):
     return opener(req, *args, **kwargs)
 
 
-def spider(roots, depth=0):
+def spider(roots, depth=0, concurrency=128):
     """Get web pages from root URLs.
 
     If depth is specified (e.g., depth=2), then this will also follow
     up to <depth> levels of links from each root.
 
     Args:
-        roots: root urls used as a starting point for spidering
-        depth: level of recursion into links
+        roots (str or list of str): root urls used as a starting point
+            for spidering
+        depth (int): level of recursion into links
+        concurrency (int): number of simultaneous requests that can be sent
 
     Returns:
         A dict of pages visited (URL) mapped to their full text and the
@@ -432,7 +434,7 @@ def spider(roots, depth=0):
                       traceback.format_exc())
 
         finally:
-            tty.debug("SPIDER: {0}".format(url))
+            tty.debug("SPIDER: [url={0}]".format(url))
 
         return pages, links, subcalls
 
@@ -456,10 +458,10 @@ def spider(roots, depth=0):
         root = url_util.parse(root)
         spider_args.append((root, root, collect))
 
-    tp = multiprocessing.pool.ThreadPool(processes=128)
+    tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:
         while current_depth <= depth:
-            tty.debug("Current depth: {0} [max={1}, len={2}]".format(
+            tty.debug("SPIDER: [depth={0}, max_depth={1}, urls={2}]".format(
                 current_depth, depth, len(spider_args))
             )
             results = tp.map(star(_spider), spider_args)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -328,7 +328,7 @@ def spider(root_urls, depth=0, concurrency=128):
     # Cache of visited links, meant to be captured by the closure below
     _visited = set()
 
-    def _spider(url, root, collect_nested):
+    def _spider(url, collect_nested):
         """Fetches URL and any pages it links to.
 
         Prints out a warning only if the root can't be fetched; it ignores
@@ -336,7 +336,6 @@ def spider(root_urls, depth=0, concurrency=128):
 
         Args:
             url (str): url being fetched and searched for links
-            root (str): base url on which we want to restrict our search
             collect_nested (bool): whether we want to collect arguments
                 for nested spidering on the links found in this url
 
@@ -374,17 +373,13 @@ def spider(root_urls, depth=0, concurrency=128):
                 if any(raw_link.endswith(s) for s in ALLOWED_ARCHIVE_TYPES):
                     continue
 
-                # Skip things outside the root directory
-                if not abs_link.startswith(root):
-                    continue
-
                 # Skip already-visited links
                 if abs_link in _visited:
                     continue
 
                 # If we're not at max depth, follow links.
                 if collect_nested:
-                    subcalls.append((abs_link, root))
+                    subcalls.append((abs_link,))
                     _visited.add(abs_link)
 
         except URLError as e:
@@ -435,7 +430,7 @@ def spider(root_urls, depth=0, concurrency=128):
     collect = current_depth < depth
     for root in root_urls:
         root = url_util.parse(root)
-        spider_args.append((root, root, collect))
+        spider_args.append((root, collect))
 
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -309,27 +309,6 @@ def list_url(url):
             for key in _iter_s3_prefix(s3, url)))
 
 
-def _urlopen(req, *args, **kwargs):
-    """Wrapper for compatibility with old versions of Python."""
-    url = req
-    try:
-        url = url.get_full_url()
-    except AttributeError:
-        pass
-
-    # We don't pass 'context' parameter because it was only introduced starting
-    # with versions 2.7.9 and 3.4.3 of Python.
-    if 'context' in kwargs:
-        del kwargs['context']
-
-    opener = urlopen
-    if url_util.parse(url).scheme == 's3':
-        import spack.s3_handler
-        opener = spack.s3_handler.open
-
-    return opener(req, *args, **kwargs)
-
-
 def spider(roots, depth=0, concurrency=128):
     """Get web pages from root URLs.
 
@@ -479,6 +458,27 @@ def spider(roots, depth=0, concurrency=128):
         tp.join()
 
     return pages, links
+
+
+def _urlopen(req, *args, **kwargs):
+    """Wrapper for compatibility with old versions of Python."""
+    url = req
+    try:
+        url = url.get_full_url()
+    except AttributeError:
+        pass
+
+    # We don't pass 'context' parameter because it was only introduced starting
+    # with versions 2.7.9 and 3.4.3 of Python.
+    if 'context' in kwargs:
+        del kwargs['context']
+
+    opener = urlopen
+    if url_util.parse(url).scheme == 's3':
+        import spack.s3_handler
+        opener = spack.s3_handler.open
+
+    return opener(req, *args, **kwargs)
 
 
 def find_versions_of_archive(

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -481,22 +481,22 @@ def spider(roots, depth=0, concurrency=128):
     return pages, links
 
 
-def find_versions_of_archive(archive_urls, list_url=None, list_depth=0):
+def find_versions_of_archive(
+        archive_urls, list_url=None, list_depth=0, concurrency=128
+):
     """Scrape web pages for new versions of a tarball.
 
-    Arguments:
+    Args:
         archive_urls (str or list or tuple): URL or sequence of URLs for
             different versions of a package. Typically these are just the
             tarballs from the package file itself. By default, this searches
             the parent directories of archives.
-
-    Keyword Arguments:
         list_url (str or None): URL for a listing of archives.
             Spack will scrape these pages for download links that look
             like the archive URL.
-
-        list_depth (int): Max depth to follow links on list_url pages.
+        list_depth (int): max depth to follow links on list_url pages.
             Defaults to 0.
+        concurrency (int): maximum number of concurrent requests
     """
     if not isinstance(archive_urls, (list, tuple)):
         archive_urls = [archive_urls]
@@ -517,7 +517,7 @@ def find_versions_of_archive(archive_urls, list_url=None, list_depth=0):
     list_urls |= additional_list_urls
 
     # Grab some web pages to scrape.
-    pages, links = spider(list_urls, depth=list_depth)
+    pages, links = spider(list_urls, depth=list_depth, concurrency=concurrency)
 
     # Scrape them for archive URLs
     regexes = []

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -309,7 +309,7 @@ def list_url(url):
             for key in _iter_s3_prefix(s3, url)))
 
 
-def spider(root_urls, depth=0, concurrency=128):
+def spider(root_urls, depth=0, concurrency=32):
     """Get web pages from root URLs.
 
     If depth is specified (e.g., depth=2), then this will also follow
@@ -477,7 +477,7 @@ def _urlopen(req, *args, **kwargs):
 
 
 def find_versions_of_archive(
-        archive_urls, list_url=None, list_depth=0, concurrency=128
+        archive_urls, list_url=None, list_depth=0, concurrency=32
 ):
     """Scrape web pages for new versions of a tarball.
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -309,14 +309,14 @@ def list_url(url):
             for key in _iter_s3_prefix(s3, url)))
 
 
-def spider(roots, depth=0, concurrency=128):
+def spider(root_urls, depth=0, concurrency=128):
     """Get web pages from root URLs.
 
     If depth is specified (e.g., depth=2), then this will also follow
     up to <depth> levels of links from each root.
 
     Args:
-        roots (str or list of str): root urls used as a starting point
+        root_urls (str or list of str): root urls used as a starting point
             for spidering
         depth (int): level of recursion into links
         concurrency (int): number of simultaneous requests that can be sent
@@ -423,8 +423,8 @@ def spider(roots, depth=0, concurrency=128):
             return func(*args)
         return _wrapper
 
-    if isinstance(roots, six.string_types):
-        roots = [roots]
+    if isinstance(root_urls, six.string_types):
+        root_urls = [root_urls]
 
     # Clear the local cache of visited pages before starting the search
     _visited.clear()
@@ -433,7 +433,7 @@ def spider(roots, depth=0, concurrency=128):
     pages, links, spider_args = {}, set(), []
 
     collect = current_depth < depth
-    for root in roots:
+    for root in root_urls:
         root = url_util.parse(root)
         spider_args.append((root, root, collect))
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1510,7 +1510,7 @@ _spack_verify() {
 _spack_versions() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -s --safe-only"
+        SPACK_COMPREPLY="-h --help -s --safe-only -c --concurrency"
     else
         _all_packages
     fi


### PR DESCRIPTION
fixes #16720 

Modifications:

- [x] `spack versions` doesn't spawn recursive pool of processes anymore
- [x]  The number of concurrent requests can be controlled via cli