### PR TITLE
chill: Patch to include gmp, isl, and libquadmath

### DIFF
--- a/var/spack/repos/builtin/packages/chill/Add-GCC-libquadmath-for-rose.patch
+++ b/var/spack/repos/builtin/packages/chill/Add-GCC-libquadmath-for-rose.patch
@@ -1,0 +1,25 @@
+From 15c3cc127d8f48324b00fd654d9630724eedcfcd Mon Sep 17 00:00:00 2001
+From: John Jolly <john.jolly@gmail.com>
+Date: Fri, 5 Jun 2020 23:54:13 -0600
+Subject: [PATCH] Add GCC libquadmath for rose
+
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 7dd92b0..a8daba1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -7,7 +7,7 @@ core_cxxflags   =-g --std=c++11
+ 
+ ## Core Libraries ##
+ core_libs     = -lcodegen -lomega
+-core_libs    += -lm -lrose -lrt -lutil -ldl
++core_libs    += -lm -lrose -lrt -lutil -ldl -lquadmath
+ core_libs    += -lboost_date_time -lboost_filesystem -lboost_program_options
+ core_libs    += -lboost_regex -lboost_system -lboost_wave -lboost_iostreams
+ 
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/chill/Add-GMPHOME-option.patch
+++ b/var/spack/repos/builtin/packages/chill/Add-GMPHOME-option.patch
@@ -1,0 +1,53 @@
+From 336dfb3a1c314b6eec23ab4f99114be94c5e518e Mon Sep 17 00:00:00 2001
+From: John Jolly <john.jolly@gmail.com>
+Date: Fri, 5 Jun 2020 23:45:39 -0600
+Subject: [PATCH] Add GMPHOME option
+
+---
+ Makefile.am  | 4 ++++
+ configure.ac | 7 +++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 541cb99..7dd92b0 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -16,6 +16,8 @@ core_libs    += -liegenlib -lisl -lgmp
+ core_libdirs  = -Lomega/code_gen/obj -Lomega/omega_lib/obj
+ core_libdirs += -L$(ROSEHOME)/lib -L$(BOOSTHOME)/lib
+ 
++core_libdirs += -L$(GMPHOME)/lib
++
+ core_libdirs += -L$(ISLHOME)/lib
+ 
+ core_libdirs += -L$(IEGENHOME)/lib
+@@ -32,6 +34,8 @@ core_includes += -I$(srcdir)/include/chill
+ core_includes += -I$(ROSEHOME)/include/rose
+ core_includes += -I$(BOOSTHOME)/include
+ 
++core_includes += -I$(GSLHOME)/include
++
+ core_includes += -I$(ISLHOME)/include
+ 
+ core_includes += -I$(IEGENHOME)/include/iegenlib
+diff --git a/configure.ac b/configure.ac
+index e146839..18ecf76 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -58,6 +58,13 @@ AC_ARG_WITH([boost],[
+     ],[
+     AC_SUBST([BOOSTHOME], ["${BOOSTHOME}"])])
+ 
++AC_ARG_WITH([gmp],[
++    AS_HELP_STRING([--with-gmp],[set path to gmp])
++    ],[
++    AC_SUBST([GMPHOME], [$withval])
++    ],[
++    AC_SUBST([GMPHOME], ["${GMPHOME}"])])
++
+ AC_ARG_WITH([iegen],[
+     AS_HELP_STRING([--with-iegen],[set path to iegenlib])
+     ],[
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/chill/Add-ISLHOME-option.patch
+++ b/var/spack/repos/builtin/packages/chill/Add-ISLHOME-option.patch
@@ -1,0 +1,53 @@
+From 3b4094b9cf1beec0b870e9ca0c3e51ed9b10dc39 Mon Sep 17 00:00:00 2001
+From: John Jolly <john.jolly@gmail.com>
+Date: Fri, 5 Jun 2020 23:21:18 -0600
+Subject: [PATCH] Add ISLHOME option
+
+---
+ Makefile.am  | 4 ++++
+ configure.ac | 7 +++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 30667a8..541cb99 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -16,6 +16,8 @@ core_libs    += -liegenlib -lisl -lgmp
+ core_libdirs  = -Lomega/code_gen/obj -Lomega/omega_lib/obj
+ core_libdirs += -L$(ROSEHOME)/lib -L$(BOOSTHOME)/lib
+ 
++core_libdirs += -L$(ISLHOME)/lib
++
+ core_libdirs += -L$(IEGENHOME)/lib
+ core_libdirs += -L$(IEGENHOME)/../lib/installed/lib
+ 
+@@ -30,6 +32,8 @@ core_includes += -I$(srcdir)/include/chill
+ core_includes += -I$(ROSEHOME)/include/rose
+ core_includes += -I$(BOOSTHOME)/include
+ 
++core_includes += -I$(ISLHOME)/include
++
+ core_includes += -I$(IEGENHOME)/include/iegenlib
+ core_includes += -I$(IEGENHOME)/../lib/installed/include
+ 
+diff --git a/configure.ac b/configure.ac
+index 8e163cd..e146839 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -65,6 +65,13 @@ AC_ARG_WITH([iegen],[
+     ],[
+     AC_SUBST([IEGENHOME], ["${IEGENHOME}"])])
+ 
++AC_ARG_WITH([isl],[
++    AS_HELP_STRING([--with-isl],[set path to isl])
++    ],[
++    AC_SUBST([ISLHOME], [$withval])
++    ],[
++    AC_SUBST([ISLHOME], ["${ISLHOME}"])])
++
+ AC_ARG_WITH([omega],[
+     AS_HELP_STRING([--with-omega],[set omega home])],[
+     AC_SUBST([OMEGAHOME], [$withval])],[
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/chill/package.py
+++ b/var/spack/repos/builtin/packages/chill/package.py
@@ -29,6 +29,12 @@ class Chill(AutotoolsPackage):
     depends_on('flex', type='build')
     # Does not currrently work with Python3
     depends_on('python@2.7:2.8')
+    depends_on('isl', type='build')
+    depends_on('gmp', type='build')
+
+    patch('Add-ISLHOME-option.patch')
+    patch('Add-GMPHOME-option.patch')
+    patch('Add-GCC-libquadmath-for-rose.patch')
 
     build_directory = 'spack-build'
 
@@ -40,27 +46,39 @@ class Chill(AutotoolsPackage):
         rose_home  = self.spec['rose'].prefix
         boost_home = self.spec['boost'].prefix
         iegen_home = self.spec['iegenlib'].prefix
+        isl_home   = self.spec['isl'].prefix
+        gmp_home   = self.spec['gmp'].prefix
 
         env.set('ROSEHOME', rose_home)
         env.set('BOOSTHOME', boost_home)
         env.set('IEGENHOME', iegen_home)
+        env.set('ISLHOME', isl_home)
+        env.set('GMPHOME', gmp_home)
 
         env.append_path('LD_LIBRARY_PATH', rose_home.lib)
         env.append_path('LD_LIBRARY_PATH', boost_home.lib)
         env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
+        env.append_path('LD_LIBRARY_PATH', isl_home.lib)
+        env.append_path('LD_LIBRARY_PATH', gmp_home.lib)
 
     def setup_run_environment(self, env):
         rose_home  = self.spec['rose'].prefix
         boost_home = self.spec['boost'].prefix
         iegen_home = self.spec['iegenlib'].prefix
+        isl_home   = self.spec['isl'].prefix
+        gmp_home   = self.spec['gmp'].prefix
 
         env.append_path('LD_LIBRARY_PATH', rose_home.lib)
         env.append_path('LD_LIBRARY_PATH', boost_home.lib)
         env.append_path('LD_LIBRARY_PATH', iegen_home.lib)
+        env.append_path('LD_LIBRARY_PATH', isl_home.lib)
+        env.append_path('LD_LIBRARY_PATH', gmp_home.lib)
 
     def configure_args(self):
         args = ['--with-rose={0}'.format(self.spec['rose'].prefix),
                 '--with-boost={0}'.format(self.spec['boost'].prefix),
-                '--with-iegen={0}'.format(self.spec['iegenlib'].prefix)]
+                '--with-iegen={0}'.format(self.spec['iegenlib'].prefix),
+                '--with-isl={0}'.format(self.spec['isl'].prefix),
+                '--with-gmp={0}'.format(self.spec['gmp'].prefix)]
 
         return args


### PR DESCRIPTION
The rose library uses the `strtoflt128` and `quadmath_snprintf`
functions. In order to successfully link the rose library, chill must
also link the GCC libquadmath library to resolve the two functions. This
patch changes the chill build to include this library.

Chill will also not compile unless headers from the gmp and isl
libraries are found in the includes path. Two patches - one each for gmp
and isl - modify the chill build process to add options to specify those
paths. These options follow the similar pattern as seen with BOOSTHOME
and ROSEHOME options which already exist in the chill build process.

Because of the addition of GMPHOME and ISLHOME options, build
requirements for gmp and isl are also added.