### PR TITLE
Add variants to petsc

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -134,16 +134,17 @@ class Petsc(Package):
     conflicts('^intel-mkl', when='@3.8.0')
 
     # These require +mpi
-    conflicts('+cgns', when='~mpi', msg="Requires +mpi")
-    conflicts('+exodusii', when='~mpi', msg="Requires +mpi")
-    conflicts('+fftw', when='~mpi', msg="Requires +mpi")
-    conflicts('+hdf5', when='~mpi', msg="Requires +mpi")
-    conflicts('+hypre', when='~mpi', msg="Requires +mpi")
-    conflicts('+moab', when='~mpi', msg="Requires +mpi")
-    conflicts('+mumps', when='~mpi', msg="Requires +mpi")
-    conflicts('+p4est', when='~mpi', msg="Requires +mpi")
-    conflicts('+superlu-dist', when='~mpi', msg="Requires +mpi")
-    conflicts('+trilinos', when='~mpi', msg="Requires +mpi")
+    mpi_msg = 'Requires +mpi'
+    conflicts('+cgns', when='~mpi', msg=mpi_msg)
+    conflicts('+exodusii', when='~mpi', msg=mpi_msg)
+    conflicts('+fftw', when='~mpi', msg=mpi_msg)
+    conflicts('+hdf5', when='~mpi', msg=mpi_msg)
+    conflicts('+hypre', when='~mpi', msg=mpi_msg)
+    conflicts('+moab', when='~mpi', msg=mpi_msg)
+    conflicts('+mumps', when='~mpi', msg=mpi_msg)
+    conflicts('+p4est', when='~mpi', msg=mpi_msg)
+    conflicts('+superlu-dist', when='~mpi', msg=mpi_msg)
+    conflicts('+trilinos', when='~mpi', msg=mpi_msg)
 
     filter_compiler_wrappers(
         'petscvariables', relative_root='lib/petsc/conf'

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -369,20 +369,20 @@ class Petsc(Package):
             library_requested = library in spec.dependencies_dict()
             options.append(
                 '--with-{library}={value}'.format(
-                    library=('libjpeg' if library=='libjpeg-turbo'
-                             else 'netcdf' if library=='netcdf-c'
-                             else 'pnetcdf' if library=='parallel-netcdf'
-                             else 'yaml' if library=='libyaml'
+                    library=('libjpeg' if library == 'libjpeg-turbo'
+                             else 'netcdf' if library == 'netcdf-c'
+                             else 'pnetcdf' if library == 'parallel-netcdf'
+                             else 'yaml' if library == 'libyaml'
                              else library),
                     value=('1' if library_requested else '0'))
             )
             if library_requested:
                 options.append(
                     '--with-{library}-dir={path}'.format(
-                        library=('libjpeg' if library=='libjpeg-turbo'
-                                 else 'netcdf' if library=='netcdf-c'
-                                 else 'pnetcdf' if library=='parallel-netcdf'
-                                 else 'yaml' if library=='libyaml'
+                        library=('libjpeg' if library == 'libjpeg-turbo'
+                                 else 'netcdf' if library == 'netcdf-c'
+                                 else 'pnetcdf' if library == 'parallel-netcdf'
+                                 else 'yaml' if library == 'libyaml'
                                  else library), path=spec[library].prefix)
                 )
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -105,47 +105,45 @@ class Petsc(Package):
             description='Enable when mpiexec is not available to run binaries')
     variant('valgrind', default=False,
             description='Enable Valgrind Client Request mechanism')
-    variant('gmp', default=False,
-            description='Enable GMP support')
     variant('jpeg', default=False,
-            description='Enable JPEG support')
+            description='Activates support for JPEG')
     variant('libpng', default=False,
-            description='Enable PNG support')
+            description='Activates support for PNG')
     variant('giflib', default=False,
-            description='Enable GIF support')
+            description='Activates support for GIF')
     variant('mpfr', default=False,
-            description='Enable MPFR support')
-    variant('netcdf', default=False,
-            description='Enable NetCDF support')
-    variant('pnetcdf', default=False,
-            description='Enable Parallel NetCDF support')
+            description='Activates support for MPFR')
     variant('moab', default=False,
-            description='Enable MOAB support')
-    variant('eigen', default=False,
-            description='Enable EIGEN support')
+            description='Acivates support for MOAB (only parallel)')
     variant('random123', default=False,
-            description='Enable Random123 support')
+            description='Activates support for Random123')
     variant('exodusii', default=False,
-            description='Enable ExodusII support')
-    variant('mstk', default=False,
-            description='Enable MSTK support')
+            description='Activates support for ExodusII (only parallel)')
     variant('cgns', default=False,
-            description='Enable CGNS support')
+            description='Activates support for CGNS (only parallel)')
     variant('memkind', default=False,
-            description='Enable Memkind support')
-    variant('muparser', default=False,
-            description='Enable Muparser support')
+            description='Activates support for Memkind')
     variant('p4est', default=False,
-            description='Enable P4Est support')
+            description='Activates support for P4Est (only parallel)')
     variant('saws', default=False,
-            description='Enable Saws support')
+            description='Activates support for Saws')
     variant('libyaml', default=False,
-            description='Enable YAML support')
-    variant('zstd', default=False,
-            description='Enable ZSTD support')
+            description='Activates support for YAML')
 
     # 3.8.0 has a build issue with MKL - so list this conflict explicitly
     conflicts('^intel-mkl', when='@3.8.0')
