### PR TITLE
bliss: add spaces to __DATE__

### DIFF
--- a/var/spack/repos/builtin/packages/bliss/package.py
+++ b/var/spack/repos/builtin/packages/bliss/package.py
@@ -24,6 +24,7 @@ class Bliss(Package):
     patch("Makefile.spack.patch")
 
     def install(self, spec, prefix):
+        filter_file('__DATE__', ' __DATE__ ', 'bliss.cc')
         # The Makefile isn't portable; use our own instead
         makeargs = ["-f", "Makefile.spack",
                     "PREFIX=%s" % prefix, "GMP_PREFIX=%s" % spec["gmp"].prefix]


### PR DESCRIPTION
In `bliss.cc` of bliss
`fprintf(fp, "bliss version %s (compiled "__DATE__")\n", bliss::version);`

> C++11 requires a space between literal and string macro.

Build with %clang failed . Therefore,  I added spaces.
`fprintf(fp, "bliss version %s (compiled " __DATE__ ")\n", bliss::version);`