### PR TITLE
Qt +webengine

### DIFF
--- a/var/spack/repos/builtin/packages/libcap/package.py
+++ b/var/spack/repos/builtin/packages/libcap/package.py
@@ -13,11 +13,13 @@ class Libcap(MakefilePackage):
     distinct privileges."""
 
     homepage = "https://sites.google.com/site/fullycapable/"
-    url      = "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.25.tar.gz"
+    url      = "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.25.tar.xz"
 
-    version('2.25', sha256='4ca80dc6f9f23d14747e4b619fd9784434c570e24a7346f326c692784ed83a86')
+    version('2.27', sha256='dac1792d0118bee6aae6ba7fb93ff1602c6a9bda812fd63916eee1435b9c486a')
+    version('2.26', sha256='b630b7c484271b3ba867680d6a14b10a86cfa67247a14631b14c06731d5a458b')
+    version('2.25', sha256='693c8ac51e983ee678205571ef272439d83afe62dd8e424ea14ad9790bc35162')
 
-    patch('libcap-fix-the-libcap-native-building-failure-on-CentOS-6.7.patch')
+    patch('libcap-fix-the-libcap-native-building-failure-on-CentOS-6.7.patch', when="@2.25")
 
     def install(self, spec, prefix):
         make_args = [

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -17,7 +17,7 @@ class Libxcomposite(AutotoolsPackage, XorgPackage):
 
     depends_on('libx11')
     depends_on('libxfixes')
-    depends_on('fixesproto@0.4:', type='build')
-    depends_on('compositeproto@0.4:', type='build')
+    depends_on('fixesproto@0.4:')
+    depends_on('compositeproto@0.4:')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -17,8 +17,8 @@ class Libxdamage(AutotoolsPackage, XorgPackage):
     depends_on('libxfixes')
     depends_on('libx11')
 
-    depends_on('damageproto@1.1:', type='build')
-    depends_on('fixesproto', type='build')
-    depends_on('xextproto', type='build')
-    depends_on('pkgconfig', type='build')
+    depends_on('damageproto@1.1:', type=('build', 'link'))
+    depends_on('fixesproto', type=('build', 'link'))
+    depends_on('xextproto', type=('build', 'link'))
+    depends_on('pkgconfig', type=('build',))
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -17,8 +17,8 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
 
     depends_on('libx11@1.6:')
 
-    depends_on('xproto', type='build')
-    depends_on('fixesproto@5.0:', type='build')
-    depends_on('xextproto', type='build')
+    depends_on('xproto', type=('build', 'link'))
+    depends_on('fixesproto@5.0:', type=('build', 'link'))
+    depends_on('xextproto', type=('build', 'link'))
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -19,9 +19,6 @@ class Libxi(AutotoolsPackage, XorgPackage):
     depends_on('libxext@1.0.99.1:')
     depends_on('libxfixes@5:')
 
-    # transient build dependency (from libxfixes), i.e. shouldn't be needed?
-    depends_on('fixesproto@5.0:', type='build')
-
-    depends_on('xproto@7.0.13:', type='build')
-    depends_on('xextproto@7.0.3:', type='build')
-    depends_on('inputproto@2.2.99.1:', type='build')
+    depends_on('xproto@7.0.13:')
+    depends_on('xextproto@7.0.3:')
+    depends_on('inputproto@2.2.99.1:')

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -18,8 +18,8 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
     depends_on('libxext')
     depends_on('libxrender')
 
-    depends_on('randrproto@1.5:', type='build')
-    depends_on('xextproto', type='build')
-    depends_on('renderproto', type='build')
+    depends_on('randrproto@1.5:', type=('build', 'link'))
+    depends_on('xextproto', type=('build', 'link'))
+    depends_on('renderproto', type=('build', 'link'))
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -27,9 +27,9 @@ class Libxtst(AutotoolsPackage, XorgPackage):
     depends_on('libxext@1.0.99.4:')
     depends_on('libxi')
 
-    depends_on('recordproto@1.13.99.1:', type='build')
-    depends_on('xextproto@7.0.99.3:', type='build')
-    depends_on('inputproto', type='build')
-    depends_on('fixesproto', type='build')
+    depends_on('recordproto@1.13.99.1:')
+    depends_on('xextproto@7.0.99.3:')
+    depends_on('inputproto')
+    depends_on('fixesproto')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')

--- a/var/spack/repos/builtin/packages/nspr/package.py
+++ b/var/spack/repos/builtin/packages/nspr/package.py
@@ -11,9 +11,13 @@ class Nspr(AutotoolsPackage):
     for system level and libc-like functions."""
 
     homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR"
-    url      = "http://ftp.mozilla.org/pub/nspr/releases/v4.13.1/src/nspr-4.13.1.tar.gz"
 
