### PR TITLE
[root] Add version 6.22

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -26,6 +26,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version('6.22.00', sha256='efd961211c0f9cd76cf4a486e4f89badbcf1d08e7535bba556862b3c1a80beed')
     version('6.20.04', sha256='1f8c76ccdb550e64e6ddb092b4a7e9d0a10655ef80044828cba12d5e7c874472')
     version('6.20.02', sha256='0997586bf097c0afbc6f08edbffcebf5eb6a4237262216114ba3f5c8087dcba6')
     version('6.20.00', sha256='68421eb0434b38b66346fa8ea6053a0fdc9a6d254e4a72019f4e3633ae118bf0')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -449,9 +449,10 @@ class Root(CMakePackage):
         return options
 
     def setup_build_environment(self, env):
-        if 'lz4' in self.spec:
-            env.append_path('CMAKE_PREFIX_PATH',
-                            self.spec['lz4'].prefix)
+        spec = self.spec
+
+        if 'lz4' in spec:
+            env.append_path('CMAKE_PREFIX_PATH', spec['lz4'].prefix)
 
         # This hack is made necessary by a header name collision between
         # asimage's "import.h" and Python's "import.h" headers...
@@ -465,20 +466,20 @@ class Root(CMakePackage):
         # into SPACK_INCLUDE_DIRS, even in a deprioritized form, because some
         # system/compiler combinations don't like having -I/usr/include around.
         def add_include_path(dep_name):
-            include_path = self.spec[dep_name].prefix.include
+            include_path = spec[dep_name].prefix.include
             if not is_system_path(include_path):
                 env.append_path('SPACK_INCLUDE_DIRS', include_path)
 
         # With that done, let's go fixing those deps
-        if self.spec.satisfies('+x @:6.08.99'):
-            add_include_path('xextproto')
-        if self.spec.satisfies('@:6.12.99'):
+        if spec.satisfies('@:6.12.99'):
             add_include_path('zlib')
-        if '+x' in self.spec:
+        if '+x' in spec:
+            if spec.satisfies('@:6.08.99') or spec.satisfies('@6.22:'):
+                add_include_path('xextproto')
             add_include_path('fontconfig')
             add_include_path('libx11')
             add_include_path('xproto')
-        if '+opengl' in self.spec:
+        if '+opengl' in spec:
             add_include_path('glew')
             add_include_path('mesa-glu')
 


### PR DESCRIPTION
From a build system point of view, this was a relatively tame release. However, the xextproto issue from <=6.08 is back in this release.

Here I'm doing the minimal step of enabling the xextproto include path hack for >=6.22. Alternate options are to...

- Enable it for every ROOT version. It does not really harm, even though it's not always necessary.
- Cross-check if current version of spack can live without the evil unsetting of the SPACK_INCLUDE_DIRS environment variable altogether, freeing us from all those include path hacks.
    * AFAIK, spack's usage of -I / -isystem has changed recently, and it was the original cause of all those include path problems. So with recent spack versions, the root package's convoluted manual include path setup may not be necessary anymore.
    * To check this, I need to know in which circumstances those include paths problems would manifest before those tricks were introduced. I think @gartung was the author of the original bugfix that unset SPACK_INCLUDE_DIRS, so he might remember a failing test scenario that I can exercise.