### PR TITLE
[M4] Add missing compiler flag on Cray Compiler

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -36,7 +36,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
         args = ['--enable-c++']
 
-        if spec.satisfies('%cce@9:') and not spec.satisfies('platform=darwin'):
+        if spec.satisfies('%cce@9:'):
             args.append('LDFLAGS=-rtlib=compiler-rt')
 
         if spec.satisfies('%clang') and not spec.satisfies('platform=darwin'):

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -36,6 +36,9 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
         args = ['--enable-c++']
 
+        if spec.satisfies('%cce@9:') and not spec.satisfies('platform=darwin'):
+            args.append('LDFLAGS=-rtlib=compiler-rt')
+
         if spec.satisfies('%clang') and not spec.satisfies('platform=darwin'):
             args.append('LDFLAGS=-rtlib=compiler-rt')
 


### PR DESCRIPTION
The new version of the Cray Compiler are based on Clang, which means we
need to add the same LDFLAG as other clang environments.