### PR TITLE
nfs-utils: fix compile error on debian

### DIFF
--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -18,6 +18,7 @@ class NfsUtils(AutotoolsPackage):
     version('2.4.1', sha256='c0dda96318af554881f4eb1590bfe91f1aba2fba59ed2ac3ba099f80fdf838e9')
     version('2.3.4', sha256='36e70b0a583751ead0034ebe5d8826caf2dcc7ee7c0beefe94d6ee5a3b0b2484')
 
+    depends_on('pkgconfig', type='build')
     depends_on('libtirpc')
     depends_on('libevent')
     depends_on('libdmx')
@@ -30,11 +31,5 @@ class NfsUtils(AutotoolsPackage):
         env.append_flags('LDFLAGS', '-lintl')
 
     def configure_args(self):
-        config_args = [
-            '--disable-gss',
-            '--with-rpcgen=internal',
-            '--with-tirpcinclude={0}'.format(
-                self.spec['libtirpc'].prefix.include.tirpc
-            )
-        ]
-        return config_args
+        args = ['--disable-gss', '--with-rpcgen=internal']
+        return args

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -30,5 +30,11 @@ class NfsUtils(AutotoolsPackage):
         env.append_flags('LDFLAGS', '-lintl')
 
     def configure_args(self):
-        args = ['--disable-gss', '--with-rpcgen=internal']
-        return args
+        config_args = [
+            '--disable-gss',
+            '--with-rpcgen=internal',
+            '--with-tirpcinclude={0}'.format(
+                self.spec['libtirpc'].prefix.include.tirpc
+            )
+        ]
+        return config_args


### PR DESCRIPTION
There's an error when compiling `nfs-utils` on debian system:
```
configure: error: libtirpc not found.
==> Error: ProcessError: Command exited with status 1:
    '/tmp/root/spack-stage/spack-stage-nfs-utils-2.4.2-eavcm4b3tfs6k3aziuyigbrcc7or2njj/spack-src/configure' '--prefix=/home/spack-develop/opt/spack/linux-debian10-aarch64/gcc-8.3.0/nfs-utils-2.4.2-eavcm4b3tfs6k3aziuyigbrcc7or2njj' '--disable-gss' '--with-rpcgen=internal'

1 error found in build log:
     45    checking for pkg-config... no
     46    checking for TIRPC... no
     47    checking for clnt_tli_create in -ltirpc... yes
     48    checking /usr/include/tirpc/netconfig.h usability... no
     49    checking /usr/include/tirpc/netconfig.h presence... no
     50    checking for /usr/include/tirpc/netconfig.h... no
  >> 51    configure: error: libtirpc not found.
```

looks `configure` on debian using a absolute include path for libtirpc.