### PR TITLE
clang: add 'version_argument', remove redundant method

### DIFF
--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -50,6 +50,8 @@ class Clang(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['flang', 'gfortran', 'xlf90_r']
 
+    version_argument = '--version'
+
     @property
     def debug_flags(self):
         return ['-gcodeview', '-gdwarf-2', '-gdwarf-3', '-gdwarf-4',
@@ -200,26 +202,6 @@ class Clang(Compiler):
         return "-fPIC"
 
     required_libs = ['libclang']
-
-    @classmethod
-    @llnl.util.lang.memoized
-    def default_version(cls, comp):
-        """The ``--version`` option works for clang compilers.
-        On most platforms, output looks like this::
-
-            clang version 3.1 (trunk 149096)
-            Target: x86_64-unknown-linux-gnu
-            Thread model: posix
-
-        On macOS, it looks like this::
-
-            Apple LLVM version 7.0.2 (clang-700.1.81)
-            Target: x86_64-apple-darwin15.2.0
-            Thread model: posix
-        """
-        compiler = Executable(comp)
-        output = compiler('--version', output=str, error=str)
-        return cls.extract_version_from_output(output)
 
     @classmethod
     @llnl.util.lang.memoized

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -389,6 +389,7 @@ def test_clang_flags():
     supported_flag_test("fc_pic_flag",  "-fPIC", "clang@2.0.0-apple")
 
     # non-Apple Clang.
+    supported_flag_test("version_argument", "--version", "clang@foo.bar")
     supported_flag_test("openmp_flag", "-fopenmp", "clang@3.3")
     unsupported_flag_test("cxx11_flag", "clang@3.2")
     supported_flag_test("cxx11_flag", "-std=c++11", "clang@3.3")


### PR DESCRIPTION
This PR fixes the `version_argument` field for clang compilers and removes a redundant method in the Clang class that shadows the Compiler class.

Clang previously used GCCs `-dumpversion` argument, which returns `4.2.1` because that was the version of GCC that clang originally targeted for compatibility. Clang's version argument is `--version`.

This was obfuscated in the past by clang having its own version of all methods to get version info. #12989 made this problem apparent by using the `version_argument` flag in a method used by clang.