### PR TITLE
Fix indentation in containerize example

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -165,7 +165,7 @@ of environments:
        # Extra instructions
        extra_instructions:
          final: |
-   RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ \[$(tput sgr0)\]"' >> ~/.bashrc
+           RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ \[$(tput sgr0)\]"' >> ~/.bashrc
 
        # Labels for the image
        labels:


### PR DESCRIPTION
$ spack containerize
Running `spack containerize` with the example `spack.yaml` file fails
with an error that ends like so:

```
[...]
  File "/local_scratch/hartzell/tmp/spack-explore-docker/lib/spack/external/ruamel/yaml/scanner.py", line 165, in need_more_tokens
    self.stale_possible_simple_keys()
  File "/local_scratch/hartzell/tmp/spack-explore-docker/lib/spack/external/ruamel/yaml/scanner.py", line 309, in stale_possible_simple_keys
    "could not find expected ':'", self.get_mark())
ruamel.yaml.scanner.ScannerError: while scanning a simple key
  in "/local_scratch/hartzell/tmp/spack-explore-docker/spack.yaml", line 26, column 1
could not find expected ':'
  in "/local_scratch/hartzell/tmp/spack-explore-docker/spack.yaml", line 28, column 5
```

Indenting the block string fixes the problem for me.

CentOS 7,

```
$ spack --version
0.14.2-1529-ec58f28c2
```