### PR TITLE
installer: don't attempt to get repo for externals from metadata dir 

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -400,7 +400,11 @@ def dump_packages(spec, path):
 
             # There's no provenance installed for the source package.  Skip it.
             # User can always get something current from the builtin repo.
-            if not os.path.isdir(source_repo_root):
+            # If it's external, treat it as current because we cannot guarantee
+            # we have the repo that it came from.
+            # The provenance could exist if the external was installed by a
+            # separate Spack instance not configured as an upstream.
+            if node.external or not os.path.isdir(source_repo_root):
                 continue
 
             # Create a source repo and get the pkg directory out of it.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -400,8 +400,8 @@ def dump_packages(spec, path):
 
             # There's no provenance installed for the source package.  Skip it.
             # User can always get something current from the builtin repo.
-            # If it's external, treat it as current because we cannot guarantee
-            # we have the repo that it came from.
+            # If it's external, skip it because it either is using the builtin
+            # repo or the provenance is already in place.
             # The provenance could exist if the external was installed by a
             # separate Spack instance not configured as an upstream.
             if node.external or not os.path.isdir(source_repo_root):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -398,12 +398,13 @@ def dump_packages(spec, path):
             source = spack.store.layout.build_packages_path(node)
             source_repo_root = os.path.join(source, node.namespace)
 
-            # There's no provenance installed for the source package.  Skip it.
-            # User can always get something current from the builtin repo.
-            # If it's external, skip it because it either is using the builtin
-            # repo or the provenance is already in place.
-            # The provenance could exist if the external was installed by a
-            # separate Spack instance not configured as an upstream.
+            # If there's no provenance installed for the package, skip it.
+            # If it's external, skip it because it either:
+            # 1) it wasn't built with Spack, so it has no Spack metadata
+            # 2) it was built by another Spack instance, and we do not
+            # (currently) use Spack metadata to associate repos with externals
+            # built be other Spack instances.
+            # Spack can always get something current from the builtin repo.
             if node.external or not os.path.isdir(source_repo_root):
                 continue
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -403,7 +403,7 @@ def dump_packages(spec, path):
             # 1) it wasn't built with Spack, so it has no Spack metadata
             # 2) it was built by another Spack instance, and we do not
             # (currently) use Spack metadata to associate repos with externals
-            # built be other Spack instances.
+            # built by other Spack instances.
             # Spack can always get something current from the builtin repo.
             if node.external or not os.path.isdir(source_repo_root):
                 continue


### PR DESCRIPTION
In computing the metadata for a package, we check the `.spack` directory regardless of whether it is an external package (that someone else installed with spack) or a package of ours. This causes problems because the local spack instance might not know about a repo used by the other spack instance.

With this PR, we will assume all externals are built with the repos that we know about (as we would for externals not built with Spack).

This fixes a bug reported on Spack slack.