### PR TITLE
ltrace: Disable "-Werror".

### DIFF
--- a/var/spack/repos/builtin/packages/ltrace/package.py
+++ b/var/spack/repos/builtin/packages/ltrace/package.py
@@ -17,3 +17,8 @@ class Ltrace(AutotoolsPackage):
     version('0.7.3', sha256='0e6f8c077471b544c06def7192d983861ad2f8688dd5504beae62f0c5f5b9503')
 
     conflicts('platform=darwin', msg='ltrace runs only on Linux.')
+
+    def configure_args(self):
+        # Disable -Werror since some functions used by ltrace
+        # have been deprecated in recent version of glibc
+        return ['--disable-werror']


### PR DESCRIPTION
Some functions used by ltrace have been deprecated in recent versions of glibc, disabling `-Werror` let you compile the code.

Another solution would be to patch the code to avoid using `readdir_r` but it would require more work since `readddir` might not be a drop-in replacement.