### PR TITLE
Make sure each develop pipeline tests associated commit

### DIFF
--- a/share/spack/gitlab/pr_pipeline.yml
+++ b/share/spack/gitlab/pr_pipeline.yml
@@ -14,7 +14,7 @@ merge_pipeline:
   - develop
   variables:
     SPACK_REPO: https://github.com/spack/spack.git
-    SPACK_REF: develop
+    SPACK_REF: ${CI_COMMIT_SHA}
   trigger:
     project: spack/e4s
     strategy: depend


### PR DESCRIPTION
Using the branch name `develop` for the post-merge pipelines leaves open the possibility that when there's a large backlog of those pipelines waiting around, more than one of them will test the same version of spack.  That can make it challenging after the fact, to determine precisely which commit introduced a breakage in the pipeline.

This change ensures that all `develop` pipelines are triggered with their own SHA, removing any ambiguity about which version of spack will be testing.