### PR TITLE
ci: fixes for compiler bootstrapping

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -332,8 +332,7 @@ class Concretizer(object):
                     if not new_target_arch.satisfies(curr_target_arch):
                         # new_target is an incorrect guess based on preferences
                         # and/or default
-                        valid_target_ranges = reversed(
-                            str(curr_target).split(','))
+                        valid_target_ranges = str(curr_target).split(',')
                         for target_range in valid_target_ranges:
                             t_min, t_sep, t_max = target_range.partition(':')
                             if not t_sep:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1812,7 +1812,10 @@ class BuildTask(object):
                                                   arch_spec=arch_spec):
             # The compiler is in the queue, identify it as dependency
             dep = spack.compilers.pkg_spec_for_compiler(compiler_spec)
-            dep.architecture = arch_spec
+            dep.constrain('platform=%s' % str(arch_spec.platform))
+            dep.constrain('os=%s' % str(arch_spec.os))
+            dep.constrain('target=%s:' %
+                          arch_spec.target.microarchitecture.family.name)
             dep.concretize()
             dep_id = package_id(dep.package)
             self.dependencies.add(dep_id)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1788,7 +1788,8 @@ class BuildTask(object):
         # to support tracking of parallel, multi-spec, environment installs.
         self.dependents = set(get_dependent_ids(self.pkg.spec))
 
-        tty.debug('Pkg id {0} has the following dependents:'.format(self.pkg_id))
+        tty.debug(
+            'Pkg id {0} has the following dependents:'.format(self.pkg_id))
         for dep_id in self.dependents:
             tty.debug('- {0}'.format(dep_id))
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -215,10 +215,8 @@ def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
     # concretizer to back off if needed for the older bootstrapping compiler
     dep.constrain('platform=%s' % str(architecture.platform))
     dep.constrain('os=%s' % str(architecture.os))
-    dep.constrain('target=%s:%s' % (
-        architecture.target.microarchitecture.family.name,
-        architecture.target.microarchitecture.name
-    ))
+    dep.constrain('target=%s:' %
+                  architecture.target.microarchitecture.family.name)
     # concrete CompilerSpec has less info than concrete Spec
     # concretize as Spec to add that information
     dep.concretize()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1030,7 +1030,7 @@ class PackageInstaller(object):
             if arch not in packages_per_compiler[compiler]:
                 packages_per_compiler[compiler][arch] = []
 
-            packages_per_compiler[compiler][arch].append(self.pkg)
+            packages_per_compiler[compiler][arch].append(request.pkg)
 
             for compiler, archs in packages_per_compiler.items():
                 for arch, packages in archs.items():
@@ -1038,7 +1038,7 @@ class PackageInstaller(object):
                         compiler, arch, packages, request, all_deps)
 
         if install_deps:
-            for dep in self.spec.traverse(order='post', root=False):
+            for dep in request.traverse_dependencies():
                 dep_pkg = dep.package
 
                 dep_id = package_id(dep_pkg)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -210,7 +210,15 @@ def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
         return []
 
     dep = spack.compilers.pkg_spec_for_compiler(compiler)
-    dep.architecture = architecture  # TODO: this may need to back off slightly
+
+    # Set the architecture for the compiler package in a way that allows the
+    # concretizer to back off if needed for the older bootstrapping compiler
+    dep.constrain('platform=%s' % str(architecture.platform))
+    dep.constrain('os=%s' % str(architecture.os))
+    dep.constrain('target=%s:%s' % (
+        architecture.target.microarchitecture.family.name,
+        architecture.target.microarchitecture.name
+    ))
     # concrete CompilerSpec has less info than concrete Spec
     # concretize as Spec to add that information
     dep.concretize()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -182,7 +182,7 @@ def _do_fake_install(pkg):
     dump_packages(pkg.spec, packages_dir)
 
 
