### PR TITLE
lmbench: fix scripts path for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/lmbench/fix_results_path_for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/lmbench/fix_results_path_for_aarch64.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/results b/scripts/results
+index cd07c15..282ed19 100755
+--- a/scripts/results
++++ b/scripts/results
+@@ -27,7 +27,7 @@ cd ../bin/$OS
+ PATH=.:${PATH}; export PATH
+ export SYNC_MAX
+ export OUTPUT
+-lmbench $CONFIG 2>../${RESULTS}
++lmbench $CONFIG 2>${RESULTS}
+ 
+ if [ X$MAIL = Xyes ]
+ then	echo Mailing results

--- a/var/spack/repos/builtin/packages/lmbench/package.py
+++ b/var/spack/repos/builtin/packages/lmbench/package.py
@@ -19,6 +19,8 @@ class Lmbench(MakefilePackage):
 
     depends_on('libtirpc')
 
+    patch('fix_results_path_for_aarch64.patch', sha256='2af57abc9058c56b6dd0697bb01a98902230bef92b117017e318faba148eef60', when='target=aarch64:')
+
     def setup_build_environment(self, env):
         env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
         env.append_flags('LDFLAGS', '-ltirpc')


### PR DESCRIPTION
When we use 'make check' in lmbench dir, it will report build error.
On aarch64 platform, some file of lmbench will have a different path with x86 platform.