### PR TITLE
Smoke tests: Switch install test warnings to debug for existing packages

### DIFF
--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -79,12 +79,12 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        tty.warn('Expected results currently based on simple {0} builds'
-                 .format(self.name))
+        tty.debug('Expected results currently based on simple {0} builds'
+                  .format(self.name))
 
         if not self.spec.satisfies('@2.10:2.12'):
-            tty.warn('Expected results have not been confirmed for {0} {1}'
-                     .format(self.name, self.spec.versin))
+            tty.debug('Expected results have not been confirmed for {0} {1}'
+                      .format(self.name, self.spec.version))
 
         # Run the simple built-in smoke test
         self._run_smoke_tests()

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -855,11 +855,11 @@ class Openmpi(AutotoolsPackage):
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        tty.warn('Expected results currently based on simple openmpi builds')
+        tty.debug('Expected results currently based on simple openmpi builds')
 
         if not self.spec.satisfies('@2.0.0:4.0.3'):
-            tty.warn('Expected results have not been confirmed for {0} {1}'
-                     .format(self.name, self.spec.version))
+            tty.debug('Expected results have not been confirmed for {0} {1}'
+                      .format(self.name, self.spec.version))
 
         # Simple version check tests on known packages
         self._test_check_versions()

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -262,12 +262,12 @@ class Umpire(CMakePackage, CudaPackage):
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        tty.warn('Expected results currently based on simple {0} builds'
-                 .format(self.name))
+        tty.debug('Expected results currently based on simple {0} builds'
+                  .format(self.name))
 
         if not self.spec.satisfies('@0.1.3:2.1.0'):
-            tty.warn('Expected results have not been confirmed for {0} {1}'
-                     .format(self.name, self.spec.version))
+            tty.debug('Expected results have not been confirmed for {0} {1}'
+                      .format(self.name, self.spec.version))
 
         # Run smoke tests
         self._run_bench_checks()


### PR DESCRIPTION
This PR switches version-related warnings to debug messages (per recent feedback from newer install test PRs).  It also fixes a bug in one message.