### PR TITLE
Ginkgo: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/CAS-HIP-NVCC-1.2.0.patch
+++ b/var/spack/repos/builtin/packages/ginkgo/CAS-HIP-NVCC-1.2.0.patch
@@ -1,0 +1,10 @@
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 884e50bf6..40618311a 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-if(GINKGO_BUILD_CUDA)
++if(GINKGO_BUILD_CUDA OR (GINKGO_BUILD_HIP AND GINKGO_HIP_PLATFORM STREQUAL "nvcc"))
+     enable_language(CUDA)
+     if (GINKGO_USE_EXTERNAL_CAS)
+         include(CudaArchitectureSelector RESULT_VARIABLE GINKGO_CAS_FILE)

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -30,30 +30,24 @@ class Ginkgo(CMakePackage, CudaPackage):
     variant('build_type', default='Release',
             description='The build type to build',
             values=('Debug', 'Release'))
-    variant('hip', default=False, description="Compile Ginkgo with HIP support")
 
     depends_on('cmake@3.9:', type='build')
     depends_on('cuda@9:',    when='+cuda')
 
     conflicts('%gcc@:5.2.9')
 
-    # HIP support was added in version 1.2.0
-    conflicts("+hip", when="@1.0.0:1.1.1")
-
-    patch('CAS-HIP-NVCC-1.2.0.patch', when='@1.2.0 +hip')
-    patch('CAS-HIP-NVCC-1.2.0.patch', when='@master +hip')
-
     def cmake_args(self):
         spec = self.spec
         return [
             '-DGINKGO_BUILD_CUDA=%s' % ('ON' if '+cuda' in spec else 'OFF'),
-            '-DGINKGO_BUILD_HIP=%s' % ('ON' if '+hip' in spec else 'OFF'),
             '-DGINKGO_BUILD_OMP=%s' % ('ON' if '+openmp' in spec else 'OFF'),
             '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
             '-DGINKGO_JACOBI_FULL_OPTIMIZATIONS=%s' % (
                 'ON' if '+full_optimizations' in spec else 'OFF'),
             '-DGINKGO_DEVEL_TOOLS=%s' % (
                 'ON' if '+develtools' in spec else 'OFF'),
+            # Drop HIP support for now
+            '-DGINKGO_BUILD_HIP=OFF',
             # As we are not exposing benchmarks, examples, tests nor doc
             # as part of the installation, disable building them altogether.
             '-DGINKGO_BUILD_BENCHMARKS=OFF',

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -18,6 +18,8 @@ class Ginkgo(CMakePackage, CudaPackage):
 
     version('develop', branch='develop')
     version('master', branch='master')
+    version('1.2.0', commit='b4be2be961fd5db45c3d02b5e004d73550722e31')  # v1.2.0
+    version('1.1.1', commit='08d2c5200d3c78015ac8a4fd488bafe1e4240cf5')  # v1.1.1
     version('1.1.0', commit='b9bec8225442b3eb2a85a870efa112ab767a17fb')  # v1.1.0
     version('1.0.0', commit='45244641e0c2b19ba33aecd25153c0bddbcbe1a0')  # v1.0.0
 
@@ -28,16 +30,24 @@ class Ginkgo(CMakePackage, CudaPackage):
     variant('build_type', default='Release',
             description='The build type to build',
             values=('Debug', 'Release'))
+    variant('hip', default=False, description="Compile Ginkgo with HIP support")
 
     depends_on('cmake@3.9:', type='build')
     depends_on('cuda@9:',    when='+cuda')
 
     conflicts('%gcc@:5.2.9')
 
+    # HIP support was added in version 1.2.0
+    conflicts("+hip", when="@1.0.0:1.1.1")
+
+    patch('CAS-HIP-NVCC-1.2.0.patch', when='@1.2.0 +hip')
+    patch('CAS-HIP-NVCC-1.2.0.patch', when='@master +hip')
+
     def cmake_args(self):
         spec = self.spec
         return [
             '-DGINKGO_BUILD_CUDA=%s' % ('ON' if '+cuda' in spec else 'OFF'),
+            '-DGINKGO_BUILD_HIP=%s' % ('ON' if '+hip' in spec else 'OFF'),
             '-DGINKGO_BUILD_OMP=%s' % ('ON' if '+openmp' in spec else 'OFF'),
             '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
             '-DGINKGO_JACOBI_FULL_OPTIMIZATIONS=%s' % (


### PR DESCRIPTION
This PR adds the new Ginkgo versions 1.1.1 and in particular 1.2.0 which provide full HIP support for the library.

I do not think there is currently a `hip` package in spack so I simply use a `variant` for this, and suppose that the system has all the correct dependencies in the default paths. Technically, we also depend on hipthrust, hipsparse and hipblas as well.

The new patch accounts for an issue which only appeared when building the Ginkgo through spack. It is (will very soon be) fixed in develop, see https://github.com/ginkgo-project/ginkgo/pull/585