### PR TITLE
Moved flake8, shell and documentation tests to Github Action

### DIFF
--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -77,7 +77,7 @@ jobs:
         git config --global user.email "spack@example.com"
         git config --global user.name "Test User"
         git fetch -u origin develop:develop
-    - name: Run unit tests
+    - name: Run flake8 tests
       run: |
           share/spack/qa/run-flake8-tests
   shell:

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -122,3 +122,21 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: shelltests,linux
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install System packages
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y coreutils ninja-build graphviz
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip six setuptools
+        pip install --upgrade -r lib/spack/docs/requirements.txt
+    - name: Build documentation
+      run: |
+          share/spack/qa/run-doc-tests

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -60,3 +60,24 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: unittests,linux
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip six setuptools flake8
+    - name: Setup git configuration
+      run: |
+        # Need this for the git tests to succeed.
+        git --version
+        git config --global user.email "spack@example.com"
+        git config --global user.name "Test User"
+        git fetch -u origin develop:develop
+    - name: Run unit tests
+      run: |
+          share/spack/qa/run-flake8-tests

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -64,8 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install Python packages
@@ -81,3 +80,45 @@ jobs:
     - name: Run unit tests
       run: |
           share/spack/qa/run-flake8-tests
+  shell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install System packages
+      run: |
+          sudo apt-get -y update
+          sudo apt-get install -y coreutils gfortran gnupg2 mercurial ninja-build patchelf zsh fish
+          # Needed for kcov
+          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip six setuptools codecov coverage
+    - name: Setup git configuration
+      run: |
+          # Need this for the git tests to succeed.
+          git --version
+          git config --global user.email "spack@example.com"
+          git config --global user.name "Test User"
+          git fetch -u origin develop:develop
+    - name: Install kcov for bash script coverage
+      env:
+          KCOV_VERSION: 38
+      run: |
+          KCOV_ROOT=$(mktemp -d)
+          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
+          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
+          mkdir -p ${KCOV_ROOT}/build
+          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
+          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
+    - name: Run shell tests
+      env:
+          COVERAGE: true
+      run: |
+          share/spack/qa/run-shell-tests
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        flags: shelltests,linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,41 +5,30 @@ branches:
     - develop
     - /^releases\/.*$/
 
-jobs:
-  include:
-    - python: '2.6'
-      dist: trusty
-      os: linux
-      language: python
-      addons:
-        apt:
-          # Everything but patchelf, that is not available for trusty
-          packages:
-            - gfortran
-            - graphviz
-            - gnupg2
-            - kcov
-            - mercurial
-            - ninja-build
-            - realpath
-            - zsh
-            - fish
-      env: [ TEST_SUITE=unit, COVERAGE=true ]
-
-cache:
-  pip: true
+language: python
+python: '2.6'
+dist: trusty
+os: linux
+addons:
+  apt:
+    packages:
+      - gfortran
+      - graphviz
+      - gnupg2
+      - kcov
+      - mercurial
+      - ninja-build
+      - realpath
+      - zsh
+      - fish
 
 # Install various dependencies
 install:
   - pip install --upgrade pip
   - pip install --upgrade six
   - pip install --upgrade setuptools
-  - pip install --upgrade codecov coverage==4.5.4
   - pip install --upgrade flake8
   - pip install --upgrade pep8-naming
-  - if [[ "$TEST_SUITE" == "doc" ]]; then
-        pip install --upgrade -r lib/spack/docs/requirements.txt;
-    fi
 
 before_script:
   # Need this for the git tests to succeed.
@@ -50,18 +39,7 @@ before_script:
   - git fetch origin ${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
 
 script:
-  - share/spack/qa/run-$TEST_SUITE-tests
-
-after_success:
-  - case "$TEST_SUITE" in
-        unit)
-            if [[ "$COVERAGE" == "true" ]]; then
-                codecov --env PYTHON_VERSION
-                        --required
-                        --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
-            fi
-            ;;
-    esac
+  - share/spack/qa/run-unit-tests
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,9 @@ branches:
     - develop
     - /^releases\/.*$/
 
-#=============================================================================
-# Build matrix
-#=============================================================================
-
-dist: bionic
-
 jobs:
-  fast_finish: true
   include:
-    - stage: 'unit tests + documentation'
-      python: '2.6'
+    - python: '2.6'
       dist: trusty
       os: linux
       language: python
@@ -33,46 +25,9 @@ jobs:
             - zsh
             - fish
       env: [ TEST_SUITE=unit, COVERAGE=true ]
-    - python: '3.8'
-      os: linux
-      language: python
-      env: TEST_SUITE=doc
-
-
-#=============================================================================
-# Environment
-#=============================================================================
-
-# Docs need graphviz to build
-addons:
-  # for Linux builds, we use APT
-  apt:
-    packages:
-      - coreutils
-      - gfortran
-      - graphviz
-      - gnupg2
-      - mercurial
-      - ninja-build
-      - patchelf
-      - zsh
-      - fish
-    update: true
 
 cache:
   pip: true
-
-before_install:
-  # Install kcov manually, since it's not packaged for bionic beaver
-  - if [[ "$KCOV_VERSION" ]]; then
-        sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
-        KCOV_ROOT=$(mktemp -d);
-        wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz;
-        tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz;
-        mkdir -p ${KCOV_ROOT}/build;
-        cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd - ;
-        make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install;
-    fi
 
 # Install various dependencies
 install:
