### PR TITLE
protobuf: support aarch64 @2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -8,12 +8,11 @@ from spack import *
 import spack.util.web
 
 
-class Protobuf(CMakePackage):
+class Protobuf(Package):
     """Google's data interchange format."""
 
     homepage = "https://developers.google.com/protocol-buffers"
     url      = "https://github.com/protocolbuffers/protobuf/archive/v3.10.1.tar.gz"
-    root_cmakelists_dir = "cmake"
 
     version('3.11.2',  sha256='e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67')
     version('3.11.1',  sha256='4f8e805825c53bbc3c9f6b6abc009b5b5679e4702bccfca1121c42ff5ec801c7')
@@ -36,6 +35,7 @@ class Protobuf(CMakePackage):
     version('3.2.0',   sha256='a839d3f1519ff9d68ab908de5a0f269650ef1fc501c10f6eefd4cae51d29b86f')
     version('3.1.0',   sha256='fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d')
     version('3.0.2',   sha256='a0a265bcc9d4e98c87416e59c33afc37cede9fb277292523739417e449b18c1e')
+    version('2.5.0',   sha256='c2665a7aa2ac1a206e61b28e014486e3de59009ea2be2bde9182e0847f38b62f')
 
     variant('shared', default=True,
             description='Enables the build of shared libraries')
@@ -43,18 +43,25 @@ class Protobuf(CMakePackage):
             description='The build type to build',
             values=('Debug', 'Release'))
 
+    depends_on('cmake', when='@3.0.2:', type='build')
     depends_on('zlib')
+    depends_on('autoconf', type='build', when='@2.5.0')
+    depends_on('automake', type='build', when='@2.5.0')
+    depends_on('libtool',  type='build', when='@2.5.0')
+    depends_on('m4',       type='build', when='@2.5.0')
 
     conflicts('%gcc@:4.6', when='@3.6.0:')  # Requires c++11
     conflicts('%gcc@:4.6', when='@3.2.0:3.3.0')  # Breaks
 
     # first fixed in 3.4.0: https://github.com/google/protobuf/pull/3406
-    patch('pkgconfig.patch', when='@:3.3.2')
+    patch('pkgconfig.patch', when='@3.0.2:3.3.2')
 
     patch('intel-v1.patch', when='@3.2:@3.6 %intel')
 
     # See https://github.com/protocolbuffers/protobuf/pull/7197
     patch('intel-v2.patch', when='@3.7:@3.11.4 %intel')
+
+    patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
     def fetch_remote_versions(self):
         """Ignore additional source artifacts uploaded with releases,
@@ -68,6 +75,7 @@ class Protobuf(CMakePackage):
 
     def cmake_args(self):
         args = [
+            '-DCMAKE_INSTALL_PREFIX=%s' % self.prefix,
             '-DBUILD_SHARED_LIBS=%s' % int('+shared' in self.spec),
             '-Dprotobuf_BUILD_TESTS:BOOL=OFF',
             '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'
@@ -75,3 +83,28 @@ class Protobuf(CMakePackage):
         if sys.platform == 'darwin':
             args.extend(['-DCMAKE_MACOSX_RPATH=ON'])
         return args
+
+    @when('@3.0.2:')
+    def install(self, spec, prefix):
+        args = self.cmake_args()
+
+        source_directory = join_path(self.stage.source_path, 'cmake')
+        build_directory = join_path(source_directory, 'build')
+
+        with working_dir(build_directory, create=True):
+            cmake(source_directory, *args)
+            make()
+            make('install')
+
+    def configure_args(self):
+        args = []
+        args.append('--prefix=%s' % self.prefix)
+        return args
+
+    @when('@2.5.0')
+    def install(self, spec, prefix):
+        args = self.configure_args()
+        autoreconf('-ifv')
+        configure(*args)
+        make()
+        make('install')

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -61,7 +61,7 @@ class Protobuf(Package):
     # See https://github.com/protocolbuffers/protobuf/pull/7197
     patch('intel-v2.patch', when='@3.7:@3.11.4 %intel')
 
-    patch('protoc.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
+    patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
     def fetch_remote_versions(self):
         """Ignore additional source artifacts uploaded with releases,

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -61,7 +61,7 @@ class Protobuf(Package):
     # See https://github.com/protocolbuffers/protobuf/pull/7197
     patch('intel-v2.patch', when='@3.7:@3.11.4 %intel')
 
