### PR TITLE
Split hepmc Into hepmc and hepmc3

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -96,7 +96,7 @@ class Acts(CMakePackage):
     depends_on('dd4hep @1.10: +geant4 +xercesc', when='+dd4hep +geant4')
     depends_on('eigen @3.2.9:', type='build')
     depends_on('geant4', when='+geant4')
-    depends_on('hepmc@3.1:', when='+hepmc3')
+    depends_on('hepmc3@3.1:', when='+hepmc3')
     depends_on('heppdt', when='+hepmc3')
     depends_on('intel-tbb', when='+examples')
     depends_on('nlohmann-json @3.2.0:', when='@0.14: +json')

--- a/var/spack/repos/builtin/packages/hepmc/package.py
+++ b/var/spack/repos/builtin/packages/hepmc/package.py
@@ -14,11 +14,6 @@ class Hepmc(CMakePackage):
     homepage = "http://hepmc.web.cern.ch/hepmc/"
     url      = "http://hepmc.web.cern.ch/hepmc/releases/hepmc2.06.09.tgz"
 
-    version('3.2.0', sha256='f132387763d170f25a7cc9f0bd586b83373c09acf0c3daa5504063ba460f89fc')
-    version('3.1.2', sha256='4133074b3928252877982f3d4b4c6c750bb7a324eb6c7bb2afc6fa256da3ecc7')
-    version('3.1.1', sha256='2fcbc9964d6f9f7776289d65f9c73033f85c15bf5f0df00c429a6a1d8b8248bb')
-    version('3.1.0', sha256='cd37eed619d58369041018b8627274ad790020a4714b54ac05ad1ebc1a6e7f8a')
-    version('3.0.0',   sha256='7ac3c939a857a5ad67bea1e77e3eb16e80d38cfdf825252ac57160634c26d9ec')
     version('2.06.10', sha256='5adedd9e3f7447e1e5fc01b72f745ab87da2c1611df89208bb3d7c6ea94c11a4')
     version('2.06.09', sha256='e0f8fddd38472c5615210894444686ac5d72df3be682f7d151b562b236d9b422')
     version('2.06.08', sha256='8be6c1793e0a045f07ddb88bb64b46de7e66a52e75fb72b3f82f9a3e3ba8a8ce')
@@ -27,51 +22,14 @@ class Hepmc(CMakePackage):
     version('2.06.05', sha256='4c411077cc97522c03b74f973264b8d9fd2b6ccec0efc7ceced2645371c73618')
 
     variant('python', default=False, description='Enable Python bindings')
-    variant('rootio', default=False, description='Enable ROOT I/O')
-    variant('interfaces', default=False, description='Install interfaces for some Monte-Carlo Event Gens')
 
     depends_on('cmake@2.8.9:', type='build')
-    depends_on('python', when='+python')
-    depends_on('root', when='+rootio')
 
-    conflicts('+python', when='@:3.1')
-    conflicts('+rootio', when='@:2')
-    conflicts('+interfaces', when='@:2')
-
-    @when('@:2')
     def cmake_args(self):
         return ['-Dmomentum:STRING=GEV', '-Dlength:STRING=MM']
 
-    @when('@3:')
-    def cmake_args(self):
-        spec = self.spec
-        args = [
-            '-Dmomentum:STRING=GEV',
-            '-Dlength:STRING=MM',
-            '-DHEPMC3_ENABLE_PYTHON={0}'.format(spec.satisfies('+python')),
-            '-DHEPMC3_ENABLE_ROOTIO={0}'.format(spec.satisfies('+rootio')),
-            '-DHEPMC3_INSTALL_INTERFACES={0}'.format(
-                spec.satisfies('+interfaces')),
-        ]
-
-        if self.spec.satisfies('+python'):
-            py_ver = spec['python'].version.up_to(2)
-            py_sitepkg = join_path(self.prefix, site_packages_dir)
-            args.extend([
-                '-DHEPMC3_PYTHON_VERSIONS={0}'.format(py_ver),
-                '-DHEPMC3_Python_SITEARCH{0}={1}'.format(
-                    py_ver.joined, py_sitepkg)
-            ])
-
-        if self.spec.satisfies('+rootio'):
-            args.append('-DROOT_DIR={0}'.format(self.spec['root'].prefix))
-
-        return args
-
     def url_for_version(self, version):
