### PR TITLE
Do not load view into environment in generated spack ci jobs

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -613,7 +613,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                     debug_flag = '-d '
 
                 job_scripts = [
-                    'spack env activate .',
+                    'spack env activate --without-view .',
                     'spack {0}ci rebuild'.format(debug_flag),
                 ]
 


### PR DESCRIPTION
Solves a problem (#17432) where spack seems to be using the wrong python version when python was a build dependency. It seems enabling the environment without loading a view is sufficient to work around that.