### PR TITLE
axom conduit mfem build fixes

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -137,6 +137,12 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("py-shroud", when="+devtools")
     depends_on("uncrustify@0.61", when="+devtools")
 
+    def flag_handler(self, name, flags):
+        if name in ('cflags', 'cxxflags', 'fflags'):
+            # the package manages these flags in another way
+            return (None, None, None)
+        return (flags, None, None)
+
     def _get_sys_type(self, spec):
         sys_type = spec.architecture
         # if on llnl systems, we can use the SYS_TYPE
@@ -211,10 +217,11 @@ class Axom(CMakePackage, CudaPackage):
             cfg.write(cmake_cache_option("ENABLE_FORTRAN", False))
 
         # use global spack compiler flags
-        cflags = ' '.join(spec.compiler_flags['cflags'])
+        cppflags = ' '.join(spec.compiler_flags['cppflags'])
+        cflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
-        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        cxxflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cxxflags'])
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
         fflags = ' '.join(spec.compiler_flags['fflags'])

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -218,10 +218,13 @@ class Axom(CMakePackage, CudaPackage):
 
         # use global spack compiler flags
         cppflags = ' '.join(spec.compiler_flags['cppflags'])
-        cflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cflags'])
+        if cppflags:
+            # avoid always ending up with ' ' with no flags defined
+            cppflags += ' '
+        cflags = cppflags + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
-        cxxflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cxxflags'])
+        cxxflags = cppflags + ' '.join(spec.compiler_flags['cxxflags'])
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
         fflags = ' '.join(spec.compiler_flags['fflags'])

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -65,10 +65,10 @@ class Axom(CMakePackage, CudaPackage):
     # -----------------------------------------------------------------------
     # Variants
     # -----------------------------------------------------------------------
-    variant('debug', default=False,
+    variant('debug',    default=False,
             description='Build debug instead of optimized version')
 
-    variant('fortran', default=True, description="Build with Fortran support")
+    variant('fortran',  default=True, description="Build with Fortran support")
 
     variant("python",   default=False, description="Build python support")
 
@@ -77,16 +77,16 @@ class Axom(CMakePackage, CudaPackage):
 
     variant("mfem",     default=False, description="Build with mfem")
     variant("hdf5",     default=True, description="Build with hdf5")
-    variant("lua",      default=False, description="Build with Lua")
+    variant("lua",      default=True, description="Build with Lua")
     variant("scr",      default=False, description="Build with SCR")
     variant("umpire",   default=True, description="Build with umpire")
 
     variant("raja",     default=True, description="Build with raja")
-    variant("cub",     default=True,
+    variant("cub",      default=True,
             description="Build with RAJA's internal CUB support")
 
     varmsg = "Build development tools (such as Sphinx, Uncrustify, etc...)"
-    variant("devtools",  default=False, description=varmsg)
+    variant("devtools", default=False, description=varmsg)
 
     # -----------------------------------------------------------------------
     # Dependencies
@@ -124,7 +124,7 @@ class Axom(CMakePackage, CudaPackage):
         depends_on('umpire cuda_arch={0}'.format(sm_),
                    when='+umpire cuda_arch={0}'.format(sm_))
 
-    depends_on("mfem~mpi~hypre~metis~gzstream", when="+mfem")
+    depends_on("mfem~mpi~hypre~metis~zlib", when="+mfem")
 
     depends_on("python", when="+python")
 
@@ -209,6 +209,31 @@ class Axom(CMakePackage, CudaPackage):
             cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER", f_compiler))
         else:
             cfg.write(cmake_cache_option("ENABLE_FORTRAN", False))
+
+        # use global spack compiler flags
+        cflags = ' '.join(spec.compiler_flags['cflags'])
+        if cflags:
+            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        if cxxflags:
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+        fflags = ' '.join(spec.compiler_flags['fflags'])
+        if fflags:
+            cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
+
+        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+            libdir = pjoin(os.path.dirname(
+                           os.path.dirname(cpp_compiler)), "lib")
+            flags = ""
+            for _libpath in [libdir, libdir + "64"]:
+                if os.path.exists(_libpath):
+                    flags += " -Wl,-rpath,{0}".format(_libpath)
+            description = ("Adds a missing libstdc++ rpath")
+            if flags:
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
+                                            description))
+
+
 
         # TPL locations
         cfg.write("#------------------{0}\n".format("-" * 60))
