### PR TITLE
Initialize new_specs in Environment.remove()

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -910,6 +910,7 @@ class Environment(object):
                 "Not found: {0}".format(query_spec))
 
         old_specs = set(self.user_specs)
+        new_specs = set()
         for spec in matches:
             if spec in list_to_change:
                 try:


### PR DESCRIPTION
`new_specs` may be left undefined by the for-loop in lines 913-929. This causes an error in the for-loop in line 932.