### PR TITLE
Fix obsolete references to wx package

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -122,7 +122,7 @@ class Gnuplot(AutotoolsPackage):
             options.append('--with-qt=no')
 
         if '+wx' in spec:
-            options.append('--with-wx=%s' % spec['wx'].prefix)
+            options.append('--with-wx=%s' % spec['wxwidgets'].prefix)
         else:
             options.append('--disable-wxwidgets')
 

--- a/var/spack/repos/builtin/packages/paraver/package.py
+++ b/var/spack/repos/builtin/packages/paraver/package.py
@@ -51,6 +51,6 @@ class Paraver(Package):
                   "--with-paraver=%s" % prefix,
                   "--with-boost=%s" % spec['boost'].prefix,
                   "--with-boost-serialization=boost_serialization",
-                  "--with-wxdir=%s" % spec['wx'].prefix.bin)
+                  "--with-wxdir=%s" % spec['wxwidgets'].prefix.bin)
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/wxpropgrid/package.py
+++ b/var/spack/repos/builtin/packages/wxpropgrid/package.py
@@ -20,7 +20,7 @@ class Wxpropgrid(Package, SourceforgePackage):
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix, "--with-wxdir=%s" %
-                  spec['wx'].prefix.bin, "--enable-unicode")
+                  spec['wxwidgets'].prefix.bin, "--enable-unicode")
 
         make()
         make("install")


### PR DESCRIPTION
Fixes #16928

A _long_ time ago, I renamed the `wx` package to `wxwidgets`. It looks like I missed some references to the old package name and no one has noticed until now.

Thanks to @payerle for the report!