### PR TITLE
autotools: Fix config.guess detection, take two

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -118,17 +118,15 @@ class AutotoolsPackage(PackageBase):
             config_file = 'config.{0}'.format(config_name)
             if os.path.exists(config_file):
                 # First search the top-level source directory
-                my_config_files[config_name] = os.path.join(
-                    self.configure_directory, config_file)
+                my_config_files[config_name] = os.path.abspath(config_file)
             else:
                 # Then search in all sub directories recursively.
                 # We would like to use AC_CONFIG_AUX_DIR, but not all packages
                 # ship with their configure.in or configure.ac.
                 config_path = next((os.path.join(r, f)
-                                    for r, ds, fs in os.walk(
-                                        self.configure_directory) for f in fs
+                                    for r, ds, fs in os.walk('.') for f in fs
                                     if f == config_file), None)
-                my_config_files[config_name] = config_path
+                my_config_files[config_name] = os.path.abspath(config_path)
 
             if my_config_files[config_name] is not None:
                 try:


### PR DESCRIPTION
The previous fix from #17149 contained a thinko that produced errors for packages that overwrite configure_directory.