### PR TITLE
gobject-introspection: Modified to build sequentially when using the Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -73,3 +73,7 @@ class GobjectIntrospection(Package):
 
     def setup_build_environment(self, env):
         env.set('SPACK_SBANG', "%s/bin/sbang" % spack_root)
+
+    @property
+    def parallel(self):
+        return not self.spec.satisfies('%fj')


### PR DESCRIPTION
When building in parallel, a certain file is deleted at unexpected times.
If we are using the Fujitsu compiler, there is a problem that access to that file will fail.

Therefore, when using the Fujitsu compiler, modify to build sequentially.