### PR TITLE
[delphes] fix root cxxstd dependency

### DIFF
--- a/var/spack/repos/builtin/packages/delphes/package.py
+++ b/var/spack/repos/builtin/packages/delphes/package.py
@@ -39,7 +39,8 @@ class Delphes(CMakePackage):
     version('3.0.5', sha256='ab64ec6d2476fbfa40562e7edb510a8ab4c4fe5be77a4353ebf315c2af181a80')
 
     depends_on('cmake', type='build')
-    depends_on('root')
+    depends_on('root cxxstd=14', when='cxxstd=14')
+    depends_on('root cxxstd=17', when='cxxstd=17')
 
     variant('build_type', default='Release',
             description='The build type to build',


### PR DESCRIPTION
Compiling delphes with default root cxxstd=11 fails (see e.g. https://sft.its.cern.ch/jira/si/jira.issueviews:issue-html/ROOT-9492/ROOT-9492.html).

With this bugfix, delphes pulls in root cxxstd=17 and builds correct.

```
[wdconinc@cvmfswrite01 aida]$ spack find -v root delphes
==> 2 installed packages
-- linux-rhel7-x86_64 / gcc@9.3.0 -------------------------------
delphes@3.4.2 build_type=Release cxxstd=17
root@6.20.04~aqua+davix~emacs+examples~fftw~fits~fortran+gdml+gminimal~graphviz+gsl~http~jemalloc+math~memstat+minuit~mlp~mysql+opengl~postgres~pythia6~pythia8+python~qt4~r~root7+rootfit+rpath~shadow~sqlite~ssl~table+tbb+threads~tmva+unuran~vc+vdt~vmc+x+xml~xrootd build_type=RelWithDebInfo cxxstd=17 patches=22af3471f3fd87c0fe8917bf9c811c6d806de6c8b9867d30a1e3d383a1b929d7
```