### PR TITLE
Valgrind: Mark as conflicting with macOS >= 10.14

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -57,6 +57,9 @@ clang: error: unknown argument: '-static-libubsan'
     # http://valgrind.10908.n7.nabble.com/Unable-to-compile-on-Mac-OS-X-10-11-td57237.html
     patch('valgrind_3_12_0_osx.patch', when='@3.12.0 platform=darwin')
 
+    for os in ('mojave', 'catalina'):
+        conflicts("os=" + os, when='@:3.15')
+
     def configure_args(self):
         spec = self.spec
         options = []


### PR DESCRIPTION
```
    '/var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-valgrind-3.15.0-mtir7ubjz7mqmjbb7bogze2qm35hl4ze/spack-src/configure' '--prefix=/ornldev/code/spack/opt/spack/clang-11.0.0-apple/valgrind/mtir7ub' '--enable-only64bit' '--build=amd64-darwin'
1 error found in build log:
     43    checking host system type... x86_64-pc-darwin
     44    checking for a supported CPU... ok (x86_64)
     45    checking for a 64-bit only build... yes
     46    checking for a 32-bit only build... no
     47    checking for a supported OS... ok (darwin)
     48    checking for the kernel version... unsupported (18.7.0)
  >> 49    configure: error: Valgrind works on Darwin 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x and 17.x (Mac OS X 10.6/7/8/9/10/11 and macOS 10.12/13)
```