### PR TITLE
dos2unix: add build depends

### DIFF
--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -14,5 +14,7 @@ class Dos2unix(MakefilePackage):
 
     version('7.3.4', sha256='8ccda7bbc5a2f903dafd95900abb5bf5e77a769b572ef25150fde4056c5f30c5')
 
+    depends_on('gettext', type='build')
+
     def install(self, spec, prefix):
         make('prefix={0}'.format(prefix), 'install')


### PR DESCRIPTION
When I install dos2unix on my `Debian` distribution, it reports error as:
```
==> 113238: dos2unix: Executing phase: 'edit'
==> [2020-06-22-14:24:23.523452, 113243] Using default implementation: skipping edit phase.
==> 113238: dos2unix: Executing phase: 'build'
==> [2020-06-22-14:24:23.524223, 113243] 'make' '-j16'
/home/spack-develop/lib/spack/env/gcc/gcc   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0   -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wconversion    -c dos2unix.c -o dos2unix.o
/home/spack-develop/lib/spack/env/gcc/gcc   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0   -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wconversion    -c querycp.c -o querycp.o
/home/spack-develop/lib/spack/env/gcc/gcc   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0   -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wconversion    -c common.c -o common.o
/home/spack-develop/lib/spack/env/gcc/gcc   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0   -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wconversion    -c unix2dos.c -o unix2dos.o
msgfmt -c po/hu.po -o po/hu.mo
make: msgfmt: Command not found
make: *** [Makefile:450: po/hu.mo] Error 127
make: *** Waiting for unfinished jobs....
```

So we need `gettext` to provide `msgfmt` command.