### PR TITLE
enable flatcc to be built with gcc@9.X.X

### DIFF
--- a/var/spack/repos/builtin/packages/flatcc/package.py
+++ b/var/spack/repos/builtin/packages/flatcc/package.py
@@ -37,6 +37,9 @@ class Flatcc(CMakePackage):
         spec = self.spec
         args = []
 
+        # allow flatcc to be built with more compilers
+        args.append('-DFLATCC_ALLOW_WERROR=OFF')
+
         if '+shared' in spec:
             args.append('-DBUILD_SHARED_LIBS=ON')
             args.append('-DFLATCC_INSTALL=ON')


### PR DESCRIPTION
`gcc` 9 and above have more warnings that break the `flatcc` build by default, because `-Werror` is enabled.  This loosens the build up so that we can build with more compilers in Spack.

- [x] Add `-DFLATCC_ALLOW_WERROR=OFF` to `flatcc` CMake arguments