### PR TITLE
HEP generator update: evtgen, tauola, photos, pythia8, lhapdf, whizard

### DIFF
--- a/var/spack/repos/builtin/packages/evtgen/g2c.patch
+++ b/var/spack/repos/builtin/packages/evtgen/g2c.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index 375e3b7..e47deac 100755
+--- a/configure
++++ b/configure
+@@ -196,7 +196,7 @@ echo "Platform is $ARCH"
+ FFLAGS="${FFLAGS_OPT}"
+ CFLAGS="${CFLAGS_OPT}"
+ CXXFLAGS="${CXXFLAGS_OPT}"
+-FLIBS="-lfrtbegin -lg2c"
++#FLIBS="-lfrtbegin -lg2c"
+ SOFLAGS="-soname"
+ 
+ if [ ${COMPMODE} = OPT ]; then
+@@ -213,7 +213,7 @@ if [ $ARCH = Linux ]; then
+   FFLAGS="${FFLAGS_OPT} -Wno-globals"
+   CFLAGS="${CFLAGS_OPT}"
+   CXXFLAGS="${CXXFLAGS_OPT}"
+-  FLIBS="-lfrtbegin -lg2c"
++  #FLIBS="-lfrtbegin -lg2c"
+   if [ ${COMPMODE} = OPT ]; then
+     FFLAGS="${FFLAGS_OPT}"
+     CFLAGS="${CFLAGS_OPT}"

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -30,10 +30,10 @@ class Evtgen(AutotoolsPackage):
     depends_on("photos", when="+photos")
 
     conflicts("^pythia8+evtgen", when="+pythia8",
-              msg="""Building pythia with evtgen bindings and
-              evtgen with pythia bindings results in a circular dependency
-              that cannot be resolved at the moment!
-              Use evtgen+pythia8^pythia8~evtgen.""")
+              msg="Building pythia with evtgen bindings and "
+              "evtgen with pythia bindings results in a circular dependency "
+              "that cannot be resolved at the moment! "
+              "Use evtgen+pythia8^pythia8~evtgen.")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Evtgen(AutotoolsPackage):
+    """ EvtGen is a Monte Carlo event generator that simulates
+        the decays of heavy flavour particles, primarily B and D mesons. """
+
+    homepage = "https://evtgen.hepforge.org/"
+    url      = "https://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/MCGeneratorsTarFiles/evtgen-1.7.0.tar.gz"
+
+    maintainers = ['vvolkl']
+
+    version('1.7.0', sha256='ec5c680f14b301888d6e265ef421e3fd36826cd7c9d8598f12aeb748ed8a2363')
+
+    variant('pythia8', default=True, description='Build with pythia8')
+    variant('tauola', default=False, description='Build with tauola')
+    variant('photos', default=False, description='Build with photos')
+
+    patch("g2c.patch")
+
+    depends_on('hepmc@:2.99.99')
+    depends_on("pythia8", when="+pythia8")
+    depends_on("tauola", when="+tauola")
+    depends_on("photos", when="+photos")
+
+    def configure_args(self):
+        args = []
+
+        args.append('--hepmcdir=%s' % self.spec["hepmc"].prefix)
+        if '+pythia8' in self.spec:
+            args.append('--pythiadir=%s' % self.spec['pythia8'].prefix)
+        if '+photos' in self.spec:
+            args.append('--photosdir=%s' % self.spec['photos'].prefix)
+        if '+tauola' in self.spec:
+            args.append('--tauoladir=%s' % self.spec['tauola'].prefix)
+
+        return args
+
+    def build(self, spec, prefix):
+        # avoid parallel compilation errors
+        # due to libext_shared depending on lib_shared
+        make('lib_shared')
+        make('all')

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -18,7 +18,6 @@ class Evtgen(AutotoolsPackage):
     version('02-00-00', sha256='02372308e1261b8369d10538a3aa65fe60728ab343fcb64b224dac7313deb719')
     version('01-07-00', sha256='2648f1e2be5f11568d589d2079f22f589c283a2960390bbdb8d9d7f71bc9c014', preferred=True)
 
