### PR TITLE
Allow detection for "-classic" version of CCE

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -33,8 +33,13 @@ class Cce(Compiler):
                   'fc': 'cce/ftn'}
 
     @property
+    def is_clang_based(self):
+        version = self.version
+        return version >= ver('9.0') and 'classic' not in str(version)
+
+    @property
     def version_argument(self):
-        if self.version >= ver('9.0'):
+        if self.is_clang_based:
             return '--version'
         return '-V'
 
@@ -50,19 +55,19 @@ class Cce(Compiler):
 
     @property
     def openmp_flag(self):
-        if self.version >= ver('9.0'):
+        if self.is_clang_based:
             return '-fopenmp'
         return "-h omp"
 
     @property
     def cxx11_flag(self):
-        if self.version >= ver('9.0'):
+        if self.is_clang_based:
             return '-std=c++11'
         return "-h std=c++11"
 
     @property
     def c99_flag(self):
-        if self.version >= ver('9.0'):
+        if self.is_clang_based:
             return '-std=c99'
         elif self.version >= ver('8.4'):
             return '-h std=c99,noconform,gnu'
@@ -75,7 +80,7 @@ class Cce(Compiler):
 
     @property
     def c11_flag(self):
-        if self.version >= ver('9.0'):
+        if self.is_clang_based:
             return '-std=c11'
         elif self.version >= ver('8.5'):
             return '-h std=c11,noconform,gnu'

--- a/lib/spack/spack/operating_systems/cray_backend.py
+++ b/lib/spack/spack/operating_systems/cray_backend.py
@@ -142,7 +142,9 @@ class CrayBackend(LinuxDistro):
         compiler_name = detect_version_args.id.compiler_name
         compiler_cls = spack.compilers.class_for_compiler_name(compiler_name)
         output = modulecmd('avail', compiler_cls.PrgEnv_compiler)
-        version_regex = r'(%s)/([\d\.]+[\d])' % compiler_cls.PrgEnv_compiler
+        version_regex = r'({0})/([\d\.]+[\d]-?[\w]*)'.format(
+            compiler_cls.PrgEnv_compiler
+        )
         matches = re.findall(version_regex, output)
         version = tuple(version for _, version in matches)
         compiler_id = detect_version_args.id

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -355,12 +355,20 @@ def test_arm_flags():
 
 
 def test_cce_flags():
+    supported_flag_test("version_argument", "--version", "cce@9.0.1")
+    supported_flag_test("version_argument", "-V", "cce@9.0.1-classic")
+    supported_flag_test("openmp_flag", "-fopenmp", "cce@9.0.1")
+    supported_flag_test("openmp_flag", "-h omp", "cce@9.0.1-classic")
     supported_flag_test("openmp_flag", "-h omp", "cce@1.0")
+    supported_flag_test("cxx11_flag", "-std=c++11", "cce@9.0.1")
+    supported_flag_test("cxx11_flag", "-h std=c++11", "cce@9.0.1-classic")
     supported_flag_test("cxx11_flag", "-h std=c++11", "cce@1.0")
     unsupported_flag_test("c99_flag", "cce@8.0")
+    supported_flag_test("c99_flag", "-std=c99", "cce@9.0.1")
     supported_flag_test("c99_flag", "-h c99,noconform,gnu", "cce@8.1")
     supported_flag_test("c99_flag", "-h std=c99,noconform,gnu", "cce@8.4")
     unsupported_flag_test("c11_flag", "cce@8.4")
+    supported_flag_test("c11_flag", "-std=c11", "cce@9.0.1")
     supported_flag_test("c11_flag", "-h std=c11,noconform,gnu", "cce@8.5")
     supported_flag_test("cc_pic_flag",  "-h PIC", "cce@1.0")
     supported_flag_test("cxx_pic_flag", "-h PIC", "cce@1.0")


### PR DESCRIPTION
fixes #17116 

This currently produces the following on PizDaint:
```console
> spack compiler find
==> Added 19 new compilers to /users/culpo/.spack/compilers.yaml
    pgi@20.1.0  pgi@19.5.0  intel@19.0.1.144  intel@18.0.1.163  gcc@8.3.0  gcc@8.1.0  gcc@7.3.0  cce@9.0.2-classic  cce@9.0.1-classic  cce@8.7.9
    pgi@19.7.0  pgi@19.4.0  intel@18.0.2.199  intel@17.0.4.196  gcc@8.2.0  gcc@7.4.1  gcc@6.1.0  cce@9.0.2          cce@9.0.1
==> Compilers are defined in the following files:
    /users/culpo/.spack/compilers.yaml
```
and distinguish between classic and non-classic flavor of the compiler. These two flavors might be turned into two different compilers in v0.16.0 or later, but this is a stopgap for the time being.