-def _packages_needed_to_bootstrap_compiler(pkg):
+def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
     """
     Return a list of packages required to bootstrap `pkg`s compiler
 
@@ -190,7 +190,11 @@ def _packages_needed_to_bootstrap_compiler(pkg):
     matches the package spec.
 
     Args:
-        pkg (Package): the package that may need its compiler installed
+        compiler (CompilerSpec): the compiler to bootstrap
+        architecture (ArchSpec): the architecture for which to boostrap the
+            compiler
+        pkgs (list of PackageBase): the packages that may need their compiler
+            installed
 
     Return:
         (list) list of tuples, (PackageBase, bool), for concretized compiler-
@@ -199,21 +203,21 @@ def _packages_needed_to_bootstrap_compiler(pkg):
             (``True``) or one of its dependencies (``False``).  The list
             will be empty if there are no compilers.
     """
-    tty.debug('Bootstrapping {0} compiler for {1}'
-              .format(pkg.spec.compiler, package_id(pkg)))
+    tty.debug('Bootstrapping {0} compiler'.format(compiler))
     compilers = spack.compilers.compilers_for_spec(
-        pkg.spec.compiler, arch_spec=pkg.spec.architecture)
+        compiler, arch_spec=architecture)
     if compilers:
         return []
 
-    dep = spack.compilers.pkg_spec_for_compiler(pkg.spec.compiler)
-    dep.architecture = pkg.spec.architecture
+    dep = spack.compilers.pkg_spec_for_compiler(compiler)
+    dep.architecture = architecture  # TODO: this may need to back off slightly
     # concrete CompilerSpec has less info than concrete Spec
     # concretize as Spec to add that information
     dep.concretize()
-    # mark compiler as depended-on by the package that uses it
-    dep._dependents[pkg.name] = spack.spec.DependencySpec(
-        pkg.spec, dep, ('build',))
+    # mark compiler as depended-on by the packages that use it
+    for pkg in pkgs:
+        dep._dependents[pkg.name] = spack.spec.DependencySpec(
+            pkg.spec, dep, ('build',))
     packages = [(s.package, False) for
                 s in dep.traverse(order='post', root=False)]
     packages.append((dep.package, True))
@@ -647,17 +651,21 @@ class PackageInstaller(object):
         return '{0}: {1}; {2}; {3}; {4}'.format(
             self.pid, requests, tasks, installed, failed)
 
-    def _add_bootstrap_compilers(self, pkg, request, all_deps):
+    def _add_bootstrap_compilers(
+            self, compiler, architecture, pkgs, request, all_deps):
         """
         Add bootstrap compilers and dependencies to the build queue.
 
         Args:
-            pkg (PackageBase): the package with possible compiler dependencies
+            compiler: the compiler to boostrap
+            architecture: the architecture for which to bootstrap the compiler
+            pkgs (PackageBase): the package with possible compiler dependencies
             request (BuildRequest): the associated install request
             all_deps (defaultdict(set)): dictionary of all dependencies and
                 associated dependents
         """
-        packages = _packages_needed_to_bootstrap_compiler(pkg)
+        packages = _packages_needed_to_bootstrap_compiler(
+            compiler, architecture, pkgs)
         for (comp_pkg, is_compiler) in packages:
             if package_id(comp_pkg) not in self.build_tasks:
                 self._add_init_task(comp_pkg, request, is_compiler, all_deps)
@@ -997,13 +1005,41 @@ class PackageInstaller(object):
             'config:install_missing_compilers', False)
 
         install_deps = request.install_args.get('install_deps')
-        if install_deps:
+        # Bootstrap compilers first
+        if install_deps and install_compilers:
+            packages_per_compiler = {}
+
             for dep in request.traverse_dependencies():
                 dep_pkg = dep.package
+                compiler = dep_pkg.spec.compiler
+                arch = dep_pkg.spec.architecture
+                if compiler not in packages_per_compiler:
+                    packages_per_compiler[compiler] = {}
 
