### PR TITLE
py-tensorflow and in-tree ROCm

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/tensorflow_rocm.patched
+++ b/var/spack/repos/builtin/packages/py-tensorflow/tensorflow_rocm.patched
@@ -1,0 +1,222 @@
+diff -ru /tmp/aweits/spack-stage/spack-stage-py-tensorflow-2.2.0-n5en5zlv7tgrltqqzghmk3r6wssdy5ye/spack-src/tensorflow/core/kernels/conv_2d_gpu.h /dev/shm/spack-src-tensorflow-patched/tensorflow/core/kernels/conv_2d_gpu.h
+--- a/tensorflow/core/kernels/conv_2d_gpu.h	2020-05-05 17:58:49.000000000 -0400
++++ b/tensorflow/core/kernels/conv_2d_gpu.h	2020-06-24 15:19:40.404740728 -0400
+@@ -236,7 +236,7 @@
+   // One extra line in the inner dimension to avoid share memory bank conflict.
+   // This is to mimic the following, but no constructor of T can be invoked.
+   //     __shared__ T shared_memory_tile[TileSizeI][TileSizeJ + 1];
+-#if GOOGLE_CUDA
++#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
+   __shared__ __align__(
+       alignof(T)) char shared_mem_raw[TileSizeI * (TileSizeJ + 1) * sizeof(T)];
+   typedef T(*SharedMemoryTile)[TileSizeJ + 1];
+
+diff -ru /tmp/aweits/spack-stage/spack-stage-py-tensorflow-2.2.0-n5en5zlv7tgrltqqzghmk3r6wssdy5ye/spack-src/tensorflow/core/lib/bfloat16/bfloat16.h /dev/shm/spack-src-tensorflow-patched/tensorflow/core/lib/bfloat16/bfloat16.h
+--- a/tensorflow/core/lib/bfloat16/bfloat16.h	2020-05-05 17:58:49.000000000 -0400
++++ b/tensorflow/core/lib/bfloat16/bfloat16.h	2020-06-24 15:19:40.368740613 -0400
+@@ -22,7 +22,7 @@
+ 
+ #include "tensorflow/core/platform/byte_order.h"
+ 
+-#ifdef __CUDACC__
++#if defined(__CUDACC__) || (defined(__HIPCC__) && defined(__HIP__))
+ // All functions callable from CUDA code must be qualified with __device__
+ #define B16_DEVICE_FUNC __host__ __device__
+ 
+diff -ru /tmp/aweits/spack-stage/spack-stage-py-tensorflow-2.2.0-n5en5zlv7tgrltqqzghmk3r6wssdy5ye/spack-src/tensorflow/core/util/gpu_launch_config.h /dev/shm/spack-src-tensorflow-patched/tensorflow/core/util/gpu_launch_config.h
+--- a/tensorflow/core/util/gpu_launch_config.h	2020-05-05 17:58:49.000000000 -0400
++++ b/tensorflow/core/util/gpu_launch_config.h	2020-06-24 15:19:40.322740467 -0400
+@@ -168,6 +168,13 @@
+       block_size_limit);
+   CHECK_EQ(err, cudaSuccess);
+ #elif TENSORFLOW_USE_ROCM
++#if TENSORFLOW_COMPILER_IS_HIP_CLANG
++  // ROCm 3.5 (hipclang) and above have the same interface as CUDA
++  // no need anymore for the unsigned int conversions
++  hipOccupancyMaxPotentialBlockSize(&block_count, &thread_per_block, func,
++                                    dynamic_shared_memory_size,
++                                    block_size_limit);
++#else
+   // Earlier versions of this HIP routine incorrectly returned void.
+   // TODO re-enable hipError_t error checking when HIP is fixed.
+   // ROCm interface uses unsigned int, convert after checking
+@@ -181,6 +188,7 @@
+   block_count = static_cast<int>(block_count_uint);
+   thread_per_block = static_cast<int>(thread_per_block_uint);
+ #endif
++#endif
+ 
+   block_count =
+       std::min(block_count, DivUp(work_element_count, thread_per_block));
+
+diff -ru /tmp/aweits/spack-stage/spack-stage-py-tensorflow-2.2.0-n5en5zlv7tgrltqqzghmk3r6wssdy5ye/spack-src/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl /dev/shm/spack-src-tensorflow-patched/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl	2020-05-05 17:58:49.000000000 -0400
++++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl	2020-06-24 15:19:40.112739798 -0400
+@@ -173,6 +173,8 @@
+   out = ' -o ' + out_file[0]
+ 
+   hipccopts = ' '
++  if HIPCC_IS_HIPCLANG:
++    hipccopts += ' --include=hip/hip_runtime.h -Wno-error=cuda-shared-init '
+   hipccopts += ' ' + hipcc_compiler_options
+   # Use -fno-gpu-rdc by default for early GPU kernel finalization
+   # This flag would trigger GPU kernels be generated at compile time, instead
+
+diff -ru /tmp/aweits/spack-stage/spack-stage-py-tensorflow-2.2.0-n5en5zlv7tgrltqqzghmk3r6wssdy5ye/spack-src/third_party/gpus/rocm_configure.bzl /dev/shm/spack-src-tensorflow-patched/third_party/gpus/rocm_configure.bzl
+--- a/third_party/gpus/rocm_configure.bzl	2020-05-05 17:58:49.000000000 -0400
++++ b/third_party/gpus/rocm_configure.bzl	2020-06-24 15:19:40.111739795 -0400
+@@ -271,8 +271,8 @@
+       A speculative real path of the rocm toolkit install directory.
+     """
+     rocm_toolkit_path = get_host_environ(repository_ctx, _ROCM_TOOLKIT_PATH, _DEFAULT_ROCM_TOOLKIT_PATH)
+-    if files_exist(repository_ctx, [rocm_toolkit_path], bash_bin) != [True]:
+-        auto_configure_fail("Cannot find rocm toolkit path.")
++#    if files_exist(repository_ctx, [rocm_toolkit_path], bash_bin) != [True]:
++#        auto_configure_fail("Cannot find rocm toolkit path.")
+     return realpath(repository_ctx, rocm_toolkit_path, bash_bin)
+ 
+ def _amdgpu_targets(repository_ctx):
+@@ -330,7 +330,7 @@
+             return "True"
+ 
+     # grep for "HIP_COMPILER=clang" in /opt/rocm/hip/lib/.hipInfo
+-    cmd = "grep HIP_COMPILER=clang %s/hip/lib/.hipInfo || true" % rocm_config.rocm_toolkit_path
++    cmd = "grep HIP_COMPILER=clang %s/lib/.hipInfo || true" % @SPACK_HIP_ROOT@
+     grep_result = execute(repository_ctx, [bash_bin, "-c", cmd], empty_stdout_fine = True)
+     result = grep_result.stdout.strip()
+     if result == "HIP_COMPILER=clang":
+@@ -436,13 +436,13 @@
+     libs_paths = [
+         (name, _rocm_lib_paths(repository_ctx, name, path))
+         for name, path in [
+-            ("hip_hcc", rocm_config.rocm_toolkit_path),
+-            ("rocblas", rocm_config.rocm_toolkit_path + "/rocblas"),
+-            ("rocfft", rocm_config.rocm_toolkit_path + "/rocfft"),
+-            ("hiprand", rocm_config.rocm_toolkit_path + "/hiprand"),
+-            ("MIOpen", rocm_config.rocm_toolkit_path + "/miopen"),
+-            ("rccl", rocm_config.rocm_toolkit_path + "/rccl"),
+-            ("hipsparse", rocm_config.rocm_toolkit_path + "/hipsparse"),
++            ("hip_hcc", @SPACK_HIP_ROOT@),
++            ("rocblas", @SPACK_ROCBLAS_ROOT@),
++            ("rocfft", @SPACK_ROCFFT_ROOT@),
++            ("hiprand", @SPACK_HIPRAND_ROOT@ + "/hiprand"),
++            ("MIOpen", @SPACK_MIOPEN_ROOT@),
++            ("rccl", @SPACK_RCCL_ROOT@),
++            ("hipsparse", @SPACK_HIPSPARSE_ROOT@),
+         ]
+     ]
+ 
+@@ -606,42 +606,72 @@
+     # rocm_toolkit_path
+     rocm_toolkit_path = rocm_config.rocm_toolkit_path
+     copy_rules = [
+-        make_copy_dir_rule(
+-            repository_ctx,
+-            name = "rocm-include",
+-            src_dir = rocm_toolkit_path + "/include",
+-            out_dir = "rocm/include",
+-        ),
++#        make_copy_dir_rule(
++#            repository_ctx,
++#            name = "rocm-include",
++#            src_dir = rocm_toolkit_path + "/include",
++#            out_dir = "rocm/include",
++#        ),
+         make_copy_dir_rule(
+             repository_ctx,
+             name = "rocfft-include",
+-            src_dir = rocm_toolkit_path + "/rocfft/include",
++            src_dir = @SPACK_ROCFFT_ROOT@ + "/include",
+             out_dir = "rocm/include/rocfft",
+         ),
+         make_copy_dir_rule(
+             repository_ctx,
+             name = "rocblas-include",
+-            src_dir = rocm_toolkit_path + "/rocblas/include",
+-            out_dir = "rocm/include/rocblas",
++            src_dir = @SPACK_ROCBLAS_ROOT@ + "/include",
++            out_dir = "rocm/include",
+         ),
+         make_copy_dir_rule(
+             repository_ctx,
+             name = "miopen-include",
+-            src_dir = rocm_toolkit_path + "/miopen/include",
+-            out_dir = "rocm/include/miopen",
++            src_dir = @SPACK_MIOPEN_ROOT@ + "/include",
++            out_dir = "rocm/include",
+         ),
+         make_copy_dir_rule(
+             repository_ctx,
+             name = "rccl-include",
+-            src_dir = rocm_toolkit_path + "/rccl/include",
++            src_dir = @SPACK_RCCL_ROOT@ + "/include",
+             out_dir = "rocm/include/rccl",
+         ),
+         make_copy_dir_rule(
+             repository_ctx,
+             name = "hipsparse-include",
+-            src_dir = rocm_toolkit_path + "/hipsparse/include",
++            src_dir = @SPACK_HIPSPARSE_ROOT@ + "/include",
+             out_dir = "rocm/include/hipsparse",
+         ),
++        make_copy_dir_rule(
++            repository_ctx,
++            name = "rocprim-include",
++            src_dir = @SPACK_ROCPRIM_ROOT@ + "/include/rocprim",
++            out_dir = "rocm/include/rocprim",
++        ),
++        make_copy_dir_rule(
++            repository_ctx,
++            name = "hipcub-include",
++            src_dir = @SPACK_HIPCUB_ROOT@ + "/include/hipcub",
++            out_dir = "rocm/include/hipcub",
++        ),
++        make_copy_dir_rule(
++            repository_ctx,
++            name = "hip-include",
++            src_dir = @SPACK_HIP_ROOT@ + "/include/hip",
++            out_dir = "rocm/include/hip",
++        ),
++        make_copy_dir_rule(
++            repository_ctx,
++            name = "hiprand-include",
++            src_dir = @SPACK_HIPRAND_ROOT@ + "/hiprand/include",
++            out_dir = "rocm/include/hiprand",
++        ),
++        make_copy_dir_rule(
++            repository_ctx,
++            name = "rocrand-include",
++            src_dir = @SPACK_HIPRAND_ROOT@ + "/rocrand/include",
++            out_dir = "rocm/include/rocrand",
++        ),
+     ]
+ 
+     rocm_libs = _find_libs(repository_ctx, rocm_config, bash_bin)
+@@ -681,11 +711,15 @@
+             "%{rccl_lib}": rocm_libs["rccl"].file_name,
+             "%{hipsparse_lib}": rocm_libs["hipsparse"].file_name,
+             "%{copy_rules}": "\n".join(copy_rules),
+-            "%{rocm_headers}": ('":rocm-include",\n' +
+-                                '":rocfft-include",\n' +
++            "%{rocm_headers}": ('":rocfft-include",\n' +
+                                 '":rocblas-include",\n' +
+                                 '":miopen-include",\n' +
+                                 '":rccl-include",\n' +
++                                '":rocprim-include",\n' +
++                                '":hipcub-include",\n' +
++                                '":hiprand-include",\n' +
++                                '":rocrand-include",\n' +
++                                '":hip-include",\n' +
+                                 '":hipsparse-include",'),
+         },
+     )
+@@ -753,7 +787,7 @@
+         tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_rocm"],
+         {
+             "%{cpu_compiler}": str(cc),
+-            "%{hipcc_path}": rocm_config.rocm_toolkit_path + "/bin/hipcc",
++            "%{hipcc_path}": @SPACK_HIP_ROOT@ + "/bin/hipcc",
+             "%{hipcc_env}": _hipcc_env(repository_ctx),
+             "%{hipcc_is_hipclang}": _hipcc_is_hipclang(repository_ctx, rocm_config, bash_bin),
+             "%{rocr_runtime_path}": rocm_config.rocm_toolkit_path + "/lib",
+Only in /dev/shm/spack-src-tensorflow-patched/tools: python_bin_path.sh

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmClangOcl(CMakePackage):
+    """OpenCL compilation with clang compiler."""
+
+    homepage = "https://github.com/RadeonOpenCompute/clang-ocl"
+    url = "https://github.com/RadeonOpenCompute/clang-ocl/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '38c95fbd0ac3d11d9bd224ad333b68b9620dde502b8a8a9f3d96ba642901e8bb')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -1,0 +1,14 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmCmake(CMakePackage):
+    """ROCM cmake modules provides cmake modules for common build
+    tasks needed for the ROCM software stack."""
+
+    homepage = "https://github.com/RadeonOpenCompute/rocm-cmake"
+    url = "https://github.com/RadeonOpenCompute/rocm-cmake/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '5fc09e168879823160f5fdf4fd1ace2702d36545bf733e8005ed4ca18c3e910f')

--- a/var/spack/repos/builtin/packages/rocm-compilersupport/package.py
+++ b/var/spack/repos/builtin/packages/rocm-compilersupport/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmCompilersupport(CMakePackage):
+    """The compiler support repository provides various Lightning
+    Compiler related services. It currently contains one library, the
+    Code Object Manager (Comgr) at lib/comgr."""
+
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport"
+    url = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/rocm-3.5.0.tar.gz"
+
+    root_cmakelists_dir = 'lib/comgr'
+
+    version('3.5.0', '25c963b46a82d76d55b2302e0e18aac8175362656a465549999ad13d07b689b9')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-device-libs')

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmDeviceLibs(CMakePackage):
+    """This repository contains the sources and CMake build system for
+    a set of AMD specific device-side language runtime libraries."""
+
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs"
+    url = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', 'dce3a4ba672c4a2da4c2260ee4dc96ff6dd51877f5e7e1993cb107372a35a378')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-rocr-runtime')

--- a/var/spack/repos/builtin/packages/rocm-hip-clang/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hip-clang/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmHipClang(CMakePackage):
+    """HIP-Clang: llvm and clang for ROCm"""
+
+    homepage = "https://github.com/RadeonOpenCompute/llvm-project"
+    url = "https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '4878fa85473b24d88edcc89938441edc85d2e8a785e567b7bd7ce274ecc2fd9c')
+    depends_on('gcc')
+
+    root_cmakelists_dir = "llvm"
+
+    def cmake_args(self):
+        spec = self.spec
+        cmake_args = [
+            "-DLLVM_ENABLE_PROJECTS=clang;lld",
+            "-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86",
+            "-DGCC_INSTALL_PREFIX={0}".format(spec["gcc"].prefix),
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-hip/hip-config.patch
+++ b/var/spack/repos/builtin/packages/rocm-hip/hip-config.patch
@@ -1,0 +1,45 @@
+--- a/hip-config.cmake.in.orig	2020-06-23 08:40:59.134949156 -0400
++++ b/hip-config.cmake.in	2020-06-23 08:41:26.194411702 -0400
+@@ -123,8 +123,8 @@
+   )
+   set_target_properties(hip::device PROPERTIES
+     INTERFACE_COMPILE_DEFINITIONS "__HIP_ROCclr__=1"
+-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/../include"
+-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/../include"
++    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
++    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+   )
+ else()
+   set_target_properties(hip::hip_hcc_static PROPERTIES
+@@ -136,8 +136,8 @@
+     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${HSA_HEADER}"
+   )
+   set_target_properties(hip::device PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/../include"
+-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/../include"
++    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
++    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+   )
+ endif()
+ 
+@@ -156,13 +156,13 @@
+     INTERFACE_LINK_LIBRARIES --hip-device-lib-path=${AMD_DEVICE_LIBS_PREFIX}/lib --hip-link
+   )
+ 
+-  set_property(TARGET hip::device APPEND PROPERTY
+-    INTERFACE_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
+-  )
+-
+-  set_property(TARGET hip::device APPEND PROPERTY
+-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
+-  )
++#  set_property(TARGET hip::device APPEND PROPERTY
++#    INTERFACE_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
++#  )
++
++#  set_property(TARGET hip::device APPEND PROPERTY
++#    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
++#  )
+ 
+   foreach(GPU_TARGET ${GPU_TARGETS})
+       set_property(TARGET hip::device APPEND PROPERTY

--- a/var/spack/repos/builtin/packages/rocm-hip/hipcc.patch
+++ b/var/spack/repos/builtin/packages/rocm-hip/hipcc.patch
@@ -1,0 +1,39 @@
+--- a/bin/hipcc.orig	2020-06-23 08:53:16.632568244 -0400
++++ b/bin/hipcc	2020-06-23 08:57:37.731394327 -0400
+@@ -8,6 +8,17 @@
+ use Cwd;
+ use Cwd 'abs_path';
+ 
++$ENV{'HIPCC_VERBOSE'}="3";
++$ENV{'HIP_CLANG_PATH'}=@HIP_CLANG_PREFIX_BIN@
++$ENV{'HIP_COMPILER'}="clang";
++$ENV{'HIP_INCLUDE_PATH'}=@SELF_PREFIX_INCLUDE@
++$ENV{'HIP_LIB_PATH'}=@SELF_PREFIX_LIB@
++$ENV{'HIP_PATH'}=@SELF_PREFIX@
++$ENV{'HIP_PLATFORM'}="hcc";
++$ENV{'HIP_ROCCLR_HOME'}=@ROCCLR_PREFIX@
++$ENV{'DEVICE_LIB_PATH'}=@DEVICE_LIBS_PREFIX@
++$ENV{'HSA_PATH'}=@RUNTIME_PREFIX@
++
+ # HIP compiler driver
+ # Will call NVCC or HCC (depending on target) and pass the appropriate include and library options for
+ # the target compiler and HIP infrastructure.
+@@ -83,6 +94,7 @@
+     $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";
+ }
+ $HIP_ROCCLR_HOME=$ENV{'HIP_ROCCLR_HOME'};
++$HIP_INCLUDE_PATH=$ENV{'HIP_INCLUDE_PATH'};
+ $HIP_LIB_PATH=$ENV{'HIP_LIB_PATH'};
+ $HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
+ $DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
+@@ -149,7 +161,9 @@
+     if (!defined $DEVICE_LIB_PATH and -e "$HIP_ROCCLR_HOME/lib/bitcode") {
+         $DEVICE_LIB_PATH = "$HIP_ROCCLR_HOME/lib/bitcode";
+     }
+-    $HIP_INCLUDE_PATH = "$HIP_ROCCLR_HOME/include";
++    if (!defined $HIP_INCLUDE_PATH) {
++	$HIP_INCLUDE_PATH = "$HIP_ROCCLR_HOME/include";
++    }
+     if (!defined $HIP_LIB_PATH) {
+         $HIP_LIB_PATH = "$HIP_ROCCLR_HOME/lib";
+     }

--- a/var/spack/repos/builtin/packages/rocm-hip/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hip/package.py
@@ -53,6 +53,7 @@ class RocmHip(CMakePackage):
                     'bin/hipcc')
 
     def cmake_args(self):
+        spec = self.spec
         cmake_args = [
             "-DHSA_PATH={0}".format(spec['rocm-roct-thunk-interface'].prefix),
             "-DHIP_CLANG_PATH={0}".format(spec['rocm-hip-clang'].prefix.bin),

--- a/var/spack/repos/builtin/packages/rocm-hip/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hip/package.py
@@ -1,0 +1,82 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.paths import spack_root
+import os
+
+
+class RocmHip(CMakePackage):
+    """HIP is a C++ Runtime API and Kernel Language that allows
+    developers to create portable applications for AMD and NVIDIA GPUs
+    from single source code."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/HIP"
+    url = "https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', 'ae8384362986b392288181bcfbe5e3a0ec91af4320c189bd83c844ed384161b3')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-rocclr')
+    depends_on('rocm-roct-thunk-interface')
+    depends_on('rocm-device-libs')
+    depends_on('rocm-compilersupport')
+    depends_on('rocm-rocr-runtime')
+    patch('hip-config.patch')
+    patch('hipcc.patch')
+
+    def patch(self):
+        filter_file(r'PROF_API_STR \"\$\{PROJECT_BINARY_DIR\}',
+                    'PROF_API_STR "${CMAKE_CURRENT_SOURCE_DIR}',
+                    'CMakeLists.txt')
+        filter_file(r'\@HIP_CLANG_PREFIX_BIN\@',
+                    '"{0}";'.format(self.spec['rocm-hip-clang'].prefix.bin),
+                    'bin/hipcc')
+        filter_file(r'\@ROCCLR_PREFIX\@',
+                    '"{0}";'.format(self.spec['rocm-rocclr'].prefix),
+                    'bin/hipcc')
+        filter_file(r'\@DEVICE_LIBS_PREFIX\@',
+                    '"{0}";'.format(self.spec['rocm-device-libs'].prefix.lib),
+                    'bin/hipcc')
+        filter_file(r'\@RUNTIME_PREFIX\@',
+                    '"{0}";'.format(self.spec['rocm-rocr-runtime'].prefix),
+                    'bin/hipcc')
+        filter_file(r'\@SELF_PREFIX_INCLUDE\@',
+                    '"{0}";'.format(self.prefix.include),
+                    'bin/hipcc')
+        filter_file(r'\@SELF_PREFIX_LIB\@',
+                    '"{0}";'.format(self.prefix.lib),
+                    'bin/hipcc')
+        filter_file(r'\@SELF_PREFIX\@',
+                    '"{0}";'.format(self.prefix),
+                    'bin/hipcc')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DHSA_PATH={0}".format(spec['rocm-roct-thunk-interface'].prefix),
+            "-DHIP_CLANG_PATH={0}".format(spec['rocm-hip-clang'].prefix.bin),
+            "-DDEVICE_LIB_PATH={0}".format(
+                spec['rocm-device-libs'].prefix.lib),
+            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
+            "-DHIP_COMPILER=clang",
+            "-DHIP_PLATFORM=rocclr",
+            "-DUSE_PROF_API=1",
+        ]
+        return cmake_args
+
+    @run_after('install')
+    def postinstall(self):
+        with working_dir(self.prefix.bin):
+            os.rename('hipcc', 'hipcc.orig')
+            install('{0}/lib/spack/env/cc'.format(spack_root), 'hipcc')
+            filter_file(r'FCC',
+                        'FCC|hipcc',
+                        'hipcc')
+            filter_file(r'command\=\"\$SPACK_CXX\"',
+                        'command="{0}/hipcc.orig"'.format(self.prefix.bin),
+                        'hipcc')
+            filter_file(r'die \"Spack compiler must be run.*',
+                        'command="%s/hipcc.orig"\n'
+                        '\texec "${command}" "$@"' % self.prefix.bin,
+                        'hipcc')

