### PR TITLE
Fix hashlib function capitalization

### DIFF
--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -133,7 +133,7 @@ class Checker(object):
     @property
     def hash_name(self):
         """Get the name of the hash function this Checker is using."""
-        return self.hash_fun().name
+        return self.hash_fun().name.lower()
 
     def check(self, filename):
         """Read the file with the specified name and check its checksum


### PR DESCRIPTION
Fixes a bug I discovered on BW (Cray CNL5) when running with Python 2.6.9.

According to the [hashlib documentation](https://docs.python.org/3/library/hashlib.html#hashlib.hash.name):

> The canonical name of this hash, always lowercase and always suitable as a parameter to new() to create another hash of this type.
> 
> _Changed in version 3.4:_ The name attribute has been present in CPython since its inception, but until Python 3.4 was not formally specified, so may not exist on some platforms.

On Python 3.4+, things work as expected:
```console
$ python
Python 3.7.7 (default, May  5 2020, 22:46:17) 
>>> import hashlib
>>> hashlib.sha256
<built-in function openssl_sha256>
>>> hashlib.sha256().name
'sha256'
```
On Python 2.6.9, the name attribute exists, but is capitalized:
```console
$ python
Python 2.6.9 (unknown, Sep 14 2018, 10:54:25) 
>>> import hashlib
>>> hashlib.sha256
<built-in function sha256>
>>> hashlib.sha256().name
'SHA256'
```
Converting the name to lowercase makes things consistent with Python 3.4+.

### Before

```console
$ spack test lib/spack/spack/test/url_fetch.py::test_hash_detection
...
________________________________________________________________ test_hash_detection[sha224] _________________________________________________________________

checksum_type = 'sha224'

    def test_hash_detection(checksum_type):
        algo = crypto.hash_fun_for_algo(checksum_type)()
        h = 'f' * (algo.digest_size * 2)  # hex -> bytes
        checker = crypto.Checker(h)
>       assert checker.hash_name == checksum_type
E       AssertionError: assert 'SHA224' == 'sha224'
E         - SHA224
E         + sha224

lib/spack/spack/test/url_fetch.py:168: AssertionError
________________________________________________________________ test_hash_detection[sha384] _________________________________________________________________

checksum_type = 'sha384'

    def test_hash_detection(checksum_type):
        algo = crypto.hash_fun_for_algo(checksum_type)()
        h = 'f' * (algo.digest_size * 2)  # hex -> bytes
        checker = crypto.Checker(h)
>       assert checker.hash_name == checksum_type
E       AssertionError: assert 'SHA384' == 'sha384'
E         - SHA384
E         + sha384

lib/spack/spack/test/url_fetch.py:168: AssertionError
________________________________________________________________ test_hash_detection[sha256] _________________________________________________________________

checksum_type = 'sha256'

    def test_hash_detection(checksum_type):
        algo = crypto.hash_fun_for_algo(checksum_type)()
        h = 'f' * (algo.digest_size * 2)  # hex -> bytes
        checker = crypto.Checker(h)
>       assert checker.hash_name == checksum_type
E       AssertionError: assert 'SHA256' == 'sha256'
E         - SHA256
E         + sha256

lib/spack/spack/test/url_fetch.py:168: AssertionError
________________________________________________________________ test_hash_detection[sha512] _________________________________________________________________

checksum_type = 'sha512'

    def test_hash_detection(checksum_type):
        algo = crypto.hash_fun_for_algo(checksum_type)()
        h = 'f' * (algo.digest_size * 2)  # hex -> bytes
        checker = crypto.Checker(h)
>       assert checker.hash_name == checksum_type
E       AssertionError: assert 'SHA512' == 'sha512'
E         - SHA512
E         + sha512

lib/spack/spack/test/url_fetch.py:168: AssertionError
```

### After

All tests pass on BW now!