### PR TITLE
py-pysam: add LDFLAGS to curl

### DIFF
--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -27,4 +27,4 @@ class PyPysam(PythonPackage):
     depends_on('htslib@:1.6', when='@:0.13')
 
     def setup_build_environment(self, env):
-        env.set('LDFLAGS', '-L' + self.spec['curl'].prefix.lib)
+        env.set('LDFLAGS', self.spec['curl'].libs.search_flags)

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -25,3 +25,6 @@ class PyPysam(PythonPackage):
     depends_on('samtools')
 
     depends_on('htslib@:1.6', when='@:0.13')
+
+    def setup_build_environment(self, env):
+        env.set('LDFLAGS', '-L' + self.spec['curl'].prefix.lib)


### PR DESCRIPTION
With %fj, build failed because fail to find libcurl.

> /opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/gcc/aarch64-linux-gnu/8.2.0/../../../../aarch64-linux-gnu/bin/ld: cannot find -lcurl

So -L(spack's curl/lib) should be add to compiler option.
I could not find fault in setup.py, so added LDFLAGS directly.
 `env.set('LDFLAGS', '-L' + self.spec['curl'].prefix.lib)`
With %gcc, build succeed. But options were similar to %fj.
And probably link to /usr/lib64.
Therefore, this patch should be applied to all compiler.