-    version('4.13.1', sha256='5e4c1751339a76e7c772c0c04747488d7f8c98980b434dc846977e43117833ab')
+    version('4.13.1',
+            url = 'http://ftp.mozilla.org/pub/nspr/releases/v4.13.1/src/nspr-4.13.1.tar.gz',
+            sha256='5e4c1751339a76e7c772c0c04747488d7f8c98980b434dc846977e43117833ab')
+    version('4.22',
+            url = 'https://ftp.mozilla.org/pub/nspr/releases/v4.22/src/nspr-4.22.tar.gz',
+            sha256='c9e4b6cc24856ec93202fe13704b38b38ba219f0f2aeac93090ce2b6c696d430')
 
     depends_on('perl', type='build')
 

--- a/var/spack/repos/builtin/packages/nspr/package.py
+++ b/var/spack/repos/builtin/packages/nspr/package.py
@@ -13,10 +13,10 @@ class Nspr(AutotoolsPackage):
     homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR"
 
     version('4.13.1',
-            url = 'http://ftp.mozilla.org/pub/nspr/releases/v4.13.1/src/nspr-4.13.1.tar.gz',
+            url='http://ftp.mozilla.org/pub/nspr/releases/v4.13.1/src/nspr-4.13.1.tar.gz',
             sha256='5e4c1751339a76e7c772c0c04747488d7f8c98980b434dc846977e43117833ab')
     version('4.22',
-            url = 'https://ftp.mozilla.org/pub/nspr/releases/v4.22/src/nspr-4.22.tar.gz',
+            url='https://ftp.mozilla.org/pub/nspr/releases/v4.22/src/nspr-4.22.tar.gz',
             sha256='c9e4b6cc24856ec93202fe13704b38b38ba219f0f2aeac93090ce2b6c696d430')
 
     depends_on('perl', type='build')

