### PR TITLE
openmpi: Added lustre package and variant to openmpi

### DIFF
--- a/var/spack/repos/builtin/packages/lustre/package.py
+++ b/var/spack/repos/builtin/packages/lustre/package.py
@@ -15,7 +15,7 @@ class Lustre(Package):
 
     version('2.12')
 
-    # Lustre is filesystem and needs to be installed on system. 
+    # Lustre is filesystem and needs to be installed on system.
     # To have it as external package in SPACK, follow below:
     # config file packages.yaml needs to be adjusted:
     #   lustre:

--- a/var/spack/repos/builtin/packages/lustre/package.py
+++ b/var/spack/repos/builtin/packages/lustre/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Lustre(Package):
+    """Lustre is a type of parallel distributed file system,
+       generally used for large-scale cluster computing."""
+
+    homepage = 'http://lustre.org/'
+    has_code = False
+
+    version('2.12')
+
+    # Lustre is filesystem and needs to be installed on system. 
+    # To have it as external package in SPACK, follow below:
+    # config file packages.yaml needs to be adjusted:
+    #   lustre:
+    #     version: [2.12]
+    #     paths:
+    #       lustre@2.12: /usr (Usual Lustre library path)
+    #     buildable: False
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -542,7 +542,7 @@ class Openmpi(AutotoolsPackage):
             singularity_opt = '--with-singularity={0}'.format(spec['singularity'].prefix)
             config_args.append(singularity_opt)
         # Lustre filesystem support
-	if spec.satisfies('+lustre'):
+        if spec.satisfies('+lustre'):
             lustre_opt = '--with-lustre={0}'.format(spec['lustre'].prefix)
             config_args.append(lustre_opt)
         # Hwloc support

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -221,6 +221,8 @@ class Openmpi(AutotoolsPackage):
     variant('gpfs', default=True, description='Enable GPFS support (if present)')
     variant('singularity', default=False,
             description="Build support for the Singularity container")
+    variant('lustre', default=False,
+            description="Lustre filesystem support")
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #
@@ -269,6 +271,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('valgrind~mpi', when='+memchecker')
     # Singularity release 3 works better
     depends_on('singularity@3.0.0:', when='+singularity')
+    depends_on('lustre', when='+lustre')
 
     depends_on('opa-psm2', when='fabrics=psm2')
     depends_on('rdma-core', when='fabrics=verbs')
@@ -538,6 +541,10 @@ class Openmpi(AutotoolsPackage):
         if spec.satisfies('+singularity @:4.9'):
             singularity_opt = '--with-singularity={0}'.format(spec['singularity'].prefix)
             config_args.append(singularity_opt)
+        # Lustre filesystem support
+	if spec.satisfies('+lustre'):
+            lustre_opt = '--with-lustre={0}'.format(spec['lustre'].prefix)
+            config_args.append(lustre_opt)
         # Hwloc support
         if spec.satisfies('@1.5.2:'):
             config_args.append('--with-hwloc={0}'.format(spec['hwloc'].prefix))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -539,7 +539,8 @@ class Openmpi(AutotoolsPackage):
 
         # Singularity container support
         if spec.satisfies('+singularity @:4.9'):
-            singularity_opt = '--with-singularity={0}'.format(spec['singularity'].prefix)
+            singularity_opt = '--with-singularity={0}'.format(
+                spec['singularity'].prefix)
             config_args.append(singularity_opt)
         # Lustre filesystem support
         if spec.satisfies('+lustre'):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -222,7 +222,7 @@ class Openmpi(AutotoolsPackage):
     variant('singularity', default=False,
             description="Build support for the Singularity container")
     variant('lustre', default=False,
-            description="Lustre filesystem support")
+            description="Lustre filesystem library support")
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #


### PR DESCRIPTION
- Lustre package added as `non-buildable`
- Openmpi added lustre variant

Lustre filesystem added as external package to Spack and should have entry in packages.yaml so during enabling variant in openmpi it's gonna look into external packages.