### PR TITLE
Add new dependencies required in latest rsync

### DIFF
--- a/var/spack/repos/builtin/packages/rsync/package.py
+++ b/var/spack/repos/builtin/packages/rsync/package.py
@@ -18,6 +18,10 @@ class Rsync(AutotoolsPackage):
 
     depends_on('zlib')
     depends_on('popt')
+    depends_on('openssl', when='@3.2:')
+    depends_on('xxhash', when='@3.2:')
+    depends_on('zstd', when='@3.2:')
+    depends_on('lz4', when='@3.2:')
 
     def configure_args(self):
         return ['--with-included-zlib=no']

--- a/var/spack/repos/builtin/packages/xxhash/package.py
+++ b/var/spack/repos/builtin/packages/xxhash/package.py
@@ -17,6 +17,7 @@ class Xxhash(MakefilePackage):
     homepage = "https://github.com/Cyan4973/xxHash"
     url      = "https://github.com/Cyan4973/xxHash/archive/v0.6.5.tar.gz"
 
+    version('0.7.4', sha256='4d9706c9da4fbdf901598f5e3b71db0eddd4ac962e827a73ebf75d66dfd820fe')
     version('0.6.5', sha256='19030315f4fc1b4b2cdb9d7a317069a109f90e39d1fe4c9159b7aaa39030eb95')
     version('0.6.4', sha256='4570ccd111df6b6386502791397906bf69b7371eb209af7d41debc2f074cdb22')
     version('0.6.3', sha256='d8c739ec666ac2af983a61dc932aaa2a8873df974d333a9922d472a121f2106e')


### PR DESCRIPTION
I added the latest rsync version but didn't realize it added dependencies. After looking at the changelog, I am able to install it with these changes.