+
+    # These require +mpi
+    conflicts('+cgns', when='~mpi', msg="Requires +mpi")
+    conflicts('+exodusii', when='~mpi', msg="Requires +mpi")
+    conflicts('+fftw', when='~mpi', msg="Requires +mpi")
+    conflicts('+hdf5', when='~mpi', msg="Requires +mpi")
+    conflicts('+hypre', when='~mpi', msg="Requires +mpi")
+    conflicts('+moab', when='~mpi', msg="Requires +mpi")
+    conflicts('+mumps', when='~mpi', msg="Requires +mpi")
+    conflicts('+p4est', when='~mpi', msg="Requires +mpi")
+    conflicts('+superlu-dist', when='~mpi', msg="Requires +mpi")
+    conflicts('+trilinos', when='~mpi', msg="Requires +mpi")
 
     filter_compiler_wrappers(
         'petscvariables', relative_root='lib/petsc/conf'
@@ -178,7 +176,6 @@ class Petsc(Package):
     # Build dependencies
     depends_on('python@2.6:2.8', type='build', when='@:3.10.99')
     depends_on('python@2.6:2.8,3.4:', type='build', when='@3.11:')
-    depends_on('eigen', type='build', when='+eigen')
 
     # Other dependencies
     depends_on('metis@5:~int64+real64', when='@:3.7.99+metis~int64+double')
@@ -191,21 +188,25 @@ class Petsc(Package):
 
     depends_on('hdf5@:1.10.99+mpi', when='@:3.12.99+hdf5+mpi')
     depends_on('hdf5+mpi', when='@3.13:+hdf5+mpi')
+    depends_on('hdf5+mpi', when='+exodusii+mpi')
+    depends_on('hdf5+mpi', when='+cgns+mpi')
     depends_on('zlib', when='+hdf5')
+    depends_on('zlib', when='+libpng')
+    depends_on('zlib', when='+p4est')
     depends_on('parmetis', when='+metis+mpi')
     depends_on('valgrind', when='+valgrind')
     # Hypre does not support complex numbers.
     # Also PETSc prefer to build it without internal superlu, likely due to
     # conflict in headers see
     # https://bitbucket.org/petsc/petsc/src/90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config/packages/hypre.py
-    depends_on('hypre@:2.13.99~internal-superlu~int64', when='@:3.8.99+hypre+mpi~complex~int64')
-    depends_on('hypre@:2.13.99~internal-superlu+int64', when='@:3.8.99+hypre+mpi~complex+int64')
-    depends_on('hypre@2.14:~internal-superlu~int64', when='@3.9:+hypre+mpi~complex~int64')
-    depends_on('hypre@2.14:~internal-superlu+int64', when='@3.9:+hypre+mpi~complex+int64')
-    depends_on('hypre@xsdk-0.2.0~internal-superlu+int64', when='@xsdk-0.2.0+hypre+mpi~complex+int64')
-    depends_on('hypre@xsdk-0.2.0~internal-superlu~int64', when='@xsdk-0.2.0+hypre+mpi~complex~int64')
-    depends_on('hypre@develop~internal-superlu+int64', when='@develop+hypre+mpi~complex+int64')
-    depends_on('hypre@develop~internal-superlu~int64', when='@develop+hypre+mpi~complex~int64')
+    depends_on('hypre@:2.13.99+mpi~internal-superlu~int64', when='@:3.8.99+hypre+mpi~complex~int64')
+    depends_on('hypre@:2.13.99+mpi~internal-superlu+int64', when='@:3.8.99+hypre+mpi~complex+int64')
+    depends_on('hypre@2.14:+mpi~internal-superlu~int64', when='@3.9:+hypre+mpi~complex~int64')
+    depends_on('hypre@2.14:+mpi~internal-superlu+int64', when='@3.9:+hypre+mpi~complex+int64')
+    depends_on('hypre@xsdk-0.2.0+mpi~internal-superlu+int64', when='@xsdk-0.2.0+hypre+mpi~complex+int64')
+    depends_on('hypre@xsdk-0.2.0+mpi~internal-superlu~int64', when='@xsdk-0.2.0+hypre+mpi~complex~int64')
+    depends_on('hypre@develop+mpi~internal-superlu+int64', when='@develop+hypre+mpi~complex+int64')
+    depends_on('hypre@develop+mpi~internal-superlu~int64', when='@develop+hypre+mpi~complex~int64')
     depends_on('superlu-dist@:4.3~int64', when='@3.4.4:3.6.4+superlu-dist+mpi~int64')
     depends_on('superlu-dist@:4.3+int64', when='@3.4.4:3.6.4+superlu-dist+mpi+int64')
     depends_on('superlu-dist@5.0.0:5.1.3~int64', when='@3.7:3.7.99+superlu-dist+mpi~int64')
@@ -224,29 +225,27 @@ class Petsc(Package):
     depends_on('superlu-dist@develop+int64', when='@develop+superlu-dist+mpi+int64')
     depends_on('mumps+mpi', when='+mumps+mpi~int64')
     depends_on('scalapack', when='+mumps+mpi~int64')
-    depends_on('trilinos@12.6.2:', when='@3.7.0:+trilinos+mpi')
-    depends_on('trilinos@xsdk-0.2.0', when='@xsdk-0.2.0+trilinos+mpi')
-    depends_on('trilinos@develop', when='@xdevelop+trilinos+mpi')
+    depends_on('trilinos@12.6.2:+mpi', when='@3.7.0:+trilinos+mpi')
+    depends_on('trilinos@xsdk-0.2.0+mpi', when='@xsdk-0.2.0+trilinos+mpi')
+    depends_on('trilinos@develop+mpi', when='@xdevelop+trilinos+mpi')
     depends_on('fftw+mpi', when='+fftw+mpi')
     depends_on('suite-sparse', when='+suite-sparse')
     depends_on('libx11', when='+X')
-    depends_on('gmp', when='+gmp')
+    depends_on('mpfr', when='+mpfr')
+    depends_on('gmp', when='+mpfr')
     depends_on('jpeg', when='+jpeg')
     depends_on('libpng', when='+libpng')
     depends_on('giflib', when='+giflib')
-    depends_on('mpfr', when='+mpfr')
-    depends_on('netcdf-c', when='+netcdf')
-    depends_on('parallel-netcdf', when='+pnetcdf')
+    depends_on('exodusii+mpi', when='+exodusii+mpi')
+    depends_on('netcdf-c+mpi', when='+exodusii+mpi')
+    depends_on('parallel-netcdf', when='+exodusii+mpi')
     depends_on('random123', when='+random123')
-    depends_on('exodusii', when='+exodusii')
-    depends_on('mstk', when='+mstk')
-    depends_on('cgns', when='+cgns')
+    depends_on('moab+mpi', when='+moab+mpi')
+    depends_on('cgns+mpi', when='+cgns+mpi')
     depends_on('memkind', when='+memkind')
-    depends_on('muparser', when='+muparser')
-    depends_on('p4est', when='+p4est')
+    depends_on('p4est+mpi', when='+p4est+mpi')
     depends_on('saws', when='+saws')
     depends_on('libyaml', when='+libyaml')
-    depends_on('zstd', when='+zstd')
 
     def url_for_version(self, version):
         if version >= Version('3.13.0'):
@@ -265,18 +264,6 @@ class Petsc(Package):
                                   if self.compiler.fc is not None else '0'),
                 '--with-mpi=0'
             ]
