### PR TITLE
autotools: set 'ldlibs' as 'LIBS'

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -55,7 +55,8 @@ class AutotoolsPackage(spack.package_base.PackageBase):
         setattr(self, "configure_flag_args", [])
         for flag, values in flags.items():
             if values:
-                values_str = "{0}={1}".format(flag.upper(), " ".join(values))
+                var_name = "LIBS" if flag == "ldlibs" else flag.upper()
+                values_str = "{0}={1}".format(var_name, " ".join(values))
                 self.configure_flag_args.append(values_str)
         # Spack's fflags are meant for both F77 and FC, therefore we
         # additionaly set FCFLAGS if required.


### PR DESCRIPTION
Autotool configure scripts should receive `LIBS` instead of `LDLIBS`.