### PR TITLE
Ruby: add warning about Avira antivirus

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -34,6 +34,10 @@ class Ruby(AutotoolsPackage):
     depends_on('openssl', when='+openssl')
     depends_on('readline', when='+readline')
 
+    # Known build issues when Avira antivirus software is running:
+    # https://github.com/rvm/rvm/issues/4313#issuecomment-374020379
+    # TODO: add check for this and warn user
+
     # gcc-7-based build requires patches (cf. https://bugs.ruby-lang.org/issues/13150)
     patch('ruby_23_gcc7.patch', level=0, when='@2.2.0:2.2.999 %gcc@7:')
     patch('ruby_23_gcc7.patch', level=0, when='@2.3.0:2.3.4 %gcc@7:')


### PR DESCRIPTION
This trips me up every time I try to build Ruby, so I added a comment.