### PR TITLE
Packages/abyss aegean

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -3,7 +3,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import numbers
 from spack import *
+
+
+def is_integral(x):
+    """multiple of 32 """
+    try:
+        return isinstance(int(x), numbers.Integral) and \
+            not isinstance(x, bool) and int(x) % 32 == 0
+    except ValueError:
+        return False
 
 
 class Abyss(AutotoolsPackage):
@@ -18,9 +28,8 @@ class Abyss(AutotoolsPackage):
     version('2.0.2', sha256='d87b76edeac3a6fb48f24a1d63f243d8278a324c9a5eb29027b640f7089422df')
     version('1.5.2', sha256='8a52387f963afb7b63db4c9b81c053ed83956ea0a3981edcad554a895adf84b1')
 
-    variant('maxk', values=int, default=0,
-            description='''set the maximum k-mer length.
-            This value must be a multiple of 32''')
+    variant('maxk', default=128, values=is_integral,
+            description='''set the maximum k-mer length.''')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -48,3 +57,5 @@ class Abyss(AutotoolsPackage):
         if self.spec['mpi'].name == 'mpich':
             args.append('--enable-mpich')
         return args
+
+    patch('fix_BloomFilter.hpp.patch', when='@2.0.0:2.1.4')

--- a/var/spack/repos/builtin/packages/aegean/package.py
+++ b/var/spack/repos/builtin/packages/aegean/package.py
@@ -21,4 +21,7 @@ class Aegean(MakefilePackage):
 
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')
+        if spec.target.family == 'aarch64':
+            makefile.filter('-m64', '')
+
         makefile.filter('/usr/local', prefix)


### PR DESCRIPTION
1) abyss 2.1.4: fails to build with GCC 8
    Change strncpy function to memcpy.
    The description of  allowed value of variant was changed.
2) aegean: remove -m64 on aarch64.
    Removed -m64 option from Makefile.
