### PR TITLE
Bugfix: Do not raise InstallError for ascent_ver

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -106,7 +106,7 @@ class VtkM(CMakePackage, CudaPackage):
 
             # logging support
             if "+logging" in spec:
-                if spec.satisfies('@:1.2.0'):
+                if not spec.satisfies('@1.3.0:,ascent_ver'):
                     raise InstallError('logging is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_LOGGING:BOOL=ON")
@@ -115,7 +115,7 @@ class VtkM(CMakePackage, CudaPackage):
 
             # mpi support
             if "+mpi" in spec:
-                if spec.satisfies('@:1.2.0'):
+                if not spec.satisfies('@1.3.0:,ascent_ver'):
                     raise InstallError('mpi is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_MPI:BOOL=ON")
@@ -125,7 +125,7 @@ class VtkM(CMakePackage, CudaPackage):
             # openmp support
             if "+openmp" in spec:
                 # openmp is added since version 1.3.0
-                if spec.satisfies('@:1.2.0'):
+                if not spec.satisfies('@1.3.0:,ascent_ver'):
                     raise InstallError('OpenMP is not supported for\
                             vtkm version lower than 1.3')
                 options.append("-DVTKm_ENABLE_OPENMP:BOOL=ON")


### PR DESCRIPTION
This PR works around a problem with `spec.satisifies` not recognizing `ascent_ver` as supporting logging and mpi/openmp, which was precluding building `ascent`.