### PR TITLE
plink-ng: new package

### DIFF
--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class PlinkNg(RPackage):
+class PlinkNg(Package):
     """A comprehensive update to the PLINK association analysis toolset."""
 
     homepage = "https://www.cog-genomics.org/plink/2.0/"

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -30,6 +30,7 @@ class PlinkNg(Package):
         env.set('ZLIB', zlib)
 
     def install(self, spec, prefix):
-        filter_file('-llapack -lcblas -lblas', '-lopenblas', 'build.sh', string=True)
+        filter_file('-llapack -lcblas -lblas', '-lopenblas',
+                    'build.sh', string=True)
         which('sh')('build.sh')
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -7,9 +7,9 @@ from spack import *
 
 
 class PlinkNg(RPackage):
-    """FIXME: Put a proper description of your package here."""
+    """A comprehensive update to the PLINK association analysis toolset."""
 
-    homepage = "https://www.example.com"
+    homepage = "https://www.cog-genomics.org/plink/2.0/"
     url      = "https://www.cog-genomics.org/static/bin/plink2_src_200511.zip"
 
     version('2_src_200511', sha256='00cff19bece88acb7a21ba098501cb677b78d22c9f3ca5bcdc869139a40db816')

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -17,7 +17,8 @@ class PlinkNg(Package):
     depends_on('zlib')
     depends_on('zstd@1.4.4:')
     depends_on('cblas')
-    depends_on('openblas')
+    depends_on('blas')
+    depends_on('lapack')
 
     conflicts('%gcc@:4.99')
 

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -19,6 +19,8 @@ class PlinkNg(RPackage):
     depends_on('cblas')
     depends_on('openblas')
 
+    conflicts('%gcc@:4.99')
+
     def setup_build_environment(self, env):
         zlib = join_path(self.spec['zlib'].prefix.lib, 'libz.a')
         env.set('ZLIB', zlib)

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -31,8 +31,8 @@ class PlinkNg(Package):
         env.set('ZLIB', zlib)
 
     def install(self, spec, prefix):
-        ld_flags = ' '.join([spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags])
-        filter_file('-llapack -lcblas -lblas', ld_flags,
+        ld_flags = [spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags]
+        filter_file('-llapack -lcblas -lblas', ' '.join(ld_flags),
                     'build.sh', string=True)
         which('sh')('build.sh')
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PlinkNg(RPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://www.example.com"
+    url      = "https://www.cog-genomics.org/static/bin/plink2_src_200511.zip"
+
+    version('2_src_200511', sha256='00cff19bece88acb7a21ba098501cb677b78d22c9f3ca5bcdc869139a40db816')
+
+    depends_on('zlib')
+    depends_on('zstd@1.4.4:')
+    depends_on('cblas')
+    depends_on('openblas')
+
+    def setup_build_environment(self, env):
+        zlib = join_path(self.spec['zlib'].prefix.lib, 'libz.a')
+        env.set('ZLIB', zlib)
+
+    def install(self, spec, prefix):
+        filter_file('-llapack -lcblas -lblas', '-lopenblas', 'build.sh', string=True)
+        which('sh')('build.sh')
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -31,7 +31,8 @@ class PlinkNg(Package):
         env.set('ZLIB', zlib)
 
     def install(self, spec, prefix):
-        filter_file('-llapack -lcblas -lblas', '-lopenblas',
+        ld_flags = ' '.join([spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags])
+        filter_file('-llapack -lcblas -lblas', ld_flags,
                     'build.sh', string=True)
         which('sh')('build.sh')
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/plink-ng/package.py
+++ b/var/spack/repos/builtin/packages/plink-ng/package.py
@@ -12,7 +12,7 @@ class PlinkNg(RPackage):
     homepage = "https://www.cog-genomics.org/plink/2.0/"
     url      = "https://www.cog-genomics.org/static/bin/plink2_src_200511.zip"
 
-    version('2_src_200511', sha256='00cff19bece88acb7a21ba098501cb677b78d22c9f3ca5bcdc869139a40db816')
+    version('200511', sha256='00cff19bece88acb7a21ba098501cb677b78d22c9f3ca5bcdc869139a40db816')
 
     depends_on('zlib')
     depends_on('zstd@1.4.4:')
@@ -20,6 +20,10 @@ class PlinkNg(RPackage):
     depends_on('openblas')
 
     conflicts('%gcc@:4.99')
+
+    def url_for_version(self, ver):
+        template = 'https://www.cog-genomics.org/static/bin/plink2_src_{0}.zip'
+        return template.format(ver)
 
     def setup_build_environment(self, env):
         zlib = join_path(self.spec['zlib'].prefix.lib, 'libz.a')


### PR DESCRIPTION
This package makes use of some standard BLAS and LAPACK functions but I was unable to get it working using the `blas` and `lapack` virtual dependencies. This recipe uses `openblas` to resolve all the needed functions but if the virtual dependencies are preferable then I can try more to get them working.

The two major problems I ran into were `atlas` build problems and it seemed that `lapack` did not actually bring any packages into the spec.