### PR TITLE
esmf: set ESMF_COMM=intelmpi also for ^intel-mpi

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -169,7 +169,7 @@ class Esmf(MakefilePackage):
                 os.environ['ESMF_CXXLINKLIBS'] = '-lmpifort'
             elif '^openmpi' in spec:
                 os.environ['ESMF_COMM'] = 'openmpi'
-            elif '^intel-parallel-studio+mpi' in spec:
+            elif '^intel-parallel-studio+mpi' in spec or '^intel-mpi' in spec:
                 os.environ['ESMF_COMM'] = 'intelmpi'
         else:
             # Force use of the single-processor MPI-bypass library.


### PR DESCRIPTION
Not only ^intel-parallel-studio+mpi provides Intel MPI but also ^intel-mpi.