### PR TITLE
glib: fix 2.56 build with python@2

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -148,7 +148,8 @@ class Glib(Package):
                 else:
                     args.append('--disable-' + value)
         else:
-            if 'tracing=dtrace' in self.spec or 'tracing=systemtap' in self.spec:
+            if ('tracing=dtrace' in self.spec
+                    or 'tracing=systemtap' in self.spec):
                 args.append('--enable-tracing')
             else:
                 args.append('--disable-tracing')

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -141,10 +141,17 @@ class Glib(Package):
             args.append('--with-libiconv=maybe')
         else:
             args.append('--with-libiconv=gnu')
-        if 'tracing=dtrace' in self.spec or 'tracing=systemtap' in self.spec:
-            args.append('--enable-tracing')
+        if self.spec.satisfies('@2.56:'):
+            for value in ('dtrace', 'systemtap'):
+                if ('tracing=' + value) in self.spec:
+                    args.append('--enable-' + value)
+                else:
+                    args.append('--disable-' + value)
         else:
-            args.append('--disable-tracing')
+            if 'tracing=dtrace' in self.spec or 'tracing=systemtap' in self.spec:
+                args.append('--enable-tracing')
+            else:
+                args.append('--disable-tracing')
         # SELinux is not available in Spack, so glib should not use it.
         args.append('--disable-selinux')
         # glib should not use the globally installed gtk-doc. Otherwise,


### PR DESCRIPTION
This fixes a "ImportError: No module named site" error, similar to https://github.com/spack/spack/issues/1819 .