### PR TITLE
Qhull: add v2019.1 and v2020.1

### DIFF
--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -30,3 +30,9 @@ class Qhull(CMakePackage):
     patch('qhull-unused-intel-17.02.patch', when='@2015.2')
 
     depends_on('cmake@3.0:', type='build')
+
+    def flag_handler(self, name, flags):
+        # See https://github.com/qhull/qhull/issues/65
+        if name == 'cxxflags' and self.version == Version('2020.1'):
+            flags.append(self.compiler.cxx11_flag)
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -18,12 +18,15 @@ class Qhull(CMakePackage):
 
     homepage = "http://www.qhull.org"
 
+    version('2020.1', sha256='1ac92a5538f61e297c72aebe4d4ffd731ceb3e6045d6d15faf1c212713798df4',
+            url="http://www.qhull.org/download/qhull-2020-src-8.0.0.tgz")
+    version('2019.1', sha256='2b7990558c363076261564f61b74db4d0d73b71869755108a469038c07dc43fb',
+            url="http://www.qhull.org/download/qhull-2019-src-7.3.2.tgz")
     version('2015.2', sha256='78b010925c3b577adc3d58278787d7df08f7c8fb02c3490e375eab91bb58a436',
             url="http://www.qhull.org/download/qhull-2015-src-7.2.0.tgz")
-
     version('2012.1', sha256='a35ecaa610550b7f05c3ce373d89c30cf74b059a69880f03080c556daebcff88',
             url="http://www.qhull.org/download/qhull-2012.1-src.tgz")
 
     patch('qhull-unused-intel-17.02.patch', when='@2015.2')
 
-    depends_on('cmake@2.6:', type='build')
+    depends_on('cmake@3.0:', type='build')


### PR DESCRIPTION
Successfully builds and passes all tests on Ubuntu 20.04 with GCC 9.3.0 (via WSL)