-        if version > Version("3.0.0"):
-            url = "http://hepmc.web.cern.ch/hepmc/releases/HepMC3-{0}.tar.gz"
-        elif version <= Version("2.06.08"):
+        if version <= Version("2.06.08"):
             url = "http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-{0}.tar.gz"
         else:
             url = "http://hepmc.web.cern.ch/hepmc/releases/hepmc{0}.tgz"

--- a/var/spack/repos/builtin/packages/hepmc/package.py
+++ b/var/spack/repos/builtin/packages/hepmc/package.py
@@ -21,8 +21,6 @@ class Hepmc(CMakePackage):
     version('2.06.06', sha256='8cdff26c10783ed4248220a84a43b7e1f9b59cc2c9a29bd634d024ca469db125')
     version('2.06.05', sha256='4c411077cc97522c03b74f973264b8d9fd2b6ccec0efc7ceced2645371c73618')
 
-    variant('python', default=False, description='Enable Python bindings')
-
     depends_on('cmake@2.8.9:', type='build')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Hepmc3(CMakePackage):
+    """The HepMC package is an object oriented, C++ event record for
+       High Energy Physics Monte Carlo generators and simulation."""
+
+    homepage = "https://cern.ch/hepmc"
+    url      = "https://gitlab.cern.ch/hepmc/HepMC3/-/archive/3.2.1/HepMC3-3.2.1.tar.gz"
+    git      = "https://gitlab.cern.ch/hepmc/HepMC3.git"
+
+    maintainers = ['vvolkl']
+
+    version('3.2.1', sha256='6e4e4bb5708af105d4bf74efc2745e6efe704e942d46a8042f7dcae37a4739fe')
+    version('3.2.0', sha256='f132387763d170f25a7cc9f0bd586b83373c09acf0c3daa5504063ba460f89fc')
+    version('3.1.2', sha256='4133074b3928252877982f3d4b4c6c750bb7a324eb6c7bb2afc6fa256da3ecc7')
+    version('3.1.1', sha256='2fcbc9964d6f9f7776289d65f9c73033f85c15bf5f0df00c429a6a1d8b8248bb')
+    version('3.1.0', sha256='cd37eed619d58369041018b8627274ad790020a4714b54ac05ad1ebc1a6e7f8a')
+    # note that version 3.0.0 is not supported
+    # conflicts with cmake configuration
+
+    variant('python', default=False, description='Enable Python bindings')
+    variant('rootio', default=False, description='Enable ROOT I/O')
+    variant('interfaces', default=False, description='Install interfaces for some Monte-Carlo Event Gens')
+
+    depends_on('cmake@2.8.9:', type='build')
+    depends_on('root', when='+rootio')
+    depends_on('python', when="+python")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = [
+            '-Dmomentum:STRING=GEV',
+            '-Dlength:STRING=MM',
+            '-DHEPMC3_ENABLE_PYTHON={0}'.format(spec.satisfies('+python')),
+            '-DHEPMC3_ENABLE_ROOTIO={0}'.format(spec.satisfies('+rootio')),
+            '-DHEPMC3_INSTALL_INTERFACES={0}'.format(
+                spec.satisfies('+interfaces')),
+        ]
+
+        if self.spec.satisfies('+python'):
+            py_ver = spec['python'].version.up_to(2)
+            py_sitepkg = join_path(self.prefix, site_packages_dir)
+            args.extend([
+                '-DHEPMC3_PYTHON_VERSIONS={0}'.format(py_ver),
+                '-DHEPMC3_Python_SITEARCH{0}={1}'.format(
+                    py_ver.joined, py_sitepkg)
+            ])
+
+        if self.spec.satisfies('+rootio'):
+            args.append('-DROOT_DIR={0}'.format(self.spec['root'].prefix))
+        return args


### PR DESCRIPTION
Since HepMC3 is basically an indepependent package from HepMC2, this splits the recipes, as discussed in #16880, which adds some generators that can use hepmc and hepmc3 concurrently.