### PR TITLE
Two new versions of Random123.

### DIFF
--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -15,6 +15,8 @@ class Random123(Package):
     homepage = "http://www.deshawresearch.com/resources_random123.html"
     url      = "http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-1.09.tar.gz"
 
+    version('1.13.2', sha256='74a1c6bb66b2684f03d3b1008642a2e9141909103cd09f428d2c60bcaa51cb40')
+    version('1.10', sha256='4afdfba4b941e33e23b5de9b7907b7e3ac326cb4d34b5fa8225edd00b5fe053b')
     version('1.09', sha256='cf6abf623061bcf3d17e5e49bf3f3f0ae400ee89ae2e97c8cb8dcb918b1ebabe')
 
     patch('ibmxl.patch', when='@1.09')
@@ -25,5 +27,7 @@ class Random123(Package):
         # We have to do our own install here.
         install_tree('include', prefix.include)
         install('./LICENSE', "%s" % prefix)
-        # used by some packages, e.g. quinoa
-        install('examples/uniform.hpp', join_path(prefix.include, 'Random123'))
+        if spec.satisfies('@1.09'):
+            # used by some packages, e.g. quinoa
+            install('examples/uniform.hpp',
+                    join_path(prefix.include, 'Random123'))


### PR DESCRIPTION
* There are two new versions of Random123 available.  Adding both.
* In the newer versions, `examples/uniform.hpp` no longer exists, so limit that install command to the old version.
