### PR TITLE
openblas: fix fj compiler support in 0.3.10

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas_fujitsu2.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas_fujitsu2.patch
@@ -1,0 +1,13 @@
+--- OpenBLAS-0.3.10/f_check	2020-07-04 00:02:19.000000000 +0900
++++ OpenBLAS-0.3.10/f_check_fix	2020-07-04 00:00:52.000000000 +0900
+@@ -337,8 +337,8 @@
+ 	    && ($flags !~ /kernel32/)
+ 	    && ($flags !~ /advapi32/)
+ 	    && ($flags !~ /shell32/)
+-	    && ($flags !~ /omp/ || ($vendor !~ /PGI/ && $flags =~ /omp/))
+-	    && ($flags !~ /[0-9]+/)
++	    && ($flags !~ /omp/ || ($vendor !~ /PGI/ && $vendor !~ /FUJITSU/ && $flags =~ /omp/))
++	    && ($flags !~ /[0-9]+/ || ($vendor == FUJITSU && $flags =~ /^-lfj90/))
+ 		&& ($flags !~ /^\-l$/)
+ 	    ) {
+ 	    $linker_l .= $flags . " ";

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -99,6 +99,7 @@ class Openblas(MakefilePackage):
 
     # Add conditions to f_check to determine the Fujitsu compiler
     patch('openblas_fujitsu.patch', when='%fj')
+    patch('openblas_fujitsu2.patch', when='@0.3.10 %fj')
 
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')


### PR DESCRIPTION
The latest 0.3.10 version openblas changed how Fortran libraries
are detected, and this broke Fujitsu compiler support.

This (new) openblas patch addresses that issue.