### PR TITLE
cuda: 10.1 and onward, installers will crash if /tmp/cuda-installer.l…

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -8,6 +8,7 @@ from glob import glob
 from llnl.util.filesystem import LibraryList
 import os
 import platform
+import llnl.util.tty as tty
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same
@@ -85,6 +86,14 @@ class Cuda(Package):
         env.set('CUDA_HOME', self.prefix)
 
     def install(self, spec, prefix):
+        if os.path.exists('/tmp/cuda-installer.log'):
+            try:
+                os.remove('/tmp/cuda-installer.log')
+            except Exception:
+                if spec.satisfies('@10.1:'):
+                    tty.die("The cuda installer will segfault due to the "
+                            "presence of /tmp/cuda-installer.log "
+                            "please remove the file and try again ")
         runfile = glob(join_path(self.stage.source_path, 'cuda*_linux*'))[0]
         chmod = which('chmod')
         chmod('+x', runfile)
@@ -110,6 +119,10 @@ class Cuda(Package):
             arguments.append('--toolkitpath=%s' % prefix)   # Where to install
 
         runfile(*arguments)
+        try:
+            os.remove('/tmp/cuda-installer.log')
+        except Exception:
+            pass
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -89,7 +89,7 @@ class Cuda(Package):
         if os.path.exists('/tmp/cuda-installer.log'):
             try:
                 os.remove('/tmp/cuda-installer.log')
-            except Exception:
+            except OSError:
                 if spec.satisfies('@10.1:'):
                     tty.die("The cuda installer will segfault due to the "
                             "presence of /tmp/cuda-installer.log "
@@ -121,7 +121,7 @@ class Cuda(Package):
         runfile(*arguments)
         try:
             os.remove('/tmp/cuda-installer.log')
-        except Exception:
+        except OSError:
             pass
 
     @property


### PR DESCRIPTION
…og exists

Try to help if user owns the file, otherwise try to provide useful
info. Clean up the file post-install to try to avoid the whole issue.