### PR TITLE
Add patch for older versions of py-tensorflow

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.1.patch
+++ b/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.1.patch
@@ -1,0 +1,14 @@
+--- a/tensorflow/contrib/__init__.py	2020-05-05 17:52:57.716350118 -0500
++++ b/tensorflow/contrib/__init__.py	2020-05-05 17:56:55.665192882 -0500
+@@ -20,7 +20,10 @@
+ 
+ # Add projects here, they will show up under tf.contrib.
+ from tensorflow.contrib import bayesflow
+-from tensorflow.contrib import cloud
++try:
++    from tensorflow.contrib import cloud
++except ImportError:
++    pass
+ from tensorflow.contrib import compiler
+ from tensorflow.contrib import copy_graph
+ from tensorflow.contrib import crf

--- a/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.10.patch
+++ b/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.10.patch
@@ -1,0 +1,14 @@
+--- a/tensorflow/contrib/__init__.py	2020-05-05 18:14:30.701463150 -0500
++++ b/tensorflow/contrib/__init__.py	2020-05-05 18:15:12.392435370 -0500
+@@ -26,7 +26,10 @@
+ from tensorflow.contrib import bayesflow
+ from tensorflow.contrib import checkpoint
+ if os.name != "nt":
+-  from tensorflow.contrib import cloud
++    try:
++        from tensorflow.contrib import cloud
++    except ImportError:
++        pass
+ from tensorflow.contrib import cluster_resolver
+ from tensorflow.contrib import coder
+ from tensorflow.contrib import compiler

--- a/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.4.patch
+++ b/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.4.patch
@@ -1,0 +1,14 @@
+--- a/tensorflow/contrib/__init__.py	2020-05-05 18:08:09.361724827 -0500
++++ b/tensorflow/contrib/__init__.py	2020-05-05 18:08:46.345699058 -0500
+@@ -20,7 +20,10 @@
+ 
+ # Add projects here, they will show up under tf.contrib.
+ from tensorflow.contrib import bayesflow
+-from tensorflow.contrib import cloud
++try:
++    from tensorflow.contrib import cloud
++except ImportError:
++    pass
+ from tensorflow.contrib import cluster_resolver
+ from tensorflow.contrib import compiler
+ from tensorflow.contrib import copy_graph

--- a/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.9.patch
+++ b/var/spack/repos/builtin/packages/py-tensorflow/contrib_cloud_1.9.patch
@@ -1,0 +1,14 @@
+--- a/tensorflow/contrib/__init__.py	2020-05-05 18:11:33.660582455 -0500
++++ b/tensorflow/contrib/__init__.py	2020-05-05 18:12:32.570541708 -0500
+@@ -25,7 +25,10 @@
+ from tensorflow.contrib import batching
+ from tensorflow.contrib import bayesflow
+ from tensorflow.contrib import checkpoint
+-from tensorflow.contrib import cloud
++try:
++    from tensorflow.contrib import cloud
++except ImportError:
++    pass
+ from tensorflow.contrib import cluster_resolver
+ from tensorflow.contrib import coder
+ from tensorflow.contrib import compiler

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -255,6 +255,14 @@ class PyTensorflow(Package, CudaPackage):
     # Allows 2.0.* releases to build with '--config=nogcp'
     patch('0001-Remove-contrib-cloud-bigtable-and-storage-ops-kernel.patch',
           when='@2.0.0:2.0.1')
+    # do not import contrib.cloud if not available
+    patch('https://github.com/tensorflow/tensorflow/commit/ed62ac8203999513dfae03498e871ea35eb60cc4.patch',
+          sha256='c37d14622a86b164e2411ea45a04f756ac61b2044d251f19ab17733c508e5305', when='@1.14.0')
+    # import_contrib_cloud patch for older versions
+    patch('contrib_cloud_1.10.patch', when='@1.10:1.13')
+    patch('contrib_cloud_1.9.patch', when='@1.9')
+    patch('contrib_cloud_1.4.patch', when='@1.4:1.8')
+    patch('contrib_cloud_1.1.patch', when='@1.1:1.3')
 
     phases = ['configure', 'build', 'install']
 


### PR DESCRIPTION
Versions of py-tensorflow between versions 1.1 and 1.14 need a patch to
avoid an import error on the cloud package even if built without support
for the cloud package.