### PR TITLE
netcdf-c: use https instead of ftp

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -13,15 +13,14 @@ class NetcdfC(AutotoolsPackage):
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     git      = "https://github.com/Unidata/netcdf-c.git"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.3.tar.gz"
+    url      = "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.7.4.tar.gz"
 
     def url_for_version(self, version):
+        url = ['https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf']
         if version >= Version('4.6.2'):
-            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-{0}.tar.gz"
-        else:
-            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-{0}.tar.gz"
-
-        return url.format(version.dotted)
+            url.append("-c")
+        url.extend(["-", str(version.dotted), ".tar.gz"])
+        return "".join(url)
 
     maintainers = ['skosukhin', 'WardF']
 

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -13,14 +13,18 @@ class NetcdfC(AutotoolsPackage):
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf"
     git      = "https://github.com/Unidata/netcdf-c.git"
-    url      = "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.7.4.tar.gz"
+    urls     = [
+        "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.4.tar.gz",
+        "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.7.4.tar.gz"
+    ]
 
     def url_for_version(self, version):
-        url = ['https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf']
-        if version >= Version('4.6.2'):
-            url.append("-c")
-        url.extend(["-", str(version.dotted), ".tar.gz"])
-        return "".join(url)
+        needs_c = version > Version('4.6.1')
+        self.urls = [spack.url.substitute_version(
+            u if needs_c else u.replace('netcdf-c', 'netcdf'),
+            self.url_version(version)
+        ) for u in NetcdfC.urls]
+        return self.urls[0]
 
     maintainers = ['skosukhin', 'WardF']
 


### PR DESCRIPTION
The ORNL internal network (and probably other corporate network) block outgoing FTP connections. NetCDF has an alternate URL with HTTPS support, so prefer using that.