### PR TITLE
Reduce output verbosity with debug levels

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -174,8 +174,8 @@ class Lock(object):
             # If the file were writable, we'd have opened it 'r+'
             raise LockROFileError(self.path)
 
-        tty.debug("{0} locking [{1}:{2}]: timeout {3} sec"
-                  .format(lock_type[op], self._start, self._length, timeout))
+        self._debug("{0} locking [{1}:{2}]: timeout {3} sec"
+                    .format(lock_type[op], self._start, self._length, timeout))
 
         poll_intervals = iter(Lock._poll_interval_generator())
         start_time = time.time()
@@ -212,9 +212,9 @@ class Lock(object):
             if self.debug:
                 # All locks read the owner PID and host
                 self._read_debug_data()
-                tty.debug('{0} locked {1} [{2}:{3}] (owner={4})'
-                          .format(lock_type[op], self.path,
-                                  self._start, self._length, self.pid))
+                self._debug('{0} locked {1} [{2}:{3}] (owner={4})'
+                            .format(lock_type[op], self.path,
+                                    self._start, self._length, self.pid))
 
                 # Exclusive locks write their PID/host
                 if op == fcntl.LOCK_EX:
@@ -474,7 +474,7 @@ class Lock(object):
                 return False
 
     def _debug(self, *args):
-        tty.debug(*args)
+        tty.debug(*args, level=tty.DETAILED)
 
     def _get_counts_desc(self):
         return '(reads {0}, writes {1})'.format(self._reads, self._writes) \
@@ -488,7 +488,7 @@ class Lock(object):
                                      format(desc, attempts_part)))
 
     def _log_acquiring(self, locktype):
-        self._debug2(self._status_msg(locktype, 'Acquiring'))
+        self._detailed(self._status_msg(locktype, 'Acquiring'))
 
     def _log_downgraded(self, wait_time, nattempts):
         attempts_part = _attempts_str(wait_time, nattempts)
@@ -498,7 +498,7 @@ class Lock(object):
                                      .format(desc, attempts_part)))
 
     def _log_downgrading(self):
-        self._debug2(self._status_msg('WRITE LOCK', 'Downgrading'))
+        self._detailed(self._status_msg('WRITE LOCK', 'Downgrading'))
 
     def _log_released(self, locktype):
         now = datetime.now()
@@ -506,7 +506,7 @@ class Lock(object):
         self._debug(self._status_msg(locktype, desc))
 
     def _log_releasing(self, locktype):
-        self._debug2(self._status_msg(locktype, 'Releasing'))
+        self._detailed(self._status_msg(locktype, 'Releasing'))
 
     def _log_upgraded(self, wait_time, nattempts):
         attempts_part = _attempts_str(wait_time, nattempts)
@@ -516,25 +516,15 @@ class Lock(object):
                                      format(desc, attempts_part)))
 
     def _log_upgrading(self):
-        self._debug2(self._status_msg('READ LOCK', 'Upgrading'))
+        self._detailed(self._status_msg('READ LOCK', 'Upgrading'))
 
     def _status_msg(self, locktype, status):
         status_desc = '[{0}] {1}'.format(status, self._get_counts_desc())
         return '{0}{1.desc}: {1.path}[{1._start}:{1._length}] {2}'.format(
             locktype, self, status_desc)
 
-    def _debug2(self, *args):
-        # TODO: Easy place to make a single, temporary change to the
-        # TODO:   debug level associated with the more detailed messages.
-        # TODO:
-        # TODO:   Someday it would be great if we could switch this to
-        # TODO:   another level, perhaps _between_ debug and verbose, or
-        # TODO:   some other form of filtering so the first level of
-        # TODO:   debugging doesn't have to generate these messages.  Using
-        # TODO:   verbose here did not work as expected because tests like
-        # TODO:   test_spec_json will write the verbose messages to the
-        # TODO:   output that is used to check test correctness.
-        tty.debug(*args)
+    def _detailed(self, *args):
+        tty.debug(*args, level=tty.LENGTHY)
 
 
 class LockTransaction(object):

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -474,7 +474,8 @@ class Lock(object):
                 return False
 
     def _debug(self, *args):
-        tty.debug(*args, level=tty.DETAILED)
+        """Output lock debug messages at the default level."""
+        tty.debug(*args, level=2)
 
     def _get_counts_desc(self):
         return '(reads {0}, writes {1})'.format(self._reads, self._writes) \
@@ -524,7 +525,8 @@ class Lock(object):
             locktype, self, status_desc)
 
     def _detailed(self, *args):
-        tty.debug(*args, level=tty.LENGTHY)
+        """Output detailed lock log messages at a more verbose level."""
+        tty.debug(*args, level=3)
 
 
 class LockTransaction(object):

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -19,19 +19,8 @@ from six.moves import input
 
 from llnl.util.tty.color import cprint, cwrite, cescape, clen
 
-# Debug levels
-#
-# Note that from a standard Python logging level perspective, the following
-# should, perhaps, be descending (from 10).
-DISABLED = 0
-BASIC = 1
-STANDARD = 2
-DETAILED = 3
-LENGTHY = 4
-
-
 # Globals
-_debug = DISABLED
+_debug = 0
 _verbose = False
 _stacktrace = False
 _timestamp = False
@@ -49,7 +38,7 @@ def is_verbose():
     return _verbose
 
 
-def is_debug(level=BASIC):
+def is_debug(level=1):
     return _debug >= level
 
 
@@ -57,7 +46,7 @@ def is_stacktrace():
     return _stacktrace
 
 
-def set_debug(level=DISABLED):
+def set_debug(level=0):
     global _debug
     assert level >= 0, 'Debug level must be a positive value'
     _debug = level
@@ -150,7 +139,7 @@ def process_stacktrace(countback):
 
 
 def show_pid():
-    return is_debug(STANDARD)
+    return is_debug(2)
 
 
 def get_timestamp(force=False):
@@ -219,7 +208,7 @@ def verbose(message, *args, **kwargs):
 
 
 def debug(message, *args, **kwargs):
-    level = kwargs.get('level', STANDARD)
+    level = kwargs.get('level', 1)
     if is_debug(level):
         kwargs.setdefault('format', 'g')
         kwargs.setdefault('stream', sys.stderr)

--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -149,11 +149,15 @@ def process_stacktrace(countback):
     return st_text
 
 
+def show_pid():
+    return is_debug(STANDARD)
+
+
 def get_timestamp(force=False):
     """Get a string timestamp"""
     if _debug or _timestamp or force:
         # Note inclusion of the PID is useful for parallel builds.
-        pid = ', {0}'.format(os.getpid()) if is_debug(STANDARD) else '' 
+        pid = ', {0}'.format(os.getpid()) if show_pid() else ''
         return '[{0}{1}] '.format(
             datetime.now().strftime("%Y-%m-%d-%H:%M:%S.%f"), pid)
     else:

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -323,14 +323,15 @@ class log_output(object):
     work within test frameworks like nose and pytest.
     """
 
-    def __init__(self, file_like=None, echo=False, debug=False, buffer=False):
+    def __init__(self, file_like=None, echo=False, debug=tty.DISABLED,
+                 buffer=False):
         """Create a new output log context manager.
 
         Args:
             file_like (str or stream): open file object or name of file where
                 output should be logged
             echo (bool): whether to echo output in addition to logging it
-            debug (bool): whether to enable tty debug mode during logging
+            debug (int): positive to enable tty debug mode during logging
             buffer (bool): pass buffer=True to skip unbuffering output; note
                 this doesn't set up any *new* buffering
 
@@ -355,7 +356,7 @@ class log_output(object):
         self._active = False  # used to prevent re-entry
 
     def __call__(self, file_like=None, echo=None, debug=None, buffer=None):
-        """Thie behaves the same as init. It allows a logger to be reused.
+        """This behaves the same as init. It allows a logger to be reused.
 
         Arguments are the same as for ``__init__()``.  Args here take
         precedence over those passed to ``__init__()``.

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -323,8 +323,7 @@ class log_output(object):
     work within test frameworks like nose and pytest.
     """
 
-    def __init__(self, file_like=None, echo=False, debug=tty.DISABLED,
-                 buffer=False):
+    def __init__(self, file_like=None, echo=False, debug=0, buffer=False):
         """Create a new output log context manager.
 
         Args:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -467,7 +467,7 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
         specfile_path, remote_specfile_path, keep_original=False)
 
     tty.debug('Buildcache for "{0}" written to \n {1}'
-              .format(spec, remote_spackfile_path), level=tty.BASIC)
+              .format(spec, remote_spackfile_path))
 
     try:
         # create an index.html for the build_cache directory so specs can be
@@ -843,15 +843,13 @@ def get_spec(spec=None, force=False):
 
         mirror_dir = url_util.local_file_path(fetch_url_build_cache)
         if mirror_dir:
-            tty.debug('Finding buildcaches in {0}'.format(mirror_dir),
-                      level=tty.BASIC)
+            tty.debug('Finding buildcaches in {0}'.format(mirror_dir))
             link = url_util.join(fetch_url_build_cache, specfile_name)
             urls.add(link)
 
         else:
             tty.debug('Finding buildcaches at {0}'
-                      .format(url_util.format(fetch_url_build_cache)),
-                      level=tty.BASIC)
+                      .format(url_util.format(fetch_url_build_cache)))
             link = url_util.join(fetch_url_build_cache, specfile_name)
             urls.add(link)
 
