### PR TITLE
netcdf-cxx4: Remove erroneous variants added in #16047/commit 993491c

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -24,12 +24,7 @@ class NetcdfCxx4(AutotoolsPackage):
     variant('static', default=True, description='Enable building static libraries')
     variant('shared', default=True, description='Enable shared library')
     variant('pic', default=True, description='Produce position-independent code (for shared libs)')
-    variant('dap', default=False, description='Enable DAP support')
-    variant('jna', default=False, description='Enable JNA support')
     variant('doxygen', default=True, description='Enable doxygen docs')
-    variant('ncgen4', default=True, description='Enable generating netcdf-4 data')
-    variant('pnetcdf', default=True, description='Enable parallel-netcdf')
-    variant('netcdf4', default=False, description='Enable netcdf-4 data structure')
 
     depends_on('netcdf-c')
 
@@ -74,31 +69,6 @@ class NetcdfCxx4(AutotoolsPackage):
             config_args.append('--with-pic')
         else:
             config_args.append('--without-pic')
-
-        if '+dap' in self.spec:
-            config_args.append('--enable-dap')
-        else:
-            config_args.append('--disable-dap')
-
-        if '+jna' in self.spec:
-            config_args.append('--enable-jna')
-        else:
-            config_args.append('--disable-jna')
-
-        if '+pnetcdf' in self.spec:
-            config_args.append('--enable-pnetcdf')
-        else:
-            config_args.append('--disable-pnetcdf')
-
-        if '+netcdf4' in self.spec:
-            config_args.append('--enable-netcdf-4')
-        else:
-            config_args.append('--disable-netcdf-4')
-
-        if '+ncgen4' in self.spec:
-            config_args.append('--enable-ncgen4')
-        else:
-            config_args.append('--disable-ncgen4')
 
         if '+doxygen' in self.spec:
             config_args.append('--enable-doxygen')


### PR DESCRIPTION
Fixes #16725
The dap, jna, pnetcdf, netcdf4, and ncgen4 variants added in #16047
and specifically their associated configure flags --enable-dap, --enable-jna,
--enable-pnetcdf, --enable-netcdf-4, --enable-ncgen4 are _not_ supported
by the configure script for netcdf-cxx4 package (These appear to be
configure args for netcdf-c package).