### PR TITLE
Add an option for find command to show if a package is from an upstream

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -358,6 +358,7 @@ def display_specs(specs, args=None, **kwargs):
     variants      = get_arg('variants', False)
     groups        = get_arg('groups', True)
     all_headers   = get_arg('all_headers', False)
+    location      = get_arg('location', False)
 
     decorator     = get_arg('decorator', None)
     if decorator is None:
@@ -389,6 +390,8 @@ def display_specs(specs, args=None, **kwargs):
         string = ""
         if hashes:
             string += gray_hash(s, hlen) + ' '
+        if location:
+            string += "^" if s.package.installed_upstream else " "
         string += depth * "    "
         string += s.cformat(format_string, transform=transform)
         return string

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -61,6 +61,9 @@ def setup_parser(subparser):
                            action='store_true',
                            dest='show_full_compiler',
                            help='show full compiler specs')
+    subparser.add_argument('--location',
+                           action='store_true',
+                           help='show if it is a local or an upstream package')
     implicit_explicit = subparser.add_mutually_exclusive_group()
     implicit_explicit.add_argument(
         '-x', '--explicit',

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -842,7 +842,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tags -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tags -c --show-concretized -f --show-flags --show-full-compiler --location -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date"
     else
         _installed_packages
     fi


### PR DESCRIPTION
This PR proposes to add the option `spack find --location` in order to show in the output if a package is in the "local" instance or in an upstream one.

Example outputs:

```bash
spack find --location -p
...
jnnhvza ^ncurses@6.1            /usr
pwndliw ^openssl@1.1.0i         /usr
us6svq2  pkg-config@0.29.2      /usr
```

```bash
spack find --location -l
...
nn75hgd ^git@2.16.4
```

```bash
spack find --location
...
^git@2.16.4
```

I find it useful when managing chained instances: e.g. a few times I found myself not understanding why I was not able to uninstall a package (i.e. getting a "not found" error from `spack uninstall`) and just later I realized it was in the upstream instance.

Thought it may be useful.

Looking forward for your feedback and suggestions.