### PR TITLE
fujitsu-mpi: Add methods, headers() and libs().

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -27,6 +27,24 @@ class FujitsuMpi(Package):
         raise InstallError(
             'Fujitsu MPI is not installable; it is vendor supplied')
 
+    @property
+    def headers(self):
+        hdrs = HeaderList(find(self.prefix.include, 'mpi.h', recursive=True))
+        hdrs.directories = os.path.dirname(hdrs[0])
+        return hdrs or None
+
+    @property
+    def libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+        libraries = ['libmpi']
+
+        if 'cxx' in query_parameters:
+            libraries = ['libmpi_cxx'] + libraries
+
+        return find_libraries(
+            libraries, root=self.prefix, shared=True, recursive=True
+        )
+
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = self.prefix.bin.mpifcc
         self.spec.mpicxx = self.prefix.bin.mpiFCC

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -30,7 +30,7 @@ class FujitsuMpi(Package):
 
     @property
     def headers(self):
-        hdrs = HeaderList(find(self.prefix.include, 'mpi.h', recursive=True))
+        hdrs = find_headers('mpi', self.prefix.include, recursive=True)
         hdrs.directories = os.path.dirname(hdrs[0])
         return hdrs or None
 

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class FujitsuMpi(Package):


### PR DESCRIPTION
Add this feature to search the Fujitsu compiler libraries and header files.
In particular, `mpi.h` is stored deep in the `include` directory, so it needs to be searched recursively with `find` method.