### PR TITLE
Fix parsing of EvtGen URL

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -464,6 +464,8 @@ def test_url_parse_offset(name, noffset, ver, voffset, path):
      'http://laws-green.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.4.0beta.1_r20171213193219.tgz'),
     ('vampirtrace', '5.14.4',
      'http://wwwpub.zih.tu-dresden.de/~mlieber/dcount/dcount.php?package=vampirtrace&get=VampirTrace-5.14.4.tar.gz'),
+    ('EvtGen', '01.07.00',
+     'https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz'),
     # (we don't actually look for these, they are picked up
     #  during the preliminary stem parsing)
     ('octopus', '6.0', 'http://octopus-code.org/down.php?file=6.0/octopus-6.0.tar.gz'),

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -553,7 +553,7 @@ def parse_version_offset(path):
         # e.g. http://gitlab.cosma.dur.ac.uk/swift/swiftsim/repository/archive.tar.gz?ref=v0.3.0
         # e.g. http://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.1
         # e.g. https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=3.8-1-0-gf15c1c3ef
-        (r'[?&](?:sha|ref|version)=[a-zA-Z\d+-]*[_-]?v?(\d[\da-zA-Z._-]*)$', suffix),
+        (r'[?&](?:sha|ref|version)=[a-zA-Z\d+-]*[_-]?v?(\d[\da-zA-Z._-]*)$', suffix),  # noqa: E501
 
         # e.g. http://slepc.upv.es/download/download.php?filename=slepc-3.6.2.tar.gz
         # e.g. http://laws-green.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.4.0beta.1_r20171213193219.tgz
@@ -565,7 +565,7 @@ def parse_version_offset(path):
 
         # github.com/repo/name/releases/download/vver/name
         # e.g. https://github.com/nextflow-io/nextflow/releases/download/v0.20.1/nextflow
-        (r'github\.com/[^/]+/[^/]+/releases/download/[a-zA-Z+._-]*v?(\d[\da-zA-Z._-]*)/', path),  # noqa
+        (r'github\.com/[^/]+/[^/]+/releases/download/[a-zA-Z+._-]*v?(\d[\da-zA-Z._-]*)/', path),  # noqa: E501
 
         # e.g. ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.26/ncbi.tar.gz
         (r'(\d[\da-zA-Z._-]*)/[^/]+$', path),

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -549,21 +549,17 @@ def parse_version_offset(path):
         # 8th Pass: Query strings
 
         # e.g. https://gitlab.cosma.dur.ac.uk/api/v4/projects/swift%2Fswiftsim/repository/archive.tar.gz?sha=v0.3.0
-        (r'\?sha=[a-zA-Z+._-]*v?(\d[\da-zA-Z._-]*)$', suffix),
-
+        # e.g. https://gitlab.kitware.com/api/v4/projects/icet%2Ficet/repository/archive.tar.bz2?sha=IceT-2.1.1
         # e.g. http://gitlab.cosma.dur.ac.uk/swift/swiftsim/repository/archive.tar.gz?ref=v0.3.0
-        (r'\?ref=[a-zA-Z+._-]*v?(\d[\da-zA-Z._-]*)$', suffix),
-
         # e.g. http://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.1
         # e.g. https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=3.8-1-0-gf15c1c3ef
-        (r'[?&]version=v?(\d[\da-zA-Z._-]*)$', suffix),
+        (r'[?&](?:sha|ref|version)=[a-zA-Z\d+-]*[_-]?v?(\d[\da-zA-Z._-]*)$', suffix),
 
         # e.g. http://slepc.upv.es/download/download.php?filename=slepc-3.6.2.tar.gz
         # e.g. http://laws-green.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.4.0beta.1_r20171213193219.tgz
-        (r'[?&]filename=[a-zA-Z\d+-]+[_-]v?(\d[\da-zA-Z.]*)', stem),
-
+        # e.g. https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz
         # e.g. http://wwwpub.zih.tu-dresden.de/%7Emlieber/dcount/dcount.php?package=otf&get=OTF-1.12.5salmon.tar.gz
-        (r'&get=[a-zA-Z\d+-]+-v?(\d[\da-zA-Z.]*)$', stem),  # noqa
+        (r'[?&](?:filename|f|get)=[a-zA-Z\d+-]+[_-]v?(\d[\da-zA-Z.]*)', stem),
 
         # 9th Pass: Version in path
 
@@ -695,6 +691,10 @@ def parse_name_offset(path, v=None):
         # ?filename=name-ver.ver
         # e.g. http://slepc.upv.es/download/download.php?filename=slepc-3.6.2.tar.gz
         (r'\?filename=([A-Za-z\d+-]+)$', stem),
+
+        # ?f=name-ver.ver
+        # e.g. https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz
+        (r'\?f=([A-Za-z\d+-]+)$', stem),
 
         # ?package=name
         # e.g. http://wwwpub.zih.tu-dresden.de/%7Emlieber/dcount/dcount.php?package=otf&get=OTF-1.12.5salmon.tar.gz


### PR DESCRIPTION
Fixes name/version parsing of a URL reported by @vvolkl in #16880. 

### Before
```console
$ spack url parse "https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz"
==> Parsing URL: https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz

==> Error: Couldn't detect version in: https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz
```
### After
```console
$ spack url parse "https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz"
==> Parsing URL: https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz

==> Matched version regex 21: r'[?&](?:filename|f|get)=[a-zA-Z\\d+-]+[_-]v?(\\d[\\da-zA-Z.]*)'
==> Matched  name   regex  6: r'\\?f=([A-Za-z\\d+-]+)$'

==> Detected:
    https://evtgen.hepforge.org/downloads?f=EvtGen-01.07.00.tar.gz
                                            ------ ~~~~~~~~
    name:    EvtGen
    version: 01.07.00

==> Substituting version 9.9.9b:
    https://evtgen.hepforge.org/downloads?f=EvtGen-9.9.9b.tar.gz
                                            ------ ~~~~~~
```
Overall URL parsing performance is unchanged:
```console
$ spack url summary
==> Generating a summary of URL parsing in Spack...

    Total URLs found:          3796
    Names correctly parsed:    3437/3796 (90.54%)
    Versions correctly parsed: 3533/3796 (93.07%)
```