### PR TITLE
ParaView: Allow all ParaView versions to depend on Python 2

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -238,37 +238,18 @@ class Paraview(CMakePackage, CudaPackage):
                 '-DPARAVIEW_QT_VERSION=%s' % spec['qt'].version[0],
             ])
 
-        # CMake flags for python are different for different versions
+        # CMake flags for python have changed with newer ParaView versions
         # Make sure Spack uses the right cmake flags
         if '+python' in spec or '+python3' in spec:
-            if spec.satisfies('@5.8:'):
-                cmake_args.append('-DPARAVIEW_USE_PYTHON:BOOL=ON')
-                if '+python3' in spec:
-                    cmake_args.append('-DPARAVIEW_PYTHON_VERSION:STRING=3')
-                else:
-                    cmake_args.append('-DPARAVIEW_PYTHON_VERSION:STRING=2')
-            elif spec.satisfies('@5.7:'):
-                cmake_args.extend([
-                    '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON',
-                    '-DPYTHON_EXECUTABLE:FILEPATH=%s' %
-                    spec['python'].command.path
-                ])
-                if '+python3' in spec:
-                    cmake_args.append('-DPARAVIEW_PYTHON_VERSION:STRING=3')
-                else:
-                    cmake_args.append('-DPARAVIEW_PYTHON_VERSION:STRING=2')
-            else:
-                cmake_args.extend([
-                    '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON',
-                    '-DPYTHON_EXECUTABLE:FILEPATH=%s' %
-                    spec['python'].command.path
-                ])
-                if '+python3' in spec:
-                    cmake_args.append('-DVTK_PYTHON_VERSION:STRING=3')
-                else:
-                    cmake_args.append('-DVTK_PYTHON_VERSION:STRING=2')
-            cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' %
-                              variant_bool('+mpi'))
+            py_use_opt = 'USE' if spec.satisfies('@5.8:') else 'ENABLE'
+            py_ver_opt = 'PARAVIEW' if spec.satisfies('@5.7:') else 'VTK'
+            py_ver_val = 3 if '+python3' in spec else 2
+            cmake_args.extend([
+                '-DPARAVIEW_%s_PYTHON:BOOL=ON' % py_use_opt,
+                '-DPYTHON_EXECUTABLE:FILEPATH=%s' % spec['python'].command.path,
+                '-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' % variant_bool('+mpi'),
+                '-D%s_PYTHON_VERSION:STRING=%d' % (py_ver_opt, py_ver_val)
+            ])
 
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -246,7 +246,8 @@ class Paraview(CMakePackage, CudaPackage):
             py_ver_val = 3 if '+python3' in spec else 2
             cmake_args.extend([
                 '-DPARAVIEW_%s_PYTHON:BOOL=ON' % py_use_opt,
-                '-DPYTHON_EXECUTABLE:FILEPATH=%s' % spec['python'].command.path,
+                '-DPYTHON_EXECUTABLE:FILEPATH=%s' %
+                spec['python'].command.path,
                 '-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' % variant_bool('+mpi'),
                 '-D%s_PYTHON_VERSION:STRING=%d' % (py_ver_opt, py_ver_val)
             ])

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -51,6 +51,8 @@ class Paraview(CMakePackage, CudaPackage):
             description='Use module kits')
 
     conflicts('+python', when='+python3')
+    # Python 2 support dropped with 5.9.0
+    conflicts('+python', when='@5.9:')
     conflicts('+python3', when='@:5.5')
     conflicts('+shared', when='+cuda')
     # Legacy rendering dropped in 5.5
@@ -266,8 +268,6 @@ class Paraview(CMakePackage, CudaPackage):
                 else:
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=2')
             cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' % variant_bool('+mpi'))
-
-
 
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -267,8 +267,8 @@ class Paraview(CMakePackage, CudaPackage):
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=3')
                 else:
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=2')
-            cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s'\
-                    % variant_bool('+mpi'))
+            cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' %
+                    variant_bool('+mpi'))
 
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -268,7 +268,7 @@ class Paraview(CMakePackage, CudaPackage):
                 else:
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=2')
             cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' %
-                    variant_bool('+mpi'))
+                              variant_bool('+mpi'))
 
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -267,7 +267,8 @@ class Paraview(CMakePackage, CudaPackage):
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=3')
                 else:
                     cmake_args.append('-DVTK_PYTHON_VERSION:STRING=2')
-            cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' % variant_bool('+mpi'))
+            cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s'\
+                    % variant_bool('+mpi'))
 
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')


### PR DESCRIPTION
@utkarshayachit @danlipsa @chuckatkins 

This PR allows newer versions of ParaView to build with Python 2. Versions newer than 5.5 had an unnecessary conflict with Python 2. ParaView's package.py also needs some logic to choose the correct CMake flags for each version. 