### PR TITLE
netlib-scalapack: Specify MPI's location for Fujitsu-MPI.

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -82,7 +82,8 @@ class NetlibScalapack(CMakePackage):
                 "-DCMAKE_Fortran_FLAGS=%s" % self.compiler.fc_pic_flag
             ])
 
-        if '^fujitsu-mpi' in spec:
+        # Specify Fujitsu-MPI's location
+        if spec.satisfies('%fj') and '^fujitsu-mpi' in spec:
             options.extend([
                 '-DMPI_C_COMPILER=%s'       % spec['mpi'].mpicc,
                 '-DMPI_CXX_COMPILER=%s'     % spec['mpi'].mpicxx,

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -82,6 +82,14 @@ class NetlibScalapack(CMakePackage):
                 "-DCMAKE_Fortran_FLAGS=%s" % self.compiler.fc_pic_flag
             ])
 
+        if '^fujitsu-mpi' in spec:
+            options.extend([
+                '-DMPI_C_COMPILER=%s'       % spec['mpi'].mpicc,
+                '-DMPI_CXX_COMPILER=%s'     % spec['mpi'].mpicxx,
+                '-DMPI_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
+                '-DMPI_BASE_DIR=%s' % spec['mpi'].prefix
+            ])
+
         return options
 
     @run_after('install')


### PR DESCRIPTION
Fujitsu-MPI wrapper commands aren't recognized from 'FindMPI' function of 'cmake'.
So, If we are using the Fujitsu compiler and Fujitsu MPI, specify the MPI path information clearly.
This fix will be removed after our considering the fundamental solution in 'cmake'.