--- a/var/spack/repos/builtin/packages/nss/nss-3.46.1-standalone-1.patch
+++ b/var/spack/repos/builtin/packages/nss/nss-3.46.1-standalone-1.patch
@@ -1,0 +1,248 @@
+Submitted By:            DJ Lucas <dj_AT_linuxfromscratch_DOT_org>
+Date:                    2016-12-27
+Initial Package Version: 3.12.4
+Upstream Status:         Not applicable
+Origin:                  Self, rediffed for nss-3.28.
+Description:             Adds auto-generated nss.pc and nss-config script, and
+                         allows building without nspr in the source tree.
+                         For 3.40.1, Requires: updated to nspr >= 4.20.
+                         For 3.46.1, Requires: updated to nspr >= 4.21.
+
+diff -Naurp nss-3.28-orig/nss/Makefile nss-3.28/nss/Makefile
+--- nss-3.28-orig/nss/Makefile	2016-12-21 05:56:27.000000000 -0600
++++ nss-3.28/nss/Makefile	2016-12-26 22:24:52.695146032 -0600
+@@ -46,7 +46,7 @@ include $(CORE_DEPTH)/coreconf/rules.mk
+ # (7) Execute "local" rules. (OPTIONAL).                              #
+ #######################################################################
+ 
+-nss_build_all: build_nspr all latest
++nss_build_all: all latest
+ 
+ nss_clean_all: clobber_nspr clobber
+ 
+diff -Naurp nss-3.28-orig/nss/config/Makefile nss-3.28/nss/config/Makefile
+--- nss-3.28-orig/nss/config/Makefile	1969-12-31 18:00:00.000000000 -0600
++++ nss-3.28/nss/config/Makefile	2016-12-26 22:20:40.008205774 -0600
+@@ -0,0 +1,40 @@
++CORE_DEPTH = ..
++DEPTH      = ..
++
++include $(CORE_DEPTH)/coreconf/config.mk
++
++NSS_MAJOR_VERSION = `grep "NSS_VMAJOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_MINOR_VERSION = `grep "NSS_VMINOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_PATCH_VERSION = `grep "NSS_VPATCH" ../lib/nss/nss.h | awk '{print $$3}'`
++PREFIX = /usr
++
++all: export libs
++
++export:
++	# Create the nss.pc file
++	mkdir -p $(DIST)/lib/pkgconfig
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@exec_prefix@,\$${prefix}," \
++	    -e "s,@libdir@,\$${prefix}/lib," \
++	    -e "s,@includedir@,\$${prefix}/include/nss," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION),g" \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    nss.pc.in > nss.pc
++	chmod 0644 nss.pc
++	ln -sf ../../../../nss/config/nss.pc $(DIST)/lib/pkgconfig
++
++	# Create the nss-config script
++	mkdir -p $(DIST)/bin
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION)," \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    nss-config.in > nss-config
++	chmod 0755 nss-config
++	ln -sf ../../../nss/config/nss-config $(DIST)/bin
++
++libs:
++
++dummy: all export libs
++
+diff -Naurp nss-3.28-orig/nss/config/nss-config.in nss-3.28/nss/config/nss-config.in
+--- nss-3.28-orig/nss/config/nss-config.in	1969-12-31 18:00:00.000000000 -0600
++++ nss-3.28/nss/config/nss-config.in	2016-12-26 22:20:40.008205774 -0600
+@@ -0,0 +1,153 @@
++#!/bin/sh
++
++prefix=@prefix@
++
++major_version=@NSS_MAJOR_VERSION@
++minor_version=@NSS_MINOR_VERSION@
++patch_version=@NSS_PATCH_VERSION@
++
++usage()
++{
++	cat <<EOF
++Usage: nss-config [OPTIONS] [LIBRARIES]
++Options:
++	[--prefix[=DIR]]
++	[--exec-prefix[=DIR]]
++	[--includedir[=DIR]]
++	[--libdir[=DIR]]
++	[--version]
++	[--libs]
++	[--cflags]
++Dynamic Libraries:
++	nss
++	nssutil
++	smime
++	ssl
++	softokn
++EOF
++	exit $1
++}
++
++if test $# -eq 0; then
++	usage 1 1>&2
++fi
++
++lib_nss=yes
++lib_nssutil=yes
++lib_smime=yes
++lib_ssl=yes
++lib_softokn=yes
++
++while test $# -gt 0; do
++  case "$1" in
++  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
++  *) optarg= ;;
++  esac
++
++  case $1 in
++    --prefix=*)
++      prefix=$optarg
++      ;;
++    --prefix)
++      echo_prefix=yes
++      ;;
++    --exec-prefix=*)
++      exec_prefix=$optarg
++      ;;
++    --exec-prefix)
++      echo_exec_prefix=yes
++      ;;
++    --includedir=*)
++      includedir=$optarg
++      ;;
++    --includedir)
++      echo_includedir=yes
++      ;;
++    --libdir=*)
++      libdir=$optarg
++      ;;
++    --libdir)
++      echo_libdir=yes
++      ;;
++    --version)
++      echo ${major_version}.${minor_version}.${patch_version}
++      ;;
++    --cflags)
++      echo_cflags=yes
++      ;;
++    --libs)
++      echo_libs=yes
++      ;;
++    nss)
++      lib_nss=yes
++      ;;
++    nssutil)
++      lib_nssutil=yes
++      ;;
++    smime)
++      lib_smime=yes
++      ;;
++    ssl)
++      lib_ssl=yes
++      ;;
++    softokn)
++      lib_softokn=yes
++      ;;
++    *)
++      usage 1 1>&2
++      ;;
++  esac
++  shift
++done
++
++# Set variables that may be dependent upon other variables
++if test -z "$exec_prefix"; then
++    exec_prefix=`pkg-config --variable=exec_prefix nss`
++fi
++if test -z "$includedir"; then
++    includedir=`pkg-config --variable=includedir nss`
++fi
++if test -z "$libdir"; then
++    libdir=`pkg-config --variable=libdir nss`
++fi
++
++if test "$echo_prefix" = "yes"; then
++    echo $prefix
++fi
++
++if test "$echo_exec_prefix" = "yes"; then
++    echo $exec_prefix
++fi
++
++if test "$echo_includedir" = "yes"; then
++    echo $includedir
++fi
++
++if test "$echo_libdir" = "yes"; then
++    echo $libdir
++fi
++
++if test "$echo_cflags" = "yes"; then
++    echo -I$includedir
++fi
++
++if test "$echo_libs" = "yes"; then
++      libdirs="-L$libdir"
++      if test -n "$lib_nss"; then
++	libdirs="$libdirs -lnss${major_version}"
++      fi
++      if test -n "$lib_nssutil"; then
++        libdirs="$libdirs -lnssutil${major_version}"
++      fi
++      if test -n "$lib_smime"; then
++	libdirs="$libdirs -lsmime${major_version}"
++      fi
++      if test -n "$lib_ssl"; then
++	libdirs="$libdirs -lssl${major_version}"
++      fi
++      if test -n "$lib_softokn"; then
++        libdirs="$libdirs -lsoftokn${major_version}"
++      fi
++      echo $libdirs
++fi      
++
+diff -Naurp nss-3.28-orig/nss/config/nss.pc.in nss-3.28/nss/config/nss.pc.in
+--- nss-3.28-orig/nss/config/nss.pc.in	1969-12-31 18:00:00.000000000 -0600
++++ nss-3.28/nss/config/nss.pc.in	2016-12-26 22:22:53.300694346 -0600
+@@ -0,0 +1,12 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: NSS
++Description: Network Security Services
++Version: @NSS_MAJOR_VERSION@.@NSS_MINOR_VERSION@.@NSS_PATCH_VERSION@
++Requires: nspr >= 4.21
++Libs: -L@libdir@ -lnss@NSS_MAJOR_VERSION@ -lnssutil@NSS_MAJOR_VERSION@ -lsmime@NSS_MAJOR_VERSION@ -lssl@NSS_MAJOR_VERSION@ -lsoftokn@NSS_MAJOR_VERSION@
++Cflags: -I${includedir}
++
+diff -Naurp nss-3.28-orig/nss/manifest.mn nss-3.28/nss/manifest.mn
+--- nss-3.28-orig/nss/manifest.mn	2016-12-21 05:56:27.000000000 -0600
++++ nss-3.28/nss/manifest.mn	2016-12-26 22:24:12.278991843 -0600
+@@ -10,4 +10,4 @@ IMPORTS =	nspr20/v4.8 \
+ 
+ RELEASE = nss
+ 
+-DIRS = coreconf lib cmd cpputil gtests
++DIRS = coreconf lib cmd cpputil gtests config

