### PR TITLE
bugfix: don't redundantly print ChildErrors

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1568,9 +1568,14 @@ class PackageInstaller(object):
             except (Exception, SystemExit) as exc:
                 # Best effort installs suppress the exception and mark the
                 # package as a failure UNLESS this is the explicit package.
-                err = 'Failed to install {0} due to {1}: {2}'
-                tty.error(err.format(pkg.name, exc.__class__.__name__,
-                          str(exc)))
+                if (not isinstance(exc, spack.error.SpackError) or
+                    not exc.printed):
+                    # SpackErrors can be printed by the build process or at
+                    # lower levels -- skip printing if already printed.
+                    # TODO: sort out this and SpackEror.print_context()
+                    err = 'Failed to install {0} due to {1}: {2}'
+                    tty.error(
+                        err.format(pkg.name, exc.__class__.__name__, str(exc)))
 
                 self._update_failed(task, True, exc)
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -180,10 +180,12 @@ def test_show_log_on_error(mock_packages, mock_archive, mock_fetch,
     assert install.error.pkg.name == 'build-error'
     assert 'Full build log:' in out
 
-    # Message shows up for ProcessError (1), ChildError (1), and output (1)
+    print(out)
+
+    # Message shows up for ProcessError (1) and output (1)
     errors = [line for line in out.split('\n')
               if 'configure: error: cannot run C compiled programs' in line]
-    assert len(errors) == 3
+    assert len(errors) == 2
 
 
 def test_install_overwrite(


### PR DESCRIPTION
A bug was introduced in #13100 where ChildErrors would be redundantly printed when raised during a build. We should eventually revisit error handling in builds and figure out what the right separation of responsibilities is for distributed builds, but for now just skip printing.

- [x] SpackErrors were designed to be printed by the forked process, not by the parent, so check if they've alreaady been printed.

@tldahlgren: FYI