### PR TITLE
half: fix __F16C__ include of immintrin.h

### DIFF
--- a/var/spack/repos/builtin/packages/half/f16fix.patch
+++ b/var/spack/repos/builtin/packages/half/f16fix.patch
@@ -1,0 +1,23 @@
+--- a/include/half.hpp.orig	2020-06-26 07:46:50.861595808 -0400
++++ b/include/half.hpp	2020-06-26 07:47:31.353286730 -0400
+@@ -266,9 +266,6 @@
+ #if HALF_ENABLE_CPP11_HASH
+ 	#include <functional>
+ #endif
+-#if HALF_ENABLE_F16C_INTRINSICS
+-	#include <immintrin.h>
+-#endif
+ 
+ 
+ #ifndef HALF_ENABLE_F16C_INTRINSICS
+@@ -281,6 +278,10 @@
+ 	#define HALF_ENABLE_F16C_INTRINSICS __F16C__
+ #endif
+ 
++#if HALF_ENABLE_F16C_INTRINSICS
++	#include <immintrin.h>
++#endif
++
+ #ifdef HALF_DOXYGEN_ONLY
+ /// Type for internal floating-point computations.
+ /// This can be predefined to a built-in floating-point type (`float`, `double` or `long double`) to override the internal 

--- a/var/spack/repos/builtin/packages/half/package.py
+++ b/var/spack/repos/builtin/packages/half/package.py
@@ -23,6 +23,8 @@ class Half(Package):
 
     version('2.1.0', sha256='ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25')
 
+    patch('f16fix.patch')
+
     def install(self, spec, prefix):
         mkdirp(prefix.include)
         install_tree('include', prefix.include)


### PR DESCRIPTION
Small fix so that immintrin.h gets included properly when the
compiler sets __F16C__. Upstream has been notified. @bvanessen
