### PR TITLE
Gnuplot fix 16928

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -122,7 +122,7 @@ class Gnuplot(AutotoolsPackage):
             options.append('--with-qt=no')
 
         if '+wx' in spec:
-            options.append('--with-wx=%s' % spec['wx'].prefix)
+            options.append('--with-wx=%s' % spec['wxwidgets'].prefix)
         else:
             options.append('--disable-wxwidgets')
 

--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -122,7 +122,7 @@ class Gnuplot(AutotoolsPackage):
             options.append('--with-qt=no')
 
         if '+wx' in spec:
-            options.append('--with-wx=%s' % spec['wxwidgets'].prefix)
+            options.append('--with-wx=%s' % spec['wx'].prefix)
         else:
             options.append('--disable-wxwidgets')
 


### PR DESCRIPTION
Fixes #16928

Getting an error
==> Error: KeyError: 'No spec with name wx in gnuplot@5.2.8%gcc@8.4.0+X ...

Looks like where adding the --with-wx configure option mistakenly referenced 'wx' instead of 'wxwidgets' as the dependent package.