### PR TITLE
Improve HPX package management of coroutines implementation

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-
+import sys
 
 class Hpx(CMakePackage, CudaPackage):
     """C++ runtime system for parallel and distributed applications."""
@@ -48,8 +48,11 @@ class Hpx(CMakePackage, CudaPackage):
         description="Support for networking through parcelports",
     )
 
+    default_generic_coroutines = True
+    if sys.platform.startswith('linux'):
+        default_generic_coroutines = False
     variant(
-        "generic_coroutines", default=False,
+        "generic_coroutines", default=default_generic_coroutines,
         description='Use Boost.Context as the underlying coroutines'
                     'context switch implementation.')
 

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -48,6 +48,11 @@ class Hpx(CMakePackage, CudaPackage):
         description="Support for networking through parcelports",
     )
 
+    variant(
+        "generic_coroutines", default=False,
+        description='Use Boost.Context as the underlying coroutines'
+                    'context switch implementation.')
+
     variant('tools', default=False, description='Build HPX tools')
     variant('examples', default=False, description='Build examples')
 
@@ -68,6 +73,12 @@ class Hpx(CMakePackage, CudaPackage):
     # boost 1.73.0 build problem with HPX 1.4.0 and 1.4.1
     # https://github.com/STEllAR-GROUP/hpx/issues/4728#issuecomment-640685308
     depends_on('boost@:1.72.0', when='@:1.4')
+
+    # COROUTINES
+    # https://github.com/STEllAR-GROUP/hpx/issues/4829
+    depends_on('boost+context', when='+generic_coroutines')
+    _msg_generic_coroutines = 'This platform requires +generic_coroutines'
+    conflicts('~generic_coroutines', when='platform=darwin', msg=_msg_generic_coroutines)
 
     # CXX Standard
     depends_on('boost cxxstd=11', when='cxxstd=11')
@@ -153,6 +164,12 @@ class Hpx(CMakePackage, CudaPackage):
         args.append('-DHPX_WITH_MAX_CPU_COUNT={0}'.format(
             spec.variants['max_cpu_count'].value
         ))
+
+        # HPX_WITH_GENERIC_CONTEXT_COROUTINES
+        args.append(
+            self.define_with_variant(
+                'HPX_WITH_GENERIC_CONTEXT_COROUTINES', 'generic_coroutines')
+        )
 
         # Examples
         args.append('-DHPX_WITH_EXAMPLES={0}'.format(

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -131,7 +131,7 @@ class Hpx(CMakePackage, CudaPackage):
         args.extend(self.instrumentation_args())
 
         if 'instrumentation=apex' in spec:
-            args += ['-DAPEX_WITH_OTF2=ON'
+            args += ['-DAPEX_WITH_OTF2=ON',
                      '-DOTF2_ROOT={0}'.format(spec['otf2'].prefix)]
 
         # Networking

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -7,6 +7,7 @@
 from spack import *
 import sys
 
+
 class Hpx(CMakePackage, CudaPackage):
     """C++ runtime system for parallel and distributed applications."""
 
@@ -49,7 +50,7 @@ class Hpx(CMakePackage, CudaPackage):
     )
 
     default_generic_coroutines = True
-    if sys.platform.startswith('linux'):
+    if sys.platform.startswith('linux') or sys.platform == 'win32':
         default_generic_coroutines = False
     variant(
         "generic_coroutines", default=default_generic_coroutines,

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -55,7 +55,7 @@ class Hpx(CMakePackage, CudaPackage):
     variant(
         "generic_coroutines", default=default_generic_coroutines,
         description='Use Boost.Context as the underlying coroutines'
-                    'context switch implementation.')
+                    ' context switch implementation.')
 
     variant('tools', default=False, description='Build HPX tools')
     variant('examples', default=False, description='Build examples')

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -79,6 +79,9 @@ class Hpx(CMakePackage, CudaPackage):
     depends_on('boost@:1.72.0', when='@:1.4')
 
     # COROUTINES
+    # ~generic_coroutines conflict is not fully implemented
+    # for additional information see:
+    # https://github.com/spack/spack/pull/17654
     # https://github.com/STEllAR-GROUP/hpx/issues/4829
     depends_on('boost+context', when='+generic_coroutines')
     _msg_generic_coroutines = 'This platform requires +generic_coroutines'


### PR DESCRIPTION
This PR aims at:
- allowing, through a variant, the selection of the coroutines implementation to use;
- for some platform a custom implementation is not provided, so it imposes the usage of a generic one;
- default implementation depends on the platform
- in case of generic implementation, add required dependency on `boost+context`;

Moreover, it fixes a minor cmake configuration problem when `instrumentation=apex` (it was concatenating two cmake variables without any space, due to a missing comma in the list initialization).

For reference see https://github.com/STEllAR-GROUP/hpx/issues/4829