-            error_message_fmt = \
-                '\t{library} support requires "+mpi" to be activated'
-
-            # If mpi is disabled (~mpi), it's an error to have any of these
-            # enabled. This generates a list of any such errors.
-            errors = [
-                error_message_fmt.format(library=x)
-                for x in ('hdf5', 'hypre', 'mumps', 'superlu-dist')
-                if ('+' + x) in self.spec]
-            if errors:
-                errors = ['incompatible variants given'] + errors
-                raise RuntimeError('\n'.join(errors))
         else:
             compiler_opts = [
                 '--with-cc=%s' % self.spec['mpi'].mpicc,
@@ -361,9 +348,8 @@ class Petsc(Package):
         for library in ('cuda', 'metis', 'hypre', 'parmetis', 'mumps',
                         'trilinos', 'fftw', 'valgrind', 'gmp', 'libpng',
                         'giflib', 'mpfr', 'netcdf-c', 'parallel-netcdf',
-                        'moab', 'eigen', 'random123', 'exodusii', 'mstk',
-                        'cgns', 'memkind', 'muparser', 'p4est', 'saws',
-                        'libyaml', 'zstd', jpeg_library):
+                        'moab', 'random123', 'exodusii', 'cgns', 'memkind',
+                        'p4est', 'saws', 'libyaml', jpeg_library):
             # Cannot check `library in spec` because of transitive deps
             # Cannot check variants because parmetis keys on +metis
             library_requested = library in spec.dependencies_dict()


### PR DESCRIPTION
This PR adds the follolwing variants to the petsc package

- gmp
- jpeg
- libpng
- giflib
- mpfr
- netcdf
- pnetcdf (parallel-netcdf)
- moab
- eigen
- random123
- exodusii
- mstk
- cgns
- memkind
- muparser
- p4est
- saws
- libyaml
- zstd