### PR TITLE
Cmake/add fujitsu mpi commands

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -239,10 +239,8 @@ class Cmake(Package):
     def install(self, spec, prefix):
         make('install')
 
-    @when('%fj')
-    @run_after('install')
-    def add_fujitsu_mpi_commands(self):
-        for f in find(self.prefix, 'FindMPI.cmake', recursive=True):
-            filter_file('mpcc_r)', 'mpcc_r mpifcc)', f, string=True)
-            filter_file('mpc++_r)', 'mpc++_r mpiFCC)', f, string=True)
-            filter_file('mpifc)', 'mpifc mpifrt)', f, string=True)
+        if spec.satisfies('%fj'):
+            for f in find(self.prefix, 'FindMPI.cmake', recursive=True):
+                filter_file('mpcc_r)', 'mpcc_r mpifcc)', f, string=True)
+                filter_file('mpc++_r)', 'mpc++_r mpiFCC)', f, string=True)
+                filter_file('mpifc)', 'mpifc mpifrt)', f, string=True)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -238,3 +238,11 @@ class Cmake(Package):
 
     def install(self, spec, prefix):
         make('install')
+
+    @when('%fj')
+    @run_after('install')
+    def add_fujitsu_mpi_commands(self):
+        for f in find(self.prefix, 'FindMPI.cmake', recursive=True):
+            filter_file('mpcc_r)', 'mpcc_r mpifcc)', f, string=True)
+            filter_file('mpc++_r)', 'mpc++_r mpiFCC)', f, string=True)
+            filter_file('mpifc)', 'mpifc mpifrt)', f, string=True)

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -82,15 +82,6 @@ class NetlibScalapack(CMakePackage):
                 "-DCMAKE_Fortran_FLAGS=%s" % self.compiler.fc_pic_flag
             ])
 
-        # Specify Fujitsu-MPI's location
-        if spec.satisfies('%fj') and '^fujitsu-mpi' in spec:
-            options.extend([
-                '-DMPI_C_COMPILER=%s'       % spec['mpi'].mpicc,
-                '-DMPI_CXX_COMPILER=%s'     % spec['mpi'].mpicxx,
-                '-DMPI_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-                '-DMPI_BASE_DIR=%s' % spec['mpi'].prefix
-            ])
-
         return options
 
     @run_after('install')


### PR DESCRIPTION
Fujitsu-MPI wrapper commands aren't recognized from 'FindMPI' function of 'cmake'.
So,  add the Fujitsu-MPI wrapper commands to the search candidates for MPI wrapper in cmake.
At the same time, remove the fix for #16798.