### PR TITLE
r: new variant

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -54,6 +54,8 @@ class R(AutotoolsPackage):
             description='Enable memory profiling')
     variant('rmath', default=False,
             description='Build standalone Rmath library')
+    variant('recommended_packages', default=True,
+            description='Recommended packages getting installed')
 
     # Virtual dependencies
     depends_on('blas', when='+external-lapack')
@@ -160,6 +162,9 @@ class R(AutotoolsPackage):
 
         if '+memory_profiling' in spec:
             config_args.append('--enable-memory-profiling')
+
+        if '~recommended_packages' in spec:
+            config_args.append('--without-recommended-packages')
 
         # Set FPICFLAGS for compilers except 'gcc'.
         if self.compiler.name != 'gcc':


### PR DESCRIPTION
R installs plenty of packages which it considers `recommended_packages`, these packages coming from this variant `--with-recommended-packages` and is default during compilation.
New variant gives you the option to do it by `--without-recommended-packages` and main motivation is, when e.g. `r-cluster` is install by Spack during activation it getting blocked owing to existence of `cluster` which installed as `recommended-packages`.