### PR TITLE
search for compiler names in order

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -576,7 +576,7 @@ def arguments_to_detect_version_fn(operating_system, paths):
                         )
                         command_arguments.append(detect_version_args)
 
-        # Order already respecs priority from compiler class
+        # Order already respects priority from compiler class
         return command_arguments
 
     fn = getattr(

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -576,9 +576,8 @@ def arguments_to_detect_version_fn(operating_system, paths):
                         )
                         command_arguments.append(detect_version_args)
 
-        # Reverse it here so that the dict creation (last insert wins)
-        # does not spoil the intended precedence.
-        return reversed(command_arguments)
+        # Order already respecs priority from compiler class
+        return command_arguments
 
     fn = getattr(
         operating_system, 'arguments_to_detect_version_fn', _default


### PR DESCRIPTION
for compilers that have multiple executable names, search the names
in the priority order in `compilers/*.py` under \<lang\>_names to ensure
that newer names are caught before backwards compatibility names.

Fixes #518
Supersedes #6327

@adamjstewart 