### PR TITLE
bugfix: local import in spec.py

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2134,6 +2134,8 @@ class Spec(object):
         consistent with requirements of its packages. See flatten() and
         normalize() for more details on this.
         """
+        import spack.concretize
+
         if not self.name:
             raise spack.error.SpecError(
                 "Attempting to concretize anonymous spec")
@@ -2145,8 +2147,7 @@ class Spec(object):
         force = False
 
         user_spec_deps = self.flat_dependencies(copy=False)
-        import spack.concretize as ce
-        concretizer = ce.Concretizer(self.copy())
+        concretizer = spack.concretize.Concretizer(self.copy())
         while changed:
             changes = (self.normalize(force, tests=tests,
                                       user_spec_deps=user_spec_deps),

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2145,8 +2145,8 @@ class Spec(object):
         force = False
 
         user_spec_deps = self.flat_dependencies(copy=False)
-        import spack.concretize
-        concretizer = spack.concretize.Concretizer(self.copy())
+        import spack.concretize as ce
+        concretizer = ce.Concretizer(self.copy())
         while changed:
             changes = (self.normalize(force, tests=tests,
                                       user_spec_deps=user_spec_deps),

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -633,3 +633,8 @@ class TestConcretize(object):
         s = Spec('mpileaks %gcc@4.5:')
         s.concretize()
         assert str(s.compiler.version) == '4.5.0'
+
+    def test_concretize_anonymous(self):
+        with pytest.raises(spack.error.SpecError):
+            s = Spec('+variant')
+            s.concretize()


### PR DESCRIPTION
Without this we have:
```console
$ spack spec apple=banana
Input spec
--------------------------------
 apple=banana

Concretized
--------------------------------
==> Error: local variable 'spack' referenced before assignment
```
With this:
```console
$ spack spec apple=banana
Input spec
--------------------------------
 apple=banana

Concretized
--------------------------------
==> Error: Attempting to concretize anonymous spec
```
@alalazo do we need this local import at all?