### PR TITLE
Added optimized version of Blis, FFTW and Libflame for AMD

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -47,6 +47,7 @@ packages:
       tbb: [intel-tbb]
       unwind: [libunwind]
       sycl: [hipsycl]
+      flame: [libflame]
     permissions:
       read: world
       write: user

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -17,8 +17,14 @@ class Amdblis(BlisBase):
 
     _name = 'amdblis'
     homepage = "https://developer.amd.com/amd-aocl/blas-library/"
-    url = "https://github.com/amd/blis/archive/2.1.tar.gz"
+    url = "https://github.com/amd/blis/archive/2.2.tar.gz"
     git = "https://github.com/amd/blis.git"
 
     version('2.2', sha256='e1feb60ac919cf6d233c43c424f6a8a11eab2c62c2c6e3f2652c15ee9063c0c9')
     version('2.1', sha256='3b1d611d46f0f13b3c0917e27012e0f789b23dbefdddcf877b20327552d72fb3')
+    version('2.0', sha256='7469680ce955f39d8d6bb7f70d2cc854222e5ef92a39488e77421300a65fad83')
+    version('1.3', sha256='6ce42054d63564f57a7276e7c63f3d01ed96a64908b484a99e68309acc968745')
+
+    @run_after('build')
+    def check(self):
+        make('check')

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -17,8 +17,10 @@ class Amdblis(BlisBase):
 
     _name = 'amdblis'
     homepage = "https://developer.amd.com/amd-aocl/blas-library/"
-    url = "https://github.com/amd/blis/archive/2.1.tar.gz"
+    url = "https://github.com/amd/blis/archive/2.2.tar.gz"
     git = "https://github.com/amd/blis.git"
 
     version('2.2', sha256='e1feb60ac919cf6d233c43c424f6a8a11eab2c62c2c6e3f2652c15ee9063c0c9')
     version('2.1', sha256='3b1d611d46f0f13b3c0917e27012e0f789b23dbefdddcf877b20327552d72fb3')
+    version('2.0', sha256='7469680ce955f39d8d6bb7f70d2cc854222e5ef92a39488e77421300a65fad83')
+    version('1.3', sha256='6ce42054d63564f57a7276e7c63f3d01ed96a64908b484a99e68309acc968745')

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -2,18 +2,34 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
 import os.path
-
 import llnl.util.lang
-
 from spack import *
+from spack.pkg.builtin.fftw import FftwBase
 
