### PR TITLE
HPX 1.4.* build problem with Boost 1.73.0

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -65,6 +65,10 @@ class Hpx(CMakePackage, CudaPackage):
     depends_on('boost@1.55.0:', when='@:1.1.0')
     depends_on('hwloc@1.6:', when='@:1.1.0')
 
+    # boost 1.73.0 build problem with HPX 1.4.0 and 1.4.1
+    # https://github.com/STEllAR-GROUP/hpx/issues/4728#issuecomment-640685308
+    depends_on('boost@:1.72.0', when='@:1.4')
+
     # CXX Standard
     depends_on('boost cxxstd=11', when='cxxstd=11')
     depends_on('boost cxxstd=14', when='cxxstd=14')


### PR DESCRIPTION
Given this https://github.com/STEllAR-GROUP/hpx/issues/4728#issuecomment-640685308 add a constraint where HPX 1.4.* cannot depend on a version of boost newer than 1.72.0