### PR TITLE
Detect FE compilers automatically on Cray

### DIFF
--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -85,22 +85,20 @@ class CrayFrontend(LinuxDistro):
             matches = re.findall(version_regex, output)
             versions = tuple(version for _, version in matches)
 
-            # Now load the modules and add to paths
+            # Now inspect the modules and add to paths
             msg = "[CRAY FE] Detected FE compiler [name={0}, versions={1}]"
             tty.debug(msg.format(compiler_module, versions))
-            with unload_programming_environment():
-                load_module(prg_env)
-                for v in versions:
-                    try:
-                        current_module = compiler_module + '/' + v
-                        out = module('show', current_module)
-                        match = extract_path_re.search(out)
-                        search_paths += match.group(1).split(':')
-                    except Exception as e:
-                        msg = ("[CRAY FE] An unexpected error occurred while "
-                               "detecting FE compiler [compiler={0}, "
-                               " version={1}, error={2}]")
-                        tty.warn(msg.format(compiler_cls.name, v, str(e)))
+            for v in versions:
+                try:
+                    current_module = compiler_module + '/' + v
+                    out = module('show', current_module)
+                    match = extract_path_re.search(out)
+                    search_paths += match.group(1).split(':')
+                except Exception as e:
+                    msg = ("[CRAY FE] An unexpected error occurred while "
+                           "detecting FE compiler [compiler={0}, "
+                           " version={1}, error={2}]")
+                    tty.debug(msg.format(compiler_cls.name, v, str(e)))
 
         search_paths = list(llnl.util.lang.dedupe(search_paths))
         return fs.search_paths_for_executables(*search_paths)

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -92,12 +92,18 @@ class CrayFrontend(LinuxDistro):
             msg = "[CRAY FE] Detected FE compiler [name={0}, versions={1}]"
             tty.debug(msg.format(compiler_module, versions))
             for v in versions:
-                current_module = compiler_module + '/' + v
-                with unload_programming_environment():
-                    load_module(prg_env)
-                    load_module(current_module)
-                    search_paths += fs.search_paths_for_executables(
-                        *get_path('PATH')
-                    )
+                try:
+                    current_module = compiler_module + '/' + v
+                    with unload_programming_environment():
+                        load_module(prg_env)
+                        load_module(current_module)
+                        search_paths += fs.search_paths_for_executables(
+                            *get_path('PATH')
+                        )
+                except Exception as e:
+                    msg = ("[CRAY FE] An unexpected error occurred while "
+                           "detecting FE compiler [compiler={0}, "
+                           " version={1}, error={2}]")
+                    tty.warn(msg.format(compiler_cls.name, v, str(e)))
 
         return llnl.util.lang.dedupe(search_paths)

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -13,7 +13,7 @@ import llnl.util.tty as tty
 
 from spack.operating_systems.linux_distro import LinuxDistro
 from spack.util.environment import get_path
-from spack.util.module_cmd import module, load_module
+from spack.util.module_cmd import module
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -22,6 +22,7 @@ import spack.compilers.xl_r
 from spack.operating_systems.cray_frontend import CrayFrontend
 import spack.util.module_cmd
 
