### PR TITLE
Failing tests will no longer kill the install

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -36,6 +36,7 @@ def update_kwargs_from_args(args, kwargs):
         'keep_prefix': args.keep_prefix,
         'keep_stage': args.keep_stage,
         'restage': not args.dont_restage,
+        'ignore_test_failures': args.ignore_test_failures,
         'install_source': args.install_source,
         'verbose': args.verbose,
         'fake': args.fake,
@@ -143,6 +144,10 @@ packages. If neither are chosen, don't run tests for any packages."""
     testing.add_argument(
         '--run-tests', action='store_true',
         help='run package tests during installation (same as --test=all)'
+    )
+    subparser.add_argument(
+        '--ignore-test-failures', action='store_true', default=False,
+        help='(with testing) test failures will not abort the install'
     )
     subparser.add_argument(
         '--log-format',

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -566,6 +566,8 @@ install_args_docstring = """
                 possible (i.e., best effort installation).
             fake (bool): Don't really build; install fake stub files instead.
             force (bool): Install again, even if already installed.
+            ignore_test_failures (bool): Proceed with installation even if
+                there are failing tests..
             install_deps (bool): Install dependencies before installing this
                 package
             install_source (bool): By default, source is not installed, but
@@ -1041,6 +1043,7 @@ class PackageInstaller(object):
         keep_stage = kwargs.get('keep_stage', False)
         skip_patch = kwargs.get('skip_patch', False)
         tests = kwargs.get('tests', False)
+        ignore_test_failures = kwargs.get('ignore_test_failures', False)
         unsigned = kwargs.get('unsigned', False)
         use_cache = kwargs.get('use_cache', True)
         verbose = kwargs.get('verbose', False)
@@ -1060,6 +1063,7 @@ class PackageInstaller(object):
             return
 
         pkg.run_tests = (tests is True or tests and pkg.name in tests)
+        pkg.ignore_test_failures = ignore_test_failures
 
         pre = '{0}: {1}:'.format(self.pid, pkg.name)
 


### PR DESCRIPTION
This PR adds an option, when running tests, to record test failures without aborting the install, as discussed with @becker33. If this is a feature spack would consider useful, I would like to iterate on this PR with you

@mcclunatic