### PR TITLE
PythonPackage: add pypi attribute to infer homepage/url/list_url

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -134,9 +134,9 @@ The zip file will not contain a ``setup.py``, but it will contain a
 ``METADATA`` file which contains all the information you need to
 write a ``package.py`` build recipe.
 
-^^^^^^^^^^^^^^^^^^^^^^^
-Finding Python packages
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^
+PyPI
+^^^^
 
 The vast majority of Python packages are hosted on PyPI - The Python
 Package Index. ``pip`` only supports packages hosted on PyPI, making
@@ -147,6 +147,26 @@ version. Click on the "Latest Version" button to the top right to see
 if a newer version is available. The download page is usually at::
 
    https://pypi.org/project/<package-name>
+
+
+Since PyPI is so common, the ``PythonPackage`` base class has a
+``pypi`` attribute that can be set. Once set, ``pypi`` will be used
+to define the ``homepage``, ``url``, and ``list_url``. For example,
+the following:
+
+.. code-block:: python
+
+   homepage = 'https://pypi.org/project/setuptools/'
+   url      = 'https://pypi.org/packages/source/s/setuptools/setuptools-49.2.0.zip'
+   list_url = 'https://pypi.org/simple/setuptools/'
+
+
+is equivalent to:
+
+.. code-block:: python
+
+   pypi = 'setuptools/setuptools-49.2.0.zip'
+
 
 ^^^^^^^^^^^
 Description
@@ -184,50 +204,11 @@ also get the homepage on the command-line by running:
 URL
 ^^^
 
-You may have noticed that Spack allows you to add multiple versions of
-the same package without adding multiple versions of the download URL.
-It does this by guessing what the version string in the URL is and
-replacing this with the requested version. Obviously, if Spack cannot
-guess the version correctly, or if non-version-related things change
-in the URL, Spack cannot substitute the version properly.
-
-Once upon a time, PyPI offered nice, simple download URLs like::
-
-   https://pypi.python.org/packages/source/n/numpy/numpy-1.13.1.zip
-
-
-As you can see, the version is 1.13.1. It probably isn't hard to guess
-what URL to use to download version 1.12.0, and Spack was perfectly
-capable of performing this calculation.
-
-However, PyPI switched to a new download URL format::
-
-   https://pypi.python.org/packages/c0/3a/40967d9f5675fbb097ffec170f59c2ba19fc96373e73ad47c2cae9a30aed/numpy-1.13.1.zip#md5=2c3c0f4edf720c3a7b525dacc825b9ae
-
-
-and more recently::
-
-   https://files.pythonhosted.org/packages/b0/2b/497c2bb7c660b2606d4a96e2035e92554429e139c6c71cdff67af66b58d2/numpy-1.14.3.zip
-
-
-As you can imagine, it is impossible for Spack to guess what URL to
-use to download version 1.12.0 given this URL. There is a solution,
-however. PyPI offers a new hidden interface for downloading
-Python packages that does not include a hash in the URL::
-
-   https://pypi.io/packages/source/n/numpy/numpy-1.13.1.zip
-
-
-This URL redirects to the https://files.pythonhosted.org URL. The general
-syntax for this https://pypi.io URL is::
-
-   https://pypi.io/packages/<type>/<first-letter-of-name>/<name>/<name>-<version>.<extension>
-
-
-Please use the https://pypi.io URL instead of the https://pypi.python.org
-URL. If both ``.tar.gz`` and ``.zip`` versions are available, ``.tar.gz``
-is preferred. If some releases offer both ``.tar.gz`` and ``.zip`` versions,
-but some only offer ``.zip`` versions, use ``.zip``.
+If ``pypi`` is set as mentioned above, ``url`` and ``list_url`` will
+be automatically set for you. If both ``.tar.gz`` and ``.zip`` versions
+are available, ``.tar.gz`` is preferred. If some releases offer both
+``.tar.gz`` and ``.zip`` versions, but some only offer ``.zip`` versions,
+use ``.zip``.
 
 Some Python packages are closed-source and do not ship ``.tar.gz`` or ``.zip``
 files on either PyPI or GitHub. If this is the case, you can still download
@@ -237,10 +218,9 @@ and can be downloaded from::
    https://pypi.io/packages/py3/a/azureml_sdk/azureml_sdk-1.11.0-py3-none-any.whl
 
 
