### PR TITLE
argobots/bolt: update package.py

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -20,21 +20,16 @@ class Argobots(AutotoolsPackage):
     git      = "https://github.com/pmodels/argobots.git"
     maintainers = ['shintaro-iwasaki']
 
-    version("master", branch="master")
-    version("1.0", sha256="36a0815f7bf99900a9c9c1eef61ef9b3b76aa2cfc4594a304f6c8c3296da8def",
-            preferred=True)
-    version("1.0rc2", sha256="7496b8bd39930a548b01aa3b1fe8f8b582c272600ef6a05ddc4398cf21dc12a2")
-    version("1.0rc1", sha256="2dc4487556dce602655a6535f501136f0edc3575708029c80b1af6dccd069ce7")
-    version("1.0b1", sha256="480b85b0e8db288400088a57c2dc5639f556843b06b0492841920c38348a2a3e")
-    version("1.0a1", sha256="bef93e06026ddeba8809474923176803e64d08e1425672cd7c5b424c797d5d9d")
+    version("main", branch="main")
+    version("1.0", sha256="36a0815f7bf99900a9c9c1eef61ef9b3b76aa2cfc4594a304f6c8c3296da8def")
 
     variant("valgrind", default=False, description="Enable Valgrind")
     variant("debug", default=False, description="Compiled with debugging symbols")
 
-    depends_on("m4", type=("build"), when="@master")
-    depends_on("autoconf", type=("build"), when="@master")
-    depends_on("automake", type=("build"), when="@master")
-    depends_on("libtool", type=("build"), when="@master")
+    depends_on("m4", type=("build"), when="@main")
+    depends_on("autoconf", type=("build"), when="@main")
+    depends_on("automake", type=("build"), when="@main")
+    depends_on("libtool", type=("build"), when="@main")
     depends_on("valgrind", when="+valgrind")
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -22,7 +22,7 @@ class Bolt(CMakePackage):
     git      = "https://github.com/pmodels/bolt.git"
     maintainers = ['shintaro-iwasaki']
 
-    version("master", branch="master")
+    version("main", branch="main")
     version("1.0", sha256="1c0d2f75597485ca36335d313a73736594e75c8a36123c5a6f54d01b5ba5c384")
 
     depends_on('argobots')


### PR DESCRIPTION
This PR updates scripts of `argobots` and `bolt`.
- `argobots`/`bolt`: move `master` to `main`
- `argobots`: remove alpha/beta/RC versions that are no longer used.
