### PR TITLE
abyss 2.1.4: fails to build with GCC 8

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/fix_BloomFilter.hpp.patch
+++ b/var/spack/repos/builtin/packages/abyss/fix_BloomFilter.hpp.patch
@@ -1,0 +1,11 @@
+--- spack-src/lib/bloomfilter/BloomFilter.hpp.org	2018-10-17 07:04:45.000000000 +0900
++++ spack-src/lib/bloomfilter/BloomFilter.hpp	2020-07-16 15:41:03.607766127 +0900
+@@ -230,7 +230,7 @@
+ 
+ 	void writeHeader(std::ostream& out) const {
+ 		FileHeader header;
+-		strncpy(header.magic, "BlOOMFXX", 8);
++		memcpy(header.magic, "BlOOMFXX", 8);
+ 		char magic[9];
+ 		strncpy(magic, header.magic, 8);
+ 		magic[8] = '\0';

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -3,7 +3,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import numbers
 from spack import *
+
+
+def is_integral(x):
+    """multiple of 32 """
+    try:
+        return isinstance(int(x), numbers.Integral) and \
+            not isinstance(x, bool) and int(x) % 32 == 0
+    except ValueError:
+        return False
 
 
 class Abyss(AutotoolsPackage):
@@ -18,9 +28,8 @@ class Abyss(AutotoolsPackage):
     version('2.0.2', sha256='d87b76edeac3a6fb48f24a1d63f243d8278a324c9a5eb29027b640f7089422df')
     version('1.5.2', sha256='8a52387f963afb7b63db4c9b81c053ed83956ea0a3981edcad554a895adf84b1')
 
-    variant('maxk', values=int, default=0,
-            description='''set the maximum k-mer length.
-            This value must be a multiple of 32''')
+    variant('maxk', default=128, values=is_integral,
+            description='''set the maximum k-mer length.''')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -48,3 +57,5 @@ class Abyss(AutotoolsPackage):
         if self.spec['mpi'].name == 'mpich':
             args.append('--enable-mpich')
         return args
+
+    patch('fix_BloomFilter.hpp.patch', when='@2.0.0:2.1.4')

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -7,7 +7,7 @@ import numbers
 from spack import *
 
 
-def is_integral(x):
+def is_multiple_32(x):
     """multiple of 32 """
     try:
         return isinstance(int(x), numbers.Integral) and \
@@ -28,8 +28,8 @@ class Abyss(AutotoolsPackage):
     version('2.0.2', sha256='d87b76edeac3a6fb48f24a1d63f243d8278a324c9a5eb29027b640f7089422df')
     version('1.5.2', sha256='8a52387f963afb7b63db4c9b81c053ed83956ea0a3981edcad554a895adf84b1')
 
-    variant('maxk', default=128, values=is_integral,
-            description='''set the maximum k-mer length.''')
+    variant('maxk', default=128, values=is_multiple_32,
+            description='set the maximum k-mer length.')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
1) abyss 2.1.4: fails to build with GCC 8
    Change strncpy function to memcpy.
    The description of  allowed value of variant was changed.
