### PR TITLE
cctools: Remove fstack-protector-all

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -45,6 +45,10 @@ class Cctools(AutotoolsPackage):
         f = 'dttools/src/memfdexe.c'
         kwargs = {'ignore_absent': False, 'backup': True, 'string': True}
         filter_file(before, after, f, **kwargs)
+        if self.spec.satisfies('%fj'):
+            makefiles = ['chirp/src/Makefile', 'grow/src/Makefile']
+            for m in makefiles:
+                filter_file('-fstack-protector-all', '', m)
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
Fujitsu C compiler does not support `fstack-protector-all` option.
So I removed from Makefiles.