### PR TITLE
cantera: Add sundials+lapack

### DIFF
--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -30,7 +30,7 @@ class Cantera(SConsPackage):
     depends_on('googletest+gmock', when='@2.3.0:')
     depends_on('eigen',           when='@2.3.0:')
     depends_on('boost')
-    depends_on('sundials@:3.1.2', when='+sundials')  # must be compiled with -fPIC
+    depends_on('sundials@:3.1.2+lapack', when='+sundials')  # must be compiled with -fPIC
     depends_on('blas')
     depends_on('lapack')
 


### PR DESCRIPTION
Cantera needs SUNDIALS_BLAS_LAPACK.
So `+lapack` is needed in depends_on('sundials').