@@ -94,9 +49,6 @@ before_script:
   # Need this to be able to compute the list of changed files
   - git fetch origin ${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
 
-#=============================================================================
-# Building
-#=============================================================================
 script:
   - share/spack/qa/run-$TEST_SUITE-tests
 
@@ -111,9 +63,6 @@ after_success:
             ;;
     esac
 
-#=============================================================================
-# Notifications
-#=============================================================================
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-#=============================================================================
-# Project settings
-#=============================================================================
 # Only build master and develop on push; do not build every branch.
 branches:
   only:
@@ -26,7 +23,6 @@ jobs:
         apt:
           # Everything but patchelf, that is not available for trusty
           packages:
-            - ccache
             - gfortran
             - graphviz
             - gnupg2
@@ -40,15 +36,7 @@ jobs:
     - python: '3.8'
       os: linux
       language: python
-      env: [ TEST_SUITE=shell, COVERAGE=true, KCOV_VERSION=38 ]
-    - python: '3.8'
-      os: linux
-      language: python
       env: TEST_SUITE=doc
-
-stages:
-  - 'style checks'
-  - 'unit tests + documentation'
 
 
 #=============================================================================
@@ -60,7 +48,6 @@ addons:
   # for Linux builds, we use APT
   apt:
     packages:
-      - ccache
       - coreutils
       - gfortran
       - graphviz
@@ -72,16 +59,10 @@ addons:
       - fish
     update: true
 
-# ~/.ccache needs to be cached directly as Travis is not taking care of it
-# (possibly because we use 'language: python' and not 'language: c')
 cache:
   pip: true
-  ccache: true
-  directories:
-    - ~/.ccache
 
 before_install:
-  - ccache -M 2G && ccache -z
   # Install kcov manually, since it's not packaged for bionic beaver
   - if [[ "$KCOV_VERSION" ]]; then
         sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev;
@@ -120,7 +101,6 @@ script:
   - share/spack/qa/run-$TEST_SUITE-tests
 
 after_success:
-  - ccache -s
   - case "$TEST_SUITE" in
         unit)
             if [[ "$COVERAGE" == "true" ]]; then
@@ -129,10 +109,6 @@ after_success:
                         --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
             fi
             ;;
-        shell)
-            codecov --env PYTHON_VERSION
-            --required
-            --flags "${TEST_SUITE}${TRAVIS_OS_NAME}";
     esac
 
 #=============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,10 @@ before_script:
   - git fetch origin ${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
 
 script:
-  - share/spack/qa/run-unit-tests
+  - python bin/spack -h
+  - python bin/spack help -a
+  - python bin/spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+  - python bin/spack test -x --verbose
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ dist: bionic
 jobs:
   fast_finish: true
   include:
-    - stage: 'style checks'
-      python: '3.8'
-      os: linux
-      language: python
-      env: TEST_SUITE=flake8
     - stage: 'unit tests + documentation'
       python: '2.6'
       dist: trusty

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1143,8 +1143,6 @@ def test_nested_reads(lock_path):
                     assert vals['read'] == 1
 
 
-@pytest.mark.skipif('macos' in os.environ.get('GITHUB_WORKFLOW', ''),
-                    reason="Skip failing test for GA on MacOS")
 def test_lock_debug_output(lock_path):
     host = socket.getfqdn()
 

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -18,7 +18,7 @@
 ORIGINAL_PATH="$PATH"
 
 . "$(dirname $0)/setup.sh"
-check_dependencies $coverage git hg svn
+check_dependencies $coverage kcov git hg svn
 
 # Clean the environment by removing Spack from the path and getting rid of
 # the spack shell function

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -37,11 +37,7 @@ bin/spack -h
 bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  spack -p --lines 20 spec openmpi
-else
-  spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
-fi
+spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -74,6 +74,9 @@ check_dependencies() {
                     spack_package=mercurial
                     pip_package=mercurial
                     ;;
+                kcov)
+                    spack_package=kcov
+                    ;;
                 svn)
                     spack_package=subversion
                     ;;

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -26,14 +26,11 @@ if [[ "$COVERAGE" == "true" ]]; then
     coverage=coverage
     coverage_run="coverage run"
 
-    # bash coverage depends on some other factors -- there are issues with
-    # kcov for Python 2.6, unit tests, and build tests.
-    if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then
-        mkdir -p coverage
-        cc_script="$SPACK_ROOT/lib/spack/env/cc"
-        bashcov=$(realpath ${QA_DIR}/bashcov)
-        sed -i~ "s@#\!/bin/bash@#\!${bashcov}@" "$cc_script"
-    fi
+    # bash coverage depends on some other factors
+    mkdir -p coverage
+    cc_script="$SPACK_ROOT/lib/spack/env/cc"
+    bashcov=$(realpath ${QA_DIR}/bashcov)
+    sed -i~ "s@#\!/bin/bash@#\!${bashcov}@" "$cc_script"
 fi
 
 #


### PR DESCRIPTION
This PR moves:
- [x] `flake8`
- [x] `shell`
- [x]  `documentation`

tests from Travis to Github Actions. It also changes Python 2.6 unit tests to not compute coverage, since previously we were computing it and consistently failing in the upload phase. As a result Python 2.6 tests now take ~15 mins. to run instead of ~25 mins.