### PR TITLE
Opencv: fix to build version 3.2.0 on Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/opencv3.2_fj.patch
+++ b/var/spack/repos/builtin/packages/opencv/opencv3.2_fj.patch
@@ -1,0 +1,20 @@
+diff -ru opencv-3.2.0.org/modules/core/include/opencv2/core/hal/intrin_neon.hpp opencv-3.2.0/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+--- opencv-3.2.0.org/modules/core/include/opencv2/core/hal/intrin_neon.hpp      2016-12-23 21:54:44.000000000 +0900
++++ opencv-3.2.0/modules/core/include/opencv2/core/hal/intrin_neon.hpp  2020-05-27 14:39:11.288700481 +0900
+@@ -282,10 +282,16 @@
+ { return (int16x4_t)a; }
+ template <typename T> static inline float16x4_t vreinterpret_f16_s16(T a)
+ { return (float16x4_t)a; }
++#ifdef vld1_f16
++#undef vld1_f16
++#endif
+ template <typename T> static inline float16x4_t vld1_f16(const T* ptr)
+ { return vreinterpret_f16_s16(vld1_s16((const short*)ptr)); }
++#ifdef vst1_f16
++#undef vst1_f16
++#endif
+ template <typename T> static inline void vst1_f16(T* ptr, float16x4_t a)
+ { vst1_s16((short*)ptr, vreinterpret_s16_f16(a)); }
+
+ struct v_float16x4
+ {

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -126,6 +126,7 @@ class Opencv(CMakePackage, CudaPackage):
     patch('opencv3.2_regacyvtk.patch', when='@3.2+vtk')
     patch('opencv3.2_ffmpeg.patch', when='@3.2+videoio')
     patch('opencv3.2_python3.7.patch', when='@3.2+python')
+    patch('opencv3.2_fj.patch', when='@3.2 %fj')
 
     depends_on('eigen', when='+eigen')
     depends_on('zlib', when='+zlib')


### PR DESCRIPTION
OpenCV 3.2.0 is not build by Fujitsu Compiler because arm_neon.h.
This PR is fixed it.