### PR TITLE
atop: fix ld error

### DIFF
--- a/var/spack/repos/builtin/packages/atop/package.py
+++ b/var/spack/repos/builtin/packages/atop/package.py
@@ -20,6 +20,9 @@ class Atop(Package):
     depends_on('zlib')
     depends_on('ncurses')
 
+    def setup_build_environment(self, env):
+        env.append_flags('LDFLAGS', '-ltinfo')
+
     def install(self, spec, prefix):
         make()
         mkdirp(prefix.bin)


### PR DESCRIPTION
fix atop build error.

```
/home/xiaojun/spack/lib/spack/env/gcc/gcc atop.o version.o various.o  deviate.o   procdbase.o acctproc.o photoproc.o photosyst.o  rawlog.o ifprop.o parseable.o showgeneric.o          showlinux.o  showsys.o showprocs.o atopsar.o  netatopif.o gpucom.o -o atop -lncurses -lz -lm -lrt
/usr/bin/ld: showgeneric.o: undefined reference to symbol 'cbreak'
//home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/ncurses-6.2-5zs46oqspomfxll4jasxilx3xnw24ylc/lib/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:36: atop] Error 1
==> Error: ProcessError: Command exited with status 2:
    'make' '-j4'
```