### PR TITLE
SZ: make ctags optional via patch from robertu94/sz 3637a87f986c

### DIFF
--- a/var/spack/repos/builtin/packages/sz/ctags-only-if-requested.patch
+++ b/var/spack/repos/builtin/packages/sz/ctags-only-if-requested.patch
@@ -1,0 +1,42 @@
+From 3637a87f986cb64ddc1bde3551e29894ab18500b Mon Sep 17 00:00:00 2001
+From: Robert Underwood <rr.underwood94@gmail.com>
+Date: Wed, 3 Jun 2020 12:48:33 -0400
+Subject: [PATCH] Don't require ctags unless we ask for it
+
+Previously this caused build failures if the user had a bad version of
+ctags.  Don't build with it.
+---
+ CMakeLists.txt | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4fd4014..d764a44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,13 +36,16 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+ 
+ #generate tags for the project if tags exist
+-find_program(TAGS ctags)
+-if(TAGS)
+-	add_custom_target(tags ALL
+-    COMMAND ${TAGS} --exclude=${CMAKE_BINARY_DIR} -f ${CMAKE_BINARY_DIR}/tags --c++-kinds=+p --fields=+iaS -R
+-		COMMENT Generating Tag files
+-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+-		)
++option(BUILD_CTAGS "enable ctags generation target" OFF)
++if(BUILD_CTAGS)
++  find_program(TAGS ctags)
++  if(TAGS)
++    add_custom_target(tags ALL
++      COMMAND ${TAGS} --exclude=${CMAKE_BINARY_DIR} -f ${CMAKE_BINARY_DIR}/tags --c++-kinds=+p --fields=+iaS -R
++      COMMENT Generating Tag files
++      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
++      )
++  endif()
+ endif()
+ 
+ option(BUILD_SHARED_LIBS "build shared libraries over static libraries" ON)
+-- 
+2.24.2 (Apple Git-127)
+

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -54,6 +54,8 @@ class Sz(CMakePackage):
     depends_on('hdf5', when="+hdf5")
     depends_on('netcdf-c', when="+netcdf")
 
+    patch('ctags-only-if-requested.patch', when='@2.1.8.1:2.1.8.3')
+
     @property
     def build_directory(self):
         """autotools needs a different build directory to work"""


### PR DESCRIPTION
This patches in commit id `3637a87f986c` from `robertu94/sz@master` for `sz@2.1.8.1:2.1.8.3`, which makes ctags functionality optional unless requested. @robertu94's commit has been merged into `sz@master` and this patch makes it available for `sz@2.1.8.1:2.1.8.3`. Fixes https://github.com/spack/spack/issues/16933 .

@disheng222 