### PR TITLE
New package: HDFView

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -57,6 +57,7 @@ class Hdf5(AutotoolsPackage):
     variant('hl', default=False, description='Enable the high-level library')
     variant('cxx', default=False, description='Enable C++ support')
     variant('fortran', default=False, description='Enable Fortran support')
+    variant('java', default=False, description='Enable Java support')
     variant('threadsafe', default=False,
             description='Enable thread-safe capabilities')
 
@@ -78,6 +79,7 @@ class Hdf5(AutotoolsPackage):
     depends_on('m4',       type='build', when='@develop')
 
     depends_on('mpi', when='+mpi')
+    depends_on('java', when='+java')
     # numactl does not currently build on darwin
     if sys.platform != 'darwin':
         depends_on('numactl', when='+mpi+fortran')
@@ -237,6 +239,7 @@ class Hdf5(AutotoolsPackage):
         extra_args += self.enable_or_disable('cxx')
         extra_args += self.enable_or_disable('hl')
         extra_args += self.enable_or_disable('fortran')
+        extra_args += self.enable_or_disable('java')
 
         api = self.spec.variants['api'].value
         if api != 'none':

--- a/var/spack/repos/builtin/packages/hdfview/fix_build.patch
+++ b/var/spack/repos/builtin/packages/hdfview/fix_build.patch
@@ -1,0 +1,12 @@
+diff --git a/build.xml b/build_fixed.xml
+index f0f2c3f..c486cbb 100644
+--- a/build.xml
++++ b/build_fixed.xml
+@@ -943,7 +943,6 @@
+             <!-- Generate list of needed Java modules by using `jdeps` on all JAR files in the release directory -->
+             <apply executable="@{java.bindir}/jdeps" output="${build.dir}/jdeps.pre" append="true" >
+                 <arg value="--print-module-deps" />
+-                <arg value="--ignore-missing-deps" />
+                 <fileset dir="${release.dir}/lib" includes="**/*.jar" />
+             </apply>
+

--- a/var/spack/repos/builtin/packages/hdfview/package.py
+++ b/var/spack/repos/builtin/packages/hdfview/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Hdfview(Package):
+    """HDFView is a visual tool written in Java for browsing
+    and editing HDF (HDF5 and HDF4) files."""
+
+    homepage = "https://www.hdfgroup.org/downloads/hdfview/"
+    url      = "https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDFView/hdfview-3.0.tar.gz"
+
+    version('3.0', sha256='e2a16d3842d8947f3d4f154ee9f48a106c7f445914a9e626a53976d678a0e934')
+
+    depends_on('ant', type='build')
+    depends_on('hdf5 +java')
+    depends_on('hdf +java -external-xdr +shared')
+
+    def install(self, spec, prefix):
+        env['HDF5LIBS'] = spec['hdf5'].prefix
+        env['HDFLIBS'] = spec['hdf'].prefix
+
+        ant = which('ant')
+        ant('deploy')
+        mkdirp(prefix.bin)
+        filter_file(
+            r'\$dir',
+            prefix,
+            'build/HDF_Group/HDFView/3.0.0/hdfview.sh'
+        )
+        install('build/HDF_Group/HDFView/3.0.0/hdfview.sh',
+                join_path(prefix.bin, 'hdfview'))
+        chmod = which('chmod')
+        chmod('+x', join_path(self.prefix.bin, 'hdfview'))
+        install_tree('build/HDF_Group/HDFView/3.0.0', prefix)


### PR DESCRIPTION
[HDFView](https://portal.hdfgroup.org/display/HDFVIEW/HDFView) is a visual tool for browsing and editing HDF4 and HDF5 files.

Additionally, Java variant/dependency has been added to the HDF5 package.
Note: Download links are different for both provided versions. While for version 3.0 an AWS-S3 URL is provided at the bottom of [this page](https://www.hdfgroup.org/downloads/hdfview/) for other versions an exceptional slow [ftp mirror](https://support.hdfgroup.org/ftp/HDF5/prev-releases/HDF-JAVA/hdfview-3.1.1/src/) is used.