### PR TITLE
netcdf-cxx4: Add 'doxygen' dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -32,6 +32,7 @@ class NetcdfCxx4(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
+    depends_on('doxygen', when='+doxygen', type='build')
 
     conflicts('~shared', when='~static')
 


### PR DESCRIPTION
`doxygen` variant was added in this pull request #16047.
But we can't find doxygen, because there is not dependency of doxygen.