### PR TITLE
spack uninstall: improve help message

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -21,10 +21,6 @@ from llnl.util import tty
 from llnl.util.tty.colify import colify
 
 description = "remove installed packages"
-description += ("\n\nSpecs to be uninstalled are specified using the spec "
-                "syntax (`spack help --spec`) and can be identified by their "
-                "hashes. To remove packages that are needed only at build "
-                "time and were not explicitly installed see `spack gc -h`.")
 section = "build"
 level = "short"
 
@@ -44,6 +40,18 @@ display_args = {
 
 
 def setup_parser(subparser):
+    epilog_msg = ("Specs to be uninstalled are specified using the spec syntax"
+                  " (`spack help --spec`) and can be identified by their "
+                  "hashes. To remove packages that are needed only at build "
+                  "time and were not explicitly installed see `spack gc -h`."
+                  "\n\nWhen using the --all option ALL packages matching the "
+                  "supplied specs will be uninstalled. For instance, "
+                  "`spack uninstall --all libelf` uninstalls all the versions "
+                  "of `libelf` currently present in Spack's store. If no spec "
+                  "is supplied, all installed packages will be uninstalled. "
+                  "If used in an environment, all packages in the environment "
+                  "will be uninstalled.")
+    subparser.epilog = epilog_msg
     subparser.add_argument(
         '-f', '--force', action='store_true', dest='force',
         help="remove regardless of whether other packages or environments "
@@ -52,12 +60,8 @@ def setup_parser(subparser):
         subparser, ['recurse_dependents', 'yes_to_all', 'installed_specs'])
     subparser.add_argument(
         '-a', '--all', action='store_true', dest='all',
-        help="USE CAREFULLY. Remove ALL installed packages that match each "
-        "supplied spec. i.e., if you `uninstall --all libelf`,"
-        " ALL versions of `libelf` are uninstalled. If no spec is "
-        "supplied, all installed packages will be uninstalled. "
-        "If used in an environment, all packages in the environment "
-        "will be uninstalled.")
+        help="remove ALL installed packages that match each supplied spec"
+    )
 
 
 def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -21,12 +21,16 @@ from llnl.util import tty
 from llnl.util.tty.colify import colify
 
 description = "remove installed packages"
+description += ("\n\nSpecs to be uninstalled are specified using the spec "
+                "syntax (`spack help --spec`) and can be identified by their "
+                "hashes. To remove packages that are needed only at build "
+                "time and were not explicitly installed see `spack gc -h`.")
 section = "build"
 level = "short"
 
 error_message = """You can either:
     a) use a more specific spec, or
-    b) specify the package by its hash (e.g. `spack uninstall /hash`), or
+    b) specify the spec by its hash (e.g. `spack uninstall /hash`), or
     c) use `spack uninstall --all` to uninstall ALL matching specs.
 """
 


### PR DESCRIPTION
fixes #12527

- [x] Mention that specs  can be uninstalled by hash also in the help message
- [x] Reference `spack gc` in case people are looking for ways to clean the store from build time dependencies.
- [x] Use "spec" instead of "package" to avoid ambiguity in the error message.

The result is the following:
```console
$ spack uninstall -h
usage: spack uninstall [-hfRya] ...

remove installed packages

positional arguments:
  installed_specs   one or more installed package specs

optional arguments:
  -h, --help        show this help message and exit
  -f, --force       remove regardless of whether other packages or environments depend on this one
  -R, --dependents  also uninstall any packages that depend on the ones given via command line
  -y, --yes-to-all  assume "yes" is the answer to every confirmation request
  -a, --all         remove ALL installed packages that match each supplied spec

Specs to be uninstalled are specified using the spec syntax (`spack help --spec`) and can be identified by their hashes. To remove packages that are needed only at build time and were not explicitly installed see `spack gc -h`.

When using the --all option ALL packages matching the supplied specs will be uninstalled. For instance, `spack uninstall --all libelf` uninstalls all the versions of `libelf` currently present in Spack's store. If no spec is supplied, all installed packages will be uninstalled. If used in an environment, all packages in the environment will be uninstalled.
```