### PR TITLE
CMake: always use lib for CMAKE_INSTALL_LIBDIR

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -157,7 +157,7 @@ class CMakePackage(PackageBase):
         # Spack does not need to consider multilib environments due to each
         # package getting its own prefix, so avoid usage of CMake's
         # GNUInstallDirs module detecting multilib platform directories.
-        args.append(define('CMAKE_INSTALL_LIBDIR','lib'))
+        args.append(define('CMAKE_INSTALL_LIBDIR', 'lib'))
 
         if primary_generator == 'Unix Makefiles':
             args.append(define('CMAKE_VERBOSE_MAKEFILE', True))

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -154,6 +154,11 @@ class CMakePackage(PackageBase):
             define('CMAKE_BUILD_TYPE', build_type),
         ]
 
+        # Spack does not need to consider multilib environments due to each
+        # package getting its own prefix, so avoid usage of CMake's
+        # GNUInstallDirs module detecting multilib platform directories.
+        args.append(define('CMAKE_INSTALL_LIBDIR','lib'))
+
         if primary_generator == 'Unix Makefiles':
             args.append(define('CMAKE_VERBOSE_MAKEFILE', True))
 


### PR DESCRIPTION
@mathstuf @utkarshayachit @danlipsa 

Fixes #17126

Don't let Spack CMake consider multilib environments by forcing lib with the general argument `-DCMAKE_INSTALL_LIBDIR:STRING=lib`