### PR TITLE
Added fail-fast argument to containerize install.

### DIFF
--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir {{ paths.environment }} \
 {{ manifest }} > {{ paths.environment }}/spack.yaml
 
 # Install the software, remove unecessary deps
-RUN cd {{ paths.environment }} && spack env activate . && spack install && spack gc -y
+RUN cd {{ paths.environment }} && spack env activate . && spack install --fail-fast && spack gc -y
 {% if strip %}
 
 # Strip all the binaries

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -12,7 +12,7 @@ EOF
   # Install all the required software
   . /opt/spack/share/spack/setup-env.sh
   spack env activate .
-  spack install
+  spack install --fail-fast
   spack gc -y
   spack env deactivate
   spack env activate --sh -d . >> {{ paths.environment }}/environment_modifications.sh


### PR DESCRIPTION
When I was using the `spack containerize` command in the past I noticed that bulk of the build would continue even if a build within the DAG failed. I noticed the `--fail-fast` argument seemed like it would be desirable here so my container build wouldn't no continue using cycles if it would ultimately fail.

@alalazo - Hope you don't mind me pinging you on this since I've noticed you working on other `containerize` related efforts. If something with this approach isn't acceptable I understand and it can be ignored.