### PR TITLE
[opencascade] depends_on freetype, tcl, tk, gl

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -32,6 +32,10 @@ class Opencascade(CMakePackage):
     depends_on('vtk', when='+vtk')
     depends_on('freeimage', when='+freeimage')
     depends_on('rapidjson', when='+rapidjson')
+    depends_on('freetype')
+    depends_on('tcl')
+    depends_on('tk')
+    depends_on('gl')
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -16,6 +16,8 @@ class Opencascade(CMakePackage):
     homepage = "https://www.opencascade.com"
     url      = "http://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_4_0;sf=tgz"
 
+    version('7.4.0p1', extension='tar.gz',
+            sha256='e00fedc221560fda31653c23a8f3d0eda78095c87519f338d4f4088e2ee9a9c0')
     version('7.4.0', extension='tar.gz',
             sha256='655da7717dac3460a22a6a7ee68860c1da56da2fec9c380d8ac0ac0349d67676')
 
@@ -36,6 +38,10 @@ class Opencascade(CMakePackage):
     depends_on('tcl')
     depends_on('tk')
     depends_on('gl')
+
+    def url_for_version(self, version):
+        url = "http://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V{0};sf=tgz"
+        return url.format(version.underscored)
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
### freetype, tcl, tk required during cmake phase
Opencascade depends on freetype, tcl, tk, per [dox/overview/overview.md](http://git.dev.opencascade.org/gitweb/?p=occt.git;a=blob;f=dox/overview/overview.md;h=8115c900737b27bb72f01f37916f16d2ea8b994d;hb=33d9a6fa21ca4fa711da7066655aa2ba854545ee#l217).

Opencascade is pretty good at finding dependencies without specifying dirs, but attempting to install on a clean spack build container ([Dockerfile](https://github.com/eic/eic-spack/blob/master/docker/ubuntu18.04/Dockerfile)) with
```
docker run --rm -it electronioncollider/spack-builder:ubuntu18.04 bash -c "spack install opencascade"
```
fails with:
```
==> Error: Failed to install opencascade due to ChildError: ProcessError: Command exited with status 1:
    'cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/cvmfs/eic.opensciencegrid.org/packages/opencascade/7.4.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-4wogqkmmaqskveg43xt4c6gv6fcbreaq' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF' '-DCMAKE_INSTALL_RPATH:STRING=/cvmfs/eic.opensciencegrid.org/packages/opencascade/7.4.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-4wogqkmmaqskveg43xt4c6gv6fcbreaq/lib;/cvmfs/eic.opensciencegrid.org/packages/opencascade/7.4.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-4wogqkmmaqskveg43xt4c6gv6fcbreaq/lib64' '-DCMAKE_PREFIX_PATH:STRING=/cvmfs/eic.opensciencegrid.org/packages/cmake/3.17.3/linux-ubuntu18.04-x86_64-gcc-7.5.0-thpwguiiywo7hewgnm76t7r6w53mt6cy' '-DUSE_TBB=OFF' '-DUSE_VTK=OFF' '-DUSE_FREEIMAGE=OFF' '-DUSE_RAPIDJSON=OFF' '/tmp/root/spack-stage/spack-stage-opencascade-7.4.0-4wogqkmmaqskveg43xt4c6gv6fcbreaq/spack-src'
1 error found in build log:
     46    This warning is for project developers.  Use -Wno-dev to suppress it.
     47    
     48    -- Could NOT find Tclsh (missing: TCL_TCLSH)
     49    -- Info: Freetype is used by OCCT
     50    -- Could NOT find Freetype (missing: FREETYPE_LIBRARY FREETYPE_INCLUDE_DIRS)
     51    -- Info: TKIVtk and TKIVtkDraw toolkits excluded due to VTK usage is disabled
  >> 52    CMake Error at CMakeLists.txt:726 (message):
     53      Could not find headers of used third-party products:
     54      3RDPARTY_TCL_INCLUDE_DIR 3RDPARTY_TK_INCLUDE_DIR
     55      3RDPARTY_FREETYPE_INCLUDE_DIR_ft2build
     56      3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2
     57    
     58    
```

Alternative solutions explored:
- Turning off with `-DUSE_TCL=OFF` or `-DUSE_FREETYPE=OFF` has no effect (those were just extrapolations based on their use for other external libraries; there's no documentation that would indicate that they should work).
- Just depending on freetype, tcl is not sufficient (tk has many more dependencies through libx11 and libxft so it was a worthwhile attempt).

### gl required during build phase
Opencascade depends on opengl, per [dox/overview/overview.md](http://git.dev.opencascade.org/gitweb/?p=occt.git;a=blob;f=dox/overview/overview.md;h=8115c900737b27bb72f01f37916f16d2ea8b994d;hb=33d9a6fa21ca4fa711da7066655aa2ba854545ee#l217) as well, which (unfortunately) means a whole lot else as well (in particular mesa pulls in llvm by default).

Even after including freetype, tcl, tk it appears that opencascade gets past the cmake phase, but fails in the build with a missing header `GL/glx.h`:
```
==> Error: Failed to install opencascade due to ChildError: ProcessError: Command exited with status 2:
    'make' '-j4'
4 errors found in build log:
     4670    [ 31%] Building CXX object src/TKService/CMakeFiles/TKService.dir/__/Aspect/Aspect_DisplayConnection.cxx.o
     4671    cd /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-build/src/TKService && /spack/lib/spack/env/gcc/g++  -DOCC_CONVERT_SIGNALS -DTKService_EXPORTS -I/cvmfs/eic.opensciencegrid.org/p
             ackages/tcl/8.6.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-aszidznovy2kcbefk4dexwf5mlrjbbcw/include -I/cvmfs/eic.opensciencegrid.org/packages/tk/8.6.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-sw4jc7z36ma3zdb2wbti7omhtrrqdqij/include -I
             /cvmfs/eic.opensciencegrid.org/packages/freetype/2.10.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-kv5tk7sbjvjgemjxxa7xel6cqvn2356x/include/freetype2 -I/tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg5
             3nzoq/spack-build/include/opencascade  -std=c++0x  -fexceptions -fPIC -Wall -Wextra -O2 -g -DNDEBUG -fPIC   -o CMakeFiles/TKService.dir/__/Aspect/Aspect_DisplayConnection.cxx.o -c /tmp/root/spack-stage/spack-stage-opencasca
             de-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-src/src/Aspect/Aspect_DisplayConnection.cxx
     4672    In file included from /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-build/include/opencascade/InterfaceGraphic.hxx:1:0,
     4673                     from /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-src/src/Aspect/Aspect_DisplayConnection.hxx:24,
     4674                     from /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-build/include/opencascade/Aspect_DisplayConnection.hxx:1,
     4675                     from /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-src/src/Aspect/Aspect_DisplayConnection.cxx:14:
  >> 4676    /tmp/root/spack-stage/spack-stage-opencascade-7.4.0-ijosajraihg3shwjclrrdd4phg53nzoq/spack-src/src/InterfaceGraphic/InterfaceGraphic.hxx:41:10: fatal error: GL/glx.h: No such file or directory
     4677     #include <GL/glx.h>
     4678              ^~~~~~~~~~
     4679    compilation terminated.
     4680    src/TKService/CMakeFiles/TKService.dir/build.make:111: recipe for target 'src/TKService/CMakeFiles/TKService.dir/__/Aspect/Aspect_DisplayConnection.cxx.o' failed
```

### new version available
Taking advantage of this PR to add the newest patch release 7.4.0p1, which required a new url_for_version().


No maintainer listed, original package by @bfovet .