### PR TITLE
Fix error when no package is specified

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -759,8 +759,8 @@ class Repo(object):
 
         """
         parent = None
-        for l in range(1, len(self._names) + 1):
-            ns = '.'.join(self._names[:l])
+        for length in range(1, len(self._names) + 1):
+            ns = '.'.join(self._names[:length])
 
             if ns not in sys.modules:
                 module = SpackNamespace(ns)
@@ -773,7 +773,7 @@ class Repo(object):
                 # This ensures that we can do things like:
                 #    import spack.pkg.builtin.mpich as mpich
                 if parent:
-                    modname = self._names[l - 1]
+                    modname = self._names[length - 1]
                     setattr(parent, modname, module)
             else:
                 # no need to set up a module

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1279,7 +1279,9 @@ class UnknownPackageError(UnknownEntityError):
         # special handling for specs that may have been intended as filenames
         # prompt the user to ask whether they intended to write './<name>'
         long_msg = None
-        if name.endswith(".yaml"):
+        if not name:
+            long_msg = "No package name has been specified."
+        elif name.endswith(".yaml"):
             long_msg = "Did you mean to specify a filename with './%s'?" % name
 
         super(UnknownPackageError, self).__init__(msg, long_msg)


### PR DESCRIPTION
Not specifying a package name currently causes an unhelpful error message:
```console
$ spack spec -I ^intel-mkl
Input spec
--------------------------------
==> Error: 'NoneType' object has no attribute 'endswith'
```

This change fixes it so we get a slightly better one:
```console
$ spack spec -I ^intel-mkl
Input spec
--------------------------------
==> Error: Package 'None' not found.
No package name has been specified.
```