### PR TITLE
environment spec lists: improve ability to query architecture in when clauses

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -647,7 +647,7 @@ named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on
    spack:
      definitions:
        - compilers: ['%gcc', '%clang']
-       - when: target == 'x86_64'
+       - when: arch.satisfies('x86_64:')
          compilers: ['%intel']
 
 .. note::
@@ -666,8 +666,12 @@ The valid variables for a ``when`` clause are:
 #. ``target``. The target string of the default Spack
    architecture on the system.
 
-#. ``architecture`` or ``arch``. The full string of the
-   default Spack architecture on the system.
+#. ``architecture`` or ``arch``. A Spack spec satisfying the default Spack
+   architecture on the system. This supports querying via the ``satisfies``
+   method, as shown above.
+
+#. ``arch_str``. The architecture string of the default Spack architecture
+   on the system.
 
 #. ``re``. The standard regex module in Python.
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -434,12 +434,14 @@ def _eval_conditional(string):
     """Evaluate conditional definitions using restricted variable scope."""
     arch = architecture.Arch(
         architecture.platform(), 'default_os', 'default_target')
+    arch_spec = spack.spec.Spec('arch=%s' % arch)
     valid_variables = {
         'target': str(arch.target),
         'os': str(arch.os),
         'platform': str(arch.platform),
-        'arch': str(arch),
-        'architecture': str(arch),
+        'arch': arch_spec,
+        'architecture': arch_spec,
+        'arch_str': str(arch),
         're': re,
         'env': os.environ,
         'hostname': socket.gethostname()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1399,6 +1399,29 @@ env:
         assert Spec('callpath') in test.user_specs
 
 
+def test_stack_definition_conditional_with_satisfaction(tmpdir):
+    filename = str(tmpdir.join('spack.yaml'))
+    with open(filename, 'w') as f:
+        f.write("""\
+env:
+  definitions:
+    - packages: [libelf, mpileaks]
+      when: arch.satisfies('platform=foo')  # will be "test" when testing
+    - packages: [callpath]
+      when: arch.satisfies('platform=test')
+  specs:
+    - $packages
+""")
+    with tmpdir.as_cwd():
+        env('create', 'test', './spack.yaml')
+
+        test = ev.read('test')
+
+        assert Spec('libelf') not in test.user_specs
+        assert Spec('mpileaks') not in test.user_specs
+        assert Spec('callpath') in test.user_specs
+
+
 def test_stack_definition_complex_conditional(tmpdir):
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:


### PR DESCRIPTION
Previously, we could only match strings.

```
spack:
  definitions:
  - mpis: [mvapich2@2.3.1]
    when: target=='haswell'
```

But we could not match ranges of targets. Now we can, using the `arch` or `architecture` fields.

```
spack:
  definitions:
  - mpis: [mvapich2@2.3.1]
    when: arch.satisfies('target=x86_64:')
```

Users can still use string matching for the architecture, against the new field `arch_str`.

```
spack:
  definitions:
  - mpis: [mvapich2@2.3.1]
    when: arch_str == 'linux-rhel7-broadwell'
```