### PR TITLE
Add public spack mirror

### DIFF
--- a/etc/spack/defaults/mirrors.yaml
+++ b/etc/spack/defaults/mirrors.yaml
@@ -1,0 +1,2 @@
+mirrors:
+  spack-public: https://spack-llnl-mirror.s3-us-west-2.amazonaws.com/


### PR DESCRIPTION
Fixes #7121 

We have created a mirror storing the latest (as of now) version of each package in Spack. Note that this only stores archives which are stable (i.e. have an unchanging checksum - which means that e.g. Git commits are not included).