### PR TITLE
Buildcache: Fix bug in binary string replacement

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -848,9 +848,9 @@ def relocate_text_bin(
                 _replace_prefix_bin(binary, old_dep_prefix, new_dep_prefix)
         _replace_prefix_bin(binary, orig_install_prefix, new_install_prefix)
 
-    # Note: Replacement of spack directory should not be done. This prevent
-    # adding duplicate padding in the case where the install root is a
-    # subdirectory of the spack
+    # Note: Replacement of spack directory should not be done. This causes
+    # an incorrect replacement path in the case where the install root is a
+    # subdirectory of the spack.
 
 
 def is_relocatable(spec):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -850,7 +850,7 @@ def relocate_text_bin(
 
     # Note: Replacement of spack directory should not be done. This causes
     # an incorrect replacement path in the case where the install root is a
-    # subdirectory of the spack.
+    # subdirectory of the spack directory.
 
 
 def is_relocatable(spec):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -846,7 +846,11 @@ def relocate_text_bin(
         for old_dep_prefix, new_dep_prefix in new_prefixes.items():
             if len(new_dep_prefix) <= len(old_dep_prefix):
                 _replace_prefix_bin(binary, old_dep_prefix, new_dep_prefix)
-        _replace_prefix_bin(binary, orig_spack, new_spack)
+        _replace_prefix_bin(binary, orig_install_prefix, new_install_prefix)
+
+    # Note: Replacement of spack directory should not be done. This prevent
+    # adding duplicate padding in the case where the install root is a
+    # subdirectory of the spack
 
 
 def is_relocatable(spec):


### PR DESCRIPTION
Only the prefixes of the package dependencies and the package itself should be replaced. Replacing the spack directory results in an incorrect directory when the install root is a subdirectory of the spack directory,