### PR TITLE
XBraid: Switch to the Github URL

### DIFF
--- a/var/spack/repos/builtin/packages/xbraid/package.py
+++ b/var/spack/repos/builtin/packages/xbraid/package.py
@@ -12,7 +12,7 @@ class Xbraid(MakefilePackage):
     """XBraid: Parallel time integration with Multigrid"""
 
     homepage = "https://computing.llnl.gov/projects/parallel-time-integration-multigrid/software"
-    url      = "https://computing.llnl.gov/projects/parallel-time-integration-multigrid/download/braid_2.2.0.tar.gz"
+    url      = "https://github.com/XBraid/xbraid/archive/v2.2.0.tar.gz"
 
     version('2.2.0', sha256='082623b2ddcd2150b3ace65b96c1e00be637876ec6c94dc8fefda88743b35ba3')
 


### PR DESCRIPTION
There are some systems that have firewall issues with the current URL.  This PR resolves that issue by switching to the Github URL.

The change has been used to successfully install a RADIUSS `BundlePackage` on an LLNL LC machine.