### PR TITLE
Set the BOOST_ROOT environment variable when library is loaded

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -512,3 +512,6 @@ class Boost(Package):
         # on Darwin; correct this
         if (sys.platform == 'darwin') and ('+shared' in spec):
             fix_darwin_install_name(prefix.lib)
+
+    def setup_run_environment(self, env):
+        env.set('BOOST_ROOT', join_path(self.prefix))

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -514,4 +514,4 @@ class Boost(Package):
             fix_darwin_install_name(prefix.lib)
 
     def setup_run_environment(self, env):
-        env.set('BOOST_ROOT', join_path(self.prefix))
+        env.set('BOOST_ROOT', self.prefix)


### PR DESCRIPTION
Some applications will look at the BOOST_ROOT environment variable to find where boost is built. I have added this into the boost build so that BOOST_ROOT will be set when the library is loaded.