### PR TITLE
hbase: refine url , java and version

### DIFF
--- a/var/spack/repos/builtin/packages/hbase/package.py
+++ b/var/spack/repos/builtin/packages/hbase/package.py
@@ -7,21 +7,24 @@ from spack import *
 
 
 class Hbase(Package):
-    """
-    Apache HBase is an open-source, distributed, versioned, column-oriented
+    """Apache HBase is an open-source, distributed, versioned, column-oriented
     store modeled after Google' Bigtable: A Distributed Storage System for
     Structured Data by Chang et al. Just as Bigtable leverages the distributed
     data storage provided by the Google File System, HBase provides
-    Bigtable-like capabilities on top of Apache Hadoop.
-    """
+    Bigtable-like capabilities on top of Apache Hadoop."""
 
-    homepage = "https://github.com/apache/hbase"
-    url      = "https://github.com/apache/hbase/archive/rel/2.2.2.tar.gz"
+    homepage = "https://archive.apache.org/"
+    url      = "http://archive.apache.org/dist/hbase/2.2.4/hbase-2.2.4-bin.tar.gz"
+    list_url = "http://archive.apache.org/dist/hbase"
+    list_depth = 1
 
-    version('2.2.2',    sha256='e9a58946e9adff1cac23a0b261ecf32da32f8d2ced0706af1d04e8a67d582926')
-    version('2.1.8',    sha256='121cea4c554879c8401f676c8eb49e39bd35d41c358e919379ad4a318844c8de')
+    version('2.2.5',  sha256='25d08f8f038d9de5beb43dfb0392e8a8b34eae7e0f2670d6c2c172abc3855194')
+    version('2.2.4',  sha256='ec91b628352931e22a091a206be93061b6bf5364044a28fb9e82f0023aca3ca4')
+    version('2.2.3',  sha256='ea8fa72aa6220e038e30bd7c439d181b10bd7225383f7f2d224ebb5f5397310a')
+    version('2.2.2',  sha256='97dcca3a031925a379a0ee6bbfb6007533fb4fdb982c23345e5fc04d6c52bebc')
+    version('2.1.8',  sha256='d8296e8405b1c39c73f0dd03fc6b4d2af754035724168fd56e8f2a0ff175ad90')
 
-    depends_on('java@7:', type='run')
+    depends_on('java@8', type='run')
 
     def install(self, spec, prefix):
         install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/hbase/package.py
+++ b/var/spack/repos/builtin/packages/hbase/package.py
@@ -14,8 +14,8 @@ class Hbase(Package):
     Bigtable-like capabilities on top of Apache Hadoop."""
 
     homepage = "https://archive.apache.org/"
-    url      = "http://archive.apache.org/dist/hbase/2.2.4/hbase-2.2.4-bin.tar.gz"
-    list_url = "http://archive.apache.org/dist/hbase"
+    url      = "https://archive.apache.org/dist/hbase/2.2.4/hbase-2.2.4-bin.tar.gz"
+    list_url = "https://archive.apache.org/dist/hbase"
     list_depth = 1
 
     version('2.2.5',  sha256='25d08f8f038d9de5beb43dfb0392e8a8b34eae7e0f2670d6c2c172abc3855194')


### PR DESCRIPTION
1) url for the spcified hbase version `https://github.com/apache/hbase/archive/rel/` will change once in a while.
so spack can not access some old vesions now.

2) According to `Table 2` on this web:
http://hbase.apache.org/book.html#basic.prerequisites
There's some compatible issue for JDK7 & JDK11
we changed the java version for hbase