### PR TITLE
ccs-qcd: Change compile option for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/ccs-qcd/package.py
+++ b/var/spack/repos/builtin/packages/ccs-qcd/package.py
@@ -4,20 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.error import SpackError
-
-
-def class_validator(pkg_name, variant_name, values):
-    values = int(values[0])
-    if values < 1 or values > 6:
-        error_msg = ("class: Choose one of the following:\n"
-                     "1  - 8x8x8x32 (default MPI config: 1x1x1)\n"
-                     "2  - 32x32x32x32 (default MPI config: 4x4x4)\n"
-                     "3  - 64x64x64x32 (default MPI config: 8x8x8)\n"
-                     "4  - 160x160x160x160 (default MPI config: 20x20x20)\n"
-                     "5  - 256x256x256x256 (default MPI config: 32x32x32)\n"
-                     "6  - 192x192x192x192 (default MPI config: 24x24x24)")
-        raise SpackError(error_msg)
 
 
 class CcsQcd(MakefilePackage):
@@ -33,24 +19,33 @@ class CcsQcd(MakefilePackage):
     version('master', branch='master')
     version('1.2.1', commit='d7c6b6923f35a824e997ba8db5bd12dc20dda45c')
 
-    variant('class', values=int, default=1,
+    variant('class', default=1, values=('1', '2', '3', '4', '5', '6'),
             description='This miniapp has five problem classes, for which the'
             ' first three are relatively small problems just for testing'
             ' this miniapp itself. The remaining two are the target problem'
             ' sizes for the HPCI FS evaluation.',
-            multi=False, validator=class_validator)
+            multi=False)
 
     depends_on('mpi')
 
     parallel = False
 
     def edit(self, spec, prefix):
+        if spec.satisfies('%gcc') and spec.satisfies('arch=aarch64:'):
+            chgopt = 'FFLAGS  =-O3 -ffixed-line-length-132 -g -fopenmp' \
+                     ' -mcmodel=large -funderscoring'
+            filter_file('FFLAGS  =.*', chgopt, join_path(
+                self.stage.source_path, 'src', 'make.gfortran.inc'))
         if '%fj' in spec:
-            filter_file('mpifrtpx', spec['mpi'].mpifc, './src/make.fx10.inc')
-            filter_file('mpifccpx', spec['mpi'].mpicc, './src/make.fx10.inc')
+            filter_file('mpifrtpx', spec['mpi'].mpifc, join_path(
+                        self.stage.source_path, 'src', 'make.fx10.inc'))
+            filter_file('mpifccpx', spec['mpi'].mpicc, join_path(
+                        self.stage.source_path, 'src', 'make.fx10.inc'))
         else:
-            filter_file('mpif90', spec['mpi'].mpifc, './src/make.gfortran.inc')
-            filter_file('mpicc', spec['mpi'].mpicc, './src/make.gfortran.inc')
+            filter_file('mpif90', spec['mpi'].mpifc, join_path(
+                        self.stage.source_path, 'src', 'make.gfortran.inc'))
+            filter_file('mpicc', spec['mpi'].mpicc, join_path(
+                        self.stage.source_path, 'src', 'make.gfortran.inc'))
 
     def build(self, spec, prefix):
         ccs_class = 'CLASS=' + spec.variants['class'].value

--- a/var/spack/repos/builtin/packages/ccs-qcd/package.py
+++ b/var/spack/repos/builtin/packages/ccs-qcd/package.py
@@ -4,6 +4,21 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import SpackError
+
+
+def class_validator(values):
+    """1, 2, 3, 4, 5, 6"""
+    values = int(values[0])
+    if values < 1 or values > 6:
+        error_msg = ("class: Choose one of the following:\n"
+                     "1  - 8x8x8x32 (default MPI config: 1x1x1)\n"
+                     "2  - 32x32x32x32 (default MPI config: 4x4x4)\n"
+                     "3  - 64x64x64x32 (default MPI config: 8x8x8)\n"
+                     "4  - 160x160x160x160 (default MPI config: 20x20x20)\n"
+                     "5  - 256x256x256x256 (default MPI config: 32x32x32)\n"
+                     "6  - 192x192x192x192 (default MPI config: 24x24x24)")
+        raise SpackError(error_msg)
 
 
 class CcsQcd(MakefilePackage):
@@ -19,7 +34,7 @@ class CcsQcd(MakefilePackage):
     version('master', branch='master')
     version('1.2.1', commit='d7c6b6923f35a824e997ba8db5bd12dc20dda45c')
 
-    variant('class', default=1, values=('1', '2', '3', '4', '5', '6'),
+    variant('class', default=1, values=class_validator,
             description='This miniapp has five problem classes, for which the'
             ' first three are relatively small problems just for testing'
             ' this miniapp itself. The remaining two are the target problem'


### PR DESCRIPTION
Fixed option string when compiling with gcc compiler.
The description of  allowed value of variant was changed.
Change to use join_path() instead of the path separator "/" to eliminate OS dependency.