### PR TITLE
revocap-refiner: add space and remove unused function.

### DIFF
--- a/var/spack/repos/builtin/packages/revocap-refiner/add_space.patch
+++ b/var/spack/repos/builtin/packages/revocap-refiner/add_space.patch
@@ -1,0 +1,37 @@
+--- spack-src/Common/kmbDebug.h.org	2020-05-26 14:12:24.977659640 +0900
++++ spack-src/Common/kmbDebug.h	2020-05-26 14:15:11.118470571 +0900
+@@ -52,29 +52,29 @@
+ 	#define REVOCAP_Debug_X(format)
+ #else
+ 	/* _DEBUG マクロに関係なく出力 */
+-	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
++	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+ 
+ 	#if defined _DEBUG || _DEBUG_
+ 	#include <cstdio>
+-	#define REVOCAP_Debug(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
++	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+ 	#else
+ 	#define REVOCAP_Debug(format, ...)
+ 	#endif
+ 
+ 	#if ( _DEBUG >= 1 ) || ( _DEBUG_ >= 1 )
+-	#define REVOCAP_Debug_1(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
++	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+ 	#else
+ 	#define REVOCAP_Debug_1(format, ...)
+ 	#endif
+ 
+ 	#if ( _DEBUG >= 2 ) || ( _DEBUG_ >= 2 )
+-	#define REVOCAP_Debug_2(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
++	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+ 	#else
+ 	#define REVOCAP_Debug_2(format, ...)
+ 	#endif
+ 
+ 	#if ( _DEBUG >= 3 ) || ( _DEBUG_ >= 3 )
+-	#define REVOCAP_Debug_3(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
++	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+ 	#else
+ 	#define REVOCAP_Debug_3(format, ...)
+ 	#endif

--- a/var/spack/repos/builtin/packages/revocap-refiner/delete_getIndices.patch
+++ b/var/spack/repos/builtin/packages/revocap-refiner/delete_getIndices.patch
@@ -1,0 +1,28 @@
+--- spack-src/Geometry/kmbBucket.h.org	2020-05-28 11:42:08.438970353 +0900
++++ spack-src/Geometry/kmbBucket.h	2020-05-28 11:43:55.449496013 +0900
+@@ -348,12 +348,6 @@
+ 
+ 		int getIndex() const{ return it->first; };
+ 
+-		void getIndices(int &i,int &j,int &k) const{
+-			i = it->first / (ynum*znum);
+-			j = (it->first - i*ynum*znum) / znum;
+-			k = it->first - i*ynum*znum - j*znum;
+-		};
+-
+ 		iterator& operator++(void){ ++it; return *this; };
+ 
+ 		iterator  operator++(int n){
+@@ -391,12 +385,6 @@
+ 
+ 		int getIndex() const{ return it->first; };
+ 
+-		void getIndices(int &i,int &j,int &k) const{
+-			i = it->first / (ynum*znum);
+-			j = (it->first - i*ynum*znum) / znum;
+-			k = it->first - i*ynum*znum - j*znum;
+-		};
+-
+ 		const_iterator& operator++(void){ ++it; return *this; };
+ 
+ 		const_iterator operator++(int n){

--- a/var/spack/repos/builtin/packages/revocap-refiner/package.py
+++ b/var/spack/repos/builtin/packages/revocap-refiner/package.py
@@ -22,6 +22,11 @@ class RevocapRefiner(MakefilePackage):
 
     parallel = False
 
+    # add space between literal and identifier.
+    patch('add_space.patch')
+    # remove unused function getIndices.
+    patch('delete_getIndices.patch')
+
     def edit(self, spec, prefix):
         cflags = ['-O']
         cxxflags = ['-O',  self.compiler.cxx_pic_flag]


### PR DESCRIPTION
I found an error building `revocap-refiner`.
- error
```
  >> 28    Common/kmbDebug.h:55:66: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
```
I added space between literal and identifier, and removed unused function `getIndices`.

I submitted this pull request.
https://github.com/FrontISTR/REVOCAP_Refiner/pull/1