### PR TITLE
add build_ext_args to link pygpu with gpuarray

### DIFF
--- a/var/spack/repos/builtin/packages/libgpuarray/package.py
+++ b/var/spack/repos/builtin/packages/libgpuarray/package.py
@@ -14,6 +14,7 @@ class Libgpuarray(CMakePackage):
     homepage = "http://deeplearning.net/software/libgpuarray/"
     url      = "https://github.com/Theano/libgpuarray/archive/v0.6.1.tar.gz"
 
+    version('0.7.6', sha256='ad1c00dd47c3d36ee1708e5167377edbfcdb7226e837ef9c68b841afbb4a4f6a')
     version('0.7.5', sha256='39c4d2e743848be43c8819c736e089ae51b11aa446cc6ee05af945c2dfd63420')
     version('0.7.2', sha256='ef11ee6f8d62d53831277fd3dcab662aa770a5b5de2d30fe3018c4af959204da')
     version('0.7.1', sha256='4d0f9dd63b0595a8c04d8cee91b2619847c033b011c71d776caa784322382ed6')

--- a/var/spack/repos/builtin/packages/py-pygpu/package.py
+++ b/var/spack/repos/builtin/packages/py-pygpu/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-
 import os
+
 
 class PyPygpu(PythonPackage):
     """Python packge for the libgpuarray C library."""
@@ -35,8 +35,9 @@ class PyPygpu(PythonPackage):
     depends_on('check')
 
     phases = ['build_ext', 'install']
+
     def build_ext_args(self, spec, prefix):
-        
+    
         _ = self.spec['libgpuarray'].prefix
         include_flags = '-I{0}'.format(os.path.join(_, 'include'))
         library_flags = '-L{0}'.format(os.path.join(_, 'lib'))

--- a/var/spack/repos/builtin/packages/py-pygpu/package.py
+++ b/var/spack/repos/builtin/packages/py-pygpu/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+import os
 
 class PyPygpu(PythonPackage):
     """Python packge for the libgpuarray C library."""
@@ -12,6 +13,7 @@ class PyPygpu(PythonPackage):
     homepage = "http://deeplearning.net/software/libgpuarray/"
     url      = "https://github.com/Theano/libgpuarray/archive/v0.6.1.tar.gz"
 
+    version('0.7.6', sha256='ad1c00dd47c3d36ee1708e5167377edbfcdb7226e837ef9c68b841afbb4a4f6a')
     version('0.7.5', sha256='39c4d2e743848be43c8819c736e089ae51b11aa446cc6ee05af945c2dfd63420')
     version('0.7.2', sha256='ef11ee6f8d62d53831277fd3dcab662aa770a5b5de2d30fe3018c4af959204da')
     version('0.7.1', sha256='4d0f9dd63b0595a8c04d8cee91b2619847c033b011c71d776caa784322382ed6')
@@ -21,7 +23,9 @@ class PyPygpu(PythonPackage):
     version('0.6.1', sha256='b2466311e0e3bacdf7a586bba0263f6d232bf9f8d785e91ddb447653741e6ea5')
     version('0.6.0', sha256='a58a0624e894475a4955aaea25e82261c69b4d22c8f15ec07041a4ba176d35af')
 
-    depends_on('libgpuarray')
+    depends_on('libgpuarray@0.7.6', when='@0.7.6')
+    depends_on('libgpuarray@0.7.5', when='@0.7.5')
+    depends_on('libgpuarray')                        # default
     # not just build-time, requires pkg_resources
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-cython@0.25:', type=('build', 'run'))
@@ -29,3 +33,12 @@ class PyPygpu(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-mako', type=('build', 'run'))
     depends_on('check')
+
+    phases = ['build_ext', 'install']
+    def build_ext_args(self, spec, prefix):
+        
+        _ = self.spec['libgpuarray'].prefix
+        include_flags = '-I{0}'.format(os.path.join(_, 'include'))
+        library_flags = '-L{0}'.format(os.path.join(_, 'lib'))
+
+        return [include_flags, library_flags]

--- a/var/spack/repos/builtin/packages/py-pygpu/package.py
+++ b/var/spack/repos/builtin/packages/py-pygpu/package.py
@@ -37,7 +37,7 @@ class PyPygpu(PythonPackage):
     phases = ['build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
-    
+
         _ = self.spec['libgpuarray'].prefix
         include_flags = '-I{0}'.format(os.path.join(_, 'include'))
         library_flags = '-L{0}'.format(os.path.join(_, 'lib'))


### PR DESCRIPTION
I could never build pygpu since the build would not recognize the include and library path. I am not really sure how this package was supposed to be used. I have now explicitly added the lib and include paths as required (mimicing the install process at https://github.com/Theano/libgpuarray).