### PR TITLE
icu4c: Mark new version as conflicting with old GCC

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -35,6 +35,8 @@ class Icu4c(AutotoolsPackage):
 
     conflicts('%intel@:16', when='@60.1:',
               msg="Intel compilers have immature C++11 and multibyte support")
+    conflicts('%gcc@:4', when='@67.1:',
+              msg="Older GCC compilers have immature C++11 support")
 
     patch('https://github.com/unicode-org/icu/commit/ddfc30860354cbcb78c2c0bcf800be5ab44a9e4f.patch',
           sha256='dfc501d78ddfabafe09dc1a7aa70f96b799164b18f6a57d616a9d48aaf989333',


### PR DESCRIPTION
`icu4c@67.1` fails to build on GCC 4.8.5. `icu4c@66.1` builds fine.

GCC 4.8.5 on rhel6:
```
utext.cpp:572:5: error: 'max_align_t' in namespace 'std' does not name a
type
     std::max_align_t    extension;
     ^
utext.cpp: In function 'UText* utext_setup_67(UText*, int32_t,
UErrorCode*)':
utext.cpp:587:73: error: 'max_align_t' is not a member of 'std'
             spaceRequired = sizeof(ExtendedUText) + extraSpace -
sizeof(std::max_align_t);
                                                                         ^
utext.cpp:587:73: note: suggested alternative:
In file included from
/projects/spack/opt/spack/gcc-4.4.7/gcc/6ln2t7b/include/c++/4.8.5/cstddef:42:0,
                 from utext.cpp:19:
/projects/spack/opt/spack/gcc-4.4.7/gcc/6ln2t7b/lib/gcc/x86_64-unknown-linux-gnu/4.8.5/include/stddef.h:
425:3: note:   'max_align_t'
 } max_align_t;
   ^
utext.cpp:598:57: error: 'struct ExtendedUText' has no member named
'extension'
                 ut->pExtra    = &((ExtendedUText *)ut)->extension;
                                                         ^
   g++   ...  loadednormalizer2impl.cpp
   g++   ...  chariter.cpp
```