### PR TITLE
gpdb: fix runtime issue

### DIFF
--- a/var/spack/repos/builtin/packages/gpdb/package.py
+++ b/var/spack/repos/builtin/packages/gpdb/package.py
@@ -27,6 +27,7 @@ class Gpdb(AutotoolsPackage):
     version('5.23.0',    sha256='b06a797eb941362d5473b84d5def349b5ce12ce87ab116bea7c74ad193738ae9')
 
     depends_on('zstd')
+    depends_on('py-setuptools@:44.99.99')
     depends_on('apr')
     depends_on('libevent')
     depends_on('curl')
@@ -35,7 +36,17 @@ class Gpdb(AutotoolsPackage):
     depends_on('libxml2')
     depends_on('flex')
     depends_on('readline')
+    depends_on('py-subprocess32', type=('build', 'run'))
+    depends_on('python@:2.8.0', type=('build', 'run'))
+    depends_on('py-lockfile', type=('build', 'run'))
+    depends_on('py-psutil', type=('build', 'run'))
+    depends_on('py-utils@:1.0.0', type=('build', 'run'))
 
     def configure_args(self):
-        args = ['--disable-orca']
+        args = ['--with-python', '--disable-orca', '--enable-depend',
+                '--with-libxml']
         return args
+
+    def setup_run_environment(self, env):
+        env.append_path('GPHOME', self.prefix)
+        env.append_path('PYTHONPATH', self.prefix.lib.python)


### PR DESCRIPTION
We lost some gpdb runtime depends in `package.py`.
And gpdb need `python2` environment.(so `setuptools` should less than version 45.0)