### PR TITLE
OpenMPI: add v4.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -33,9 +33,10 @@ class Openmpi(AutotoolsPackage):
     version('master', branch='master')
 
     # Current
-    version('4.0.3', sha256='1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03')  # libmpi.so.40.20.3
+    version('4.0.4', sha256='47e24eb2223fe5d24438658958a313b6b7a55bb281563542e1afc9dec4a31ac4')  # libmpi.so.40.20.4
 
     # Still supported
+    version('4.0.3', sha256='1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03')  # libmpi.so.40.20.3
     version('4.0.2', sha256='900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057')  # libmpi.so.40.20.2
     version('4.0.1', sha256='cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709')  # libmpi.so.40.20.1
     version('4.0.0', sha256='2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b')  # libmpi.so.40.20.0


### PR DESCRIPTION
Bug fix release:

4.0.4 -- June, 2020
-----------------------
- Fix a memory patcher issue intercepting shmat and shmdt.  This was
  observed on RHEL 8.x ppc64le (see README for more info).
- Fix an illegal access issue caught using gcc's address sanitizer.
  Thanks to  Georg Geiser for reporting.
- Add checks to avoid conflicts with a libevent library shipped with LSF.
- Switch to linking against libevent_core rather than libevent, if present.
- Add improved support for UCX 1.9 and later.
- Fix an ABI compatibility issue with the Fortran 2008 bindings.
  Thanks to Alastair McKinstry for reporting.
- Fix an issue with rpath of /usr/lib64 when building OMPI on
  systems with Lustre.  Thanks to David Shrader for reporting.
- Fix a memory leak occurring with certain MPI RMA operations.
- Fix an issue with ORTE's mapping of MPI processes to resources.
  Thanks to Alex Margolin for reporting and providing a fix.
- Correct a problem with incorrect error codes being returned
  by OMPI MPI_T functions.
- Fix an issue with debugger tools not being able to attach
  to mpirun more than once.  Thanks to Gregory Lee for reporting.
- Fix an issue with the Fortran compiler wrappers when using
  NAG compilers.  Thanks to Peter Brady for reporting.
- Fix an issue with the ORTE ssh based process launcher at scale.
  Thanks to Benjamín Hernández for reporting.
- Address an issue when using shared MPI I/O operations.  OMPIO will
  now successfully return from the file open statement but will
  raise an error if the file system does not supported shared I/O
  operations.  Thanks to Romain Hild for reporting.
- Fix an issue with MPI_WIN_DETACH.  Thanks to Thomas Naughton for reporting.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>