### PR TITLE
AbstractVariant: fix satisfaction check 

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -657,7 +657,7 @@ class FlagMap(lang.HashableMap):
             return all(k in other and set(self[k]) == set(other[k])
                        for k in self)
 
-        return all(set(self[k]) <= set(other(k))
+        return all(set(self[k]) == set(other[k])
                    for k in self if k in other)
 
     def constrain(self, other):
@@ -2726,9 +2726,10 @@ class Spec(object):
                 and not self.compiler.compatible(other.compiler):
             return False
 
-        # no need to check check compiler_flag compatibility
-        # because compiler flags can only be incompatible if spec is concrete
-        # and we already checked for that.
+        # Check compiler flag compatibility
+        if self.compiler_flags and other.compiler_flags \
+                and not self.compiler_flags.compatible(other.compiler_flags):
+            return False
 
         # if dep check dep compat
         if deps and not other.satisfies_dependencies(self):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -346,6 +346,8 @@ class TestSpecSematics(object):
         b = Spec(spec_str)
         assert not a.satisfies(b)
         assert not a.satisfies(spec_str)
+        assert not a.compatible(b)
+        assert not a.compatible(spec_str)
         # A concrete spec cannot be constrained further
         with pytest.raises(UnsatisfiableSpecError):
             a.constrain(b)
@@ -354,8 +356,8 @@ class TestSpecSematics(object):
         spec_str = 'multivalue_variant foo="bar,baz"'
         b = Spec(spec_str)
         # The specs are abstract and they **could** be constrained
-        assert a.satisfies(b)
-        assert a.satisfies(spec_str)
+        assert a.compatible(b)
+        assert a.compatible(spec_str)
         # An abstract spec can instead be constrained
         assert a.constrain(b)
 
@@ -366,6 +368,8 @@ class TestSpecSematics(object):
         b = Spec(spec_str)
         assert not a.satisfies(b)
         assert not a.satisfies(spec_str)
+        assert not a.compatible(b)
+        assert not a.compatible(spec_str)
         # A concrete spec cannot be constrained further
         with pytest.raises(UnsatisfiableSpecError):
             a.constrain(b)
@@ -374,8 +378,8 @@ class TestSpecSematics(object):
         spec_str = 'multivalue_variant foo="bar,baz,quux"'
         b = Spec(spec_str)
         # The specs are abstract and they **could** be constrained
-        assert a.satisfies(b)
-        assert a.satisfies(spec_str)
+        assert a.compatible(b)
+        assert a.compatible(spec_str)
         # An abstract spec can instead be constrained
         assert a.constrain(b)
         # ...but will fail during concretization if there are
@@ -390,8 +394,7 @@ class TestSpecSematics(object):
         # The specs are abstract and they **could** be constrained,
         # as before concretization I don't know which type of variant
         # I have (if it is not a BV)
-        assert a.satisfies(b)
-        assert a.satisfies(spec_str)
+        assert a.compatible(b)
         # A variant cannot be parsed as single-valued until we try to
         # concretize. This means that we can constrain the variant above
         assert a.constrain(b)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -45,15 +45,19 @@ def check_satisfies(target_spec, constraint_spec, target_concrete=False):
 
     # If target satisfies constraint, then we should be able to constrain
     # constraint by target.  Reverse is not always true.
-    constraint.copy().constrain(target)
+    # if we can constrain, it's also compatible.
+    const = constraint.copy()
+    const.compatible(target)
+    const.constrain(target)
 
 
-def check_unsatisfiable(target_spec, constraint_spec, target_concrete=False):
+def check_unsatisfiable(target_spec, constraint_spec, target_concrete=False, compatible=False):
 
     target = make_spec(target_spec, target_concrete)
     constraint = _specify(constraint_spec)
 
     assert not target.satisfies(constraint)
+    assert target.compatible(constraint) == compatible
 
     with pytest.raises(UnsatisfiableSpecError):
         constraint.copy().constrain(target)
@@ -162,7 +166,8 @@ class TestSpecSematics(object):
         check_unsatisfiable('foo@4.0%pgi@4.5', '@1:3%pgi@4.4:4.6')
 
         check_satisfies('foo %gcc@4.7.3', '%gcc@4.7')
-        check_unsatisfiable('foo %gcc@4.7', '%gcc@4.7.3')
+        # This is unsatisfiable but the reverse is compatible
+        check_unsatisfiable('foo %gcc@4.7', '%gcc@4.7.3', compatible=True)
 
     def test_satisfies_architecture(self):
         check_satisfies(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -51,8 +51,8 @@ def check_satisfies(target_spec, constraint_spec, target_concrete=False):
     const.constrain(target)
 
 
-def check_unsatisfiable(target_spec, constraint_spec, target_concrete=False, compatible=False):
-
+def check_unsatisfiable(target_spec, constraint_spec, target_concrete=False,
+                        compatible=False):
     target = make_spec(target_spec, target_concrete)
     constraint = _specify(constraint_spec)
 

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -488,7 +488,8 @@ class VariantMap(lang.HashableMap):
         if not strict_or_concrete:
             to_be_checked = filter(lambda x: x in self, to_be_checked)
 
-        return all(k in self and self[k].satisfies(other[k]) for k in to_be_checked)
+        return all(k in self and self[k].satisfies(other[k])
+                   for k in to_be_checked)
 
     def compatible(self, other):
         """Returns True iff it's possible to constrain this VariantMap by other


### PR DESCRIPTION
With abstract and multi-value variants "other.satisfies(self)" cannot any longer be a perfect check for whether it is possible to "self.constrain(other)". @alalazo recognized this and created `Variant.compatible` methods for the classes that derive from `AbstractVariant`.

This PR fixes `AbstractVariant.satisfies` to properly implement satisfaction, rather than compatibility. This requires adding a method to the `Spec` class that checks for compatibility between two specs, as satisfiability no longer works to check for ability to constrain one spec by another.

This in turn fixes a bug in SpecList matrix exclusion for non-boolean variants.

Fixes #16841 