### PR TITLE
readline: fix linking to ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -29,7 +29,8 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
 
     def build(self, spec, prefix):
         options = [
-            'SHLIB_LIBS=-L{0} -lncursesw'.format(spec['ncurses'].prefix.lib)
+            'SHLIB_LIBS=-L{0} -lncursesw -ltinfo'.format(
+                spec['ncurses'].prefix.lib)
         ]
 
         make(*options)


### PR DESCRIPTION
### Before

```console
$ ldd -r lib/libreadline.so
        linux-vdso.so.1 (0x00007fffc89c4000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fccb0930000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fccb0b85000)
undefined symbol: UP    (lib/libreadline.so)
undefined symbol: PC    (lib/libreadline.so)
undefined symbol: BC    (lib/libreadline.so)
undefined symbol: tputs (lib/libreadline.so)
undefined symbol: tgoto (lib/libreadline.so)
undefined symbol: tgetflag      (lib/libreadline.so)
undefined symbol: tgetent       (lib/libreadline.so)
undefined symbol: tgetnum       (lib/libreadline.so)
undefined symbol: tgetstr       (lib/libreadline.so)
```

### After

```console
$ ldd -r lib/libreadline.so
        linux-vdso.so.1 (0x00007fffc2655000)
        libtinfo.so.6 => /home/adam/spack/opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/ncurses-6.2-v3z5jtv4ztmho7onysxesbp2wqrrbn5x/lib/libtinfo.so.6 (0x00007fee85eb0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fee85cb0000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fee85f4b000)
```

I have no idea why this change is necessary and why it was working until now. If anyone has any ideas, I would love to know. It seems like the library no longer links to `libncursesw` at all, but only to `libtinfo`.

Fixes #17058