@@ -875,8 +873,7 @@ def get_specs(allarch=False):
             mirror.fetch_url, _build_cache_relative_path)
 
         tty.debug('Finding buildcaches at {0}'
-                  .format(url_util.format(fetch_url_build_cache)),
-                  level=tty.BASIC)
+                  .format(url_util.format(fetch_url_build_cache)))
 
         index_url = url_util.join(fetch_url_build_cache, 'index.json')
 
@@ -927,8 +924,7 @@ def get_keys(install=False, trust=False, force=False):
 
         mirror_dir = url_util.local_file_path(fetch_url_build_cache)
         if mirror_dir:
-            tty.debug('Finding public keys in {0}'.format(mirror_dir),
-                      level=tty.BASIC)
+            tty.debug('Finding public keys in {0}'.format(mirror_dir))
             files = os.listdir(str(mirror_dir))
             for file in files:
                 if re.search(r'\.key', file) or re.search(r'\.pub', file):
@@ -936,8 +932,7 @@ def get_keys(install=False, trust=False, force=False):
                     keys.add(link)
         else:
             tty.debug('Finding public keys at {0}'
-                      .format(url_util.format(fetch_url_build_cache)),
-                      level=tty.BASIC)
+                      .format(url_util.format(fetch_url_build_cache)))
             # For s3 mirror need to request index.html directly
             p, links = web_util.spider(
                 url_util.join(fetch_url_build_cache, 'index.html'))
@@ -955,16 +950,14 @@ def get_keys(install=False, trust=False, force=False):
                         stage.fetch()
                     except fs.FetchError:
                         continue
-            tty.debug('Found key {0}'.format(link), level=tty.BASIC)
+            tty.debug('Found key {0}'.format(link))
             if install:
                 if trust:
                     Gpg.trust(stage.save_filename)
-                    tty.debug('Added this key to trusted keys.',
-                              level=tty.BASIC)
+                    tty.debug('Added this key to trusted keys.')
                 else:
                     tty.debug('Will not add this key to trusted keys.'
-                              'Use -t to install all downloaded keys',
-                              level=tty.BASIC)
+                              'Use -t to install all downloaded keys')
 
 
 def needs_rebuild(spec, mirror_url, rebuild_on_errors=False):
@@ -1051,8 +1044,7 @@ def check_specs_against_mirrors(mirrors, specs, output_file=None,
     """
     rebuilds = {}
     for mirror in spack.mirror.MirrorCollection(mirrors).values():
-        tty.debug('Checking for built specs at {0}'.format(mirror.fetch_url),
-                  level=tty.BASIC)
+        tty.debug('Checking for built specs at {0}'.format(mirror.fetch_url))
 
         rebuild_list = []
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -466,8 +466,8 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     web_util.push_to_url(
         specfile_path, remote_specfile_path, keep_original=False)
 
-    tty.msg('Buildcache for "%s" written to \n %s' %
-            (spec, remote_spackfile_path))
+    tty.debug('Buildcache for "{0}" written to \n {1}'
+              .format(spec, remote_spackfile_path), level=tty.BASIC)
 
     try:
         # create an index.html for the build_cache directory so specs can be
@@ -843,13 +843,15 @@ def get_spec(spec=None, force=False):
 
         mirror_dir = url_util.local_file_path(fetch_url_build_cache)
         if mirror_dir:
-            tty.msg("Finding buildcaches in %s" % mirror_dir)
+            tty.debug('Finding buildcaches in {0}'.format(mirror_dir),
+                      level=tty.BASIC)
             link = url_util.join(fetch_url_build_cache, specfile_name)
             urls.add(link)
 
         else:
-            tty.msg("Finding buildcaches at %s" %
-                    url_util.format(fetch_url_build_cache))
+            tty.debug('Finding buildcaches at {0}'
+                      .format(url_util.format(fetch_url_build_cache)),
+                      level=tty.BASIC)
             link = url_util.join(fetch_url_build_cache, specfile_name)
             urls.add(link)
 
@@ -872,8 +874,9 @@ def get_specs(allarch=False):
         fetch_url_build_cache = url_util.join(
             mirror.fetch_url, _build_cache_relative_path)
 
-        tty.msg("Finding buildcaches at %s" %
-                url_util.format(fetch_url_build_cache))
+        tty.debug('Finding buildcaches at {0}'
+                  .format(url_util.format(fetch_url_build_cache)),
+                  level=tty.BASIC)
 
         index_url = url_util.join(fetch_url_build_cache, 'index.json')
 
@@ -924,15 +927,17 @@ def get_keys(install=False, trust=False, force=False):
 
         mirror_dir = url_util.local_file_path(fetch_url_build_cache)
         if mirror_dir:
-            tty.msg("Finding public keys in %s" % mirror_dir)
+            tty.debug('Finding public keys in {0}'.format(mirror_dir),
+                      level=tty.BASIC)
             files = os.listdir(str(mirror_dir))
             for file in files:
                 if re.search(r'\.key', file) or re.search(r'\.pub', file):
                     link = url_util.join(fetch_url_build_cache, file)
                     keys.add(link)
         else:
-            tty.msg("Finding public keys at %s" %
-                    url_util.format(fetch_url_build_cache))
+            tty.debug('Finding public keys at {0}'
+                      .format(url_util.format(fetch_url_build_cache)),
+                      level=tty.BASIC)
             # For s3 mirror need to request index.html directly
             p, links = web_util.spider(
                 url_util.join(fetch_url_build_cache, 'index.html'))
@@ -950,14 +955,16 @@ def get_keys(install=False, trust=False, force=False):
                         stage.fetch()
                     except fs.FetchError:
                         continue
-            tty.msg('Found key %s' % link)
+            tty.debug('Found key {0}'.format(link), level=tty.BASIC)
             if install:
                 if trust:
                     Gpg.trust(stage.save_filename)
-                    tty.msg('Added this key to trusted keys.')
+                    tty.debug('Added this key to trusted keys.',
+                              level=tty.BASIC)
                 else:
-                    tty.msg('Will not add this key to trusted keys.'
-                            'Use -t to install all downloaded keys')
+                    tty.debug('Will not add this key to trusted keys.'
+                              'Use -t to install all downloaded keys',
+                              level=tty.BASIC)
 
 
 def needs_rebuild(spec, mirror_url, rebuild_on_errors=False):
@@ -1044,7 +1051,8 @@ def check_specs_against_mirrors(mirrors, specs, output_file=None,
     """
     rebuilds = {}
     for mirror in spack.mirror.MirrorCollection(mirrors).values():
-        tty.msg('Checking for built specs at %s' % mirror.fetch_url)
+        tty.debug('Checking for built specs at {0}'.format(mirror.fetch_url),
+                  level=tty.BASIC)
 
         rebuild_list = []
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -289,10 +289,12 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.msg("Already downloaded %s" % self.archive_file)
+            tty.debug('Already downloaded {0}'.format(self.archive_file),
+                      level=tty.BASIC)
             return
 
         url = None
+        errors = []
         for url in self.candidate_urls:
             try:
                 partial_file, save_file = self._fetch_from_url(url)
@@ -300,8 +302,10 @@ class URLFetchStrategy(FetchStrategy):
                     os.rename(partial_file, save_file)
                 break
             except FetchError as e:
-                tty.msg(str(e))
-                pass
+                errors.append(str(e))
+
+        for msg in errors:
+            tty.debug(msg, level=tty.BASIC)
 
         if not self.archive_file:
             raise FailedDownloadError(url)
@@ -312,7 +316,7 @@ class URLFetchStrategy(FetchStrategy):
         if self.stage.save_filename:
             save_file = self.stage.save_filename
             partial_file = self.stage.save_filename + '.part'
-        tty.msg("Fetching %s" % url)
+        tty.debug('Fetching {0}'.format(url), level=tty.BASIC)
         if partial_file:
             save_args = ['-C',
                          '-',  # continue partial downloads
@@ -327,6 +331,8 @@ class URLFetchStrategy(FetchStrategy):
             '-',  # print out HTML headers
             '-L',  # resolve 3xx redirects
             url,
+            '--stderr',  # redirect stderr output
+            '-',         # redirect to stdout
         ]
 
         if not spack.config.get('config:verify_ssl'):
@@ -412,8 +418,9 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def expand(self):
         if not self.expand_archive:
-            tty.msg("Staging unexpanded archive %s in %s" % (
-                    self.archive_file, self.stage.source_path))
+            tty.debug('Staging unexpanded archive {0} in {1}'
+                      .format(self.archive_file, self.stage.source_path),
+                      level=tty.BASIC)
             if not self.stage.expanded:
                 mkdirp(self.stage.source_path)
             dest = os.path.join(self.stage.source_path,
@@ -421,7 +428,8 @@ class URLFetchStrategy(FetchStrategy):
             shutil.move(self.archive_file, dest)
             return
 
-        tty.msg("Staging archive: %s" % self.archive_file)
+        tty.debug('Staging archive: {0}'.format(self.archive_file),
+                  level=tty.BASIC)
 
         if not self.archive_file:
             raise NoArchiveFileError(
@@ -564,7 +572,7 @@ class CacheURLFetchStrategy(URLFetchStrategy):
                 raise
 
         # Notify the user how we fetched.
-        tty.msg('Using cached archive: %s' % path)
+        tty.debug('Using cached archive: {0}'.format(path))
 
 
 class VCSFetchStrategy(FetchStrategy):
@@ -594,7 +602,8 @@ class VCSFetchStrategy(FetchStrategy):
 
     @_needs_stage
     def check(self):
-        tty.msg("No checksum needed when fetching with %s" % self.url_attr)
+        tty.debug('No checksum needed when fetching with {0}'
+                  .format(self.url_attr), level=tty.BASIC)
 
     @_needs_stage
     def expand(self):
@@ -672,7 +681,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        tty.msg("Getting go resource:", self.url)
+        tty.debug('Getting go resource: {0}'.format(self.url), level=tty.BASIC)
 
         with working_dir(self.stage.path):
             try:
@@ -788,10 +797,12 @@ class GitFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.msg("Already fetched {0}".format(self.stage.source_path))
+            tty.debug('Already fetched {0}'.format(self.stage.source_path),
+                      level=tty.BASIC)
             return
 
-        tty.msg("Cloning git repository: {0}".format(self._repo_info()))
+        tty.debug('Cloning git repository: {0}'.format(self._repo_info()),
+                  level=tty.BASIC)
 
         git = self.git
         if self.commit:
@@ -959,10 +970,12 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.msg("Already fetched %s" % self.stage.source_path)
+            tty.debug('Already fetched {0}'.format(self.stage.source_path),
+                      level=tty.BASIC)
             return
 
-        tty.msg("Checking out subversion repository: %s" % self.url)
+        tty.debug('Checking out subversion repository: {0}'
+                  .format(self.url), level=tty.BASIC)
 
         args = ['checkout', '--force', '--quiet']
         if self.revision:
@@ -1068,13 +1081,15 @@ class HgFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.msg("Already fetched %s" % self.stage.source_path)
+            tty.debug('Already fetched {0}'.format(self.stage.source_path),
+                      level=tty.BASIC)
             return
 
         args = []
         if self.revision:
             args.append('at revision %s' % self.revision)
-        tty.msg("Cloning mercurial repository:", self.url, *args)
+        tty.debug('Cloning mercurial repository: {0} {1}'
+                  .format(self.url, args), level=tty.BASIC)
 
         args = ['clone']
 
@@ -1130,7 +1145,8 @@ class S3FetchStrategy(URLFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.msg("Already downloaded %s" % self.archive_file)
+            tty.debug('Already downloaded {0}'.format(self.archive_file),
+                      level=tty.BASIC)
             return
 
         parsed_url = url_util.parse(self.url)
@@ -1138,7 +1154,7 @@ class S3FetchStrategy(URLFetchStrategy):
             raise FetchError(
                 'S3FetchStrategy can only fetch from s3:// urls.')
 
-        tty.msg("Fetching %s" % self.url)
+        tty.debug('Fetching {0}'.format(self.url), level=tty.BASIC)
 
         basename = os.path.basename(parsed_url.path)
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -289,8 +289,7 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file),
-                      level=tty.BASIC)
+            tty.debug('Already downloaded {0}'.format(self.archive_file))
             return
 
         url = None
@@ -305,7 +304,7 @@ class URLFetchStrategy(FetchStrategy):
                 errors.append(str(e))
 
         for msg in errors:
-            tty.debug(msg, level=tty.BASIC)
+            tty.debug(msg)
 
         if not self.archive_file:
             raise FailedDownloadError(url)
@@ -316,7 +315,7 @@ class URLFetchStrategy(FetchStrategy):
         if self.stage.save_filename:
             save_file = self.stage.save_filename
             partial_file = self.stage.save_filename + '.part'
-        tty.debug('Fetching {0}'.format(url), level=tty.BASIC)
+        tty.debug('Fetching {0}'.format(url))
         if partial_file:
             save_args = ['-C',
                          '-',  # continue partial downloads
@@ -419,8 +418,7 @@ class URLFetchStrategy(FetchStrategy):
     def expand(self):
         if not self.expand_archive:
             tty.debug('Staging unexpanded archive {0} in {1}'
-                      .format(self.archive_file, self.stage.source_path),
-                      level=tty.BASIC)
+                      .format(self.archive_file, self.stage.source_path))
             if not self.stage.expanded:
                 mkdirp(self.stage.source_path)
             dest = os.path.join(self.stage.source_path,
@@ -428,8 +426,7 @@ class URLFetchStrategy(FetchStrategy):
             shutil.move(self.archive_file, dest)
             return
 
-        tty.debug('Staging archive: {0}'.format(self.archive_file),
-                  level=tty.BASIC)
+        tty.debug('Staging archive: {0}'.format(self.archive_file))
 
         if not self.archive_file:
             raise NoArchiveFileError(
@@ -603,7 +600,7 @@ class VCSFetchStrategy(FetchStrategy):
     @_needs_stage
     def check(self):
         tty.debug('No checksum needed when fetching with {0}'
-                  .format(self.url_attr), level=tty.BASIC)
+                  .format(self.url_attr))
 
     @_needs_stage
     def expand(self):
@@ -681,7 +678,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        tty.debug('Getting go resource: {0}'.format(self.url), level=tty.BASIC)
+        tty.debug('Getting go resource: {0}'.format(self.url))
 
         with working_dir(self.stage.path):
             try:
@@ -797,12 +794,10 @@ class GitFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path),
-                      level=tty.BASIC)
+            tty.debug('Already fetched {0}'.format(self.stage.source_path))
             return
 
-        tty.debug('Cloning git repository: {0}'.format(self._repo_info()),
-                  level=tty.BASIC)
+        tty.debug('Cloning git repository: {0}'.format(self._repo_info()))
 
         git = self.git
         if self.commit:
@@ -970,12 +965,10 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path),
-                      level=tty.BASIC)
+            tty.debug('Already fetched {0}'.format(self.stage.source_path))
             return
 