-Note that instead of ``<type>`` being ``source``, it is now ``py3`` since this
-wheel will work for any generic version of Python 3. You may see Python-specific
-or OS-specific URLs. Note that when you add a ``.whl`` URL, you should add
-``expand=False`` to ensure that Spack doesn't try to extract the wheel:
+You may see Python-specific or OS-specific URLs. Note that when you add a
+``.whl`` URL, you should add ``expand=False`` to ensure that Spack doesn't
+try to extract the wheel:
 
 .. code-block:: python
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -89,6 +89,26 @@ class PythonPackage(PackageBase):
     py_namespace = None
 
     @property
+    def homepage(self):
+        if self.pypi:
+            name = self.pypi.split('/')[0]
+            return 'https://pypi.org/' + name + '/'
+
+    @property
+    def url(self):
+        if self.pypi:
+            return (
+                'https://files.pythonhosted.org/packages/source/'
+                + self.pypi[0] + '/' + self.pypi
+            )
+
+    @property
+    def list_url(self):
+        if self.pypi:
+            name = self.pypi.split('/')[0]
+            return 'https://pypi.org/simple/' + name + '/'
+
+    @property
     def import_modules(self):
         """Names of modules that the Python package provides.
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -72,6 +72,9 @@ class PythonPackage(PackageBase):
        def configure(self, spec, prefix):
            self.setup_py('configure')
     """
+    #: Package name, version, and extension on PyPI
+    pypi = None
+
     # Default phases
     phases = ['build', 'install']
 
@@ -92,7 +95,7 @@ class PythonPackage(PackageBase):
     def homepage(self):
         if self.pypi:
             name = self.pypi.split('/')[0]
-            return 'https://pypi.org/' + name + '/'
+            return 'https://pypi.org/project/' + name + '/'
 
     @property
     def url(self):

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -117,7 +117,7 @@ class PackageTemplate(BundlePackageTemplate):
         make()
         make('install')"""
 
-    url_line = """    url      = \"{url}\""""
+    url_line = '    url      = "{url}"'
 
     def __init__(self, name, url, versions):
         super(PackageTemplate, self).__init__(name, versions)