--- a/var/spack/repos/builtin/packages/nss/package.py
+++ b/var/spack/repos/builtin/packages/nss/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install nss
+#
+# You can edit this file again by typing:
+#
+#     spack edit nss
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+# TODO: Use gyp/ninja build system to have a faster compilation.
+
+
+class Nss(MakefilePackage):
+    """Network Security Services (NSS) is a set of libraries designed to support
+    cross-platform development of security-enabled client and server
+    applications."""
+
+    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
+
+    version(
+        '3.46.1',
+        url=
+        "https://ftp.Mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1.tar.gz",
+        sha256=
+        '3bf7e0ed7db98803f134c527c436cc68415ff17257d34bd75de14e9a09d13651')
+
+    # Compile instructions from Linux From Scratch:
+    # see http://www.linuxfromscratch.org/blfs/view/cvs/postlfs/nss.html
+
+    patch('nss-3.46.1-standalone-1.patch')
+    parallel = False
+
+    depends_on('zlib')
+    depends_on('nspr')
+    depends_on('sqlite@3:')
+
+    build_directory = "nss"
+
+    @property
+    def build_targets(self):
+        args = [
+            'USE_SYSTEM_ZLIB=1', 'NSS_ENABLE_WERROR=0', 'USE_64=1',
+            'BUILD_OPT=1', 'NSS_USE_SYSTEM_SQLITE=1'
+        ]
+        args.append('NSPR_INCLUDE_DIR={}/nspr'.format(
+            self.spec['nspr'].prefix.include))
+        return args

--- a/var/spack/repos/builtin/packages/nss/package.py
+++ b/var/spack/repos/builtin/packages/nss/package.py
@@ -22,18 +22,14 @@ class Nss(MakefilePackage):
 
     version(
         '3.46.1',
-        url=
-        "https://ftp.Mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1.tar.gz",
-        sha256=
-        '3bf7e0ed7db98803f134c527c436cc68415ff17257d34bd75de14e9a09d13651',
+        url="https://ftp.Mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1.tar.gz",
+        sha256='3bf7e0ed7db98803f134c527c436cc68415ff17257d34bd75de14e9a09d13651',
         when='~nspr')
 
     version(
         '3.46.1',
-        url=
-        "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1-with-nspr-4.21.tar.gz",
-        sha256=
-        '5ec5a4e4247eb60b8c15d5151e5b5ce6c14a751e4f2158c9435f498bd5c547f4',
+        url="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1-with-nspr-4.21.tar.gz",
+        sha256='5ec5a4e4247eb60b8c15d5151e5b5ce6c14a751e4f2158c9435f498bd5c547f4',
         when='+nspr')
 
     variant("nspr", default=True, description="Enable internal nspr")

--- a/var/spack/repos/builtin/packages/nss/package.py
+++ b/var/spack/repos/builtin/packages/nss/package.py
@@ -3,26 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install nss
-#
-# You can edit this file again by typing:
-#
-#     spack edit nss
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
-from spack import *
-
 # TODO: Use gyp/ninja build system to have a faster compilation.
+
+import glob
+from os import makedirs
+
+from llnl.util.filesystem import install_tree, join_path, FileFilter, install
+from spack.build_systems.makefile import MakefilePackage
+from spack.directives import version, variant, depends_on, patch
 
 
 class Nss(MakefilePackage):
@@ -37,26 +25,87 @@ class Nss(MakefilePackage):
         url=
         "https://ftp.Mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1.tar.gz",
         sha256=
-        '3bf7e0ed7db98803f134c527c436cc68415ff17257d34bd75de14e9a09d13651')
+        '3bf7e0ed7db98803f134c527c436cc68415ff17257d34bd75de14e9a09d13651',
+        when='~nspr')
+
+    version(
+        '3.46.1',
+        url=
+        "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_1_RTM/src/nss-3.46.1-with-nspr-4.21.tar.gz",
+        sha256=
+        '5ec5a4e4247eb60b8c15d5151e5b5ce6c14a751e4f2158c9435f498bd5c547f4',
+        when='+nspr')
+
+    variant("nspr", default=True, description="Enable internal nspr")
 
     # Compile instructions from Linux From Scratch:
     # see http://www.linuxfromscratch.org/blfs/view/cvs/postlfs/nss.html