-        tty.debug('Checking out subversion repository: {0}'
-                  .format(self.url), level=tty.BASIC)
+        tty.debug('Checking out subversion repository: {0}'.format(self.url))
 
         args = ['checkout', '--force', '--quiet']
         if self.revision:
@@ -1081,15 +1074,14 @@ class HgFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path),
-                      level=tty.BASIC)
+            tty.debug('Already fetched {0}'.format(self.stage.source_path))
             return
 
         args = []
         if self.revision:
             args.append('at revision %s' % self.revision)
         tty.debug('Cloning mercurial repository: {0} {1}'
-                  .format(self.url, args), level=tty.BASIC)
+                  .format(self.url, args))
 
         args = ['clone']
 
@@ -1145,8 +1137,7 @@ class S3FetchStrategy(URLFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file),
-                      level=tty.BASIC)
+            tty.debug('Already downloaded {0}'.format(self.archive_file))
             return
 
         parsed_url = url_util.parse(self.url)
@@ -1154,7 +1145,7 @@ class S3FetchStrategy(URLFetchStrategy):
             raise FetchError(
                 'S3FetchStrategy can only fetch from s3:// urls.')
 
-        tty.debug('Fetching {0}'.format(self.url), level=tty.BASIC)
+        tty.debug('Fetching {0}'.format(self.url))
 
         basename = os.path.basename(parsed_url.path)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1156,11 +1156,11 @@ class PackageInstaller(object):
             pkg._total_time = time.time() - start_time
             build_time = pkg._total_time - pkg._fetch_time
 
-            tty.msg('{0} Successfully installed {1}'
-                    .format(pre, pkg_id),
-                    'Fetch: {0}.  Build: {1}.  Total: {2}.'
-                    .format(_hms(pkg._fetch_time), _hms(build_time),
-                            _hms(pkg._total_time)))
+            tty.debug('{0} Successfully installed {1}'
+                      .format(pre, pkg_id),
+                      'Fetch: {0}.  Build: {1}.  Total: {2}.'
+                      .format(_hms(pkg._fetch_time), _hms(build_time),
+                              _hms(pkg._total_time)))
             _print_installed_pkg(pkg.prefix)
 
             # preserve verbosity across runs

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -452,7 +452,8 @@ def install_msg(name, pid):
     Return:
         (str) Colorized installing message
     """
-    return '{0}: '.format(pid) + colorize('@*{Installing} @*g{%s}' % name)
+    pre = '{0}: '.format(pid) if tty.show_pid() else ''
+    return pre + colorize('@*{Installing} @*g{%s}' % name)
 
 
 def log(pkg):
@@ -1061,7 +1062,8 @@ class PackageInstaller(object):
 
         pkg.run_tests = (tests is True or tests and pkg.name in tests)
 
-        pre = '{0}: {1}:'.format(self.pid, pkg.name)
+        pid = '{0}: '.format(self.pid) if tty.show_pid() else ''
+        pre = '{0}{1}:'.format(pid, pkg.name)
 
         def build_process():
             """
@@ -1189,7 +1191,8 @@ class PackageInstaller(object):
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
-            tty.debug('{0} {1}'.format(self.pid, str(e)))
+            pre = '{0}'.format(self.pid) if tty.show_pid() else ''
+            tty.debug('{0}{1}'.format(pid, str(e)))
             tty.debug('Package stage directory : {0}'
                       .format(pkg.stage.source_path))
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -240,7 +240,7 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False):
         tty.debug('{0}: installing from source'.format(pre))
         return False
 
