### PR TITLE
package/pocl: add dependency for icd variant, or else build fails

### DIFF
--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -71,6 +71,8 @@ class Pocl(CMakePackage):
     variant("icd", default=False,
             description="Support a system-wide ICD loader")
 
+    depends_on('ocl-icd', when='+icd')
+
     def url_for_version(self, version):
         if version >= Version('1.0'):
             url = "https://github.com/pocl/pocl/archive/v{0}.tar.gz"


### PR DESCRIPTION
Requires #17078 
Related to #17049 