### PR TITLE
remove one-shot entrypoint/switch default entrypoint to spack-env

### DIFF
--- a/share/spack/docker/entrypoint.bash
+++ b/share/spack/docker/entrypoint.bash
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-mode=oneshot
+mode=spackenv
 
 if [ "$( basename "$0" )" '=' 'spack-env' ] ; then
     mode=spackenv
@@ -88,52 +88,6 @@ case "$mode" in
 
             exit 1
         fi
-        ;;
-
-    "oneshot")
-        # Scenario 4: Run a one-shot Spack command from the host command
-        # line.
-        #
-        # Triggered by providing arguments to `docker run`.  Arguments
-        # are passed along to the container's underlying spack
-        # installation, allowing users to use the image as if it were
-        # spack, itself.  Pass volume mount information to `docker run`
-        # to persist the effects of running in this mode.
-        #
-        # This is the default behavior when running with a CMD override.
-        #
-        # Examples:
-        #   # concretize the same spec on different OSes
-        #   docker run --rm spack/ubuntu-xenial spec zlib
-        #   docker run --rm spack/centos7 spec zlib
-        #
-        #   # a "wetter" dry-run;
-        #   # install a package and then throw away the results.
-        #   docker run --rm spack/centos7 install libiconv
-        #   docker run --rm spack/centos7 find libiconv
-        #     ==> No package matches the query: libiconv
-        #
-        #   # use docker volumes to persist changes
-        #   docker run --rm -v ...:/spack spack/centos7 install ...
-        #   docker run --rm -v ...:/spack spack/centos7 install ...
-        #   docker run --rm -v ...:/spack spack/centos7 install ...
-        exec 3>&1
-        exec 4>&2
-
-        exec 1>&-
-        exec 2>&-
-
-        . $SPACK_ROOT/share/spack/setup-env.sh
-        unset CURRENTLY_BUILDING_DOCKER_IMAGE
-
-        exec 1>&3
-        exec 2>&4
-
-        exec 3>&-
-        exec 4>&-
-
-        spack "$@"
-        exit $?
         ;;
 
     *)


### PR DESCRIPTION
(Further) simplifies the `ENTRYPOINT` for the docker images.  This change removes the `one-shot` default entrypoint and replaces it with the `spack-env` entrypoint.  Combined with the `interactive-shell` default `CMD`, these changes yield the following behavior:

 - Before these changes: when running the image with no `ENTRYPOINT` or `CMD` override, an interactive shell session was created.  This session had spack loaded and ready for immediate use.  This behavior is preserved by the changes.

 - Before these changes: when running the image with a `CMD` override, the `CMD` was taken as a set of arguments to spack, itself (i.e.: `spack '...'`).  These changes remove this behavior.  Instead, the `CMD` is ran as in `/usr/bin/env sh -c '...'`, except that the passed commands can use Spack without the need to source its loading script. Existing uses of the prior behavior can accomplish the same by just adding `spack` to the beginning of the `CMD`:

```bash
 $ docker run --rm ... spack/ubuntu-bionic spec hdf5  # before
 $ docker run --rm ... spack/ubuntu-bionic spack spec hdf5  # after
```

 - The `docker-shell` variant continues to work as before.  `RUN` commands in a `Dockerfile` that use our image as a base can still run spack commands without needing to source spack's loading script.

Without these changes, `spack ci` users would need to explicitly override the `ENTRYPOINT` of jobs that run using our images.  This requirement precluded use in environments where entrypoint overrides were disabled, or ignored, such as with the Kubernetes executor (see [this issue](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4125)).  With these changes, the `ENTRYPOINT` now works, by default, in a manner compatible with all Gitlab CI use cases.