### PR TITLE
Geant4 +Python: Load Module

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -56,6 +56,7 @@ class Geant4(CMakePackage):
 
     # Python, with boost requirement dealt with in cxxstd section
     depends_on('python@3:', when='+python')
+    extends('python', when='+python')
     conflicts('+python', when='@:10.6.1',
               msg='Geant4 <= 10.6.1 cannont be built with Python bindings')
 


### PR DESCRIPTION
Adding `extends('python')` makes sure that a
```
spack load -r geant4 +python
python -c "import Geant4"
```
can find the Python module, which is installed in the right location already.

Follow-up to #16868