### PR TITLE
intel-mpi: fix for wrong structure name instroduced in ea8a0be4

### DIFF
--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -67,5 +67,5 @@ class IntelMpi(IntelPackage):
     def setup_run_environment(self, env):
         super(IntelMPI, self).setup_run_environment(env)
 
-        for name, value in self.mpi_compiler.wrappers.items():
+        for name, value in self.mpi_compiler_wrappers.items():
             env.set(name, value)


### PR DESCRIPTION
it's mpi_compiler_wrappers and not mpi_compiler.wrappers (**underscore** instead of **dot** in front of "wrappers")

fixes #17371 (2nd part)