### PR TITLE
spack create: ask how many to download

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -65,7 +65,7 @@ def checksum(parser, args):
 
     version_lines = spack.stage.get_checksums_for_versions(
         url_dict, pkg.name, keep_stage=args.keep_stage,
-        batch=(args.batch or len(args.versions) > 0),
+        batch=(args.batch or len(args.versions) > 0 or len(url_dict) == 1),
         fetch_options=pkg.fetch_options)
 
     print()

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -514,7 +514,7 @@ class BuildSystemGuesser:
         # Determine the build system based on the files contained
         # in the archive.
         for pattern, bs in clues:
-            if any(re.search(pattern, l) for l in lines):
+            if any(re.search(pattern, line) for line in lines):
                 self.build_system = bs
                 break
 

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -445,6 +445,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--skip-editor', action='store_true',
         help="skip the edit session for the package (e.g., automation)")
+    subparser.add_argument(
+        '-b', '--batch', action='store_true',
+        help="don't ask which versions to checksum")
 
 
 class BuildSystemGuesser:
@@ -629,7 +632,8 @@ def get_versions(args, name):
 
         versions = spack.stage.get_checksums_for_versions(
             url_dict, name, first_stage_function=guesser,
-            keep_stage=args.keep_stage, batch=True)
+            keep_stage=args.keep_stage,
+            batch=(args.batch or len(url_dict) == 1))
     else:
         versions = unhashed_versions
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -639,7 +639,7 @@ _spack_containerize() {
 _spack_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --keep-stage -n --name -t --template -r --repo -N --namespace -f --force --skip-editor"
+        SPACK_COMPREPLY="-h --help --keep-stage -n --name -t --template -r --repo -N --namespace -f --force --skip-editor -b --batch"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
Fixes #17354 

@glennpj @alalazo @iarspider can you see if this PR contains the desired behavior? Here's what I think is best:

1. If `--batch` is supplied to `spack create` or `spack checksum`, download everything
2. If only a single version is found, don't bother asking how many versions to download, just download it
3. If one or more versions are passed to `spack checksum`, download all of them
4. Otherwise, ask how many to download/checksum

Would love to add unit tests for `spack checksum`, but unit tests that require an internet connection are unreliable. Thoughts on how to make this work?