### PR TITLE
Allow GNUPGHOME to come from env via SPACK_GNUPGHOME, if set

### DIFF
--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -13,7 +13,7 @@ from spack.util.executable import which
 
 _gnupg_version_re = r"^gpg \(GnuPG\) (.*)$"
 
-GNUPGHOME = spack.paths.gpg_path
+GNUPGHOME = os.getenv('SPACK_GNUPGHOME', spack.paths.gpg_path)
 
 
 def parse_keys_output(output):


### PR DESCRIPTION
Instead of hardcoding GNUPGHOME, this PR allows it to come from the environment via `SPACK_GNUPGHOME`, if set. This resolves an issue preventing Spack CI pipelines from working consistently on the NERSC Cori login nodes due to failure of intermittent failure of `spack gpg` commands for unknown reasons.

@shahzebsiddiqui @tgamblin @becker33 @scottwittenburg 