### PR TITLE
Some minor fixes to set_permissions() in file_permissions.py

### DIFF
--- a/lib/spack/spack/test/permissions.py
+++ b/lib/spack/spack/test/permissions.py
@@ -45,3 +45,14 @@ def test_chmod_rejects_world_writable_suid(tmpdir):
     perms = stat.S_IWOTH
     with pytest.raises(InvalidPermissionsError):
         set_permissions(path, perms)
+
+
+def test_chmod_rejects_world_writable_sgid(tmpdir):
+    path = str(tmpdir.join('file').ensure())
+    print(type(tmpdir))
+    mode = stat.S_ISGID
+    fs.chmod_x(path, mode)
+
+    perms = stat.S_IWOTH
+    with pytest.raises(InvalidPermissionsError):
+        set_permissions(path, perms)

--- a/lib/spack/spack/test/permissions.py
+++ b/lib/spack/spack/test/permissions.py
@@ -27,9 +27,21 @@ def test_chmod_real_entries_ignores_suid_sgid(tmpdir):
 
 def test_chmod_rejects_group_writable_suid(tmpdir):
     path = str(tmpdir.join('file').ensure())
-    mode = stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX
+    print(type(tmpdir))
+    mode = stat.S_ISUID
     fs.chmod_x(path, mode)
 
-    perms = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    perms = stat.S_IWGRP
+    with pytest.raises(InvalidPermissionsError):
+        set_permissions(path, perms)
+
+
+def test_chmod_rejects_world_writable_suid(tmpdir):
+    path = str(tmpdir.join('file').ensure())
+    print(type(tmpdir))
+    mode = stat.S_ISUID
+    fs.chmod_x(path, mode)
+
+    perms = stat.S_IWOTH
     with pytest.raises(InvalidPermissionsError):
         set_permissions(path, perms)

--- a/lib/spack/spack/test/permissions.py
+++ b/lib/spack/spack/test/permissions.py
@@ -27,7 +27,6 @@ def test_chmod_real_entries_ignores_suid_sgid(tmpdir):
 
 def test_chmod_rejects_group_writable_suid(tmpdir):
     path = str(tmpdir.join('file').ensure())
-    print(type(tmpdir))
     mode = stat.S_ISUID
     fs.chmod_x(path, mode)
 
@@ -38,7 +37,6 @@ def test_chmod_rejects_group_writable_suid(tmpdir):
 
 def test_chmod_rejects_world_writable_suid(tmpdir):
     path = str(tmpdir.join('file').ensure())
-    print(type(tmpdir))
     mode = stat.S_ISUID
     fs.chmod_x(path, mode)
 
@@ -49,7 +47,6 @@ def test_chmod_rejects_world_writable_suid(tmpdir):
 
 def test_chmod_rejects_world_writable_sgid(tmpdir):
     path = str(tmpdir.join('file').ensure())
-    print(type(tmpdir))
     mode = stat.S_ISGID
     fs.chmod_x(path, mode)
 

--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -33,6 +33,11 @@ def set_permissions(path, perms, group=None):
         if perms & st.S_IWGRP:
             raise InvalidPermissionsError(
                 "Attempting to set suid with group writable")
+    # Or world writable sgid binaries
+    if perms & st.S_ISGID:
+        if perms & st.S_IWOTH:
+            raise InvalidPermissionsError(
+                "Attempting to set sgid with world writable")
 
     fs.chmod_x(path, perms)
 

--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -25,10 +25,14 @@ def set_permissions(path, perms, group=None):
     # Preserve higher-order bits of file permissions
     perms |= os.stat(path).st_mode & (st.S_ISUID | st.S_ISGID | st.S_ISVTX)
 
-    # Do not let users create world writable suid binaries
-    if perms & st.S_ISUID and perms & st.S_IWGRP:
-        raise InvalidPermissionsError(
-            "Attepting to set suid with world writable")
+    # Do not let users create world/group writable suid binaries
+    if perms & st.S_ISUID:
+        if perms & st.S_IWOTH:
+            raise InvalidPermissionsError(
+                "Attempting to set suid with world writable")
+        if perms & st.S_IWGRP:
+            raise InvalidPermissionsError(
+                "Attempting to set suid with group writable")
 
     fs.chmod_x(path, perms)
 


### PR DESCRIPTION
The set_permissions() routine claims to prevent users from creating
world writable suid binaries.  However, it seems to only be checking
for/preventing group writable suid binaries.

This patch modifies the routine to check for both world and group
writable suid binaries, and complain appropriately.

(This is a resubmission of #15544 which seems to have slipped between the cracks, and since then I  deleted and recreated my fork of spack, so I am not sure how viable the former is.

I first encountered this when building singularity a while back and confused by the "world-writable" error message on a file which was only group writable.  

I see that since then, singularity package.py creates a script to add suid rather than go through this script --- that is a better way in my opinion.  But while the set_permissions routine still exists, it should correctly check both group and world write perms on suid binaries and report problems correctly.
)


