### PR TITLE
Add user-meamc as a supported package in LAMMPS

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -60,7 +60,7 @@ class Lammps(CMakePackage, CudaPackage):
                           'kokkos', 'latte', 'manybody', 'mc', 'meam', 'misc',
                           'molecule', 'mpiio', 'peri', 'poems', 'python',
                           'qeq', 'replica', 'rigid', 'shock', 'snap', 'spin',
-                          'srd', 'user-atc', 'user-h5md', 'user-lb',
+                          'srd', 'user-meamc', 'user-atc', 'user-h5md', 'user-lb',
                           'user-misc', 'user-netcdf', 'user-omp', 'user-reaxc',
                           'voronoi']
 
@@ -120,6 +120,8 @@ class Lammps(CMakePackage, CudaPackage):
     conflicts('+user-misc', when='~manybody')
     conflicts('%gcc@9:', when='@:20200303+openmp')
     conflicts('+kokkos', when='@:20200227')
+    conflicts('+meamc', when='@20181212:')
+    conflicts('+user-meamc', when='@:20181212')
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")


### PR DESCRIPTION
The package USER-MEAMC fully replaces the original MEAM package, which has been removed from LAMMPS after the 12 December 2018 version. Therefore, we need to add user-meamc as a supported package while keeping the old meam.