### PR TITLE
add compilers to mpi setup_run_environment methods forall mpi

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -34,6 +34,11 @@ class FujitsuMpi(Package):
         self.spec.mpifc = self.prefix.bin.mpifrt
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env):
+
+    def setup_run_environment(self, env):
+        # Because MPI are both compilers and runtimes, we set up the compilers
+        # as part of run environment
         env.set('MPICC', self.prefix.bin.mpifcc)
         env.set('MPICXX', self.prefix.bin.mpiFCC)
         env.set('MPIF77', self.prefix.bin.mpifrt)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -34,7 +34,7 @@ class FujitsuMpi(Package):
         self.spec.mpifc = self.prefix.bin.mpifrt
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env):
+        self.setup_run_environment(env)
 
     def setup_run_environment(self, env):
         # Because MPI are both compilers and runtimes, we set up the compilers

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -63,3 +63,9 @@ class IntelMpi(IntelPackage):
             'F90':  spack_fc,
             'FC':   spack_fc,
         })
+
+    def setup_run_environment(self, *args):
+        super(self, IntelMpi).setup_run_environment(*args)
+        # We can fake the dependent spec because it isn't used
+        # This allows us to setup mpi compilers in run env
+        self.setup_dependent_build_environment(*args, None)

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -68,4 +68,4 @@ class IntelMpi(IntelPackage):
         super(self, IntelMpi).setup_run_environment(*args)
         # We can fake the dependent spec because it isn't used
         # This allows us to setup mpi compilers in run env
-        self.setup_dependent_build_environment(*args, None)
+        self.setup_dependent_build_environment(*args, dependent_spec=None)

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -64,8 +64,8 @@ class IntelMpi(IntelPackage):
             'FC':   spack_fc,
         })
 
-    def setup_run_environment(self, *args):
-        super(self, IntelMpi).setup_run_environment(*args)
-        # We can fake the dependent spec because it isn't used
-        # This allows us to setup mpi compilers in run env
-        self.setup_dependent_build_environment(*args, dependent_spec=None)
+    def setup_run_environment(self, env):
+        super(self, IntelMpi).setup_run_environment(env)
+
+        for name, value in self.mpi_compiler.wrappers.items():
+            env.set(name, value)

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -225,3 +225,9 @@ class IntelParallelStudio(IntelPackage):
             'F90':  spack_fc,
             'FC':   spack_fc,
         })
+
+    def setup_run_environment(self, *args):
+        super(self, IntelParallelStudio).setup_run_environment(*args)
+        # We can fake the dependent spec because it isn't used
+        # This allows us to setup mpi compilers in run env
+        self.setup_dependent_build_environment(*args, None)

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -226,8 +226,8 @@ class IntelParallelStudio(IntelPackage):
             'FC':   spack_fc,
         })
 
-    def setup_run_environment(self, *args):
-        super(self, IntelParallelStudio).setup_run_environment(*args)
-        # We can fake the dependent spec because it isn't used
-        # This allows us to setup mpi compilers in run env
-        self.setup_dependent_build_environment(*args, dependent_spec=None)
+    def setup_run_environment(self, env):
+        super(self, IntelParallelStudio).setup_run_environment(env)
+
+        for name, value in self.mpi_compiler_wrappers.items():
+            env.set(name, value)

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -230,4 +230,4 @@ class IntelParallelStudio(IntelPackage):
         super(self, IntelParallelStudio).setup_run_environment(*args)
         # We can fake the dependent spec because it isn't used
         # This allows us to setup mpi compilers in run env
