### PR TITLE
Update the change to add gomp compatibity to llvm-openmp.

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -30,9 +30,7 @@ class LlvmOpenmp(CMakePackage):
         ]
         # Add optional support for both Intel and gcc compilers
         if self.spec.satisfies('+multicompat'):
-            cmake_args.extend([
-                '-DKMP_GOMP_COMPAT=1'
-            ])
+            cmake_args.append('-DKMP_GOMP_COMPAT=1')
         return cmake_args
 
     @property

--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -18,10 +18,22 @@ class LlvmOpenmp(CMakePackage):
 
     depends_on('cmake@2.8:', type='build')
 
+    variant('multicompat', default=False,
+            description="Support gomp as well as the Intel openMP runtime library.")
+
     def cmake_args(self):
+
         # Disable LIBOMP_INSTALL_ALIASES, otherwise the library is installed as
         # libgomp alias which can conflict with GCC's libgomp.
-        return ['-DLIBOMP_INSTALL_ALIASES=OFF']
+        cmake_args = [
+            '-DLIBOMP_INSTALL_ALIASES=OFF'
+        ]
+        # Add optional support for both Intel and gcc compilers
+        if self.spec.satisfies('+multicompat'):
+            cmake_args.extend([
+                '-DKMP_GOMP_COMPAT=1'
+            ])
+        return cmake_args
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -19,7 +19,7 @@ class LlvmOpenmp(CMakePackage):
     depends_on('cmake@2.8:', type='build')
 
     variant('multicompat', default=False,
-            description="Support gomp as well as the Intel openMP runtime library.")
+            description="Support gomp and the Intel openMP runtime library.")
 
     def cmake_args(self):
 


### PR DESCRIPTION
Update the change to add gomp compatibity to llvm-openmp by adding the -DKMP_GOMP_COMPAT=1 setting to the cmake args for llvm-openmp.  This allows this library to replace libgomp as well as libomp.