### PR TITLE
Smoke tests: hdf5 version checks and check_install

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -371,3 +371,26 @@ HDF5 version {version} {version}
                 print('-' * 80)
                 raise RuntimeError("HDF5 install check failed")
         shutil.rmtree(checkdir)
+
+    def _test_check_versions(self):
+        """Perform version checks on selected installed package binaries."""
+        spec_vers_str = 'Version {0}'.format(self.spec.version)
+
+        exes = [
+            'h5copy', 'h5diff', 'h5dump', 'h5format_convert', 'h5ls',
+            'h5mkgrp', 'h5repack', 'h5stat', 'h5unjam',
+        ]
+        use_short_opt = ['h52gif', 'h5repart', 'h5unjam']
+        for exe in exes:
+            reason = 'test version of {0} is {1}'.format(exe, spec_vers_str)
+            option = '-V' if exe in use_short_opt else '--version'
+            self.run_test(exe, [option], spec_vers_str, None, installed=True,
+                          purpose=reason, skip_missing=True)
+
+    def test(self):
+        """Perform smoke tests on the installed package."""
+        # Simple version check tests on known binaries
+        self._test_check_versions()
+
+        # Run existing install check
+        self.check_install()


### PR DESCRIPTION
Preliminary version checks for a subset of installed binaries across a number of versions.  Also calls the existing `check_install`.

This PR has been run against versions: 1.8.10, 1.8.14, 1.8.16, 1.8.21, 1.10.0, 1.10.2, 1.10.6, and 1.12.0.

TODO:
- [x] Run the install tests once able to successfully install multiple versions of `hdf5`