### PR TITLE
blktrace: fix CC fixation to gcc

### DIFF
--- a/var/spack/repos/builtin/packages/blktrace/package.py
+++ b/var/spack/repos/builtin/packages/blktrace/package.py
@@ -27,5 +27,12 @@ class Blktrace(MakefilePackage):
 
     depends_on('libaio')
 
+    def edit(self, spec, prefix):
+        makefiles = ['Makefile', 'btreplay/Makefile',
+                     'btt/Makefile', 'iowatcher/Makefile']
+        for m in makefiles:
+            makefile = FileFilter(m)
+            makefile.filter('CC.*=.*', 'CC = {0}'.format(spack_cc))
+
     def install(self, spec, prefix):
         install_tree('.', prefix)


### PR DESCRIPTION
In `Makefile`s of blktrace, `gcc` was used to all compile.
> CC     = gcc

So I fixed this to use spack specified compiler.
`makefile.filter('CC.*=.*', 'CC = {0}'.format(spack_cc))`