### PR TITLE
package/qt: add conflict for old gcc

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -151,6 +151,10 @@ class Qt(Package):
     depends_on("double-conversion", when='@5.7:')
     depends_on("pcre2+multibyte", when='@5.9:')
 
+    # gcc@4 is not supported as of Qt@5.14
+    # https://doc.qt.io/qt-5.14/supported-platforms.html
+    conflicts('%gcc@:4.99', when='@5.14:')
+
     # Non-macOS dependencies and special macOS constraints
     if MACOS_VERSION is None:
         depends_on("fontconfig", when='freetype=spack')


### PR DESCRIPTION
as of version 5.14, QT doesn't support gcc@4 anymore.

https://doc.qt.io/qt-5.14/supported-platforms.html