### PR TITLE
Add support for aliases

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -229,3 +229,11 @@ config:
   flags:
     # Whether to keep -Werror flags active in package builds.
     keep_werror: 'none'
+
+  # A mapping of aliases that can be used to define new commands. For instance,
+  # `sp: spec -I` will define a new command `sp` that will execute `spec` with
+  # the `-I` argument. Aliases cannot override existing commands.
+  aliases:
+    concretise: concretize
+    containerise: containerize
+    rm: remove

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -304,3 +304,17 @@ To work properly, this requires your terminal to reset its title after
 Spack has finished its work, otherwise Spack's status information will
 remain in the terminal's title indefinitely. Most terminals should already
 be set up this way and clear Spack's status information.
+
+-----------
+``aliases``
+-----------
+
+Aliases can be used to define new Spack commands. They can be either shortcuts
+for longer commands or include specific arguments for convenience. For instance,
+if users want to use ``spack install``'s ``-v`` argument all the time, they can
+create a new alias called ``inst`` that will always call ``install -v``:
+
+.. code-block:: yaml
+
+   aliases:
+     inst: install -v

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -796,7 +796,9 @@ def names(args: Namespace, out: IO) -> None:
     commands = copy.copy(spack.cmd.all_commands())
 
     if args.aliases:
-        commands.extend(spack.main.aliases.keys())
+        aliases = spack.config.get("config:aliases")
+        if aliases:
+            commands.extend(aliases.keys())
 
     colify(commands, output=out)
 
@@ -812,8 +814,10 @@ def bash(args: Namespace, out: IO) -> None:
     parser = spack.main.make_argument_parser()
     spack.main.add_all_commands(parser)
 
-    aliases = ";".join(f"{key}:{val}" for key, val in spack.main.aliases.items())
-    out.write(f'SPACK_ALIASES="{aliases}"\n\n')
+    aliases_config = spack.config.get("config:aliases")
+    if aliases_config:
+        aliases = ";".join(f"{key}:{val}" for key, val in aliases_config.items())
+        out.write(f'SPACK_ALIASES="{aliases}"\n\n')
 
     writer = BashCompletionWriter(parser.prog, out, args.aliases)
     writer.write(parser)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -881,8 +881,17 @@ def resolve_alias(cmd_name, cmd):
     Returns:
         (str, list): new command name and arguments.
     """
+    aliases = spack.config.get("config:aliases")
+
+    if aliases:
+        for key, value in aliases.items():
+            if " " in key:
+                tty.warn(
+                    f"Alias '{key}' (mapping to '{value}') contains a space"
+                    ", which is not supported."
+                )
+
     if cmd_name not in spack.cmd.all_commands():
-        aliases = spack.config.get("config:aliases")
         alias = None
 
         if aliases:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -671,7 +671,6 @@ class SpackCommand:
                 Windows, where it is always False.
         """
         self.parser = make_argument_parser()
-        self.command = self.parser.add_command(command_name)
         self.command_name = command_name
         # TODO: figure out how to support this on windows
         self.subprocess = subprocess if sys.platform != "win32" else False
@@ -703,13 +702,14 @@ class SpackCommand:
 
         if self.subprocess:
             p = sp.Popen(
-                [spack.paths.spack_script, self.command_name] + prepend + list(argv),
+                [spack.paths.spack_script] + prepend + [self.command_name] + list(argv),
                 stdout=sp.PIPE,
                 stderr=sp.STDOUT,
             )
             out, self.returncode = p.communicate()
             out = out.decode()
         else:
+            command = self.parser.add_command(self.command_name)
             args, unknown = self.parser.parse_known_args(
                 prepend + [self.command_name] + list(argv)
             )
@@ -717,7 +717,7 @@ class SpackCommand:
             out = io.StringIO()
             try:
                 with log_output(out, echo=True):
-                    self.returncode = _invoke_command(self.command, self.parser, args, unknown)
+                    self.returncode = _invoke_command(command, self.parser, args, unknown)
 
             except SystemExit as e:
                 self.returncode = e.code

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -22,6 +22,7 @@ import subprocess as sp
 import sys
 import traceback
 import warnings
+from typing import List, Tuple
 
 import archspec.cpu
 
