### PR TITLE
cp2k: variant tuning `lmax` was broken

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -68,7 +68,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     variant('lmax',
             description='Maximum supported angular momentum (HFX and others)',
             default='5',
-            values=list(HFX_LMAX_RANGE),
+            values=['{0}'.format(i) for i in HFX_LMAX_RANGE],
             multi=False)
 
     depends_on('python', type='build')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -68,7 +68,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     variant('lmax',
             description='Maximum supported angular momentum (HFX and others)',
             default='5',
-            values=['{0}'.format(i) for i in HFX_LMAX_RANGE],
+            values=map(str, HFX_LMAX_RANGE),
             multi=False)
 
     depends_on('python', type='build')


### PR DESCRIPTION
- `spack install cp2k lmax=6` now works