### PR TITLE
openjdk and jdk: extend the list of provided versions of java

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -60,6 +60,7 @@ class Jdk(Package):
             url='https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz')
 
     provides('java@14', when='@14.0:14.999')
+    provides('java@13', when='@13.0:13.999')
     provides('java@12', when='@12.0:12.999')
     provides('java@11', when='@11.0:11.999')
     provides('java@10', when='@10.0:10.999')

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -44,8 +44,10 @@ class Openjdk(Package):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
-    provides('java@8', when='@1.8.0:1.8.999')
     provides('java@11', when='@11.0:11.99')
+    provides('java@10', when='@10.0:10.99')
+    provides('java@9', when='@9.0:9.99')
+    provides('java@8', when='@1.8.0:1.8.999')
 
     conflicts('target=ppc64:', msg='openjdk is only available for x86_64 and aarch64')
     conflicts('target=ppc64le:', msg='openjdk is only available for x86_64 and aarch64')


### PR DESCRIPTION
I don't know much about backward compatibility (e.g. whether we can say that `openjdk 10.x` provides not only `java 10` but `java 9` too) but with this, I at least can have an external installation of `openjdk 9.x` that satisfies `java@8:`.