### PR TITLE
cray compilers: fix bug with verifying cray compilers

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -299,7 +299,7 @@ class Compiler(object):
         """
         def accessible_exe(exe):
             # compilers may contain executable names (on Cray or user edited)
-            if not os.path.abspath(exe):
+            if not os.path.isabs(exe):
                 exe = spack.util.executable.which_string(exe)
                 if not exe:
                     return False

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -298,11 +298,15 @@ class Compiler(object):
         compiler are not accessible.
         """
         def accessible_exe(exe):
-            # Cray compilers may not have absolute paths
-            exe = spack.util.executable.which_string(exe)
-            return exe and os.path.isfile(exe) and os.access(exe, os.X_OK)
+            # compilers may contain executable names (on Cray or user edited)
+            if not os.path.abspath(exe):
+                exe = spack.util.executable.which_string(exe)
+                if not exe:
+                    return False
+            return os.path.isfile(exe) and os.access(exe, os.X_OK)
 
-        # setup environment before verifying relative paths
+        # setup environment before verifying in case we have executable names
+        # instead of absolute paths
         with self._compiler_environment():
             missing = [cmp for cmp in (self.cc, self.cxx, self.f77, self.fc)
                        if cmp and not accessible_exe(cmp)]

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -297,11 +297,17 @@ class Compiler(object):
         Raises a CompilerAccessError if any of the non-null paths for the
         compiler are not accessible.
         """
-        missing = [cmp for cmp in (self.cc, self.cxx, self.f77, self.fc)
-                   if cmp and not (os.path.isfile(cmp) and
-                                   os.access(cmp, os.X_OK))]
-        if missing:
-            raise CompilerAccessError(self, missing)
+        def accessible_exe(exe):
+            # Cray compilers may not have absolute paths
+            exe = spack.util.executable.which_string(exe)
+            return exe and os.path.isfile(exe) and os.access(exe, os.X_OK)
+
+        # setup environment before verifying relative paths
+        with self._compiler_environment():
+            missing = [cmp for cmp in (self.cc, self.cxx, self.f77, self.fc)
+                       if cmp and not accessible_exe(cmp)]
+            if missing:
+                raise CompilerAccessError(self, missing)
 
     @property
     def version(self):


### PR DESCRIPTION
Fixes #17301 

Compiler verification now accounts for the fact that cray backend compilers use relative paths to the cray compiler wrappers.