### PR TITLE
cleverleaf: Add C++ link flags for Fujitsu.

### DIFF
--- a/var/spack/repos/builtin/packages/cleverleaf/fujitsu_add_link_flags.patch
+++ b/var/spack/repos/builtin/packages/cleverleaf/fujitsu_add_link_flags.patch
@@ -1,0 +1,10 @@
+--- spack-src/CMakeLists.txt.org	2020-06-29 14:38:00.737544597 +0900
++++ spack-src/CMakeLists.txt	2020-06-29 14:40:33.758297327 +0900
+@@ -24,6 +24,6 @@
+ 
+ add_definitions(-DVERSION="git" -DHOST_NAME="cab")
+ 
+-set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
++set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "--linkfortran")
+ 
+ add_subdirectory (src)

--- a/var/spack/repos/builtin/packages/cleverleaf/package.py
+++ b/var/spack/repos/builtin/packages/cleverleaf/package.py
@@ -24,6 +24,10 @@ class Cleverleaf(CMakePackage):
     depends_on('boost')
     depends_on('cmake@3.1:', type='build')
 
+    # The Fujitsu compiler requires the '--linkfortran'
+    # option to combine C++ and Fortran programs.
+    patch('fujitsu_add_link_flags.patch', when='%fj')
+
     def flag_handler(self, name, flags):
         if self.spec.satisfies('%intel') and name in ['cppflags', 'cxxflags']:
             flags.append(self.compiler.cxx11_flag)


### PR DESCRIPTION
The Fujitsu compiler requires the '--linkfortran' option to combine C++ and Fortran programs.
This option will find and link the required Fortran libraries.