### PR TITLE
Updated slate package to use new git repo.  Added maintainer.

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -16,10 +16,10 @@ class Slate(Package):
     solvers."""
 
     homepage = "https://icl.utk.edu/slate/"
-    hg      = "https://bitbucket.org/icl/slate"
-    maintainers = ['G-Ragghianti']
+    url      = "https://bitbucket.org/icl/slate_git"
+    maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('develop', hg=hg)
+    version('develop', git=url, submodules=True)
 
     variant('cuda',   default=True, description='Build with CUDA support.')
     variant('mpi',    default=True, description='Build with MPI support.')
@@ -27,7 +27,6 @@ class Slate(Package):
 
     depends_on('cuda@9:', when='+cuda')
     depends_on('intel-mkl')
-    depends_on('mercurial', type='build')
     depends_on('mpi', when='+mpi')
 
     conflicts('%gcc@:5')

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -16,7 +16,7 @@ class Slate(Package):
     solvers."""
 
     homepage = "https://icl.utk.edu/slate/"
-    url      = "https://bitbucket.org/icl/slate_git"
+    url      = "https://bitbucket.org/icl/slate"
     maintainers = ['G-Ragghianti', 'mgates3']
 
     version('develop', git=url, submodules=True)

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -16,10 +16,10 @@ class Slate(Package):
     solvers."""
 
     homepage = "https://icl.utk.edu/slate/"
-    url      = "https://bitbucket.org/icl/slate"
+    git      = "https://bitbucket.org/icl/slate"
     maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('develop', git=url, submodules=True)
+    version('develop', submodules=True)
 
     variant('cuda',   default=True, description='Build with CUDA support.')
     variant('mpi',    default=True, description='Build with MPI support.')


### PR DESCRIPTION
The repository for SLATE is changing from mercurial to git on Friday, June 19th.  This update adds support for the git repo and adds a second package maintainer. Please only approve this PR after the repo has been changed to git.