### PR TITLE
new jmol version 14.31; url_for_version function; java path for run environment

### DIFF
--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -30,7 +30,7 @@ class Jmol(Package):
             # no subdirs - tarball was unpacked in spack-src
             install_tree('./', prefix)
 
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('PATH', self.prefix)
-        run_env.set('JMOL_HOME', self.prefix)
-        run_env.prepend_path('PATH', self.spec['java'].prefix.bin)
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix)
+        env.set('JMOL_HOME', self.prefix)
+        env.prepend_path('PATH', self.spec['java'].prefix.bin)

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-
+import os.path
 
 class Jmol(Package):
     """Jmol: an open-source Java viewer for chemical structures in 3D
@@ -17,16 +17,18 @@ class Jmol(Package):
     version('14.8.0' , sha256='8ec45e8d289aa0762194ca71848edc7d736121ddc72276031a253a3651e6d588')
 
     def url_for_version(self, version):
-        url='https://sourceforge.net/projects/jmol/files/Jmol/Version%20{0}/Jmol%20{1}/Jmol-{1}-full.tar.gz'
+        url='https://sourceforge.net/projects/jmol/files/Jmol/Version%20{0}/Jmol%20{1}/Jmol-{1}-binary.tar.gz'
         return url.format(version.up_to(2), version)
 
     depends_on('java', type='run')
 
     def install(self, spec, prefix):
-        if self.version >= Version('14.31.0'):
-            install_tree('./', prefix)
-        else:
+        if  os.path.exists('jmol-{0}'.format(self.version)):
+            # tar ball contains subdir with different versions
             install_tree('jmol-{0}'.format(self.version), prefix)
+        else:
+            # no subdirs - tarball was unpacked in spack-src
+            install_tree('./', prefix)
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PATH', self.prefix)

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -13,13 +13,22 @@ class Jmol(Package):
     homepage = "http://jmol.sourceforge.net/"
     url      = "https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.8/Jmol%2014.8.0/Jmol-14.8.0-binary.tar.gz"
 
-    version('14.8.0', sha256='8ec45e8d289aa0762194ca71848edc7d736121ddc72276031a253a3651e6d588')
+    version('14.31.0', sha256='eee0703773607c8bd6d51751d0d062c3e10ce44c11e1d7828e4ea3d5f710e892')
+    version('14.8.0' , sha256='8ec45e8d289aa0762194ca71848edc7d736121ddc72276031a253a3651e6d588')
+
+    def url_for_version(self, version):
+        url='https://sourceforge.net/projects/jmol/files/Jmol/Version%20{0}/Jmol%20{1}/Jmol-{1}-full.tar.gz'
+        return url.format(version.up_to(2), version)
 
     depends_on('java', type='run')
 
     def install(self, spec, prefix):
-        install_tree('jmol-{0}'.format(self.version), prefix)
+        if self.version >= Version('14.31.0'):
+            install_tree('./', prefix)
+        else:
+            install_tree('jmol-{0}'.format(self.version), prefix)
 
-    def setup_run_environment(self, env):
-        env.prepend_path('PATH', self.prefix)
-        env.set('JMOL_HOME', self.prefix)
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('PATH', self.prefix)
+        run_env.set('JMOL_HOME', self.prefix)
+        run_env.prepend_path('PATH', self.spec['java'].prefix.bin)

--- a/var/spack/repos/builtin/packages/jmol/package.py
+++ b/var/spack/repos/builtin/packages/jmol/package.py
@@ -6,24 +6,25 @@
 from spack import *
 import os.path
 
+
 class Jmol(Package):
     """Jmol: an open-source Java viewer for chemical structures in 3D
     with features for chemicals, crystals, materials and biomolecules."""
 
     homepage = "http://jmol.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.8/Jmol%2014.8.0/Jmol-14.8.0-binary.tar.gz"
+    url = "https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.8/Jmol%2014.8.0/Jmol-14.8.0-binary.tar.gz"
 
     version('14.31.0', sha256='eee0703773607c8bd6d51751d0d062c3e10ce44c11e1d7828e4ea3d5f710e892')
-    version('14.8.0' , sha256='8ec45e8d289aa0762194ca71848edc7d736121ddc72276031a253a3651e6d588')
+    version('14.8.0', sha256='8ec45e8d289aa0762194ca71848edc7d736121ddc72276031a253a3651e6d588')
 
     def url_for_version(self, version):
-        url='https://sourceforge.net/projects/jmol/files/Jmol/Version%20{0}/Jmol%20{1}/Jmol-{1}-binary.tar.gz'
+        url = 'https://sourceforge.net/projects/jmol/files/Jmol/Version%20{0}/Jmol%20{1}/Jmol-{1}-binary.tar.gz'
         return url.format(version.up_to(2), version)
 
     depends_on('java', type='run')
 
     def install(self, spec, prefix):
-        if  os.path.exists('jmol-{0}'.format(self.version)):
+        if os.path.exists('jmol-{0}'.format(self.version)):
             # tar ball contains subdir with different versions
             install_tree('jmol-{0}'.format(self.version), prefix)
         else:


### PR DESCRIPTION
- added latest version of jmol
- added a url_for_version function; tested for remote version 14.30.2
- java path is added to the run environment; tested with openjdk@11.0.2 
- fixed installation path issue; works for old 14.8.0 and new 14.31.0