### PR TITLE
libxv: Issue #16820, make videoproto a link dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -19,6 +19,6 @@ class Libxv(AutotoolsPackage, XorgPackage):
     depends_on('libxext')
 
     depends_on('xextproto', type='build')
-    depends_on('videoproto', type=('build', 'link'))
+    depends_on('videoproto')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -19,6 +19,6 @@ class Libxv(AutotoolsPackage, XorgPackage):
     depends_on('libxext')
 
     depends_on('xextproto', type='build')
-    depends_on('videoproto', type='build')
+    depends_on('videoproto', type=('build', 'link'))
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
See all issue #16820
libxv includes Xvlib.h, which has a line
which is part of videoproto package

But had videoproto as a build dependency only.
This patch makes it a link dependency as well as build dependency.