### PR TITLE
CudaPackage: maintainers are listed in the docstring

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -12,8 +12,9 @@ import spack.variant
 class CudaPackage(PackageBase):
     """Auxiliary class which contains CUDA variant, dependencies and conflicts
     and is meant to unify and facilitate its usage.
+
+    Maintainers: ax3l, svenevs
     """
-    maintainers = ['ax3l', 'svenevs']
 
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
     # https://developer.nvidia.com/cuda-gpus


### PR DESCRIPTION
fixes #17396

This prevents the class attribute to be inherited and saves both ax3l and svenevs from becoming the default maintainers of every Cuda package.