### PR TITLE
New package: r-dss

### DIFF
--- a/var/spack/repos/builtin/packages/r-biocgenerics/package.py
+++ b/var/spack/repos/builtin/packages/r-biocgenerics/package.py
@@ -14,6 +14,7 @@ class RBiocgenerics(RPackage):
     homepage = "https://bioconductor.org/packages/BiocGenerics"
     git      = "https://git.bioconductor.org/packages/BiocGenerics.git"
 
+    version('0.34.0', commit='f7c2020')
     version('0.30.0', commit='fc7c3af4a5635a30988a062ed09332c13ca1d1a8')
     version('0.28.0', commit='041fc496504f2ab1d4d863fffb23372db214394b')
     version('0.26.0', commit='5b2a6df639e48c3cd53789e0b174aec9dda6b67d')

--- a/var/spack/repos/builtin/packages/r-bsseq/package.py
+++ b/var/spack/repos/builtin/packages/r-bsseq/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RBsseq(RPackage):
+    """A collection of tools for analyzing and visualizing bisulfite sequencing
+    data."""
+
+    homepage = "https://github.com/kasperdanielhansen/bsseq"
+    git      = "https://git.bioconductor.org/packages/bsseq"
+
+    version('1.24.4', commit='8fe7a03')
+    version('1.22.0', commit='d4f7301')
+    version('1.20.0', commit='07e398b')
+
+    depends_on('r@3.5:', type=('build', 'run'))
+
+    depends_on('r-biocgenerics', type=('build', 'run'))
+
+    depends_on('r-genomicranges@1.29.14:', type=('build', 'run'))
+    depends_on('r-genomicranges@1.33.6:', when='@1.24.4:', type=('build', 'run'))
+
+    depends_on('r-summarizedexperiment@1.9.18:', type=('build', 'run'))
+    depends_on('r-summarizedexperiment@1.17.4:', when='@1.24.4:', type=('build', 'run'))
+
+    depends_on('r-iranges@2.11.16:', type=('build', 'run'))
+    depends_on('r-iranges@2.22.2:', when='@1.24.4:', type=('build', 'run'))
+
+    depends_on('r-genomeinfodb', type=('build', 'run'))
+    depends_on('r-scales', type=('build', 'run'))
+    depends_on('r-biobase', type=('build', 'run'))
+    depends_on('r-locfit', type=('build', 'run'))
+    depends_on('r-gtools', type=('build', 'run'))
+    depends_on('r-data-table@1.11.8:', type=('build', 'run'))
+
+    depends_on('r-s4vectors', type=('build', 'run'))
+    depends_on('r-s4vectors@0.23.11:', when='@1.22.0:', type=('build', 'run'))
+    depends_on('r-s4vectors@0.25.14:', when='@1.24.4', type=('build', 'run'))
+
+    depends_on('r-r-utils@2.0.0:', type=('build', 'run'))
+    depends_on('r-delayedmatrixstats@1.5.2:', type=('build', 'run'))
+    depends_on('r-permute', type=('build', 'run'))
+    depends_on('r-limma', type=('build', 'run'))
+    depends_on('r-delayedarray@0.9.8:', type=('build', 'run'))
+    depends_on('r-rcpp', type=('build', 'run'))
+    depends_on('r-biocparallel', type=('build', 'run'))
+    depends_on('r-bsgenome', type=('build', 'run'))
+    depends_on('r-biostrings', type=('build', 'run'))
+    depends_on('r-hdf5array@1.11.9:', type=('build', 'run'))
+    depends_on('r-rhdf5', type=('build', 'run'))
+    depends_on('r-beachmat', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-dss/package.py
+++ b/var/spack/repos/builtin/packages/r-dss/package.py
@@ -7,7 +7,9 @@ from spack import *
 
 
 class RDss(RPackage):
-    """DSS is an R library performing differntial analysis for count-based
+    """Dispersion shrinkage for sequencing data.
+
+    DSS is an R library performing differntial analysis for count-based
     sequencing data. It detectes differentially expressed genes (DEGs) from
     RNA-seq, and differentially methylated loci or regions (DML/DMRs) from
     bisulfite sequencing (BS-seq). The core of DSS is a new dispersion

--- a/var/spack/repos/builtin/packages/r-dss/package.py
+++ b/var/spack/repos/builtin/packages/r-dss/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class RDss(RPackage):
+    """DSS is an R library performing differntial analysis for count-based
+    sequencing data. It detectes differentially expressed genes (DEGs) from
+    RNA-seq, and differentially methylated loci or regions (DML/DMRs) from
+    bisulfite sequencing (BS-seq). The core of DSS is a new dispersion
+    shrinkage method for estimating the dispersion parameter from Gamma-Poisson
+    or Beta-Binomial distributions."""
+
+    homepage = "http://bioconductor.org/packages/DSS/"
+    git      = "https://git.bioconductor.org/packages/DSS"
+
+    version('2.36.0', commit='841c7ed')
+    version('2.34.0', commit='f9819c7')
+    version('2.32.0', commit='ffb502d')
+
+    depends_on('r@3.3:', type=('build', 'run'))
+    depends_on('r-biobase', type=('build', 'run'))
+    depends_on('r-bsseq', type=('build', 'run'))
+    depends_on('r-biocparallel', when='@2.36.0:', type=('build', 'run'))
+    depends_on('r-delayedarray', when='@2.36.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-iranges/package.py
+++ b/var/spack/repos/builtin/packages/r-iranges/package.py
@@ -19,6 +19,7 @@ class RIranges(RPackage):
     homepage = "https://bioconductor.org/packages/IRanges"
     git      = "https://git.bioconductor.org/packages/IRanges.git"
 
+    version('2.22.2', commit='8c5e991')
     version('2.18.3', commit='c98a7ba074e72f2e5ec98252dffe9d3392711972')
     version('2.16.0', commit='26834c6868d7c279dd8ac1bb9daa16e6fef273c2')
     version('2.14.12', commit='00af02756c14771a23df9efcf379409ab6eb3041')
@@ -38,3 +39,5 @@ class RIranges(RPackage):
     depends_on('r-s4vectors@0.19.11:', when='@2.16.0:', type=('build', 'run'))
 
     depends_on('r-s4vectors@0.21.9:', when='@2.18.3:', type=('build', 'run'))
+
+    depends_on('r-s4vectors@0.25.14:', when='@2.22.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-s4vectors/package.py
+++ b/var/spack/repos/builtin/packages/r-s4vectors/package.py
@@ -21,6 +21,7 @@ class RS4vectors(RPackage):
     homepage = "https://bioconductor.org/packages/S4Vectors"
     git      = "https://git.bioconductor.org/packages/S4Vectors.git"
 
+    version('0.26.1', commit='935769c')
     version('0.22.1', commit='d25e517b48ca4184a4c2ee1f8223c148a55a8b8a')
     version('0.20.1', commit='1878b2909086941e556c5ea953c6fd86aebe9b02')
     version('0.18.3', commit='d6804f94ad3663828440914920ac933b934aeff1')
@@ -30,4 +31,5 @@ class RS4vectors(RPackage):
     depends_on('r@3.3.0:', type=('build', 'run'))
     depends_on('r-biocgenerics@0.21.1:', type=('build', 'run'))
 
-    depends_on('r-biocgenerics@0.23.3:', when='@0.16.0:', type=('build', 'run'))
+    depends_on('r-biocgenerics@0.23.3:', when='@0.16.0:0.22.1', type=('build', 'run'))
+    depends_on('r-biocgenerics@0.31.1:', when='@0.26.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-summarizedexperiment/package.py
+++ b/var/spack/repos/builtin/packages/r-summarizedexperiment/package.py
@@ -17,6 +17,7 @@ class RSummarizedexperiment(RPackage):
     homepage = "https://bioconductor.org/packages/SummarizedExperiment"
     git      = "https://git.bioconductor.org/packages/SummarizedExperiment.git"
 
+    version('1.18.2', commit='e22fafe')
     version('1.14.1', commit='2c68d99e11c7345e5ed388370822ea48395c64a4')
     version('1.12.0', commit='5f8416864636add121ec1d6737ebb89a42227fd7')
     version('1.10.1', commit='7ad2e991c8285bfc4b2e15b29d94cc86d07f8f2b')


### PR DESCRIPTION
This PR adds the r-dss package and the r-bsseq package, also new, as a
dependency. This includes the latest versions, which required updates to
the following dependencies:

- r-biocgenerics
- r-iranges
- r-s4vectors
- r-summarizedexperiment

Older versions of r-dss and r-bsseq are included as well to ensure
compatibility with older versions of the above dependencies.