### PR TITLE
bugfix: use getattr for variation.prefix/suffix

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -681,8 +681,8 @@ def make_compiler_list(detected_versions):
     sort_fn = lambda variation: (
         'cc' not in by_compiler_id[variation],  # None last
         'cxx' not in by_compiler_id[variation],  # None last
-        variation.prefix,
-        variation.suffix,
+        getattr(variation, 'prefix', None),
+        getattr(variation, 'suffix', None),
     )
 
     compilers = []


### PR DESCRIPTION
Replace:
1. Use `getattr(variation, 'prefix', None)` instead of `variation.prefix` 
2. Use `getattr(variation, 'suffix', None)` instead of `variation.suffix` 

Resolves issue preventing `spack compiler find` from working on NERSC Cori.

@becker33 @shahzebsiddiqui 