### PR TITLE
parallel-netcdf: Add missing perl dependency

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -50,6 +50,8 @@ class ParallelNetcdf(AutotoolsPackage):
     depends_on('automake', when='@master', type='build')
     depends_on('libtool', when='@master', type='build')
 
+    depends_on('perl', type='build')
+
     conflicts('+shared', when='@:1.9%nag+fortran')
     conflicts('+shared', when='@:1.8')
 


### PR DESCRIPTION
parallel-netcdf's buildiface script needs perl during build.