### PR TITLE
py-mpi4py: Implement headers Property

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -30,3 +30,8 @@ class PyMpi4py(PythonPackage):
 
     def build_args(self, spec, prefix):
         return ['--mpicc=%s -shared' % spec['mpi'].mpicc]
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix.lib)
+        return headers


### PR DESCRIPTION
py-mpi4py installs its header files at a difficult-to-predict location:

    $prefix/lib/python-x.y/site-packages/mpi4py/include

With the new `headers` properties, dependent packages have now an easy
way to obtain this location:

    spec['py-mpi4py'].headers.directories[0]