### PR TITLE
libffi: prevent version 3.3 from adding contradictory tuning flags

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -23,3 +23,11 @@ class Libffi(AutotoolsPackage, SourcewarePackage):
     def headers(self):
         # The headers are probably in self.prefix.lib but we search everywhere
         return find_headers('ffi', self.prefix, recursive=True)
+
+    def configure_args(self):
+        args = []
+        if self.spec.version >= Version('3.3'):
+            # Spack adds its own target flags, so tell libffi not to
+            # second-guess us
+            args.append('--without-gcc-arch')
+        return args


### PR DESCRIPTION
Newer versions of libffi try to use march/mtune based on the compiling CPU, which is not the desired behavior. Disable CPU autodetection to allow spack's compiler wrapper to set tuning flags.

Fixes #17187.