### PR TITLE
Per os config

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -608,6 +608,12 @@ def _add_platform_scope(cfg, scope_type, name, path):
     plat_path = os.path.join(path, platform)
     cfg.push_scope(scope_type(plat_name, plat_path))
 
+def _add_os_scope(cfg, scope_type, name, path):
+    """Add a platform-specific subdirectory for the current platform."""
+    os = spack.architecture.sys_type().split('-')[1]
+    os_name = '%s/%s' % (name, os)
+    os_path = os.path.join(path, os)
+    cfg.push_scope(scope_type(os_name, os_path))
 
 def _add_command_line_scopes(cfg, command_line_scopes):
     """Add additional scopes from the --config-scope argument.
@@ -626,6 +632,7 @@ def _add_command_line_scopes(cfg, command_line_scopes):
         name = 'cmd_scope_%d' % i
         cfg.push_scope(ImmutableConfigScope(name, path))
         _add_platform_scope(cfg, ImmutableConfigScope, name, path)
+        _add_os_scope(cfg, ImmutableConfigScope, name, path)
 
 
 def _config():
@@ -651,6 +658,7 @@ def _config():
 
         # Each scope can have per-platfom overrides in subdirectories
         _add_platform_scope(cfg, ConfigScope, name, path)
+        _add_os_scope(cfg, ConfigScope, name, path)
 
     # add command-line scopes
     _add_command_line_scopes(cfg, command_line_scopes)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -170,6 +170,7 @@ class ConfigScope(object):
 
 class SingleFileScope(ConfigScope):
     """This class represents a configuration scope in a single YAML file."""
+
     def __init__(self, name, path, schema, yaml_path=None):
         """Similar to ``ConfigScope`` but can be embedded in another schema.
 
@@ -275,6 +276,7 @@ class InternalConfigScope(ConfigScope):
     config file settings are accessed the same way, and Spack can easily
     override settings from files.
     """
+
     def __init__(self, name, data=None):
         super(InternalConfigScope, self).__init__(name, None)
         self.sections = syaml.syaml_dict()
@@ -608,12 +610,14 @@ def _add_platform_scope(cfg, scope_type, name, path):
     plat_path = os.path.join(path, platform)
     cfg.push_scope(scope_type(plat_name, plat_path))
 
+
 def _add_os_scope(cfg, scope_type, name, path):
     """Add an os-specific subdirectory for the current platform."""
     os = spack.architecture.sys_type().split('-')[1]
     os_name = '%s/%s' % (name, os)
     os_path = '%s/%s' % (path, os)
     cfg.push_scope(scope_type(os_name, os_path))
+
 
 def _add_command_line_scopes(cfg, command_line_scopes):
     """Add additional scopes from the --config-scope argument.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -613,9 +613,9 @@ def _add_platform_scope(cfg, scope_type, name, path):
 
 def _add_os_scope(cfg, scope_type, name, path):
     """Add an os-specific subdirectory for the current platform."""
-    os = spack.architecture.sys_type().split('-')[1]
-    os_name = '%s/%s' % (name, os)
-    os_path = '%s/%s' % (path, os)
+    oss = spack.architecture.sys_type().split('-')[1]
+    os_name = '%s/%s' % (name, oss)
+    os_path = os.path.join(path, oss)
     cfg.push_scope(scope_type(os_name, os_path))
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -609,10 +609,10 @@ def _add_platform_scope(cfg, scope_type, name, path):
     cfg.push_scope(scope_type(plat_name, plat_path))
 
 def _add_os_scope(cfg, scope_type, name, path):
-    """Add a platform-specific subdirectory for the current platform."""
+    """Add an os-specific subdirectory for the current platform."""
     os = spack.architecture.sys_type().split('-')[1]
     os_name = '%s/%s' % (name, os)
-    os_path = os.path.join(path, os)
+    os_path = '%s/%s' % (path, os)
     cfg.push_scope(scope_type(os_name, os_path))
 
 def _add_command_line_scopes(cfg, command_line_scopes):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -588,10 +588,10 @@ def _add_platform_scope(cfg, scope_type, name, path):
     cfg.push_scope(scope_type(plat_name, plat_path))
 
 def _add_os_scope(cfg, scope_type, name, path):
