### PR TITLE
qt: add missing libSM dependency

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -158,6 +158,7 @@ class Qt(Package):
     # Non-macOS dependencies and special macOS constraints
     if MACOS_VERSION is None:
         depends_on("fontconfig", when='freetype=spack')
+        depends_on("libsm")
         depends_on("libx11")
         depends_on("libxcb")
         depends_on("libxkbcommon")


### PR DESCRIPTION
See https://github.com/spack/spack/issues/15082 and https://github.com/spack/spack/pull/16226 . Without this change, downstream code can fail because QT bring in a system libSM that might link against a different libuuid from the ones that spack uses.