### PR TITLE
scons: support Fujitsu Fortran moddir option

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -25,6 +25,15 @@ class Scons(PythonPackage):
     depends_on('python@:2', when='@:2', type=('build', 'run'))
     depends_on('py-setuptools', when='@3.0.2:', type='build')
 
+    def patch(self):
+        if self.spec.satisfies('%fj'):
+            filter_file(
+                'env[\'FORTRANMODDIRPREFIX\'] = "-J"',
+                'env[\'FORTRANMODDIRPREFIX\'] = "-M"',
+                'engine/SCons/Tool/gfortran.py',
+                string=True
+            )
+
     # Prevent passing --single-version-externally-managed to
     # setup.py, which it does not support.
     @when('@3.0.2:')


### PR DESCRIPTION
SCons recognizes Fujitsu Fortran compiler as gfortran.
So SCons sets FORTRANMODDIRPREFIX to `-J`
> env['FORTRANMODDIRPREFIX'] = "-J"

However, FORTRANMODDIRPREFIX in Fujitsu Fortran is `-M`.
So I patched this line in `%fj`.