### PR TITLE
Recognize system installed gcc-10 as a valid compiler

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -27,7 +27,7 @@ class Gcc(Compiler):
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.
-    suffixes = [r'-mp-\d\.\d', r'-\d\.\d', r'-\d', r'\d\d']
+    suffixes = [r'-mp-\d+\.\d+', r'-\d+\.\d+', r'-\d+', r'\d\d']
 
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'gcc/gcc',


### PR DESCRIPTION
Now that the version number of GCC reached double digits, an update to the regex is needed to recognize `gcc-10` as an executable to be inspected when searching for compilers.

**Before**

```console
$ which gcc-10
/usr/bin/gcc-10

$ spack compiler find --scope=site
==> Added 13 new compilers to /home/culpo/PycharmProjects/spack/etc/spack/compilers.yaml
    gcc@9.3.0  gcc@7.5.0  gcc@5.5.0  clang@9.0.0  clang@7.0.0  clang@5.0.1  clang@3.9.1
    gcc@8.4.0  gcc@6.5.0  gcc@4.8    clang@8.0.0  clang@6.0.1  clang@4.0.1
==> Compilers are defined in the following files:
    /home/culpo/PycharmProjects/spack/etc/spack/compilers.yaml
```

**After**

```console
$ which gcc-10
/usr/bin/gcc-10

$ spack compiler find --scope=site
==> Added 14 new compilers to /home/culpo/PycharmProjects/spack/etc/spack/compilers.yaml
    gcc@10.1.0  gcc@8.4.0  gcc@6.5.0  gcc@4.8      clang@8.0.0  clang@6.0.1  clang@4.0.1
    gcc@9.3.0   gcc@7.5.0  gcc@5.5.0  clang@9.0.0  clang@7.0.0  clang@5.0.1  clang@3.9.1
==> Compilers are defined in the following files:
    /home/culpo/PycharmProjects/spack/etc/spack/compilers.yaml
```