@@ -434,7 +459,7 @@ class Axom(CMakePackage, CudaPackage):
                 description = ("Adds a missing rpath for libraries "
                                "associated with the fortran compiler")
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
-                                            "-Wl,-rpath," + libdir,
+                                            "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir,
                                             description))
 
             if "+cuda" in spec:
@@ -484,15 +509,6 @@ class Axom(CMakePackage, CudaPackage):
 
                 cfg.write("# nvcc does not like gtest's 'pthreads' flag\n")
                 cfg.write(cmake_cache_option("gtest_disable_pthreads", True))
-
-        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
-            clanglibdir = pjoin(os.path.dirname(
-                                os.path.dirname(cpp_compiler)), "lib")
-            flags = "-Wl,-rpath,{0}".format(clanglibdir)
-            description = ("Adds a missing rpath for libraries "
-                           "associated with the fortran compiler")
-            cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
-                                        description))
 
         cfg.write("\n")
         cfg.close()

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -240,8 +240,6 @@ class Axom(CMakePackage, CudaPackage):
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
                                             description))
 
-
-
         # TPL locations
         cfg.write("#------------------{0}\n".format("-" * 60))
         cfg.write("# TPLs\n")
@@ -465,9 +463,9 @@ class Axom(CMakePackage, CudaPackage):
                                       os.path.dirname(f_compiler)), "lib")
                 description = ("Adds a missing rpath for libraries "
                                "associated with the fortran compiler")
+                linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
-                                            "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir,
-                                            description))
+                                            linker_flags, description))
 
             if "+cuda" in spec:
                 cfg.write("#------------------{0}\n".format("-" * 60))

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -148,10 +148,10 @@ class Conduit(Package):
     phases = ["configure", "build", "install"]
 
     def flag_handler(self, name, flags):
-            if name in ('cflags', 'cxxflags', 'fflags'):
-                # the package manages these flags in another way
-                return (None, None, None)
-            return (flags, None, None)
+        if name in ('cflags', 'cxxflags', 'fflags'):
+            # the package manages these flags in another way
+            return (None, None, None)
+        return (flags, None, None)
 
     def setup_build_environment(self, env):
         env.set('CTEST_OUTPUT_ON_FAILURE', '1')
@@ -410,8 +410,8 @@ class Conduit(Package):
                     # Grab lib directory for the current fortran compiler
                     libdir = os.path.join(os.path.dirname(
                                           os.path.dirname(f_compiler)), "lib")
-                    flags  = "${BLT_EXE_LINKER_FLAGS} "
-                    flags += "-lstdc++ -Wl,-rpath,{0} -Wl,-rpath,{0}64".format(libdir)
+                    flags  = "${BLT_EXE_LINKER_FLAGS} -lstdc++ "
+                    flags += "-Wl,-rpath,{0} -Wl,-rpath,{0}64".format(libdir)
                     cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
                                                 flags))
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -350,6 +350,29 @@ class Conduit(Package):
         else:
             cfg.write(cmake_cache_entry("BUILD_SHARED_LIBS", "OFF"))
 
+        # use global spack compiler flags
+        cflags = ' '.join(spec.compiler_flags['cflags'])
+        if cflags:
+            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        if cxxflags:
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+        fflags = ' '.join(spec.compiler_flags['fflags'])
+        if fflags:
+            cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
+
+        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+            libdir = os.path.join(os.path.dirname(
+                                  os.path.dirname(f_compiler)), "lib")
+            flags = ""
+            for _libpath in [libdir, libdir + "64"]:
+                if os.path.exists(_libpath):
+                    flags += " -Wl,-rpath,{0}".format(_libpath)
+            description = ("Adds a missing libstdc++ rpath")
+            if flags:
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
+                                            description))
+
         #######################
         # Unit Tests
         #######################
@@ -380,7 +403,8 @@ class Conduit(Package):
                     # Grab lib directory for the current fortran compiler
                     libdir = os.path.join(os.path.dirname(
                                           os.path.dirname(f_compiler)), "lib")
