### PR TITLE
PyTorch: add v1.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -50,6 +50,7 @@ class PyTorch(PythonPackage, CudaPackage):
     ]
 
     version('master', branch='master', submodules=True)
+    version('1.5.1', tag='v1.5.1', submodules=True)
     version('1.5.0', tag='v1.5.0', submodules=True)
     version('1.4.1', tag='v1.4.1', submodules=True)
     version('1.4.0', tag='v1.4.0', submodules=True,
@@ -170,7 +171,7 @@ class PyTorch(PythonPackage, CudaPackage):
     # https://github.com/pytorch/pytorch/pull/35607
     # https://github.com/pytorch/pytorch/pull/37865
     # Fixes CMake configuration error when XNNPACK is disabled
-    patch('xnnpack.patch', when='@1.5.0')
+    patch('xnnpack.patch', when='@1.5.0:1.5.999')
 
     # https://github.com/pytorch/pytorch/pull/37086
     # Fixes compilation with Clang 9.0.0 and Apple Clang 11.0.3


### PR DESCRIPTION
Successfully installs on Ubuntu 20.04 with Python 3.7.7 and GCC 9.3.0 (via WSL).

https://github.com/pytorch/pytorch/releases/tag/v1.5.1