### PR TITLE
llvm-flang: Only build offload code if cuda enabled

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-flang/package.py
+++ b/var/spack/repos/builtin/packages/llvm-flang/package.py
@@ -238,6 +238,7 @@ class LlvmFlang(CMakePackage, CudaPackage):
                         spec['libelf'].prefix.include,
                         spec['hwloc'].prefix.include))
 
+            # Only build if offload target.
             cmake(*args)
             make()
             make('install')

--- a/var/spack/repos/builtin/packages/llvm-flang/package.py
+++ b/var/spack/repos/builtin/packages/llvm-flang/package.py
@@ -238,6 +238,6 @@ class LlvmFlang(CMakePackage, CudaPackage):
                         spec['libelf'].prefix.include,
                         spec['hwloc'].prefix.include))
 
-        cmake(*args)
-        make()
-        make('install')
+            cmake(*args)
+            make()
+            make('install')


### PR DESCRIPTION
The current version of `package.py` for `llvm-flang` executes `cmake(*args)` always as part of the post install.  If nVidia device offload is not part of the build, this results in referencing `args` without it being set and the error:

```
==> Error: UnboundLocalError: local variable 'args' referenced before assignment
```

Looking at previous version of `package.py` (https://github.com/owainkenwayucl/spack/blob/d1c708bdf3d95b63a8aaaac66a9434222d77b4ce/var/spack/repos/builtin/packages/llvm-flang/package.py) this whole routine appears to be only required for offload, so indent `cmake/make/install` to be under the `if` and only executed if part of an offload nvptx build.