### PR TITLE
camx: Change compile option for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/camx/package.py
+++ b/var/spack/repos/builtin/packages/camx/package.py
@@ -60,6 +60,10 @@ class Camx(MakefilePackage):
 
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')
+        if spec.target.family == 'aarch64':
+            makefile.filter('-mcmodel=medium', '-mcmodel=large')
+            makefile = FileFilter('./MPI/util/Makefile')
+            makefile.filter('-mcmodel=medium', '-mcmodel=large')
 
         # Support Intel MPI.
         if spec['mpi'].name == 'intel-mpi':


### PR DESCRIPTION
Fixed option string when compiling with gcc compiler.