### PR TITLE
Update Stanford Legion Package

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -21,24 +21,24 @@ class Legion(CMakePackage):
        that is orthogonal to correctness, thereby enabling easy porting and
        tuning of Legion applications to new architectures.
     """
-    homepage = "http://legion.stanford.edu/"
-    url      = "https://github.com/StanfordLegion/legion/tarball/legion-17.02.0"
-    git      = "https://github.com/StanfordLegion/legion.git"
+    homepage = "http://legion.stanford.edu"
+    git      = "https://gitlab.com/StanfordLegion/legion.git"
 
     version('master', branch='master')
     version('ctrl-rep', branch='control_replication')
-    version('19.12.0', sha256='ea517638de7256723bb9c119796d4d9d4ef662c52d0151ad24af5288e5a72e7d')
-    version('19.09.1', sha256='c507133fb9dce16b7fcccd7eb2933d13cce96ecf835da60a27c0f66840cabf51')
-    version('19.09.0', sha256='a01c3e3c6698cafb64b77a66341cc06d039faed4fa31b764159f021b94ce13e8')
-    version('19.06.0', sha256='31cd97e9264c510ab83b1f9e8e1e6bf72021a0c6ee4a028966fce08736e39fbf')
-    version('19.04.0', sha256='279bbc8dcdab4c75be570318989a9fc9821178143e9db9c3f62e58bf9070b5ac')
-    version('18.12.0', sha256='71f2c409722975c0ad92f2caffcc9eaa9260f7035e2b55b731d819eb6a94016c')
-    version('18.09.0', sha256='58c5a3072d2b5086225982563c23524692ca5758cbfda8d0f0a4f00ef17b3b8d')
-    version('18.05.0', sha256='4c3cef548b3a459827e4c36b5963c06b6fcf0a4ca1800fbb0f73e6ba3b1cced4')
-    version('18.02.0', sha256='e08aeef98003593391a56f11a99d9d65af49647fe87a2a5e8837c8682a337a60')
-    version('17.10.0', sha256='af4f1e9215e57c4aac4805ae2bf53defe13eeaf192576bf5a702978f43171b1e')
-    version('17.08.0', sha256='20aabdb0fabb1e32aa713cd5fa406525093f8dad33fca5d23046408d42d3c7b3')
-    version('17.02.0', sha256='423d8699729b0e7fef663740e239aa722cca544f6bda8c9f782eaba4274bf60a')
+    version('20.03.0', tag='legion-20.03.0')
+    version('19.12.0', tag='legion-19.12.0')
+    version('19.09.1', tag='legion-19.09.1')
+    version('19.09.0', tag='legion-19.09.0')
+    version('19.06.0', tag='legion-19.06.0')
+    version('19.04.0', tag='legion-19.04.0')
+    version('18.12.0', tag='legion-18.12.0')
+    version('18.09.0', tag='legion-18.09.0')
+    version('18.05.0', tag='legion-18.05.0')
+    version('18.02.0', tag='legion-18.02.0')
+    version('17.10.0', tag='legion-17.10.0')
+    version('17.08.0', tag='legion-17.08.0')
+    version('17.02.0', tag='legion-17.02.0')
 
     variant('mpi', default=True,
             description='Build on top of mpi conduit for mpi inoperability')


### PR DESCRIPTION
- Switch to real project repository (previous was a mirror that is not
  kept up-to-date)
- Changed sha256 hashes to named tags
- Added version 20.03.0