-                # First push any missing compilers (if requested)
-                if install_compilers:
-                    self._add_bootstrap_compilers(dep_pkg, request, all_deps)
+                if arch not in packages_per_compiler[compiler]:
+                    packages_per_compiler[compiler][arch] = []
+
+                packages_per_compiler[compiler][arch].append(dep_pkg)
+
+            compiler = request.pkg.spec.compiler
+            arch = request.pkg.spec.architecture
+
+            if compiler not in packages_per_compiler:
+                packages_per_compiler[compiler] = {}
+
+            if arch not in packages_per_compiler[compiler]:
+                packages_per_compiler[compiler][arch] = []
+
+            packages_per_compiler[compiler][arch].append(self.pkg)
+
+            for compiler, archs in packages_per_compiler.items():
+                for arch, packages in archs.items():
+                    self._add_bootstrap_compilers(
+                        compiler, arch, packages, request, all_deps)
+
+        if install_deps:
+            for dep in self.spec.traverse(order='post', root=False):
+                dep_pkg = dep.package
 
                 dep_id = package_id(dep_pkg)
                 if dep_id not in self.build_tasks:
@@ -1014,13 +1050,9 @@ class PackageInstaller(object):
                 # of the spec.
                 spack.store.db.clear_failure(dep, force=False)
 
-            # Push any missing compilers (if requested) as part of the
-            # package dependencies.
-            if install_compilers:
-                self._add_bootstrap_compilers(request.pkg, request, all_deps)
-
         install_package = request.install_args.get('install_package')
         if install_package and request.pkg_id not in self.build_tasks:
+
             # Be sure to clear any previous failure
             spack.store.db.clear_failure(request.spec, force=True)
 
@@ -1749,6 +1781,10 @@ class BuildTask(object):
         # Set of dependents, which needs to include the requesting package
         # to support tracking of parallel, multi-spec, environment installs.
         self.dependents = set(get_dependent_ids(self.pkg.spec))
+
+        tty.debug('Pkg id {0} has the following dependents:'.format(self.pkg_id))
+        for dep_id in self.dependents:
+            tty.debug('- {0}'.format(dep_id))
 
         # Set of dependencies
         #

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -349,16 +349,21 @@ node_target_weight(Package, Weight)
     target_weight(Target, Package, Weight).
 
 % compatibility rules for targets among nodes
-node_target_match_pref(Package, Target) :- node_target_set(Package, Target).
 node_target_match_pref(Dependency, Target)
-  :- depends_on(Package, Dependency), node_target_match_pref(Package, Target),
+  :- depends_on(Package, Dependency),
+     node_target_match_pref(Package, Target),
+     not node_target_set(Dependency, _).
+
+node_target_match_pref(Dependency, Target)
+  :- depends_on(Package, Dependency),
+     node_target_set(Package, Target),
+     not node_target_match_pref(Package, Target),
      not node_target_set(Dependency, _).
 
 node_target_match_pref(Dependency, Target)
   :- depends_on(Package, Dependency),
      root(Package), node_target(Package, Target),
-     not node_target_match_pref(Package, _),
-     not node_target_set(Dependency, _).
+     not node_target_match_pref(Package, _).
 
 node_target_match(Package, 1)
   :- node_target(Package, Target), node_target_match_pref(Package, Target).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -349,10 +349,19 @@ node_target_weight(Package, Weight)
     target_weight(Target, Package, Weight).
 
 % compatibility rules for targets among nodes
-node_target_match_parent(Dependency, Target)
+node_target_match_pref(Package, Target) :- node_target_set(Package, Target).
+node_target_match_pref(Dependency, Target)
+  :- depends_on(Package, Dependency), node_target_match_pref(Package, Target),
+     not node_target_set(Dependency, _).
+
+node_target_match_pref(Dependency, Target)
   :- depends_on(Package, Dependency),
-     node_target(Package, Target),
-     node_target(Dependency, Target).
+     root(Package), node_target(Package, Target),
+     not node_target_match_pref(Package, _),
+     not node_target_set(Dependency, _).
+
+node_target_match(Package, 1)
+  :- node_target(Package, Target), node_target_match_pref(Package, Target).
 
 derive_target_from_parent(Parent, Package)
   :- depends_on(Parent, Package), not package_target_weight(_, Package, _).
