### PR TITLE
Bugfix/install missing compiler from buildcache

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1057,6 +1057,9 @@ class PackageInstaller(object):
         if use_cache and \
                 _install_from_cache(pkg, cache_only, explicit, unsigned):
             self._update_installed(task)
+            if task.compiler:
+                spack.compilers.add_compilers_to_config(
+                    spack.compilers.find_compilers([pkg.spec.prefix]))
             return
 
         pkg.run_tests = (tests is True or tests and pkg.name in tests)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -29,6 +29,9 @@ from six.moves.urllib.error import HTTPError, URLError
 install = SpackCommand('install')
 env = SpackCommand('env')
 add = SpackCommand('add')
+mirror = SpackCommand('mirror')
+uninstall = SpackCommand('uninstall')
+buildcache = SpackCommand('buildcache')
 
 
 @pytest.fixture()
@@ -731,6 +734,40 @@ def test_compiler_bootstrap(
 
     # Test succeeds if it does not raise an error
     install('a%gcc@2.0')
+
+
+def test_compiler_bootstrap_from_binary_mirror(
+        install_mockery_mutable_config, mock_packages, mock_fetch,
+        mock_archive, mutable_config, monkeypatch, tmpdir):
+    """Make sure installing compiler from buildcache registers compiler"""
+
+    # Create a temp mirror directory for buildcache usage
+    mirror_dir = tmpdir.join('mirror_dir')
+    mirror_url = 'file://{0}'.format(mirror_dir.strpath)
+
+    # Install a compiler, because we want to put it in a buildcache
+    install('gcc@2.0')
+
+    # Put installed compiler in the buildcache
+    buildcache('create', '-u', '-a', '-f', '-d', mirror_dir.strpath, 'gcc@2.0')
+
+    # Now uninstall the compiler
+    uninstall('-y', 'gcc@2.0')
+
+    monkeypatch.setattr(spack.concretize.Concretizer,
+                        'check_for_compiler_existence', False)
+    spack.config.set('config:install_missing_compilers', True)
+    assert CompilerSpec('gcc@2.0') not in compilers.all_compiler_specs()
+
+    # Configure the mirror where we put that buildcache w/ the compiler
+    mirror('add', 'test-mirror', mirror_url)
+
+    # Now make sure that when the compiler is installed from binary mirror,
+    # it also gets configured as a compiler.  Test succeeds if it does not
+    # raise an error
+    install('--no-check-signature', '--cache-only', '--only',
+            'dependencies', 'b%gcc@2.0')
+    install('--no-cache', '--only', 'package', 'b%gcc@2.0')
 
 
 @pytest.mark.regression('16221')


### PR DESCRIPTION
This PR fixes an issue I (and others) have seen when running compiler bootstrapping pipelines using the `spack ci` sub-commands.  The first commit here adds a test that mimics what we do in pipelines, where the bootstrapped compiler is installed and put into a binary mirror in some stage of the pipeline, and then in a later stage, we attempt to use `install-missing-compilers: true` to have that compiler installed from the binary mirror during installation of the spec that needs it.

Without the fix in the second commit, the test in the first commit fails with the message:

```console
spack.installer.InstallError: Cannot proceed with b: 1 uninstalled dependency: gcc
```

... which corresponds to the issue I've seen in pipeline logs.