### PR TITLE
adept-utils: 1.0.1 does not build w/ boost 1.73.0 or newer

### DIFF
--- a/var/spack/repos/builtin/packages/adept-utils/package.py
+++ b/var/spack/repos/builtin/packages/adept-utils/package.py
@@ -15,6 +15,6 @@ class AdeptUtils(CMakePackage):
     version('1.0.1', sha256='259f777aeb368ede3583d3617bb779f0fde778319bf2122fdd216bdf223c015e')
     version('1.0',   sha256='fed29366c9bcf5f3799220ae3b351d2cb338e2aa42133d61584ea650aa8d6ff7')
 
-    depends_on('boost')
+    depends_on('boost@:1.72.0')
     depends_on('mpi')
     depends_on('cmake@2.8:', type='build')


### PR DESCRIPTION
For point release v0.15.2 we would like this package to build with spack out of the box, and there is an issue building it with the latest `boost`.