### PR TITLE
Fix missing dependency in Mono

### DIFF
--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -27,6 +27,7 @@ class Mono(AutotoolsPackage):
     depends_on('cmake~openssl', type=('build'))
     depends_on('iconv')
     depends_on('perl', type=('build'))
+    depends_on('python', type=('build'))
 
     version('6.8.0.105', sha256='578799c44c3c86a9eb5daf6dec6c60a24341940fd376371956d4a46cf8612178',
             url='https://download.mono-project.com/sources/mono/mono-6.8.0.105.tar.xz')

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -29,6 +29,8 @@ class Mono(AutotoolsPackage):
     depends_on('perl', type=('build'))
     depends_on('python', type=('build'))
 
+    version('6.8.0.123', sha256='e2e42d36e19f083fc0d82f6c02f7db80611d69767112af353df2f279744a2ac5',
+            url='https://download.mono-project.com/sources/mono/mono-6.8.0.123.tar.xz')
     version('6.8.0.105', sha256='578799c44c3c86a9eb5daf6dec6c60a24341940fd376371956d4a46cf8612178',
             url='https://download.mono-project.com/sources/mono/mono-6.8.0.105.tar.xz')
     version('5.18.0.240', sha256='143e80eb00519ff496742e78ee07403a3c3629437f3a498eee539de8108da895')


### PR DESCRIPTION
Mono requires `python` executable for building.

Update to last mono version as well.