### PR TITLE
libflame: replace 'no' with 'none' as possible value of 'threads' variant

### DIFF
--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -30,9 +30,9 @@ class Libflame(AutotoolsPackage):
             ' to their corresponding native C implementations'
             ' in libflame.')
 
-    variant('threads', default='no',
+    variant('threads', default='none',
             description='Multithreading support',
-            values=('pthreads', 'openmp', 'no'),
+            values=('pthreads', 'openmp', 'none'),
             multi=False)
 
     variant('static', default=True,
@@ -70,6 +70,12 @@ class Libflame(AutotoolsPackage):
             flags.append('-std=gnu99')
         return (flags, None, None)
 
+    def enable_or_disable_threads(self, variant, options):
+        opt_val = self.spec.variants['threads'].value
+        if variant_val == 'none':
+            opt_val = 'no'
+        return ['--enable-multithreading={0}'.format(opt_val)]
+
     def configure_args(self):
         # Libflame has a secondary dependency on BLAS,
         # but doesn't know which library name to expect:
@@ -96,10 +102,9 @@ class Libflame(AutotoolsPackage):
         else:
             config_args.append("--disable-debug")
 
-        config_args.append('--enable-multithreading='
-                           + self.spec.variants['threads'].value)
+        config_args.extend(self.enable_or_disable('threads'))
 
-        if 'no' != self.spec.variants['threads'].value:
+        if 'none' != self.spec.variants['threads'].value:
             config_args.append("--enable-supermatrix")
         else:
             config_args.append("--disable-supermatrix")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/16970

As noted in #16970, Spack is currently having issues managing specs with variants that can have a value of "no"/"yes" - the internal yaml parsing confuses these for boolean values which can change the actual Spec after writing-to/reading-from yaml form.

This is an in-the-meantime fix while I can look into whether/how-to get our yaml storage/restoration to preserve "yes"/"no" as strings (or whether we want to make sure that Spec variants don't use those values in the future)