### PR TITLE
ffmpeg: set compilers command.

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -110,8 +110,8 @@ class Ffmpeg(AutotoolsPackage):
         spec = self.spec
         config_args = [
             '--enable-pic',
-            '--cc={}'.format(spack_cc),
-            '--cxx={}'.format(spack_cxx),
+            '--cc={0}'.format(spack_cc),
+            '--cxx={0}'.format(spack_cxx)
         ]
 
         # '+X' meta variant #

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -108,7 +108,11 @@ class Ffmpeg(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = ['--enable-pic']
+        config_args = [
+            '--enable-pic',
+            '--cc={}'.format(spack_cc),
+            '--cxx={}'.format(spack_cxx),
+        ]
 
         # '+X' meta variant #
 


### PR DESCRIPTION
ffmpeg is specifies C and c++ compilers by --cc and --cxx options.
This PR is added --cc and --cxx options to specify compileres.