### PR TITLE
spack module_cmd: set LD_LIBRARY_PATH for python in subshell.

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -92,7 +92,7 @@ required_command_properties = ['level', 'section', 'description']
 
 #: Recorded directory where spack command was originally invoked
 spack_working_dir = None
-
+spack_ld_library_path = os.environ['LD_LIBRARY_PATH']
 
 def set_working_dir():
     """Change the working directory to getcwd, or spack prefix if no cwd."""

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -94,6 +94,7 @@ required_command_properties = ['level', 'section', 'description']
 spack_working_dir = None
 spack_ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
 
+
 def set_working_dir():
     """Change the working directory to getcwd, or spack prefix if no cwd."""
     global spack_working_dir

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -92,7 +92,7 @@ required_command_properties = ['level', 'section', 'description']
 
 #: Recorded directory where spack command was originally invoked
 spack_working_dir = None
-spack_ld_library_path = os.environ['LD_LIBRARY_PATH']
+spack_ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
 
 def set_working_dir():
     """Change the working directory to getcwd, or spack prefix if no cwd."""

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+import os
 
 import llnl.util.filesystem as fs
-
+import spack
 import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 
 
-def test_read_unicode(tmpdir):
+def test_read_unicode(tmpdir, working_env):
     script_name = 'print_unicode.py'
 
     with tmpdir.as_cwd():
-
+        os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
         # make a script that prints some unicode
         with open(script_name, 'w') as f:
             f.write('''#!{0}

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -12,7 +12,6 @@ import os
 import sys
 import json
 import re
-import sys
 
 import spack
 import llnl.util.tty as tty

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -12,7 +12,9 @@ import os
 import sys
 import json
 import re
+import sys
 
+import spack
 import llnl.util.tty as tty
 
 # This list is not exhaustive. Currently we only use load and unload
@@ -25,9 +27,18 @@ _cmd_template = "'module ' + ' '.join(args) + ' 2>&1'"
 def module(*args):
     module_cmd = eval(_cmd_template)  # So we can monkeypatch for testing
     if args[0] in module_change_commands:
+        os.environ['SPACK_LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
+
         # Do the module manipulation, then output the environment in JSON
         # and read the JSON back in the parent process to update os.environ
-        module_cmd += ' >/dev/null;' + sys.executable + ' -c %s' % py_cmd
+        # Manipulate LD_LIBRARY_PATH so that python will run properly, then
+        # restore the new value
+        module_cmd += ' >/dev/null;'
+        module_cmd += 'export SPACK_NEW_LD_LIBRARY_PATH=$LD_LIBRARY_PATH;'
+        module_cmd += 'LD_LIBRARY_PATH="$SPACK_LD_LIBRARY_PATH" '
+        module_cmd += '%s -c %s;' % (sys.executable, py_cmd)
+        module_cmd += 'echo $SPACK_NEW_LD_LIBRARY_PATH'
+
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
@@ -36,13 +47,17 @@ def module(*args):
 
         # Cray modules spit out warnings that we cannot supress.
         # This hack skips to the last output (the environment)
-        env_output = str(module_p.communicate()[0].decode())
-        env = env_output.strip().split('\n')[-1]
+        env_output = str(module_p.communicate()[0].decode()).strip().split('\n')
+        env = env_output[-2]
+        new_ld_library_path = env_output[-1]
 
         # Update os.environ with new dict
         env_dict = json.loads(env)
         os.environ.clear()
         os.environ.update(env_dict)
+        if new_ld_library_path:
+            os.environ['LD_LIBRARY_PATH'] = new_ld_library_path
+
     else:
         # Simply execute commands that don't change state and return output
         module_p = subprocess.Popen(module_cmd,


### PR DESCRIPTION
We have a long-standing bug on systems for which the system python does not RPATH its own libraries. This PR fixes that by recording the LD_LIBRARY_PATH at Spack startup and using it to run `sys.executable` when we need python in a subshell.

This is refactored from #11989, which was too large in scope.