### PR TITLE
Add new versions of zsh

### DIFF
--- a/var/spack/repos/builtin/packages/zsh/package.py
+++ b/var/spack/repos/builtin/packages/zsh/package.py
@@ -18,9 +18,9 @@ class Zsh(AutotoolsPackage):
     version('5.8', sha256='dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27')
     version('5.7.1', sha256='7260292c2c1d483b2d50febfa5055176bd512b32a8833b116177bf5f01e77ee8')
     version('5.6.2', sha256='a50bd66c0557e8eca3b8fa24e85d0de533e775d7a22df042da90488623752e9e')
-    version('5.4.2', sha256='957bcdb2c57f64c02f673693ea5a7518ef24b6557aeb3a4ce222cefa6d74acc9')
-    version('5.3.1', sha256='3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e')
-    version('5.1.1', sha256='94ed5b412023761bc8d2f03c173f13d625e06e5d6f0dff2c7a6e140c3fa55087')
+    version('5.4.2', sha256='a80b187b6b770f092ea1f53e89021d06c03d8bbe6a5e996bcca3267de14c5e52')
+    version('5.3.1', sha256='fc886cb2ade032d006da8322c09a7e92b2309177811428b121192d44832920da')
+    version('5.1.1', sha256='74e9453b5470b3c0970f9f93cfd603d241c3d7b1968adc0e4b3951073e8d3dec')
 
     # Testing for terminal related things causes failures in e.g. Jenkins.
     # See e.g. https://www.zsh.org/mla/users/2003/msg00845.html,

--- a/var/spack/repos/builtin/packages/zsh/package.py
+++ b/var/spack/repos/builtin/packages/zsh/package.py
@@ -13,8 +13,11 @@ class Zsh(AutotoolsPackage):
     """
 
     homepage = "http://www.zsh.org"
-    url = "http://downloads.sourceforge.net/project/zsh/zsh/5.4.2/zsh-5.4.2.tar.gz"
+    url = "http://downloads.sourceforge.net/project/zsh/zsh/5.4.2/zsh-5.4.2.tar.xz"
 
+    version('5.8', sha256='dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27')
+    version('5.7.1', sha256='7260292c2c1d483b2d50febfa5055176bd512b32a8833b116177bf5f01e77ee8')
+    version('5.6.2', sha256='a50bd66c0557e8eca3b8fa24e85d0de533e775d7a22df042da90488623752e9e')
     version('5.4.2', sha256='957bcdb2c57f64c02f673693ea5a7518ef24b6557aeb3a4ce222cefa6d74acc9')
     version('5.3.1', sha256='3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e')
     version('5.1.1', sha256='94ed5b412023761bc8d2f03c173f13d625e06e5d6f0dff2c7a6e140c3fa55087')


### PR DESCRIPTION
Also, switches to downloading the `.xz` archives instead of `.tar.gz` since newer versions only have the `.xz` archives. Older archives appear to also have `.xz` so I updated the sha strings accordingly.