### PR TITLE
Fix docs about containers on cray

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1247,6 +1247,6 @@ environment variables may be propagated into containers that are not
 using the Cray programming environment.
 
 To ensure that Spack does not autodetect the Cray programming
-environment, unset the environment variable ``CRAYPE_VERSION``. This
+environment, unset the environment variable ``MODULEPATH``. This
 will cause Spack to treat a linux container on a Cray system as a base
 linux distro.

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -111,14 +111,14 @@ class Cray(Platform):
     @classmethod
     def detect(cls):
         """
-        Detect whether this system is a cray machine.
+        Detect whether this system is a Cray machine.
 
-        We detect the cray platform based on the availability through `module`
-        of the cray programming environment. If this environment is available,
-        we can use it to find compilers, target modules, etc. If the cray
+        We detect the Cray platform based on the availability through `module`
+        of the Cray programming environment. If this environment is available,
+        we can use it to find compilers, target modules, etc. If the Cray
         programming environment is not available via modules, then we will
-        treat it as a standard linux system, as the cray compiler wrappers
-        and other componenets of the cray programming environment are
+        treat it as a standard linux system, as the Cray compiler wrappers
+        and other components of the Cray programming environment are
         irrelevant without module support.
         """
         return 'opt/cray' in os.environ.get('MODULEPATH', '')


### PR DESCRIPTION
The docs were out of sync with the detection mechanism that's currently based on MODULEPATH.

Also fixes a typo and spells Cray with a capital in the docstring.