### PR TITLE
py-openpyxl: add 3.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-openpyxl/package.py
+++ b/var/spack/repos/builtin/packages/py-openpyxl/package.py
@@ -10,11 +10,15 @@ class PyOpenpyxl(PythonPackage):
     """A Python library to read/write Excel 2010 xlsx/xlsm files"""
 
     homepage = "http://openpyxl.readthedocs.org/"
-    url      = "https://pypi.io/packages/source/o/openpyxl/openpyxl-2.4.5.tar.gz"
+    url      = "https://pypi.io/packages/source/o/openpyxl/openpyxl-3.0.3.tar.gz"
 
+    version('3.0.3', sha256='547a9fc6aafcf44abe358b89ed4438d077e9d92e4f182c87e2dc294186dc4b64')
     version('2.4.5', sha256='78c331e819fb0a63a1339d452ba0b575d1a31f09fdcce793a31bec7e9ef4ef21')
 
-    depends_on('python@2.6:2.8,3.0:3.1,3.3:')
+    depends_on('python@3.6:',         when='@3.0:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.5:', when='@2.6:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', when='@2.5:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.3:', when='@2.1:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
 


### PR DESCRIPTION
Successfully installs on WSL Ubuntu 20.04 with Python 3.7.7 and GCC 9.3.0.