-    tty.debug('Successfully installed {0} from binary cache'.format(pkg_id))
+    tty.msg('Successfully installed {0} from binary cache'.format(pkg_id))
     _print_installed_pkg(pkg.spec.prefix)
     spack.hooks.post_install(pkg.spec)
     return True
@@ -273,19 +273,19 @@ def _process_external_package(pkg, explicit):
     spec = pkg.spec
 
     if spec.external_module:
-        tty.msg('{0} has external module in {1}'
-                .format(pre, spec.external_module))
-        tty.msg('{0} is actually installed in {1}'
-                .format(pre, spec.external_path))
+        tty.debug('{0} has external module in {1}'
+                  .format(pre, spec.external_module), level=tty.BASIC)
+        tty.debug('{0} is actually installed in {1}'
+                  .format(pre, spec.external_path), level=tty.BASIC)
     else:
-        tty.msg("{0} externally installed in {1}"
-                .format(pre, spec.external_path))
+        tty.debug('{0} externally installed in {1}'
+                  .format(pre, spec.external_path), level=tty.BASIC)
 
     try:
         # Check if the package was already registered in the DB.
         # If this is the case, then just exit.
         rec = spack.store.db.get_record(spec)
-        tty.msg('{0} already registered in DB'.format(pre))
+        tty.debug('{0} already registered in DB'.format(pre), level=tty.BASIC)
 
         # Update the value of rec.explicit if it is necessary
         _update_explicit_entry_in_db(pkg, rec, explicit)
@@ -294,11 +294,11 @@ def _process_external_package(pkg, explicit):
         # If not, register it and generate the module file.
         # For external packages we just need to run
         # post-install hooks to generate module files.
-        tty.msg('{0} generating module file'.format(pre))
+        tty.debug('{0} generating module file'.format(pre), level=tty.BASIC)
         spack.hooks.post_install(spec)
 
         # Add to the DB
-        tty.msg('{0} registering into DB'.format(pre))
+        tty.debug('{0} registering into DB'.format(pre), level=tty.BASIC)
         spack.store.db.add(spec, None, explicit=explicit)
 
 
@@ -320,8 +320,8 @@ def _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned):
     tarball = binary_distribution.download_tarball(binary_spec)
     # see #10063 : install from source if tarball doesn't exist
     if tarball is None:
-        tty.msg('{0} exists in binary cache but with different hash'
-                .format(pkg.name))
+        tty.debug('{0} exists in binary cache but with different hash'
+                  .format(pkg.name), level=tty.BASIC)
         return False
 
     pkg_id = package_id(pkg)
@@ -369,7 +369,7 @@ def _update_explicit_entry_in_db(pkg, rec, explicit):
         with spack.store.db.write_transaction():
             rec = spack.store.db.get_record(pkg.spec)
             message = '{s.name}@{s.version} : marking the package explicit'
-            tty.msg(message.format(s=pkg.spec))
+            tty.debug(message.format(s=pkg.spec), level=tty.BASIC)
             rec.explicit = True
 
 
@@ -1082,8 +1082,9 @@ class PackageInstaller(object):
                     pkg.do_stage()
 
             pkg_id = package_id(pkg)
-            tty.msg('{0} Building {1} [{2}]'
-                    .format(pre, pkg_id, pkg.build_system_class))
+            tty.debug('{0} Building {1} [{2}]'
+                      .format(pre, pkg_id, pkg.build_system_class),
+                      level=tty.BASIC)
 
             # get verbosity from do_install() parameter or saved value
             echo = verbose
@@ -1104,8 +1105,8 @@ class PackageInstaller(object):
                     if install_source and os.path.isdir(source_path):
                         src_target = os.path.join(pkg.spec.prefix, 'share',
                                                   pkg.name, 'src')
-                        tty.msg('{0} Copying source to {1}'
-                                .format(pre, src_target))
+                        tty.debug('{0} Copying source to {1}'
+                                  .format(pre, src_target), level=tty.BASIC)
                         fs.install_tree(pkg.stage.source_path, src_target)
 
                     # Do the real install in the source directory.
@@ -1156,11 +1157,12 @@ class PackageInstaller(object):
             pkg._total_time = time.time() - start_time
             build_time = pkg._total_time - pkg._fetch_time
 
-            tty.msg('{0} Successfully installed {1}'
-                    .format(pre, pkg_id),
-                    'Fetch: {0}.  Build: {1}.  Total: {2}.'
-                    .format(_hms(pkg._fetch_time), _hms(build_time),
-                            _hms(pkg._total_time)))
+            tty.debug('{0} Successfully installed {1}'
+                      .format(pre, pkg_id),
+                      'Fetch: {0}.  Build: {1}.  Total: {2}.'
+                      .format(_hms(pkg._fetch_time), _hms(build_time),
+                              _hms(pkg._total_time)),
+                      level=tty.BASIC)
             _print_installed_pkg(pkg.prefix)
 
             # preserve verbosity across runs

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -273,19 +273,19 @@ def _process_external_package(pkg, explicit):
     spec = pkg.spec
 
     if spec.external_module:
-        tty.debug('{0} has external module in {1}'
-                  .format(pre, spec.external_module), level=tty.BASIC)
+        tty.msg('{0} has external module in {1}'
+                .format(pre, spec.external_module))
         tty.debug('{0} is actually installed in {1}'
-                  .format(pre, spec.external_path), level=tty.BASIC)
+                  .format(pre, spec.external_path))
     else:
-        tty.debug('{0} externally installed in {1}'
-                  .format(pre, spec.external_path), level=tty.BASIC)
+        tty.msg('{0} externally installed in {1}'
+                .format(pre, spec.external_path))
 
     try:
         # Check if the package was already registered in the DB.
         # If this is the case, then just exit.
         rec = spack.store.db.get_record(spec)
-        tty.debug('{0} already registered in DB'.format(pre), level=tty.BASIC)
+        tty.debug('{0} already registered in DB'.format(pre))
 
         # Update the value of rec.explicit if it is necessary
         _update_explicit_entry_in_db(pkg, rec, explicit)
@@ -294,11 +294,11 @@ def _process_external_package(pkg, explicit):
         # If not, register it and generate the module file.
         # For external packages we just need to run
         # post-install hooks to generate module files.
-        tty.debug('{0} generating module file'.format(pre), level=tty.BASIC)
+        tty.debug('{0} generating module file'.format(pre))
         spack.hooks.post_install(spec)
 
         # Add to the DB
-        tty.debug('{0} registering into DB'.format(pre), level=tty.BASIC)
+        tty.debug('{0} registering into DB'.format(pre))
         spack.store.db.add(spec, None, explicit=explicit)
 
 
@@ -320,8 +320,8 @@ def _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned):
     tarball = binary_distribution.download_tarball(binary_spec)
     # see #10063 : install from source if tarball doesn't exist
     if tarball is None:
-        tty.debug('{0} exists in binary cache but with different hash'
-                  .format(pkg.name), level=tty.BASIC)
+        tty.msg('{0} exists in binary cache but with different hash'
+                .format(pkg.name))
         return False
 
     pkg_id = package_id(pkg)
@@ -369,7 +369,7 @@ def _update_explicit_entry_in_db(pkg, rec, explicit):
         with spack.store.db.write_transaction():
             rec = spack.store.db.get_record(pkg.spec)
             message = '{s.name}@{s.version} : marking the package explicit'
-            tty.debug(message.format(s=pkg.spec), level=tty.BASIC)
+            tty.debug(message.format(s=pkg.spec))
             rec.explicit = True
 
 
@@ -1083,8 +1083,7 @@ class PackageInstaller(object):
 
             pkg_id = package_id(pkg)
             tty.debug('{0} Building {1} [{2}]'
-                      .format(pre, pkg_id, pkg.build_system_class),
-                      level=tty.BASIC)
+                      .format(pre, pkg_id, pkg.build_system_class))
 
             # get verbosity from do_install() parameter or saved value
             echo = verbose
@@ -1106,7 +1105,7 @@ class PackageInstaller(object):
                         src_target = os.path.join(pkg.spec.prefix, 'share',
                                                   pkg.name, 'src')
                         tty.debug('{0} Copying source to {1}'
-                                  .format(pre, src_target), level=tty.BASIC)
+                                  .format(pre, src_target))
                         fs.install_tree(pkg.stage.source_path, src_target)
 
                     # Do the real install in the source directory.
@@ -1157,12 +1156,11 @@ class PackageInstaller(object):
             pkg._total_time = time.time() - start_time
             build_time = pkg._total_time - pkg._fetch_time
 
-            tty.debug('{0} Successfully installed {1}'
-                      .format(pre, pkg_id),
-                      'Fetch: {0}.  Build: {1}.  Total: {2}.'
-                      .format(_hms(pkg._fetch_time), _hms(build_time),
-                              _hms(pkg._total_time)),
-                      level=tty.BASIC)
+            tty.msg('{0} Successfully installed {1}'
+                    .format(pre, pkg_id),
+                    'Fetch: {0}.  Build: {1}.  Total: {2}.'
+                    .format(_hms(pkg._fetch_time), _hms(build_time),
+                            _hms(pkg._total_time)))
             _print_installed_pkg(pkg.prefix)
 
             # preserve verbosity across runs

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1125,7 +1125,7 @@ class PackageInstaller(object):
                                 pass
 
                         # cache debug settings