-                    flags = "-lstdc++ -Wl,-rpath," + libdir
+                    flags  = "${BLT_EXE_LINKER_FLAGS} "
+                    flags += "-lstdc++ -Wl,-rpath,{0} -Wl,-rpath,{0}64".format(libdir)
                     cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
                                                 flags))
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -358,10 +358,13 @@ class Conduit(Package):
 
         # use global spack compiler flags
         cppflags = ' '.join(spec.compiler_flags['cppflags'])
-        cflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cflags'])
+        if cppflags:
+            # avoid always ending up with ' ' with no flags defined
+            cppflags += ' '
+        cflags = cppflags + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
-        cxxflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cxxflags'])
+        cxxflags = cppflags + ' '.join(spec.compiler_flags['cxxflags'])
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
         fflags = ' '.join(spec.compiler_flags['fflags'])

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -147,6 +147,12 @@ class Conduit(Package):
     # build phases used by this package
     phases = ["configure", "build", "install"]
 
+    def flag_handler(self, name, flags):
+            if name in ('cflags', 'cxxflags', 'fflags'):
+                # the package manages these flags in another way
+                return (None, None, None)
+            return (flags, None, None)
+
     def setup_build_environment(self, env):
         env.set('CTEST_OUTPUT_ON_FAILURE', '1')
 
@@ -351,10 +357,11 @@ class Conduit(Package):
             cfg.write(cmake_cache_entry("BUILD_SHARED_LIBS", "OFF"))
 
         # use global spack compiler flags
-        cflags = ' '.join(spec.compiler_flags['cflags'])
+        cppflags = ' '.join(spec.compiler_flags['cppflags'])
+        cflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
-        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        cxxflags = cppflags + ' ' + ' '.join(spec.compiler_flags['cxxflags'])
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
         fflags = ' '.join(spec.compiler_flags['fflags'])

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -371,12 +371,12 @@ class Mfem(Package):
             debug_flag_found = any(f in self.compiler.debug_flags for f in cxxflags)
 
             if '+debug' in spec:
-                if debug_flag_found:
+                if not debug_flag_found:
                     cxxflags.append('-g')
-                if opt_flag_found:
+                if not opt_flag_found:
                     cxxflags.append('-O0')
             else:
-                if opt_flag_found:
+                if not opt_flag_found:
                     cxxflags.append('-O2')
 
             cxxflags = [(xcompiler + flag) for flag in cxxflags]

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -366,6 +366,19 @@ class Mfem(Package):
         cxxflags = spec.compiler_flags['cxxflags']
 
         if cxxflags:
+            # Add opt/debug flags if they are not present in global cxx flags
+            opt_flag_found = any(f in self.compiler.opt_flags for f in cxxflags)
+            debug_flag_found = any(f in self.compiler.debug_flags for f in cxxflags)
+
+            if '+debug' in spec:
+                if debug_flag_found:
+                    cxxflags.append('-g')
+                if opt_flag_found:
+                    cxxflags.append('-O0')
+            else:
+                if opt_flag_found:
+                    cxxflags.append('-O2')
+
             cxxflags = [(xcompiler + flag) for flag in cxxflags]
             if '+cuda' in spec:
                 cxxflags += [

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -367,8 +367,10 @@ class Mfem(Package):
 
         if cxxflags:
             # Add opt/debug flags if they are not present in global cxx flags
-            opt_flag_found = any(f in self.compiler.opt_flags for f in cxxflags)
-            debug_flag_found = any(f in self.compiler.debug_flags for f in cxxflags)
+            opt_flag_found = any(f in self.compiler.opt_flags
+                                 for f in cxxflags)
+            debug_flag_found = any(f in self.compiler.debug_flags
+                                   for f in cxxflags)
 
             if '+debug' in spec:
                 if not debug_flag_found:


### PR DESCRIPTION
* Axom and Conduit now honor the global compiler flags

* MFEM will now add debug or opt flags depending on what variant is set and if they are not present already in the global flags.  For example, when you need to override the standard library at a global level, but still want packages to honor their various debug variants.