### PR TITLE
Trilinos: fix ^hdf5~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -340,6 +340,7 @@ class Trilinos(CMakePackage):
 
     # MPI related dependencies
     depends_on('mpi', when='+mpi')
+    depends_on('hdf5+mpi', when="+hdf5+mpi")
     depends_on('netcdf-c+mpi', when="+netcdf~pnetcdf+mpi")
     depends_on('netcdf-c+mpi+parallel-netcdf', when="+netcdf+pnetcdf@master,12.12.1:")
     depends_on('parallel-netcdf', when="+netcdf+pnetcdf@master,12.12.1:")


### PR DESCRIPTION
Trilinos epetraext HDF5 output requires HDF5 parallel. Require parallel HDF5 when building `trilinos+hdf5+mpi`.

```
[ 70%] Building CXX object
packages/epetraext/src/CMakeFiles/epetraext.dir/inout/EpetraExt_HDF5.cpp.o
cd
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/epetraext/src
&& /projects/spack/opt/spack/gcc-8.3.0/openmpi/qmjv3wp/bin/mpic++
-Depetraext_EXPORTS
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/epetraext/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/transform
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/coloring
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/model_evaluator
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/block
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/restrict
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/triutils/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/triutils/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/epetra/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetra/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/teuchos/kokkoscomm/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/kokkoscomm/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/teuchos/kokkoscompat/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/kokkoscompat/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/parameterlist/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/parser/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/teuchos/core/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/core/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/kokkos/core/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/kokkos/core/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/comm/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/remainder/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-build/packages/teuchos/remainder/src
-I/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/teuchos/numerics/src
-I/projects/spack/opt/spack/gcc-8.3.0/hdf5/p2mpta5/include  -std=c++11
-O2 -g -DNDEBUG -fPIC   -o
CMakeFiles/epetraext.dir/inout/EpetraExt_HDF5.cpp.o -c
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:
In member function 'void EpetraExt::HDF5::Create(std::__cxx11::string)':
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:347:5:
error: 'H5Pset_fapl_mpio' was not declared in this scope
     H5Pset_fapl_mpio(plist_id_, mpiComm, MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:347:5:
note: suggested alternative: 'H5Pset_fapl_stdio'
     H5Pset_fapl_mpio(plist_id_, mpiComm, MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
     H5Pset_fapl_stdio
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:
In member function 'void EpetraExt::HDF5::Open(std::__cxx11::string,
int)':
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:382:5:
error: 'H5Pset_fapl_mpio' was not declared in this scope
     H5Pset_fapl_mpio(plist_id_, MPI_COMM_WORLD, MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:382:5:
note: suggested alternative: 'H5Pset_fapl_stdio'
     H5Pset_fapl_mpio(plist_id_, MPI_COMM_WORLD, MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
     H5Pset_fapl_stdio
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:384:5:
error: 'H5Pset_fapl_mpio' was not declared in this scope
     H5Pset_fapl_mpio(plist_id_, MpiComm->Comm(), MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:384:5:
note: suggested alternative: 'H5Pset_fapl_stdio'
     H5Pset_fapl_mpio(plist_id_, MpiComm->Comm(), MPI_INFO_NULL);
     ^~~~~~~~~~~~~~~~
     H5Pset_fapl_stdio
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:
In member function 'void EpetraExt::HDF5::Write(const string&, const
Epetra_MultiVector&, bool)':
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1065:3:
error: 'H5Pset_dxpl_mpio' was not declared in this scope
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1065:3:
note: suggested alternative: 'H5Pset_fapl_stdio'
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
   H5Pset_fapl_stdio
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:
In member function 'void EpetraExt::HDF5::Read(const string&,
Epetra_MultiVector*&, bool, const int&)':
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1159:3:
error: 'H5Pset_dxpl_mpio' was not declared in this scope
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1159:3:
note: suggested alternative: 'H5Pset_fapl_stdio'
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
   H5Pset_fapl_stdio
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:
In member function 'void EpetraExt::HDF5::Write(const string&, const
string&, int, int, hid_t, const void*)':
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1704:3:
error: 'H5Pset_dxpl_mpio' was not declared in this scope
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
/tmp/s3j/spack-stage/spack-stage-trilinos-12.18.1-rrecf537l7r4or3ngdprhqzim7tnqjzk/spack-src/packages/epetraext/src/inout/EpetraExt_HDF5.cpp:1704:3:
note: suggested alternative: 'H5Pset_fapl_stdio'
   H5Pset_dxpl_mpio(plist_id_, H5FD_MPIO_COLLECTIVE);
   ^~~~~~~~~~~~~~~~
   H5Pset_fapl_stdio
```