### PR TITLE
mozjs@1.8.5: fix compile issue

### DIFF
--- a/var/spack/repos/builtin/packages/mozjs/Bug-638056-Avoid-The-cacheFlush-support-is-missing-o.patch
+++ b/var/spack/repos/builtin/packages/mozjs/Bug-638056-Avoid-The-cacheFlush-support-is-missing-o.patch
@@ -1,0 +1,20 @@
+From: Mike Hommey <mh@glandium.org>
+Date: Fri, 18 Mar 2011 09:25:57 +0100
+Subject: Bug 638056 - Avoid "The cacheFlush support is missing on this
+ platform" error on exotic platforms
+
+---
+ js/src/Makefile.in |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+--- a/js/src/Makefile.in
++++ b/js/src/Makefile.in
+@@ -382,7 +382,7 @@ CPPSRCS += 	checks.cc \
+ # END enclude sources for V8 dtoa
+ #############################################
+ 
+-ifeq (,$(filter-out powerpc sparc,$(TARGET_CPU)))
++ifeq (,$(filter arm %86 x86_64,$(TARGET_CPU)))
+ 
+ VPATH +=	$(srcdir)/assembler \
+ 		$(srcdir)/assembler/wtf \

--- a/var/spack/repos/builtin/packages/mozjs/fix-811665.patch
+++ b/var/spack/repos/builtin/packages/mozjs/fix-811665.patch
@@ -1,0 +1,153 @@
+Description: Fix FTBFS with gcc6
+ Most fixes are returning NULL instead of false and a narrowing issues.
+Author: Tobias Frost <tobi@debian.org>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811665
+Last-Update: 2016-09-25
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/js/src/ctypes/CTypes.cpp
++++ b/js/src/ctypes/CTypes.cpp
+@@ -4753,7 +4753,7 @@ NewFunctionInfo(JSContext* cx,
+   for (JSUint32 i = 0; i < argLength; ++i) {
+     bool isEllipsis;
+     if (!IsEllipsis(cx, argTypes[i], &isEllipsis))
+-      return false;
++      return NULL;
+     if (isEllipsis) {
+       fninfo->mIsVariadic = true;
+       if (i < 1) {
+--- a/js/src/jsapi.cpp
++++ b/js/src/jsapi.cpp
+@@ -3985,7 +3985,7 @@ JS_Enumerate(JSContext *cx, JSObject *ob
+     AutoIdVector props(cx);
+     JSIdArray *ida;
+     if (!GetPropertyNames(cx, obj, JSITER_OWNONLY, &props) || !VectorToIdArray(cx, props, &ida))
+-        return false;
++        return NULL;
+     for (size_t n = 0; n < size_t(ida->length); ++n)
+         JS_ASSERT(js_CheckForStringIndex(ida->vector[n]) == ida->vector[n]);
+     return ida;
+--- a/js/src/jsfun.cpp
++++ b/js/src/jsfun.cpp
+@@ -2051,7 +2051,7 @@ fun_toStringHelper(JSContext *cx, JSObje
+ 
+     JSString *str = JS_DecompileFunction(cx, fun, indent);
+     if (!str)
+-        return false;
++        return NULL;
+ 
+     if (!indent)
+         cx->compartment->toSourceCache.put(fun, str);
+@@ -2657,7 +2657,7 @@ LookupInterpretedFunctionPrototype(JSCon
+     const Shape *shape = funobj->nativeLookup(id);
+     if (!shape) {
+         if (!ResolveInterpretedFunctionPrototype(cx, funobj))
+-            return false;
++            return NULL;
+         shape = funobj->nativeLookup(id);
+     }
+     JS_ASSERT(!shape->configurable());
+--- a/js/src/jsiter.cpp
++++ b/js/src/jsiter.cpp
+@@ -425,7 +425,7 @@ NewIteratorObject(JSContext *cx, uintN f
+          */
+         JSObject *obj = js_NewGCObject(cx, FINALIZE_OBJECT0);
+         if (!obj)
+-            return false;
++            return NULL;
+         obj->init(cx, &js_IteratorClass, NULL, NULL, NULL, false);
+         obj->setMap(cx->compartment->emptyEnumeratorShape);
+         return obj;
+--- a/js/src/jsparse.cpp
++++ b/js/src/jsparse.cpp
+@@ -3352,7 +3352,7 @@ Parser::functionDef(JSAtom *funAtom, Fun
+     if (!outertc->inFunction() && bodyLevel && funAtom && !lambda && outertc->compiling()) {
+         JS_ASSERT(pn->pn_cookie.isFree());
+         if (!DefineGlobal(pn, outertc->asCodeGenerator(), funAtom))
+-            return false;
++            return NULL;
+     }
+ 
+     pn->pn_blockid = outertc->blockid();
+--- a/js/src/jsstr.cpp
++++ b/js/src/jsstr.cpp
+@@ -1734,7 +1734,7 @@ class RegExpGuard
+         if (flat) {
+             patstr = flattenPattern(cx, fm.patstr);
+             if (!patstr)
+-                return false;
++                return NULL;
+         } else {
+             patstr = fm.patstr;
+         }
+@@ -3408,7 +3408,7 @@ js_InitStringClass(JSContext *cx, JSObje
+                                  UndefinedValue(), NULL, NULL,
+                                  JSPROP_READONLY | JSPROP_PERMANENT | JSPROP_SHARED, 0, 0,
+                                  NULL)) {
+-        return JS_FALSE;
++        return NULL;
+     }
+ 
+     return proto;
+--- a/js/src/jstypedarray.cpp
++++ b/js/src/jstypedarray.cpp
+@@ -1334,7 +1334,7 @@ class TypedArrayTemplate
+         if (size != 0 && count >= INT32_MAX / size) {
+             JS_ReportErrorNumber(cx, js_GetErrorMessage, NULL,
+                                  JSMSG_NEED_DIET, "size and count");
+-            return false;
++            return NULL;
+         }
+ 
+         int32 bytelen = size * count;
+@@ -1668,7 +1668,7 @@ TypedArrayConstruct(JSContext *cx, jsint
+ 
+       default:
+         JS_NOT_REACHED("shouldn't have gotten here");
+-        return false;
++        return NULL;
+     }
+ }
+ 
+--- a/js/src/jsxml.cpp
++++ b/js/src/jsxml.cpp
+@@ -282,7 +282,7 @@ NewXMLNamespace(JSContext *cx, JSLinearS
+ 
+     obj = NewBuiltinClassInstanceXML(cx, &js_NamespaceClass);
+     if (!obj)
+-        return JS_FALSE;
++        return NULL;
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNamePrefixVal()));
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNameURIVal()));
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNamespaceDeclared()));
+@@ -431,7 +431,7 @@ ConvertQNameToString(JSContext *cx, JSOb
+         size_t length = str->length();
+         jschar *chars = (jschar *) cx->malloc((length + 2) * sizeof(jschar));
+         if (!chars)
+-            return JS_FALSE;
++            return NULL;
+         *chars = '@';
+         const jschar *strChars = str->getChars(cx);
+         if (!strChars) {
+--- a/js/src/methodjit/InvokeHelpers.cpp
++++ b/js/src/methodjit/InvokeHelpers.cpp
+@@ -728,7 +728,7 @@ AtSafePoint(JSContext *cx)
+ {
+     JSStackFrame *fp = cx->fp();
+     if (fp->hasImacropc())
+-        return false;
++        return NULL;
+ 
+     JSScript *script = fp->script();
+     return script->maybeNativeCodeForPC(fp->isConstructing(), cx->regs->pc);
+--- a/js/src/nanojit/NativeX64.cpp
++++ b/js/src/nanojit/NativeX64.cpp
+@@ -1899,7 +1899,7 @@ namespace nanojit
+          }
+     }
+ 
+-    static const AVMPLUS_ALIGN16(int64_t) negateMask[] = {0x8000000000000000LL,0};
++    static const AVMPLUS_ALIGN16(int64_t) negateMask[] = {(int64_t) 0x8000000000000000ULL,0};
+ 
+     void Assembler::asm_fneg(LIns *ins) {
+         Register rr, ra;

--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -31,11 +31,15 @@ class Mozjs(AutotoolsPackage):
     configure_directory = 'js/src'
     build_directory = 'js/src/spack-build'
 
-    patch('perl-bug.patch')
+    patch('perl-bug.patch', sha256='9f7d8502d85a4125e975a84cae11a8b34e696172d56f8ebc7ecf6d21fa3c30c9')
+    patch('Bug-638056-Avoid-The-cacheFlush-support-is-missing-o.patch',
+          sha256='b1c869a65f5ebc10741d4631cc2e1e166c6ed53035cfa56bede55a4c19b7b118', when='@1.8.5')
+    patch('fix-811665.patch',
+          sha256='2b298b8a693865b38e2b0d33277bb5ffe152c6ecf43648e85113fec586aa4752', when='@1.8.5')
 
     def configure_args(self):
         spec = self.spec
-        return [
+        config_args = [
             '--enable-readline',    # enables readline support in JS shell
             '--enable-threadsafe',  # enables support for multiple threads
             '--enable-system-ffi',
@@ -43,3 +47,8 @@ class Mozjs(AutotoolsPackage):
             '--with-system-nspr',
             '--with-nspr-prefix={0}'.format(spec['nspr'].prefix),
         ]
+        if spec.target.family == 'aarch64':
+            config_args.append('--host=aarch64-linux-gnu')
+        if spec.satisfies('@1.8.5'):
+            config_args.append('--disable-readline')
+        return config_args

--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -25,13 +25,16 @@ class Mozjs(AutotoolsPackage):
     depends_on('python@2.7.3:2.8', type='build')
     depends_on('nspr', when='@:27')
     depends_on('libffi@3.0.9:')
-    depends_on('readline')
+    depends_on('readline', when='@17.0.0:')
     depends_on('zlib@1.2.3')
 
     configure_directory = 'js/src'
     build_directory = 'js/src/spack-build'
 
-    patch('perl-bug.patch', sha256='9f7d8502d85a4125e975a84cae11a8b34e696172d56f8ebc7ecf6d21fa3c30c9')
+    patch('perl-bug.patch')
+    # Note: According to https://github.com/apache/couchdb-pkg/tree/master/js/rpm/SOURCES
+    #       There is some patch for mozjs@1.8.5 to fix compile issue.
+    #       Patches required to fix the issue:https://bugzilla.mozilla.org/show_bug.cgi?id=638056   
     patch('Bug-638056-Avoid-The-cacheFlush-support-is-missing-o.patch',
           sha256='b1c869a65f5ebc10741d4631cc2e1e166c6ed53035cfa56bede55a4c19b7b118', when='@1.8.5')
     patch('fix-811665.patch',


### PR DESCRIPTION
According to https://github.com/apache/couchdb-pkg/tree/master/js/rpm/SOURCES
There is some patch for mozjs@1.8.5 to fix compile issue.