@@ -585,5 +594,5 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 
 % Maximize the number of matches for targets in the DAG, try
 % to select the preferred target.
-#maximize{ 1@4,Package,Target : node_target_match_parent(Package, Target) }.
+#maximize{ Weight@4,Package : node_target_match(Package, Weight) }.
 #minimize{ Weight@3,Package : node_target_weight(Package, Weight) }.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -349,19 +349,10 @@ node_target_weight(Package, Weight)
     target_weight(Target, Package, Weight).
 
 % compatibility rules for targets among nodes
-node_target_match_pref(Package, Target) :- node_target_set(Package, Target).
-node_target_match_pref(Dependency, Target)
-  :- depends_on(Package, Dependency), node_target_match_pref(Package, Target),
-     not node_target_set(Dependency, _).
-
-node_target_match_pref(Dependency, Target)
+node_target_match_parent(Dependency, Target)
   :- depends_on(Package, Dependency),
-     root(Package), node_target(Package, Target),
-     not node_target_match_pref(Package, _),
-     not node_target_set(Dependency, _).
-
-node_target_match(Package, 1)
-  :- node_target(Package, Target), node_target_match_pref(Package, Target).
+     node_target(Package, Target),
+     node_target(Dependency, Target).
 
 derive_target_from_parent(Parent, Package)
   :- depends_on(Parent, Package), not package_target_weight(_, Package, _).
@@ -594,5 +585,5 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 
 % Maximize the number of matches for targets in the DAG, try
 % to select the preferred target.
-#maximize{ Weight@4,Package : node_target_match(Package, Weight) }.
+#maximize{ 1@4,Package,Target : node_target_match_parent(Package, Target) }.
 #minimize{ Weight@3,Package : node_target_weight(Package, Weight) }.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -22,6 +22,6 @@
 #show version_weight/2.
 #show compiler_version_match/2.
 #show compiler_weight/2.
-#show node_target_match_parent/2.
+#show node_target_match/2.
 #show node_target_weight/2.
 #show external_spec/2.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -22,6 +22,6 @@
 #show version_weight/2.
 #show compiler_version_match/2.
 #show compiler_weight/2.
-#show node_target_match/2.
+#show node_target_match_parent/2.
 #show node_target_weight/2.
 #show external_spec/2.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -436,7 +436,6 @@ class ArchSpec(object):
                         results.append('%s:%s' % (n_min, n_max))
         return results
 
