### PR TITLE
kallisto: Remove mpich dependency

### DIFF
--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -18,7 +18,6 @@ class Kallisto(CMakePackage):
 
     depends_on('zlib')
     depends_on('hdf5')
-    depends_on('mpich')
 
     # htslib isn't built in time to be used....
     parallel = False


### PR DESCRIPTION
Fixes #17550
kallisto does not depend on mpich or MPI, except possibly indirectly
through hdf5 (but that should be handled by hdf5).