### PR TITLE
bazel: patch to allow py-tensorflow (and likely other bazel packages)…

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/disabledepcheck.patch
+++ b/var/spack/repos/builtin/packages/bazel/disabledepcheck.patch
@@ -1,0 +1,11 @@
+--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java.orig  2020-03-25 08:54:37.914186251 -0400
++++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java       2020-03-25 08:55:01.356250657 -0400
+@@ -148,7 +148,7 @@
+         if (execPath.startsWith(execRoot)) {
+           execPathFragment = execPath.relativeTo(execRoot); // funky but tolerable path
+         } else {
+-          problems.add(execPathFragment.getPathString());
++          //          problems.add(execPathFragment.getPathString());
+           continue;
+         }
+       }

--- a/var/spack/repos/builtin/packages/bazel/disabledepcheck_old.patch
+++ b/var/spack/repos/builtin/packages/bazel/disabledepcheck_old.patch
@@ -1,0 +1,11 @@
+--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java.orig    2020-06-08 13:42:14.035342560 -0400
++++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java 2020-06-08 13:42:25.149375458 -0400
+@@ -963,7 +963,7 @@
+           // are, it's probably due to a non-hermetic #include, & we should stop
+           // the build with an error.
+           if (execPath.startsWith(execRoot)) {
+-            execPathFragment = execPath.relativeTo(execRoot); // funky but tolerable path
++             //  execPathFragment = execPath.relativeTo(execRoot); // funky but tolerable path
+           } else {
+             problems.add(execPathFragment.getPathString());
+             continue;

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -94,6 +94,8 @@ class Bazel(Package):
     version('0.3.1',  sha256='218d0e28b4d1ee34585f2ac6b18d169c81404d93958815e73e60cc0368efcbb7')
     version('0.3.0',  sha256='357fd8bdf86034b93902616f0844bd52e9304cccca22971ab7007588bf9d5fb3')
 
+    variant('nodepfail', default=True, description='Disable failing dependency checks due to injected absolute paths - required for most builds using bazel with spack')
+
     # https://docs.bazel.build/versions/master/install-compile-source.html#bootstrap-bazel
     # Until https://github.com/spack/spack/issues/14058 is fixed, use jdk to build bazel
     # Strict dependency on java@8 as per
@@ -127,6 +129,9 @@ class Bazel(Package):
     patch('compile-0.6.patch',  when='@0.6:0.8')
     patch('compile-0.4.patch',  when='@0.4:0.5')
     patch('compile-0.3.patch',  when='@:0.3')
+
+    patch('disabledepcheck.patch', when='@0.3.2:+nodepfail')
+    patch('disabledepcheck_old.patch', when='@0.3.0:0.3.1+nodepfail')
 
     phases = ['bootstrap', 'install']
 


### PR DESCRIPTION
… to build.

bazel uses gcc's -MF option to write dependencies to a
file. Post-compilation, bazel reads this file and makes some
determinations.

"Since gcc is given only relative paths on the command line,
 non-system include paths here should never be absolute. If they
 are, it's probably due to a non-hermetic #include, & we should stop
 the build with an error."

Spack directly injects absolute paths, which appear in this file and
cause bazel to fail the build despite the fact that compilation
succeeded.

This patch disables this failure mode by default, and allows for it
to be turned back on by using the '~nodepfail' variant.