-
     variant('pythia8', default=True, description='Build with pythia8')
     variant('tauola', default=False, description='Build with tauola')
     variant('photos', default=False, description='Build with photos')

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -11,11 +11,13 @@ class Evtgen(AutotoolsPackage):
         the decays of heavy flavour particles, primarily B and D mesons. """
 
     homepage = "https://evtgen.hepforge.org/"
-    url      = "https://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/MCGeneratorsTarFiles/evtgen-1.7.0.tar.gz"
+    url      = "http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/MCGeneratorsTarFiles/evtgen-R01-07-00.tar.gz"
 
     maintainers = ['vvolkl']
 
-    version('1.7.0', sha256='ec5c680f14b301888d6e265ef421e3fd36826cd7c9d8598f12aeb748ed8a2363')
+    version('02-00-00', sha256='02372308e1261b8369d10538a3aa65fe60728ab343fcb64b224dac7313deb719')
+    version('01-07-00', sha256='2648f1e2be5f11568d589d2079f22f589c283a2960390bbdb8d9d7f71bc9c014', preferred=True)
+
 
     variant('pythia8', default=True, description='Build with pythia8')
     variant('tauola', default=False, description='Build with tauola')

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -29,6 +29,12 @@ class Evtgen(AutotoolsPackage):
     depends_on("tauola", when="+tauola")
     depends_on("photos", when="+photos")
 
+    conflicts("pythia8+evtgen", when="+pythia8",
+              msg="""Building pythia with evtgen bindings and
+              evtgen with pythia bindings results in a circular dependency
+              that cannot be resolved at the moment!
+              Use evtgen+pythia8^pythia8~evtgen.""")
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -29,7 +29,7 @@ class Evtgen(AutotoolsPackage):
     depends_on("tauola", when="+tauola")
     depends_on("photos", when="+photos")
 
-    conflicts("pythia8+evtgen", when="+pythia8",
+    conflicts("^pythia8+evtgen", when="+pythia8",
               msg="""Building pythia with evtgen bindings and
               evtgen with pythia bindings results in a circular dependency
               that cannot be resolved at the moment!

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack import *
+
+
+class Lhapdf(AutotoolsPackage):
+    """LHAPDF is a general purpose C++ interpolator,
+       used for evaluating PDFs from discretised data files. """
+
+    homepage = "https://lhapdf.hepforge.org/"
+    url      = "https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.2.3.tar.gz"
+
+    version('6.2.3', sha256='d6e63addc56c57b6286dc43ffc56d901516f4779a93a0f1547e14b32cfd82dd1')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+
+    depends_on('python',        type=('build', 'run'))
+    depends_on('py-cython',     type='build')
+    depends_on('py-setuptools', type='build')
+    depends_on('boost',         type='build')
+    depends_on('yaml-cpp',      type='build', when='@:6.1.5')
+
+    def configure_args(self):
+        args = ['--with-boost=' + self.spec['boost'].prefix,
+                'FCFLAGS=-O3','CFLAGS=-O3', 'CXXFLAGS=-O3']
+
+        if self.spec.satisfies('@:6.1.5'):
+            args.append('--with-yaml-cpp=' + self.spec['yaml-cpp'].prefix)
+
+        return args
+

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack import *
 
 
@@ -30,10 +28,8 @@ class Lhapdf(AutotoolsPackage):
 
     def configure_args(self):
         args = ['--with-boost=' + self.spec['boost'].prefix,
-                'FCFLAGS=-O3','CFLAGS=-O3', 'CXXFLAGS=-O3']
+                'FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3']
 
         if self.spec.satisfies('@:6.1.5'):
             args.append('--with-yaml-cpp=' + self.spec['yaml-cpp'].prefix)
-
         return args
-

--- a/var/spack/repos/builtin/packages/photos/package.py
+++ b/var/spack/repos/builtin/packages/photos/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Photos(AutotoolsPackage):
+    """ Photos is a Monte Carlo program for bremsstrahlung in the decay
+         of particles and resonances."""
+
+    homepage = "http://photospp.web.cern.ch/photospp/"
+    url      = "http://photospp.web.cern.ch/photospp/resources/PHOTOS.3.61/PHOTOS.3.61-LHC.tar.gz"
+
+    version('3.61', sha256='acd3bcb769ba2a3e263de399e9b89fd6296405c9cbc5045b83baba3e60db4b26')
+
+    maintainers = ['vvolkl']
+
+    depends_on('hepmc@:2.99.99')
+
+    def configure_args(self):
+        args = []
+
+        args.append('--with-hepmc=%s' % self.spec["hepmc"].prefix)
+        args.append('--without-hepmc3')
+        return args

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -24,7 +24,7 @@ class Pythia8(AutotoolsPackage):
 
     variant('shared', default=True, description='Build shared library')
     variant('hepmc', default=True, description='Build HepMC2 extensions')
