### PR TITLE
precice: Add version 2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -19,6 +19,7 @@ class Precice(CMakePackage):
     maintainers = ['fsimonis', 'MakisH']
 
     version('develop', branch='develop')
+    version('2.1.0', sha256='1e6432724f70d0c6c05fdd645e0026754edbc547719a35bf1d3c12a779b1d00e')
     version('2.0.2', sha256='72864480f32696e7b6da94fd404ef5cd6586e2e1640613e46b75f1afac8569ed')
     version('2.0.1', sha256='e4fe2d2063042761ab325f8c802f88ae088c90862af288ad1a642967d074bd50')
     version('2.0.0', sha256='c8979d366f06e35626a8da08a1c589df77ec13972eb524a1ba99a011e245701f')
@@ -48,6 +49,7 @@ class Precice(CMakePackage):
     depends_on('libxml2')
     depends_on('mpi', when='+mpi')
     depends_on('petsc@3.6:', when='+petsc')
+    depends_on('petsc@3.12:', when='+petsc@2.1.0:')
 
     # Python 3 support was added in version 2.0
     depends_on('python@2.7:2.8', when='@:1.9+python', type=('build', 'run'))


### PR DESCRIPTION
This PR adds version 2.1.0 of the xSDK member preCICE.