### PR TITLE
Fixture to mock an arbitrarily named executable

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1099,3 +1099,20 @@ def clear_directive_functions():
     # proceeding with subsequent tests that may depend on the original
     # functions.
     spack.directives.DirectiveMeta._directives_to_be_executed = []
+
+
+@pytest.fixture
+def mock_executable(tmpdir):
+    """Factory to create a mock executable in a temporary directory that
+    output a custom string when run.
+    """
+    import jinja2
+
+    def _factory(name, output, subdir=('bin',)):
+        f = tmpdir.mkdir(*subdir).join(name)
+        t = jinja2.Template('#!/bin/bash\n{{ output }}\n')
+        f.write(t.render(output=output))
+        f.chmod(0o755)
+        return str(f)
+
+    return _factory

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -107,16 +107,9 @@ def expected_patchelf_path(request, mutable_database, monkeypatch):
 
 
 @pytest.fixture()
-def mock_patchelf(tmpdir):
-    import jinja2
-
+def mock_patchelf(tmpdir, mock_executable):
     def _factory(output):
-        f = tmpdir.mkdir('bin').join('patchelf')
-        t = jinja2.Template('#!/bin/bash\n{{ output }}\n')
-        f.write(t.render(output=output))
-        f.chmod(0o755)
-        return str(f)
-
+        return mock_executable('patchelf', output=output)
     return _factory
 
 


### PR DESCRIPTION
Modifications:
- [x] Added a new fixture that mocks an arbitrarily named executable
- [x] Make it such that the executable can be placed in an arbitrary subdirectory
- [x] Implemented `mock_patchelf` in terms of `mock_executable`