+    # patch('nss-3.46.1-standalone-1.patch')
+    patch('pkgconfig.patch')
 
-    patch('nss-3.46.1-standalone-1.patch')
     parallel = False
-
     depends_on('zlib')
-    depends_on('nspr')
+    depends_on('nspr', when='~nspr')
     depends_on('sqlite@3:')
 
     build_directory = "nss"
 
+    def edit(self, spec, prefix):
+        nss_major_version = 3
+        nss_minor_version = 46
+        nss_patch_version = 1
+        nspr_major_version = 4
+        nspr_minor_version = 21
+        nspr_patch_version = 0
+
+        pkg_filter = FileFilter('pkgconfig/nss.pc', 'pkgconfig/nspr.pc')
+        pkg_filter.filter('@prefix@', format(prefix))
+        pkg_filter.filter('@exec_prefix@', format(prefix.bin))
+        pkg_filter.filter('@libdir@', format(prefix.lib))
+        pkg_filter.filter('@includedir@', format(prefix.include))
+        pkg_filter.filter('@NSS_MAJOR_VERSION@', format(nss_major_version))
+        pkg_filter.filter('@NSS_MINOR_VERSION@', format(nss_minor_version))
+        pkg_filter.filter('@NSS_PATCH_VERSION@', format(nss_patch_version))
+        pkg_filter.filter('@NSPR_MAJOR_VERSION@', format(nspr_major_version))
+        pkg_filter.filter('@NSPR_MINOR_VERSION@', format(nspr_minor_version))
+        pkg_filter.filter('@NSPR_PATCH_VERSION@', format(nspr_patch_version))
+        pkg_filter.filter(
+            '@NSPR_MIN_VERSION@', '{}.{}'.format(nspr_major_version,
+                                                 nspr_minor_version))
+
     @property
     def build_targets(self):
         args = [
-            'USE_SYSTEM_ZLIB=1', 'NSS_ENABLE_WERROR=0', 'USE_64=1',
-            'BUILD_OPT=1', 'NSS_USE_SYSTEM_SQLITE=1'
+            'nss_build_all', 'USE_SYSTEM_ZLIB=1', 'NSS_ENABLE_WERROR=0',
+            'USE_64=1', 'BUILD_OPT=1'
         ]
-        args.append('NSPR_INCLUDE_DIR={}/nspr'.format(
-            self.spec['nspr'].prefix.include))
+        args.append('NSS_USE_SYSTEM_SQLITE=1')
+        if self.spec.satisfies('~nspr'):
+            args.append('NSPR_INCLUDE_DIR={}/nspr'.format(
+                self.spec['nspr'].prefix.include))
         return args
+
+    def install(self, spec, prefix):
+        for d in [prefix.bin, prefix.lib, prefix.include]:
+            try:
+                makedirs(d)
+            except FileExistsError:
+                pass
+        base_path = 'dist'
+        install_tree(join_path(base_path, 'public/dbm'),
+                     prefix.include,
+                     symlinks=False)
+        install_tree(join_path(base_path, 'public/nss'),
+                     prefix.include,
+                     symlinks=False)
+        compile_dir = glob.glob(join_path(base_path, '*.OBJ'))[0]
+        install_tree(join_path(compile_dir, 'include'),
+                     prefix.include,
+                     symlinks=False)
+        install_tree(join_path(compile_dir, 'lib'), prefix.lib, symlinks=False)
+        install_tree(join_path(compile_dir, 'bin'), prefix.bin, symlinks=False)
+        pkgconfig_dir = join_path(prefix.lib, 'pkgconfig')
+        makedirs(pkgconfig_dir)
+        install('pkgconfig/nss.pc', pkgconfig_dir)
+        if spec.satisfies('+nspr'):
+            install('pkgconfig/nspr.pc', pkgconfig_dir)

