### PR TITLE
adios: fix configure.ac/autotools issue that casues problems on some systems

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -105,6 +105,10 @@ class Adios(AutotoolsPackage):
     #   https://github.com/ornladios/ADIOS/pull/204
     patch('zfp051.patch', when='@1.11.0:1.13.1')
 
+    # Fix a bug in configure.ac that causes automake issues on RHEL 7.7
+    patch('https://github.com/ornladios/ADIOS/pull/207.patch', when='@1.12.0:',
+          sha256='01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640')
+
     def validate(self, spec):
         """Checks if incompatible variants have been activated at the same time
 


### PR DESCRIPTION
This fixes an issue where the autotools where complaining that a conditional used in a `Makefile.am` must be created by `AM_CONDITIONAL`.

Curiously, using `autoconf@2.69` and `automake@1.16.1` on Ubuntu didn't show the problem, but using the same versions on RHEL  caused the install to fail.