### PR TITLE
protobuf: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -12,8 +12,13 @@ class Protobuf(Package):
     """Google's data interchange format."""
 
     homepage = "https://developers.google.com/protocol-buffers"
-    url      = "https://github.com/protocolbuffers/protobuf/archive/v3.10.1.tar.gz"
+    url      = "https://github.com/protocolbuffers/protobuf/archive/v3.12.2.tar.gz"
 
+    version('3.12.2',  sha256='bb8ce9ba11eb7bccf080599fe7cad9cc461751c8dd1ba61701c0070d58cde973')
+    version('3.12.1',  sha256='cb9b3f9d625b5739a358268eb3421de11cacd90025f5f7672c3930553eca810e')
+    version('3.12.0',  sha256='946ba5371e423e1220d2cbefc1f65e69a1e81ca5bab62a03d66894172983cfcd')
+    version('3.11.4',  sha256='a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9')
+    version('3.11.3',  sha256='cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852')
     version('3.11.2',  sha256='e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67')
     version('3.11.1',  sha256='4f8e805825c53bbc3c9f6b6abc009b5b5679e4702bccfca1121c42ff5ec801c7')
     version('3.11.0',  sha256='6d356a6279cc76d2d5c4dfa6541641264b59eae0bc96b852381361e3400d1f1c')


### PR DESCRIPTION
Add versions from 3.11.3 to 3.12.2. I leave 3.12.3 out on purpose. 