### PR TITLE
Fix rpath on darwin for package metis

### DIFF
--- a/var/spack/repos/builtin/packages/metis/darwin_cmake_rpath.patch
+++ b/var/spack/repos/builtin/packages/metis/darwin_cmake_rpath.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.2)
+ project(METIS)
+
+ set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -52,9 +52,11 @@ class Metis(Package):
     conflicts('@:4.999', when='+real64')
 
     depends_on('cmake@2.8:', when='@5:', type='build')
+    depends_on('cmake@3:', when='platform=darwin')
 
     patch('install_gklib_defs_rename.patch', when='@5:')
     patch('gklib_nomisleadingindentation_warning.patch', when='@5: %gcc@6:')
+    patch('darwin_cmake_rpath.patch', when='platform=darwin')
 
     @when('@5:')
     def patch(self):


### PR DESCRIPTION
This PR introduces a patch to the metis package which changes the `cmake_minimum_required` from `2.8` to `3.2`. The reasoning for this is that on macOS the rpath default settings are more reasonable on cmake version `3.2.`.

The patch is only applied on macOS and when an appropriate cmake version is available.