### PR TITLE
CUDA 11.0.2

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -26,6 +26,7 @@ class CudaPackage(PackageBase):
         '50', '52', '53',
         '60', '61', '62',
         '70', '72', '75',
+        '80',
     ]
 
     # FIXME: keep cuda and cuda_arch separate to make usage easier until
@@ -49,6 +50,7 @@ class CudaPackage(PackageBase):
 
     # CUDA version vs Architecture
     # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+    # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
     depends_on('cuda@:6.0',     when='cuda_arch=10')
     depends_on('cuda@:6.5',     when='cuda_arch=11')
     depends_on('cuda@2.1:6.5',  when='cuda_arch=12')
@@ -59,8 +61,8 @@ class CudaPackage(PackageBase):
 
     depends_on('cuda@5.0:10.2', when='cuda_arch=30')
     depends_on('cuda@5.0:10.2', when='cuda_arch=32')
-    depends_on('cuda@5.0:10.2', when='cuda_arch=35')
-    depends_on('cuda@6.5:10.2', when='cuda_arch=37')
+    depends_on('cuda@5.0:',     when='cuda_arch=35')
+    depends_on('cuda@6.5:',     when='cuda_arch=37')
 
     depends_on('cuda@6.0:',     when='cuda_arch=50')
     depends_on('cuda@6.5:',     when='cuda_arch=52')
@@ -73,6 +75,8 @@ class CudaPackage(PackageBase):
     depends_on('cuda@9.0:',     when='cuda_arch=70')
     depends_on('cuda@9.0:',     when='cuda_arch=72')
     depends_on('cuda@10.0:',    when='cuda_arch=75')
+
+    depends_on('cuda@11.0:',    when='cuda_arch=80')
 
     # There are at least three cases to be aware of for compiler conflicts
     # 1. Linux x86_64
@@ -89,12 +93,15 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@7:', when='+cuda ^cuda@:9.1' + arch_platform)
     conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
     conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89' + arch_platform)
+    conflicts('%gcc@:4,10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
     conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27' + arch_platform)
     conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5' + arch_platform)
     conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8' + arch_platform)
     conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1' + arch_platform)
-    conflicts('%pgi@:16', when='+cuda ^cuda@9.2.88:10' + arch_platform)
-    conflicts('%pgi@:17', when='+cuda ^cuda@10.2.89' + arch_platform)
+    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
+    conflicts('%pgi@:17,20:',
+              when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
+    conflicts('%pgi@:17,20.2:', when='+cuda ^cuda@11.0.2' + arch_platform)
     conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
     conflicts('%clang@:3.7,4:',
               when='+cuda ^cuda@8.0:9.0' + arch_platform)
@@ -105,7 +112,8 @@ class CudaPackage(PackageBase):
     conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105' + arch_platform)
     conflicts('%clang@:3.7,8.1:',
               when='+cuda ^cuda@10.1.105:10.1.243' + arch_platform)
-    conflicts('%clang@:3.2,9.0:', when='+cuda ^cuda@10.2.89' + arch_platform)
+    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89' + arch_platform)
+    conflicts('%clang@:5,10:', when='+cuda ^cuda@11.0.2' + arch_platform)
 
     # x86_64 vs. ppc64le differ according to NVidia docs
     # Linux ppc64le compiler conflicts from Table from the docs below:
@@ -120,6 +128,8 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@6:', when='+cuda ^cuda@:9' + arch_platform)
     conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
     conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243' + arch_platform)
+    # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
+    conflicts('%gcc@:4,10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
     conflicts('%pgi', when='+cuda ^cuda@:8' + arch_platform)
     conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185' + arch_platform)
     conflicts('%pgi@:17', when='+cuda ^cuda@:10' + arch_platform)
@@ -129,6 +139,7 @@ class CudaPackage(PackageBase):
     conflicts('%clang@7:', when='+cuda ^cuda@10.0.130' + arch_platform)
     conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105' + arch_platform)
     conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89' + arch_platform)
+    conflicts('%clang@:5,10.0:', when='+cuda ^cuda@11.0.2' + arch_platform)
 
     # Intel is mostly relevant for x86_64 Linux, even though it also
     # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
@@ -142,11 +153,13 @@ class CudaPackage(PackageBase):
     conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
     conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
     conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
+    conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
+    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.0.2')
 
     # XL is mostly relevant for ppc64le Linux
     conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
     conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
-    conflicts('%xl@17:', when='+cuda ^cuda@:10.2.89')
+    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.0.2')
 
     # Mac OS X
     # platform = ' platform=darwin'
@@ -157,7 +170,7 @@ class CudaPackage(PackageBase):
     # `clang-apple@x.y.z as a possible fix.
     # Compiler conflicts will be eventual taken from here:
     # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#abstract
-    conflicts('platform=darwin', when='+cuda ^cuda@11.0:')
+    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2:')
 
     # Make sure cuda_arch can not be used without +cuda
     for value in cuda_arch_values:

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -22,6 +22,9 @@ import llnl.util.tty as tty
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.0.2': {
+        'Linux-x86_64': ('48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1', 'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'),
+        'Linux-ppc64le': ('db06d0f3fbf6f7aa1f106fc921ad1c86162210a26e8cb65b171c5240a3bf75da', 'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_ppc64le.run')},
     '10.2.89': {
         'Linux-x86_64': ('560d07fdcf4a46717f2242948cd4f92c5f9b6fc7eae10dd996614da913d5ca11', 'http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'),
         'Linux-ppc64le': ('5227774fcb8b10bd2d8714f0a716a75d7a2df240a9f2a49beb76710b1c0fc619', 'http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux_ppc64le.run')},


### PR DESCRIPTION
- [x] wait for general release: CUDA Toolkit 11.0.2-1 (NVCC 11.0.194)
- [x] compute capability support
- [x] compiler conflicts
  - [x] ppc64le
  - [x] conflict pre-C++11 compilers as recommended, since too many default math libs depend on C++11 host now
- [x] minimal check: `spack install cuda-memtest`
- [x] new download links
- with respect to #17018 and other collisions, we should set `--tmpdir=` to a `mktemp -d`ir that we create and control (also: problem is gone with 11.0.2 as far as I tested) - can be cleaned up in a follow-up PR.
```
  --tmpdir=<path>
    Performs any temporary actions within <path> instead of /tmp. Useful in
    cases where /tmp cannot be used (doesn't exist, is full, is mounted with
    'noexec', etc.).
```
- [x] let people test their things

cc @svenevs preparing this already