### PR TITLE
Add new package: netkit-ftp

### DIFF
--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-C-Frame121.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-C-Frame121.patch
@@ -1,0 +1,25 @@
+--- netkit-ftp-0.17/ftp/ftp.c.rasold	2005-10-26 16:56:09.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2005-10-26 16:56:46.000000000 +0200
+@@ -1253,14 +1253,14 @@
+ 		switch (data_addr.su_family) {
+ 		case AF_INET:
+ #if 0
+-			if (try_epsv) {
+-				result = command(pasvcmd = "EPSV 1");
+-				if (code / 10 == 22 && code != 229) {
+-					fprintf(stderr,
+-				  "wrong server: return code must be 229\n");
+-					result = COMPLETE + 1;
+-				}
+-			} else {
++/*@*/			if (try_epsv) {
++/*@*/				result = command(pasvcmd = "EPSV 1");
++/*@*/				if (code / 10 == 22 && code != 229) {
++/*@*/					fprintf(stderr,
++/*@*/				  "wrong server: return code must be 229\n");
++/*@*/					result = COMPLETE + 1;
++/*@*/				}
++/*@*/			} else {
+ #endif
+ 			result = COMPLETE + 1;
+ 

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-acct.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-acct.patch
@@ -1,0 +1,12 @@
+--- netkit-ftp-0.17/ftp/ftp.c.acct	Sun Jan 21 00:08:29 2001
++++ netkit-ftp-0.17/ftp/ftp.c	Sun Jan 21 00:09:04 2001
+@@ -254,7 +254,8 @@
+ 	if (n == CONTINUE) {
+ 		aflag++;
+ 		/* fflush(stdout); */
+-		zacct = getpass("Account:");
++		if(zacct==NULL)
++			zacct = getpass("Account:");
+ 		n = command("ACCT %s", zacct);
+ 	}
+ 	if (n != COMPLETE) {

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-acct_ovl.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-acct_ovl.patch
@@ -1,0 +1,13 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.acct_ovl netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.acct_ovl	2011-09-09 15:36:36.087956561 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2011-09-09 15:41:16.457495370 +0200
+@@ -1837,8 +1837,7 @@ account(int argc, char *argv[])
+ 		while (argc > 1) {
+ 			--argc;
+ 			++argv;
+-			strncat(buf, *argv, sizeof(buf)-strlen(buf));
+-			buf[sizeof(buf)-1] = 0;
++			strncat(buf, *argv, sizeof(buf)-strlen(buf)-1);
+ 		}
+ 		ap = buf;
+ 	}

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-active-mode-option.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-active-mode-option.patch
@@ -1,0 +1,35 @@
+--- netkit-ftp-0.17/ftp/main.c.orig	2012-08-22 14:13:47.452058828 +0200
++++ netkit-ftp-0.17/ftp/main.c	2012-08-22 14:16:47.964124112 +0200
+@@ -87,7 +87,8 @@ static
+ void
+ usage(void)
+ {
+-	printf("\n\tUsage: { ftp | pftp } [-pinegvtd] [hostname]\n");
++	printf("\n\tUsage: { ftp | pftp } [-Apinegvtd] [hostname]\n");
++	printf("\t   -A: enable active mode\n");
+ 	printf("\t   -p: enable passive mode (default for ftp and pftp)\n");
+ 	printf("\t   -i: turn off prompting during mget\n");
+ 	printf("\t   -n: inhibit auto-login\n");
+@@ -166,6 +167,10 @@ main(volatile int argc, char **volatile
+ 				passivemode = 1;
+ 				break;
+ 
++			case 'A':
++				passivemode = 0;
++				break;
++
+ 			case 'g':
+ 				doglob = 0;
+ 				break;
+--- netkit-ftp-0.17/ftp/ftp.1.orig      2009-10-26 15:38:34.000000000 -0500
++++ netkit-ftp-0.17/ftp/ftp.1   2009-10-26 15:41:12.000000000 -0500
+@@ -58,6 +58,9 @@
+ Options may be specified at the command line, or to the
+ command interpreter.
+ .Bl -tag -width flag
++.It Fl A
++Use active mode for data transfers. This is useful for transmissions
++to servers which do not support passive connections (for whatever reason.)
+ .It Fl p
+ Use passive mode for data transfers. Allows use of ftp in environments
+ where a firewall prevents connections from the outside world back to

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-arg_max.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-arg_max.patch
@@ -1,0 +1,55 @@
+diff -up netkit-ftp-0.17/ftp/glob.c.arg_max netkit-ftp-0.17/ftp/glob.c
+--- netkit-ftp-0.17/ftp/glob.c.arg_max	2008-04-07 11:41:14.000000000 +0200
++++ netkit-ftp-0.17/ftp/glob.c	2008-04-07 12:01:53.000000000 +0200
+@@ -50,6 +50,7 @@ char glob_rcsid[] = 
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #include "ftp_var.h"  /* for protos only */
+ #include "glob.h"
+@@ -57,7 +58,7 @@ char glob_rcsid[] = 
+ #define	QUOTE 0200
+ #define	TRIM 0177
+ #define	eq(a,b)		(strcmp(a, b)==0)
+-#define	GAVSIZ		(ARG_MAX/6)
++#define	GAVSIZ		(sysconf(_SC_ARG_MAX)/6)
+ #define	isdir(d)	((d.st_mode & S_IFMT) == S_IFDIR)
+ 
+ const char *globerr;
+@@ -115,7 +116,7 @@ char **
+ ftpglob(const char *v)
+ {
+ 	char agpath[BUFSIZ];
+-	entry agargv[GAVSIZ];
++	entry *agargv;
+ 	centry vv[2];
+ 	vv[0].text = v;
+ 	vv[1].text = NULL;
+@@ -133,6 +134,8 @@ ftpglob(const char *v)
+ 	/* added ()'s to sizeof, (ambigious math for the compiler) */
+ 	lastgpathp = agpath + (sizeof(agpath)- 2);
+ 
++	agargv = (entry *)malloc(sizeof (entry) * GAVSIZ);
++	if (agargv == NULL) fatal("Out of memory");
+ 	ginit(agargv); 
+ 	globcnt = 0;
+ 	collect(v);
+@@ -156,7 +159,7 @@ ginit(entry *agargv)
+ 	gargv = agargv; 
+ 	sortbas = agargv; 
+ 	gargc = 0;
+-	gnleft = ARG_MAX - 4;
++	gnleft = sysconf(_SC_ARG_MAX) - 4;
+ }
+ 
+ static 
+@@ -674,6 +677,7 @@ efree(entry *av) 
+ {
+     int i;
+     for (i=0; av[i].text; i++) free(av[i].text);
++    free((void *)av);
+ }
+ 
+ static

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-bitrate.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-bitrate.patch
@@ -1,0 +1,14 @@
+diff -up netkit-ftp-0.17/ftp/ftp.c.old netkit-ftp-0.17/ftp/ftp.c
+--- netkit-ftp-0.17/ftp/ftp.c.old	2008-01-28 10:23:17.000000000 +0100
++++ netkit-ftp-0.17/ftp/ftp.c	2008-01-28 10:32:01.000000000 +0100
+@@ -1609,8 +1609,8 @@ ptransfer(const char *direction, long lo
+ 		s = td.tv_sec + (td.tv_usec / 1000000.);
+ #define	nz(x)	((x) == 0 ? 1 : (x))
+ 		bs = bytes / nz(s);
+-		printf("%lld bytes %s in %.3g secs (%.2g Kbytes/sec)\n",
+-		    bytes, direction, s, bs / 1024.0);
++		printf("%lld bytes %s in %.3g secs (%.2f Kbytes/sec)\n",
++		    bytes, direction, s, bs / 1000.0);
+ 	}
+ }
+ 

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-case.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-case.patch
@@ -1,0 +1,16 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.case netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.case	2008-04-23 14:52:59.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2008-04-23 14:58:07.000000000 +0200
+@@ -831,8 +831,11 @@ mget(int argc, char **argv)
+ 						tp++;
+ 						tp2++;
+ 					}
++					tp = tmpbuf;
++				}
++				else {
++					tp = cp;
+ 				}
+-				tp = tmpbuf;
+ 			}
+ 			if (ntflag) {
+ 				tp = dotrans(tp);

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-chkmalloc.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-chkmalloc.patch
@@ -1,0 +1,33 @@
+diff -up netkit-ftp-0.17/ftp/ruserpass.c.chkmalloc netkit-ftp-0.17/ftp/ruserpass.c
+--- netkit-ftp-0.17/ftp/ruserpass.c.chkmalloc	2008-12-01 11:54:15.000000000 +0100
++++ netkit-ftp-0.17/ftp/ruserpass.c	2008-12-01 11:56:06.000000000 +0100
+@@ -137,7 +137,8 @@ next:
+ 			if (token()) {
+ 				if (*aname == 0) { 
+ 					*aname = malloc((unsigned) strlen(tokval) + 1);
+-					(void) strcpy(*aname, tokval);
++					if (*aname != NULL)
++						(void) strcpy(*aname, tokval);
+ 				} else {
+ 					if (strcmp(*aname, tokval))
+ 						goto next;
+@@ -158,7 +159,8 @@ next:
+ 			}
+ 			if (token() && *apass == 0) {
+ 				*apass = malloc((unsigned) strlen(tokval) + 1);
+-				(void) strcpy(*apass, tokval);
++				if (*apass != NULL)
++					(void) strcpy(*apass, tokval);
+ 			}
+ 			break;
+ 		case ACCOUNT:
+@@ -170,7 +172,8 @@ next:
+ 			}
+ 			if (token() && *aacct == 0) {
+ 				*aacct = malloc((unsigned) strlen(tokval) + 1);
+-				(void) strcpy(*aacct, tokval);
++				if (*aacct != NULL)
++					(void) strcpy(*aacct, tokval);
+ 			}
+ 			break;
+ 		case MACDEF:

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-commands-leaks.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-commands-leaks.patch
@@ -1,0 +1,13 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.orig netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.orig	2011-09-05 14:41:34.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2011-09-05 14:44:44.000000000 +0200
+@@ -499,6 +499,9 @@ usage:
+ 	}
+ 	sendrequest(cmd, argv[1], argv[2],
+ 	    argv[1] != oldargv1 || argv[2] != oldargv2);
++	if (argv[1] != oldargv1) {
++		free(argv[1]);
++	}
+ }
+ 
+ void mabort(int);

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-data.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-data.patch
@@ -1,0 +1,24 @@
+--- netkit-ftp-0.17/ftp/ftp.c.data	2005-12-02 15:31:27.000000000 +0100
++++ netkit-ftp-0.17/ftp/ftp.c	2005-12-02 15:35:46.000000000 +0100
+@@ -1223,6 +1223,7 @@
+ static int
+ initconn(void)
+ {
++	int rc;
+ 	u_char *p, *a;
+ 	int result, tmpno = 0;
+ 	socklen_t len;
+@@ -1240,6 +1241,13 @@
+ 	}
+ #endif
+ 	if (passivemode) {
++		if (data >= 0){
++			rc = close (data);
++			data = -1;
++			if (rc == -1){
++				perror ("ftp: close");
++			}
++		}
+ 		data_addr = hisctladdr;
+ 		data = socket(data_addr.su_family, SOCK_STREAM, 0);
+ 		if (data < 0) {

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-fdleak.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-fdleak.patch
@@ -1,0 +1,11 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.old netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.old	2007-10-17 16:28:57.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2007-10-17 16:33:41.000000000 +0200
+@@ -764,6 +764,7 @@ usage:
+ 
+ 	recvrequest("RETR", argv[2], argv[1], modestr,
+ 		    argv[1] != oldargv1 || argv[2] != oldargv2);
++	(void) close(data), data = -1;
+ 	restart_point = 0;
+ 	return (0);
+ }

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-fprintf.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-fprintf.patch
@@ -1,0 +1,225 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.old netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.old	2007-11-15 13:34:31.000000000 +0100
++++ netkit-ftp-0.17/ftp/cmds.c	2007-11-15 13:44:44.000000000 +0100
+@@ -137,7 +137,7 @@ static char *pathprotect(char *name)
+ 		if (name[i]=='.' && gotdots>=0) gotdots++;
+ 		else if (name[i]=='/' && gotdots<0) gotdots=0;
+ 		else if (name[i]=='/' && gotdots==2) {
+-		    printf("Warning: embedded .. in %.*s (changing to !!)\n",
++		    fprintf(stderr, "Warning: embedded .. in %.*s (changing to !!)\n",
+ 			   len-1, name);
+ 		    name[i-1] = '!';
+ 		    name[i-2] = '!';
+@@ -167,7 +167,7 @@ another(int *pargc, char ***pargv, const
+ 	int ret;
+ 
+ 	if (len >= sizeof(line) - 3) {
+-		printf("sorry, arguments too long\n");
++		fprintf(stderr, "sorry, arguments too long\n");
+ 		intr(0);
+ 	}
+ 	printf("(%s) ", prompt);
+@@ -195,7 +195,7 @@ setpeer(int argc, char *argv[])
+ 	char *port;
+ 
+ 	if (connected) {
+-		printf("Already connected to %s, use close first.\n",
++		fprintf(stderr, "Already connected to %s, use close first.\n",
+ 			hostname);
+ 		code = -1;
+ 		return;
+@@ -278,7 +278,7 @@ setpeer(int argc, char *argv[])
+ 				unix_server = 0;
+ 			if (overbose && 
+ 			    !strncmp(reply_string, "215 TOPS20", 10))
+-				printf(
++				fprintf(stderr, 
+ "Remember to set tenex mode when transfering binary files from this machine.\n");
+ 		}
+ 		verbose = overbose;
+@@ -316,7 +316,7 @@ do_settype(const char *thetype) 
+ 		if (strcmp(thetype, p->t_name) == 0)
+ 			break;
+ 	if (p->t_name == 0) {
+-		printf("%s: unknown mode\n", thetype);
++		fprintf(stderr, "%s: unknown mode\n", thetype);
+ 		code = -1;
+ 		return;
+ 	}
+@@ -378,7 +378,7 @@ changetype(int newtype, int show)
+ 		if (newtype == p->t_type)
+ 			break;
+ 	if (p->t_name == 0) {
+-		printf("ftp: internal error: unknown type %d\n", newtype);
++		fprintf(stderr, "ftp: internal error: unknown type %d\n", newtype);
+ 		return;
+ 	}
+ 	if (newtype == TYPE_L && bytename[0] != '\0')
+@@ -428,7 +428,7 @@ settenex(void)
+ void
+ setmode(void)
+ {
+-	printf("We only support %s mode, sorry.\n", modename);
++	fprintf(stderr, "We only support %s mode, sorry.\n", modename);
+ 	code = -1;
+ }
+ 
+@@ -439,7 +439,7 @@ setmode(void)
+ void
+ setform(void)
+ {
+-	printf("We only support %s format, sorry.\n", formname);
++	fprintf(stderr, "We only support %s format, sorry.\n", formname);
+ 	code = -1;
+ }
+ 
+@@ -449,7 +449,7 @@ setform(void)
+ void
+ setstruct(void)
+ {
+-	printf("We only support %s structure, sorry.\n", structname);
++	fprintf(stderr, "We only support %s structure, sorry.\n", structname);
+ 	code = -1;
+ }
+ 
+@@ -594,7 +594,7 @@ mput(int argc, char *argv[])
+ 		}
+ 		gargs = ftpglob(argv[i]);
+ 		if (globerr != NULL) {
+-			printf("%s\n", globerr);
++			fprintf(stderr, "%s\n", globerr);
+ 			if (gargs) {
+ 				blkfree(gargs);
+ 				free((char *)gargs);
+@@ -906,7 +906,7 @@ remglob(char *argv[], int doswitch)
+ 		umask(oldumask);
+ 
+ 		if (fd<0) {
+-			printf("Error creating temporary file, oops\n");
++			fprintf(stderr, "Error creating temporary file, oops\n");
+ 			return NULL;
+ 		}
+ 		
+@@ -931,13 +931,13 @@ remglob(char *argv[], int doswitch)
+ 		}
+ 		verbose = oldverbose; hash = oldhash;
+ 		if (badglob) {
+-			printf("Refusing to handle insecure file list\n");
++			fprintf(stderr, "Refusing to handle insecure file list\n");
+ 			close(fd);
+ 			return NULL;
+ 		}
+ 		ftemp = fdopen(fd, "r");
+ 		if (ftemp == NULL) {
+-			printf("fdopen failed, oops\n");
++			fprintf(stderr, "fdopen failed, oops\n");
+ 			return NULL;
+ 		}
+ 		rewind(ftemp);
+@@ -1006,7 +1006,7 @@ checkglob(int fd, const char *pattern)
+ 		while (*sp == '/')
+ 			sp++;
+ 		if (nrslash >= MAXPATHLEN) {
+-			printf("Incredible pattern: %s\n", pattern);
++			fprintf(stderr, "Incredible pattern: %s\n", pattern);
+ 			return 0;
+ 		}
+ 		dotdot[nrslash++] = isdotdotglob(sp);
+@@ -1019,7 +1019,7 @@ checkglob(int fd, const char *pattern)
+ 		if ((sp = strchr(buffer, '\n')) != 0) {
+ 			*sp = '\0';
+ 		} else {
+-			printf("Extremely long filename from server: %s",
++			fprintf(stderr, "Extremely long filename from server: %s",
+ 				buffer);
+ 			okay = 0;
+ 			break;
+@@ -1038,7 +1038,7 @@ checkglob(int fd, const char *pattern)
+ 	}
+ 
+ 	if (!okay)
+-		printf("Filename provided by server "
++		fprintf(stderr, "Filename provided by server "
+ 		       "doesn't match pattern `%s': %s\n", pattern, buffer);
+ 
+ 	fclose(fp);
+@@ -1061,14 +1061,14 @@ status(void)
+ 	if (connected) 
+ 		printf("Connected to %s.\n", hostname);
+ 	else 
+-		printf("Not connected.\n");
++		fprintf(stderr, "Not connected.\n");
+ 	if (!proxy) {
+ 		pswitch(1);
+ 		if (connected) {
+ 			printf("Connected for proxy commands to %s.\n", hostname);
+ 		}
+ 		else {
+-			printf("No proxy connection.\n");
++			fprintf(stderr, "No proxy connection.\n");
+ 		}
+ 		pswitch(0);
+ 	}
+@@ -1218,7 +1218,7 @@ setdebug(int argc, char *argv[])
+ 	if (argc > 1) {
+ 		val = atoi(argv[1]);
+ 		if (val < 0) {
+-			printf("%s: bad debugging value.\n", argv[1]);
++			fprintf(stderr, "%s: bad debugging value.\n", argv[1]);
+ 			code = -1;
+ 			return;
+ 		}
+@@ -1248,7 +1248,7 @@ cd(int argc, char *argv[])
+ 	}
+ 	if (command("CWD %s", argv[1]) == ERROR && code == 500) {
+ 		if (verbose)
+-			printf("CWD command not recognized, trying XCWD\n");
++			fprintf(stderr, "CWD command not recognized, trying XCWD\n");
+ 		(void) command("XCWD %s", argv[1]);
+ 	}
+ }
+@@ -1546,7 +1546,7 @@ user(int argc, char *argv[])
+ 		aflag++;
+ 	}
+ 	if (n != COMPLETE) {
+-		fprintf(stdout, "Login failed.\n");
++		fprintf(stderr, "Login failed.\n");
+ 		return;
+ 	}
+ 	if (!aflag && argc == 4) {
+@@ -1567,7 +1567,7 @@ pwd(void)
+ 	 */
+ 	verbose = 1;
+ 	if (command("PWD") == ERROR && code == 500) {
+-		printf("PWD command not recognized, trying XPWD\n");
++		fprintf(stderr, "PWD command not recognized, trying XPWD\n");
+ 		(void) command("XPWD");
+ 	}
+ 	verbose = oldverbose;
+@@ -1587,7 +1587,7 @@ makedir(int argc, char *argv[])
+ 	}
+ 	if (command("MKD %s", argv[1]) == ERROR && code == 500) {
+ 		if (verbose)
+-			printf("MKD command not recognized, trying XMKD\n");
++			fprintf(stderr, "MKD command not recognized, trying XMKD\n");
+ 		(void) command("XMKD %s", argv[1]);
+ 	}
+ }
+@@ -1606,7 +1606,7 @@ removedir(int argc, char *argv[])
+ 	}
+ 	if (command("RMD %s", argv[1]) == ERROR && code == 500) {
+ 		if (verbose)
+-			printf("RMD command not recognized, trying XRMD\n");
++			fprintf(stderr, "RMD command not recognized, trying XRMD\n");
+ 		(void) command("XRMD %s", argv[1]);
+ 	}
+ }
+@@ -2212,7 +2212,7 @@ cdup(void)
+ {
+ 	if (command("CDUP") == ERROR && code == 500) {
+ 		if (verbose)
+-			printf("CDUP command not recognized, trying XCUP\n");
++			fprintf(stderr, "CDUP command not recognized, trying XCUP\n");
+ 		(void) command("XCUP");
+ 	}
+ }

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-getlogin.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-getlogin.patch
@@ -1,0 +1,37 @@
+--- netkit-ftp-0.17-dist/ftp/ftp.c	2012-10-02 14:44:06.328343277 +0200
++++ netkit-ftp-0.17-new/ftp/ftp.c	2012-10-03 09:07:47.381868330 +0200
+@@ -328,14 +328,12 @@ dologin(const char *host)
+ 		return(0);
+ 	}
+ 	while (luser == NULL) {
+-		char *myname = getlogin();
++		char *myname = NULL;
+ 
+-		if (myname == NULL) {
+-			struct passwd *pp = getpwuid(getuid());
++		struct passwd *pp = getpwuid(getuid());
+ 
+-			if (pp != NULL)
+-				myname = pp->pw_name;
+-		}
++		if (pp != NULL)
++			myname = pp->pw_name;
+ 		if (myname)
+ 			printf("Name (%s:%s): ", host, myname);
+ 		else
+--- netkit-ftp-0.17-dist/ftp/main.c	2012-10-02 14:44:06.330343274 +0200
++++ netkit-ftp-0.17-new/ftp/main.c	2012-10-03 09:07:36.849862227 +0200
+@@ -204,12 +204,7 @@ main(volatile int argc, char **volatile
+ 	/*
+ 	 * Set up the home directory in case we're globbing.
+ 	 */
+-	cp = getlogin();
+-	if (cp != NULL) {
+-		pw = getpwnam(cp);
+-	}
+-	if (pw == NULL)
+-		pw = getpwuid(getuid());
++	pw = getpwuid(getuid());
+ 	if (pw != NULL) {
+ 		strncpy(homedir, pw->pw_dir, sizeof(homedir));
+ 		homedir[sizeof(homedir)-1] = 0;

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-linelen.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-linelen.patch
@@ -1,0 +1,33 @@
+--- netkit-ftp-0.17-dist/ftp/ftp_var.h	2012-10-29 10:02:44.455342130 +0100
++++ netkit-ftp-0.17-new/ftp/ftp_var.h	2012-10-29 10:02:31.292342775 +0100
+@@ -54,6 +54,7 @@
+ #define Extern extern
+ #endif
+ 
++#define LINELEN PATH_MAX+200
+ 
+ /*
+  * Options and other state info.
+@@ -109,9 +110,9 @@ Extern int	ftp_port;	/* htons'd port num
+ 
+ Extern sigjmp_buf toplevel;	/* non-local goto stuff for cmd scanner */
+ 
+-Extern char	line[200];	/* input line buffer */
++Extern char	line[LINELEN];	/* input line buffer */
+ Extern char	*stringbase;	/* current scan point in line buffer */
+-Extern char	argbuf[200];	/* argument storage buffer */
++Extern char	argbuf[LINELEN];	/* argument storage buffer */
+ Extern char	*argbase;	/* current storage point in arg buffer */
+ Extern int	cpend;		/* flag: if != 0, then pending server reply */
+ Extern int	mflag;		/* flag: if != 0, then active multi command */
+--- netkit-ftp-0.17/ftp/domacro.c	2012-10-29 10:02:44.394342130 +0100
++++ netkit-ftp-0.17-new/ftp/domacro.c	2012-10-29 10:02:31.292342775 +0100
+@@ -53,7 +53,7 @@ domacro(int argc, char *argv[])
+ 	register int i, j;
+ 	register char *cp1, *cp2;
+ 	int count = 2, loopflg = 0;
+-	char line2[200];
++	char line2[LINELEN];
+ 	struct cmd *c;
+ 
+ 	if (argc < 2 && !another(&argc, &argv, "macro name")) {

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-longint.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-longint.patch
@@ -1,0 +1,135 @@
+--- netkit-ftp-0.17/ftp/ftp.c.rasold	2005-08-22 14:22:50.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2005-08-22 14:23:02.000000000 +0200
+@@ -139,7 +139,7 @@
+ static char *gunique(char *);
+ static void proxtrans(const char *cmd, char *local, char *remote);
+ static int initconn(void);
+-static void ptransfer(const char *direction, long bytes, 
++static void ptransfer(const char *direction, long long bytes, 
+ 		      const struct timeval *t0, 
+ 		      const struct timeval *t1);
+ static void tvsub(struct timeval *tdiff, 
+@@ -579,7 +579,7 @@
+ 	int (*volatile closefunc)(FILE *);
+ 	void (*volatile oldintr)(int);
+ 	void (*volatile oldintp)(int);
+-	volatile long bytes = 0, hashbytes = HASHBYTES;
++	volatile long long bytes = 0, hashbytes = HASHBYTES;
+ 	char buf[BUFSIZ], *bufp;
+ 	const char *volatile lmode;
+ 
+@@ -713,14 +713,14 @@
+ 				if ((d = write(fileno(dout), bufp, c)) <= 0)
+ 					break;
+ 			if (hash) {
+-				while (bytes >= hashbytes) {
+-					(void) putchar('#');
+-					hashbytes += HASHBYTES;
+-				}
+-				(void) fflush(stdout);
+-			}
++				while (bytes >= hashbytes) {        /* <-- 'long long' signed overflow is  */
++					(void) putchar('#');        /* possible. In this case, we can      */
++					hashbytes += HASHBYTES;     /* 'cycle' there for very long time.   */
++				}                                   /* Search 'hasbytes' in file down,     */
++				(void) fflush(stdout);              /* there are similar parts.            */
++			}                                           /*           <praszyk@redhat.com>      */
+ 			if (tick && (bytes >= hashbytes)) {
+-				printf("\rBytes transferred: %ld", bytes);
++				printf("\rBytes transferred: %lld", bytes);
+ 				(void) fflush(stdout);
+ 				while (bytes >= hashbytes)
+ 					hashbytes += TICKBYTES;
+@@ -733,7 +733,7 @@
+ 			(void) fflush(stdout);
+ 		}
+ 		if (tick) {
+-			(void) printf("\rBytes transferred: %ld\n", bytes);
++			(void) printf("\rBytes transferred: %lld\n", bytes);
+ 			(void) fflush(stdout);
+ 		}
+ 		if (c < 0)
+@@ -755,7 +755,7 @@
+ 					hashbytes += HASHBYTES;
+ 				}
+ 				if (tick && (bytes >= hashbytes)) {
+-					(void) printf("\rBytes transferred: %ld",
++					(void) printf("\rBytes transferred: %lld",
+ 						bytes);
+ 					(void) fflush(stdout);
+ 					while (bytes >= hashbytes)
+@@ -780,7 +780,7 @@
+ 			(void) fflush(stdout);
+ 		}
+ 		if (tick) {
+-			(void) printf("\rBytes transferred: %ld\n", bytes);
++			(void) printf("\rBytes transferred: %lld\n", bytes);
+ 			(void) fflush(stdout);
+ 		}
+ 		if (ferror(fin))
+@@ -853,9 +853,9 @@
+ 	void (*volatile oldintp)(int);
+ 	void (*volatile oldintr)(int);
+ 	volatile int is_retr, tcrflag, bare_lfs = 0;
+-	static unsigned bufsize;
++	static unsigned bufsize=0;
+ 	static char *buf;
+-	volatile long bytes = 0, hashbytes = HASHBYTES;
++	volatile long long bytes = 0, hashbytes = HASHBYTES;
+ 	register int c, d;
+ 	struct timeval start, stop;
+ 	struct stat st;
+@@ -1031,7 +1031,7 @@
+ 				(void) fflush(stdout);
+ 			}
+ 			if (tick && (bytes >= hashbytes) && is_retr) {
+-				(void) printf("\rBytes transferred: %ld",
++				(void) printf("\rBytes transferred: %lld",
+ 					bytes);
+ 				(void) fflush(stdout);
+ 				while (bytes >= hashbytes)
+@@ -1045,7 +1045,7 @@
+ 			(void) fflush(stdout);
+ 		}
+ 		if (tick && is_retr) {
+-			(void) printf("\rBytes transferred: %ld\n", bytes);
++			(void) printf("\rBytes transferred: %lld\n", bytes);
+ 			(void) fflush(stdout);
+ 		}
+ 		if (c < 0) {
+@@ -1095,7 +1095,7 @@
+ 					hashbytes += HASHBYTES;
+ 				}
+ 				if (tick && (bytes >= hashbytes) && is_retr) {
+-					printf("\rBytes transferred: %ld",
++					printf("\rBytes transferred: %lld",
+ 						bytes);
+ 					fflush(stdout);
+ 					while (bytes >= hashbytes)
+@@ -1126,7 +1126,7 @@
+ 			(void) fflush(stdout);
+ 		}
+ 		if (tick && is_retr) {
+-			(void) printf("\rBytes transferred: %ld\n", bytes);
++			(void) printf("\rBytes transferred: %lld\n", bytes);
+ 			(void) fflush(stdout);
+ 		}
+ 		if (bare_lfs) {
+@@ -1540,7 +1540,7 @@
+ }
+ 
+ static void
+-ptransfer(const char *direction, long bytes, 
++ptransfer(const char *direction, long long bytes, 
+ 	  const struct timeval *t0, 
+ 	  const struct timeval *t1)
+ {
+@@ -1552,7 +1552,7 @@
+ 		s = td.tv_sec + (td.tv_usec / 1000000.);
+ #define	nz(x)	((x) == 0 ? 1 : (x))
+ 		bs = bytes / nz(s);
+-		printf("%ld bytes %s in %.3g secs (%.2g Kbytes/sec)\n",
++		printf("%lld bytes %s in %.3g secs (%.2g Kbytes/sec)\n",
+ 		    bytes, direction, s, bs / 1024.0);
+ 	}
+ }

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-longnames.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-longnames.patch
@@ -1,0 +1,106 @@
+--- netkit-ftp-0.17/ftp/cmds.c.longnames	2006-07-25 11:13:55.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2006-07-24 17:52:10.000000000 +0200
+@@ -1057,10 +1057,9 @@
+ status(void)
+ {
+ 	int i;
+-
+-	if (connected)
++	if (connected) 
+ 		printf("Connected to %s.\n", hostname);
+-	else
++	else 
+ 		printf("Not connected.\n");
+ 	if (!proxy) {
+ 		pswitch(1);
+@@ -1081,7 +1080,7 @@
+ 		onoff(runique));
+ 	printf("Case: %s; CR stripping: %s\n",onoff(mcase),onoff(crflag));
+ 	if (ntflag) {
+-		printf("Ntrans: (in) %s (out) %s\n", ntin,ntout);
++		printf("Ntrans: (in) %s (out) %s\n",ntin,ntout);
+ 	}
+ 	else {
+ 		printf("Ntrans: off\n");
+@@ -1948,14 +1947,14 @@
+ 	}
+ 	ntflag++;
+ 	code = ntflag;
+-	(void) strncpy(ntin, argv[1], 16);
+-	ntin[16] = '\0';
++	(void) strncpy(ntin, argv[1], NTRANS_MAX);
++	ntin[NTRANS_MAX] = '\0';
+ 	if (argc == 2) {
+ 		ntout[0] = '\0';
+ 		return;
+ 	}
+-	(void) strncpy(ntout, argv[2], 16);
+-	ntout[16] = '\0';
++	(void) strncpy(ntout, argv[2], NTRANS_MAX);
++ 	ntout[NTRANS_MAX] = '\0';
+ }
+ 
+ static char *
+@@ -1965,10 +1964,10 @@
+ 	char *cp1, *cp2 = new;
+ 	register int i, ostop, found;
+ 
+-	for (ostop = 0; *(ntout + ostop) && ostop < 16; ostop++);
++	for (ostop = 0; *(ntout + ostop) && ostop < NTRANS_MAX; ostop++);
+ 	for (cp1 = name; *cp1; cp1++) {
+ 		found = 0;
+-		for (i = 0; *(ntin + i) && i < 16; i++) {
++		for (i = 0; *(ntin + i) && i < NTRANS_MAX; i++) {
+ 			if (*cp1 == *(ntin + i)) {
+ 				found++;
+ 				if (i < ostop) {
+--- netkit-ftp-0.17/ftp/ftp.c.longnames	2006-07-25 11:13:56.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2006-07-24 17:46:14.000000000 +0200
+@@ -1656,8 +1656,8 @@
+ 		int runqe;
+ 		int mcse;
+ 		int ntflg;
+-		char nti[17];
+-		char nto[17];
++		char nti[NTRANS_MAX+1];
++		char nto[NTRANS_MAX+1];
+ 		int mapflg;
+ 		char mi[MAXPATHLEN];
+ 		char mo[MAXPATHLEN];
+@@ -1712,11 +1712,11 @@
+ 	mcase = op->mcse;
+ 	ip->ntflg = ntflag;
+ 	ntflag = op->ntflg;
+-	(void) strncpy(ip->nti, ntin, 16);
+-	(ip->nti)[16] = '\0';		/* shouldn't use strlen */
++	(void) strncpy(ip->nti, ntin, NTRANS_MAX);
++	(ip->nti)[NTRANS_MAX] = '\0';		/* shouldn't use strlen */
+ 	(void) strcpy(ntin, op->nti);
+-	(void) strncpy(ip->nto, ntout, 16);
+-	(ip->nto)[16] = '\0';
++	(void) strncpy(ip->nto, ntout, NTRANS_MAX);
++	(ip->nto)[NTRANS_MAX] = '\0';
+ 	(void) strcpy(ntout, op->nto);
+ 	ip->mapflg = mapflag;
+ 	mapflag = op->mapflg;
+--- netkit-ftp-0.17/ftp/ftp_var.h.longnames	2006-07-25 11:13:56.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp_var.h	2006-07-24 15:49:37.000000000 +0200
+@@ -42,6 +42,7 @@
+ 
+ #include <setjmp.h>
+ #include <sys/param.h>
++#define NTRANS_MAX	64
+ 
+ /*
+  * Tick counter step size.
+@@ -82,8 +83,8 @@
+ Extern char     pasv[64];       /* passive port for proxy data connection */
+ Extern int      passivemode;    /* passive mode enabled */
+ Extern char	*altarg;	/* argv[1] with no shell-like preprocessing  */
+-Extern char	ntin[17];	/* input translation table */
+-Extern char	ntout[17];	/* output translation table */
++Extern char	ntin[NTRANS_MAX+1];	/* input translation table */
++Extern char	ntout[NTRANS_MAX+1];	/* output translation table */
+ Extern char	mapin[MAXPATHLEN];	/* input map template */
+ Extern char	mapout[MAXPATHLEN];	/* output map template */
+ Extern char	typename[32];		/* name of file transfer type */

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-lsn-timeout.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-lsn-timeout.patch
@@ -1,0 +1,24 @@
+--- netkit-ftp-0.17/ftp/ftp.c.to	2012-08-10 15:49:08.510257542 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2012-08-10 15:49:32.386220785 +0200
+@@ -1245,6 +1245,10 @@ initconn(void)
+ 	u_int ad[16], po[2], af, alen, plen;
+ 	char *pasvcmd = NULL;
+ 	char hbuf[MAXHOSTNAMELEN], pbuf[NI_MAXSERV];
++	struct timeval timeout;
++
++	timeout.tv_sec = 30;
++	timeout.tv_usec = 0;
+ 
+ #ifdef INET6
+ 	if (myctladdr.su_family == AF_INET6
+@@ -1486,6 +1490,10 @@ noport:
+ 			perror("ftp: setsockopt (reuse address)");
+ 			goto bad;
+ 		}
++	if (setsockopt (data, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout,
++                sizeof(timeout)) < 0) {
++		perror("ftp: setsockopt failed\n");
++	}
+ 	if (bind(data, (struct sockaddr *)&data_addr, sizeof (data_addr)) < 0) {
+ 		perror("ftp: bind");
+ 		goto bad;

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-man.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-man.patch
@@ -1,0 +1,30 @@
+diff -up netkit-ftp-0.17/ftp/ftp.1.man netkit-ftp-0.17/ftp/ftp.1
+--- netkit-ftp-0.17/ftp/ftp.1.man	2011-03-29 09:35:52.588039000 +0200
++++ netkit-ftp-0.17/ftp/ftp.1	2011-03-29 09:36:45.365651621 +0200
+@@ -197,7 +197,7 @@ current remote machine working directory
+ Change the permission modes of the file
+ .Ar file-name
+ on the remote
+-sytem to
++system to
+ .Ar mode  .
+ .It Ic close
+ Terminate the
+@@ -342,7 +342,7 @@ Set the inactivity timer on the remote s
+ seconds.
+ If
+ .Ar seconds
+-is ommitted, the current inactivity timer is printed.
++is omitted, the current inactivity timer is printed.
+ .It Ic lcd Op Ar directory
+ Change the working directory on the local machine.
+ If
+@@ -850,7 +850,7 @@ Set the default umask on the remote serv
+ .Ar newmask  .
+ If
+ .Ar newmask
+-is ommitted, the current umask is printed.
++is omitted, the current umask is printed.
+ .It Xo
+ .Ic user Ar user-name
+ .Op Ar password

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-multihome.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-multihome.patch
@@ -1,0 +1,98 @@
+--- netkit-ftp-0.17/ftp/ftp_var.h.rasold	2006-01-12 11:23:16.000000000 +0100
++++ netkit-ftp-0.17/ftp/ftp_var.h	2006-01-12 11:24:06.000000000 +0100
+@@ -69,6 +69,7 @@
+ Extern int	bell;		/* ring bell on cmd completion */
+ Extern int	doglob;		/* glob local file names */
+ Extern int	autologin;	/* establish user account on connection */
++Extern int	multihome;	/* multi homed host, use same interface for cmd and data channels */
+ Extern int	proxy;		/* proxy server connection active */
+ Extern int	proxflag;	/* proxy connection exists */
+ Extern int	sunique;	/* store files on server with unique name */
+--- netkit-ftp-0.17/ftp/ftp.c.rasold	2006-01-12 11:14:55.000000000 +0100
++++ netkit-ftp-0.17/ftp/ftp.c	2006-01-12 11:22:42.000000000 +0100
+@@ -132,6 +132,7 @@
+ static sigjmp_buf ptabort;
+ static int ptabflg = 0;
+ static int abrtflag = 0;
++struct sockaddr_in source;
+ 
+ void lostpeer(int);
+ extern int connected;
+@@ -153,7 +154,7 @@
+ char *
+ hookup(const char *host, const char *port)
+ {
+-	int s, tos, error;
++	int s, tos, error, alen;
+ 	socklen_t len;
+ 	static char hostnamebuf[256];
+ 	struct addrinfo hints, *res, *res0;
+@@ -278,7 +279,11 @@
+ 	}
+ 	if (verbose)
+ 		printf("Connected to %s (%s).\n", hostname, hbuf);
+-	if (getreply(0) > 2) { 	/* read startup message from server */
++	alen = sizeof(source);
++	getsockname(s,(struct sockaddr*)&source, &alen);
++	source.sin_port = 0;    /* We just want the addr, not the port */
++
++	if (getreply(0) > 2) { 	/* read startup message from server    */
+ 		if (cin)
+ 			(void) fclose(cin);
+ 		if (cout)
+@@ -1254,6 +1259,13 @@
+ 			perror("ftp: socket");
+ 			return(1);
+ 		}
++		if((multihome) &&
++			bind(data, (struct sockaddr*)&source, sizeof(source)) == -1) {
++			close(data);
++			data = -1;
++			perror("ftp multihome bind");
++			return(1);
++                }
+ 		if (options & SO_DEBUG &&
+ 		    setsockopt(data, SOL_SOCKET, SO_DEBUG, (char *)&on,
+ 			       sizeof (on)) < 0)
+--- netkit-ftp-0.17/ftp/main.c.rasold	2006-01-12 11:24:27.000000000 +0100
++++ netkit-ftp-0.17/ftp/main.c	2006-01-12 11:27:20.000000000 +0100
+@@ -93,6 +93,7 @@
+ 	printf("\t   -n: inhibit auto-login\n");
+ 	printf("\t   -e: disable readline support, if present\n");
+ 	printf("\t   -g: disable filename globbing\n");
++	printf("\t   -m: don't force data channel interface to the same as control channel\n");
+ 	printf("\t   -v: verbose mode\n");
+ 	printf("\t   -t: enable packet tracing [nonfunctional]\n");
+ 	printf("\t   -d: enable debugging\n");
+@@ -120,6 +121,7 @@
+ 	doglob = 1;
+ 	interactive = 1;
+ 	autologin = 1;
++	multihome = 1;
+ 	passivemode = 1;
+ 
+         cp = strrchr(argv[0], '/');
+@@ -172,6 +174,10 @@
+ 				rl_inhibit = 1;
+ 				break;
+ 				
++			case 'm':
++				multihome = 0;
++				break;
++
+ 			case 'h':
+ 				usage();
+ 				exit(0);
+--- netkit-ftp-0.17/ftp/ftp.1.rasold	2006-01-12 11:14:09.000000000 +0100
++++ netkit-ftp-0.17/ftp/ftp.1	2006-01-12 11:15:48.000000000 +0100
+@@ -92,6 +92,10 @@
+ executable. Otherwise, does nothing.
+ .It Fl g
+ Disables file name globbing.
++.It Fl m
++The default requires that ftp explicitly binds to the same interface for the data
++channel as the control channel in passive mode. Useful on multi-homed
++clients. This option disables this behavior.
+ .It Fl v
+ Verbose option forces
+ .Nm ftp

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-multiipv6.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-multiipv6.patch
@@ -1,0 +1,66 @@
+--- netkit-ftp-0.17/ftp/ftp.c.multiipv6	2006-08-02 15:03:26.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2006-08-02 15:06:19.000000000 +0200
+@@ -78,9 +78,7 @@
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <arpa/ftp.h>
+-#include <arpa/inet.h>
+ #include <arpa/telnet.h>
+-
+ #include <stdio.h>
+ #include <signal.h>
+ #include <string.h>
+@@ -132,7 +130,7 @@
+ static sigjmp_buf ptabort;
+ static int ptabflg = 0;
+ static int abrtflag = 0;
+-struct sockaddr_in source;
++struct sockaddr_storage source;
+ 
+ void lostpeer(int);
+ extern int connected;
+@@ -154,8 +152,8 @@
+ char *
+ hookup(const char *host, const char *port)
+ {
+-	int s, tos, error, alen;
+-	socklen_t len;
++	int s, tos, error;
++	socklen_t len, alen;
+ 	static char hostnamebuf[256];
+ 	struct addrinfo hints, *res, *res0;
+ 	char hbuf[MAXHOSTNAMELEN], pbuf[NI_MAXSERV];
+@@ -281,7 +279,15 @@
+ 		printf("Connected to %s (%s).\n", hostname, hbuf);
+ 	alen = sizeof(source);
+ 	getsockname(s,(struct sockaddr*)&source, &alen);
+-	source.sin_port = 0;    /* We just want the addr, not the port */
++	switch (source.ss_family) {
++	    /* We just want the addr, not the port */
++	    case AF_INET:
++		((struct sockaddr_in *) &source)->sin_port = 0;
++	        break;
++	    case AF_INET6:
++		((struct sockaddr_in6 *) &source)->sin6_port = 0;
++	        break;
++	}
+ 
+ 	if (getreply(0) > 2) { 	/* read startup message from server    */
+ 		if (cin)
+@@ -1260,11 +1266,11 @@
+ 			return(1);
+ 		}
+ 		if((multihome) &&
+-			bind(data, (struct sockaddr*)&source, sizeof(source)) == -1) {
+-			close(data);
+-			data = -1;
+-			perror("ftp multihome bind");
+-			return(1);
++                       bind(data, (struct sockaddr *)&source, sizeof(source)) == -1) {
++                       close(data);
++                       data = -1;
++                       perror("ftp multihome bind");
++                       return(1);
+                 }
+ 		if (options & SO_DEBUG &&
+ 		    setsockopt(data, SOL_SOCKET, SO_DEBUG, (char *)&on,

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-nodebug.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-nodebug.patch
@@ -1,0 +1,11 @@
+--- netkit-ftp-0.17/ftp/Makefile.nodebug	2006-11-14 15:02:36.000000000 +0100
++++ netkit-ftp-0.17/ftp/Makefile	2007-01-30 13:58:15.000000000 +0100
+@@ -17,7 +17,7 @@
+ 
+ install: ftp
+ 	install -d $(INSTALLROOT)$(BINDIR)
+-	install -s -m$(BINMODE) ftp $(INSTALLROOT)$(BINDIR)
++	install -m$(BINMODE) ftp $(INSTALLROOT)$(BINDIR)
+ 	ln -sf ftp $(INSTALLROOT)$(BINDIR)/pftp
+ 	install -d $(INSTALLROOT)$(MANDIR)/man1
+ 	install -m$(MANMODE) ftp.1 $(INSTALLROOT)$(MANDIR)/man1

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-pre20000412.pasv-security.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-pre20000412.pasv-security.patch
@@ -1,0 +1,49 @@
+diff -urN netkit-ftp-0.17-pre20000412/ftp/ftp.1 netkit-ftp-0.17-pre20000412.new/ftp/ftp.1
+--- netkit-ftp-0.17-pre20000412/ftp/ftp.1	Thu Apr 13 03:56:03 2000
++++ netkit-ftp-0.17-pre20000412.new/ftp/ftp.1	Wed Aug 16 14:13:10 2000
+@@ -62,8 +62,10 @@
+ Use passive mode for data transfers. Allows use of ftp in environments
+ where a firewall prevents connections from the outside world back to
+ the client machine. Requires that the ftp server support the PASV
+-command. This is the default if invoked as
+-.Nm pftp.
++command. This is the default now for
++.Nm all
++clients (ftp and pftp) due to security concerns using the PORT transfer mode.
++The flag is kept for compatibility only and has no effect anymore.
+ .It Fl i
+ Turns off interactive prompting during multiple file transfers.
+ .It Fl n
+diff -urN netkit-ftp-0.17-pre20000412/ftp/ftp.c netkit-ftp-0.17-pre20000412.new/ftp/ftp.c
+--- netkit-ftp-0.17-pre20000412/ftp/ftp.c	Mon Dec 13 21:33:20 1999
++++ netkit-ftp-0.17-pre20000412.new/ftp/ftp.c	Wed Aug 16 14:12:50 2000
+@@ -883,7 +883,7 @@
+ 	}
+ 	if (fstat(fileno(fout), &st) < 0 || st.st_blksize == 0)
+ 		st.st_blksize = BUFSIZ;
+-	if (st.st_blksize > bufsize) {
++	if ((unsigned)st.st_blksize > bufsize) {
+ 		if (buf)
+ 			(void) free(buf);
+ 		buf = malloc((unsigned)st.st_blksize);
+diff -urN netkit-ftp-0.17-pre20000412/ftp/main.c netkit-ftp-0.17-pre20000412.new/ftp/main.c
+--- netkit-ftp-0.17-pre20000412/ftp/main.c	Sat Oct  2 15:25:23 1999
++++ netkit-ftp-0.17-pre20000412.new/ftp/main.c	Wed Aug 16 13:58:57 2000
+@@ -87,7 +87,7 @@
+ usage(void)
+ {
+ 	printf("\n\tUsage: { ftp | pftp } [-pinegvtd] [hostname]\n");
+-	printf("\t   -p: enable passive mode (default for pftp)\n");
++	printf("\t   -p: enable passive mode (default for ftp and pftp)\n");
+ 	printf("\t   -i: turn off prompting during mget\n");
+ 	printf("\t   -n: inhibit auto-login\n");
+ 	printf("\t   -e: disable readline support, if present\n");
+@@ -118,7 +118,7 @@
+ 	doglob = 1;
+ 	interactive = 1;
+ 	autologin = 1;
+-	passivemode = 0;
++	passivemode = 1;
+ 
+         cp = strrchr(argv[0], '/');
+         cp = (cp == NULL) ? argv[0] : cp+1;

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-printf.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-printf.patch
@@ -1,0 +1,11 @@
+--- netkit-ftp-0.17/ftp/cmds.c.printf	2005-05-24 22:12:24.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2005-05-24 22:12:37.000000000 +0200
+@@ -2223,7 +2223,7 @@
+ 		printf("restart: offset not specified\n");
+ 	else {
+ 		restart_point = atol(argv[1]);
+-		printf("restarting at %ld. %s\n", restart_point,
++		printf("restarting at %ld. %s\n", (long)restart_point,
+ 		    "execute get, put or append to initiate transfer");
+ 	}
+ }

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-remove-nested-include.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-remove-nested-include.patch
@@ -1,0 +1,18 @@
+--- netkit-ftp-0.17/ftp/ftp.c	2012-07-20 07:55:48.545151322 +0200
++++ netkit-ftp-0.17-new/ftp/ftp.c	2012-07-20 08:05:07.941468914 +0200
+@@ -74,6 +74,7 @@ char ftp_rcsid[] =
+ #include <sys/socket.h>
+ #include <sys/time.h>
+ #include <sys/file.h>
++#include <sys/poll.h>
+ 
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+@@ -820,7 +821,6 @@ sendrequest(const char *cmd, char *local
+ 	/* It can be later removed.                              */
+ 	if (old_code_l == 150 && code == 150 && cpend == 1
+ 	    && sunique == 1 && cin !=  NULL && fileno (cin) >=  0 ) {
+-		#include <sys/poll.h>
+ 		struct pollfd  fds_events_l [2] ;
+ 		int rc;
+ 

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-runique_mget.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-runique_mget.patch
@@ -1,0 +1,13 @@
+--- netkit-ftp-0.17/ftp/ftp.c.runique_mget	2004-12-07 12:05:49.360133092 +0100
++++ netkit-ftp-0.17/ftp/ftp.c	2004-12-07 12:06:48.480883902 +0100
+@@ -923,7 +923,9 @@
+ 				return;
+ 			}
+ 		}
+-		else if (runique && (local = gunique(local)) == NULL) {
++		else if (runique && (strcmp(cmd, "NLST") != 0) && 
++			 (local = gunique(local)) == NULL)
++		{
+ 			(void) signal(SIGINT, oldintr);
+ 			code = -1;
+ 			return;

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-segv.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-segv.patch
@@ -1,0 +1,82 @@
+--- netkit-ftp-0.17/ftp/ftp.c.segv	2004-06-14 11:04:38.000000000 -0400
++++ netkit-ftp-0.17/ftp/ftp.c	2004-06-14 11:06:46.000000000 -0400
+@@ -472,6 +472,8 @@
+ 					return (0);
+ 				}
+ 				lostpeer(0);
++				fclose(cout);
++				cout = NULL;
+ 				if (verbose) {
+ 					printf("421 Service not available, remote server has closed connection\n");
+ 					(void) fflush(stdout);
+@@ -529,7 +531,14 @@
+ 			cpend = 0;
+ 		(void) signal(SIGINT,oldintr);
+ 		if (code == 421 || originalcode == 421)
++		{
+ 			lostpeer(0);
++			if(cout)
++			{
++				fclose(cout);
++				cout = NULL;
++			}
++		}
+ 		if (abrtflag && oldintr != cmdabort && oldintr != SIG_IGN)
+ 			(*oldintr)(SIGINT);
+ 		return (n - '0');
+@@ -1790,6 +1799,11 @@
+ 			if (ptabflg)
+ 				code = -1;
+ 			lostpeer(0);
++			if(cout != NULL)
++			{
++				fclose(cout);
++				cout = NULL;
++			}
+ 		}
+ 		(void) getreply(0);
+ 		(void) getreply(0);
+@@ -1815,6 +1829,11 @@
+ 			perror("reset");
+ 			code = -1;
+ 			lostpeer(0);
++			if(cout != NULL)
++			{
++				fclose(cout);
++				cout = NULL;
++			}
+ 		}
+ 		else if (nfnd) {
+ 			(void) getreply(0);
+@@ -1897,6 +1916,11 @@
+ 		if (ptabflg)
+ 			code = -1;
+ 		lostpeer(0);
++		if(cout != NULL)
++		{
++			fclose(cout);
++			cout = NULL;
++		}
+ 	}
+ 	if (din && FD_ISSET(fileno(din), &mask)) {
+ 		while (read(fileno(din), buf, BUFSIZ) > 0)
+--- netkit-ftp-0.17/ftp/main.c.segv	2004-06-14 11:03:18.000000000 -0400
++++ netkit-ftp-0.17/ftp/main.c	2004-06-14 11:03:42.000000000 -0400
+@@ -235,8 +235,6 @@
+ 	if (connected) {
+ 		if (cout != NULL) {
+ 			shutdown(fileno(cout), 1+1);
+-			fclose(cout);
+-			cout = NULL;
+ 		}
+ 		if (data >= 0) {
+ 			shutdown(data, 1+1);
+@@ -249,8 +247,6 @@
+ 	if (connected) {
+ 		if (cout != NULL) {
+ 			shutdown(fileno(cout), 1+1);
+-			fclose(cout);
+-			cout = NULL;
+ 		}
+ 		connected = 0;
+ 	}

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-sigseg.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-sigseg.patch
@@ -1,0 +1,16 @@
+--- netkit-ftp-0.17-orig/ftp/ftp.c	2007-08-06 23:32:49.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2007-08-06 23:31:06.000000000 +0200
+@@ -483,8 +483,10 @@ getreply(int expecteof)
+ 					return (0);
+ 				}
+ 				lostpeer(0);
+-				fclose(cout);
+-				cout = NULL;
++				if (cout) {
++					fclose(cout);
++					cout = NULL;
++				}
+ 				if (verbose) {
+ 					printf("421 Service not available, remote server has closed connection\n");
+ 					(void) fflush(stdout);
+

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-size.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-size.patch
@@ -1,0 +1,12 @@
+diff -up netkit-ftp-0.17/ftp/cmds.c.size netkit-ftp-0.17/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c.size	2007-10-10 14:17:18.000000000 +0200
++++ netkit-ftp-0.17/ftp/cmds.c	2007-10-10 14:17:18.000000000 +0200
+@@ -1650,6 +1650,8 @@ quote1(const char *initial, int argc, ch
+ 	register int i, len;
+ 	char buf[BUFSIZ];		/* must be >= sizeof(line) */
+ 
++	if (strncmp(argv[1],"size",4) == 0)
++	    changetype(TYPE_I, 1);
+ 	(void) strcpy(buf, initial);
+ 	if (argc > 1) {
+ 		len = strlen(buf);

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-stamp.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-stamp.patch
@@ -1,0 +1,23 @@
+--- netkit-ftp-0.17/ftp/Makefile.stamp	2007-02-07 05:21:13.000000000 -0500
++++ netkit-ftp-0.17/ftp/Makefile	2007-02-07 05:26:13.453244000 -0500
+@@ -16,14 +16,14 @@
+ cmds.o glob.o: glob.h
+ 
+ install: ftp
+-	install -d $(INSTALLROOT)$(BINDIR)
+-	install -m$(BINMODE) ftp $(INSTALLROOT)$(BINDIR)
++	install -p -d $(INSTALLROOT)$(BINDIR)
++	install -p -m$(BINMODE) ftp $(INSTALLROOT)$(BINDIR)
+ 	ln -sf ftp $(INSTALLROOT)$(BINDIR)/pftp
+-	install -d $(INSTALLROOT)$(MANDIR)/man1
+-	install -m$(MANMODE) ftp.1 $(INSTALLROOT)$(MANDIR)/man1
++	install -p -d $(INSTALLROOT)$(MANDIR)/man1
++	install -p -m$(MANMODE) ftp.1 $(INSTALLROOT)$(MANDIR)/man1
+ 	ln -sf ftp.1 $(INSTALLROOT)$(MANDIR)/man1/pftp.1
+-	install -d $(INSTALLROOT)$(MANDIR)/man5
+-	install -m$(MANMODE) netrc.5 $(INSTALLROOT)$(MANDIR)/man5
++	install -p -d $(INSTALLROOT)$(MANDIR)/man5
++	install -p -m$(MANMODE) netrc.5 $(INSTALLROOT)$(MANDIR)/man5
+ 
+ clean:
+ 	rm -f *.o ftp

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-token.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-token.patch
@@ -1,0 +1,75 @@
+diff -rup netkit-ftp-0.17/ftp/ruserpass.c netkit-ftp-0.17-new/ftp/ruserpass.c
+--- netkit-ftp-0.17/ftp/ruserpass.c	2012-10-29 15:11:10.593841089 +0100
++++ netkit-ftp-0.17-new/ftp/ruserpass.c	2012-10-29 15:13:14.379822697 +0100
+@@ -58,7 +58,8 @@ static int token(void);
+ #define	ID	10
+ #define	MACH	11
+ 
+-static char tokval[100];
++#define MAXTOKENLEN 4096
++static char tokval[MAXTOKENLEN];
+ 
+ static struct toktab {
+ 	const char *tokstr;
+@@ -249,13 +250,16 @@ bad:
+ 	return(-1);
+ }
+ 
+-static 
++static
+ int
+ token(void)
+ {
+ 	char *cp;
+ 	int c;
+ 	struct toktab *t;
++	size_t toklen = 0;
++	int showwarn = 1;
++	int quote = 0;
+ 
+ 	if (feof(cfile))
+ 		return (0);
+@@ -266,20 +270,32 @@ token(void)
+ 		return (0);
+ 	cp = tokval;
+ 	if (c == '"') {
+-		while ((c = getc(cfile)) != EOF && c != '"') {
+-			if (c == '\\')
+-				c = getc(cfile);
+-			*cp++ = c;
+-		}
+-	} else {
++		quote = 1;
++	}
++	else {
+ 		*cp++ = c;
+-		while ((c = getc(cfile)) != EOF
+-		    && c != '\n' && c != '\t' && c != ' ' && c != ',') {
+-			if (c == '\\')
+-				c = getc(cfile);
+-			*cp++ = c;
++		toklen++;
++	}
++	while ((c = getc(cfile)) != EOF) {
++		if (c == '"')
++			break;
++		if (c == '\\')
++			c = getc(cfile);
++		if (!quote && (c == '\n' || c == '\t' || c == ' ' || c == ','))
++			break;
++		if (toklen >= MAXTOKENLEN) {
++			if (showwarn) {
++				fprintf(stderr,
++						"Warning: .netrc token too long, will be trunctated to %zd characters\n",
++						toklen);
++				showwarn = 0;
++			}
++			continue;
+ 		}
++		*cp++ = c;
++		toklen++;
+ 	}
++
+ 	*cp = 0;
+ 	if (tokval[0] == 0)
+ 		return (0);

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-volatile.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-volatile.patch
@@ -1,0 +1,39 @@
+--- netkit-ftp-0.17/configure.volatile	2004-06-14 12:08:26.000000000 -0400
++++ netkit-ftp-0.17/configure	2004-06-14 12:52:41.000000000 -0400
+@@ -193,8 +193,8 @@
+ cat <<EOF >__conftest.c
+ #include <unistd.h>
+ #include <signal.h>
+-int count=0;
+-void handle(int foo) { count++; }
++volatile int count=0;
++void handle(int foo) { count++; write(1,"X",1);}
+ int main() {
+     int pid=getpid();
+     signal(SIGINT, handle);
+@@ -209,20 +209,20 @@
+ if (
+       $CC $CFLAGS  __conftest.c  -o __conftest || exit 1
+       ./__conftest || exit 1
+-   ) >/dev/null 2>&1; then
++   ); then
+     echo 'yes'
+ else
+     if (
+           $CC $CFLAGS -D__USE_BSD_SIGNAL __conftest.c  -o __conftest || exit 1
+           ./__conftest || exit 1
+-       ) >/dev/null 2>&1; then
++       ); then
+         echo '-D__USE_BSD_SIGNAL'
+         CFLAGS="$CFLAGS -D__USE_BSD_SIGNAL"
+     else
+         echo 'no'
+-        echo 'This package needs BSD signal semantics to run.'
+-        rm -f __conftest*
+-        exit
++        echo '***WARNING***: This package needs BSD signal semantics to run.'
++	echo '***WARNING***: Assuming its just ia64 buildroot breakage.'
++        CFLAGS="$CFLAGS -D__USE_BSD_SIGNAL"
+     fi
+ fi
+ rm -f __conftest*

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-vsftp165083.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-0.17-vsftp165083.patch
@@ -1,0 +1,47 @@
+--- netkit-ftp-0.17/ftp/ftp.c.vsftp	2005-08-29 16:07:35.000000000 +0200
++++ netkit-ftp-0.17/ftp/ftp.c	2005-08-30 10:58:10.000000000 +0200
+@@ -582,6 +582,7 @@
+ 	volatile long long bytes = 0, hashbytes = HASHBYTES;
+ 	char buf[BUFSIZ], *bufp;
+ 	const char *volatile lmode;
++        int old_code_l;
+ 
+ 	if (verbose && printnames) {
+ 		if (local && *local != '-')
+@@ -799,7 +800,35 @@
+ 	(void) fclose(dout);
+ 	/* closes data as well, so discard it */
+ 	data = -1;
+-	(void) getreply(0);
++	old_code_l = code;
++	(void) getreply(0);
++
++	/* Following "if" will avoid a bug #165083 in ftp-server */
++	/* It can be later removed.                              */
++	if (old_code_l == 150 && code == 150 && cpend == 1
++	    && sunique == 1 && cin !=  NULL && fileno (cin) >=  0 ) {
++		#include <sys/poll.h>
++		struct pollfd  fds_events_l [2] ;
++		int rc;
++
++		fds_events_l [0] .fd = fileno (cin);
++		fds_events_l [0] .events = POLLIN | POLLERR | POLLHUP;
++           
++		rc = poll (fds_events_l, 1, 5000);
++		switch (rc) {
++		case  1:
++			(void) getreply (0);
++			break;
++		case  0:
++			fprintf (stderr, "ftp: no answer from ftp-server "
++			                 "(more than 5 sec).\n");
++			break;
++		case -1:
++			perror("ftp: poll");
++			break;
++		}
++	}
++
+ 	(void) signal(SIGINT, oldintr);
+ 	if (oldintp)
+ 		(void) signal(SIGPIPE, oldintp);

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-locale.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp-locale.patch
@@ -1,0 +1,18 @@
+--- netkit-ftp-0.17/ftp/main.c.locale	2004-12-15 16:52:14.504193752 +0000
++++ netkit-ftp-0.17/ftp/main.c	2004-12-15 16:52:51.719133655 +0000
+@@ -51,6 +51,7 @@
+ 
+ /* #include <arpa/ftp.h>	<--- unused? */
+ 
++#include <locale.h>
+ #include <signal.h>
+ #include <unistd.h>
+ #include <string.h>
+@@ -109,6 +110,7 @@
+ 
+ 	tick = 0;
+ 
++	setlocale (LC_ALL, "");
+ 	sp = getservbyname("ftp", "tcp");
+ 	if (sp == 0) {
+ 		fprintf(stderr, "ftp: ftp/tcp: unknown service\n");

--- a/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp.usagi-ipv6.patch
+++ b/var/spack/repos/builtin/packages/netkit-ftp/netkit-ftp.usagi-ipv6.patch
@@ -1,0 +1,928 @@
+diff -uNr netkit-ftp-0.17/CVS/Entries netkit-ftp/CVS/Entries
+diff -uNr netkit-ftp-0.17/ChangeLog netkit-ftp/ChangeLog
+--- netkit-ftp-0.17/ChangeLog	Sun Jul 23 04:38:08 2000
++++ netkit-ftp/ChangeLog	Tue Nov 28 03:50:10 2000
+@@ -1,3 +1,6 @@
++28-Nov-2000:
++	IPv6 support. (Hiroyuki YAMAMORI <h-yamamo@db3.so-net.ne.jp>)
++
+ 8-Jul-2000:
+ 	Fix misused printf-function call (not %n-exploitable though).
+ 
+diff -uNr netkit-ftp-0.17/configure netkit-ftp/configure
+--- netkit-ftp-0.17/configure	Sat Jul 29 21:00:28 2000
++++ netkit-ftp/configure	Sat Jan 27 06:14:54 2001
+@@ -24,6 +24,7 @@
+     --binmode=mode        Mode for binaries [755]
+     --manmode=mode        Mode for manual pages [644]
+     --with-c-compiler=cc  Program for compiling C source [guessed]
++    --enable-ipv6         Enable IPv6 support
+ EOF
+ 	exit 0;;
+ 	--verbose) ;;
+@@ -39,6 +40,11 @@
+ 	--manmode=*) MANMODE=`echo $1 | sed 's/^[^=]*=//'` ;;
+ 	--with-c-compiler=*) CC=`echo $1 | sed 's/^[^=]*=//'` ;;
+ 	--without-readline|--disable-readline) WITHOUT_READLINE=1;;
++
++	--disable-ipv6) ENABLE_IPV6=no;;
++	--enable-ipv6=*) ENABLE_IPV6=`echo $1 | sed 's/^[^=]*=//'`;;
++	--enable-ipv6) ENABLE_IPV6=yes;;
++
+ 	*) echo "Unrecognized option: $1"; exit 1;;
+ esac 
+ shift
+@@ -142,6 +148,42 @@
+ 
+ LDFLAGS=
+ LIBS=
++
++rm -f __conftest*
++
++##################################################
++## Enable IPv6
++echo -n "Whether to enable IPv6 support... "
++if [ x"$ENABLE_IPV6" = x"yes" ]; then
++    echo yes
++    CFLAGS="$CFLAGS -DINET6"
++else
++    echo no
++fi
++
++rm -f __conftest*
++
++## Search IPv6 Library / Headers
++if [ x"$ENABLE_IPV6" = x"yes" ]; then
++    echo -n "Search for IPv6 library... "
++    inet6libdirs="/usr/local/v6/lib /usr/local/lib /usr /usr/inet6/lib"
++    inet6libs="inet6"
++    inet6found=no
++    for inet6libdir in $inet6libdirs; do
++        for inet6lib in $inet6libs; do
++            if [ -d $inet6libdir ] && [ -f $inet6libdir/lib$inet6lib.a ]; then
++                inet6found=yes
++                break 2
++            fi
++        done
++    done
++    if [ x"$inet6found" = x"yes" ]; then
++        echo "$inet6libdir/lib$inet6lib.a"
++        LIBS="$LIBS -L$inet6libdir -l$inet6lib"
++    else
++        echo "not found"
++    fi
++fi
+ 
+ rm -f __conftest*
+ 
+diff -uNr netkit-ftp-0.17/ftp/CVS/Entries netkit-ftp/ftp/CVS/Entries
+--- netkit-ftp-0.17/ftp/CVS/Entries	Thu Jan  1 02:00:00 1970
++++ netkit-ftp/ftp/CVS/Entries	Mon Feb 19 06:50:49 2001
+@@ -0,0 +1,16 @@
++/.cvsignore/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/Makefile/1.4/Sat Jan 27 05:57:08 2001//
++/cmds.c/1.3/Fri Jan 12 21:36:27 2001//
++/cmds.h/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/cmdtab.c/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/domacro.c/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/ftp.1/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/ftp.c/1.11/Sun Feb 11 12:26:59 2001//
++/ftp_var.h/1.3/Fri Jan 12 21:36:27 2001//
++/glob.c/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/glob.h/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/main.c/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/netrc.5/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/pathnames.h/1.1.1.1/Fri Nov  3 19:18:15 2000//
++/ruserpass.c/1.1.1.1/Fri Nov  3 19:18:15 2000//
++D
+diff -uNr netkit-ftp-0.17/ftp/CVS/Repository netkit-ftp/ftp/CVS/Repository
+--- netkit-ftp-0.17/ftp/CVS/Repository	Thu Jan  1 02:00:00 1970
++++ netkit-ftp/ftp/CVS/Repository	Mon Feb 19 06:50:49 2001
+@@ -0,0 +1 @@
++usagi/src/netkit-ftp/ftp
+diff -uNr netkit-ftp-0.17/ftp/CVS/Root netkit-ftp/ftp/CVS/Root
+--- netkit-ftp-0.17/ftp/CVS/Root	Thu Jan  1 02:00:00 1970
++++ netkit-ftp/ftp/CVS/Root	Mon Feb 19 06:50:49 2001
+@@ -0,0 +1 @@
++:pserver:anoncvs@anoncvs.linux-ipv6.org:/cvsroot/usagi
+diff -uNr netkit-ftp-0.17/ftp/Makefile netkit-ftp/ftp/Makefile
+--- netkit-ftp-0.17/ftp/Makefile	Sun Aug  1 09:00:12 1999
++++ netkit-ftp/ftp/Makefile	Sat Jan 27 07:57:08 2001
+@@ -16,10 +16,13 @@
+ cmds.o glob.o: glob.h
+ 
+ install: ftp
++	install -d $(INSTALLROOT)$(BINDIR)
+ 	install -s -m$(BINMODE) ftp $(INSTALLROOT)$(BINDIR)
+ 	ln -sf ftp $(INSTALLROOT)$(BINDIR)/pftp
++	install -d $(INSTALLROOT)$(MANDIR)/man1
+ 	install -m$(MANMODE) ftp.1 $(INSTALLROOT)$(MANDIR)/man1
+ 	ln -sf ftp.1 $(INSTALLROOT)$(MANDIR)/man1/pftp.1
++	install -d $(INSTALLROOT)$(MANDIR)/man5
+ 	install -m$(MANMODE) netrc.5 $(INSTALLROOT)$(MANDIR)/man5
+ 
+ clean:
+diff -uNr netkit-ftp-0.17/ftp/cmds.c netkit-ftp/ftp/cmds.c
+--- netkit-ftp-0.17/ftp/cmds.c	Sun Jul 23 04:36:59 2000
++++ netkit-ftp/ftp/cmds.c	Fri Jan 12 23:36:27 2001
+@@ -1,3 +1,5 @@
++/* $USAGI$ */
++
+ /*
+  * Copyright (c) 1985, 1989 Regents of the University of California.
+  * All rights reserved.
+@@ -35,7 +37,7 @@
+  * from: @(#)cmds.c	5.26 (Berkeley) 3/5/91
+  */
+ char cmds_rcsid[] = 
+-   "$Id: cmds.c,v 1.33 2000/07/23 01:36:59 dholland Exp $";
++   "$Id: cmds.c,v 1.3 2001/01/12 21:36:27 sekiya Exp $";
+ 
+ /*
+  * FTP User Program -- Command Routines.
+@@ -190,7 +192,7 @@
+ setpeer(int argc, char *argv[])
+ {
+ 	char *host;
+-	unsigned short port;
++	char *port;
+ 
+ 	if (connected) {
+ 		printf("Already connected to %s, use close first.\n",
+@@ -205,22 +207,17 @@
+ 		code = -1;
+ 		return;
+ 	}
+-	port = ftp_port;
++	port = NULL;
+ 	if (argc > 2) {
+-		port = atoi(argv[2]);
+-		if (port < 1) {
+-			printf("%s: bad port number-- %s\n", argv[1], argv[2]);
+-			printf ("usage: %s host-name [port]\n", argv[0]);
+-			code = -1;
+-			return;
+-		}
+-		port = htons(port);
++		port = argv[2];
+ 	}
+ 	host = hookup(argv[1], port);
+ 	if (host) {
+ 		int overbose;
+ 
+ 		connected = 1;
++		try_epsv = 1;
++		try_eprt = 1;
+ 		/*
+ 		 * Set up defaults for FTP.
+ 		 */
+diff -uNr netkit-ftp-0.17/ftp/cmdtab.c netkit-ftp/ftp/cmdtab.c
+--- netkit-ftp-0.17/ftp/cmdtab.c	Tue Sep 28 18:36:05 1999
++++ netkit-ftp/ftp/cmdtab.c	Fri Nov  3 21:18:15 2000
+@@ -35,7 +35,7 @@
+  * from: @(#)cmdtab.c	5.10 (Berkeley) 6/1/90
+  */
+ char cmdtab_rcsid[] = 
+-  "$Id: cmdtab.c,v 1.8 1999/09/28 15:36:05 dholland Exp $";
++  "$Id: cmdtab.c,v 1.1.1.1 2000/11/03 19:18:15 mk Exp $";
+ 
+ #include <string.h>   /* for NULL */
+ #include "ftp_var.h"
+diff -uNr netkit-ftp-0.17/ftp/domacro.c netkit-ftp/ftp/domacro.c
+--- netkit-ftp-0.17/ftp/domacro.c	Thu Aug 15 02:27:28 1996
++++ netkit-ftp/ftp/domacro.c	Fri Nov  3 21:18:15 2000
+@@ -35,7 +35,7 @@
+  * from: @(#)domacro.c	1.8 (Berkeley) 9/28/90
+  */
+ char domacro_rcsid[] = 
+-  "$Id: domacro.c,v 1.4 1996/08/14 23:27:28 dholland Exp $";
++  "$Id: domacro.c,v 1.1.1.1 2000/11/03 19:18:15 mk Exp $";
+ 
+ #include <errno.h>
+ #include <ctype.h>
+diff -uNr netkit-ftp-0.17/ftp/ftp.1 netkit-ftp/ftp/ftp.1
+--- netkit-ftp-0.17/ftp/ftp.1	Mon Jul 31 02:56:59 2000
++++ netkit-ftp/ftp/ftp.1	Fri Nov  3 21:18:15 2000
+@@ -30,7 +30,7 @@
+ .\" SUCH DAMAGE.
+ .\"
+ .\"	from: @(#)ftp.1	6.18 (Berkeley) 7/30/91
+-.\"	$Id: ftp.1,v 1.14 2000/07/30 23:56:59 dholland Exp $
++.\"	$Id: ftp.1,v 1.1.1.1 2000/11/03 19:18:15 mk Exp $
+ .\"
+ .Dd August 15, 1999
+ .Dt FTP 1
+diff -uNr netkit-ftp-0.17/ftp/ftp.c netkit-ftp/ftp/ftp.c
+--- netkit-ftp-0.17/ftp/ftp.c	Mon Dec 13 22:33:20 1999
++++ netkit-ftp/ftp/ftp.c	Sun Feb 11 14:26:59 2001
+@@ -1,3 +1,34 @@
++/* $USAGI$ */
++
++/*
++ * Copyright (C) 1997 and 1998 WIDE Project.
++ * All rights reserved.
++ * 
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the project nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ * 
++ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
+ /*
+  * Copyright (c) 1985, 1989 Regents of the University of California.
+  * All rights reserved.
+@@ -35,7 +66,7 @@
+  * From: @(#)ftp.c	5.38 (Berkeley) 4/22/91
+  */
+ char ftp_rcsid[] = 
+-  "$Id: ftp.c,v 1.25 1999/12/13 20:33:20 dholland Exp $";
++  "$Id: ftp.c,v 1.11 2001/02/11 12:26:59 yoshfuji Exp $";
+ 
+ #include <sys/param.h>
+ #include <sys/stat.h>
+@@ -63,14 +94,38 @@
+ #include "ftp_var.h"
+ #include "cmds.h"
+ 
++#ifdef _USAGI
++#include "version.h"
++#else
+ #include "../version.h"
++#endif
++
++union sockunion {
++	struct sockinet {
++		u_short	si_family;
++		u_short	si_port;
++	} su_si;
++	struct	sockaddr		su_sa;
++	struct	sockaddr_in  		su_sin;
++#ifdef INET6
++	struct	sockaddr_in6 		su_sin6;
++#endif
++};
++#define	su_family	su_sa.sa_family
++#define	su_port		su_si.si_port
++
++#ifdef INET6
++#define ex_af2prot(a) (a == AF_INET ? 1 : (a == AF_INET6 ? 2 : 0))
++#else
++#define ex_af2prot(a) (a == AF_INET ? 1 : 0)
++#endif
+ 
+ int data = -1;
+ off_t restart_point = 0;
+ 
+-static struct sockaddr_in hisctladdr;
+-static struct sockaddr_in data_addr;
+-static struct sockaddr_in myctladdr;
++static union sockunion hisctladdr;
++static union sockunion data_addr;
++static union sockunion myctladdr;
+ static int ptflag = 0;
+ static sigjmp_buf recvabort;
+ static sigjmp_buf sendabort;
+@@ -96,79 +151,119 @@
+ static FILE *dataconn(const char *);
+ 
+ char *
+-hookup(char *host, int port)
++hookup(const char *host, const char *port)
+ {
+-	register struct hostent *hp = 0;
+-	int s, tos;
++	int s, tos, error;
+ 	socklen_t len;
+ 	static char hostnamebuf[256];
+-
++	struct addrinfo hints, *res, *res0;
++	char hbuf[MAXHOSTNAMELEN], pbuf[NI_MAXSERV];
++	char *cause = "ftp: unknown";
++
++	if (port) {
++		strncpy(pbuf, port, sizeof(pbuf) - 1);
++		pbuf[sizeof(pbuf) - 1] = '\0';
++	} else {
++		sprintf(pbuf, "%d", ntohs(ftp_port));
++	}
+ 	memset(&hisctladdr, 0, sizeof(hisctladdr));
+-	if (inet_aton(host, &hisctladdr.sin_addr)) {
+-		hisctladdr.sin_family = AF_INET;
+-		strncpy(hostnamebuf, host, sizeof(hostnamebuf));
+-		hostnamebuf[sizeof(hostnamebuf)-1]=0;
+-	} 
+-	else {
+-		hp = gethostbyname(host);
+-		if (hp == NULL) {
+-			fprintf(stderr, "ftp: %s: ", host);
+-			herror((char *)NULL);
+-			code = -1;
+-			return((char *) 0);
++	memset(&hints, 0, sizeof(hints));
++	hints.ai_flags = AI_CANONNAME;
++	hints.ai_socktype = SOCK_STREAM;
++	error = getaddrinfo(host, pbuf, &hints, &res0);
++	if (error) {
++		if (port) {
++			strcpy(hbuf, " ");
++		} else {
++			hbuf[0] = '\0';
++			pbuf[0] = '\0';
+ 		}
+-		hisctladdr.sin_family = hp->h_addrtype;
+-		if (hp->h_length > (int)sizeof(hisctladdr.sin_addr)) {
+-			hp->h_length = sizeof(hisctladdr.sin_addr);
+-		}
+-		memcpy(&hisctladdr.sin_addr, hp->h_addr_list[0], hp->h_length);
+-		(void) strncpy(hostnamebuf, hp->h_name, sizeof(hostnamebuf));
+-		hostnamebuf[sizeof(hostnamebuf)-1] = 0;
+-	}
+-	hostname = hostnamebuf;
+-	s = socket(hisctladdr.sin_family, SOCK_STREAM, 0);
+-	if (s < 0) {
+-		perror("ftp: socket");
++		fprintf(stderr, "ftp: %s%s%s: %s\n", host, hbuf, pbuf,
++						gai_strerror(error));
+ 		code = -1;
+ 		return (0);
+ 	}
+-	hisctladdr.sin_port = port;
+-	while (connect(s, (struct sockaddr *)&hisctladdr, sizeof (hisctladdr)) < 0) {
+-		if (hp && hp->h_addr_list[1]) {
+-			int oerrno = errno;
+-
+-			fprintf(stderr, "ftp: connect to address %s: ",
+-				inet_ntoa(hisctladdr.sin_addr));
+-			errno = oerrno;
+-			perror((char *) 0);
+-			hp->h_addr_list++;
+-			memcpy(&hisctladdr.sin_addr, hp->h_addr_list[0], 
+-			       hp->h_length);
+-			fprintf(stdout, "Trying %s...\n",
+-				inet_ntoa(hisctladdr.sin_addr));
+-			(void) close(s);
+-			s = socket(hisctladdr.sin_family, SOCK_STREAM, 0);
+-			if (s < 0) {
+-				perror("ftp: socket");
+-				code = -1;
+-				return (0);
++
++	if (res0->ai_canonname) {
++		struct addrinfo h, *a;
++		memset(&h, 0, sizeof(h));
++		h.ai_family = PF_UNSPEC;
++		h.ai_socktype = SOCK_STREAM;
++		h.ai_flags = AI_NUMERICHOST;
++		if (!getaddrinfo(res0->ai_canonname, NULL, &h, &a)) {
++			strncpy(hostnamebuf, res0->ai_canonname, sizeof(hostnamebuf));
++			freeaddrinfo(a);
++		} else
++			strncpy(hostnamebuf, host, sizeof(hostnamebuf));
++	}
++	else
++		strncpy(hostnamebuf, host, sizeof(hostnamebuf));
++	hostnamebuf[sizeof(hostnamebuf) - 1] = '\0';
++	hostname = hostnamebuf;
++	
++	s = -1;
++	for (res = res0; res; res = res->ai_next) {
++		if (!ex_af2prot(res->ai_family)) {
++			cause = "ftp: mismatch address family";
++			errno = EPROTONOSUPPORT;
++			continue;
++		}
++		if ((size_t)res->ai_addrlen > sizeof(hisctladdr)) {
++			cause = "ftp: mismatch struct sockaddr size";
++			errno = EPROTO;
++			continue;
++		}
++		if (getnameinfo(res->ai_addr, res->ai_addrlen,
++				hbuf, sizeof(hbuf), NULL, 0,
++				NI_NUMERICHOST))
++			strcpy(hbuf, "???");
++		if (res0->ai_next)	/* if we have multiple possibilities */
++			fprintf(stdout, "Trying %s...\n", hbuf);
++		s = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
++		if (s < 0) {
++			cause = "ftp: socket";
++			continue;
++		}
++		while ((error = connect(s, res->ai_addr, res->ai_addrlen)) < 0
++				&& errno == EINTR) {
++			;
++		}
++		if (error) {
++			/* this "if" clause is to prevent print warning twice */
++			if (res->ai_next) {
++				fprintf(stderr,
++					"ftp: connect to address %s", hbuf);
++				perror("");
+ 			}
++			cause = "ftp: connect";
++			close(s);
++			s = -1;
+ 			continue;
+ 		}
+-		perror("ftp: connect");
++		/* finally we got one */
++		break;
++	}
++	if (s < 0) {
++		perror(cause);
+ 		code = -1;
+-		goto bad;
++		freeaddrinfo(res0);
++		return NULL;
+ 	}
+-	len = sizeof (myctladdr);
++	len = res->ai_addrlen;
++	memcpy(&hisctladdr, res->ai_addr, len);
++	freeaddrinfo(res0);
+ 	if (getsockname(s, (struct sockaddr *)&myctladdr, &len) < 0) {
+ 		perror("ftp: getsockname");
+ 		code = -1;
+ 		goto bad;
+ 	}
+ #ifdef IP_TOS
++	if (hisctladdr.su_family == AF_INET)
++	{
+ 	tos = IPTOS_LOWDELAY;
+ 	if (setsockopt(s, IPPROTO_IP, IP_TOS, (char *)&tos, sizeof(int)) < 0)
+ 		perror("ftp: setsockopt TOS (ignored)");
++	}
+ #endif
+ 	cin = fdopen(s, "r");
+ 	cout = fdopen(s, "w");
+@@ -182,7 +277,7 @@
+ 		goto bad;
+ 	}
+ 	if (verbose)
+-		printf("Connected to %s.\n", hostname);
++		printf("Connected to %s (%s).\n", hostname, hbuf);
+ 	if (getreply(0) > 2) { 	/* read startup message from server */
+ 		if (cin)
+ 			(void) fclose(cin);
+@@ -392,8 +487,10 @@
+ 			}
+ 			if (dig < 4 && isdigit(c))
+ 				code = code * 10 + (c - '0');
+-			if (!pflag && code == 227)
++			if (!pflag && (code == 227 || code == 228))
+ 				pflag = 1;
++			else if (!pflag && code == 229)
++				pflag = 100;
+ 			if (dig > 4 && pflag == 1 && isdigit(c))
+ 				pflag = 2;
+ 			if (pflag == 2) {
+@@ -405,6 +502,8 @@
+ 					pflag = 3;
+ 				}
+ 			}
++			if (pflag == 100 && c == '(')
++				pflag = 2;
+ 			if (dig == 4 && c == '-') {
+ 				if (continuation)
+ 					code = 0;
+@@ -1083,15 +1182,25 @@
+ static int
+ initconn(void)
+ {
+-	register char *p, *a;
++	u_char *p, *a;
+ 	int result, tmpno = 0;
+ 	socklen_t len;
+ 	int on = 1;
+-	int tos;
+-	u_long a1,a2,a3,a4,p1,p2;
+-
++	int tos, error = 0;
++	u_int ad[16], po[2], af, alen, plen;
++	char *pasvcmd = NULL;
++	char hbuf[MAXHOSTNAMELEN], pbuf[NI_MAXSERV];
++
++#ifdef INET6
++	if (myctladdr.su_family == AF_INET6
++	 && (IN6_IS_ADDR_LINKLOCAL(&myctladdr.su_sin6.sin6_addr)
++	  || IN6_IS_ADDR_SITELOCAL(&myctladdr.su_sin6.sin6_addr))) {
++		fprintf(stderr, "use of scoped address can be troublesome\n");
++	}
++#endif
+ 	if (passivemode) {
+-		data = socket(AF_INET, SOCK_STREAM, 0);
++		data_addr = hisctladdr;
++		data = socket(data_addr.su_family, SOCK_STREAM, 0);
+ 		if (data < 0) {
+ 			perror("ftp: socket");
+ 			return(1);
+@@ -1100,52 +1209,203 @@
+ 		    setsockopt(data, SOL_SOCKET, SO_DEBUG, (char *)&on,
+ 			       sizeof (on)) < 0)
+ 			perror("ftp: setsockopt (ignored)");
+-		if (command("PASV") != COMPLETE) {
++		switch (data_addr.su_family) {
++		case AF_INET:
++#if 0
++			if (try_epsv) {
++				result = command(pasvcmd = "EPSV 1");
++				if (code / 10 == 22 && code != 229) {
++					fprintf(stderr,
++				  "wrong server: return code must be 229\n");
++					result = COMPLETE + 1;
++				}
++			} else {
++#endif
++			result = COMPLETE + 1;
++
++			if (result != COMPLETE) {
++				try_epsv = 0;
++				result = command(pasvcmd = "PASV");
++			}
++			break;
++#ifdef INET6
++		case AF_INET6:
++			if (try_epsv) {
++				result = command(pasvcmd = "EPSV 2");
++				if (code / 10 == 22 && code != 229) {
++					fprintf(stderr,
++				  "wrong server: return code must be 229\n");
++					result = COMPLETE + 1;
++				}
++			} else {
++				result = COMPLETE + 1;
++			}
++			if (result != COMPLETE) {
++				try_epsv = 0;
++				result = command(pasvcmd = "LPSV");
++			}
++			break;
++#endif
++		default:
++			result = COMPLETE + 1;
++			break;
++		}
++		if (result != COMPLETE) {
+ 			printf("Passive mode refused.\n");
+-			return(1);
++			goto bad;
+ 		}
+ 
++#define pack2(var) \
++	(((var[0] & 0xff) << 8) | ((var[1] & 0xff) << 0))
++#define pack4(var) \
++	((((var)[0] & 0xff) << 24) | (((var)[1] & 0xff) << 16) | \
++	 (((var)[2] & 0xff) << 8) | (((var)[3] & 0xff) << 0))
++
+ 		/*
+ 		 * What we've got at this point is a string of comma separated
+ 		 * one-byte unsigned integer values, separated by commas.
+-		 * The first four are the an IP address. The fifth is the MSB
+-		 * of the port number, the sixth is the LSB. From that we'll
+-		 * prepare a sockaddr_in.
+ 		 */
+-
+-		if (sscanf(pasv,"%ld,%ld,%ld,%ld,%ld,%ld",
+-			   &a1,&a2,&a3,&a4,&p1,&p2)
+-		    != 6) 
+-		{
+-			printf("Passive mode address scan failure. Shouldn't happen!\n");
+-			return(1);
++		error = 0;
++		if (strcmp(pasvcmd, "PASV") == 0) {
++			if (data_addr.su_family != AF_INET) {
++				error = 2;
++				goto psv_done;
++			}
++			if (code / 10 == 22 && code != 227) {
++				error = 227;
++				goto psv_done;
++			}
++			if (sscanf(pasv, "%u,%u,%u,%u,%u,%u",
++					&ad[0], &ad[1], &ad[2], &ad[3],
++					&po[0], &po[1]) != 6) {
++				error = 1;
++				goto psv_done;
++			}
++			data_addr.su_sin.sin_addr.s_addr = htonl(pack4(ad));
++			data_addr.su_port = htons(pack2(po));
++		} else
++		    if (strcmp(pasvcmd, "LPSV") == 0) {
++			if (code / 10 == 22 && code != 228) {
++				error = 228;
++				goto psv_done;
++			}
++			switch (data_addr.su_family) {
++			case AF_INET:
++				if (sscanf(pasv, "%u,%u,%u,%u,%u,%u,%u,%u,%u",
++						&af, &alen,
++						&ad[0], &ad[1], &ad[2], &ad[3],
++						&plen, &po[0], &po[1]) != 9) {
++					error = 1;
++					goto psv_done;
++				}
++				if (af != 4 || alen != 4 || plen != 2) {
++					error = 2;
++					goto psv_done;
++				}
++				data_addr.su_sin.sin_addr.s_addr =
++							htonl(pack4(ad));
++				data_addr.su_port = htons(pack2(po));
++				break;
++#ifdef INET6
++			case AF_INET6:
++				if (sscanf(pasv,
++	"%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u",
++				  &af, &alen,
++				  &ad[0], &ad[1], &ad[2], &ad[3],
++				  &ad[4], &ad[5], &ad[6], &ad[7],
++				  &ad[8], &ad[9], &ad[10], &ad[11],
++				  &ad[12], &ad[13], &ad[14], &ad[15],
++				  &plen, &po[0], &po[1]) != 21) {
++					error = 1;
++					goto psv_done;
++				}
++				if (af != 6 || alen != 16 || plen != 2) {
++					error = 2;
++					goto psv_done;
++				}
++				data_addr.su_sin6.sin6_addr.s6_addr32[0] =
++							htonl(pack4(ad));
++				data_addr.su_sin6.sin6_addr.s6_addr32[1] =
++							htonl(pack4(ad+4));
++				data_addr.su_sin6.sin6_addr.s6_addr32[2] =
++							htonl(pack4(ad+8));
++				data_addr.su_sin6.sin6_addr.s6_addr32[3] =
++							htonl(pack4(ad+12));
++				data_addr.su_port = htons(pack2(po));
++				break;
++#endif
++			default:
++				error = 1;
++			}
++		} else if (strncmp(pasvcmd, "EPSV", 4) == 0) {
++			char delim[4];
++			u_int epsvpo;
++
++			if (code / 10 == 22 && code != 229) {
++				error = 229;
++				goto psv_done;
++			}
++			if (sscanf(pasv, "%c%c%c%u%c", &delim[0], &delim[1],
++					&delim[2], &epsvpo, &delim[3]) != 5) {
++				error = 1;
++				goto psv_done;
++			}
++			if (delim[0] != delim[1] || delim[0] != delim[2]
++			 || delim[0] != delim[3]) {
++				error = 1;
++				goto psv_done;
++			}
++			data_addr.su_port = htons(epsvpo);
++		} else {
++			error = 1;
++		}
++psv_done:
++		switch (error) {
++		case 0:
++			break;
++		case 1:
++			fprintf(stderr,
++		  "Passive mode address scan failure. Shouldn't happen!\n");
++			goto bad;
++		case 2:
++			fprintf(stderr,
++			  "Passive mode AF mismatch. Shouldn't happen!\n");
++			goto bad;
++		case 227:
++		case 228:
++		case 229:
++			fprintf(stderr,
++			  "wrong server: return code must be %d\n", error);
++			goto bad;
++		default:
++			fprintf(stderr, "Bug\n");
+ 		}
+ 
+-		data_addr.sin_family = AF_INET;
+-		data_addr.sin_addr.s_addr = htonl((a1 << 24) | (a2 << 16) |
+-						  (a3 << 8) | a4);
+-		data_addr.sin_port = htons((p1 << 8) | p2);
+-
+ 		if (connect(data, (struct sockaddr *) &data_addr,
+-		    sizeof(data_addr))<0) {
++			    (data_addr.su_family == AF_INET ?
++			     sizeof(data_addr.su_sin) :
++			     sizeof(data_addr.su_sin6)))<0) {
+ 			perror("ftp: connect");
+ 			return(1);
+ 		}
+ #ifdef IP_TOS
++		if (data_addr.su_family == AF_INET)
++		{
+ 		tos = IPTOS_THROUGHPUT;
+ 		if (setsockopt(data, IPPROTO_IP, IP_TOS, (char *)&tos,
+ 		    sizeof(tos)) < 0)
+ 			perror("ftp: setsockopt TOS (ignored)");
++		}
+ #endif
+ 		return(0);
+ 	}
+ noport:
+ 	data_addr = myctladdr;
+ 	if (sendport)
+-		data_addr.sin_port = 0;	/* let system pick one */ 
++		data_addr.su_port = 0;	/* let system pick one */ 
+ 	if (data != -1)
+ 		(void) close(data);
+-	data = socket(AF_INET, SOCK_STREAM, 0);
++	data = socket(data_addr.su_family, SOCK_STREAM, 0);
+ 	if (data < 0) {
+ 		perror("ftp: socket");
+ 		if (tmpno)
+@@ -1172,13 +1432,47 @@
+ 	if (listen(data, 1) < 0)
+ 		perror("ftp: listen");
+ 	if (sendport) {
+-		a = (char *)&data_addr.sin_addr;
+-		p = (char *)&data_addr.sin_port;
+-#define	UC(b)	(((int)b)&0xff)
+-		result =
+-		    command("PORT %d,%d,%d,%d,%d,%d",
+-		      UC(a[0]), UC(a[1]), UC(a[2]), UC(a[3]),
+-		      UC(p[0]), UC(p[1]));
++		af = ex_af2prot(data_addr.su_family);
++		if (try_eprt && af > 1) {      /* only IPv6 */
++			if (getnameinfo((struct sockaddr *)&data_addr, len,
++					hbuf, sizeof(hbuf), pbuf, sizeof(pbuf),
++					NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
++				result = command("EPRT |%d|%s|%s|",
++							af, hbuf, pbuf);
++				if (result != COMPLETE) {
++					try_eprt = 0;
++				}
++			} else {
++				result = ERROR;
++			}
++		} else {
++			result = COMPLETE + 1;
++		}
++		if (result == COMPLETE)
++			goto prt_done;
++
++		p = (u_char *)&data_addr.su_port;
++		switch (data_addr.su_family) {
++		case AF_INET:
++			a = (u_char *)&data_addr.su_sin.sin_addr;
++			result = command("PORT %u,%u,%u,%u,%u,%u",
++				a[0], a[1], a[2], a[3], p[0], p[1]);
++			break;
++#ifdef INET6
++		case AF_INET6:
++			a = (u_char *)&data_addr.su_sin6.sin6_addr;
++			result = command(
++	"LPRT 6,16,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,2,%d,%d",
++				a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7],
++				a[8], a[9],a[10],a[11],a[12],a[13],a[14],a[15],
++				p[0], p[1]);
++			break;
++#endif
++		default:
++			result = COMPLETE + 1; /* xxx */
++		}
++
++	prt_done:
+ 		if (result == ERROR && sendport == -1) {
+ 			sendport = 0;
+ 			tmpno = 1;
+@@ -1189,9 +1483,12 @@
+ 	if (tmpno)
+ 		sendport = 1;
+ #ifdef IP_TOS
++	if (data_addr.su_family == AF_INET)
++	{
+ 	on = IPTOS_THROUGHPUT;
+ 	if (setsockopt(data, IPPROTO_IP, IP_TOS, (char *)&on, sizeof(int)) < 0)
+ 		perror("ftp: setsockopt TOS (ignored)");
++	}
+ #endif
+ 	return (0);
+ bad:
+@@ -1204,7 +1501,7 @@
+ static FILE *
+ dataconn(const char *lmode)
+ {
+-	struct sockaddr_in from;
++	union sockunion from;
+ 	int s, tos;
+ 	socklen_t fromlen = sizeof(from);
+ 
+@@ -1220,9 +1517,12 @@
+ 	(void) close(data);
+ 	data = s;
+ #ifdef IP_TOS
++	if (from.su_family == AF_INET)
++	{
+ 	tos = IPTOS_THROUGHPUT;
+ 	if (setsockopt(s, IPPROTO_IP, IP_TOS, (char *)&tos, sizeof(int)) < 0)
+ 		perror("ftp: setsockopt TOS (ignored)");
++	}
+ #endif
+ 	return (fdopen(data, lmode));
+ }
+@@ -1284,8 +1584,8 @@
+ 	static struct comvars {
+ 		int connect;
+ 		char name[MAXHOSTNAMELEN];
+-		struct sockaddr_in mctl;
+-		struct sockaddr_in hctl;
++		union sockunion mctl;
++		union sockunion hctl;
+ 		FILE *in;
+ 		FILE *out;
+ 		int tpe;
+@@ -1323,7 +1623,7 @@
+ 	connected = op->connect;
+ 	if (hostname) {
+ 		(void) strncpy(ip->name, hostname, sizeof(ip->name) - 1);
+-		ip->name[strlen(ip->name)] = '\0';
++		ip->name[sizeof(ip->name) - 1] = '\0';
+ 	} 
+ 	else {
+ 		ip->name[0] = 0;
+@@ -1352,18 +1652,18 @@
+ 	ip->ntflg = ntflag;
+ 	ntflag = op->ntflg;
+ 	(void) strncpy(ip->nti, ntin, 16);
+-	(ip->nti)[strlen(ip->nti)] = '\0';
++	(ip->nti)[16] = '\0';		/* shouldn't use strlen */
+ 	(void) strcpy(ntin, op->nti);
+ 	(void) strncpy(ip->nto, ntout, 16);
+-	(ip->nto)[strlen(ip->nto)] = '\0';
++	(ip->nto)[16] = '\0';
+ 	(void) strcpy(ntout, op->nto);
+ 	ip->mapflg = mapflag;
+ 	mapflag = op->mapflg;
+ 	(void) strncpy(ip->mi, mapin, MAXPATHLEN - 1);
+-	(ip->mi)[strlen(ip->mi)] = '\0';
++	(ip->mi)[MAXPATHLEN - 1] = '\0';
+ 	(void) strcpy(mapin, op->mi);
+ 	(void) strncpy(ip->mo, mapout, MAXPATHLEN - 1);
+-	(ip->mo)[strlen(ip->mo)] = '\0';
++	(ip->mo)[MAXPATHLEN - 1] = '\0';
+ 	(void) strcpy(mapout, op->mo);
+ 	(void) signal(SIGINT, oldintr);
+ 	if (abrtflag) {
+diff -uNr netkit-ftp-0.17/ftp/ftp_var.h netkit-ftp/ftp/ftp_var.h
+--- netkit-ftp-0.17/ftp/ftp_var.h	Sat Oct  2 21:39:17 1999
++++ netkit-ftp/ftp/ftp_var.h	Fri Jan 12 23:36:27 2001
+@@ -1,3 +1,5 @@
++/* $USAGI$ */
++
+ /*
+  * Copyright (c) 1985, 1989 Regents of the University of California.
+  * All rights reserved.
+@@ -31,7 +33,7 @@
+  * SUCH DAMAGE.
+  *
+  *	from: @(#)ftp_var.h	5.9 (Berkeley) 6/1/90
+- *	$Id: ftp_var.h,v 1.12 1999/10/02 18:39:17 dholland Exp $
++ *	$Id: ftp_var.h,v 1.3 2001/01/12 21:36:27 sekiya Exp $
+  */
+ 
+ /*
+@@ -112,6 +114,8 @@
+ Extern int	mflag;		/* flag: if != 0, then active multi command */
+ 
+ Extern int	options;	/* used during socket creation */
++Extern int	try_epsv;	/* try EPSV for this session */
++Extern int	try_eprt;	/* try EPRT for this session */
+ 
+ /*
+  * Format of command table.
+@@ -140,7 +144,7 @@
+ Extern char macbuf[4096];
+ #define MACBUF_SIZE 4096
+ 
+-char *hookup(char *host, int port);
++char *hookup(const char *host, const char *port);
+ struct cmd *getcmd(const char *);
+ char **makeargv(int *pargc, char **parg);
+ int dologin(const char *host);

--- a/var/spack/repos/builtin/packages/netkit-ftp/package.py
+++ b/var/spack/repos/builtin/packages/netkit-ftp/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class NetkitFtp(AutotoolsPackage):
+    """The standard UNIX FTP (File Transfer Protocol) client."""
+
+    homepage = "http://ftp.linux.org.uk/pub/linux/Networking/netkit/"
+    url      = "http://ftp.linux.org.uk/pub/linux/Networking/netkit/netkit-ftp-0.17.tar.gz"
+
+    version('0.17', sha256='61c913299b81a4671ff089aac821329f7db9bc111aa812993dd585798b700349')
+
+#    parallel = False
+
+    depends_on('readline')
+    depends_on('ncurses')
+
+    patch('netkit-ftp-0.17-pre20000412.pasv-security.patch', sha256='edfd2f7636dfc156b544895fd82d93116fdce82728c1945c8e43ecdf1e67c8b6')
+    patch('netkit-ftp-0.17-acct.patch', sha256='892610782802f789bced600154d5211bdce334290700e5d0bb96c32798348ba2')
+    patch('netkit-ftp.usagi-ipv6.patch', sha256='ecbc92594f77c3ae22a4d284a0abe4bfcf51c40e8d5731f6f9997fe6667e6404')
+    patch('netkit-ftp-0.17-segv.patch', sha256='ff54caec26085e97932969307f318ff8c25e256266388049e81afb40fcd2a94c')
+    patch('netkit-ftp-0.17-volatile.patch', sha256='6842009651d85dbb6d7c550d5369043d817cfb08c9859cc42f0debf2b1a0c3e3')
+    patch('netkit-ftp-0.17-runique_mget.patch', sha256='12be7c13ce3e32bf722ae7290ed4053a2270a67b4c8effb79b9043ec4eae9c86')
+    patch('netkit-ftp-locale.patch', sha256='2ae34e69c63379cd437cf79c872afb95d98c17bcca1c8fc9bae0ad72415304ed')
+    patch('netkit-ftp-0.17-printf.patch', sha256='36576937907b221e85b5d78924fc9730bc7bfb183404469054611b19e399110b')
+    patch('netkit-ftp-0.17-longint.patch', sha256='f8fe86e393dddc7ee7af5c7d40c73530be0cc8c8e77247298d6d1289e2ad77b8')
+    patch('netkit-ftp-0.17-vsftp165083.patch', sha256='df1e9af7903bc44cf4e6189d143f5bc4c5fbe7cfc9c7bf9e58e77dbc16cc3910')
+    patch('netkit-ftp-0.17-C-Frame121.patch', sha256='b4429406e37346cc73898ac926cdcdcad00d569dabf15a2751916042c17f08d6')
+    patch('netkit-ftp-0.17-data.patch', sha256='89d8a4a1e7dd3075e6f8880229eeb5a555b1da97c94a52ec933bfff087dd3b71')
+    patch('netkit-ftp-0.17-multihome.patch', sha256='1777b65e8257f5df0ad75f83b8dc879f364c86dc4ea3b9d0ace65e6bd5e56503')
+    patch('netkit-ftp-0.17-longnames.patch', sha256='58775b4c5d141239904ec325c8d57fd6b48041a109affb606922e94662a1b114')
+    patch('netkit-ftp-0.17-multiipv6.patch', sha256='e9a0b15f9850bb4bf43b44a1d24dc50460911a03a81688af9875bdd0c9b5c4ea')
+    patch('netkit-ftp-0.17-nodebug.patch', sha256='13cbd40cbcc5f371a3de9bfa2db389efebf9f170359e805402221d4bd6744f97')
+    patch('netkit-ftp-0.17-stamp.patch', sha256='3edab6bfeb2eaa548f5f4913a51ff51e6faa4f80b74371754334f110d72ea1e6')
+    patch('netkit-ftp-0.17-sigseg.patch', sha256='f8ece2c062220c72c2c2b0740bbf8291f211ab9e7c6cd839319b6373febc15a0')
+    patch('netkit-ftp-0.17-size.patch', sha256='6658d955acfb835ce8f0a6f4a774522735d37e370349e548c40a13175f88114a')
+    patch('netkit-ftp-0.17-fdleak.patch', sha256='982a771ff3ea66f5bbd9d2650512a35aafb324ca2b704757826089746be40806')
+    patch('netkit-ftp-0.17-fprintf.patch', sha256='93840645b583e42f14954ff9e8ec5d8374b9c8992d1cf7705abc5536797871f6')
+    patch('netkit-ftp-0.17-bitrate.patch', sha256='9cd6f881ff888e59c5eeb44cc6e092d48177a08f69c2d3f2676d6a67d03d9c35')
+    patch('netkit-ftp-0.17-arg_max.patch', sha256='e38bd3d24923839b0409989063ec61753fe9c52e08ea4d3ec3f347c6103a46b3')
+    patch('netkit-ftp-0.17-case.patch', sha256='0023b5096863a6ecaf89d92a599507d45b14414d0bbe4b2b59c60aaabcb22cc3')
+    patch('netkit-ftp-0.17-chkmalloc.patch', sha256='e6ccfa3c3f1aa3f2b53823a58acc5dd48c47640c67ca075e98c809633f840770')
+    patch('netkit-ftp-0.17-man.patch', sha256='44dcd22c41f71968819c84ef4596781a903949f500e479e250d25ac9f1684860')
+    patch('netkit-ftp-0.17-acct_ovl.patch', sha256='ba80bf071ee87788afd0e5c8928ccf8fa8d3e13a0ee09deadbbb67f597642098')
+    patch('netkit-ftp-0.17-remove-nested-include.patch', sha256='5f218a76516ba5e3274d0e0c188f4234d0a952afa673f7d12e8d33251b1805a6')
+    patch('netkit-ftp-0.17-linelen.patch', sha256='476c32040df648a353ec5406654effcaad60134c979f927fbb1d8925c8b3ba50')
+    patch('netkit-ftp-0.17-active-mode-option.patch', sha256='bfc98e1f440138ced582568ecde488359c55edf803234171cc58ff473cde4749')
+    patch('netkit-ftp-0.17-commands-leaks.patch', sha256='d93f72192fdb46b9cab39c704dbee52bb7a036658d7b8690790a517aa9a9d0de')
+    patch('netkit-ftp-0.17-lsn-timeout.patch', sha256='ebd4f7ead187b6c13cb309da2b54bc98149d28875ab091eccd804db0cb5de06d')
+    patch('netkit-ftp-0.17-getlogin.patch', sha256='e0024406c9d7a92415ed27620046cb99cc882d4c29a17791c61ab3bd5e215ef2')
+    patch('netkit-ftp-0.17-token.patch', sha256='df7fbe869306bc064ec389c24b9580fe08a81e6bb8d31c35430b3d41f4f89839')
+
+    def configure_args(self):
+        config_args = [
+            '--enable-ipv6'
+        ]
+        return config_args


### PR DESCRIPTION
When I transplant `netkit-ftp` to `spack`, I found lots of issue should be fixed, and I can't find the netkit-ftp community.
So I tried to get src.rpm from CentOS repo, and I think the patches in src.rpm should be add to this package.

```
$ cat ftp.spec
Name:           ftp
Version:        0.17
Release:        79
Summary:        The standard UNIX FTP (File Transfer Protocol) client
License:        BSD with advertising
URL:            ftp://ftp.linux.org.uk/pub/linux/Networking/netkit
Source0:        ftp://ftp.linux.org.uk/pub/linux/Networking/netkit/netkit-ftp-%{version}.tar.gz

#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0001:      netkit-ftp-0.17-pre20000412.pasv-security.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0002:      netkit-ftp-0.17-acct.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0003:      netkit-ftp.usagi-ipv6.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0004:      netkit-ftp-0.17-segv.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0005:      netkit-ftp-0.17-volatile.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0006:      netkit-ftp-0.17-runique_mget.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0007:      netkit-ftp-locale.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0008:      netkit-ftp-0.17-printf.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0009:      netkit-ftp-0.17-longint.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0010:      netkit-ftp-0.17-vsftp165083.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0011:      netkit-ftp-0.17-C-Frame121.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0012:      netkit-ftp-0.17-data.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0013:      netkit-ftp-0.17-multihome.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0014:      netkit-ftp-0.17-longnames.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0015:      netkit-ftp-0.17-multiipv6.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0016:      netkit-ftp-0.17-nodebug.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0017:      netkit-ftp-0.17-stamp.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0018:      netkit-ftp-0.17-sigseg.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0019:      netkit-ftp-0.17-size.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0020:      netkit-ftp-0.17-fdleak.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0021:      netkit-ftp-0.17-fprintf.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0022:      netkit-ftp-0.17-bitrate.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0023:      netkit-ftp-0.17-arg_max.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0024:      netkit-ftp-0.17-case.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0025:      netkit-ftp-0.17-chkmalloc.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0026:      netkit-ftp-0.17-man.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0027:      netkit-ftp-0.17-acct_ovl.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0028:      netkit-ftp-0.17-remove-nested-include.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0029:      netkit-ftp-0.17-linelen.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0030:      netkit-ftp-0.17-active-mode-option.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0031:      netkit-ftp-0.17-commands-leaks.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0032:      netkit-ftp-0.17-lsn-timeout.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0033:      netkit-ftp-0.17-getlogin.patch
#PATCH-FIX-https://bugzilla.redhat.com/ patch from fedora project
Patch0034:      netkit-ftp-0.17-token.patch
```