### PR TITLE
Version 1.13.2 still needs the XL patch.

### DIFF
--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -21,6 +21,7 @@ class Random123(Package):
 
     patch('ibmxl.patch', when='@1.09')
     patch('arm-gcc.patch', when='@1.09')
+    patch('v1132-xl161.patch', when='@1.13.2')
 
     def install(self, spec, prefix):
         # Random123 doesn't have a build system.

--- a/var/spack/repos/builtin/packages/random123/v1132-xl161.patch
+++ b/var/spack/repos/builtin/packages/random123/v1132-xl161.patch
@@ -1,0 +1,13 @@
+diff --git a/include/Random123/features/compilerfeatures.h b/include/Random123/features/compilerfeatures.h
+index 2341a7a..3c5d999 100644
+--- a/include/Random123/features/compilerfeatures.h
++++ b/include/Random123/features/compilerfeatures.h
+@@ -206,7 +206,7 @@ added to each of the *features.h files, AND to examples/ut_features.cpp.
+ #include "nvccfeatures.h"
+ #elif defined(__ICC)
+ #include "iccfeatures.h"
+-#elif defined(__xlC__)
++#elif defined(__xlC__) || defined(__ibmxl__)
+ #include "xlcfeatures.h"
+ #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+ #include "sunprofeatures.h"


### PR DESCRIPTION
The newer version (1.13.2) still needs the same XL patch that is applied to version 1.09, but the file has been modified, so the old patch file doesn't work.  New patch file takes care of the issue.