### PR TITLE
suite-sparse: Change the condition to add C11 flag.

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -102,7 +102,7 @@ class SuiteSparse(Package):
         # GraphBLAS/Demo/Program/wildtype_demo.c. For many compilers this is
         # not an issue because c11 or newer is their default. However, for some
         # compilers (e.g. xlc) the c11 flag is necessary.
-        if spec.satisfies('@5.4:'):
+        if spec.satisfies('@5.4:5.7.1') and ('%xl' in spec or '%xl_r' in spec):
             make_args += ['CFLAGS+=%s' % self.compiler.c11_flag]
 
         # 64bit blas in UMFPACK:


### PR DESCRIPTION
Suite-sparse combines the `CFLAGS` values into `CF` macro.
However, since `CF` is combined to the compile command during C++ compilation too,
so if `CF` has options that C++ does not accept, an error occurs.
This error is the result of commit of https://github.com/spack/spack/pull/15500.

This fix creates a C++ only macro `CXXF` from `CF`. Modify to use `CXXF` when compiling C ++.
Also modify pgi.patch, which is affected by the above modification.