### PR TITLE
[hepmc3] gcc@9.3.0 patch for @3.1.2:3.2.1, conflicts for earlier @:3.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch
+++ b/var/spack/repos/builtin/packages/hepmc3/ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch
@@ -1,0 +1,12 @@
+diff --git a/search/include/HepMC3/Feature.h b/search/include/HepMC3/Feature.h
+index 0bd4f92b059d315c4a17ab03d49ba5b20af75d8e..e7717516a99c5c3d2553be2aca21378fb1ae7977 100644
+--- a/search/include/HepMC3/Feature.h
++++ b/search/include/HepMC3/Feature.h
+@@ -293,7 +293,7 @@ public:
+         EvaluatorPtr functor = m_internal;
+         return [value, functor](ConstGenParticlePtr input)->bool{
+             Feature_type local = (*functor)(input);
+-            return fabs(local - value) <= ((fabs(local) < fabs(value))? fabs(value) : fabs(local)) * std::numeric_limits<Feature_type>::epsilon();
++            return std::less_equal<Feature_type>{}(fabs(local - value) ,  std::numeric_limits<Feature_type>::epsilon());
+         };
+     } 

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -32,6 +32,8 @@ class Hepmc3(CMakePackage):
     depends_on('root', when='+rootio')
     depends_on('python', when="+python")
 
+    patch('ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch', when="@:3.2.1 %gcc@9.3.0")
+
     def cmake_args(self):
         spec = self.spec
         args = [

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -16,6 +16,7 @@ class Hepmc3(CMakePackage):
 
     maintainers = ['vvolkl']
 
+    version('3.2.2', sha256='0e8cb4f78f804e38f7d29875db66f65e4c77896749d723548cc70fb7965e2d41')
     version('3.2.1', sha256='6e4e4bb5708af105d4bf74efc2745e6efe704e942d46a8042f7dcae37a4739fe')
     version('3.2.0', sha256='f132387763d170f25a7cc9f0bd586b83373c09acf0c3daa5504063ba460f89fc')
     version('3.1.2', sha256='4133074b3928252877982f3d4b4c6c750bb7a324eb6c7bb2afc6fa256da3ecc7')

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -32,7 +32,8 @@ class Hepmc3(CMakePackage):
     depends_on('root', when='+rootio')
     depends_on('python', when="+python")
 
-    patch('ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch', when="@:3.2.1 %gcc@9.3.0")
+    conflicts('%gcc@9.3.0', when="@:3.1.1")
+    patch('ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch', when="@3.1.2:3.2.1 %gcc@9.3.0")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Patch is from https://gitlab.cern.ch/hepmc/HepMC3/-/commit/ba38f14d8f56c16cc4105d98f6d4540c928c6150, which is included in upstream master and upstream releases as of hepmc3@3.2.2.

This ensure at least one version of hepmc3 compiles with gcc@9.3.0.