### PR TITLE
libelf: Add extra location

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -19,7 +19,11 @@ class Libelf(AutotoolsPackage):
     # homepage = "http://www.mr511.de/software/english.html"
 
     homepage = "https://directory.fsf.org/wiki/Libelf"
-    url      = "https://fossies.org/linux/misc/old/libelf-0.8.13.tar.gz"
+
+    urls = [
+        'https://fossies.org/linux/misc/old/libelf-0.8.13.tar.gz',
+        'https://ftp.osuosl.org/pub/blfs/conglomeration/libelf/libelf-0.8.13.tar.gz'
+    ]
 
     version('0.8.13', sha256='591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d')
 


### PR DESCRIPTION
fossies.org is down. Consequently, e.g. llvm can not be built with cuda enabled since libelf is required.