### PR TITLE
py-astropy: force re-cythonization of distributed .pyx files

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class PyAstropy(PythonPackage):
@@ -52,12 +53,20 @@ class PyAstropy(PythonPackage):
     depends_on('py-asdf@2.3:', when='+extras', type=('build', 'run'))
     depends_on('py-bottleneck', when='+extras', type=('build', 'run'))
     depends_on('py-pytest', when='+extras', type=('build', 'run'))
+    depends_on('py-cython', type='build')
 
     # System dependencies
     depends_on('erfa')
     depends_on('wcslib')
     depends_on('cfitsio')
     depends_on('expat')
+
+    def patch(self):
+        # forces the rebuild of files with cython
+        # avoids issues with PyCode_New() in newer
+        # versions of python in the distributed
+        # cython-ized files
+        os.remove('astropy/cython_version.py')
 
     def build_args(self, spec, prefix):
         args = [


### PR DESCRIPTION
astropy 3.2.1 fails to build with python 3.8.3 with
errors similar to this:

astropy/stats/_stats.c:318:11: error: too many arguments to function 'PyCode_New'
PyCode_New(a, 0, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)

These are files that are generated by cython, but are included in the
tarball. Since there's apparently been an API change to PyCode_New, they will
need to be re-cythonized to compile correctly.