### PR TITLE
Ascent & Conduit: ~python default

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -50,13 +50,13 @@ class Ascent(Package, CudaPackage):
     ###########################################################################
 
     variant("shared", default=True, description="Build Ascent as shared libs")
-    variant('test', default=True, description='Enable Ascent unit tests')
+    variant("test", default=True, description='Enable Ascent unit tests')
 
     variant("mpi", default=True, description="Build Ascent MPI Support")
     variant("serial", default=True, description="build serial (non-mpi) libraries")
 
     # variants for language support
-    variant("python", default=True, description="Build Ascent Python support")
+    variant("python", default=False, description="Build Ascent Python support")
     variant("fortran", default=True, description="Build Ascent Fortran support")
 
     # variants for runtime features

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -54,10 +54,10 @@ class Conduit(Package):
     ###########################################################################
 
     variant("shared", default=True, description="Build Conduit as shared libs")
-    variant('test', default=True, description='Enable Conduit unit tests')
+    variant("test", default=True, description='Enable Conduit unit tests')
 
     # variants for python support
-    variant("python", default=True, description="Build Conduit Python support")
+    variant("python", default=False, description="Build Conduit Python support")
     variant("fortran", default=True, description="Build Conduit Fortran support")
 
     # variants for comm and i/o


### PR DESCRIPTION
Packages that build optional python bindings do not build them by default in Spack:
https://spack.readthedocs.io/en/latest/packaging_guide.html#variant-names

This reduces long dependency trees and build times, e.g. for apps just using C/C++/Fortran bindings of a library.