### PR TITLE
cray module do not work without CRAY_LD_LIBRARY_PATH

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -32,6 +32,7 @@ There are two parts to the build environment:
 Skimming this module is a nice way to get acquainted with the types of
 calls you can make from within the install() function.
 """
+import re
 import inspect
 import multiprocessing
 import os
@@ -148,11 +149,14 @@ def clean_environment():
     env.unset('DYLD_LIBRARY_PATH')
     env.unset('DYLD_FALLBACK_LIBRARY_PATH')
 
-    # On Cray systems newer than CNL5, unset CRAY_LD_LIBRARY_PATH to avoid
-    # interference with Spack dependencies. CNL5 (e.g. Blue Waters) requires
-    # these variables to be set.
+    # On Cray "cluster" systems, unset CRAY_LD_LIBRARY_PATH to avoid
+    # interference with Spack dependencies.
+    # CNL requires these variables to be set (or at least some of them,
+    # depending on the CNL version).
     hostarch = arch.Arch(arch.platform(), 'default_os', 'default_target')
-    if str(hostarch.platform) == 'cray' and str(hostarch.os) != 'cnl5':
+    on_cray = str(hostarch.platform) == 'cray'
+    using_cnl = re.match(r'cnl\d+', str(hostarch.os))
+    if on_cray and not using_cnl:
         env.unset('CRAY_LD_LIBRARY_PATH')
         for varname in os.environ.keys():
             if 'PKGCONF' in varname:

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -127,7 +127,7 @@ def get_path_args_from_module_line(line):
         # OPERATION VAR_NAME PATH_ARG
         words = line.split()
         if len(words) > 2:
-            path_arg = line.split()[2]
+            path_arg = words[2]
         else:
             return []
 


### PR DESCRIPTION
Fixes a bug reported by @nicholas-sly on slack.

The PrgEnv-* modules on Cray CNL systems seem to fail to load if CRAY_LD_LIBRARY_PATH is unset.

This PR expands the scope of OSs for which CRAY_LD_LIBRARY_PATH is not cleaned, from CNL5 to the entire CNL* series.