--- a/var/spack/repos/builtin/packages/nss/pkgconfig.patch
+++ b/var/spack/repos/builtin/packages/nss/pkgconfig.patch
@@ -1,0 +1,30 @@
+diff -Naurp nss-3.46.1.ori/pkgconfig/nspr.pc nss-3.46.1/pkgconfig/nspr.pc
+--- nss-3.46.1.ori/pkgconfig/nspr.pc	1970-01-01 01:00:00.000000000 +0100
++++ nss-3.46.1/pkgconfig/nspr.pc	2019-10-29 15:24:45.002273718 +0100
+@@ -0,0 +1,10 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: NSPR
++Description: The Netscape Portable Runtime
++Version: @NSPR_MAJOR_VERSION@.@NSPR_MINOR_VERSION@.@NSPR_PATCH_VERSION@
++Libs: -L${libdir} -lplds@NSPR_MAJOR_VERSION@ -lplc@NSPR_MAJOR_VERSION@ -lnspr@NSPR_MAJOR_VERSION@
++Cflags: -I${includedir}
+diff -Naurp nss-3.46.1.ori/pkgconfig/nss.pc nss-3.46.1/pkgconfig/nss.pc
+--- nss-3.46.1.ori/pkgconfig/nss.pc	1970-01-01 01:00:00.000000000 +0100
++++ nss-3.46.1/pkgconfig/nss.pc	2019-10-29 15:24:45.002273718 +0100
+@@ -0,0 +1,12 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: NSS
++Description: Network Security Services
++Version: @NSS_MAJOR_VERSION@.@NSS_MINOR_VERSION@.@NSS_PATCH_VERSION@
++Requires: nspr >= @NSPR_MIN_VERSION@
++Libs: -L${libdir} -lnss@NSS_MAJOR_VERSION@ -lnssutil@NSS_MAJOR_VERSION@ -lsmime@NSS_MAJOR_VERSION@ -lssl@NSS_MAJOR_VERSION@ -lsoftokn@NSS_MAJOR_VERSION@
++Cflags: -I${includedir}
++

--- a/var/spack/repos/builtin/packages/pciutils/package.py
+++ b/var/spack/repos/builtin/packages/pciutils/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+def makefile_onoff(option):
+    if option:
+        return "ON"
+    return "OFF"
+
+
+class Pciutils(MakefilePackage):
+    """The PCI Utilities package contains a library for portable access to PCI bus
+    configuration registers and several utilities based on this library."""
+
+    homepage = "https://mj.ucw.cz/sw/pciutils/"
+    url      = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.6.2.tar.xz"
+
+    version('3.6.2', sha256='db452ec986edefd88af0d222d22f6102f8030a8633fdfe846c3ae4bde9bb93f3')
+
+    variant('zlib', default=False, description="Enable zlib support.")
+    variant('shared', default=True, description="Build as a shared library.")
+
+    depends_on('zlib', when='+zlib')
+    depends_on('curl', type="run")  # when updating database
+
+    def make_options(self):
+        spec = self.spec
+        return ['PREFIX={}'.format(self.prefix),
+                'ZLIB={}'.format(makefile_onoff("+zlib" in spec)),
+                'SHARED={}'.format(makefile_onoff("+shared" in spec))]
+
+    @property
+    def build_targets(self):
+        return self.make_options()
+
+    @property
+    def install_targets(self):
+        args = self.make_options()
+        args.append('install')
+        return args

--- a/var/spack/repos/builtin/packages/pciutils/package.py
+++ b/var/spack/repos/builtin/packages/pciutils/package.py
@@ -29,9 +29,9 @@ class Pciutils(MakefilePackage):
 
     def make_options(self):
         spec = self.spec
-        return ['PREFIX='+self.prefix,
-                'ZLIB='+makefile_onoff('+zlib' in spec),
-                'SHARED='+makefile_onoff('+shared' in spec)]
+        return ['PREFIX=' + self.prefix,
+                'ZLIB=' + makefile_onoff('+zlib' in spec),
+                'SHARED=' + makefile_onoff('+shared' in spec)]
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/pciutils/package.py
+++ b/var/spack/repos/builtin/packages/pciutils/package.py
@@ -29,9 +29,9 @@ class Pciutils(MakefilePackage):
 
     def make_options(self):
         spec = self.spec
-        return ['PREFIX={}'.format(self.prefix),
-                'ZLIB={}'.format(makefile_onoff("+zlib" in spec)),
-                'SHARED={}'.format(makefile_onoff("+shared" in spec))]
+        return ['PREFIX='+self.prefix,
+                'ZLIB='+makefile_onoff('+zlib' in spec),
+                'SHARED='+makefile_onoff('+shared' in spec)]
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -32,7 +32,9 @@ class PkgConfig(AutotoolsPackage):
         env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
     def configure_args(self):
-        config_args = ['--enable-shared']
+        config_args = ['--enable-shared',
+                       '--without-system-include-path',
+                       '--without-system-library-path']
 
         if '+internal_glib' in self.spec:
             # There's a bootstrapping problem here;

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -128,15 +128,6 @@ class Qt(Package):
           sha256='ffa41e75d0d544a517e80f068464502623bb53a11f35cd22278b37372920cf46',
           when='@5.13:5.13.99 %gcc@9')
 
-    # Fix build of QT4 with GCC 9
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925811
-    patch("qt4-gcc9-qforeach.patch", when="@4:4.999 %gcc@9")
-
-    # https://bugreports.qt.io/browse/QTBUG-74196
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89585
-    patch('qt4-gcc8.3-asm-volatile-fix.patch', when='@4')
-    patch('qt5-gcc8.3-asm-volatile-fix.patch', when='@5.0.0:5.12.1')
-
     # Build-only dependencies
     depends_on("pkgconfig", type='build')
     depends_on("flex", when='+webkit', type='build')
