### PR TITLE
lua: Fix build

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -54,7 +54,7 @@ class Lua(Package):
              'MYLDFLAGS=-L%s -L%s' % (
                  spec['readline'].prefix.lib,
                  spec['ncurses'].prefix.lib),
-             'MYLIBS=-lncursesw -ltermcap',
+             'MYLIBS=-lncursesw -ltinfow',
              'CC=%s -std=gnu99 %s' % (spack_cc,
                                       self.compiler.cc_pic_flag),
              target)


### PR DESCRIPTION
PR #17108 broke the build. Spack's ncurses package does not provide a libtermcap, so we need to use libtinfow.

@mhaseeb123 @glennpj