-    variant('evtgen', default=True, description='Build EvtGen extensions')
+    variant('evtgen', default=False, description='Build EvtGen extensions')
     variant('root', default=False, description='Build ROOT extensions')
     variant('fastjet', default=False, description='Build fastjet extensions')
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -41,12 +41,20 @@ class Pythia8(AutotoolsPackage):
             args.append('--enable-shared')
         if '+hepmc' in self.spec:
             args.append('--with-hepmc=%s' % self.spec["hepmc"].prefix)
+        else:
+            args.append('--without-hepmc')
         if '+fastjet' in self.spec:
             args.append('--with-fastjet3=%s' % self.spec["fastjet"].prefix)
+        else:
+            args.append('--without-fastjet')
         if '+evtgen' in self.spec:
             args.append('--with-evtgen=%s' % self.spec["evtgen"].prefix)
+        else:
+            args.append('--without-evtgen')
         if '+root' in self.spec:
             args.append('--with-root=%s' % self.spec["root"].prefix)
+        else:
+            args.append('--without-evtgen')
 
         return args
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -23,13 +23,32 @@ class Pythia8(AutotoolsPackage):
     version('8212', sha256='f8fb4341c7e8a8be3347eb26b00329a388ccf925313cfbdba655a08d7fd5a70e')
 
     variant('shared', default=True, description='Build shared library')
+    variant('hepmc', default=True, description='Build HepMC2 extensions')
+    variant('evtgen', default=False, description='Build EvtGen extensions')
+    variant('root', default=False, description='Build ROOT extensions')
+    variant('fastjet', default=False, description='Build fastjet extensions')
 
     depends_on('rsync', type='build')
+    depends_on('hepmc@:2.99.99', when="+hepmc")
+    depends_on('root', when="+root")
+    depends_on('evtgen', when="+evtgen")
+    depends_on("fastjet@3.0.0:", when="+fastjet")
 
     def configure_args(self):
         args = []
 
         if '+shared' in self.spec:
             args.append('--enable-shared')
+        if '+hepmc' in self.spec:
+            args.append('--with-hepmc=%s' % self.spec["hepmc"].prefix)
+        if '+fastjet' in self.spec:
+            args.append('--with-fastjet3=%s' % self.spec["fastjet"].prefix)
+        if '+evtgen' in self.spec:
+            args.append('--with-evtgen=%s' % self.spec["evtgen"].prefix)
+        if '+root' in self.spec:
+            args.append('--with-root=%s' % self.spec["root"].prefix)
 
         return args
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set('PYTHIA8DATA', self.prefix.share.Pythia8.xmldoc)

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -34,6 +34,12 @@ class Pythia8(AutotoolsPackage):
     depends_on('evtgen', when="+evtgen")
     depends_on("fastjet@3.0.0:", when="+fastjet")
 
+    conflicts("evtgen+pythia8", when="+evtgen",
+              msg="""Building pythia with evtgen bindings and
+              evtgen with pythia bindings results in a circular dependency
+              that cannot be resolved at the moment!
+              Use pythia8+evtgen^evtgen~pythia8""")
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -24,7 +24,7 @@ class Pythia8(AutotoolsPackage):
 
     variant('shared', default=True, description='Build shared library')
     variant('hepmc', default=True, description='Build HepMC2 extensions')
-    variant('evtgen', default=False, description='Build EvtGen extensions')
+    variant('evtgen', default=True, description='Build EvtGen extensions')
     variant('root', default=False, description='Build ROOT extensions')
     variant('fastjet', default=False, description='Build fastjet extensions')
 
@@ -35,10 +35,10 @@ class Pythia8(AutotoolsPackage):
     depends_on("fastjet@3.0.0:", when="+fastjet")
 
     conflicts("^evtgen+pythia8", when="+evtgen",
-              msg="""Building pythia with evtgen bindings and
-              evtgen with pythia bindings results in a circular dependency
-              that cannot be resolved at the moment!
-              Use pythia8+evtgen^evtgen~pythia8""")
+              msg="Building pythia with evtgen bindings and "
+              "evtgen with pythia bindings results in a circular dependency "
+              "that cannot be resolved at the moment! "
+              "Use pythia8+evtgen^evtgen~pythia8")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -34,7 +34,7 @@ class Pythia8(AutotoolsPackage):
     depends_on('evtgen', when="+evtgen")
     depends_on("fastjet@3.0.0:", when="+fastjet")
 