-
     def constrain(self, other):
         """Projects all architecture fields that are specified in the given
         spec onto the instance spec if they're missing from the instance

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -238,7 +238,7 @@ def test_satisfy_strict_constraint_when_not_concrete(
     # lists with concrete targets, lists compared to ranges
     (('x86_64,haswell', 'core2:broadwell', 'haswell'))
 ])
-@pytest.mark.usefixtures('mock_packages')
+@pytest.mark.usefixtures('mock_packages', 'config')
 def test_concretize_target_ranges(
         root_target_range, dep_target_range, result
 ):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -234,7 +234,7 @@ def test_satisfy_strict_constraint_when_not_concrete(
     (('haswell:icelake', 'broadwell', 'broadwell')),
     # multiple ranges in lists with multiple overlaps
     (('x86_64:nocona,haswell:broadwell', 'nocona:haswell,skylake:',
-      'haswell')),
+      'nocona')),
     # lists with concrete targets, lists compared to ranges
     (('x86_64,haswell', 'core2:broadwell', 'haswell'))
 ])

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -224,6 +224,7 @@ def test_satisfy_strict_constraint_when_not_concrete(
     constraint = spack.spec.ArchSpec(constraint_tuple)
     assert not architecture.satisfies(constraint, strict=True)
 
+
 @pytest.mark.parametrize('root_target_range,dep_target_range,result', [
     (('x86_64:nocona', 'x86_64:core2', 'nocona')),  # pref not in intersection
     (('x86_64:core2', 'x86_64:nocona', 'nocona')),
@@ -231,7 +232,8 @@ def test_satisfy_strict_constraint_when_not_concrete(
     (('ivybridge', 'nocona:skylake', 'ivybridge')),  # one side concrete
     (('haswell:icelake', 'broadwell', 'broadwell')),
     # multiple ranges in lists with multiple overlaps
-    (('x86_64:nocona,haswell:broadwell', 'nocona:haswell,skylake:', 'haswell')),
+    (('x86_64:nocona,haswell:broadwell', 'nocona:haswell,skylake:',
+      'haswell')),
     # lists with concrete targets, lists compared to ranges
     (('x86_64,haswell', 'core2:broadwell', 'haswell'))
 ])

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -12,6 +12,7 @@ import platform as py_platform
 import pytest
 
 import spack.architecture
+import spack.concretize
 from spack.spec import Spec
 from spack.platforms.cray import Cray
 from spack.platforms.linux import Linux
@@ -243,8 +244,9 @@ def test_concretize_target_ranges(
 ):
     # use foobar=bar to make the problem simpler for the old concretizer
     # the new concretizer should not need that help
-    spec = Spec('a foobar=bar target=%s ^b target=%s' %
+    spec = Spec('a %%gcc@10 foobar=bar target=%s ^b target=%s' %
                 (root_target_range, dep_target_range))
-    spec.concretize()
+    with spack.concretize.disable_compiler_existence_check():
+        spec.concretize()
 
     assert str(spec).count('arch=test-debian6-%s' % result) == 2

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -450,7 +450,8 @@ def test_packages_needed_to_bootstrap_compiler_none(install_mockery):
     spec.concretize()
     assert spec.concrete
 
-    packages = inst._packages_needed_to_bootstrap_compiler(spec.package)
+    packages = inst._packages_needed_to_bootstrap_compiler(
+        spec.compiler, spec.architecture, [spec.package])
     assert not packages
 
 
@@ -468,7 +469,8 @@ def test_packages_needed_to_bootstrap_compiler_packages(install_mockery,
     monkeypatch.setattr(spack.compilers, 'pkg_spec_for_compiler', _conc_spec)
     monkeypatch.setattr(spack.spec.Spec, 'concretize', _noop)
 
-    packages = inst._packages_needed_to_bootstrap_compiler(spec.package)
+    packages = inst._packages_needed_to_bootstrap_compiler(
+        spec.compiler, spec.architecture, [spec.package])
     assert packages
 
 
@@ -626,7 +628,7 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
 def test_add_bootstrap_compilers(install_mockery, monkeypatch):
     from collections import defaultdict
 
-    def _pkgs(pkg):
+    def _pkgs(compiler, architecture, pkgs):
         spec = spack.spec.Spec('mpi').concretized()
         return [(spec.package, True)]
 
@@ -636,7 +638,7 @@ def test_add_bootstrap_compilers(install_mockery, monkeypatch):
     all_deps = defaultdict(set)
 
     monkeypatch.setattr(inst, '_packages_needed_to_bootstrap_compiler', _pkgs)
-    installer._add_bootstrap_compilers(request.pkg, request, all_deps)
+    installer._add_bootstrap_compilers('fake', 'fake', [request.pkg], request, all_deps)
 
     ids = list(installer.build_tasks)
     assert len(ids) == 1

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -638,7 +638,8 @@ def test_add_bootstrap_compilers(install_mockery, monkeypatch):
     all_deps = defaultdict(set)
 
     monkeypatch.setattr(inst, '_packages_needed_to_bootstrap_compiler', _pkgs)
-    installer._add_bootstrap_compilers('fake', 'fake', [request.pkg], request, all_deps)
+    installer._add_bootstrap_compilers(
+        'fake', 'fake', [request.pkg], request, all_deps)
 
     ids = list(installer.build_tasks)
     assert len(ids) == 1


### PR DESCRIPTION
The commits here developed by @haampie, along with #17536, are allowing compiler bootstrapping pipelines to work again in the wake of the distributed builds PR.

The commit changing the `package_id` format may be controversial, so I want to get some feedback on this before I spend any time fixing the tests which are failing as a result.