### PR TITLE
Fix global activation check for upstream extendees

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1027,6 +1027,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         if not self.is_extension:
             raise ValueError(
                 "is_activated called on package that is not an extension.")
+        if self.extendee_spec.package.installed_upstream:
+            # If this extends an upstream package, it cannot be activated for
+            # it. This bypasses construction of the extension map, which can
+            # can fail when run in the context of a downstream Spack instance
+            return False
         extensions_layout = view.extensions_layout
         exts = extensions_layout.extension_map(self.extendee_spec)
         return (self.name in exts) and (exts[self.name] == self.spec)


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/15966

Short-circuit is_activated check when the extendee is installed upstream. In this case, return false immediately. This avoids creating an `extension_map` in the context of the downstream Spack, which can fail: validation of the `extension_map` is based on reading the directory layout rather than the database, which means that upstream specs are omitted from the validation.