-    patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
+    patch('protoc.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
     def fetch_remote_versions(self):
         """Ignore additional source artifacts uploaded with releases,
@@ -75,7 +75,6 @@ class Protobuf(Package):
 
     def cmake_args(self):
         args = [
-            '-DCMAKE_INSTALL_PREFIX=%s' % self.prefix,
             '-DBUILD_SHARED_LIBS=%s' % int('+shared' in self.spec),
             '-Dprotobuf_BUILD_TESTS:BOOL=OFF',
             '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'
@@ -87,6 +86,7 @@ class Protobuf(Package):
     @when('@3.0.2:')
     def install(self, spec, prefix):
         args = self.cmake_args()
+        args.extend(std_cmake_args)
 
         source_directory = join_path(self.stage.source_path, 'cmake')
         build_directory = join_path(source_directory, 'build')

--- a/var/spack/repos/builtin/packages/protobuf/protoc2.5.0_aarch64.patch
+++ b/var/spack/repos/builtin/packages/protobuf/protoc2.5.0_aarch64.patch
@@ -1,0 +1,113 @@
+diff -uprN /src/google/protobuf/stubs/atomicops_internals_arm_gcc.h  /src/google/protobuf/stubs/atomicops_internals_arm_gcc.h
+--- /src/google/protobuf/subs/atomicops_internals_arm_gcc.h	2018-08-03 08:50:58.579413324 +0000
++++ /src/google/protobuf/stubs/atomicops_internals_arm_gcc.h	2018-08-03 08:50:58.711413322 +0000
+@@ -68,6 +68,30 @@ inline Atomic32 NoBarrier_CompareAndSwap
+   } while (prev_value == old_value);
+   return prev_value;
+ }
++inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
++                                         Atomic64 old_value,
++                                         Atomic64 new_value) {
++  Atomic64 prev;
++  int32_t temp;
++
++  __asm__ __volatile__ (  // NOLINT
++    "0:                                    \n\t"
++    "ldxr %[prev], %[ptr]                  \n\t"
++    "cmp %[prev], %[old_value]             \n\t"
++    "bne 1f                                \n\t"
++    "stxr %w[temp], %[new_value], %[ptr]   \n\t"
++    "cbnz %w[temp], 0b                     \n\t"
++    "1:                                    \n\t"
++    : [prev]"=&r" (prev),
++      [temp]"=&r" (temp),
++      [ptr]"+Q" (*ptr)
++    : [old_value]"IJr" (old_value),
++      [new_value]"r" (new_value)
++    : "cc", "memory"
++  );  // NOLINT
++
++  return prev;
++}
+ 
+ inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
+                                          Atomic32 new_value) {
+@@ -105,6 +129,15 @@ inline Atomic32 Acquire_CompareAndSwap(v
+   return NoBarrier_CompareAndSwap(ptr, old_value, new_value);
+ }
+ 
++inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
++                                       Atomic64 old_value,
++                                       Atomic64 new_value) {
++  Atomic64 prev = NoBarrier_CompareAndSwap(ptr, old_value, new_value);
++  MemoryBarrier();
++
++  return prev;
++}
++
+ inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
+                                        Atomic32 old_value,
+                                        Atomic32 new_value) {
+@@ -115,8 +148,11 @@ inline void NoBarrier_Store(volatile Ato
+   *ptr = value;
+ }
+ 
+-inline void MemoryBarrier() {
++/*inline void MemoryBarrier() {
+   pLinuxKernelMemoryBarrier();
++}*/
++inline void MemoryBarrier() {
++  __asm__ __volatile__ ("dmb ish" ::: "memory");  // NOLINT
+ }
+ 
+ inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
+@@ -129,6 +165,15 @@ inline void Release_Store(volatile Atomi
+   *ptr = value;
+ }
+ 
++inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
++  __asm__ __volatile__ (  // NOLINT
++    "stlr %x[value], %[ptr]  \n\t"
++    : [ptr]"=Q" (*ptr)
++    : [value]"r" (value)
++    : "memory"
++  );  // NOLINT
++}
++
+ inline Atomic32 NoBarrier_Load(volatile const Atomic32* ptr) {
+   return *ptr;
+ }
+@@ -139,6 +184,19 @@ inline Atomic32 Acquire_Load(volatile co
+   return value;
+ }
+ 
++inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
++  Atomic64 value;
++
++  __asm__ __volatile__ (  // NOLINT
++    "ldar %x[value], %[ptr]  \n\t"
++    : [value]"=r" (value)
++    : [ptr]"Q" (*ptr)
++    : "memory"
++  );  // NOLINT
++
++  return value;
++}
++
+ inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
+   MemoryBarrier();
+   return *ptr;
+diff -uprN /src/google/protobuf/stubs/platform_macros.h /src/google/protobuf/stubs/platform_macros.h
+--- /src/google/protobuf/stubs/platform_macros.h	2018-08-03 08:50:58.543413325 +0000
++++ /src/google/protobuf/stubs/platform_macros.h	2018-08-03 08:50:58.595413324 +0000
+@@ -57,6 +57,9 @@
+ #elif defined(__ppc__)
+ #define GOOGLE_PROTOBUF_ARCH_PPC 1
+ #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
++#elif defined(__aarch64__)
++#define GOOGLE_PROTOBUF_ARCH_ARM 1
++#define GOOGLE_PROTOBUF_ARCH_64_BIT 1
+ #else
+ #error Host architecture was not detected as supported by protobuf
+ #endif
+


### PR DESCRIPTION
Hbase depends on an old protobuf version 2.5.0, but the old version cannot support aarch64 platform.
According to this issue:
https://issues.apache.org/jira/browse/HBASE-19146
Some one reported it to Google and want them to release a new version base on 2.5.0 to support aarch64. But looks like Google guys didn't do that:
https://github.com/protocolbuffers/protobuf/issues/5115

So, we attached a special patch for aarch64 with protobuf@2.5.0.
And because protobuf changed it's package type, we enabled that package according to @alalazo 's suggestion (e.g. https://github.com/spack/spack/pull/15420)