### PR TITLE
Fix mac QT install for change to compiler name

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -178,6 +178,7 @@ class Qt(Package):
 
     # Mapping for compilers/systems in the QT 'mkspecs'
     compiler_mapping = {'intel': ('icc',),
+                        'apple-clang': ('clang-libc++', 'clang'),
                         'clang': ('clang-libc++', 'clang'),
                         'gcc': ('g++',)}
     platform_mapping = {'darwin': 'macx'}


### PR DESCRIPTION
The change of compiler name from `clang` to `apple-clang` broke the compiler detection in the QT package. This PR fixes it.