### PR TITLE
PySCF new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -27,11 +27,7 @@ class PyPyscf(PythonPackage):
     depends_on('blas')
     depends_on('libcint+coulomb_erf+f12')
     depends_on('libxc')
-    depends_on('xcfun')
-
-    # conflicts
-    conflicts('^xcfun@2.0.0a3:',
-              msg='PySCF does not support recent version of the xcfun API')
+    depends_on('xcfun@:2.0.0a2')  # PySCF does not support recent version of the xcfun API'
 
     def setup_build_environment(self, env):
         # Tell PSCF where supporting libraries are located."

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -38,6 +38,6 @@ class PyPyscf(PythonPackage):
         pyscf_search_dir.append(spec['libcint'].prefix)
         pyscf_search_dir.append(spec['libxc'].prefix)
         pyscf_search_dir.append(spec['xcfun'].prefix)
-        pyscf_search_dir.append(spec['xcfun'].prefix + '/include/XCFun')
+        pyscf_search_dir.append(spec['xcfun'].prefix.include.XCFun)
 
         env.set('PYSCF_INC_DIR', format(":").join(pyscf_search_dir))

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -27,7 +27,11 @@ class PyPyscf(PythonPackage):
     depends_on('blas')
     depends_on('libcint+coulomb_erf+f12')
     depends_on('libxc')
-    depends_on('xcfun@pyscf')
+    depends_on('xcfun')
+
+    # conflicts
+    conflicts('^xcfun@2.0.0a3:',
+              msg='PySCF does not support recent version of the xcfun API')
 
     def setup_build_environment(self, env):
         # Tell PSCF where supporting libraries are located."

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class PyPyscf(PythonPackage):
+    """PySCF is a collection of electronic structure programs powered
+    by Python."""
+
+    homepage = "https://sunqm.github.io/pyscf/"
+    git      = "https://github.com/pyscf/pyscf"
+
+    maintainers = ['naromero77']
+
+    version('1.7.3', tag='v1.7.3')
+
+    # dependencies
+    depends_on('cmake@2.8:', type='build')
+    depends_on('python@2.6:', type=('build', 'run'))
+    depends_on('py-numpy@1.8.0:', type=('build', 'run'))
+    depends_on('py-scipy@0.12:', type=('build', 'run'))
+    depends_on('py-h5py@2.3.0:', type=('build', 'run'))
+    depends_on('blas')
+    depends_on('libcint+coulomb_erf+f12')
+    depends_on('libxc')
+    depends_on('xcfun@pyscf')
+
+    def setup_build_environment(self, env):
+        # Tell PSCF where supporting libraries are located."
+        spec = self.spec
+
+        pyscf_search_dir = []
+        pyscf_search_dir.append(spec['blas'].prefix)
+        pyscf_search_dir.append(spec['libcint'].prefix)
+        pyscf_search_dir.append(spec['libxc'].prefix)
+        pyscf_search_dir.append(spec['xcfun'].prefix)
+        pyscf_search_dir.append(spec['xcfun'].prefix + '/include/XCFun')
+
+        env.set('PYSCF_INC_DIR', format(":").join(pyscf_search_dir))

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -40,4 +40,4 @@ class PyPyscf(PythonPackage):
         pyscf_search_dir.append(spec['xcfun'].prefix)
         pyscf_search_dir.append(spec['xcfun'].prefix.include.XCFun)
 
-        env.set('PYSCF_INC_DIR', format(":").join(pyscf_search_dir))
+        env.set('PYSCF_INC_DIR', ":".join(pyscf_search_dir))

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -16,6 +16,8 @@ class Xcfun(CMakePackage):
 
     version('2.0.0a6',
             sha256='a51086490890393439f98c5e3e4e1622908fe934bbc5063b1d4363cc4c15496d')
+    version('2.0.0a2',
+            sha256='f29e80fdb5c8089fb0eeb7827659111005cb13eb42bf75fcb0c034f6bd067c31')
 
     extends('python')
     depends_on('cmake@3.11:', type='build')

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -18,7 +18,6 @@ class Xcfun(CMakePackage):
     version('master', branch='master')
     version('2.0.0a6',
             sha256='a51086490890393439f98c5e3e4e1622908fe934bbc5063b1d4363cc4c15496d')
-    version('pyscf', commit='355f42497a9cd17d16ae91da1f1aaaf93756ae8b')
 
     extends('python')
     depends_on('cmake@3.11:', type='build')

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -11,9 +11,11 @@ class Xcfun(CMakePackage):
 
     homepage = "https://github.com/dftlibs/xcfun"
     url = "https://github.com/dftlibs/xcfun/archive/v2.0.0a4.tar.gz"
+    git = "https://github.com/dftlibs/xcfun"
 
     maintainers = ['robertodr', 'bast']
 
+    version('master', branch='master')
     version('2.0.0a6',
             sha256='a51086490890393439f98c5e3e4e1622908fe934bbc5063b1d4363cc4c15496d')
 

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -11,11 +11,9 @@ class Xcfun(CMakePackage):
 
     homepage = "https://github.com/dftlibs/xcfun"
     url = "https://github.com/dftlibs/xcfun/archive/v2.0.0a4.tar.gz"
-    git = "https://github.com/dftlibs/xcfun"
 
     maintainers = ['robertodr', 'bast']
 
-    version('master', branch='master')
     version('2.0.0a6',
             sha256='a51086490890393439f98c5e3e4e1622908fe934bbc5063b1d4363cc4c15496d')
 

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -18,6 +18,7 @@ class Xcfun(CMakePackage):
     version('master', branch='master')
     version('2.0.0a6',
             sha256='a51086490890393439f98c5e3e4e1622908fe934bbc5063b1d4363cc4c15496d')
+    version('pyscf', commit='355f42497a9cd17d16ae91da1f1aaaf93756ae8b')
 
     extends('python')
     depends_on('cmake@3.11:', type='build')


### PR DESCRIPTION
PySCF appears to incompatible with officially tagged versions of the `xcfun` library which is why I had to fetch a particular commit from the `xcfun` package.

@prckent 