-                        debug_enabled = tty.is_debug()
+                        debug_level = tty.debug_level()
 
                         # Spawn a daemon that reads from a pipe and redirects
                         # everything to log_path
@@ -1134,11 +1134,11 @@ class PackageInstaller(object):
                                     pkg.phases, pkg._InstallPhase_phases):
 
                                 with logger.force_echo():
-                                    inner_debug = tty.is_debug()
-                                    tty.set_debug(debug_enabled)
+                                    inner_debug_level = tty.debug_level()
+                                    tty.set_debug(debug_level)
                                     tty.msg("{0} Executing phase: '{1}'"
                                             .format(pre, phase_name))
-                                    tty.set_debug(inner_debug)
+                                    tty.set_debug(inner_debug_level)
 
                                 # Redirect stdout and stderr to daemon pipe
                                 phase = getattr(pkg, phase_attr)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -215,18 +215,18 @@ def _hms(seconds):
 
 def _install_from_cache(pkg, cache_only, explicit, unsigned=False):
     """
-    Install the package from binary cache
+    Extract the package from binary cache
 
     Args:
         pkg (PackageBase): the package to install from the binary cache
-        cache_only (bool): only install from binary cache
+        cache_only (bool): only extract from binary cache
         explicit (bool): ``True`` if installing the package was explicitly
             requested by the user, otherwise, ``False``
         unsigned (bool): ``True`` if binary package signatures to be checked,
             otherwise, ``False``
 
     Return:
-        (bool) ``True`` if the package was installed from binary cache,
+        (bool) ``True`` if the package was extract from binary cache,
             ``False`` otherwise
     """
     installed_from_cache = _try_install_from_binary_cache(pkg, explicit,
@@ -237,10 +237,10 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False):
         if cache_only:
             tty.die('{0} when cache-only specified'.format(pre))
 
-        tty.debug('{0}: installing from source'.format(pre))
+        tty.msg('{0}: installing from source'.format(pre))
         return False
 
-    tty.msg('Successfully installed {0} from binary cache'.format(pkg_id))
+    tty.debug('Successfully extracted {0} from binary cache'.format(pkg_id))
     _print_installed_pkg(pkg.spec.prefix)
     spack.hooks.post_install(pkg.spec)
     return True
@@ -314,7 +314,7 @@ def _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned):
             otherwise, ``False``
 
     Return:
-        (bool) ``True`` if the package was installed from binary cache,
+        (bool) ``True`` if the package was extracted from binary cache,
             else ``False``
     """
     tarball = binary_distribution.download_tarball(binary_spec)
@@ -325,7 +325,7 @@ def _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned):
         return False
 
     pkg_id = package_id(pkg)
-    tty.msg('Installing {0} from binary cache'.format(pkg_id))
+    tty.msg('Extracting {0} from binary cache'.format(pkg_id))
     binary_distribution.extract_tarball(binary_spec, tarball, allow_root=False,
                                         unsigned=unsigned, force=False)
     pkg.installed_from_binary_cache = True
@@ -335,10 +335,10 @@ def _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned):
 
 def _try_install_from_binary_cache(pkg, explicit, unsigned=False):
     """
-    Try to install the package from binary cache.
+    Try to extract the package from binary cache.
 
     Args:
-        pkg (PackageBase): the package to be installed from binary cache
+        pkg (PackageBase): the package to be extracted from binary cache
         explicit (bool): the package was explicitly requested by the user
         unsigned (bool): ``True`` if binary package signatures to be checked,
             otherwise, ``False``

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -363,7 +363,15 @@ def make_argument_parser(**kwargs):
         metavar='DIR', help="add a custom configuration scope")
     parser.add_argument(
         '-d', '--debug', action='store_true',
-        help="write out debug logs during compile")
+        help="write out basic debug messages")
+    parser.add_argument(
+        '-dd', action='store_true',
+        help="write out basic and standard debug messages")
+    parser.add_argument(
+        '-ddd', action='store_true',
+        help="write out basic, standard and detailed debug messages")
+    parser.add_argument(
+        '-dddd', action='store_true', help="write out all debug messages")
     parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
@@ -409,7 +417,7 @@ def make_argument_parser(**kwargs):
         help="lines of profile output or 'all' (default: 20)")
     parser.add_argument(
         '-v', '--verbose', action='store_true',
-        help="print additional output during builds")
+        help="print additional, verbose output")
     parser.add_argument(
         '--stacktrace', action='store_true',
         help="add stacktraces to all printed statements")
@@ -435,12 +443,15 @@ def setup_main_options(args):
 
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
-    tty.set_debug(args.debug)
+    debug_level = tty.LENGTHY if args.dddd else \
+        tty.DETAILED if args.ddd else tty.STANDARD if args.dd else \
+        tty.BASIC if args.debug else tty.DISABLED
+    tty.set_debug(debug_level)
     tty.set_stacktrace(args.stacktrace)
 
-    # debug must be set first so that it can even affect behvaior of
+    # debug must be set first so that it can even affect behavior of
     # errors raised by spack.config.
-    if args.debug:
+    if debug_level:
         spack.error.debug = True
         spack.util.debug.register_interrupt_handler()
         spack.config.set('config:debug', True, scope='command_line')

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -362,16 +362,9 @@ def make_argument_parser(**kwargs):
         '-C', '--config-scope', dest='config_scopes', action='append',
         metavar='DIR', help="add a custom configuration scope")
     parser.add_argument(
-        '-d', '--debug', action='store_true',
-        help="write out basic debug messages")
-    parser.add_argument(
-        '-dd', action='store_true',
-        help="write out basic and standard debug messages")
-    parser.add_argument(
-        '-ddd', action='store_true',
-        help="write out basic, standard and detailed debug messages")
-    parser.add_argument(
-        '-dddd', action='store_true', help="write out all debug messages")
+        '-d', '--debug', action='count', default=0,
+        help="write out debug messages "
+             "(more d's for more verbosity: -d, -dd, -ddd, etc.)")
     parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
@@ -417,7 +410,7 @@ def make_argument_parser(**kwargs):
         help="lines of profile output or 'all' (default: 20)")
     parser.add_argument(
         '-v', '--verbose', action='store_true',
-        help="print additional, verbose output")
+        help="print additional output during builds")
     parser.add_argument(
         '--stacktrace', action='store_true',
         help="add stacktraces to all printed statements")
@@ -443,15 +436,12 @@ def setup_main_options(args):
 
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
-    debug_level = tty.LENGTHY if args.dddd else \
-        tty.DETAILED if args.ddd else tty.STANDARD if args.dd else \
-        tty.BASIC if args.debug else tty.DISABLED
-    tty.set_debug(debug_level)
+    tty.set_debug(args.debug)
     tty.set_stacktrace(args.stacktrace)
 
     # debug must be set first so that it can even affect behavior of
     # errors raised by spack.config.
-    if debug_level:
+    if args.debug:
         spack.error.debug = True
         spack.util.debug.register_interrupt_handler()
         spack.config.set('config:debug', True, scope='command_line')

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1123,7 +1123,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if not self.has_code:
             tty.debug('No fetch required for {0}: package has no code.'
-                      .format(self.name), level=tty.BASIC)
+                      .format(self.name))
 
         start_time = time.time()
         checksum = spack.config.get('config:checksum')
@@ -1140,7 +1140,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                                                     default=False)
                 if ignore_checksum:
                     tty.debug('Fetching with no checksum. {0}'
-                              .format(ck_msg), level=tty.BASIC)
+                              .format(ck_msg))
 
             if not ignore_checksum:
                 raise FetchError("Will not fetch %s" %
@@ -1196,8 +1196,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # If there are no patches, note it.
         if not patches and not has_patch_fun:
-            tty.debug('No patches needed for {0}'.format(self.name),
-                      level=tty.BASIC)
+            tty.debug('No patches needed for {0}'.format(self.name))
             return
 
         # Construct paths to special files in the archive dir used to
@@ -1210,18 +1209,15 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # If we encounter an archive that failed to patch, restage it
         # so that we can apply all the patches again.
         if os.path.isfile(bad_file):
-            tty.debug('Patching failed last time. Restaging.',
-                      level=tty.BASIC)
+            tty.debug('Patching failed last time. Restaging.')
             self.stage.restage()
 
         # If this file exists, then we already applied all the patches.
         if os.path.isfile(good_file):
-            tty.debug('Already patched {0}'.format(self.name),
-                      level=tty.BASIC)
+            tty.debug('Already patched {0}'.format(self.name))
             return
         elif os.path.isfile(no_patches_file):
-            tty.debug('No patches needed for {0}'.format(self.name),
-                      level=tty.BASIC)
+            tty.debug('No patches needed for {0}'.format(self.name))
             return
 
         # Apply all the patches for specs that match this one
@@ -1230,8 +1226,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             try:
                 with working_dir(self.stage.source_path):
                     patch.apply(self.stage)
-                tty.debug('Applied patch {0}'.format(patch.path_or_url),
-                          level=tty.BASIC)
+                tty.debug('Applied patch {0}'.format(patch.path_or_url))
                 patched = True
             except spack.error.SpackError as e:
                 tty.debug(e)
@@ -1245,8 +1240,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             try:
                 with working_dir(self.stage.source_path):
                     self.patch()
-                tty.debug('Ran patch() for {0}'.format(self.name),
-                          level=tty.BASIC)
+                tty.debug('Ran patch() for {0}'.format(self.name))
                 patched = True
             except spack.multimethod.NoSuchMethodError:
                 # We are running a multimethod without a default case.
@@ -1256,8 +1250,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                     # directive, AND the patch function didn't apply, say
                     # no patches are needed.  Otherwise, we already
                     # printed a message for each patch.
-                    tty.debug('No patches needed for {0}'.format(self.name),
-                              level=tty.BASIC)
+                    tty.debug('No patches needed for {0}'.format(self.name))
             except spack.error.SpackError as e:
                 tty.debug(e)
 
@@ -1349,8 +1342,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if os.path.exists(makefile):
                 break
         else:
-            tty.debug('No Makefile found in the build directory',
-                      level=tty.BASIC)
+            tty.debug('No Makefile found in the build directory')
             return False
 
         # Check if 'target' is a valid target.
@@ -1382,7 +1374,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         for missing_target_msg in missing_target_msgs:
             if missing_target_msg.format(target) in stderr:
                 tty.debug("Target '{0}' not found in {1}"
-                          .format(target, makefile), level=tty.BASIC)
+                          .format(target, makefile))
                 return False
 
         return True
