### PR TITLE
env: no automatic activation

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -167,15 +167,6 @@ Any directory can be treated as an environment if it contains a file
 
    $ spack env activate -d /path/to/directory
 
-Spack commands that are environment sensitive will also act on the
-environment any time the current working directory contains a
-``spack.yaml`` file. Changing working directory to a directory
-containing a ``spack.yaml`` file is equivalent to the command:
-
-.. code-block:: console
-
-   $ spack env activate -d /path/to/dir --without-view
-
 Anonymous specs can be created in place using the command:
 
 .. code-block:: console

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -45,6 +45,7 @@ for setting up a build pipeline are as follows:
         tags:
           - <custom-tag>
         script:
+          - spack env activate .
           - spack ci generate
             --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/pipeline.yml"
         artifacts:
@@ -384,6 +385,7 @@ a custom spack and make sure the generated rebuild jobs will clone it too:
      - git clone ${SPACK_REPO} --branch ${SPACK_REF}
      - . ./spack/share/spack/setup-env.sh
    script:
+     - spack env activate .
      - spack ci generate
        --spack-repo ${SPACK_REPO} --spack-ref ${SPACK_REF}
        --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/pipeline.yml"

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -612,7 +612,10 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                 if 'enable-debug-messages' in gitlab_ci:
                     debug_flag = '-d '
 
-                job_scripts = ['spack {0}ci rebuild'.format(debug_flag)]
+                job_scripts = [
+                  'spack env activate .',
+                  'spack {0}ci rebuild'.format(debug_flag),
+                ]
 
                 compiler_action = 'NONE'
                 if len(phases) > 1:

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -613,8 +613,8 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                     debug_flag = '-d '
 
                 job_scripts = [
-                  'spack env activate .',
-                  'spack {0}ci rebuild'.format(debug_flag),
+                    'spack env activate .',
+                    'spack {0}ci rebuild'.format(debug_flag),
                 ]
 
                 compiler_action = 'NONE'

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -247,18 +247,13 @@ def find_environment(args):
         # at env_dir (env and env_dir are mutually exclusive)
         env = getattr(args, 'env_dir', None)
 
-        # if no argument, look for a manifest file
+        # if no argument, look for the environment variable
         if not env:
-            if os.path.exists(manifest_name):
-                env = os.getcwd()
+            env = os.environ.get(spack_env_var)
 
-            # if no env, env_dir, or manifest try the environment
+            # nothing was set; there's no active environment
             if not env:
-                env = os.environ.get(spack_env_var)
-
-                # nothing was set; there's no active environment
-                if not env:
-                    return None
+                return None
 
     # if we get here, env isn't the name of a spack environment; it has
     # to be a path to an environment, or there is something wrong.


### PR DESCRIPTION
Fixes #15850 

This PR removes the feature (or anti-feature, as @citibeth pointed out) that Spack treats a spack.yaml file in the working directory as an active environment.

With this PR, users have to type `spack env activate .` to activate an environment from the working directory.

TODO:
- [x] @scottwittenburg is investigating whether there are additional changes necessary to the `spack ci` command.