### PR TITLE
cmake: Add linker option for VerifyFortranC when using Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/fujitsu_add_linker_option.patch
+++ b/var/spack/repos/builtin/packages/cmake/fujitsu_add_linker_option.patch
@@ -1,0 +1,10 @@
+--- spack-src/Modules/FortranCInterface/Verify/CMakeLists.txt.org	2020-06-05 15:54:59.559043595 +0900
++++ spack-src/Modules/FortranCInterface/Verify/CMakeLists.txt	2020-06-05 15:58:28.150062948 +0900
+@@ -4,6 +4,7 @@
+ cmake_minimum_required(VERSION ${CMAKE_VERSION})
+ project(VerifyFortranC C Fortran)
+ 
++set (CMAKE_EXE_LINKER_FLAGS "--linkfortran")
+ option(VERIFY_CXX "Whether to verify C++ and Fortran" OFF)
+ if(VERIFY_CXX)
+   enable_language(CXX)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -142,6 +142,10 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4681
     patch('ignore_crayxc_warnings.patch', when='@3.7:3.17.2')
 
+    # The Fujitsu compiler requires the '--linkfortran' option
+    # to combine C++ and Fortran programs.
+    patch('fujitsu_add_linker_option.patch', when='%fj')
+
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166


### PR DESCRIPTION
@chuckatkins 
The Fujitsu compiler requires the '--linkfortran' option to combine C++ and Fortran programs.
This option will find and link the required Fortran libraries.