### PR TITLE
Fixes an error for package libnetworkit 7.0

### DIFF
--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -31,7 +31,7 @@ class Libnetworkit(CMakePackage):
     depends_on('libtlx')
     depends_on('py-sphinx', when='+doc', type='build')
 
-    patch('0001-Name-agnostic-import-of-tlx-library.patch', when='@6.1')
+    patch('0001-Name-agnostic-import-of-tlx-library.patch', when='@6.1:')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
The patch fixing the install-paths for external dependency is also needed by version 7.0. WIthout it the installation via `spack install libnetworkit@7.0` fails.