### PR TITLE
py-horovod: add latest version

### DIFF
--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -14,6 +14,7 @@ class PyHorovod(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master', submodules=True)
+    version('0.19.5', tag='v0.19.5', submodules=True)
     version('0.19.4', tag='v0.19.4', submodules=True)
     version('0.19.3', tag='v0.19.3', submodules=True)
     version('0.19.2', tag='v0.19.2', submodules=True)


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.7 and GCC 9.3.0 (via WSL)