### PR TITLE
Package/dssp

### DIFF
--- a/var/spack/repos/builtin/packages/dssp/package.py
+++ b/var/spack/repos/builtin/packages/dssp/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class Dssp(AutotoolsPackage):
-    """The source code for building the mkdssp utility."""
+    """'mkdssp' utility. (dictionary of protein secondary structure)"""
 
     homepage = "https://github.com/cmbi/dssp"
     url      = "https://github.com/cmbi/dssp/archive/3.1.4.tar.gz"

--- a/var/spack/repos/builtin/packages/dssp/package.py
+++ b/var/spack/repos/builtin/packages/dssp/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Dssp(AutotoolsPackage):
+    """The source code for building the mkdssp utility."""
+
+    homepage = "https://github.com/cmbi/dssp"
+    url      = "https://github.com/cmbi/dssp/archive/3.1.4.tar.gz"
+
+    version('3.1.4', sha256='496282b4b5defc55d111190ab9f1b615a9574a2f090e7cf5444521c747b272d4')
+    version('2.3.0', sha256='4c95976d86dc64949cb0807fbd58c7bee5393df0001999405863dc90f05846c6')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+    depends_on('boost@1.48:')
+
+    def configure_args(self):
+        args = [
+            "--with-boost=%s" % self.spec['boost'].prefix]
+        return args
+
+    @run_after('configure')
+    def edit(self):
+        makefile = FileFilter(join_path(self.stage.source_path, 'Makefile'))
+        makefile.filter('.*-Werror .*', '                    -Wno-error \\')

--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -7,9 +7,13 @@ from spack import *
 
 
 class Hssp(AutotoolsPackage):
-    """The source code for building the mkhssp and hsspconv programs is bundled in the hssp 
-       project. The mkhssp executable creates stockholm files with hssp annotations in them.
-       The hsspconv executable converts stockholm to the original hssp format."""
+    """The source code for building the mkhssp and hsspconv programs is bundled
+       in the hssp project.
+
+       The mkhssp executable creates stockholm files with hssp annotations in
+       them. The hsspconv executable converts stockholm to the original hssp
+       format.
+    """
 
     homepage = "https://github.com/cmbi/hssp"
     url      = "https://github.com/cmbi/hssp/archive/3.0.10.tar.gz"

--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Xssp(AutotoolsPackage):
+class Hssp(AutotoolsPackage):
     """The source code for building the mkdssp, mkhssp, hsspconv, and hsspsoap
        programs is bundled in the xssp project"""
 
-    homepage = "https://github.com/cmbi/xssp"
-    url      = "https://github.com/cmbi/xssp/archive/3.0.10.tar.gz"
+    homepage = "https://github.com/cmbi/hssp"
+    url      = "https://github.com/cmbi/hssp/archive/3.0.10.tar.gz"
 
     version('3.0.10', sha256='b475d6fa62098df0e54c8dbdaa0b32de93bf5a393335f73f9b5a7e95f3090d2a')
     version('3.0.9',  sha256='42a9a93c48d22478212dcaf6ceb3feb64443e4cb2e8cccdd402b47a595d16658')

--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -7,8 +7,9 @@ from spack import *
 
 
 class Hssp(AutotoolsPackage):
-    """The source code for building the mkdssp, mkhssp, hsspconv, and hsspsoap
-       programs is bundled in the xssp project"""
+    """The source code for building the mkhssp and hsspconv programs is bundled in the hssp 
+       project. The mkhssp executable creates stockholm files with hssp annotations in them.
+       The hsspconv executable converts stockholm to the original hssp format."""
 
     homepage = "https://github.com/cmbi/hssp"
     url      = "https://github.com/cmbi/hssp/archive/3.0.10.tar.gz"


### PR DESCRIPTION
Previously, spack package `xssp` installed two utils: `dssp` and `hssp`. Now, the tool authors have removed the `xssp` repository, and replaced with two that must be installed separately. The link to `xssp` redirects to `hssp`, and therefore, spack package `xssp` would install only `hssp`.

In this PR, I create a new spack package `dssp` and rename `xssp` to `hssp`.

CC: @asmaahassan90 (maintainer of `xssp`)