@@ -871,15 +872,15 @@ def restore_macos_dyld_vars():
             os.environ[dyld_var] = os.environ[stored_var_name]
 
 
-def resolve_alias(cmd_name, cmd):
+def resolve_alias(cmd_name: str, cmd: List[str]) -> Tuple[str, List[str]]:
     """Resolves aliases in the given command.
 
     Args:
-        cmd_name (string): command name.
-        cmd (list): command line arguments.
+        cmd_name: command name.
+        cmd: command line arguments.
 
     Returns:
-        (str, list): new command name and arguments.
+        new command name and arguments.
     """
     all_commands = spack.cmd.all_commands()
     aliases = spack.config.get("config:aliases")

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -881,6 +881,7 @@ def resolve_alias(cmd_name, cmd):
     Returns:
         (str, list): new command name and arguments.
     """
+    all_commands = spack.cmd.all_commands()
     aliases = spack.config.get("config:aliases")
 
     if aliases:
@@ -890,8 +891,13 @@ def resolve_alias(cmd_name, cmd):
                     f"Alias '{key}' (mapping to '{value}') contains a space"
                     ", which is not supported."
                 )
+            if key in all_commands:
+                tty.warn(
+                    f"Alias '{key}' (mapping to '{value}') attempts to override"
+                    " built-in command."
+                )
 
-    if cmd_name not in spack.cmd.all_commands():
+    if cmd_name not in all_commands:
         alias = None
 
         if aliases:

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -92,6 +92,7 @@ properties = {
             "url_fetch_method": {"type": "string", "enum": ["urllib", "curl"]},
             "additional_external_search_paths": {"type": "array", "items": {"type": "string"}},
             "binary_index_ttl": {"type": "integer", "minimum": 0},
+            "aliases": {"type": "object", "patternProperties": {r"\w[\w-]*": {"type": "string"}}},
         },
         "deprecatedProperties": {
             "properties": ["terminal_title"],

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -67,6 +67,7 @@ def test_override_alias():
 
     out = install(fail_on_error=False, global_args=["-c", "config:aliases:install:find"])
     assert "install requires a package argument or active environment" in out
+    assert "Alias 'install' (mapping to 'find') attempts to override built-in command" in out
 
     out = install(fail_on_error=False, global_args=["-c", "config:aliases:foo bar:find"])
     assert "Alias 'foo bar' (mapping to 'find') contains a space, which is not supported" in out

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -68,6 +68,9 @@ def test_override_alias():
     out = install(fail_on_error=False, global_args=["-c", "config:aliases:install:find"])
     assert "install requires a package argument or active environment" in out
 
+    out = install(fail_on_error=False, global_args=["-c", "config:aliases:foo bar:find"])
+    assert "Alias 'foo bar' (mapping to 'find') contains a space, which is not supported" in out
+
     out = instal(fail_on_error=False, global_args=["-c", "config:aliases:instal:find"])
     assert "install requires a package argument or active environment" not in out
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -58,6 +58,20 @@ def test_subcommands():
     assert "spack compiler add" in out2
 
 
+@pytest.mark.not_on_windows("subprocess not supported on Windows")
+def test_override_alias():
+    """Test that spack commands cannot be overriden by aliases."""
+
+    install = spack.main.SpackCommand("install", subprocess=True)
+    instal = spack.main.SpackCommand("instal", subprocess=True)
+
+    out = install(fail_on_error=False, global_args=["-c", "config:aliases:install:find"])
+    assert "install requires a package argument or active environment" in out
+
+    out = instal(fail_on_error=False, global_args=["-c", "config:aliases:instal:find"])
+    assert "install requires a package argument or active environment" not in out
+
+
 def test_rst():
     """Do some simple sanity checks of the rst writer."""
     out1 = commands("--format=rst")


### PR DESCRIPTION
Aliases can be used to define new commands. For instance, `sp: spec -I` will define a new command `sp` that will execute `spec` with the `-I` argument. Aliases cannot override existing commands.

This is still WIP and is missing some things, including schema adaptions and porting the old aliases to the new system. It already works in general. For convenience, there is an example alias `sp` (which I will remove for the final version). I would just like to get some feedback on whether this is something of interest.

@adamjstewart @tgamblin @alalazo

Closes #2705