### PR TITLE
hpcviewer, ibm-java: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin/packages/hpcviewer/package.py
@@ -37,6 +37,9 @@ class Hpcviewer(Package):
     maintainers = ['mwkrentel']
 
     viewer_sha = {
+        ('2020.07', 'x86_64'):  '19951662626c7c9817c4a75269c85810352dc48ae9a62dfb6ce4a5b502de2118',
+        ('2020.07', 'ppc64'):   '3f5d9358ef8ff9ba4f6dcaa4d7132f41ba55f0c132d9fd1e2f6da18341648a4e',
+        ('2020.07', 'ppc64le'): 'e236a8578dc247279d1021aa35bac47e2d4864b906efcef76c0610ee0086b353',
         ('2020.05', 'x86_64'):  '27f99c94a69abd005303fb58360b0d1b3eb7d223cab81c38ae6ccdd83ec15106',
         ('2020.05', 'ppc64'):   '469bce07a75476c132d3791ca49e38db015917c9c36b4810e477bc1c54a13d68',
         ('2020.05', 'ppc64le'): 'fc4491bf6d9eaf2b7f2d39b722c978597a881ece557fb05a4cf27caabb9e0b99',
@@ -70,6 +73,9 @@ class Hpcviewer(Package):
     }
 
     trace_sha = {
+        ('2020.07', 'x86_64'):  '52aea55b1d40b9453c106ac5a83020a08839b9be1e71dbd1a9f471e5f3a55d43',
+        ('2020.07', 'ppc64'):   '3d9222310a18618704015aecbcab7f7c5a2cedbd5ecd8ace1bfc7e98d11b8d36',
+        ('2020.07', 'ppc64le'): '2f0a8b95033a5816d468b87c8c139f08a307714e2e27a1cb4a35e1c5a8083cca',
         ('2020.05', 'x86_64'):  'a0b925099a00c10fcb38e937068e50937175fd46dc086121525e546a63a7fd83',
         ('2020.05', 'ppc64'):   '40526f62f36e5b6438021c2b557256638d41a6b8f4e101534b5230ac644a9b85',
         ('2020.05', 'ppc64le'): 'c16e83b59362adcebecd4231374916a2b3a3c016f75a45b24e8398f777a24f89',

--- a/var/spack/repos/builtin/packages/ibm-java/package.py
+++ b/var/spack/repos/builtin/packages/ibm-java/package.py
@@ -22,6 +22,8 @@ class IbmJava(Package):
     # not be available for download.
 
     version_list = [
+        ('8.0.6.11', 'ppc64',   '6fd17a6b9a34bb66e0db37f6402dc1b7612d54084c94b859f4a42f445fd174d4'),
+        ('8.0.6.11', 'ppc64le', 'd69ff7519e32e89db88a9a4d4d88d1881524073ac940f35d3860db2c6647be2e'),
         ('8.0.6.10', 'ppc64',   'ff5151ead88f891624eefe33d80d56c325ca0aa4b93bd96c135cad326993eda2'),
         ('8.0.6.10', 'ppc64le', 'ea99ab28dd300b08940882d178247e99aafe5a998b1621cf288dfb247394e067'),
         ('8.0.6.7',  'ppc64',   'a1accb461a039af4587ea86511e317fea1d423e7f781459a17ed3947afed2982'),


### PR DESCRIPTION
Add hpcviewer version 2020.07 and ibm-java 8.0.6.11.