### PR TITLE
environment-views: fix bug where missing recipe/repo breaks env commands

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -351,6 +351,9 @@ def env_status(args):
                     % (ev.manifest_name, env.path))
         else:
             tty.msg('In environment %s' % env.name)
+
+        # Check if environment views can be safely activated
+        env.check_views()
     else:
         tty.msg('No active environment')
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -185,10 +185,10 @@ def activate(
         tty.die(
             'Environment view is broken due to a missing package or repo.\n',
             '  To activate without views enabled, activate with:\n',
-            '    spack env activate -V {}\n'.format(env.name),
+            '    spack env activate -V {0}\n'.format(env.name),
             '  To remove it and resolve the issue, '
             'force concretize with the command:\n',
-            '    spack -e {} concretize --force'.format(env.name))
+            '    spack -e {0} concretize --force'.format(env.name))
 
     return cmds
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -381,9 +381,6 @@ def make_argument_parser(**kwargs):
     env_group.add_argument(
         '-E', '--no-env', dest='no_env', action='store_true',
         help="run without any environments activated (see spack env)")
-    env_group.add_argument(
-        '--no-env-view', dest='no_env_view', action='store_true',
-        help="run without any activating views for environments activated")
     parser.add_argument(
         '--use-env-repo', action='store_true',
         help="when running in an environment, use its package repository")
@@ -712,7 +709,7 @@ def main(argv=None):
     if not args.no_env:
         env = ev.find_environment(args)
         if env:
-            ev.activate(env, args.use_env_repo, not args.no_env_view)
+            ev.activate(env, args.use_env_repo, add_view=False)
 
     if args.print_shell_vars:
         print_setup_info(*args.print_shell_vars.split(','))

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -381,6 +381,9 @@ def make_argument_parser(**kwargs):
     env_group.add_argument(
         '-E', '--no-env', dest='no_env', action='store_true',
         help="run without any environments activated (see spack env)")
+    env_group.add_argument(
+        '--no-env-view', dest='no_env_view', action='store_true',
+        help="run without any activating views for environments activated")
     parser.add_argument(
         '--use-env-repo', action='store_true',
         help="when running in an environment, use its package repository")
@@ -709,7 +712,7 @@ def main(argv=None):
     if not args.no_env:
         env = ev.find_environment(args)
         if env:
-            ev.activate(env, args.use_env_repo)
+            ev.activate(env, args.use_env_repo, not args.no_env_view)
 
     if args.print_shell_vars:
         print_setup_info(*args.print_shell_vars.split(','))

--- a/lib/spack/spack/util/mock_package.py
+++ b/lib/spack/spack/util/mock_package.py
@@ -77,6 +77,8 @@ class MockPackageMultiRepo(object):
     def get(self, spec):
         if not isinstance(spec, spack.spec.Spec):
             spec = Spec(spec)
+        if spec.name not in self.spec_to_pkg:
+            raise spack.repo.UnknownPackageError(spec.fullname)
         return self.spec_to_pkg[spec.name]
 
     def get_pkg_class(self, name):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -318,7 +318,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --no-env-view --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test uninstall unload url verify versions view"
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -318,7 +318,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --no-env-view --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test uninstall unload url verify versions view"
     fi


### PR DESCRIPTION
Issue:
When a recipe or a repo has been removed from Spack and an environment
is active, it causes the view activation to crash Spack before any
commands can be executed. Further, the resulting error message is not clear
in explaining the issue or a workaround.

Solution:
Catch the error for both unknown packages and repos and emit a clear error
message with options of what to do.

Added a `--no-env-view` flag to the main entry point to skip view activation
for cases like this. Additionally, this forces view regeneration to always start
from scratch to ensure old links are cleaned up properly.