### PR TITLE
Fix redundant reset of terminal in prompt example

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -71,7 +71,7 @@ Environments:
     && yum install -y libgomp \
     && rm -rf /var/cache/yum  && yum clean all
 
-   RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ \[$(tput sgr0)\]"' >> ~/.bashrc
+   RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ "' >> ~/.bashrc
 
 
    LABEL "app"="gromacs"
@@ -165,7 +165,7 @@ of environments:
        # Extra instructions
        extra_instructions:
          final: |
-           RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ \[$(tput sgr0)\]"' >> ~/.bashrc
+           RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ "' >> ~/.bashrc
 
        # Labels for the image
        labels:
@@ -293,7 +293,7 @@ following ``Dockerfile``:
     && yum install -y libgomp \
     && rm -rf /var/cache/yum  && yum clean all
 
-   RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ \[$(tput sgr0)\]"' >> ~/.bashrc
+   RUN echo 'export PS1="\[$(tput bold)\]\[$(tput setaf 1)\][gromacs]\[$(tput setaf 2)\]\u\[$(tput sgr0)\]:\w $ "' >> ~/.bashrc
 
 
    LABEL "app"="gromacs"


### PR DESCRIPTION
I know that it's just an example, but I was trying to figure out what was going on and it wasn't making sense....

`tput sgr0` resets the terminal state (http://linuxcommand.org/lc3_adv_tput.php) and I can't see any reason to do it twice.  Deleting the second occurrence doesn't seem to break the fancy prompt effect.