### PR TITLE
[geant4] depends_on qt@5: +opengl when +qt

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -88,7 +88,7 @@ class Geant4(CMakePackage):
     depends_on("libx11", when='+x11')
     depends_on("libxmu", when='+x11')
     depends_on("motif", when='+motif')
-    depends_on("qt@5:", when="+qt")
+    depends_on("qt@5: +opengl", when="+qt")
 
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.


### PR DESCRIPTION
This adds `+opengl` to the current `depends_on qt@5:`.

The Geant4 cmake check requires Qt5OpenGL_FOUND, so we must require
the Qt5 +opengl variant. If not, the cmake phase fall through to Qt4
and fails due to a missing Qt4::QtGui target.

In Geant4InterfaceOptions.cmake:
```
  if(Qt5Core_FOUND
      AND Qt5Gui_FOUND
      AND Qt5Widgets_FOUND
      AND Qt5OpenGL_FOUND
      AND Qt5PrintSupport_FOUND)
```

Ref: https://github.com/Geant4/geant4/blob/master/cmake/Modules/Geant4InterfaceOptions.cmake#L90
(5baee230e93612916bcea11ebf822756cfa7282c, "Import Geant4 10.6.0 source tree")