### PR TITLE
put m4-patch into repo instead of downloading from fedoraproject(down)

### DIFF
--- a/var/spack/repos/builtin/packages/m4/m4-1.4.18-glibc-change-work-around.patch
+++ b/var/spack/repos/builtin/packages/m4/m4-1.4.18-glibc-change-work-around.patch
@@ -1,0 +1,115 @@
+diff -up m4-1.4.18/lib/fflush.c.orig m4-1.4.18/lib/fflush.c
+--- m4-1.4.18/lib/fflush.c.orig	2018-05-02 12:35:59.536851666 +0200
++++ m4-1.4.18/lib/fflush.c	2018-05-02 12:37:02.768958606 +0200
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff -up m4-1.4.18/lib/fpending.c.orig m4-1.4.18/lib/fpending.c
+--- m4-1.4.18/lib/fpending.c.orig	2018-05-02 12:35:32.305806774 +0200
++++ m4-1.4.18/lib/fpending.c	2018-05-02 12:35:44.944827347 +0200
+@@ -32,7 +32,7 @@ __fpending (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return fp->_IO_write_ptr - fp->_IO_write_base;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+diff -up m4-1.4.18/lib/fpurge.c.orig m4-1.4.18/lib/fpurge.c
+--- m4-1.4.18/lib/fpurge.c.orig	2018-05-02 12:38:13.586078669 +0200
++++ m4-1.4.18/lib/fpurge.c	2018-05-02 12:38:38.785121867 +0200
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff -up m4-1.4.18/lib/freadahead.c.orig m4-1.4.18/lib/freadahead.c
+--- m4-1.4.18/lib/freadahead.c.orig	2016-12-31 14:54:41.000000000 +0100
++++ m4-1.4.18/lib/freadahead.c	2018-05-02 11:43:19.570336724 +0200
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff -up m4-1.4.18/lib/freading.c.orig m4-1.4.18/lib/freading.c
+--- m4-1.4.18/lib/freading.c.orig	2018-05-02 12:37:33.970011368 +0200
++++ m4-1.4.18/lib/freading.c	2018-05-02 12:37:59.393054359 +0200
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff -up m4-1.4.18/lib/fseeko.c.orig m4-1.4.18/lib/fseeko.c
+--- m4-1.4.18/lib/fseeko.c.orig	2018-05-02 11:44:17.947460233 +0200
++++ m4-1.4.18/lib/fseeko.c	2018-05-02 12:39:49.537216897 +0200
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+diff -up m4-1.4.18/lib/stdio-impl.h.orig m4-1.4.18/lib/stdio-impl.h
+--- m4-1.4.18/lib/stdio-impl.h.orig	2016-12-31 14:54:42.000000000 +0100
++++ m4-1.4.18/lib/stdio-impl.h	2018-05-02 11:43:19.570336724 +0200
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -21,8 +21,8 @@ class M4(AutotoolsPackage):
     # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
     patch('secure_snprintf.patch', when='platform_os = highsierra')
     # https://bugzilla.redhat.com/show_bug.cgi?id=1573342
-    patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
-
+    # patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
+    patch('m4-1.4.18-glibc-change-work-around.patch', when='@1.4.18')
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")
 


### PR DESCRIPTION
m4 doesn't currently build, as trying to download a patch from fedoraproject fails because that site is down at the moment.
```
$ spack install m4
[+] /home/repr/cw-software/.spack/opt/spack/linux-debian10-x86_64/gcc-8.3.0/libsigsegv-2.12-w3hx4owtzlqntc5dhwliwxrdzxgcebuf
==> 28291: Installing m4
==> Using cached archive: /home/repr/cw-software/.spack/var/spack/cache/_source-cache/archive/ab/ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab.tar.gz
==> Fetching https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch
-#O=#    #     #                                                                                                                          
curl: (22) The requested URL returned error: 503 Service Temporarily Unavailable
==> Failed to fetch file from URL: https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch
    URL https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch was not found!
==> Fetching from https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch failed.
==> Error: FetchError: All fetchers failed for spack-stage-hklrsfk3
```

This problem will probably disappear by itself after a while, but generally it would seem safer and more robust to have that patch locally to avoid such problems (it's not very large).

This PR simply adds a single commit adding and using that patch locally instead of from remote: