### PR TITLE
Cray compiler: fix implicit rpaths for classic versions

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -152,6 +152,10 @@ def _parse_non_system_link_dirs(string):
     """
     link_dirs = _parse_link_paths(string)
 
+    # Remove directories that do not exist. Some versions of the Cray compiler
+    # report nonexistent directories
+    link_dirs = [d for d in link_dirs if os.path.isdir(d)]
+
     # Return set of directories containing needed compiler libs, minus
     # system paths. Note that 'filter_system_paths' only checks for an
     # exact match, while 'in_system_subdirectory' checks if a path contains

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -619,18 +619,26 @@ def dirs_with_libfiles(tmpdir_factory):
 
 
 @pytest.fixture(scope='function', autouse=True)
-def disable_compiler_execution(monkeypatch):
-    def noop(*args):
-        return []
+def disable_compiler_execution(monkeypatch, request):
+    """
+    This fixture can be disabled for tests of the compiler link path
+    functionality by::
 
-    # Compiler.determine_implicit_rpaths actually runs the compiler. So this
-    # replaces that function with a noop that simulates finding no implicit
-    # RPATHs
-    monkeypatch.setattr(
-        spack.compiler.Compiler,
-        '_get_compiler_link_paths',
-        noop
-    )
+        @pytest.mark.enable_compiler_link_paths
+
+    If a test is marked in that way this is a no-op."""
+    if 'enable_compiler_link_paths' not in request.keywords:
+        def noop(*args):
+            return []
+
+        # Compiler.determine_implicit_rpaths actually runs the compiler. So
+        # replace that function with a noop that simulates finding no implicit
+        # RPATHs
+        monkeypatch.setattr(
+            spack.compiler.Compiler,
+            '_get_compiler_link_paths',
+            noop
+        )
 
 
 @pytest.fixture(scope='function')

--- a/lib/spack/spack/test/link_paths.py
+++ b/lib/spack/spack/test/link_paths.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import pytest
 import os
 
 import spack.paths
@@ -11,6 +11,13 @@ from spack.compiler import _parse_non_system_link_dirs
 #: directory with sample compiler data
 datadir = os.path.join(spack.paths.test_path, 'data',
                        'compiler_verbose_output')
+
+
+@pytest.fixture(autouse=True)
+def allow_nonexistent_paths(monkeypatch):
+    # Allow nonexistent paths to be detected as part of the output
+    # for testing purposes.
+    monkeypatch.setattr(os.path, 'isdir', lambda x: True)
 
 
 def check_link_paths(filename, paths):


### PR DESCRIPTION
The Cray compiler (classic) outputs garbage after version 9.0 when run in verbose mode.

We previously assumed that every directory referenced by the compiler actually exists. Now we check for it in case it does not.