### PR TITLE
Adding the missing -ltermcap for lua

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -54,7 +54,7 @@ class Lua(Package):
              'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
-             'MYLIBS=-lncursesw',
+             'MYLIBS=-lncursesw -ltermcap',
              'CC=%s -std=gnu99 %s' % (spack_cc,
                                       self.compiler.cc_pic_flag),
              target)


### PR DESCRIPTION
`lua` needs termcap to successfully build. Adding the missing library.