### PR TITLE
autotools: Fix config.guess detection, take three

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -123,10 +123,10 @@ class AutotoolsPackage(PackageBase):
                 # Then search in all sub directories recursively.
                 # We would like to use AC_CONFIG_AUX_DIR, but not all packages
                 # ship with their configure.in or configure.ac.
-                config_path = next((os.path.join(r, f)
+                config_path = next((os.path.abspath(os.path.join(r, f))
                                     for r, ds, fs in os.walk('.') for f in fs
                                     if f == config_file), None)
-                my_config_files[config_name] = os.path.abspath(config_path)
+                my_config_files[config_name] = config_path
 
             if my_config_files[config_name] is not None:
                 try:


### PR DESCRIPTION
Fixes a problem with the `papi` package on PPC/ARM reported in Slack.

This piece of code is becoming my personal nightmare. :laughing:

Edit: I guess having tests for this would be a good idea but I'm still not sure how to best test this. It can be quite hard to catch these errors since this function is skipped completely on x86.