+
 @pytest.mark.parametrize('version_str,expected_version', [
     ('Arm C/C++/Fortran Compiler version 19.0 (build number 73) (based on LLVM 7.0.2)\n' # NOQA
      'Target: aarch64--linux-gnu\n'

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test detection of compiler version"""
 import pytest
+import os
+
+import llnl.util.filesystem as fs
 
 import spack.compilers.arm
 import spack.compilers.cce
@@ -16,6 +19,8 @@ import spack.compilers.pgi
 import spack.compilers.xl
 import spack.compilers.xl_r
 
+from spack.operating_systems.cray_frontend import CrayFrontend
+import spack.util.module_cmd
 
 @pytest.mark.parametrize('version_str,expected_version', [
     ('Arm C/C++/Fortran Compiler version 19.0 (build number 73) (based on LLVM 7.0.2)\n' # NOQA
@@ -189,3 +194,41 @@ def test_xl_version_detection(version_str, expected_version):
 
     version = spack.compilers.xl_r.XlR.extract_version_from_output(version_str)
     assert version == expected_version
+
+
+@pytest.mark.parametrize('compiler,version', [
+    ('gcc', '8.1.0'),
+    ('gcc', '1.0.0-foo'),
+    ('pgi', '19.1'),
+    ('pgi', '19.1a'),
+    ('intel', '9.0.0'),
+    ('intel', '0.0.0-foobar')
+])
+def test_cray_frontend_compiler_detection(
+        compiler, version, tmpdir, monkeypatch, working_env
+):
+    """Test that the Cray frontend properly finds compilers form modules"""
+    # setup the fake compiler directory
+    compiler_dir = tmpdir.join(compiler)
+    compiler_exe = compiler_dir.join('cc').ensure()
+    fs.set_executable(str(compiler_exe))
+
+    # mock modules
+    def _module(cmd, *args):
+        module_name = '%s/%s' % (compiler, version)
+        module_contents = 'prepend-path PATH %s' % compiler_dir
+        if cmd == 'avail':
+            return module_name if compiler in args[0] else ''
+        if cmd == 'show':
+            return module_contents if module_name in args else ''
+    monkeypatch.setattr(spack.operating_systems.cray_frontend, 'module',
+                        _module)
+
+    # remove PATH variable
+    os.environ.pop('PATH', None)
+
+    # get a CrayFrontend object
+    cray_fe_os = CrayFrontend()
+
+    paths = cray_fe_os.compiler_search_paths
+    assert paths == [str(compiler_dir)]


### PR DESCRIPTION
fixes #12665

This PR ensures that more front-end compilers are detected automatically on Cray. It does so by iterating on compilers supported on Cray machines, loading their PE and module and checking the PATH. For instance, before this PR we had on Piz Daint:
```console
> time spack compiler find
==> Added 19 new compilers to /users/culpo/.spack/compilers.yaml
    pgi@20.1.0  pgi@19.5.0  intel@19.0.1.144  intel@18.0.1.163  gcc@8.3.0  gcc@8.1.0  gcc@7.3.0  cce@9.0.2-classic  cce@9.0.1-classic  cce@8.7.9
    pgi@19.7.0  pgi@19.4.0  intel@18.0.2.199  intel@17.0.4.196  gcc@8.2.0  gcc@7.4.1  gcc@6.1.0  cce@9.0.2          cce@9.0.1
==> Compilers are defined in the following files:
    /users/culpo/.spack/compilers.yaml

real	0m1,098s
user	0m0,915s
sys	0m0,344s
```
while after
```console
> time spack  compiler find
==> Added 32 new compilers to /users/culpo/.spack/compilers.yaml
    pgi@20.1.0  pgi@19.5.0  intel@19.0.1.144  intel@18.0.1.163  gcc@8.3.0  gcc@8.1.0  gcc@7.3.0          cce@9.0.2
    pgi@20.1    pgi@19.5    intel@19.0.1.144  intel@18.0.1      gcc@8.3.0  gcc@8.1.0  gcc@6.1.0          cce@9.0.1-classic
    pgi@19.7.0  pgi@19.4.0  intel@18.0.2.199  intel@17.0.4.196  gcc@8.2.0  gcc@7.4.1  gcc@6.1.0          cce@9.0.1
    pgi@19.7    pgi@19.4    intel@18.0.2      intel@17.0.4      gcc@8.2.0  gcc@7.3.0  cce@9.0.2-classic  cce@8.7.9
==> Compilers are defined in the following files:
    /users/culpo/.spack/compilers.yaml

real	0m7,187s
user	0m6,669s
sys	0m2,419s
```

A few caveats:
- `spack compiler find` is much slower on Cray (~20x~ 7x in this example) However this command needs to be executed a single time, so it might be acceptable
- ~`cce` compilers ARE NOT detected on the front-end to avoid spurious `sles15` entries with `cc` etc. recorded as a compiler~