### PR TITLE
Enable mysql for macos

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -132,8 +132,10 @@ class Mysql(CMakePackage):
         if '+client_only' in self.spec:
             options.append('-DWITHOUT_SERVER:BOOL=ON')
         options.append('-DWITH_EDITLINE=system')
-        options.append('-Dlibedit_INCLUDE_DIR={0}'.format(spec['libedit'].prefix.include))
-        options.append('-Dlibedit_LIBRARY={0}'.format(spec['libedit'].libs.directories[0]))
+        options.append('-Dlibedit_INCLUDE_DIR={0}'.format(
+            spec['libedit'].prefix.include))
+        options.append('-Dlibedit_LIBRARY={0}'.format(
+            spec['libedit'].libs.directories[0]))
         return options
 
     def _fix_dtrace_shebang(self, env):

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -113,6 +113,7 @@ class Mysql(CMakePackage):
     depends_on('ncurses')
     depends_on('openssl')
     depends_on('libtirpc', when='@5.7.0: platform=linux')
+    depends_on('libedit', type=['build', 'run'])
     depends_on('perl', type=['build', 'test'], when='@:7.99.99')
     depends_on('bison@2.1:', type='build')
     depends_on('m4', type='build', when='@develop platform=solaris')
@@ -130,8 +131,9 @@ class Mysql(CMakePackage):
             options.append('-DBOOST_ROOT={0}'.format(spec['boost'].prefix))
         if '+client_only' in self.spec:
             options.append('-DWITHOUT_SERVER:BOOL=ON')
-        if spec.platform == 'darwin':
-            options.append('-DWITH_EDITLINE=system')
+        options.append('-DWITH_EDITLINE=system')
+        options.append('-Dlibedit_INCLUDE_DIR={0}'.format(spec['libedit'].prefix.include))
+        options.append('-Dlibedit_LIBRARY={0}'.format(spec['libedit'].libs.directories[0]))
         return options
 
     def _fix_dtrace_shebang(self, env):

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -130,6 +130,8 @@ class Mysql(CMakePackage):
             options.append('-DBOOST_ROOT={0}'.format(spec['boost'].prefix))
         if '+client_only' in self.spec:
             options.append('-DWITHOUT_SERVER:BOOL=ON')
+        if spec.platform == 'darwin':
+            options.append('-DWITH_EDITLINE=system')
         return options
 
     def _fix_dtrace_shebang(self, env):

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -112,7 +112,7 @@ class Mysql(CMakePackage):
     depends_on('rpcsvc-proto')
     depends_on('ncurses')
     depends_on('openssl')
-    depends_on('libtirpc', when='@5.7.0:')
+    depends_on('libtirpc', when='@5.7.0: platform=linux')
     depends_on('perl', type=['build', 'test'], when='@:7.99.99')
     depends_on('bison@2.1:', type='build')
     depends_on('m4', type='build', when='@develop platform=solaris')


### PR DESCRIPTION
I get the following error message, if I do not use editline from the
system

```
>> 3090    Undefined symbols for architecture x86_64:
     3091      "_tgetent", referenced from:
     3092          _terminal_set in libedit.a(terminal.c.o)
     3093      "_tgetflag", referenced from:
     3094          _terminal_set in libedit.a(terminal.c.o)
     3095      "_tgetnum", referenced from:
     3096          _terminal_set in libedit.a(terminal.c.o)

     ...

     3110          _terminal_insertwrite in libedit.a(terminal.c.o)
     3111          _terminal_clear_EOL in libedit.a(terminal.c.o)
     3112          _terminal_clear_screen in libedit.a(terminal.c.o)
     3113          _terminal_beep in libedit.a(terminal.c.o)
     3114          ...
     3115    ld: symbol(s) not found for architecture x86_64
```