### PR TITLE
Set ROOT environment correctly when ~rpath

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -492,12 +492,16 @@ class Root(CMakePackage):
         env.prepend_path('PATH', self.prefix.bin)
         env.append_path('CMAKE_MODULE_PATH', '{0}/cmake'
                         .format(self.prefix))
+        if "+rpath" not in self.spec:
+            env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.set('ROOTSYS', self.prefix)
         env.set('ROOT_VERSION', 'v{0}'.format(self.version.up_to(1)))
         env.prepend_path('PYTHONPATH', self.prefix.lib)
         env.prepend_path('PATH', self.prefix.bin)
+        if "+rpath" not in self.spec:
+            env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
 
     def _process_opts(self, *opt_lists):
         """Process all provided boolean option lists into CMake arguments.


### PR DESCRIPTION
Hi ROOT recipe maintainers,
@chissg  @HadrienG2 @drbenmorgan 
As far as I can tell, turning off the `rpath` variant actually has no effect (due to spack setting the relevant compiler options?). Here is the log of me looking at the `readelf` output of a root binary from spack `+rpath`, from spack `~rpath` and from the lcg releases: https://gist.github.com/vvolkl/e95b58bbfb0d0dc9b54ef31dc4013df5 -- the RPATH entry is the same for both spack installations, but missing in the external installation.

 This is not a problem in itself, but it makes it tricky to use an external installation of root in `packages.yaml` - dependent packages that try to generate dictionaries will typically fail with linker errors. I tried to work around it in the PODIO recipe: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/podio/package.py#L47 (at the time not really knowing what was the exact issue) but I think it would be better if the ROOT recipe handled this correctly.

My proposal in this PR is to use the `~rpath` variant to set up the environment for possible external installations that really do not have a working rpath set up -- so I can add 

```
  root:
    buildable: false
    paths:
      root ~rpath: /cvmfs/sft.cern.ch/lcg/releases/LCG_97_FCC_2/ROOT/v6.20.04/x86_64-centos7-gcc8-opt
```
in a `packages.yaml`.