-    conflicts("evtgen+pythia8", when="+evtgen",
+    conflicts("^evtgen+pythia8", when="+evtgen",
               msg="""Building pythia with evtgen bindings and
               evtgen with pythia bindings results in a circular dependency
               that cannot be resolved at the moment!

--- a/var/spack/repos/builtin/packages/tauola/package.py
+++ b/var/spack/repos/builtin/packages/tauola/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Tauola(AutotoolsPackage):
+    """ Tauola is a event generator for tau decays."""
+
+    homepage = "https://tauolapp.web.cern.ch/tauolapp/"
+    url      = "https://tauolapp.web.cern.ch/tauolapp/resources/TAUOLA.1.1.8/TAUOLA.1.1.8-LHC.tar.gz"
+
+    version('1.1.8', sha256='3f734e8a967682869cca2c1ffebd3e055562613c40853cc81820d8b666805ed5')
+
+    maintainers = ['vvolkl']
+
+    depends_on('hepmc@:2.99.99')
+
+    def configure_args(self):
+        args = []
+
+        args.append('--with-hepmc=%s' % self.spec["hepmc"].prefix)
+        args.append('--without-hepmc3')
+        return args

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Whizard(AutotoolsPackage):
+    """WHIZARD is a program system designed for the efficient calculation
+      of multi-particle scattering cross sections
+      and simulated event samples."""
+
+    homepage = "whizard.hepforge.org"
+    url      = "https://whizard.hepforge.org/downloads/?f=whizard-2.8.2.tar.gz"
+
+    maintainers = ['vvolkl']
+
+    version('3.0.0_alpha', sha256='4636e5a10350bb67ccc98cd105bc891ea04f3393c2420f81be3d21240be20009')
+    version('2.8.2', sha256='32c9be342d01b3fc6f947fddce74bf2d81ece37fb39bca1f37778fb0c07e2568', prefered=True)
+    version('2.8.1', sha256='0c759ce0598e25f38e04659f745c5963d238c4b5c12209f16449b6c0bc6dc64e')
+    version('2.8.0', sha256='3b5175eafa879d1baca20237d18fb2b18bee89631e73ada499de9c082d009696')
+
+    variant('hepmc', default=True,
+            description="builds with hepmc")
+
+    variant('pythia8', default=True,
+            description="builds with pythia8")
+
+    variant('fastjet', default=False,
+            description="builds with fastjet")
+
+    variant('lcio', default=False,
+            description="builds with lcio")
+
+    variant('lhapdf', default=False,
+            description="builds with fastjet")
+
+    variant('openmp', default=False,
+            description="builds with openmp")
+
+    variant('latex', default=False,
+            description="data visualization with latex")
+
+    depends_on('ocaml', type='build', when="@3:")
+    depends_on('ocaml@:4.8.2', type='build', when="@:2.99.99")
+    depends_on('hepmc', when="+hepmc")
+    depends_on('pythia8', when="+pythia8")
+    depends_on('lhapdf', when="+lhapdf")
+    depends_on('fastjet', when="+fastjet")
+    depends_on('texlive', when="+latex")
+
+    def configure_args(self):
+        spec = self.spec
+        args = [
+            '--enable-hepmc=%s' % ("yes" if "+hepmc" in spec else "no"),
+            '--enable-fastjet=%s' % ("yes" if "+fastjet" in spec else "no"),
+            '--enable-pythia8=%s' % ("yes" if "+pythia8" in spec else "no"),
+            '--enable-lcio=%s' % ("yes" if "+lcio" in spec else "no"),
+            '--enable-lhapdf=%s' % ("yes" if "+lhapdf" in spec else "no"),
+            # todo: openloops
+            # todo: hoppet
+            # todo: recola
+            # todo: looptools
+            # todo: gosam
+            # todo: pythia6
+        ]
+        if "+openmp" not in spec:
+            args.append('--disable-openmp')
+
+        return args
+
+    def url_for_version(self, version):
+        major = str(version[0])
+        minor = str(version[1])
+        patch = str(version[2])
+        if len(version) == 4:
+            url = "https://whizard.hepforge.org/downloads/?f=whizard-%s.%s.%s_%s.tar.gz" % (major, minor, patch, version[3])
+        else:
+            url = "https://whizard.hepforge.org/downloads/?f=whizard-%s.%s.%s.tar.gz" % (major, minor, patch)
+        return url


### PR DESCRIPTION
Adding another HEP generator recipe.  It works, but there are some remaining questions, for which any suggestions are welcome:
* I could not get the download from the actual hepforge.org site `https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz` to work (checksum and install). I'm happy to maintain the github mirror I set up instead though.
* There are some optional dependencies on generators that are not in spack yet. Should I comment out those variants for now?
* I needed the `g2c.patch` with gcc 9.3.0. but some cursory research suggests  that older versions of gfortran may need those flags.