### PR TITLE
Docs: fix rst link to spack ci

### DIFF
--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -103,7 +103,7 @@ needed for pipeline operation that should not be visible in a spack environment
 file.  These environment variables are described in more detail
 :ref:`ci_environment_variables`.
 
-.. _cmd_spack_ci:
+.. _cmd-spack-ci:
 
 ^^^^^^^^^^^^^^^^^^
 ``spack ci``
@@ -112,7 +112,7 @@ file.  These environment variables are described in more detail
 Super-command for functionality related to generating pipelines and executing
 pipeline jobs.
 
-.. _cmd_spack_ci_generate:
+.. _cmd-spack-ci-generate:
 
 ^^^^^^^^^^^^^^^^^^^^^
 ``spack ci generate``
@@ -121,7 +121,7 @@ pipeline jobs.
 Concretizes the specs in the active environment, stages them (as described in
 :ref:`staging_algorithm`), and writes the resulting ``.gitlab-ci.yml`` to disk.
 
-.. _cmd_spack_ci_rebuild:
+.. _cmd-spack-ci-rebuild:
 
 ^^^^^^^^^^^^^^^^^^^^
 ``spack ci rebuild``


### PR DESCRIPTION
Fixes #17135 

Thanks for the bug report @adrienbernede. I checked other commands and didn't see any where we accidentally used underscores. If you notice any other commands that should link to some section of the docs, let me know.

@scottwittenburg if you're curious, the command that handles this is here: https://github.com/spack/spack/blob/develop/lib/spack/spack/cmd/commands.py#L213