### PR TITLE
Update error message when `UnavailableCompilerVersionError` is triggered

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -727,7 +727,9 @@ class UnavailableCompilerVersionError(spack.error.SpackError):
             )
 
         super(UnavailableCompilerVersionError, self).__init__(
-            err_msg, "Run 'spack compiler find' to add compilers.")
+            err_msg, "Run 'spack compiler find' to add compilers or "
+            "'spack compilers' to see which compilers are already recognized"
+            " by spack.")
 
 
 class NoValidVersionError(spack.error.SpackError):


### PR DESCRIPTION
`spack compilers` ended up being more useful for me than `spack compiler find` when I encountered this error.

Thank you!