### PR TITLE
Revert "ParaView: conflict ~opengl2 with versions 5.5 and up (#16742)"

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -54,9 +54,6 @@ class Paraview(CMakePackage, CudaPackage):
     conflicts('+python', when='@5.6:')
     conflicts('+python3', when='@:5.5')
     conflicts('+shared', when='+cuda')
-    # Legacy rendering dropped in 5.5
-    # See commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c
-    conflicts('~opengl2', when='@5.5:')
 
     # Workaround for
     # adding the following to your packages.yaml


### PR DESCRIPTION
This reverts commit 7449bf8bab94315f02ee200c9b65363edb7134f7.
This change does not allow us to compile paraview with osmesa:

spack install paraview+osmesa~opengl2

will give

1. "~opengl2" conflicts with "paraview@5.5:"
