### PR TITLE
iegenlib: Add build dependencies for automake and libtool

### DIFF
--- a/var/spack/repos/builtin/packages/iegenlib/package.py
+++ b/var/spack/repos/builtin/packages/iegenlib/package.py
@@ -23,6 +23,8 @@ class Iegenlib(CMakePackage):
 
     depends_on('cmake@2.6:', type='build')
     depends_on('autoconf',   type='build')
+    depends_on('automake',   type='build')
+    depends_on('libtool',    type='build')
     depends_on('texinfo',    type='build')
     depends_on('isl')
 

--- a/var/spack/repos/builtin/packages/iegenlib/package.py
+++ b/var/spack/repos/builtin/packages/iegenlib/package.py
@@ -18,8 +18,8 @@ class Iegenlib(CMakePackage):
 
     version('master', branch='master')
     version('2018-07-03',
-        url="https://github.com/CompOpt4Apps/IEGenLib/archive/fc479ee6ff01dba26beffc1dc6bacdba03262138.zip",
-        sha256='b4c0b368363fcc1e34b388057cc0940bb87fc336cebb0772fd6055f45009b12b')
+            url="https://github.com/CompOpt4Apps/IEGenLib/archive/fc479ee6ff01dba26beffc1dc6bacdba03262138.zip",
+            sha256='b4c0b368363fcc1e34b388057cc0940bb87fc336cebb0772fd6055f45009b12b')
 
     depends_on('cmake@2.6:', type='build')
     depends_on('autoconf',   type='build')


### PR DESCRIPTION
The install build for iegenlib failed when performed on a clean install of Ubuntu 20.04. This was due to automake and libtool missing. Adding these dependencies resolves the build failure.