### PR TITLE
CMake: Fix compilation with Intel compilers on some systems.

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/intel-cxx-bootstrap.patch
+++ b/var/spack/repos/builtin/packages/cmake/intel-cxx-bootstrap.patch
@@ -1,0 +1,11 @@
+--- a/bootstrap	2020-07-24 11:02:56.488414260 +0200
++++ b/bootstrap	2020-07-24 11:03:20.763775094 +0200
+@@ -1179,7 +1179,7 @@
+ }
+ #endif
+ 
+-#if (__cplusplus >= 201703L || defined(__INTEL_COMPILER) && defined(__cpp_if_constexpr))
++#if (__cplusplus >= 201703L || defined(__INTEL_COMPILER) && defined(__cpp_deduction_guides))
+ #include <optional>
+ template <typename T,
+           typename std::invoke_result<decltype(&T::get), T>::type = nullptr>

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -136,6 +136,10 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
     patch('intel-c-gnu11.patch', when='@3.6.0:3.6.1')
 
+    # Cannot build with Intel again, should be fixed in 3.17.4 and 3.18.1
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/21013
+    patch('intel-cxx-bootstrap.patch', when='@3.17.0:3.17.3,3.18.0')
+
     # https://gitlab.kitware.com/cmake/cmake/issues/18232
     patch('nag-response-files.patch', when='@3.7:3.12')
 


### PR DESCRIPTION
Systems with older GNU compilers were not affected.

Fixes #15901 and fixes #17605.