### PR TITLE
spack help --spec: add compiler flags

### DIFF
--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -35,6 +35,10 @@ spec expression syntax:
       @g{%compiler@version}             build with specific compiler version
       @g{%compiler@min:max}             specific version range (see above)
 
+    compiler flags:
+      @g{cflags="flags"}                cppflags, cflags, cxxflags,
+                                    fflags, ldflags, ldlibs
+
     variants:
       @B{+variant}                      enable <variant>
       @r{-variant} or @r{~variant}          disable <variant>


### PR DESCRIPTION
I was going to suggest this to a user who couldn't remember the syntax, but it wasn't in the help message until now.