@@ -603,7 +594,7 @@ class Qt(Package):
         else:
             config_args.extend(['-platform', 'linux-g++'])
             # Linux-only QT5 dependencies
-            if '+xcb' in specs:
+            if '+xcb' in spec:
                 config_args.append('-system-xcb')
 
         if '~webkit' in spec:

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -109,6 +109,7 @@ class Qt(Package):
           sha256='c49b228c27e3ad46ec3af4bac0e9985af5b5b28760f238422d32e14f98e49b1e',
           working_dir='qtbase',
           when='@5.10:5.12.0 %gcc@9:')
+
     # https://github.com/Homebrew/homebrew-core/pull/5951
     patch('qt5-restore-pc-files.patch', when='@5.9:5.11 platform=darwin')
     # https://github.com/spack/spack/issues/14400
@@ -116,6 +117,21 @@ class Qt(Package):
     patch('qt5-12-intel-overflow.patch', when='@5.12:5.14.0 %intel')
     # https://bugreports.qt.io/browse/QTBUG-78937
     patch('qt5-12-configure.patch', when='@5.12')
+
+    # Fix INT64 build failure with new versions
+    patch('https://github.com/qt/qtbase/pull/24.patch',
+          working_dir='qtbase',
+          sha256='ffa41e75d0d544a517e80f068464502623bb53a11f35cd22278b37372920cf46',
+          when='@5.13:5.13.99 %gcc@9')
+
+    # Fix build of QT4 with GCC 9
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925811
+    patch("qt4-gcc9-qforeach.patch", when="@4:4.999 %gcc@9")
+
+    # https://bugreports.qt.io/browse/QTBUG-74196
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89585
+    patch('qt4-gcc8.3-asm-volatile-fix.patch', when='@4')
+    patch('qt5-gcc8.3-asm-volatile-fix.patch', when='@5.0.0:5.12.1')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -78,9 +78,7 @@ class Qt(Package):
     variant('xcb', default=True, description="enable qt-xcb")
     variant('webengine', default=False, description="Enable webengine")
 
-    conflicts('+webengine', when='~webkit')
     conflicts('+webengine', when='~opengl')
-#    conflicts('+webengine', when='~sql')
 
     # Patches for qt@3
     patch('qt3-accept.patch', when='@3')
@@ -176,8 +174,8 @@ class Qt(Package):
     depends_on("pciutils", when="+webengine")
     depends_on("ruby", when="+webkit", type='build')
     depends_on("libxslt", when="+webkit")
-    #depends_on("gcc", type=('build', 'link'))
     depends_on("gettext", when="+webengine")
+    depends_on("nss", when="+webengine")  # for chromium
 
     # gcc@4 is not supported as of Qt@5.14
     # https://doc.qt.io/qt-5.14/supported-platforms.html
@@ -190,6 +188,7 @@ class Qt(Package):
         depends_on("libxcb", when="~xcb")
         depends_on("libxkbcommon")
         conflicts('+webengine', when='~dbus')
+        conflicts('+webengine', when='+xcb')
         depends_on("fontconfig", when="+webengine")
         depends_on("xcb-util-image", when="~xcb")
         depends_on("xcb-util-keysyms", when="~xcb")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -75,7 +75,6 @@ class Qt(Package):
             description="Build with OpenSSL support.")
     variant('freetype', default='spack', description='Freetype2 support',
             values=('spack', 'qt', 'none'), multi=False)
-    variant('xcb', default=True, description="enable qt-xcb")
     variant('webengine', default=False, description="Enable webengine")
 
     conflicts('+webengine', when='~opengl')
@@ -177,27 +176,24 @@ class Qt(Package):
     if MACOS_VERSION is None:
         depends_on("fontconfig", when='freetype=spack')
         depends_on("libx11")
-        depends_on("libxcb", when="~xcb")
+        depends_on("libxcb")
         depends_on("libxkbcommon")
         conflicts('+webengine', when='~dbus')
-        conflicts('+webengine', when='+xcb')
         depends_on("fontconfig", when="+webengine")
-        depends_on("xcb-util-image", when="~xcb")
-        depends_on("xcb-util-keysyms", when="~xcb")
-        depends_on("xcb-util-renderutil", when="~xcb")
-        depends_on("xcb-util-wm", when="~xcb")
-        depends_on("libdrm", when='+webengine~xcb')
-        depends_on("libxcomposite", when='+webengine~xcb')
-        depends_on("libxcursor", when='+webengine~xcb')
-        depends_on("libxi", when='+webengine~xcb')
-        depends_on("libxrandr", when='+webengine~xcb')
-        depends_on("libxscrnsaver", when='+webengine~xcb')
-        depends_on("libxtst", when='+webengine~xcb')
+        depends_on("xcb-util-image")
+        depends_on("xcb-util-keysyms")
+        depends_on("xcb-util-renderutil")
+        depends_on("xcb-util-wm")
+        depends_on("libdrm", when='+webengine')
+        depends_on("libxcomposite", when='+webengine')
+        depends_on("libxcursor", when='+webengine')
+        depends_on("libxi", when='+webengine')
+        depends_on("libxrandr", when='+webengine')
+        depends_on("libxscrnsaver", when='+webengine')
+        depends_on("libxtst", when='+webengine')
         depends_on("libxext", when='@3:4.99')
