### PR TITLE
blat: fix CC fixation to gcc

### DIFF
--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -21,5 +21,6 @@ class Blat(Package):
         env.set('MACHTYPE', 'x86_64')
 
     def install(self, spec, prefix):
+        filter_file('CC=.*', 'CC={0}'.format(spack_cc), 'inc/common.mk')
         mkdirp(prefix.bin)
         make("BINDIR=%s" % prefix.bin)


### PR DESCRIPTION
In `inc/common.mk` of blat, `gcc` was used to all compile.
( `inc/common.mk` is included from all Makefile. )
> CC=gcc
%.o: %.c
	${CC} ${COPT} ${CFLAGS} ${HG_DEFS} ${LOWELAB_DEFS} ${HG_WARN} ${HG_INC} ${XINC} -o $@ -c $<

So I fixed this to use spack specified compiler.
`filter_file('CC=.*', 'CC={0}'.format(spack_cc), 'inc/common.mk')`