-        self.setup_dependent_build_environment(*args, None)
+        self.setup_dependent_build_environment(*args, dependent_spec=None)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -160,7 +160,9 @@ spack package at this time.''',
         if self.spec.satisfies('%gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_run_environment(self, env):
+        # Because MPI implementations provide compilers, they have to add to
+        # their run environments the code to make the compilers available.
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
         if self.spec.external_module and 'cray' in self.spec.external_module:
@@ -179,6 +181,9 @@ spack package at this time.''',
         env.set('MPICH_F77', spack_f77)
         env.set('MPICH_F90', spack_fc)
         env.set('MPICH_FC', spack_fc)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
 
     def setup_dependent_package(self, module, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -176,14 +176,14 @@ spack package at this time.''',
             env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
             env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
         env.set('MPICH_CC', spack_cc)
         env.set('MPICH_CXX', spack_cxx)
         env.set('MPICH_F77', spack_f77)
         env.set('MPICH_F90', spack_fc)
         env.set('MPICH_FC', spack_fc)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
 
     def setup_dependent_package(self, module, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -39,6 +39,11 @@ class Mpt(Package):
         )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+    def setup_run_environment(self, env):
+        # Because MPI is both runtime and compiler, we have to setup the mpi
+        # compilers as part of the run environment.
         env.set('MPICC',  self.prefix.bin.mpicc)
         env.set('MPICXX', self.prefix.bin.mpicxx)
         env.set('MPIF77', self.prefix.bin.mpif77)

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -41,6 +41,11 @@ class Mpt(Package):
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
 
+        # use the Spack compiler wrappers under MPI
+        env.set('MPICC_CC', spack_cc)
+        env.set('MPICXX_CXX', spack_cxx)
+        env.set('MPIF90_F90', spack_fc)
+
     def setup_run_environment(self, env):
         # Because MPI is both runtime and compiler, we have to setup the mpi
         # compilers as part of the run environment.
@@ -48,9 +53,6 @@ class Mpt(Package):
         env.set('MPICXX', self.prefix.bin.mpicxx)
         env.set('MPIF77', self.prefix.bin.mpif77)
         env.set('MPIF90', self.prefix.bin.mpif90)
-        env.set('MPICC_CC', spack_cc)
-        env.set('MPICXX_CXX', spack_cxx)
-        env.set('MPIF90_F90', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
         if 'platform=cray' in self.spec:

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -208,7 +208,14 @@ class Mvapich2(AutotoolsPackage):
         if 'process_managers=slurm' in self.spec:
             env.set('SLURM_MPI_TYPE', 'pmi2')
 
+        # Because MPI functions as a compiler, we need to treat it as one and
+        # add its compiler paths to the run environment.
+        self.setup_compiler_environment(env)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_compiler_environment(env)
+
+    def setup_compiler_environment(self, env):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
         if self.spec.external_module and 'cray' in self.spec.external_module:

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -215,6 +215,13 @@ class Mvapich2(AutotoolsPackage):
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_compiler_environment(env)
 
+        # use the Spack compiler wrappers under MPI
+        env.set('MPICH_CC', spack_cc)
+        env.set('MPICH_CXX', spack_cxx)
+        env.set('MPICH_F77', spack_f77)
+        env.set('MPICH_F90', spack_fc)
+        env.set('MPICH_FC', spack_fc)
+
     def setup_compiler_environment(self, env):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
         # Cray MPIs always have cray in the module name, e.g. "cray-mvapich"
@@ -228,12 +235,6 @@ class Mvapich2(AutotoolsPackage):
             env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx'))
             env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
             env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
-
-        env.set('MPICH_CC', spack_cc)
-        env.set('MPICH_CXX', spack_cxx)
-        env.set('MPICH_F77', spack_f77)
-        env.set('MPICH_F90', spack_fc)
-        env.set('MPICH_FC', spack_fc)
 
     def setup_dependent_package(self, module, dependent_spec):
         # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -297,7 +297,9 @@ class Openmpi(AutotoolsPackage):
             libraries, root=self.prefix, shared=True, recursive=True
         )
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_run_environment(self, env):
+        # Because MPI is both a runtime and a compiler, we have to setup the
+        # compiler components as part of the run environment.
         env.set('MPICC',  join_path(self.prefix.bin, 'mpicc'))
         env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
         env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
@@ -307,6 +309,9 @@ class Openmpi(AutotoolsPackage):
         env.set('OMPI_CXX', spack_cxx)
         env.set('OMPI_FC', spack_fc)
         env.set('OMPI_F77', spack_f77)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -305,13 +305,14 @@ class Openmpi(AutotoolsPackage):
         env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
         env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+        # Use the spack compiler wrappers under MPI
         env.set('OMPI_CC', spack_cc)
         env.set('OMPI_CXX', spack_cxx)
         env.set('OMPI_FC', spack_fc)
         env.set('OMPI_F77', spack_f77)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -56,3 +56,27 @@ class SpectrumMpi(Package):
         env.set('OMPI_F77', spack_f77)
 
         env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+
+    def setup_run_environment(self, env):
+        # Because MPI functions as a compiler we need to setup the compilers
+        # in the run environment, like any compiler
+        if '%xl' in self.spec or '%xl_r' in self.spec:
+            env.set('MPICC', os.path.join(self.prefix.bin, 'mpixlc'))
+            env.set('MPICXX', os.path.join(self.prefix.bin, 'mpixlC'))
+            env.set('MPIF77', os.path.join(self.prefix.bin, 'mpixlf'))
+            env.set('MPIF90', os.path.join(self.prefix.bin, 'mpixlf'))
+        elif '%pgi' in self.spec:
+            env.set('MPICC', os.path.join(self.prefix.bin, 'mpipgicc'))
+            env.set('MPICXX', os.path.join(self.prefix.bin, 'mpipgic++'))
+            env.set('MPIF77', os.path.join(self.prefix.bin, 'mpipgifort'))
+            env.set('MPIF90', os.path.join(self.prefix.bin, 'mpipgifort'))
+        else:
+            env.set('MPICC', os.path.join(self.prefix.bin, 'mpicc'))
+            env.set('MPICXX', os.path.join(self.prefix.bin, 'mpic++'))
+            env.set('MPIF77', os.path.join(self.prefix.bin, 'mpif77'))
+            env.set('MPIF90', os.path.join(self.prefix.bin, 'mpif90'))
+
+        env.set('OMPI_CC', spack_cc)
+        env.set('OMPI_CXX', spack_cxx)
+        env.set('OMPI_FC', spack_fc)
+        env.set('OMPI_F77', spack_f77)

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -75,8 +75,3 @@ class SpectrumMpi(Package):
             env.set('MPICXX', os.path.join(self.prefix.bin, 'mpic++'))
             env.set('MPIF77', os.path.join(self.prefix.bin, 'mpif77'))
             env.set('MPIF90', os.path.join(self.prefix.bin, 'mpif90'))
-
-        env.set('OMPI_CC', spack_cc)
-        env.set('OMPI_CXX', spack_cxx)
-        env.set('OMPI_FC', spack_fc)
-        env.set('OMPI_F77', spack_f77)


### PR DESCRIPTION
Make sure MPI updates its compiler names in both dependent build environments AND run environments because it functions as a compiler.