-    """Add a platform-specific subdirectory for the current platform."""
+    """Add an os-specific subdirectory for the current platform."""
     os = spack.architecture.sys_type().split('-')[1]
     os_name = '%s/%s' % (name, os)
-    os_path = os.path.join(path, os)
+    os_path = '%s/%s' % (path, os)
     cfg.push_scope(scope_type(os_name, os_path))
 
 def _add_command_line_scopes(cfg, command_line_scopes):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -587,6 +587,12 @@ def _add_platform_scope(cfg, scope_type, name, path):
     plat_path = os.path.join(path, platform)
     cfg.push_scope(scope_type(plat_name, plat_path))
 
+def _add_os_scope(cfg, scope_type, name, path):
+    """Add a platform-specific subdirectory for the current platform."""
+    os = spack.architecture.sys_type().split('-')[1]
+    os_name = '%s/%s' % (name, os)
+    os_path = os.path.join(path, os)
+    cfg.push_scope(scope_type(os_name, os_path))
 
 def _add_command_line_scopes(cfg, command_line_scopes):
     """Add additional scopes from the --config-scope argument.
@@ -605,6 +611,7 @@ def _add_command_line_scopes(cfg, command_line_scopes):
         name = 'cmd_scope_%d' % i
         cfg.push_scope(ImmutableConfigScope(name, path))
         _add_platform_scope(cfg, ImmutableConfigScope, name, path)
+        _add_os_scope(cfg, ImmutableConfigScope, name, path)
 
 
 def _config():
@@ -630,6 +637,7 @@ def _config():
 
         # Each scope can have per-platfom overrides in subdirectories
         _add_platform_scope(cfg, ConfigScope, name, path)
+        _add_os_scope(cfg, ConfigScope, name, path)
 
     # add command-line scopes
     _add_command_line_scopes(cfg, command_line_scopes)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -169,6 +169,7 @@ class ConfigScope(object):
 
 class SingleFileScope(ConfigScope):
     """This class represents a configuration scope in a single YAML file."""
+
     def __init__(self, name, path, schema, yaml_path=None):
         """Similar to ``ConfigScope`` but can be embedded in another schema.
 
@@ -274,6 +275,7 @@ class InternalConfigScope(ConfigScope):
     config file settings are accessed the same way, and Spack can easily
     override settings from files.
     """
+
     def __init__(self, name, data=None):
         super(InternalConfigScope, self).__init__(name, None)
         self.sections = syaml.syaml_dict()
@@ -587,12 +589,14 @@ def _add_platform_scope(cfg, scope_type, name, path):
     plat_path = os.path.join(path, platform)
     cfg.push_scope(scope_type(plat_name, plat_path))
 
+
 def _add_os_scope(cfg, scope_type, name, path):
     """Add an os-specific subdirectory for the current platform."""
     os = spack.architecture.sys_type().split('-')[1]
     os_name = '%s/%s' % (name, os)
     os_path = '%s/%s' % (path, os)
     cfg.push_scope(scope_type(os_name, os_path))
+
 
 def _add_command_line_scopes(cfg, command_line_scopes):
     """Add additional scopes from the --config-scope argument.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -170,7 +170,6 @@ class ConfigScope(object):
 
 class SingleFileScope(ConfigScope):
     """This class represents a configuration scope in a single YAML file."""
-
     def __init__(self, name, path, schema, yaml_path=None):
         """Similar to ``ConfigScope`` but can be embedded in another schema.
 
@@ -276,7 +275,6 @@ class InternalConfigScope(ConfigScope):
     config file settings are accessed the same way, and Spack can easily
     override settings from files.
     """
-
     def __init__(self, name, data=None):
         super(InternalConfigScope, self).__init__(name, None)
         self.sections = syaml.syaml_dict()


### PR DESCRIPTION
This is a resubmit of https://github.com/spack/spack/pull/13686
I've rebased the branch off of develop again.

This is a really simple change to allow per-operating-system config files; This is very useful in particular for shared filesystems, if you want to support,say, multiple CentOS releases, defining
what packages are on the system in packages.yaml for example needs to be differrent per
operating system, as opposed to other scope options.  With this patch you can have
$SPACK_ROOT/etc/spack/centos6/packages.yaml
$SPACK_ROOT/etc/spack/centos7/packages.yaml
all applying to the appropriate operating system.
