### PR TITLE
Use libstdc++ to fix build error of biobloom

### DIFF
--- a/var/spack/repos/builtin/packages/sdsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/sdsl-lite/package.py
@@ -33,6 +33,10 @@ class SdslLite(Package):
 
         with working_dir('sdsl-lite-{0}'.format(spec.version.dotted)):
             if '%fj' in spec:
-                filter_file('stdlib=libc', 'stdlib=libstdc', './CMakeLists.txt')
+                filter_file(
+                    'stdlib=libc',
+                    'stdlib=libstdc',
+                    './CMakeLists.txt'
+                )
             helper = Executable('./install.sh')
             helper(prefix)

--- a/var/spack/repos/builtin/packages/sdsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/sdsl-lite/package.py
@@ -32,5 +32,7 @@ class SdslLite(Package):
         tar('-xvf', self.stage.archive_file)
 
         with working_dir('sdsl-lite-{0}'.format(spec.version.dotted)):
+            if '%fj' in spec:
+                filter_file('stdlib=libc', 'stdlib=libstdc', './CMakeLists.txt')
             helper = Executable('./install.sh')
             helper(prefix)

--- a/var/spack/repos/builtin/packages/sdsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/sdsl-lite/package.py
@@ -32,7 +32,7 @@ class SdslLite(Package):
         tar('-xvf', self.stage.archive_file)
 
         with working_dir('sdsl-lite-{0}'.format(spec.version.dotted)):
-            if '%fj' in spec:
+            if self.spec.satisfies('%fj'):
                 filter_file(
                     'stdlib=libc',
                     'stdlib=libstdc',


### PR DESCRIPTION
`spack install biobloom%fj` failed with errors such as
```console
> 101    /fefs/home/n0026/work/spack/lib/spack/env/fj/case-insensitive/FCC -
            Wall -Wextra -Werror  -fopenmp -w -fopenmp  -o biobloommimaker biob
            loommimaker-BioBloomMIMaker.o biobloommimaker-Options.o ../Common/l
            ibcommon.a -lz -lsdsl -ldl
     102    /opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/gcc/aar
            ch64-linux-gnu/8.2.0/../../../../aarch64-linux-gnu/bin/ld: biobloom
            mimaker-BioBloomMIMaker.o: in function `bool sdsl::store_to_file<sd
            sl::bit_vector_il<512u> >(sdsl::bit_vector_il<512u> const&, std::__
            cxx11::basic_string<char, std::char_traits<char>, std::allocator<ch
            ar> > const&)` 
     103    /fefs/home/n0026/work/spack/opt/spack/linux-rhel8-thunderx2/fj-4.1.
            0/sdsl-lite-2.1.1-wbul254d5iaeyd6xykzzi3jb5akqrsbd/include/sdsl/io.
            hpp:660: undefined reference to `sdsl::osfstream::osfstream(std::__
            cxx11::basic_string<char, std::char_traits<char>, std::allocator<ch
            ar> > const&, std::_Ios_Openmode)`
```
Mismatch of stdlib is the reason of these errors. So I patched `-stdlib=libc++` to `-stdlib=stdlibc++` in CMakeLists.txt of sdsl-lite.
```console
> if( CMAKE_COMPILER_IS_GNUCXX )
    append_cxx_compiler_flags("-std=c++11 -Wall -Wextra -DNDEBUG" "GCC" CMAKE_CXX_FLAGS)
    append_cxx_compiler_flags("-O3 -ffast-math -funroll-loops" "GCC" CMAKE_CXX_OPT_FLAGS)
    if ( CODE_COVERAGE )
        append_cxx_compiler_flags("-g -fprofile-arcs -ftest-coverage -lgcov" "GCC" CMAKE_CXX_FLAGS)
    endif()
else()
    if( CMAKE_COMPILER_IS_CLANGXX )
		append_cxx_compiler_flags("-std=c++11 -DNDEBUG" "CLANG" CMAKE_CXX_FLAGS)
		append_cxx_compiler_flags("-stdlib=libc++" "CLANG" CMAKE_CXX_FLAGS)
		append_cxx_compiler_flags("-O3 -ffast-math -funroll-loops -D__extern_always_inline=\"extern __always_inline\" " "CLANG" CMAKE_CXX_OPT_FLAGS)
	else()
```