### PR TITLE
Doc: E4S Build Cache Link

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -57,6 +57,12 @@ Build caches are installed via:
 
    $ spack buildcache install
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+List of popular build caches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* `Extreme-scale Scientific Software Stack (E4S) <https://e4s-project.github.io/>`_: `build cache <https://oaciss.uoregon.edu/e4s/inventory.html>`_
+
 
 ----------
 Relocation


### PR DESCRIPTION
Link to the E4S build cache in the according section of the docs.

cc @maherou