-        depends_on("libxdamage", when='+webengine~xcb')
-#        depends_on("libicu", when="+webengine")
-#        depends_on("libcap", when='+webengine')
-        depends_on("python@2.:2.99", type=('build',), when='+webengine')
+        depends_on("libxdamage", when='+webengine')
+        depends_on("python@2.7.5:2.99", type=('build',), when='+webengine')
         conflicts('+framework',
                   msg="QT cannot be built as a framework except on macOS.")
     else:
@@ -443,11 +439,6 @@ class Qt(Package):
         else:
             config_args.append('-static')
 
-        if '+xcb' in self.spec:
-            config_args.append('-qt-xcb')
-        else:
-            config_args.append('-system-xcb')
-
         if self.spec.satisfies('@5:'):
             pcre = self.spec['pcre'] if self.spec.satisfies('@5.0:5.8') \
                 else self.spec['pcre2']
@@ -596,8 +587,7 @@ class Qt(Package):
                 config_args.append('-no-xinput2')
         else:
             # Linux-only QT5 dependencies
-            if '+xcb' in spec:
-                config_args.append('-system-xcb')
+            config_args.append('-system-xcb')
 
         # if '~webkit' in spec:
         #     config_args.extend([

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -121,6 +121,7 @@ class Qt(Package):
     patch('qt5-12-intel-overflow.patch', when='@5.12:5.14.0 %intel')
     # https://bugreports.qt.io/browse/QTBUG-78937
     patch('qt5-12-configure.patch', when='@5.12')
+    patch('qt5-webengine-yasm.patch', when='@5.: +webengine')
 
     # Fix INT64 build failure with new versions
     patch('https://github.com/qt/qtbase/pull/24.patch',
@@ -194,7 +195,9 @@ class Qt(Package):
         depends_on("libxtst", when='+webengine~xcb')
         depends_on("libxext", when='@3:4.99')
         depends_on("libxdamage", when='+webengine~xcb')
-        depends_on("libcap", when='+webengine')
+#        depends_on("libicu", when="+webengine")
+#        depends_on("libcap", when='+webengine')
+        depends_on("python@2.:2.99", type=('build',), when='+webengine')
         conflicts('+framework',
                   msg="QT cannot be built as a framework except on macOS.")
     else:
@@ -592,16 +595,15 @@ class Qt(Package):
             if version < Version('5.12'):
                 config_args.append('-no-xinput2')
         else:
-            config_args.extend(['-platform', 'linux-g++'])
             # Linux-only QT5 dependencies
             if '+xcb' in spec:
                 config_args.append('-system-xcb')
 
-        if '~webkit' in spec:
-            config_args.extend([
-                '-skip',
-                'webengine' if version >= Version('5.7') else 'qtwebkit',
-            ])
+        # if '~webkit' in spec:
+        #     config_args.extend([
+        #         '-skip',
+        #         'webengine' if version >= Version('5.7') else 'qtwebkit',
+        #     ])
 
         if spec.satisfies('@5.7'):
             config_args.extend(['-skip', 'virtualkeyboard'])

--- a/var/spack/repos/builtin/packages/qt/qt5-webengine-yasm.patch
+++ b/var/spack/repos/builtin/packages/qt/qt5-webengine-yasm.patch
@@ -1,0 +1,11 @@
+--- a/qtwebengine/src/3rdparty/chromium/third_party/yasm/source/config/linux/config.h  2020-01-20 10:37:42.000000000 +0000
++++ b/qtwebengine/src/3rdparty/chromium/third_party/yasm/source/config/linux/config.h   2020-05-01 13:42:26.469818853 +0000
+@@ -5,7 +5,7 @@
+ #define CPP_PROG "cc -E"
+ 
+ /* */
+-#define ENABLE_NLS 1
++/* #undef ENABLE_NLS */
+ 
+ /* Define to 1 if you have the `abort' function. */
+ #define HAVE_ABORT 1


### PR DESCRIPTION
Enable build of `qtwebengine`.

Still a work in progress as concretizer cannot manage python in build dependencies properly.
Qt webengine needs Python 2 at build time while some dependencies use Meson so Python 3 at build time also.

Fix several bugs in dependencies for X packages, that should be also `link` and not only `build`.