### PR TITLE
update 'spack env -h' message

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -353,7 +353,8 @@ def env_status(args):
 # env loads
 #
 def env_loads_setup_parser(subparser):
-    """list modules for an installed environment '(see spack module loads)'"""
+    """list modules for an installed environment
+'(see spack module tcl loads)'"""
     subparser.add_argument(
         'env', nargs='?', help='name of env to generate loads file for')
     subparser.add_argument(


### PR DESCRIPTION
since 'spack module loads' has been moved to 'spack module tcl loads',
update the help message accordingly