### PR TITLE
bugfix: fix cache_extra_test_sources' file copy

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1503,14 +1503,14 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         paths = [srcs] if isinstance(srcs, string_types) else srcs
 
-        skip_file = lambda p: p not in paths
         for path in paths:
             src_path = os.path.join(self.stage.source_path, path)
             dest_path = os.path.join(self.install_test_root, path)
             if os.path.isdir(src_path):
-                fsys.copy_tree(src_path, dest_path)
+                fsys.install_tree(src_path, dest_path)
             else:
-                fsys.copy_tree(src_path, dest_path, ignore=skip_file)
+                fsys.mkdirp(os.path.dirname(dest_path))
+                fsys.copy(src_path, dest_path)
 
     test_requires_compiler = False
     test_failures = None


### PR DESCRIPTION
This PR resolves issue where extra test source files were being created as directories, not copied as files.

Unit tests are also added to confirm proper copies.