### PR TITLE
adios2: fix to build on Fujitsu MPI and Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -119,10 +119,20 @@ class Adios2(CMakePackage):
     # See https://github.com/ornladios/ADIOS2/pull/1899
     patch('2.5-fix-clear_cache.patch', when='@2.5.0')
 
+    @when('%fj')
+    def patch(self):
+        """ add fujitsu mpi commands #16864 """
+        f = join_path('cmake', 'upstream', 'FindMPI.cmake')
+        filter_file('mpcc_r)', 'mpcc_r mpifcc)', f, string=True)
+        filter_file('mpc++_r)', 'mpcc_r mpiFCC)', f, string=True)
+        filter_file('mpf77_r', 'mpf77_r mpifrt', f, string=True)
+
     def setup_build_environment(self, env):
         # https://github.com/ornladios/ADIOS2/issues/2228
         if self.spec.satisfies('%gcc@10: +fortran'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+        elif self.spec.satisfies('%fj +fortran'):
+            env.set('FFLAGS', '-Ccpp')
 
     def cmake_args(self):
         spec = self.spec
@@ -184,6 +194,12 @@ class Adios2(CMakePackage):
         if spec.satisfies('~shared'):
             args.append('-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL={0}'.format(
                 'ON' if '+pic' in spec else 'OFF'))
+
+        if spec.satisfies('%fj'):
+            args.extend([
+                '-DCMAKE_Fortran_SUBMODULE_EXT=.smod',
+                '-DCMAKE_Fortran_SUBMODULE_SEP=.'
+            ])
 
         if spec.satisfies('+python') or self.run_tests:
             args.append('-DPYTHON_EXECUTABLE:FILEPATH=%s'


### PR DESCRIPTION
 - Add Fujitsu MPI compiler command to cmake configuration file (#16864)
-   Add -Ccpp flag to fflags
-   Add cmake flags to handle Fujitsu Fortran submodule file.