### PR TITLE
mxnet: avoid GNU parallel shuffle when without openmp.

### DIFF
--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -46,6 +46,7 @@ class Mxnet(MakefilePackage):
 
     patch('makefile.patch', when='@0.10:0.11')
     patch('makefile.opencv.patch', when='@1.6.0')
+    patch('parallell_shuffle.patch', when='@1.6.0')
 
     def build(self, spec, prefix):
         # copy template configuration file

--- a/var/spack/repos/builtin/packages/mxnet/parallell_shuffle.patch
+++ b/var/spack/repos/builtin/packages/mxnet/parallell_shuffle.patch
@@ -1,0 +1,13 @@
+--- a/src/operator/random/shuffle_op.cc	2020-01-31 08:45:22.000000000 +0900
++++ b/src/operator/random/shuffle_op.cc	2020-06-15 11:34:32.000000000 +0900
+@@ -22,8 +22,8 @@
+  * \file shuffle_op.cc
+  * \brief Operator to shuffle elements of an NDArray
+  */
+-#if !defined (__ANDROID__) && ((__GNUC__ > 4 &&\
+-    !defined(__clang__major__)) || (__clang_major__ > 4 && __linux__))
++#if ((__GNUC__ > 4 && !defined(__clang__major__)) || (__clang_major__ > 4 && __linux__)) && \
++  defined(_OPENMP) && !defined(__ANDROID__)
+         #define USE_GNU_PARALLEL_SHUFFLE
+ #endif
+ 


### PR DESCRIPTION
mxnet 1.6 is used GNU parallel shuffle when gcc and clang version 4 or newer.
GNU parallel shuffle is used OpenMP, so this header file is included omp.h.

This PR is avoid include omp.h when OpenMP dose not used.