### PR TITLE
Cython: add v0.29.21

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -10,7 +10,7 @@ class PyCython(PythonPackage):
     """The Cython compiler for writing C extensions for the Python language."""
 
     homepage = "https://pypi.python.org/pypi/cython"
-    url      = "https://pypi.io/packages/source/c/cython/Cython-0.29.16.tar.gz"
+    url      = "https://pypi.io/packages/source/c/cython/Cython-0.29.21.tar.gz"
 
     import_modules = [
         'cython', 'Cython', 'Cython.Build', 'Cython.Compiler',
@@ -20,6 +20,7 @@ class PyCython(PythonPackage):
         'Cython.Tempita', 'pyximport',
     ]
 
+    version('0.29.21', sha256='e57acb89bd55943c8d8bf813763d20b9099cc7165c0f16b707631a7654be9cad')
     version('0.29.16', sha256='232755284f942cbb3b43a06cd85974ef3c970a021aef19b5243c03ee2b08fa05')
     version('0.29.15', sha256='60d859e1efa5cc80436d58aecd3718ff2e74b987db0518376046adedba97ac30')
     version('0.29.14', sha256='e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.7 and GCC 9.3.0 (via WSL)