### PR TITLE
Activate environment in container file

### DIFF
--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir {{ paths.environment }} \
 {{ manifest }} > {{ paths.environment }}/spack.yaml
 
 # Install the software, remove unecessary deps
-RUN cd {{ paths.environment }} && spack install && spack gc -y
+RUN cd {{ paths.environment }} && spack env activate . && spack install && spack gc -y
 {% if strip %}
 
 # Strip all the binaries

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -14,6 +14,7 @@ EOF
   spack env activate .
   spack install
   spack gc -y
+  spack env deactivate
   spack env activate --sh -d . >> {{ paths.environment }}/environment_modifications.sh
 {% if strip %}
 

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -11,6 +11,7 @@ EOF
 
   # Install all the required software
   . /opt/spack/share/spack/setup-env.sh
+  spack env activate .
   spack install
   spack gc -y
   spack env activate --sh -d . >> {{ paths.environment }}/environment_modifications.sh


### PR DESCRIPTION
Fixes #17315

This PR will ensure that the container recipes will build the spack
environment by first activating the environment.