### PR TITLE
Ignore __pycache__ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /var/spack/environments
 /var/spack/repos/*/index.yaml
 /var/spack/repos/*/lock
+__pycache__/
 *.pyc
 /opt
 *~


### PR DESCRIPTION
I'm trying out Spack on Windows using the Ubuntu WSL, which contains Python 3.8. So far, everything works fine, but I noticed the following untracked directory:
```
lib/spack/external/jsonschema/__pycache__/
```
There are `__pycache__` directories throughout Spack, but they are normally ignored because we ignore `*.pyc` files. In this case, the offending directory contains a `exceptions.cpython-38.pyc.140647793774000` file. I don't know if this is specific to Python 3.8, but https://github.com/github/gitignore/blob/master/Python.gitignore includes `__pycache__`, so we should too.

Honestly, we should probably copy all of https://github.com/github/gitignore/blob/master/Python.gitignore into our `.gitignore`. Let me know if you want me to do that.