### PR TITLE
bugfix/tests: check rpath presence not equality

### DIFF
--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -337,7 +337,8 @@ def test_make_elf_binaries_relative(hello_world, copy_binary, tmpdir):
         [str(new_binary)], [str(orig_binary)], str(orig_binary.dirpath())
     )
 
-    assert rpaths_for(new_binary) == '$ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib'
+    # Some compilers add rpaths so ensure changes included in final result
+    assert '$ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib' in rpaths_for(new_binary)
 
 
 def test_raise_if_not_relocatable(monkeypatch):


### PR DESCRIPTION
The new `test_make_elf_binaries_relative` path check suffers the same issue as those for rpath tests in #16637; namely, some compilers add rpaths.  

This PR changes from an equality comparison to 'contains' to reflect this difference.

The output I was getting _prior to_ this change was:
```
=================================== FAILURES ===================================
_______________________ test_make_elf_binaries_relative ________________________

hello_world = <function hello_world.<locals>._factory at 0x2aab66598a60>
copy_binary = <function copy_binary.<locals>._copy_somewhere at 0x2aab66598f28>
tmpdir = local('/tmp/$USER/pytest-of-$USER/pytest-0/test_make_elf_binaries_relativ0')

    @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
    def test_make_elf_binaries_relative(hello_world, copy_binary, tmpdir):
        orig_binary = hello_world(rpaths=[
            str(tmpdir.mkdir('lib')), str(tmpdir.mkdir('lib64')), '/opt/local/lib'
        ])
        new_binary = copy_binary(orig_binary)
    
        spack.relocate.make_elf_binaries_relative(
            [str(new_binary)], [str(orig_binary)], str(orig_binary.dirpath())
        )
    
>       assert rpaths_for(new_binary) == '$ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib'
E       AssertionError: assert '/usr/tce/pac...opt/local/lib' == '$ORIGIN/lib:$...opt/local/lib'
E         - /usr/tce/packages/gcc/gcc-4.9.3/lib:/usr/tce/packages/gcc/gcc-4.9.3/lib64:$ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib
E         + $ORIGIN/lib:$ORIGIN/lib64:/opt/local/lib

lib/spack/spack/test/relocate.py:340: AssertionError
```