### PR TITLE
cscope: Link tinfow instead of tinfo

### DIFF
--- a/var/spack/repos/builtin/packages/cscope/package.py
+++ b/var/spack/repos/builtin/packages/cscope/package.py
@@ -21,7 +21,7 @@ class Cscope(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('pkgconfig', type='build')
 
-    build_targets = ['CURSES_LIBS=-lncursesw -ltinfo']
+    build_targets = ['CURSES_LIBS=-lncursesw -ltinfow']
 
     def url_for_version(self, version):
         url = "https://sourceforge.net/projects/cscope/files/cscope/{0}{1}/cscope-{1}.tar.gz"


### PR DESCRIPTION
Whenever attempting to use any ncurses functionality within cscope, a
page fault would result within the ncurses library.

    Program received signal SIGSEGV, Segmentation fault.
    0x00007ffff7fad3cf in termattrs_sp () from .../lib/libncursesw.so.6
    (gdb) bt
    #0  0x00007ffff7fad3cf in termattrs_sp () from .../lib/libncursesw.so.6
    #1  0x00007ffff7faa794 in _nc_setupscreen_sp () from .../lib/libncursesw.so.6
    #2  0x00007ffff7fa614c in newterm_sp () from .../lib/libncursesw.so.6
    #3  0x00007ffff7fa65b9 in newterm () from .../lib/libncursesw.so.6
    #4  0x00007ffff7fa2970 in initscr () from .../lib/libncursesw.so.6
    #5  0x0000000000403dc2 in main (argc=<optimized out>, argv=0x7fffffffcea8) at main.c:574

This is due to a conflict between libtinfo.so and libtinfow.so. Both are
linked into cscope:

    $ ldd $(which cscope)
    /bin/bash: .../lib/libtinfo.so.6: no version information available (required by /bin/bash)
        linux-vdso.so.1 (0x00007fff5dbcb000)
        libncursesw.so.6 => .../lib/libncursesw.so.6 (0x00007f435cc69000)
        libtinfo.so.6 => .../lib/libtinfo.so.6 (0x00007f435cc2c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f435ca29000)
        libtinfow.so.6 => .../lib/libtinfow.so.6 (0x00007f435c9e8000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f435cca7000)

Specifically linking libtinfow.so instead of libtinfo.so resolves the
issue.

All instances of '...' above represent the path to the installed ncurses
for Spack.