### PR TITLE
spack install: improve error message with no args

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -268,7 +268,7 @@ environment variables:
         return
 
     if not args.spec and not args.specfiles:
-        # if there are no args but an active environment or spack.yaml file
+        # if there are no args but an active environment
         # then install the packages from it.
         env = ev.get_env(args, 'install')
         if env:
@@ -289,7 +289,15 @@ environment variables:
                 env.regenerate_views()
             return
         else:
-            tty.die("install requires a package argument or a spack.yaml file")
+            msg = "install requires a package argument or active environment"
+            if 'spack.yaml' in os.listdir(os.getcwd()):
+                # There's a spack.yaml file in the working dir, the user may
+                # have intended to use that
+                msg += "\n\n"
+                msg += "Did you mean to use the environment"
+                msg += " in the current directory?\n"
+                msg += "    Try 'spack -e . install'"
+            tty.die(msg)
 
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -294,9 +294,12 @@ environment variables:
                 # There's a spack.yaml file in the working dir, the user may
                 # have intended to use that
                 msg += "\n\n"
-                msg += "Did you mean to use the environment"
-                msg += " in the current directory?\n"
-                msg += "    Try 'spack -e . install'"
+                msg += "Did you mean to install using the `spack.yaml`"
+                msg += " in this directory? Try: \n"
+                msg += "    spack env activate .\n"
+                msg += "    spack install\n"
+                msg += "  OR\n"
+                msg += "    spack --env . install"
             tty.die(msg)
 
     if args.no_checksum:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -746,3 +746,27 @@ def test_compiler_bootstrap_already_installed(
     # Test succeeds if it does not raise an error
     install('gcc@2.0')
     install('a%gcc@2.0')
+
+
+def test_install_fails_no_args(tmpdir):
+    # ensure no spack.yaml in dirrectory
+    with tmpdir.as_cwd():
+        output = install(fail_on_error=False)
+
+    # check we got the short version of the error message with no spack.yaml
+    assert 'requires a package argument or active environment' in output
+    assert 'spack env activate .' not in output
+    assert 'using the `spack.yaml` in this directory' not in output
+
+
+def test_install_fails_no_args_suggests_env_activation(tmpdir):
+    # ensure spack.yaml in dirrectory
+    tmpdir.ensure('spack.yaml')
+
+    with tmpdir.as_cwd():
+        output = install(fail_on_error=False)
+
+    # check we got the long version of the error message with spack.yaml
+    assert 'requires a package argument or active environment' in output
+    assert 'spack env activate .' in output
+    assert 'using the `spack.yaml` in this directory' in output

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -749,7 +749,7 @@ def test_compiler_bootstrap_already_installed(
 
 
 def test_install_fails_no_args(tmpdir):
-    # ensure no spack.yaml in dirrectory
+    # ensure no spack.yaml in directory
     with tmpdir.as_cwd():
         output = install(fail_on_error=False)
 
@@ -760,7 +760,7 @@ def test_install_fails_no_args(tmpdir):
 
 
 def test_install_fails_no_args_suggests_env_activation(tmpdir):
-    # ensure spack.yaml in dirrectory
+    # ensure spack.yaml in directory
     tmpdir.ensure('spack.yaml')
 
     with tmpdir.as_cwd():


### PR DESCRIPTION
The error message was not updated when the behavior of Spack environments was changed to not automatically activate the local environment in #17258. The previous error message no longer makes sense.