### PR TITLE
flux: update versions and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -15,6 +15,8 @@ class FluxCore(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-core.git"
 
     version('master', branch='master')
+    version('0.16.0', sha256='1582f7fb4d2313127418c34de7c9ce4f5fef00622d19cedca7bed929f4709f10')
+    version('0.15.0', sha256='51bc2eae69501f802459fc82f191eb5e8ae0b4f7e9e77ac18543a850cc8445f5')
     version('0.11.3', sha256='91b5d7dca8fc28a77777c4e4cb8717fc3dc2c174e70611740689a71901c6de7e')
     version('0.11.2', sha256='ab8637428cd9b74b2dff4842d10e0fc4acc8213c4e51f31d32a4cbfbdf730412')
     version('0.11.1', sha256='3c8495db0f3b701f6dfe3e2a75aed794fc561e9f28284e8c02ac67693bfe890e')
@@ -46,6 +48,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("python", type=('build', 'run'))
     depends_on("python@2.7:2.99", when="@0.1.0:0.11.0")
     depends_on("python@2.7:", when="@0.11.1:")
+    depends_on("python@3.6:", when="@0.17.0:,master")
     depends_on("py-cffi", type=('build', 'run'))
     depends_on("py-six", type=('build', 'run'), when="@0.11.0:")
     depends_on("py-pyyaml", type=('build', 'run'), when="@0.11.0:")

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -45,10 +45,13 @@ class FluxCore(AutotoolsPackage):
     depends_on("lua@5.1:5.2.99", when="@0.10.0:,master")
     depends_on("lua-luaposix")
     depends_on("munge", when="@0.1.0:0.10.0")
-    depends_on("python", type=('build', 'run'))
-    depends_on("python@2.7:2.99", when="@0.1.0:0.11.0")
-    depends_on("python@2.7:", when="@0.11.1:")
-    depends_on("python@3.6:", when="@0.17.0:,master")
+    # `link` dependency on python due to Flux's `pymod` module
+    depends_on("python", type=('build', 'run', 'link'))
+    depends_on("python@2.7:2.99",
+               when="@0.1.0:0.11.0",
+               type=('build', 'run', 'link'))
+    depends_on("python@2.7:", when="@0.11.1:", type=('build', 'run', 'link'))
+    depends_on("python@3.6:", when="@0.17.0:,master", type=('build', 'run', 'link'))
     depends_on("py-cffi", type=('build', 'run'))
     depends_on("py-six", type=('build', 'run'), when="@0.11.0:")
     depends_on("py-pyyaml", type=('build', 'run'), when="@0.11.0:")

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -15,6 +15,7 @@ class FluxSched(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-sched.git"
 
     version('master', branch='master')
+    version('0.8.0', sha256='45bc3cefb453d19c0cb289f03692fba600a39045846568d258e4b896ca19ca0d')
     version('0.7.1', sha256='a35e555a353feed6b7b814ae83d05362356f9ee33ffa75d7dfb7e2fe86c21294')
     version('0.7.0', sha256='69267a3aaacaedd9896fd90cfe17aef266cba4fb28c77f8123d95a31ce739a7b')
     version('0.6.0', sha256='3301d4c10810414228e5969b84b75fe1285abb97453070eb5a77f386d8184f8d')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -36,13 +36,14 @@ class FluxSched(AutotoolsPackage):
     depends_on("pkgconfig")
 
     depends_on("flux-core", type=('build', 'link', 'run'))
-    depends_on("flux-core+cuda", when='+cuda')
-    depends_on("flux-core@0.8.0", when='@0.4.0')
-    depends_on("flux-core@0.9.0", when='@0.5.0')
-    depends_on("flux-core@0.10.0", when='@0.6.0')
-    depends_on("flux-core@0.11.0", when='@0.7.0')
-    depends_on("flux-core@0.11.2:0.11.99", when='@0.7.1')
-    depends_on("flux-core@master", when='@master')
+    depends_on("flux-core+cuda", when='+cuda', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.8.0", when='@0.4.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.9.0", when='@0.5.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.10.0", when='@0.6.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.11.0", when='@0.7.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.11.2:0.11.99", when='@0.7.1', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.16.0:0.16.99", when='@0.8.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@master", when='@master', type=('build', 'run', 'link'))
 
     # Need autotools when building on master:
     depends_on("autoconf", type='build', when='@master')


### PR DESCRIPTION
flux-core: add v0.16; add new dependence on Python 3.6+ for master and v0.17
flux-sched: add v0.8 along with corresponding flux-core dependency
both: add dependency types to depdendencies that have a `when` argument