--- a/var/spack/repos/builtin/packages/rocm-hipcub/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hipcub/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmHipcub(CMakePackage):
+    """hipCUB is a thin wrapper library on top of rocPRIM or CUB. It
+    enables developers to port project using CUB library to the HIP
+    layer and to run them on AMD hardware. In ROCm environment hipCUB
+    uses rocPRIM library as the backend, however, on CUDA platforms it
+    uses CUB instead."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipCUB"
+    url = "https://github.com/ROCmSoftwarePlatform/hipCUB/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '1eb2cb5f6e90ed1b7a9ac6dd86f09ec2ea27bceb5a92eeffa9c2123950c53b9d')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+    depends_on('rocm-rocprim')
+
+    def patch(self):
+        filter_file(r'find_package\(HIP 1\.5\.18263.*',
+                    '',
+                    'cmake/VerifyCompiler.cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+            "-DHIP_PLATFORM=hcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-hiprand/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hiprand/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmHiprand(CMakePackage):
+    """The rocRAND project provides functions that generate
+    pseudo-random and quasi-random numbers. The rocRAND library is
+    implemented in the HIP programming language and optimised for
+    AMD's latest discrete GPUs. It is designed to run on top of AMD's
+    Radeon Open Compute ROCm runtime, but it also works on CUDA
+    enabled GPUs."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocRAND"
+    url = "https://github.com/ROCmSoftwarePlatform/rocRAND/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '592865a45e7ef55ad9d7eddc8082df69eacfd2c1f3e9c57810eb336b15cd5732')
+    depends_on('rocm-hip')
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix)
+        headers.directories = [self.prefix.hiprand.include,
+                               self.prefix.rocrand.include]
+        return headers
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocm-hipsparse/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmHipsparse(CMakePackage):
+    """hipSPARSE is a SPARSE marshalling library, with multiple
+    supported backends. It sits between the application and a 'worker'
+    SPARSE library, marshalling inputs into the backend library and
+    marshalling results back to the application. hipSPARSE exports an
+    interface that does not require the client to change, regardless
+    of the chosen backend. Currently, hipSPARSE supports rocSPARSE and
+    cuSPARSE as backends."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipSPARSE"
+    url = "https://github.com/ROCmSoftwarePlatform/hipSPARSE/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', 'fa16b2a307a5d9716066c2876febcbc1cef855bf0c96d235d2d8f2206a0fb69d')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+    depends_on('rocm-rocsparse')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-miopen/package.py
+++ b/var/spack/repos/builtin/packages/rocm-miopen/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmMiopen(CMakePackage):
+    """AMD's library for high performance machine learning primitives."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/MIOpen"
+    url = "https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', 'aa362e69c4dce7f5751f0ee04c745735ea5454c8101050e9b92cc60fa3c0fb82')
+    depends_on('rocm-hip')
+    depends_on('rocm-rocblas')
+    depends_on('rocm-cmake')
+    depends_on('rocm-clang-ocl')
+    depends_on('sqlite')
+    depends_on('boost@1.58:+pic')
+    depends_on('half')
+    depends_on('bzip2')
+
+    def patch(self):
+        filter_file(r'debug \$\{Boost_FILESYSTEM_LIBRARY_DEBUG\}',
+                    '',
+                    'src/CMakeLists.txt')
+        filter_file(r'debug \$\{Boost_SYSTEM_LIBRARY_DEBUG\}',
+                    '',
+                    'src/CMakeLists.txt')
+        filter_file(r'debug \$\{Boost_FILESYSTEM_LIBRARY_DEBUG\}',
+                    '',
+                    'speedtests/CMakeLists.txt')
+        filter_file(r'debug \$\{Boost_SYSTEM_LIBRARY_DEBUG\}',
+                    '',
+                    'speedtests/CMakeLists.txt')
+        filter_file(r'\$\{CLANG_TIDY_EXE\}',
+                    '/bin/true',
+                    'cmake/ClangTidy.cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+            "-DCLANG_TIDY_COMMAND=/bin/true",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rccl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rccl/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRccl(CMakePackage):
+    """RCCL (pronounced "Rickle") is a stand-alone library of standard
+    collective communication routines for GPUs, implementing
+    all-reduce, all-gather, reduce, broadcast, reduce-scatter, gather,
+    scatter, and all-to-all. There is also initial support for direct
+    GPU-to-GPU send and receive operations. It has been optimized to
+    achieve high bandwidth on platforms using PCIe, xGMI as well as
+    networking using InfiniBand Verbs or TCP/IP sockets. RCCL supports
+    an arbitrary number of GPUs installed in a single node or multiple
+    nodes, and can be used in either single- or multi-process (e.g.,
+    MPI) applications."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rccl"
+    url = "https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '290b57a66758dce47d0bfff3f5f8317df24764e858af67f60ddcdcadb9337253')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocblas/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRocblas(CMakePackage):
+    """rocBLAS is AMD's library for BLAS on ROCm. It is implemented in
+    the HIP programming language and optimized for AMD's GPUs."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocBLAS"
+    url = "https://github.com/ROCmSoftwarePlatform/rocBLAS/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '3e372c7c0504c0f18b5e69989083e68a45131e675912082961a736cb3b1222fb')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+    depends_on('python@3:', type='build')
+    depends_on('py-pyyaml', type='build')
+    depends_on('py-msgpack', type='build')
+
+    resource(name='ROCm-Tensile',
+             url='https://github.com/ROCmSoftwarePlatform/Tensile/archive/rocm-3.5.0.tar.gz',
+             sha256='1afd2e28065849dc418efdc79fc3216208963cabc0c4efb870440b1c051a0f20',
+             destination='spack-resource-tensile')
+
+    def patch(self):
+        filter_file(r'HCC=.*',
+                    'HCC=hipcc',
+                    'header_compilation_tests.sh')
+        filter_file(r'\-hc ',
+                    '',
+                    'header_compilation_tests.sh')
+        file_to_patch = ('spack-resource-tensile/Tensile-rocm-3.5.0/'
+                         'Tensile/Source/lib/include/Tensile/llvm/YAML.hpp')
+        filter_file(r'Impl::inputOne\(io, key, \*value\);',
+                    'Impl::inputOne(io, key.str(), *value);',
+                    file_to_patch)
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+            "-DTensile_TEST_LOCAL_PATH={0}".format(
+                join_path(self.stage.source_path,
+                          'spack-resource-tensile/Tensile-rocm-3.5.0')),
+            "-DTensile_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocclr/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+
+class RocmRocclr(CMakePackage):
+    """ROCclr is a virtual device interface that compute runtimes
+    interact with to different backends such as ROCr or PAL This
+    abstraction allows runtimes to work on Windows as well as on Linux
+    without much effort."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCclr"
+    url = "https://github.com/ROCm-Developer-Tools/ROCclr/archive/roc-3.5.0.tar.gz"
+
+    version('3.5.0', '87c1ee9f02b8aa487b628c543f058198767c474cec3d21700596a73c028959e1')
+    depends_on('rocm-compilersupport')
+    resource(name='ROCm-OpenCL-Runtime',
+             url='https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.5.0.tar.gz',
+             sha256='511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0',
+             destination='spack-resource-opencl')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DOPENCL_DIR={0}".format(
+                'spack-resource-opencl/ROCm-OpenCL-Runtime-roc-3.5.0'),
+        ]
+        return cmake_args
+
+    @run_after('install')
+    def install_cmake_file(self):
+        with working_dir(self.build_directory):
+            libfile = "libamdrocclr_static.a"
+            libpath = os.path.join(self.prefix.lib, libfile)
+            filter_file(r'IMPORTED_LOCATION_RELWITHDEBINFO .+',
+                        'IMPORTED_LOCATION_RELWITHDEBINFO "{0}"'.format(
+                            libpath),
+                        "amdrocclr_staticTargets.cmake")
+            install("amdrocclr_staticTargets.cmake",
+                    self.prefix.lib)

--- a/var/spack/repos/builtin/packages/rocm-rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocfft/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRocfft(CMakePackage):
+    """rocFFT is a software library for computing Fast Fourier
+    Transforms (FFT) written in HIP. It is part of AMD's software
+    ecosystem based on ROCm. In addition to AMD GPU devices, the
+    library can also be compiled with the CUDA compiler using HIP
+    tools for running on Nvidia GPU devices."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocFFT"
+    url = "https://github.com/ROCmSoftwarePlatform/rocFFT/archive/3.5.0.tar.gz"
+
+    version('3.5.0', '8e81701974c4c3b61b706aa805a50c7c7925d89e31f924b722e9f777bd2ae6d0')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocprim/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRocprim(CMakePackage):
+    """The rocPRIM is a header-only library providing HIP parallel
+    primitives for developing performant GPU-accelerated code on AMD
+    ROCm platform."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocPRIM"
+    url = "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.1', '12b2220303562976dd2557506728e3b250167215e500cfd446fe7ebe0022f9f2')
+    version('3.5.0', '29302dbeb27ae88632aa1be43a721f03e7e597c329602f9ca9c9c530c1def40d')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+
+    def patch(self):
+        filter_file(r'find_package\(HIP 1\.5\.18263.*',
+                    '',
+                    'cmake/VerifyCompiler.cmake')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+            "-DHIP_PLATFORM=clang",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rocr-runtime/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocr-runtime/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRocrRuntime(CMakePackage):
+    """This repository includes the user-mode API interfaces and
+    libraries necessary for host applications to launch compute
+    kernels to available HSA ROCm kernel agents. Reference source code
+    for the core runtime is also available."""
+
+    homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime"
+    url = "https://github.com/RadeonOpenCompute/ROCR-Runtime/archive/rocm-3.5.0.tar.gz"
+
+    root_cmakelists_dir = "src"
+
+    version('3.5.0', '52c12eec3e3404c0749c70f156229786ee0c3e6d3c979aed9bbaea500fa1f3b8')
+    depends_on('rocm-roct-thunk-interface')
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix)
+        headers.directories = [self.prefix.include]
+        return headers
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocm-rocsparse/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRocsparse(CMakePackage):
+    """rocSPARSE exposes a common interface that provides Basic Linear
+    Algebra Subroutines for sparse computation implemented on top of
+    AMD's Radeon Open Compute ROCm runtime and toolchains. rocSPARSE
+    is created using the HIP programming language and optimized for
+    AMD's latest discrete GPUs."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocSPARSE"
+    url = "https://github.com/ROCmSoftwarePlatform/rocSPARSE/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', '9ca6bae7da78abbb47143c3d77ff4a8cd7d63979875fc7ebc46b400769fd9cb5')
+    depends_on('rocm-hip-clang')
+    depends_on('rocm-hip')
+    depends_on('rocm-cmake')
+    depends_on('rocm-rocprim')
+
+    def cmake_args(self):
+        cmake_args = [
+            "-DCMAKE_CXX_COMPILER=hipcc",
+        ]
+        return cmake_args

--- a/var/spack/repos/builtin/packages/rocm-roct-thunk-interface/package.py
+++ b/var/spack/repos/builtin/packages/rocm-roct-thunk-interface/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class RocmRoctThunkInterface(CMakePackage):
+    """This repository includes the user-mode API interfaces used to
+    interact with the ROCk driver. Currently supported agents include
+    only the AMD/ATI Fiji family of discrete GPUs."""
+
+    homepage = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface"
+    url = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-3.5.0.tar.gz"
+
+    version('3.5.0', 'd9f458c16cb62c3c611328fd2f2ba3615da81e45f3b526e45ff43ab4a67ee4aa')
+
+    @run_after("install")
+    def post_install(self):
+        with working_dir(self.build_directory):
+            make('build-dev')
+            make('install-dev')


### PR DESCRIPTION
After a few conversations with @parallelo in slack, this is what is
required to build tensorflow with ROCm in spack. After this work
started, I discovered the existence of
https://github.com/RadeonOpenCompute/rocm-spack. At some point these
two efforts should be combined upstream? Also, I do not currently
have hardware to validate/test this on.
@gkathirv @srekolam @streamhsa @radhaksri @adamjstewart 
