### PR TITLE
Relocation of sbang needs to be done when the spack prefix changes even if the install tree has not changed.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -603,7 +603,7 @@ def relocate_package(spec, allow_root):
         if not is_backup_file(text_name):
             text_names.append(text_name)
 
-# If we are installing back to the same location don't replace anything
+# If we are not installing back to the same install tree do the relocation
     if old_layout_root != new_layout_root:
         files_to_relocate = [os.path.join(workdir, filename)
                              for filename in buildinfo.get('relocate_binaries')
@@ -652,6 +652,17 @@ def relocate_package(spec, allow_root):
                 buildinfo['relocate_binaries'])))
         # relocate the install prefixes in binary files including dependencies
         relocate.relocate_text_bin(files_to_relocate,
+                                   old_prefix, new_prefix,
+                                   old_spack_prefix,
+                                   new_spack_prefix,
+                                   prefix_to_prefix)
+
+# If we are installing back to the same location
+# relocate the sbang location if the spack directory changed
+    else:
+        if old_spack_prefix != new_spack_prefix:
+            relocate.relocate_text(text_names,
+                                   old_layout_root, new_layout_root,
                                    old_prefix, new_prefix,
                                    old_spack_prefix,
                                    new_spack_prefix,

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -804,15 +804,17 @@ def relocate_text(
             where they should be relocated
     """
     # TODO: reduce the number of arguments (8 seems too much)
-    sbang_regex = r'#!/bin/bash {0}/bin/sbang'.format(orig_spack)
-    new_sbang = r'#!/bin/bash {0}/bin/sbang'.format(new_spack)
+    orig_sbang = '#!/bin/bash {0}/bin/sbang'.format(orig_spack)
+    new_sbang = '#!/bin/bash {0}/bin/sbang'.format(new_spack)
 
     for file in files:
         _replace_prefix_text(file, orig_install_prefix, new_install_prefix)
         for orig_dep_prefix, new_dep_prefix in new_prefixes.items():
             _replace_prefix_text(file, orig_dep_prefix, new_dep_prefix)
         _replace_prefix_text(file, orig_layout_root, new_layout_root)
-        _replace_prefix_text(file, sbang_regex, new_sbang)
+        # relocate the sbang location only if the spack directory changed
+        if orig_spack != new_spack:
+            _replace_prefix_text(file, orig_sbang, new_sbang)
 
 
 def relocate_text_bin(


### PR DESCRIPTION
Not sure how to do a unit test on this one. It requires using the same install_tree but using a different spack directory when installing the buildcache.