### PR TITLE
Make the largest layer of the docker image cacheable

### DIFF
--- a/share/spack/docker/centos-6.dockerfile
+++ b/share/spack/docker/centos-6.dockerfile
@@ -9,20 +9,6 @@ ENV DOCKERFILE_BASE=centos            \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
 
-COPY bin   $SPACK_ROOT/bin
-COPY etc   $SPACK_ROOT/etc
-COPY lib   $SPACK_ROOT/lib
-COPY share $SPACK_ROOT/share
-COPY var   $SPACK_ROOT/var
-RUN mkdir -p $SPACK_ROOT/opt/spack
-
-RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/docker-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/interactive-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/spack-env
-
 RUN yum update -y \
  && yum install -y epel-release \
  && yum update -y \
@@ -49,6 +35,20 @@ RUN yum update -y \
  && pip install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all
+
+COPY bin   $SPACK_ROOT/bin
+COPY etc   $SPACK_ROOT/etc
+COPY lib   $SPACK_ROOT/lib
+COPY share $SPACK_ROOT/share
+COPY var   $SPACK_ROOT/var
+RUN mkdir -p $SPACK_ROOT/opt/spack
+
+RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/docker-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/interactive-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \
  && cp $SPACK_ROOT/share/spack/docker/modules.yaml \

--- a/share/spack/docker/centos-7.dockerfile
+++ b/share/spack/docker/centos-7.dockerfile
@@ -9,20 +9,6 @@ ENV DOCKERFILE_BASE=centos            \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
 
-COPY bin   $SPACK_ROOT/bin
-COPY etc   $SPACK_ROOT/etc
-COPY lib   $SPACK_ROOT/lib
-COPY share $SPACK_ROOT/share
-COPY var   $SPACK_ROOT/var
-RUN mkdir -p $SPACK_ROOT/opt/spack
-
-RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/docker-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/interactive-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/spack-env
-
 RUN yum update -y \
  && yum install -y epel-release \
  && yum update -y \
@@ -49,6 +35,20 @@ RUN yum update -y \
  && pip install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all
+
+COPY bin   $SPACK_ROOT/bin
+COPY etc   $SPACK_ROOT/etc
+COPY lib   $SPACK_ROOT/lib
+COPY share $SPACK_ROOT/share
+COPY var   $SPACK_ROOT/var
+RUN mkdir -p $SPACK_ROOT/opt/spack
+
+RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/docker-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/interactive-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \
  && cp $SPACK_ROOT/share/spack/docker/modules.yaml \

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -9,20 +9,6 @@ ENV DOCKERFILE_BASE=ubuntu:16.04      \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
 
-COPY bin   $SPACK_ROOT/bin
-COPY etc   $SPACK_ROOT/etc
-COPY lib   $SPACK_ROOT/lib
-COPY share $SPACK_ROOT/share
-COPY var   $SPACK_ROOT/var
-RUN mkdir -p $SPACK_ROOT/opt/spack
-
-RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/docker-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/interactive-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/spack-env
-
 RUN apt-get -yqq update \
  && apt-get -yqq install --no-install-recommends \
         build-essential \
@@ -47,6 +33,20 @@ RUN apt-get -yqq update \
  && locale-gen en_US.UTF-8 \
  && pip3 install boto3 \
  && rm -rf /var/lib/apt/lists/*
+
+COPY bin   $SPACK_ROOT/bin
+COPY etc   $SPACK_ROOT/etc
+COPY lib   $SPACK_ROOT/lib
+COPY share $SPACK_ROOT/share
+COPY var   $SPACK_ROOT/var
+RUN mkdir -p $SPACK_ROOT/opt/spack
+
+RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/docker-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/interactive-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-env
 
 # Add LANG default to en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -9,20 +9,6 @@ ENV DOCKERFILE_BASE=ubuntu            \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
 
-COPY bin   $SPACK_ROOT/bin
-COPY etc   $SPACK_ROOT/etc
-COPY lib   $SPACK_ROOT/lib
-COPY share $SPACK_ROOT/share
-COPY var   $SPACK_ROOT/var
-RUN mkdir -p $SPACK_ROOT/opt/spack
-
-RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/docker-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/interactive-shell \
- && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
-          /usr/local/bin/spack-env
-
 RUN apt-get -yqq update \
  && apt-get -yqq install --no-install-recommends \
         build-essential \
@@ -47,6 +33,20 @@ RUN apt-get -yqq update \
  && locale-gen en_US.UTF-8 \
  && pip3 install boto3 \
  && rm -rf /var/lib/apt/lists/*
+
+COPY bin   $SPACK_ROOT/bin
+COPY etc   $SPACK_ROOT/etc
+COPY lib   $SPACK_ROOT/lib
+COPY share $SPACK_ROOT/share
+COPY var   $SPACK_ROOT/var
+RUN mkdir -p $SPACK_ROOT/opt/spack
+
+RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/docker-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/interactive-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-env
 
 # Add LANG default to en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
Currently docker images don't benefit from layer caching for the dependencies installed through the package manager, since files from the spack folder are copied over in the step before that.

This PR should make building docker images faster when cache is available, and should reduce the download size when a new version is available in the registry.