### PR TITLE
Use process cpu affinity instead of hardware specs to get cpu count

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -65,7 +65,6 @@ from spack.util.executable import Executable
 from spack.util.module_cmd import load_module, get_path_from_module, module
 from spack.util.log_parse import parse_log_events, make_log_context
 
-
 #
 # This can be set by the user to globally disable parallel builds.
 #
@@ -450,7 +449,7 @@ def _set_variables_for_single_module(pkg, module):
         return
 
     jobs = spack.config.get('config:build_jobs', 16) if pkg.parallel else 1
-    jobs = min(jobs, multiprocessing.cpu_count())
+    jobs = min(jobs, spack.util.cpus.cpus_available())
     assert jobs is not None, "no default set for config:build_jobs"
 
     m = module

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -5,7 +5,6 @@
 
 
 import argparse
-import multiprocessing
 
 import spack.cmd
 import spack.config
@@ -102,7 +101,7 @@ class SetParallelJobs(argparse.Action):
                   '[expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, jobs))
 
-        jobs = min(jobs, multiprocessing.cpu_count())
+        jobs = min(jobs, spack.util.cpus.cpus_available())
         spack.config.set('config:build_jobs', jobs, scope='command_line')
 
         setattr(namespace, 'jobs', jobs)
@@ -112,7 +111,7 @@ class SetParallelJobs(argparse.Action):
         # This default is coded as a property so that look-up
         # of this value is done only on demand
         return min(spack.config.get('config:build_jobs', 16),
-                   multiprocessing.cpu_count())
+                   spack.util.cpus.cpus_available())
 
     @default.setter
     def default(self, value):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -34,7 +34,6 @@ import copy
 import os
 import re
 import sys
-import multiprocessing
 from contextlib import contextmanager
 from six import iteritems
 from ordereddict_backport import OrderedDict
@@ -57,6 +56,7 @@ import spack.schema.modules
 import spack.schema.config
 import spack.schema.upstreams
 import spack.schema.env
+import spack.util.cpus
 from spack.error import SpackError
 
 # Hacked yaml for configuration files preserves line numbers.
@@ -107,7 +107,7 @@ config_defaults = {
         'verify_ssl': True,
         'checksum': True,
         'dirty': False,
-        'build_jobs': min(16, multiprocessing.cpu_count()),
+        'build_jobs': min(16, spack.util.cpus.cpus_available()),
         'build_stage': '$tempdir/spack-stage',
     }
 }

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import multiprocessing
 
 import pytest
-
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
@@ -32,8 +30,9 @@ def ncores(monkeypatch, request):
     def _cpu_count():
         return request.param
 
-    # Patch multiprocessing.cpu_count() to return the value we need
-    monkeypatch.setattr(multiprocessing, 'cpu_count', _cpu_count)
+    # Patch spack.util.cpus.cpus_available() to return the value we need
+    monkeypatch.setattr('spack.util.cpus.cpus_available', _cpu_count)
+
     # Patch the configuration parts that have been cached already
     monkeypatch.setitem(spack.config.config_defaults['config'],
                         'build_jobs', min(16, request.param))

--- a/lib/spack/spack/util/cpus.py
+++ b/lib/spack/spack/util/cpus.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import platform
+import multiprocessing
+
+
+def cpus_available():
+    if platform.system() == 'Linux':
+        try:
+            return len(os.sched_getaffinity(0))  # novermin
+        except Exception:
+            pass
+
+    return multiprocessing.cpu_count()


### PR DESCRIPTION
When using spack in slurm and/or containers I found that spack does not respect the number of cores made available to the process, but rather takes as many threads as the hardware provides. This is an issue mainly in CI, where spack commands may be executed on different nodes with a different core count, and where many commands like `spack install` are generated or implicit (e.g. in `spack ci rebuild`) s.t. one cannot easily pass the true number of cores available.

As an example, in my case spack was running `make -j72`, whereas only `8` cores were available. This happens because of the following:
- The CI job got scheduled on a machine with 72 threads according to `nproc --all`
- I have configured `build_jobs` to a high/unlimited number with the idea to make spack autodetect the number of cores available. (This seems sensible to me for CI: same config for different nodes, some nodes have a large number of cores, so the default limit of 16 is too small).
- Our CI uses Slurm to start jobs, where one can control the number of cores per task via the `SLURM_CPUS_PER_TASK` variable, I had set it to 8, because I want to run multiple jobs on the same node. (Same story with Kubernetes and cpu requests or your favorite docker setup with the `--cpus` flag)
- `spack` uses the Python call `multiprocessing.cpu_count()` to attempt to limit the number of build jobs to the number of cores available, but this returns the number of cores on the hardware level (72) instead of the number of cores available to the process (8).

Note that this is the same difference between calling `$ nproc --all` (returns 72) and `$ nproc` (returns 8). The latter is correct.

To fix this I'm using `len(os.sched_getaffinity(0))`, which is linux-specific, to get the number of cores/threads actually available. According to the man page using `0` is equivalent to getting the cpu affinity for the current process, so this should be fine.

To reproduce in Docker:

```
$ docker run --cpuset-cpus=0,1 spack/ubuntu-bionic install llvm+clang
```

it should have exactly 2 cores available for the process, but with the default config will build with `make -j16` if you have at least 16 procs.

To reproduce with Slurm:

```
$ srun -N1 -n1 -c2 spack install llvm+clang
```
it should have exactly 2 cores available for the process, but builds with `-j16` in the default config if you have at least 16 procs.