### PR TITLE
[util-linux] disabling systemd

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -44,6 +44,7 @@ class UtilLinux(AutotoolsPackage):
         config_args = [
             '--disable-use-tty-group',
             '--disable-makeinstall-chown',
+            '--without-systemd'
         ]
         config_args.extend(self.enable_or_disable('libuuid'))
         return config_args


### PR DESCRIPTION
If systemd support is enabled, install will attempt to modify files in
system systemd directories.