### PR TITLE
Fix typo for allow_sgid

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -160,4 +160,4 @@ config:
 
   # Set to 'false' to allow installation on filesystems that doesn't allow setgid bit
   # manipulation by unprivileged user (e.g. AFS)
-  config:allow_sgid: true
+  allow_sgid: true


### PR DESCRIPTION
fixes #14425

The config: prefix should be included in the actual option name and makes it impossible to change this option.