### PR TITLE
allow `spack ci generate` to accept `--output-file <file>` where file has no preceding path

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -38,7 +38,7 @@ def setup_parser(subparser):
     generate = subparsers.add_parser('generate', help=ci_generate.__doc__)
     generate.add_argument(
         '--output-file', default=None,
-        help="Absolute path to file where generated jobs file should be " +
+        help="Path to file where generated jobs file should be " +
              "written.  The default is .gitlab-ci.yml in the root of the " +
              "repository.")
     generate.add_argument(
@@ -88,10 +88,10 @@ def ci_generate(args):
     use_dependencies = args.dependencies
 
     if not output_file:
-        gen_ci_dir = os.getcwd()
-        output_file = os.path.join(gen_ci_dir, '.gitlab-ci.yml')
+        output_file = os.path.abspath(".gitlab-ci.yml")
     else:
-        gen_ci_dir = os.path.dirname(output_file)
+        output_file_path = os.path.abspath(output_file)
+        gen_ci_dir = os.path.dirname(output_file_path)
         if not os.path.exists(gen_ci_dir):
             os.makedirs(gen_ci_dir)
 


### PR DESCRIPTION
This PR makes it so `spack ci generate` allows `--output-file <file>` to accept <file> wo/ a preceding path.

This PR makes it possible to do this:
```
$> spack ci generate --output-file pipeline.yml
```

Where right now, using `spack@develop` (commit 1602b7a56192c23fb7fc110a1c8a17ec0837bdd3), this is what happens if you were to try it:

```
$> cat spack.yaml
spack:
  view: false
  specs:
  - python
  gitlab-ci:
    mappings:
      - match: ['target=x86_64']
        runner-attributes:
          image: ecpe4s/ubuntu18.04-spack:0.14.2
          tags:
          - x86_64

$> ls
spack.yaml

$> spack -d ci generate pipeline.yml
==> [2020-06-26-08:43:09.975585, 67678] Imported gpg from built-in commands
==> [2020-06-26-08:43:09.979875, 67678] Imported gpg from built-in commands
==> [2020-06-26-08:43:09.981589, 67678] Imported compiler from built-in commands
==> [2020-06-26-08:43:09.984692, 67678] Imported compiler from built-in commands
==> [2020-06-26-08:43:09.984958, 67678] Imported ci from built-in commands
==> [2020-06-26-08:43:09.986329, 67678] Imported ci from built-in commands
==> [2020-06-26-08:43:09.987350, 67678] Reading config file /Users/walker/test-env/spack.yaml
Traceback (most recent call last):
  File "/Users/walker/spack/bin/spack", line 64, in <module>
    sys.exit(spack.main.main())
  File "/Users/walker/spack/lib/spack/spack/main.py", line 761, in main
    return _invoke_command(command, parser, args, unknown)
  File "/Users/walker/spack/lib/spack/spack/main.py", line 489, in _invoke_command
    return_val = command(parser, args)
  File "/Users/walker/spack/lib/spack/spack/cmd/ci.py", line 394, in ci
    args.func(args)
  File "/Users/walker/spack/lib/spack/spack/cmd/ci.py", line 96, in ci_generate
    os.makedirs(gen_ci_dir)
  File "/Users/walker/miniconda3/lib/python3.7/os.py", line 223, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''

$> spack ci generate --output-file ./pipeline.yml
... OK

$> ls
spack.yaml pipeline.yml
```

@scottwittenburg 