@@ -1410,8 +1402,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Check if we have a Ninja build script
         if not os.path.exists('build.ninja'):
-            tty.debug('No Ninja build script found in the build directory',
-                      level=tty.BASIC)
+            tty.debug('No Ninja build script found in the build directory')
             return False
 
         # Get a list of all targets in the Ninja build script
@@ -1424,7 +1415,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if not matches:
             tty.debug("Target '{0}' not found in build.ninja"
-                      .format(target), level=tty.BASIC)
+                      .format(target))
             return False
 
         return True
@@ -1732,11 +1723,11 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 if deprecator:
                     spack.store.db.deprecate(specs[0], deprecator)
                     tty.debug('Deprecating stale DB entry for {0}'
-                              .format(spec.short_spec), level=tty.BASIC)
+                              .format(spec.short_spec))
                 else:
                     spack.store.db.remove(specs[0])
                     tty.debug('Removed stale DB entry for {0}'
-                              .format(spec.short_spec), level=tty.BASIC)
+                              .format(spec.short_spec))
                 return
             else:
                 raise InstallError(str(spec) + " is not installed.")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1122,9 +1122,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             raise ValueError("Can only fetch concrete packages.")
 
         if not self.has_code:
-            tty.msg(
-                "No fetch required for %s: package has no code." % self.name
-            )
+            tty.debug('No fetch required for {0}: package has no code.'
+                      .format(self.name), level=tty.BASIC)
 
         start_time = time.time()
         checksum = spack.config.get('config:checksum')
@@ -1140,7 +1139,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 ignore_checksum = tty.get_yes_or_no("  Fetch anyway?",
                                                     default=False)
                 if ignore_checksum:
-                    tty.msg("Fetching with no checksum.", ck_msg)
+                    tty.debug('Fetching with no checksum. {0}'
+                              .format(ck_msg), level=tty.BASIC)
 
             if not ignore_checksum:
                 raise FetchError("Will not fetch %s" %
@@ -1196,7 +1196,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # If there are no patches, note it.
         if not patches and not has_patch_fun:
-            tty.msg("No patches needed for %s" % self.name)
+            tty.debug('No patches needed for {0}'.format(self.name),
+                      level=tty.BASIC)
             return
 
         # Construct paths to special files in the archive dir used to
@@ -1209,15 +1210,18 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         # If we encounter an archive that failed to patch, restage it
         # so that we can apply all the patches again.
         if os.path.isfile(bad_file):
-            tty.msg("Patching failed last time. Restaging.")
+            tty.debug('Patching failed last time. Restaging.',
+                      level=tty.BASIC)
             self.stage.restage()
 
         # If this file exists, then we already applied all the patches.
         if os.path.isfile(good_file):
-            tty.msg("Already patched %s" % self.name)
+            tty.debug('Already patched {0}'.format(self.name),
+                      level=tty.BASIC)
             return
         elif os.path.isfile(no_patches_file):
-            tty.msg("No patches needed for %s" % self.name)
+            tty.debug('No patches needed for {0}'.format(self.name),
+                      level=tty.BASIC)
             return
 
         # Apply all the patches for specs that match this one
@@ -1226,7 +1230,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             try:
                 with working_dir(self.stage.source_path):
                     patch.apply(self.stage)
-                tty.msg('Applied patch %s' % patch.path_or_url)
+                tty.debug('Applied patch {0}'.format(patch.path_or_url),
+                          level=tty.BASIC)
                 patched = True
             except spack.error.SpackError as e:
                 tty.debug(e)
@@ -1240,7 +1245,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             try:
                 with working_dir(self.stage.source_path):
                     self.patch()
-                tty.msg("Ran patch() for %s" % self.name)
+                tty.debug('Ran patch() for {0}'.format(self.name),
+                          level=tty.BASIC)
                 patched = True
             except spack.multimethod.NoSuchMethodError:
                 # We are running a multimethod without a default case.
@@ -1250,12 +1256,13 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                     # directive, AND the patch function didn't apply, say
                     # no patches are needed.  Otherwise, we already
                     # printed a message for each patch.
-                    tty.msg("No patches needed for %s" % self.name)
+                    tty.debug('No patches needed for {0}'.format(self.name),
+                              level=tty.BASIC)
             except spack.error.SpackError as e:
                 tty.debug(e)
 
                 # Touch bad file if anything goes wrong.
-                tty.msg("patch() function failed for %s" % self.name)
+                tty.msg('patch() function failed for {0}'.format(self.name))
                 touch(bad_file)
                 raise
 
@@ -1342,7 +1349,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if os.path.exists(makefile):
                 break
         else:
-            tty.msg('No Makefile found in the build directory')
+            tty.debug('No Makefile found in the build directory',
+                      level=tty.BASIC)
             return False
 
         # Check if 'target' is a valid target.
@@ -1373,7 +1381,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         for missing_target_msg in missing_target_msgs:
             if missing_target_msg.format(target) in stderr:
-                tty.msg("Target '" + target + "' not found in " + makefile)
+                tty.debug("Target '{0}' not found in {1}"
+                          .format(target, makefile), level=tty.BASIC)
                 return False
 
         return True
@@ -1401,7 +1410,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Check if we have a Ninja build script
         if not os.path.exists('build.ninja'):
-            tty.msg('No Ninja build script found in the build directory')
+            tty.debug('No Ninja build script found in the build directory',
+                      level=tty.BASIC)
             return False
 
         # Get a list of all targets in the Ninja build script
@@ -1413,7 +1423,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                    if line.startswith(target + ':')]
 
         if not matches:
-            tty.msg("Target '" + target + "' not found in build.ninja")
+            tty.debug("Target '{0}' not found in build.ninja"
+                      .format(target), level=tty.BASIC)
             return False
 
         return True
@@ -1720,11 +1731,12 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
             if specs:
                 if deprecator:
                     spack.store.db.deprecate(specs[0], deprecator)
-                    tty.msg("Deprecating stale DB entry for "
-                            "%s" % spec.short_spec)
+                    tty.debug('Deprecating stale DB entry for {0}'
+                              .format(spec.short_spec), level=tty.BASIC)
                 else:
                     spack.store.db.remove(specs[0])
-                    tty.msg("Removed stale DB entry for %s" % spec.short_spec)
+                    tty.debug('Removed stale DB entry for {0}'
+                              .format(spec.short_spec), level=tty.BASIC)
                 return
             else:
                 raise InstallError(str(spec) + " is not installed.")
@@ -1797,7 +1809,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                 error_msg += "\n\nThe error:\n\n{0}".format(tb_msg)
                 tty.warn(error_msg)
 
-        tty.msg("Successfully uninstalled %s" % spec.short_spec)
+        tty.msg('Successfully uninstalled {0}'.format(spec.short_spec))
 
     def do_uninstall(self, force=False):
         """Uninstall this package by spec."""

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -457,6 +457,11 @@ class Stage(object):
                 for fetcher in dynamic_fetchers:
                     yield fetcher
 
+        def print_errors(errors):
+            for msg in errors:
+                tty.debug(msg, level=tty.BASIC)
+
+        errors = []
         for fetcher in generate_fetchers():
             try:
                 fetcher.stage = self
@@ -467,13 +472,17 @@ class Stage(object):
                 # Don't bother reporting when something is not cached.
                 continue
             except spack.error.SpackError as e:
-                tty.msg("Fetching from %s failed." % fetcher)
+                errors.append('Fetching from {0} failed.'.format(fetcher))
                 tty.debug(e)
                 continue
         else:
-            err_msg = "All fetchers failed for %s" % self.name
+            print_errors(errors)
+
+            err_msg = 'All fetchers failed for {0}'.format(self.name)
             self.fetcher = self.default_fetcher
             raise fs.FetchError(err_msg, None)
+
+        print_errors(errors)
 
     def check(self):
         """Check the downloaded archive against a checksum digest.
@@ -535,9 +544,11 @@ class Stage(object):
         downloaded."""
         if not self.expanded:
             self.fetcher.expand()
