### PR TITLE
Magics fix and update

### DIFF
--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -89,7 +89,7 @@ class Magics(CMakePackage):
 
     # Even if netcdf is disabled and -DENABLE_NETCDF=OFF is set, building
     # magics still requires legacy netcdf-cxx
-    depends_on('netcdf-cxx', when='@4.2.4:4.3.1')
+    depends_on('netcdf-cxx', when='@4.1.0:4.3.1')
 
     # Optional dependencies
     depends_on('netcdf-cxx', when='+netcdf')
@@ -142,7 +142,7 @@ class Magics(CMakePackage):
                 args.append('-DENABLE_ECCODES=OFF')
 
         # magics@4.2.4:4.3.1 cannot be built without netcdf
-        if '+netcdf' in self.spec or self.spec.satisfies('@4.2.4:4.3.1'):
+        if '+netcdf' in self.spec or self.spec.satisfies('@4.1.0:4.3.1'):
             args.append('-DENABLE_NETCDF=ON')
         else:
             args.append('-DENABLE_NETCDF=OFF')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -64,7 +64,10 @@ class Magics(CMakePackage):
     depends_on('perl-xml-parser', type='build')
 
     # Non-optional dependencies
-    depends_on('proj@:5')
+    # change of proj4 api starting from version 4.3.0
+    # https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
+    depends_on('proj@:5', when='@:4.2.6')
+    depends_on('proj@6:', when='@4.3:')
     depends_on('boost')
     depends_on('expat')
 
@@ -85,8 +88,8 @@ class Magics(CMakePackage):
     depends_on('grib-api', when='grib=grib-api')
 
     # Even if netcdf is disabled and -DENABLE_NETCDF=OFF is set, building
-    # magics requires netcdf at least in versions TODO
-    depends_on('netcdf-cxx', when='@4.2.4')
+    # magics still requires legacy netcdf-cxx
+    depends_on('netcdf-cxx', when='@4.2.4:4.3.1')
 
     # Optional dependencies
     depends_on('netcdf-cxx', when='+netcdf')
@@ -138,7 +141,8 @@ class Magics(CMakePackage):
             if self.spec.satisfies('@2.29.1:'):
                 args.append('-DENABLE_ECCODES=OFF')
 
-        if '+netcdf' in self.spec:
+        # magics@4.2.4:4.3.1 cannot be built without netcdf
+        if '+netcdf' in self.spec or self.spec.satisfies('@4.2.4:4.3.1'):
             args.append('-DENABLE_NETCDF=ON')
         else:
             args.append('-DENABLE_NETCDF=OFF')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -19,7 +19,12 @@ class Magics(CMakePackage):
 
     # The policy on which minor releases remain available and which get deleted
     # after a newer version becomes available is unclear.
-    version('4.2.4', sha256='920c7dbb1aaabe65a31c6c18010829210f8b2f8d614b6c405dc5a4530e346f07') 
+    version('4.4.0', sha256='544058cd334f3e28a16d00ea7811e13cdf282f9c1ebec2ad7868171d925abd24')
+    version('4.3.3', sha256='27d3de71cf41f3d557fd85dabaea2baaab34c4c6422a5b5b15071a6a53387601')
+    version('4.3.1', sha256='b1995e2f5bf24943715446d1302cc5d7de4cacfe4cee7c3cfd1037ac183cd181')
+    version('4.3.0', sha256='f6c0d32c243913e53320dd94ce8e1e6a64bd9a44af77d5ac32c062bc18355b8a')
+    version('4.2.6', sha256='9b34a375d9125ab6e8a715b970da2e479f96370bac6a5bb8a015a079ed9e027c')
+    version('4.2.4', sha256='920c7dbb1aaabe65a31c6c18010829210f8b2f8d614b6c405dc5a4530e346f07')
     version('4.1.0', sha256='da626c31f53716990754dd72ab7b2f3902a8ad924b23ef3309bd14900d170541')
     version('2.34.3', sha256='38487562e83c0470f94d9c7fb9418cbadf92f1e643033237baba2abdc77e6238')
     version('2.34.1', sha256='8df27f8f262ebc32a61f8696df15a7b4a6e4203b2a8e53fe7aa13caa1c4e3fa4')
@@ -78,6 +83,10 @@ class Magics(CMakePackage):
     # GRIB support is non-optional, regardless of what the instruction says.
     depends_on('eccodes', when='grib=eccodes')
     depends_on('grib-api', when='grib=grib-api')
+
+    # Even if netcdf is disabled and -DENABLE_NETCDF=OFF is set, building
+    # magics requires netcdf at least in versions TODO
+    depends_on('netcdf-cxx', when='@4.2.4')
 
     # Optional dependencies
     depends_on('netcdf-cxx', when='+netcdf')


### PR DESCRIPTION
- Adds new versions of magics
- Since magics@4.3, proj@6 is required (see also [source](https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status) and https://github.com/spack/spack/pull/11763). 
- In addition it seems that @4.1.0:4.3.1' requires netcdf (legacy interface) even though it shouldn't - even if `-DENABLE_NETCDF=OFF` is set, building magics still requires netcdf. This also fixes https://github.com/spack/spack/issues/14182 (or rather bypasses the problem).