### PR TITLE
ncl: fix compilation errors with Intel compilers

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -144,7 +144,8 @@ class Ncl(Package):
             c2f_flags.extend(['-lgfortran', '-lm'])
         elif self.compiler.name == 'intel':
             fc_flags.append('-fp-model precise')
-            cc_flags.append('-fp-model precise -std=c99 -D_POSIX_C_SOURCE=2 -D_GNU_SOURCE')
+            cc_flags.append('-fp-model precise'.
+                            '-std=c99 -D_POSIX_C_SOURCE=2 -D_GNU_SOURCE')
             c2f_flags.extend(['-lifcore', '-lifport'])
 
         if self.spec.satisfies('%gcc@10:'):

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -144,7 +144,7 @@ class Ncl(Package):
             c2f_flags.extend(['-lgfortran', '-lm'])
         elif self.compiler.name == 'intel':
             fc_flags.append('-fp-model precise')
-            cc_flags.append('-fp-model precise')
+            cc_flags.append('-fp-model precise -std=c99 -D_POSIX_C_SOURCE=2 -D_GNU_SOURCE')
             c2f_flags.extend(['-lifcore', '-lifport'])
 
         if self.spec.satisfies('%gcc@10:'):

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -144,8 +144,9 @@ class Ncl(Package):
             c2f_flags.extend(['-lgfortran', '-lm'])
         elif self.compiler.name == 'intel':
             fc_flags.append('-fp-model precise')
-            cc_flags.append('-fp-model precise'.
-                            '-std=c99 -D_POSIX_C_SOURCE=2 -D_GNU_SOURCE')
+            cc_flags.append('-fp-model precise'
+                            ' -std=c99'
+                            ' -D_POSIX_C_SOURCE=2 -D_GNU_SOURCE')
             c2f_flags.extend(['-lifcore', '-lifport'])
 
         if self.spec.satisfies('%gcc@10:'):


### PR DESCRIPTION
The Intel compilers are more strict and require special command
line options (like -std=c99) to properly compile NCL.