### PR TITLE
Don't detect "classic" on Cray to avoid a compiler bug

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -91,16 +91,24 @@ class Cce(Compiler):
 
     @property
     def cc_pic_flag(self):
+        if self.is_clang_based:
+            return "-fPIC"
         return "-h PIC"
 
     @property
     def cxx_pic_flag(self):
+        if self.is_clang_based:
+            return "-fPIC"
         return "-h PIC"
 
     @property
     def f77_pic_flag(self):
+        if self.is_clang_based:
+            return "-fPIC"
         return "-h PIC"
 
     @property
     def fc_pic_flag(self):
+        if self.is_clang_based:
+            return "-fPIC"
         return "-h PIC"

--- a/lib/spack/spack/operating_systems/cray_backend.py
+++ b/lib/spack/spack/operating_systems/cray_backend.py
@@ -146,7 +146,8 @@ class CrayBackend(LinuxDistro):
             compiler_cls.PrgEnv_compiler
         )
         matches = re.findall(version_regex, output)
-        version = tuple(version for _, version in matches)
+        version = tuple(version for _, version in matches
+                        if 'classic' not in version)
         compiler_id = detect_version_args.id
         value = detect_version_args._replace(
             id=compiler_id._replace(version=version)

--- a/lib/spack/spack/operating_systems/cray_frontend.py
+++ b/lib/spack/spack/operating_systems/cray_frontend.py
@@ -83,7 +83,8 @@ class CrayFrontend(LinuxDistro):
                 compiler_cls.PrgEnv_compiler
             )
             matches = re.findall(version_regex, output)
-            versions = tuple(version for _, version in matches)
+            versions = tuple(version for _, version in matches
+                             if 'classic' not in version)
 
             # Now inspect the modules and add to paths
             msg = "[CRAY FE] Detected FE compiler [name={0}, versions={1}]"

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -377,6 +377,10 @@ def test_cce_flags():
     supported_flag_test("cxx_pic_flag", "-h PIC", "cce@1.0")
     supported_flag_test("f77_pic_flag", "-h PIC", "cce@1.0")
     supported_flag_test("fc_pic_flag",  "-h PIC", "cce@1.0")
+    supported_flag_test("cc_pic_flag",  "-fPIC", "cce@9.1.0")
+    supported_flag_test("cxx_pic_flag", "-fPIC", "cce@9.1.0")
+    supported_flag_test("f77_pic_flag", "-fPIC", "cce@9.1.0")
+    supported_flag_test("fc_pic_flag",  "-fPIC", "cce@9.1.0")
     supported_flag_test("debug_flags", ['-g', '-G0', '-G1', '-G2', '-Gfast'],
                         'cce@1.0')
 


### PR DESCRIPTION
Spack always concretize to `-classic` version of `cce` compilers when detected. This commit is a workaround to be able to use Clang based `cce` compilers until a fix is coded for v0.15.1.

To reproduce the bug:
```console
>>> s = spack.spec.Spec('zlib%cce@9.0.2')
>>> s.concretize()
>>> s.package.compiler.c99_flag
'-h std=c99,noconform,gnu'
>>> s.package.compiler.is_clang_based
False
>>> str(s.package.compiler.version)
'9.0.2-classic'
>>> str(s)
'zlib@1.2.11%cce@9.0.2+optimize+pic+shared patches=e93f7400712c2814905815204dadbdebcb91dc77dd586f60cbc82efa102fb539 arch=cray-cnl7-haswell'
```