-            tty.msg("Created stage in %s" % self.path)
+            tty.debug('Created stage in {0}'.format(self.path),
+                      level=tty.BASIC)
         else:
-            tty.msg("Already staged %s in %s" % (self.name, self.path))
+            tty.debug('Already staged {0} in {1}'.format(self.name, self.path),
+                      level=tty.BASIC)
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -708,13 +719,14 @@ class DIYStage(object):
         pass
 
     def fetch(self, *args, **kwargs):
-        tty.msg("No need to fetch for DIY.")
+        tty.debug('No need to fetch for DIY.', level=tty.BASIC)
 
     def check(self):
-        tty.msg("No checksum needed for DIY.")
+        tty.debug('No checksum needed for DIY.', level=tty.BASIC)
 
     def expand_archive(self):
-        tty.msg("Using source directory: %s" % self.source_path)
+        tty.debug('Using source directory: {0}'.format(self.source_path),
+                  level=tty.BASIC)
 
     @property
     def expanded(self):
@@ -732,7 +744,7 @@ class DIYStage(object):
         pass
 
     def cache_local(self):
-        tty.msg("Sources for DIY stages are not cached")
+        tty.debug('Sources for DIY stages are not cached', level=tty.BASIC)
 
 
 def ensure_access(file):
@@ -782,12 +794,13 @@ def get_checksums_for_versions(
     max_len = max(len(str(v)) for v in sorted_versions)
     num_ver = len(sorted_versions)
 
-    tty.msg("Found {0} version{1} of {2}:".format(
-            num_ver, '' if num_ver == 1 else 's', name),
-            "",
-            *spack.cmd.elide_list(
-                ["{0:{1}}  {2}".format(str(v), max_len, url_dict[v])
-                 for v in sorted_versions]))
+    tty.debug('Found {0} version{1} of {2}:'.format(
+              num_ver, '' if num_ver == 1 else 's', name),
+              '',
+              *spack.cmd.elide_list(
+                  ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
+                   for v in sorted_versions]),
+              level=tty.BASIC)
     print()
 
     if batch:
@@ -802,9 +815,10 @@ def get_checksums_for_versions(
     versions = sorted_versions[:archives_to_fetch]
     urls = [url_dict[v] for v in versions]
 
-    tty.msg("Downloading...")
+    tty.debug('Downloading...', level=tty.BASIC)
     version_hashes = []
     i = 0
+    errors = []
     for url, version in zip(urls, versions):
         try:
             if fetch_options:
@@ -825,10 +839,12 @@ def get_checksums_for_versions(
                     hashlib.sha256, stage.archive_file)))
                 i += 1
         except FailedDownloadError:
-            tty.msg("Failed to fetch {0}".format(url))
+            errors.append('Failed to fetch {0}'.format(url))
         except Exception as e:
-            tty.msg("Something failed on {0}, skipping.".format(url),
-                    "  ({0})".format(e))
+            tty.msg('Something failed on {0}, skipping.  ({1})'.format(url, e))
+
+    for msg in errors:
+        tty.debug(msg, level=tty.BASIC)
 
     if not version_hashes:
         tty.die("Could not fetch any versions for {0}".format(name))
@@ -843,8 +859,9 @@ def get_checksums_for_versions(
     ])
 
     num_hash = len(version_hashes)
-    tty.msg("Checksummed {0} version{1} of {2}:".format(
-        num_hash, '' if num_hash == 1 else 's', name))
+    tty.debug('Checksummed {0} version{1} of {2}:'.format(
+              num_hash, '' if num_hash == 1 else 's', name),
+              level=tty.BASIC)
 
     return version_lines
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -459,7 +459,7 @@ class Stage(object):
 
         def print_errors(errors):
             for msg in errors:
-                tty.debug(msg, level=tty.BASIC)
+                tty.debug(msg)
 
         errors = []
         for fetcher in generate_fetchers():