@@ -270,14 +270,20 @@ class PythonPackageTemplate(PackageTemplate):
         args = []
         return args"""
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, url, *args, **kwargs):
         # If the user provided `--name py-numpy`, don't rename it py-py-numpy
         if not name.startswith('py-'):
             # Make it more obvious that we are renaming the package
             tty.msg("Changing package name from {0} to py-{0}".format(name))
             name = 'py-{0}'.format(name)
 
-        super(PythonPackageTemplate, self).__init__(name, *args, **kwargs)
+        # If URL is from PyPI, use `pypi` URL
+        if 'files.pythonhosted.org' in url or 'pypi.org' in url or \
+                'pypi.python.org' in url or 'pypi.io' in url:
+            url = '/'.join(url.split('/')[-2:])
+            self.url_line = '    pypi     = "{url}"'
+
+        super(PythonPackageTemplate, self).__init__(name, url, *args, **kwargs)
 
 
 class RPackageTemplate(PackageTemplate):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -644,6 +644,15 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     #: index of patches by sha256 sum, built lazily
     _patches_by_hash = None
 
+    #: Package homepage where users can find more information about the package
+    homepage = None
+
+    #: Default list URL (place to find available versions)
+    list_url = None
+
+    #: Link depth to which list_url should be searched for new versions
+    list_depth = 0
+
     #: List of strings which contains GitHub usernames of package maintainers.
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers = []
@@ -680,13 +689,6 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             msg = "a package can have either a 'url' or a 'urls' attribute"
             msg += " [package '{0.name}' defines both]"
             raise ValueError(msg.format(self))
-
-        # Set a default list URL (place to find available versions)
-        if not hasattr(self, 'list_url'):
-            self.list_url = None
-
-        if not hasattr(self, 'list_depth'):
-            self.list_depth = 0
 
         # init internal variables
         self._stage = None

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -56,7 +56,11 @@ def find_list_urls(url):
     GitLab     https://gitlab.\*/<repo>/<name>/tags
     BitBucket  https://bitbucket.org/<repo>/<name>/downloads/?tab=tags
     CRAN       https://\*.r-project.org/src/contrib/Archive/<name>
+    PyPI       https://pypi.org/simple/<name>/
     =========  =======================================================
+
+    Note: this function is called by `spack versions` and `spack checksum`
+    but not by `spack fetch` or `spack install`.
 
     Parameters:
         url (str): The download URL for the package
@@ -91,6 +95,15 @@ def find_list_urls(url):
         # e.g. https://cloud.r-project.org/src/contrib/rgl_0.98.1.tar.gz
         (r'(.*\.r-project\.org/src/contrib)/([^_]+)',
          lambda m: m.group(1) + '/Archive/' + m.group(2)),
+
+        # PyPI
+        # e.g. https://pypi.io/packages/source/n/numpy/numpy-1.19.4.zip
+        # e.g. https://www.pypi.io/packages/source/n/numpy/numpy-1.19.4.zip
+        # e.g. https://pypi.org/packages/source/n/numpy/numpy-1.19.4.zip
+        # e.g. https://pypi.python.org/packages/source/n/numpy/numpy-1.19.4.zip
+        # e.g. https://files.pythonhosted.org/packages/source/n/numpy/numpy-1.19.4.zip
+        (r'.*(?:pypi|pythonhosted)[^/]+/packages/[^/]+/./([^/]+)',
+         lambda m: 'https://pypi.org/simple/' + m.group(1) + '/'),
     ]
 
     list_urls = set([os.path.dirname(url)])

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -59,8 +59,8 @@ def find_list_urls(url):
     PyPI       https://pypi.org/simple/<name>/
     =========  =======================================================
 
-    Note: this function is called by `spack versions` and `spack checksum`
-    but not by `spack fetch` or `spack install`.
+    Note: this function is called by `spack versions`, `spack checksum`,
+    and `spack create`, but not by `spack fetch` or `spack install`.
 
     Parameters:
         url (str): The download URL for the package
@@ -102,7 +102,8 @@ def find_list_urls(url):
         # e.g. https://pypi.org/packages/source/n/numpy/numpy-1.19.4.zip
         # e.g. https://pypi.python.org/packages/source/n/numpy/numpy-1.19.4.zip
         # e.g. https://files.pythonhosted.org/packages/source/n/numpy/numpy-1.19.4.zip
-        (r'.*(?:pypi|pythonhosted)[^/]+/packages/[^/]+/./([^/]+)',
+        # e.g. https://pypi.io/packages/py2.py3/o/opencensus-context/opencensus_context-0.1.1-py2.py3-none-any.whl
+        (r'(?:pypi|pythonhosted)[^/]+/packages/[^/]+/./([^/]+)',
          lambda m: 'https://pypi.org/simple/' + m.group(1) + '/'),
     ]
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -554,7 +554,10 @@ def find_versions_of_archive(
         #   .sha256
         #   .sig
         # However, SourceForge downloads still need to end in '/download'.
-        url_regex += r'(\/download)?$'
+        url_regex += r'(\/download)?'
+        # PyPI adds #sha256=... to the end of the URL
+        url_regex += '(#sha256=.*)?'
+        url_regex += '$'
 
         regexes.append(url_regex)
 

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -11,7 +11,7 @@ class PyMatplotlib(PythonPackage):
     and interactive visualizations in Python."""
 
     homepage = "https://matplotlib.org/"
-    pypi     = "matplotlib/matplotlib-3.3.3.tar.gz"
+    pypi     = "matplotlib/matplotlib-3.3.2.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = [

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -12,6 +12,7 @@ class PyMatplotlib(PythonPackage):
 
     homepage = "https://matplotlib.org/"
     url      = "https://pypi.io/packages/source/m/matplotlib/matplotlib-3.3.2.tar.gz"
