### PR TITLE
energyplus: add 9.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/energyplus/package.py
+++ b/var/spack/repos/builtin/packages/energyplus/package.py
@@ -19,13 +19,20 @@ class Energyplus(Package):
     # versions require explicit URLs as they contain hashes
     version('8.9.0', sha256='13a5192b25815eb37b3ffd019ce3b99fd9f854935f8cc4362814f41c56e9ca98',
             url="https://github.com/NREL/EnergyPlus/releases/download/v8.9.0-WithIDDFixes/EnergyPlus-8.9.0-eba93e8e1b-Linux-x86_64.tar.gz")
+    version('9.3.0', sha256='c939dc4f867224e110485a8e0712ce4cfb1e06f8462bc630b54f83a18c93876c',
+            url="https://github.com/NREL/EnergyPlus/releases/download/v9.3.0/EnergyPlus-9.3.0-baff08990c-Linux-x86_64.tar.gz")
 
     def install(self, spec, prefix):
         # binary distribution, we just unpack to lib/energyplus
         # and then symlink the appropriate targets
 
         # there is only one folder with a semi-predictable name so we glob it
-        install_tree(glob.glob('EnergyPlus*')[0],
+        source_dir = '.'
+
+        if spec.satisfies('@:8.9.9'):
+            source_dir = glob.glob('EnergyPlus*')[0]
+
+        install_tree(source_dir,
                      join_path(prefix.lib, 'energyplus'))
 
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/energyplus/package.py
+++ b/var/spack/repos/builtin/packages/energyplus/package.py
@@ -17,10 +17,10 @@ class Energyplus(Package):
     homepage = "https://energyplus.net"
 
     # versions require explicit URLs as they contain hashes
-    version('8.9.0', sha256='13a5192b25815eb37b3ffd019ce3b99fd9f854935f8cc4362814f41c56e9ca98',
-            url="https://github.com/NREL/EnergyPlus/releases/download/v8.9.0-WithIDDFixes/EnergyPlus-8.9.0-eba93e8e1b-Linux-x86_64.tar.gz")
     version('9.3.0', sha256='c939dc4f867224e110485a8e0712ce4cfb1e06f8462bc630b54f83a18c93876c',
             url="https://github.com/NREL/EnergyPlus/releases/download/v9.3.0/EnergyPlus-9.3.0-baff08990c-Linux-x86_64.tar.gz")
+    version('8.9.0', sha256='13a5192b25815eb37b3ffd019ce3b99fd9f854935f8cc4362814f41c56e9ca98',
+            url="https://github.com/NREL/EnergyPlus/releases/download/v8.9.0-WithIDDFixes/EnergyPlus-8.9.0-eba93e8e1b-Linux-x86_64.tar.gz")
 
     def install(self, spec, prefix):
         # binary distribution, we just unpack to lib/energyplus

--- a/var/spack/repos/builtin/packages/energyplus/package.py
+++ b/var/spack/repos/builtin/packages/energyplus/package.py
@@ -36,9 +36,6 @@ class Energyplus(Package):
                      join_path(prefix.lib, 'energyplus'))
 
         mkdirp(prefix.bin)
-        os.symlink(join_path(prefix.lib, 'energyplus/energyplus'),
-                   join_path(prefix.bin, 'energyplus'))
-        os.symlink(join_path(prefix.lib, 'energyplus/EPMacro'),
-                   join_path(prefix.bin, 'EPMacro'))
-        os.symlink(join_path(prefix.lib, 'energyplus/ExpandObjects'),
-                   join_path(prefix.bin, 'ExpandObjects'))
+        for b in ['energyplus', 'EPMacro', 'ExpandObjects']:
+            os.symlink(join_path(prefix.lib.energyplus, b),
+                       join_path(prefix.bin, b))

--- a/var/spack/repos/builtin/packages/energyplus/package.py
+++ b/var/spack/repos/builtin/packages/energyplus/package.py
@@ -32,8 +32,7 @@ class Energyplus(Package):
         if spec.satisfies('@:8.9.9'):
             source_dir = glob.glob('EnergyPlus*')[0]
 
-        install_tree(source_dir,
-                     join_path(prefix.lib, 'energyplus'))
+        install_tree(source_dir, prefix.lib.enregyplus)
 
         mkdirp(prefix.bin)
         for b in ['energyplus', 'EPMacro', 'ExpandObjects']:


### PR DESCRIPTION
`energyplus` is a binary package which links to a newer C++ ABI provided with newer gccs. Is it good practice to add a runtime dependency on gcc?