### PR TITLE
libgd: add libjpeg path to LIBS

### DIFF
--- a/var/spack/repos/builtin/packages/libgd/package.py
+++ b/var/spack/repos/builtin/packages/libgd/package.py
@@ -36,3 +36,12 @@ class Libgd(AutotoolsPackage):
     depends_on('jpeg')
     depends_on('libtiff')
     depends_on('fontconfig')
+
+    def patch(self):
+        p = self.spec['jpeg'].libs.search_flags
+        filter_file(
+            'LIBJPEG_LIBS " -ljpeg"',
+            'LIBJPEG_LIBS "{0} -ljpeg"'.format(p),
+            'configure',
+            string=True
+        )


### PR DESCRIPTION
Configure script fails to find spack `jpeg` path. 
So I added `jpeg` path to `LIBS` of configure script.
I found this problem during build of `perl-gd%fj`.
Probably previous `libgd` and `perl-gd%gcc` linked to /usr/lib64/libjpeg.
Therefore, this patch should be applied to all compiler.