### PR TITLE
fix isaac-server dependency

### DIFF
--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -28,7 +28,7 @@ class IsaacServer(CMakePackage):
 
     depends_on('cmake@3.3:', type='build')
     depends_on('jpeg', type='link')
-    depends_on('jansson', type='link')
+    depends_on('jansson@:2.9', type='link')
     depends_on('boost@1.56.0:', type='link')
     depends_on('libwebsockets@2.1.1:', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')


### PR DESCRIPTION
isaac-server can not find jansson if jansson2.10+ is used.