### PR TITLE
Mention that packages can be uninstalled by hash

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -26,7 +26,8 @@ level = "short"
 
 error_message = """You can either:
     a) use a more specific spec, or
-    b) use `spack uninstall --all` to uninstall ALL matching specs.
+    b) specify the package by its hash (e.g. `spack uninstall /hash`), or
+    c) use `spack uninstall --all` to uninstall ALL matching specs.
 """
 
 # Arguments for display_specs when we find ambiguity


### PR DESCRIPTION
Minor change to the error thrown by `spack uninstall` when the spec is ambiguous, now explicitly mentions that packages can be uninstalled by their hash, for issue #12527