### PR TITLE
Support for user-defined scripts to customize pipeline jobs

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -237,8 +237,11 @@ def ci_rebuild(args):
 
         # Make a copy of the environment file, so we can overwrite the changed
         # version in between the two invocations of "spack install"
-        env_src_path = os.path.join(current_directory, 'spack.yaml')
-        env_dst_path = os.path.join(current_directory, 'spack.yaml_BACKUP')
+        env_src_path = env.manifest_path
+        env_dirname = os.path.dirname(env_src_path)
+        env_filename = os.path.basename(env_src_path)
+        env_copyname = '{0}_BACKUP'.format(env_filename)
+        env_dst_path = os.path.join(env_dirname, env_copyname)
         shutil.copyfile(env_src_path, env_dst_path)
 
         tty.debug('job concrete spec path: {0}'.format(job_spec_yaml_path))
@@ -327,8 +330,10 @@ def ci_rebuild(args):
                     first_pass_args))
                 spack_cmd(*first_pass_args)
 
-                # Overwrite the changed environment file so it doesn't
+                # Overwrite the changed environment file so it doesn't break
                 # the next install invocation.
+                tty.debug('Copying {0} to {1}'.format(
+                    env_dst_path, env_src_path))
                 shutil.copyfile(env_dst_path, env_src_path)
 
                 second_pass_args = install_args + [

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -46,15 +46,6 @@ def setup_parser(subparser):
         help="Absolute path of additional location where generated jobs " +
              "yaml file should be copied.  Default is not to copy.")
     generate.add_argument(
-        '--spack-repo', default=None,
-        help="Provide a url for this argument if a custom spack repo " +
-             "should be cloned as a step in each generated job.")
-    generate.add_argument(
-        '--spack-ref', default=None,
-        help="Provide a git branch or tag if a custom spack branch " +
-             "should be checked out as a step in each generated job.  " +
-             "This argument is ignored if no --spack-repo is provided.")
-    generate.add_argument(
         '--optimize', action='store_true', default=False,
         help="(Experimental) run the generated document through a series of "
              "optimization passes designed to reduce the size of the "
@@ -82,8 +73,6 @@ def ci_generate(args):
 
     output_file = args.output_file
     copy_yaml_to = args.copy_to
-    spack_repo = args.spack_repo
-    spack_ref = args.spack_ref
     run_optimizer = args.optimize
     use_dependencies = args.dependencies
 
@@ -97,8 +86,7 @@ def ci_generate(args):
 
     # Generate the jobs
     spack_ci.generate_gitlab_ci_yaml(
-        env, True, output_file, spack_repo, spack_ref,
-        run_optimizer=run_optimizer,
+        env, True, output_file, run_optimizer=run_optimizer,
         use_dependencies=use_dependencies)
 
     if copy_yaml_to:

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -91,16 +91,27 @@ properties = {
                                         },
                                     },
                                 },
+                                'before_script': {
+                                    'type': 'array',
+                                    'default': [],
+                                    'items': {'type': 'string'}
+                                },
+                                'script': {
+                                    'type': 'array',
+                                    'default': [],
+                                    'items': {'type': 'string'}
+                                },
+                                'after_script': {
+                                    'type': 'array',
+                                    'default': [],
+                                    'items': {'type': 'string'}
+                                },
                             },
                         },
                     },
                 },
             },
             'enable-artifacts-buildcache': {
-                'type': 'boolean',
-                'default': False,
-            },
-            'enable-debug-messages': {
                 'type': 'boolean',
                 'default': False,
             },

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -63,7 +63,7 @@ properties = {
                 'items': {
                     'type': 'object',
                     'additionalProperties': False,
-                    'required': ['match', 'runner-attributes'],
+                    'required': ['match'],
                     'properties': {
                         'match': {
                             'type': 'array',
@@ -79,12 +79,10 @@ properties = {
                                 'image': image_schema,
                                 'tags': {
                                     'type': 'array',
-                                    'default': [],
                                     'items': {'type': 'string'}
                                 },
                                 'variables': {
                                     'type': 'object',
-                                    'default': {},
                                     'patternProperties': {
                                         r'[\w\d\-_\.]+': {
                                             'type': 'string',
@@ -93,23 +91,45 @@ properties = {
                                 },
                                 'before_script': {
                                     'type': 'array',
-                                    'default': [],
                                     'items': {'type': 'string'}
                                 },
                                 'script': {
                                     'type': 'array',
-                                    'default': [],
                                     'items': {'type': 'string'}
                                 },
                                 'after_script': {
                                     'type': 'array',
-                                    'default': [],
                                     'items': {'type': 'string'}
                                 },
                             },
                         },
                     },
                 },
+            },
+            'image': image_schema,
+            'tags': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            },
+            'variables': {
+                'type': 'object',
+                'patternProperties': {
+                    r'[\w\d\-_\.]+': {
+                        'type': 'string',
+                    },
+                },
+            },
+            'before_script': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            },
+            'script': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            },
+            'after_script': {
+                'type': 'array',
+                'items': {'type': 'string'}
             },
             'enable-artifacts-buildcache': {
                 'type': 'boolean',

--- a/share/spack/gitlab/pr_pipeline.yml
+++ b/share/spack/gitlab/pr_pipeline.yml
@@ -12,7 +12,7 @@ merge_pipeline:
   only:
   - develop
   variables:
-    SPACK_REF: develop
+    SPACK_REF: ${CI_COMMIT_SHA}
   trigger:
     project: spack/e4s
     strategy: depend

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -465,7 +465,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --copy-to --spack-repo --spack-ref --optimize --dependencies"
+    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies"
 }
 
 _spack_ci_rebuild() {


### PR DESCRIPTION
Allow users to specify whatever `before_script` and `after_script` they want in their `spack.yaml`, on a per-runner basis.  Users can also specify their own `script`, but if they don't, we'll generate the standard `spack ci rebuild` script for them.

For a more in-depth discussion of this proposed change, see #17164, or take a look at the test and documentation added by this change.