@@ -544,11 +544,9 @@ class Stage(object):
         downloaded."""
         if not self.expanded:
             self.fetcher.expand()
-            tty.debug('Created stage in {0}'.format(self.path),
-                      level=tty.BASIC)
+            tty.debug('Created stage in {0}'.format(self.path))
         else:
-            tty.debug('Already staged {0} in {1}'.format(self.name, self.path),
-                      level=tty.BASIC)
+            tty.debug('Already staged {0} in {1}'.format(self.name, self.path))
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -719,14 +717,13 @@ class DIYStage(object):
         pass
 
     def fetch(self, *args, **kwargs):
-        tty.debug('No need to fetch for DIY.', level=tty.BASIC)
+        tty.debug('No need to fetch for DIY.')
 
     def check(self):
-        tty.debug('No checksum needed for DIY.', level=tty.BASIC)
+        tty.debug('No checksum needed for DIY.')
 
     def expand_archive(self):
-        tty.debug('Using source directory: {0}'.format(self.source_path),
-                  level=tty.BASIC)
+        tty.debug('Using source directory: {0}'.format(self.source_path))
 
     @property
     def expanded(self):
@@ -744,7 +741,7 @@ class DIYStage(object):
         pass
 
     def cache_local(self):
-        tty.debug('Sources for DIY stages are not cached', level=tty.BASIC)
+        tty.debug('Sources for DIY stages are not cached')
 
 
 def ensure_access(file):
@@ -799,8 +796,7 @@ def get_checksums_for_versions(
               '',
               *spack.cmd.elide_list(
                   ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
-                   for v in sorted_versions]),
-              level=tty.BASIC)
+                   for v in sorted_versions]))
     print()
 
     if batch:
@@ -815,7 +811,7 @@ def get_checksums_for_versions(
     versions = sorted_versions[:archives_to_fetch]
     urls = [url_dict[v] for v in versions]
 
-    tty.debug('Downloading...', level=tty.BASIC)
+    tty.debug('Downloading...')
     version_hashes = []
     i = 0
     errors = []
@@ -844,7 +840,7 @@ def get_checksums_for_versions(
             tty.msg('Something failed on {0}, skipping.  ({1})'.format(url, e))
 
     for msg in errors:
-        tty.debug(msg, level=tty.BASIC)
+        tty.debug(msg)
 
     if not version_hashes:
         tty.die("Could not fetch any versions for {0}".format(name))
@@ -860,8 +856,7 @@ def get_checksums_for_versions(
 
     num_hash = len(version_hashes)
     tty.debug('Checksummed {0} version{1} of {2}:'.format(
-              num_hash, '' if num_hash == 1 else 's', name),
-              level=tty.BASIC)
+              num_hash, '' if num_hash == 1 else 's', name))
 
     return version_lines
 

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import pytest
+
+from llnl.util.filesystem import mkdirp, touch
+
+from spack.stage import Stage
+from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
+
+
+def test_fetch_missing_cache(tmpdir):
+    """Ensure raise a missing cache file."""
+    testpath = str(tmpdir)
+
+    fetcher = CacheURLFetchStrategy(url='file:///not-a-real-cache-file')
+    with Stage(fetcher, path=testpath):
+        with pytest.raises(NoCacheError, match=r'No cache'):
+            fetcher.fetch()
+
+
+def test_fetch(tmpdir):
+    """Ensure a fetch after expanding is effectively a no-op."""
+    testpath = str(tmpdir)
+    cache = os.path.join(testpath, 'cache.tar.gz')
+    touch(cache)
+    url = 'file:///{0}'.format(cache)
+
+    fetcher = CacheURLFetchStrategy(url=url)
+    with Stage(fetcher, path=testpath) as stage:
+        source_path = stage.source_path
+        mkdirp(source_path)
+        fetcher.fetch()

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -130,8 +130,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
 
     # make sure that output from the actual package file appears in the
     # right place in the build log.
-    assert re.search(r"BEFORE INSTALL\n==>( \[.+\])? './configure'", out)
-    assert "'install'\nAFTER INSTALL" in out
+    assert "Executing phase: 'install'" in out
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -130,7 +130,8 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
 
     # make sure that output from the actual package file appears in the
     # right place in the build log.
-    assert "Executing phase: 'install'" in out
+    assert "BEFORE INSTALL" in out
+    assert "AFTER INSTALL" in out
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -344,10 +344,9 @@ def test_nosource_pkg_install(
 
     # Make sure install works even though there is no associated code.
     pkg.do_install()
-
-    # Also make sure an error is raised if `do_fetch` is called.
-    pkg.do_fetch()
-    assert "No fetch required for nosource" in capfd.readouterr()[0]
+    out = capfd.readouterr()
+    assert "Installing dependency-install" in out[0]
+    assert "Missing a source id for nosource" in out[1]
 
 
 def test_nosource_pkg_install_post_install(

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -155,7 +155,7 @@ def test_process_external_package_module(install_mockery, monkeypatch, capfd):
     spec.external_module = 'unchecked_module'
     inst._process_external_package(spec.package, False)
 
-    out = capfd.readouterr()[0]
+    out = capfd.readouterr()[1]
     assert 'has external module in {0}'.format(spec.external_module) in out
     assert 'is actually installed in {0}'.format(spec.external_path) in out
 
@@ -168,7 +168,7 @@ def test_process_binary_cache_tarball_none(install_mockery, monkeypatch,
     pkg = spack.repo.get('trivial-install-test-package')
     assert not inst._process_binary_cache_tarball(pkg, None, False, False)
 
-    assert 'exists in binary cache but' in capfd.readouterr()[0]
+    assert 'exists in binary cache but' in capfd.readouterr()[1]
 
 
 def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -102,7 +102,13 @@ def test_hms(sec, result):
 def test_install_msg():
     name = 'some-package'
     pid = 123456
-    expected = "{0}: Installing {1}".format(pid, name)
+    base_result = 'Installing {0}'.format(name)
+
+    tty._debug = tty.BASIC
+    assert inst.install_msg(name, pid) == base_result
+
+    tty._debug = tty.STANDARD
+    expected = "{0}: {1}".format(pid, base_result)
     assert inst.install_msg(name, pid) == expected
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -190,7 +190,7 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
     spec = spack.spec.Spec('a').concretized()
     assert inst._process_binary_cache_tarball(spec.package, spec, False, False)
 
-    assert 'Installing a from binary cache' in capfd.readouterr()[0]
+    assert 'Extracting a from binary cache' in capfd.readouterr()[0]
 
 
 def test_try_install_from_binary_cache(install_mockery, mock_packages,

--- a/lib/spack/spack/test/llnl/util/tty/tty.py
+++ b/lib/spack/spack/test/llnl/util/tty/tty.py
@@ -9,11 +9,11 @@ import pytest
 import llnl.util.tty as tty
 
 
-def test_get_timestamp():
+def test_get_timestamp(monkeypatch):
     """Ensure the results of get_timestamp are reasonable."""
 
     # Debug disabled should return an empty string
-    tty._debug = tty.DISABLED
+    monkeypatch.setattr(tty, '_debug', 0)
     assert not tty.get_timestamp(False), 'Expected an empty string'
 
     # Debug disabled but force the timestamp should return a string
@@ -21,18 +21,13 @@ def test_get_timestamp():
 
     pid_str = ' {0}'.format(os.getpid())
 
-    # Basic debugging should return a timestamp sans pid
-    tty._debug = tty.BASIC
+    # Level 1 debugging should return a timestamp WITHOUT the pid
+    monkeypatch.setattr(tty, '_debug', 1)
     out_str = tty.get_timestamp(False)
     assert out_str and pid_str not in out_str, 'Expected no PID in results'
 
-    # Standard debugging should return a timestamp WITH the pid
-    tty._debug = tty.STANDARD
-    out_str = tty.get_timestamp(False)
-    assert out_str and pid_str in out_str, 'Expected PID in results'
-
-    # Detailed debugging should return a timestamp WITH the pid
-    tty._debug = tty.DETAILED
+    # Level 2 debugging should also return a timestamp WITH the pid
+    monkeypatch.setattr(tty, '_debug', 2)
     out_str = tty.get_timestamp(False)
     assert out_str and pid_str in out_str, 'Expected PID in results'
 

--- a/lib/spack/spack/test/llnl/util/tty/tty.py
+++ b/lib/spack/spack/test/llnl/util/tty/tty.py
@@ -5,6 +5,7 @@
 
 import os
 
+import pytest
 import llnl.util.tty as tty
 
 
@@ -34,3 +35,58 @@ def test_get_timestamp():
     tty._debug = tty.DETAILED
     out_str = tty.get_timestamp(False)
     assert out_str and pid_str in out_str, 'Expected PID in results'
+
+
+@pytest.mark.parametrize('msg,enabled,trace,newline', [
+    ('', False, False, False),           # Nothing is output
+    (Exception(''), True, False, True),  # Exception  output
+    ('trace', True, True, False),        # stacktrace output
+    ('newline', True, False, True),      # newline in output
+    ('no newline', True, False, False)   # no newline output
+])
+def test_msg(capfd, monkeypatch, enabled, msg, trace, newline):
+    """Ensure the output from msg with options is appropriate."""
+
+    # temporarily use the parameterized settings
+    monkeypatch.setattr(tty, '_msg_enabled', enabled)
+    monkeypatch.setattr(tty, '_stacktrace', trace)
+
+    expected = [msg if isinstance(msg, str) else 'Exception: ']
+    if newline:
+        expected[0] = '{0}\n'.format(expected[0])
+    if trace:
+        expected.insert(0, '.py')
+
+    tty.msg(msg, newline=newline)
+    out = capfd.readouterr()[0]
+    for msg in expected:
+        assert msg in out
+
+
+@pytest.mark.parametrize('msg,trace,wrap', [
+    (Exception(''), False, False),  # Exception  output
+    ('trace', True, False),         # stacktrace output
+    ('wrap', False, True),          # wrap in output
+])
+def test_info(capfd, monkeypatch, msg, trace, wrap):
+    """Ensure the output from info with options is appropriate."""
+
+    # temporarily use the parameterized settings
+    monkeypatch.setattr(tty, '_stacktrace', trace)
+
+    expected = [msg if isinstance(msg, str) else 'Exception: ']
+    if trace:
+        expected.insert(0, '.py')
+
+    extra = 'This extra argument *should* make for a sufficiently long line' \
+        ' that needs to be wrapped if the option is enabled.'
+    args = [msg, extra]
+
+    num_newlines = 3 if wrap else 2
+
+    tty.info(*args, wrap=wrap, countback=3)
+    out = capfd.readouterr()[0]
+    for msg in expected:
+        assert msg in out
+
+    assert out.count('\n') == num_newlines

--- a/lib/spack/spack/test/llnl/util/tty/tty.py
+++ b/lib/spack/spack/test/llnl/util/tty/tty.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import llnl.util.tty as tty
+
+
+def test_get_timestamp():
+    """Ensure the results of get_timestamp are reasonable."""
+
+    # Debug disabled should return an empty string
+    tty._debug = tty.DISABLED
+    assert not tty.get_timestamp(False), 'Expected an empty string'
+
+    # Debug disabled but force the timestamp should return a string
+    assert tty.get_timestamp(True), 'Expected a timestamp/non-empty string'
+
+    pid_str = ' {0}'.format(os.getpid())
+
+    # Basic debugging should return a timestamp sans pid
+    tty._debug = tty.BASIC
+    out_str = tty.get_timestamp(False)
+    assert out_str and pid_str not in out_str, 'Expected no PID in results'
+
+    # Standard debugging should return a timestamp WITH the pid
+    tty._debug = tty.STANDARD
+    out_str = tty.get_timestamp(False)
+    assert out_str and pid_str in out_str, 'Expected PID in results'
+
+    # Detailed debugging should return a timestamp WITH the pid
+    tty._debug = tty.DETAILED
+    out_str = tty.get_timestamp(False)
+    assert out_str and pid_str in out_str, 'Expected PID in results'

--- a/lib/spack/spack/test/s3_fetch.py
+++ b/lib/spack/spack/test/s3_fetch.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import pytest
 
 import spack.fetch_strategy as spack_fs
@@ -27,3 +28,19 @@ def test_s3fetchstrategy_bad_url(tmpdir):
         assert fetcher.archive_file is None
         with pytest.raises(spack_fs.FetchError):
             fetcher.fetch()
+
+
+def test_s3fetchstrategy_downloaded(tmpdir):
+    """Ensure fetch with archive file already downloaded is a noop."""
+    testpath = str(tmpdir)
+    archive = os.path.join(testpath, 's3.tar.gz')
+
+    class Archived_S3FS(spack_fs.S3FetchStrategy):
+        @property
+        def archive_file(self):
+            return archive
+
+    url = 's3:///{0}'.format(archive)
+    fetcher = Archived_S3FS(url=url)
+    with spack_stage.Stage(fetcher, path=testpath):
+        fetcher.fetch()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -318,7 +318,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug -dd -ddd -dddd --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test uninstall unload url verify versions view"
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -318,7 +318,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug -dd -ddd -dddd --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test uninstall unload url verify versions view"
     fi


### PR DESCRIPTION
This PR adds support for and use of multiple levels of debug messages to help reduce normal and debug output verbosity.  You can now use multiple `-d` and or `--debug` options on the command line to indicate increasing levels of verbosity.  

At this point three (3) debugs (as `-ddd` or any combination of three `-d` and or `--debug`), is the most detailed and is currently reserved for detailed lock log messages.  This change along with moving locking debug messages to the next level of verbosity allows us to address complaints about excessive locking messages.

~Additional changes to output include:~

- ~Messages considered 'excessive' (for installs) should be output at the `basic` (1) level.~
- ~Existing debug messages are generally output at the `standard` (2) level.~
- ~Process ids are also removed from regular (2) and basic (1) debug output.~
- ~Locking messages only output using the `detailed` (3) debug level.~


TODO:

- [x] Add the new debug levels with `standard` being the default for existing debug messages
- [x] Only add the PID to the timestamp if at the `standard` debug level
- [x] Add Spack command line options `-dd`, `-ddd`, and `-dddd`
- [x] Change locking messages to only be shown at the `detailed` level
- [x] Switch install output messages to debugging to reduce verbosity
- [x] Remove (redundant?) curl stderr output
- [x] Update tests
- [x] Use `argparse`'s count to track number of debugs to indicate verbosity
- [x] Merge basic and regular debug messages into one, making it the lowest debug level
- [x] Eliminate internal textual variables for debug levels
- [x] Combine lock logging methods