-class FftwBase(AutotoolsPackage):
-    """Base class for building Fftw, shared with the AMD optimized version
-    of the library in the 'amdfftw' package.
+
+class Amdfftw(FftwBase):
+    """AMD Optimized FFTW.
+
+    FFTW is a comprehensive collection of fast C routines for
+    computing the Discrete Fourier Transform (DFT) and various special
+    cases thereof. It is an open-source implementation of the Fast
+    Fourier transform algorithm. It can compute transforms of real and
+    complex-values arrays of arbitrary size and dimension.
+    AMD Optimized FFTW is the optimized FFTW implementation targeted
+    for AMD CPUs.
     """
+
+    _name = 'amdfftw'
+    homepage = "https://developer.amd.com/amd-aocl/fftw/"
+    url = "https://github.com/amd/amd-fftw/archive/2.2.tar.gz"
+    git = "https://github.com/amd/amd-fftw.git"
+
+    version('2.2', sha256='de9d777236fb290c335860b458131678f75aa0799c641490c644c843f0e246f8')
+    version('2.1', sha256='b58e063ddc9bb178dbc9914ae863e26ca511011357dd3ddf36fc014f5875d18c')
+    version('2.0', sha256='277b43aedbb667eda20611f52772d10c37c26b137bc5ff108554bd5f133a5e58')
+
     variant(
         'precision', values=any_combination_of(
             'float', 'double', 'long_double', 'quad'
@@ -22,6 +38,7 @@ class FftwBase(AutotoolsPackage):
     )
     variant('openmp', default=False, description="Enable OpenMP support.")
     variant('mpi', default=True, description='Activate MPI support')
+    variant('enable-single', default=False, description='Enable Single support.')
     variant(
         'pfft_patches', default=False,
         description='Add extra transpose functions for PFFT compatibility')
@@ -30,6 +47,7 @@ class FftwBase(AutotoolsPackage):
     depends_on('automake', type='build', when='+pfft_patches')
     depends_on('autoconf', type='build', when='+pfft_patches')
     depends_on('libtool', type='build', when='+pfft_patches')
+    depends_on('texinfo')
 
     # https://github.com/FFTW/fftw3/commit/902d0982522cdf6f0acd60f01f59203824e8e6f3
     conflicts('%gcc@8:8.9999', when="@3.3.7")
@@ -96,7 +114,13 @@ class FftwBase(AutotoolsPackage):
         options = [
             '--prefix={0}'.format(prefix),
             '--enable-shared',
-            '--enable-threads'
+            '--enable-threads',
+	    '--enable-sse2',
+            '--enable-avx',
+            '--enable-avx2',
+            '--enable-mpi',
+            '--enable-openmp',
+            '--enable-amd-opt'
         ]
         if not self.compiler.f77 or not self.compiler.fc:
             options.append("--disable-fortran")
@@ -112,6 +136,9 @@ class FftwBase(AutotoolsPackage):
                 options.insert(0, 'CFLAGS=' + self.compiler.openmp_flag)
         if '+mpi' in spec:
             options.append('--enable-mpi')
+
+        if '+single' in self.spec:
+            options.append("--enable-single")
 
         # Specific SIMD support.
         # all precisions
@@ -181,26 +208,3 @@ class FftwBase(AutotoolsPackage):
 
     def install(self, spec, prefix):
         self.for_each_precision_make('install')
-
-class Fftw(FftwBase):
-    """FFTW is a C subroutine library for computing the discrete Fourier
-       transform (DFT) in one or more dimensions, of arbitrary input
-       size, and of both real and complex data (as well as of even/odd
-       data, i.e. the discrete cosine/sine transforms or DCT/DST). We
-       believe that FFTW, which is free software, should become the FFT
-       library of choice for most applications."""
-
-    homepage = "http://www.fftw.org"
-    url = "http://www.fftw.org/fftw-3.3.4.tar.gz"
-    list_url = "http://www.fftw.org/download.html"
-
-    version('3.3.8', sha256='6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303')
-    version('3.3.7', sha256='3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573')
-    version('3.3.6-pl2', sha256='a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2')
-    version('3.3.5', sha256='8ecfe1b04732ec3f5b7d279fdb8efcad536d555f9d1e8fabd027037d45ea8bcf')
-    version('3.3.4', sha256='8f0cde90929bc05587c3368d2f15cd0530a60b8a9912a8e2979a72dbe5af0982')
-    version('2.1.5', sha256='f8057fae1c7df8b99116783ef3e94a6a44518d49c72e2e630c24b689c6022630')
-
-    patch('pfft-3.3.5.patch', when="@3.3.5:+pfft_patches", level=0)
-    patch('pfft-3.3.4.patch', when="@3.3.4+pfft_patches", level=0)
-    patch('pgi-3.3.6-pl2.patch', when="@3.3.6-pl2%pgi", level=0)

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -1,0 +1,129 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+import os.path
+import llnl.util.lang
+from spack import *
+from spack.pkg.builtin.fftw import FftwBase
+
+
+class Amdfftw(FftwBase):
+    """FFTW (AMD Optimized version) is a comprehensive collection of
+    fast C routines for computing the Discrete Fourier Transform (DFT)
+    and various special cases thereof.
+
+    It is an open-source implementation of the Fast Fourier transform
+    algorithm. It can compute transforms of real and complex-values
+    arrays of arbitrary size and dimension.
+    AMD Optimized FFTW is the optimized FFTW implementation targeted
+    for AMD CPUs.
+    """
+
+    _name = 'amdfftw'
+    homepage = "https://developer.amd.com/amd-aocl/fftw/"
+    url = "https://github.com/amd/amd-fftw/archive/2.2.tar.gz"
+    git = "https://github.com/amd/amd-fftw.git"
+
+    version('2.2', sha256='de9d777236fb290c335860b458131678f75aa0799c641490c644c843f0e246f8')
+    version('2.1', sha256='b58e063ddc9bb178dbc9914ae863e26ca511011357dd3ddf36fc014f5875d18c')
+    version('2.0', sha256='277b43aedbb667eda20611f52772d10c37c26b137bc5ff108554bd5f133a5e58')
+
+
+    variant('enable-single', default=False, description='Enable Single support.')
+ 
+    depends_on('texinfo')
+
+
+    def configure(self, spec, prefix):
+        # Base options
+        options = [
+            '--prefix={0}'.format(prefix),
+            '--enable-shared',
+            '--enable-threads',
+	    '--enable-sse2',
+	    '--enable-avx',
+	    '--enable-avx2',
+	    '--enable-mpi',
+	    '--enable-openmp',
+	    '--enable-amd-opt'
+        ]
+        if not self.compiler.f77 or not self.compiler.fc:
+            options.append("--disable-fortran")
+        if spec.satisfies('@:2'):
+            options.append('--enable-type-prefix')
+
+        # Variants that affect every precision
+        if '+openmp' in spec:
+            # Note: Apple's Clang does not support OpenMP.
+            if spec.satisfies('%clang'):
+                ver = str(self.compiler.version)
+                if ver.endswith('-apple'):
+                    raise InstallError("Apple's clang does not support OpenMP")
+            options.append('--enable-openmp')
+            if spec.satisfies('@:2'):
+                # TODO: libtool strips CFLAGS, so 2.x libxfftw_threads
+                #       isn't linked to the openmp library. Patch Makefile?
+                options.insert(0, 'CFLAGS=' + self.compiler.openmp_flag)
+        if '+mpi' in spec:
+            options.append('--enable-mpi')
+
+        if '+single' in self.spec:
+            options.append("--enable-single")
+
+        # Specific SIMD support.
+        # all precisions
+        simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                         'kcvi', 'vsx', 'neon']
+        # float only
+        float_simd_features = ['altivec', 'sse']
+
+        simd_options = []
+        for feature in simd_features:
+            msg = '--enable-{0}' if feature in spec.target else '--disable-{0}'
+            simd_options.append(msg.format(feature))
+
+        # If no features are found, enable the generic ones
+        if not any(f in spec.target for f in
+                   simd_features + float_simd_features):
+            simd_options += [
+                '--enable-generic-simd128',
+                '--enable-generic-simd256'
+            ]
+
+        simd_options += [
+            '--enable-fma' if 'fma' in spec.target else '--disable-fma'
+        ]
+
+        # Double is the default precision, for all the others we need
+        # to enable the corresponding option.
+        enable_precision = {
+            'float': ['--enable-float'],
+            'double': None,
+            'long_double': ['--enable-long-double'],
+            'quad': ['--enable-quad-precision']
+        }
+
+        # Different precisions must be configured and compiled one at a time
+        configure = Executable('../configure')
+        for precision in self.selected_precisions:
+            opts = (enable_precision[precision] or []) + options[:]
+
+            # SIMD optimizations are available only for float and double
+            # starting from FFTW 3
+            if precision in ('float', 'double') and spec.satisfies('@3:'):
+                opts += simd_options
+
+            # float-only acceleration
+            if precision == 'float':
+                for feature in float_simd_features:
+                    if feature in spec.target:
+                        msg = '--enable-{0}'
+                    else:
+                        msg = '--disable-{0}'
+                    opts.append(msg.format(feature))
+
+            with working_dir(precision, create=True):
+                configure(*opts)
+

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.pkg.builtin.libflame import LibflameBase
+
+
+class Amdlibflame(LibflameBase):
+    """libFLAME is a portable library for dense matrix computations,
+    providing much of the functionality present in Linear Algebra
+    Package (LAPACK). It includes a compatibility layer, FLAPACK,
+    which includes complete LAPACK implementation. The library
+    provides scientific and numerical computing communities with a
+    modern, high-performance dense linear algebra library that is
+    extensible, easy to use, and available under an open source
+    license. libFLAME is a C-only implementation and does not
+    depend on any external FORTRAN libraries including LAPACK.
+    There is an optional backward compatibility layer, lapack2flame
+    that maps LAPACK routine invocations to their corresponding
+    native C implementations in libFLAME. This allows legacy
+    applications to start taking advantage of libFLAME with
+    virtually no changes to their source code.
+    In combination with BLIS library which includes optimizations
+    for the AMD EPYC processor family, libFLAME enables running
+    high performing LAPACK functionalities on AMD platform."""
+
+    _name = 'amdlibflame'
+    homepage = "http://developer.amd.com/amd-cpu-libraries/blas-library/#libflame"
+    url = "https://github.com/amd/libflame/archive/2.2.tar.gz"
+    git = "https://github.com/amd/libflame.git"
+
+    version('2.2', sha256='12b9c1f92d2c2fa637305aaa15cf706652406f210eaa5cbc17aaea9fcfa576dc')
+    version('2.1', sha256='dc2dcaabd4a90ecb328bee3863db0908e412bf7ce5fb8f5e93377fdbca9abb65')
+    version('2.0', sha256='c80517b455df6763341f67654a6bda909f256a4927ffe9b4f0a2daed487d3739')
+    provides('flame@5.2', when='@2:')
+
+
+    def configure_args(self):
+        # Libflame has a secondary dependency on BLAS,
+        # but doesn't know which library name to expect:
+        # https://github.com/flame/libflame/issues/24
+        config_args = ['LIBS=' + self.spec['blas'].libs.link_flags]
+
+        if '+lapack2flame' in self.spec:
+            config_args.append("--enable-lapack2flame")
+        else:
+            config_args.append("--disable-lapack2flame")
+
+        if '+static' in self.spec:
+            config_args.append("--enable-static-build")
+        else:
+            config_args.append("--disable-static-build")
+
+        if '+shared' in self.spec:
+            config_args.append("--enable-dynamic-build")
+        else:
+            config_args.append("--disable-dynamic-build")
+
+        if '+debug' in self.spec:
+            config_args.append("--enable-debug")
+        else:
+            config_args.append("--disable-debug")
+
+        config_args.extend(self.enable_or_disable('threads'))
+
+        if 'none' != self.spec.variants['threads'].value:
+            config_args.append("--enable-supermatrix")
+        else:
+            config_args.append("--disable-supermatrix")
+
+        # https://github.com/flame/libflame/issues/21
+        config_args.append("--enable-max-arg-list-hack")
+        config_args.append("--enable-external-lapack-interfaces")
+
+        return config_args
+
+    def install(self, spec, prefix):
+        make()
+
+        # make install in parallel fails with message 'File already exists'
+        make("install", parallel=False)

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.pkg.builtin.libflame import LibflameBase
+
+
+class Amdlibflame(LibflameBase):
+    """libFLAME (AMD Optimized version) is a portable library for
+    dense matrix computations, providing much of the functionality
+    present in Linear Algebra Package (LAPACK). It includes a
+    compatibility layer, FLAPACK, which includes complete LAPACK
+    implementation.
+
+    The library provides scientific and numerical computing communities
+    with a modern, high-performance dense linear algebra library that is
+    extensible, easy to use, and available under an open source
+    license. libFLAME is a C-only implementation and does not
+    depend on any external FORTRAN libraries including LAPACK.
+    There is an optional backward compatibility layer, lapack2flame
+    that maps LAPACK routine invocations to their corresponding
+    native C implementations in libFLAME. This allows legacy
+    applications to start taking advantage of libFLAME with
+    virtually no changes to their source code.
+
+    In combination with BLIS library which includes optimizations
+    for the AMD EPYC processor family, libFLAME enables running
+    high performing LAPACK functionalities on AMD platform."""
+
+    _name = 'amdlibflame'
+    homepage = "http://developer.amd.com/amd-cpu-libraries/blas-library/#libflame"
+    url = "https://github.com/amd/libflame/archive/2.2.tar.gz"
+    git = "https://github.com/amd/libflame.git"
+
+    version('2.2', sha256='12b9c1f92d2c2fa637305aaa15cf706652406f210eaa5cbc17aaea9fcfa576dc')
+    version('2.1', sha256='dc2dcaabd4a90ecb328bee3863db0908e412bf7ce5fb8f5e93377fdbca9abb65')
+    version('2.0', sha256='c80517b455df6763341f67654a6bda909f256a4927ffe9b4f0a2daed487d3739')
+    provides('flame@5.2', when='@2:')
+
+
+    def configure_args(self):
+        args = super(Amdlibflame, self).configure_args()
+        args.append("--enable-external-lapack-interfaces")
+        return args
+
+    def install(self, spec, prefix):
+        make()
+
+        # make install in parallel fails with message 'File already exists'
+        make("install", parallel=False)

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -5,34 +5,14 @@
 
 import os
 import os.path
-
 import llnl.util.lang
-
 from spack import *
 
 
-class Fftw(AutotoolsPackage):
-    """FFTW is a C subroutine library for computing the discrete Fourier
-       transform (DFT) in one or more dimensions, of arbitrary input
-       size, and of both real and complex data (as well as of even/odd
-       data, i.e. the discrete cosine/sine transforms or DCT/DST). We
-       believe that FFTW, which is free software, should become the FFT
-       library of choice for most applications."""
-
-    homepage = "http://www.fftw.org"
-    url = "http://www.fftw.org/fftw-3.3.4.tar.gz"
-    list_url = "http://www.fftw.org/download.html"
-
-    version('3.3.8', sha256='6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303')
-    version('3.3.7', sha256='3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573')
-    version('3.3.6-pl2', sha256='a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2')
-    version('3.3.5', sha256='8ecfe1b04732ec3f5b7d279fdb8efcad536d555f9d1e8fabd027037d45ea8bcf')
-    version('3.3.4', sha256='8f0cde90929bc05587c3368d2f15cd0530a60b8a9912a8e2979a72dbe5af0982')
-    version('2.1.5', sha256='f8057fae1c7df8b99116783ef3e94a6a44518d49c72e2e630c24b689c6022630')
-
-    patch('pfft-3.3.5.patch', when="@3.3.5:+pfft_patches", level=0)
-    patch('pfft-3.3.4.patch', when="@3.3.4+pfft_patches", level=0)
-    patch('pgi-3.3.6-pl2.patch', when="@3.3.6-pl2%pgi", level=0)
+class FftwBase(AutotoolsPackage):
+    """Base class for building Fftw, shared with the AMD optimized version
+    of the library in the 'amdfftw' package.
+    """
 
     variant(
         'precision', values=any_combination_of(
@@ -57,7 +37,6 @@ class Fftw(AutotoolsPackage):
               msg='Long double precision is not supported in FFTW 2')
     conflicts('precision=quad', when='@2.1.5',
               msg='Quad precision is not supported in FFTW 2')
-    conflicts('+openmp', when='%apple-clang', msg="Apple's clang does not support OpenMP")
 
     provides('fftw-api@2', when='@2.1.5')
     provides('fftw-api@3', when='@3:')
@@ -125,6 +104,11 @@ class Fftw(AutotoolsPackage):
 
         # Variants that affect every precision
         if '+openmp' in spec:
+            # Note: Apple's Clang does not support OpenMP.
+            if spec.satisfies('%clang'):
+                ver = str(self.compiler.version)
+                if ver.endswith('-apple'):
+                    raise InstallError("Apple's clang does not support OpenMP")
             options.append('--enable-openmp')
             if spec.satisfies('@:2'):
                 # TODO: libtool strips CFLAGS, so 2.x libxfftw_threads
@@ -201,3 +185,26 @@ class Fftw(AutotoolsPackage):
 
     def install(self, spec, prefix):
         self.for_each_precision_make('install')
+
+class Fftw(FftwBase):
+    """FFTW is a C subroutine library for computing the discrete Fourier
+       transform (DFT) in one or more dimensions, of arbitrary input
+       size, and of both real and complex data (as well as of even/odd
+       data, i.e. the discrete cosine/sine transforms or DCT/DST). We
+       believe that FFTW, which is free software, should become the FFT
+       library of choice for most applications."""
+
+    homepage = "http://www.fftw.org"
+    url = "http://www.fftw.org/fftw-3.3.4.tar.gz"
+    list_url = "http://www.fftw.org/download.html"
+
+    version('3.3.8', sha256='6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303')
+    version('3.3.7', sha256='3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573')
+    version('3.3.6-pl2', sha256='a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2')
+    version('3.3.5', sha256='8ecfe1b04732ec3f5b7d279fdb8efcad536d555f9d1e8fabd027037d45ea8bcf')
+    version('3.3.4', sha256='8f0cde90929bc05587c3368d2f15cd0530a60b8a9912a8e2979a72dbe5af0982')
+    version('2.1.5', sha256='f8057fae1c7df8b99116783ef3e94a6a44518d49c72e2e630c24b689c6022630')
+
+    patch('pfft-3.3.5.patch', when="@3.3.5:+pfft_patches", level=0)
+    patch('pfft-3.3.4.patch', when="@3.3.4+pfft_patches", level=0)
+    patch('pgi-3.3.6-pl2.patch', when="@3.3.6-pl2%pgi", level=0)

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -6,22 +6,9 @@
 from spack import *
 
 
-class Libflame(AutotoolsPackage):
-    """libflame is a portable library for dense matrix computations,
-    providing much of the functionality present in LAPACK, developed
-    by current and former members of the Science of High-Performance
-    Computing (SHPC) group in the Institute for Computational
-    Engineering and Sciences at The University of Texas at Austin.
-    libflame includes a compatibility layer, lapack2flame, which
-    includes a complete LAPACK implementation."""
-
-    homepage = "https://www.cs.utexas.edu/~flame/web/libFLAME.html"
-    url      = "https://github.com/flame/libflame/archive/5.1.0.tar.gz"
-    git      = "https://github.com/flame/libflame.git"
-
-    version('master', branch='master')
-    version('5.2.0', sha256='997c860f351a5c7aaed8deec00f502167599288fd0559c92d5bfd77d0b4d475c')
-    version('5.1.0', sha256='e7189b750890bd781fe773f366b374518dd1d89a6513d3d6261bf549826384d1')
+class LibflameBase(AutotoolsPackage):
+    """Base class for building Libflame, shared with the AMD
+    optimized version of the library in the 'libflame' package"""
 
     provides('lapack', when='+lapack2flame')
 
@@ -119,3 +106,22 @@ class Libflame(AutotoolsPackage):
         # The shared library is not installed correctly on Darwin; fix this
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(self.prefix.lib)
+
+class Libflame(LibflameBase):
+    """libflame is a portable library for dense matrix computations,
+    providing much of the functionality present in LAPACK, developed
+    by current and former members of the Science of High-Performance
+    Computing (SHPC) group in the Institute for Computational
+    Engineering and Sciences at The University of Texas at Austin.
+    libflame includes a compatibility layer, lapack2flame, which
+    includes a complete LAPACK implementation."""
+
+    homepage = "https://www.cs.utexas.edu/~flame/web/libFLAME.html"
+    url      = "https://github.com/flame/libflame/archive/5.1.0.tar.gz"
+    git      = "https://github.com/flame/libflame.git"
+
+    version('master', branch='master')
+    version('5.2.0', sha256='997c860f351a5c7aaed8deec00f502167599288fd0559c92d5bfd77d0b4d475c')
+    version('5.1.0', sha256='e7189b750890bd781fe773f366b374518dd1d89a6513d3d6261bf549826384d1')
+
+    provides('flame@5.2', when='@5.2.0')


### PR DESCRIPTION
The package has been refactored to be able to 
reuse the build logic for the fork of the project
optimized for AMD.