### PR TITLE
Updated unison to v2.51.2

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -29,12 +29,22 @@ class Ocaml(Package):
 
     sanity_check_file = ['bin/ocaml']
 
+    variant(
+        'force-safe-string', default=True,
+        description='Enforce safe (immutable) strings'
+    )
+
     def url_for_version(self, version):
         url = "http://caml.inria.fr/pub/distrib/ocaml-{0}/ocaml-{1}.tar.gz"
         return url.format(str(version)[:-2], version)
 
     def install(self, spec, prefix):
-        configure('-prefix', '{0}'.format(prefix))
+        base_args = ['-prefix', '{0}'.format(prefix)]
+
+        if self.spec.satisfies('~force-safe-string'):
+            base_args += ['--disable-force-safe-string']
+
+        configure(*(base_args))
 
         make('world.opt')
         make('install', 'PREFIX={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/unison/4.08-compatibility.patch
+++ b/var/spack/repos/builtin/packages/unison/4.08-compatibility.patch
@@ -1,0 +1,52 @@
+From 29fa058c3127f3b47c347dcaa4a94f4c0e888308 Mon Sep 17 00:00:00 2001
+From: Jaap Boender <jaapb@kerguelen.org>
+Date: Thu, 21 Mar 2019 12:26:51 +0000
+Subject: [PATCH] Compatibility with OCaml 4.08
+
+---
+ src/files.ml                 | 2 +-
+ src/recon.ml                 | 4 ++--
+ src/system/system_generic.ml | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/files.ml b/src/files.ml
+index ba42ad57..5babf21e 100644
+--- a/src/files.ml
++++ b/src/files.ml
+@@ -722,7 +722,7 @@ let get_files_in_directory dir =
+   with End_of_file ->
+     dirh.System.closedir ()
+   end;
+-  Sort.list (<) !files
++  List.sort String.compare !files
+ 
+ let ls dir pattern =
+   Util.convertUnixErrorsToTransient
+diff --git a/src/recon.ml b/src/recon.ml
+index 5ed358d7..0df2cfe4 100644
+--- a/src/recon.ml
++++ b/src/recon.ml
+@@ -651,8 +651,8 @@ let rec reconcile
+ 
+ (* Sorts the paths so that they will be displayed in order                   *)
+ let sortPaths pathUpdatesList =
+-  Sort.list
+-    (fun (p1, _) (p2, _) -> Path.compare p1 p2 <= 0)
++  List.sort
++    Path.compare
+     pathUpdatesList
+ 
+ let rec enterPath p1 p2 t =
+diff --git a/src/system/system_generic.ml b/src/system/system_generic.ml
+index ed8e18f3..0e28a781 100755
+--- a/src/system/system_generic.ml
++++ b/src/system/system_generic.ml
+@@ -47,7 +47,7 @@ let open_out_gen = open_out_gen
+ let chmod = Unix.chmod
+ let chown = Unix.chown
+ let utimes = Unix.utimes
+-let link = Unix.link
++let link s d = Unix.link s d
+ let openfile = Unix.openfile
+ let opendir f =
+   let h = Unix.opendir f in

--- a/var/spack/repos/builtin/packages/unison/large.patch
+++ b/var/spack/repos/builtin/packages/unison/large.patch
@@ -1,0 +1,49 @@
+diff -Nrua /usr/ports/net/unison/patches/patch-bytearray_stubs_c ./patches/patch-bytearray_stubs_c
+--- /usr/ports/net/unison/patches/patch-bytearray_stubs_c	Thu Jan  1 01:00:00 1970
++++ ./patches/patch-bytearray_stubs_c	Tue Jan 17 08:44:39 2017
+@@ -0,0 +1,45 @@
++Fix rare SIGSEGV when transferring large replicas.
++Fix a theoretical integer overflow. 
++
++Patches from here:
++https://caml.inria.fr/mantis/view.php?id=7431#c17026
++and here:
++https://caml.inria.fr/mantis/view.php?id=7431#c16962
++
++Related issue reports:
++https://github.com/bcpierce00/unison/issues/48
++https://caml.inria.fr/mantis/view.php?id=7431
++https://bugzilla.redhat.com/show_bug.cgi?id=1401759
++
++Thanks to Alex Markley and OCaml developers
++--- bytearray_stubs.c.orig	Tue Jan 17 08:41:00 2017
+++++ bytearray_stubs.c	Tue Jan 17 08:41:21 2017
++@@ -5,6 +5,7 @@
++ 
++ #include "caml/intext.h"
++ #include "caml/bigarray.h"
+++#include "caml/memory.h"
++ 
++ CAMLprim value ml_marshal_to_bigarray(value v, value flags)
++ {
++@@ -21,15 +22,18 @@ CAMLprim value ml_marshal_to_bigarray(value v, value f
++ 
++ CAMLprim value ml_unmarshal_from_bigarray(value b, value ofs)
++ {
+++  CAMLparam1(b); /* Holds [b] live until unmarshalling completes. */
+++  value result;
++   struct caml_bigarray *b_arr = Bigarray_val(b);
++-  return input_value_from_block (Array_data (b_arr, ofs),
+++  result = input_value_from_block (Array_data (b_arr, ofs),
++                                  b_arr->dim[0] - Long_val(ofs));
+++  CAMLreturn(result);
++ }
++ 
++ CAMLprim value ml_blit_string_to_bigarray
++ (value s, value i, value a, value j, value l)
++ {
++-  char *src = String_val(s) + Int_val(i);
+++  char *src = String_val(s) + Long_val(i);
++   char *dest = Array_data(Bigarray_val(a), j);
++   memcpy(dest, src, Long_val(l));
++   return Val_unit;

--- a/var/spack/repos/builtin/packages/unison/package.py
+++ b/var/spack/repos/builtin/packages/unison/package.py
@@ -15,18 +15,22 @@ class Unison(Package):
        other."""
 
     homepage = "https://www.cis.upenn.edu/~bcpierce/unison/"
-    url      = "https://www.seas.upenn.edu/~bcpierce/unison//download/releases/stable/unison-2.48.4.tar.gz"
+    url      = "https://github.com/bcpierce00/unison/archive/v2.51.2.tar.gz"
+    maintainers = ["hseara"]
 
-    version('2.48.4', sha256='30aa53cd671d673580104f04be3cf81ac1e20a2e8baaf7274498739d59e99de8')
+    version('2.51.2', sha256='a2efcbeab651be6df69cc9b253011a07955ecb91fb407a219719451197849d5e')
+    version('2.48.15v4', sha256='f8c7e982634bbe1ed6510fe5b36b6c5c55c06caefddafdd9edc08812305fdeec')
 
-    depends_on('ocaml', type='build')
+    depends_on('ocaml@4.10.0:~force-safe-string', type='build')
+
+    patch('large.patch', level=0)
+    patch('4.08-compatibility.patch', when='^ocaml@4.08:')
 
     parallel = False
 
     def install(self, spec, prefix):
-        make('./mkProjectInfo')
-        make('UISTYLE=text')
+        make('UISTYLE=text DEBUGGING=false THREADS=true')
 
         mkdirp(prefix.bin)
-        install('unison', prefix.bin)
+        install('src/unison', prefix.bin)
         set_executable(join_path(prefix.bin, 'unison'))


### PR DESCRIPTION
The current package does not work. Updated to the latest unison version.

Also several ocaml versions which it depends on do not compile, e.g. 4.09.0.
Added compilation option that is required for many ocaml projects and bumped 
4.10.0 as a prerequisite.

The patches are taken from archlinux.or and are required to [build the package](https://github.com/bcpierce00/unison/issues/277)

The patches can be found [here](https://git.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/unison).
