### PR TITLE
[whizard] add zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -49,6 +49,7 @@ class Whizard(AutotoolsPackage):
     depends_on('lhapdf', when="+lhapdf")
     depends_on('fastjet', when="+fastjet")
     depends_on('texlive', when="+latex")
+    depends_on('zlib')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Missed dependency when creating the recipe, due to it being installed as system package on the machine I was testing on.