+    list_url = "https://pypi.org/simple/matplotlib/"
 
     maintainers = ['adamjstewart']
     import_modules = [

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -11,8 +11,7 @@ class PyMatplotlib(PythonPackage):
     and interactive visualizations in Python."""
 
     homepage = "https://matplotlib.org/"
-    url      = "https://pypi.io/packages/source/m/matplotlib/matplotlib-3.3.2.tar.gz"
-    list_url = "https://pypi.org/simple/matplotlib/"
+    pypi     = "matplotlib/matplotlib-3.3.3.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = [

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -16,8 +16,7 @@ class PyNumpy(PythonPackage):
     number capabilities"""
 
     homepage = "https://numpy.org/"
-    url      = "https://pypi.io/packages/source/n/numpy/numpy-1.19.4.zip"
-    list_url = "https://pypi.org/simple/numpy/"
+    pypi     = "numpy/numpy-1.19.4.zip"
     git      = "https://github.com/numpy/numpy.git"
 
     maintainers = ['adamjstewart']

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -17,6 +17,7 @@ class PyNumpy(PythonPackage):
 
     homepage = "https://numpy.org/"
     url      = "https://pypi.io/packages/source/n/numpy/numpy-1.19.4.zip"
+    list_url = "https://pypi.org/simple/numpy/"
     git      = "https://github.com/numpy/numpy.git"
 
     maintainers = ['adamjstewart']

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -12,8 +12,7 @@ class PyScipy(PythonPackage):
     as routines for numerical integration and optimization."""
 
     homepage = "https://www.scipy.org/"
-    url      = "https://pypi.io/packages/source/s/scipy/scipy-1.5.4.tar.gz"
-    list_url = "https://pypi.org/simple/scipy/"
+    pypi     = "scipy/scipy-1.5.4.tar.gz"
     git      = "https://github.com/scipy/scipy.git"
 
     maintainers = ['adamjstewart']

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -13,6 +13,7 @@ class PyScipy(PythonPackage):
 
     homepage = "https://www.scipy.org/"
     url      = "https://pypi.io/packages/source/s/scipy/scipy-1.5.4.tar.gz"
+    list_url = "https://pypi.org/simple/scipy/"
     git      = "https://github.com/scipy/scipy.git"
 
     maintainers = ['adamjstewart']


### PR DESCRIPTION
I just discovered https://pypi.org/simple/ and [PEP 503](https://www.python.org/dev/peps/pep-0503/). This finally allows us to use `spack versions` and `spack checksum` on PyPI packages properly! For example:

### Before

```console
$ spack versions py-numpy
==> Safe versions (already checksummed):
  master  1.18.4  1.18.1  1.17.4  1.17.1  1.16.5  1.16.2  1.15.4  1.15.1  1.14.5  1.14.2  1.13.3  1.12.1  1.11.2  1.10.4  1.9.1
  1.19.0  1.18.3  1.18.0  1.17.3  1.17.0  1.16.4  1.16.1  1.15.3  1.15.0  1.14.4  1.14.1  1.13.1  1.12.0  1.11.1  1.9.3
  1.18.5  1.18.2  1.17.5  1.17.2  1.16.6  1.16.3  1.16.0  1.15.2  1.14.6  1.14.3  1.14.0  1.13.0  1.11.3  1.11.0  1.9.2
==> Remote versions (not yet checksummed):
==> Warning: Found no unchecksummed versions for py-numpy
```

### After
```console
$ spack versions py-numpy
==> Safe versions (already checksummed):
  master  1.18.4  1.18.1  1.17.4  1.17.1  1.16.5  1.16.2  1.15.4  1.15.1  1.14.5  1.14.2  1.13.3  1.12.1  1.11.2  1.10.4  1.9.1
  1.19.0  1.18.3  1.18.0  1.17.3  1.17.0  1.16.4  1.16.1  1.15.3  1.15.0  1.14.4  1.14.1  1.13.1  1.12.0  1.11.1  1.9.3
  1.18.5  1.18.2  1.17.5  1.17.2  1.16.6  1.16.3  1.16.0  1.15.2  1.14.6  1.14.3  1.14.0  1.13.0  1.11.3  1.11.0  1.9.2
==> Remote versions (not yet checksummed):
  1.19.0rc2  1.17.0rc2  1.16.0rc1  1.14.0rc1  1.12.1rc1  1.12.0b1   1.11.0rc2  1.10.2        1.9.0  1.8.0  1.7.0  1.6.0
  1.19.0rc1  1.17.0rc1  1.15.0rc2  1.13.0rc2  1.12.0rc2  1.11.2rc1  1.11.0rc1  1.10.1        1.8.2  1.7.2  1.6.2
  1.18.0rc1  1.16.0rc2  1.15.0rc1  1.13.0rc1  1.12.0rc1  1.11.1rc1  1.11.0b3   1.10.0.post2  1.8.1  1.7.1  1.6.1
```
This PR modifies `PythonPackage` to accept a `pypi` variable that defines the `homepage`, `url`, and `list_url` for every Python package like @alalazo and others have done for GNU/SourceForge/etc. Progress so far:

- [x] Add `pypi` variable to `PythonPackage` base class
- [x] Auto-populate `homepage`, `url`, and `list_url` if `pypi` is set
- [x] Update `spack create` to set `pypi` instead of `url`
- [x] Add `spack versions/checksum/create` support for PyPI URLs
- [x] Update `PythonPackage` documentation

If this works well, we can do the same for `cran`, `cpan`, and other similar language-specific software repositories.

Closes #2281
Closes #2335
Alternative to #2718