### PR TITLE
scons: add fj compiler support with separate file

### DIFF
--- a/var/spack/repos/builtin/packages/scons/fjcompiler.patch
+++ b/var/spack/repos/builtin/packages/scons/fjcompiler.patch
@@ -1,0 +1,179 @@
+diff -u -r -N a/engine/SCons/Tool/fcc.py b/engine/SCons/Tool/fcc.py
+--- a/engine/SCons/Tool/fcc.py	1970-01-01 09:00:00.000000000 +0900
++++ b/engine/SCons/Tool/fcc.py	2020-07-21 17:28:12.000000000 +0900
+@@ -0,0 +1,82 @@
++"""SCons.Tool.fcc
++
++Tool-specific initialization for Fujitsu C/C++ compiler.
++
++There normally shouldn't be any need to import this module directly.
++It will usually be imported through the generic SCons.Tool.Tool()
++selection method.
++
++"""
++
++#
++# Copyright (c) 2001 - 2019 The SCons Foundation
++#
++# Permission is hereby granted, free of charge, to any person obtaining
++# a copy of this software and associated documentation files (the
++# "Software"), to deal in the Software without restriction, including
++# without limitation the rights to use, copy, modify, merge, publish,
++# distribute, sublicense, and/or sell copies of the Software, and to
++# permit persons to whom the Software is furnished to do so, subject to
++# the following conditions:
++#
++# The above copyright notice and this permission notice shall be included
++# in all copies or substantial portions of the Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
++# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
++# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
++# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
++# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
++# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++#
++
++__revision__ = "src/engine/SCons/Tool/fcc.py bee7caf9defd6e108fc2998a2520ddb36a967691 2019-12-17 02:07:09 bdeegan"
++
++from . import cc
++from . import cxx
++import os
++import re
++import subprocess
++
++import SCons.Util
++import SCons.Tool
++
++from . import gcc
++
++compilers = ['fcc']
++
++
++def generate(env):
++    """Add Builders and construction variables for Fujitsu C/C++ compiler to an Environment."""
++    static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
++
++    if 'CC' not in env:
++        env['CC'] = env.Detect(compilers) or compilers[0]
++
++    cc.generate(env)
++
++    env['SHCCFLAGS'] = SCons.Util.CLVar('$CCFLAGS -fPIC')
++    # determine C compiler version
++    version = gcc.detect_version(env, env['CC'])
++    if version:
++        env['CCVERSION'] = version
++
++    if 'CXX' not in env:
++        env['CXX'] = env.Detect('FCC') or 'FCC'
++
++    cxx.generate(env)
++
++    # determine C++ compiler version
++    version = gcc.detect_version(env, env['CXX'])
++    if version:
++        env['CXXVERSION'] = version
++
++def exists(env):
++    return env.Detect(compilers)
++
++# Local Variables:
++# tab-width:4
++# indent-tabs-mode:nil
++# End:
++# vim: set expandtab tabstop=4 shiftwidth=4:
+diff -u -r -N a/engine/SCons/Tool/frt.py b/engine/SCons/Tool/frt.py
+--- a/engine/SCons/Tool/frt.py	1970-01-01 09:00:00.000000000 +0900
++++ b/engine/SCons/Tool/frt.py	2020-07-21 17:28:57.000000000 +0900
+@@ -0,0 +1,63 @@
++"""SCons.Tool.frt
++
++Tool-specific initialization for frt, the Fujitsu Fortran 95/Fortran
++2003 compiler.
++
++There normally shouldn't be any need to import this module directly.
++It will usually be imported through the generic SCons.Tool.Tool()
++selection method.
++
++"""
++
++#
++# Copyright (c) 2001 - 2019 The SCons Foundation
++#
++# Permission is hereby granted, free of charge, to any person obtaining
++# a copy of this software and associated documentation files (the
++# "Software"), to deal in the Software without restriction, including
++# without limitation the rights to use, copy, modify, merge, publish,
++# distribute, sublicense, and/or sell copies of the Software, and to
++# permit persons to whom the Software is furnished to do so, subject to
++# the following conditions:
++#
++# The above copyright notice and this permission notice shall be included
++# in all copies or substantial portions of the Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
++# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
++# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
++# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
++# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
++# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++#
++
++__revision__ = "src/engine/SCons/Tool/frt.py bee7caf9defd6e108fc2998a2520ddb36a967691 2019-12-17 02:07:09 bdeegan"
++
++import SCons.Util
++
++from . import fortran
++
++def generate(env):
++    """Add Builders and construction variables for frt to an
++    Environment."""
++    fortran.generate(env)
++
++    for dialect in ['F77', 'F90', 'FORTRAN', 'F95', 'F03', 'F08']:
++        env['%s' % dialect] = 'frt'
++        env['SH%s' % dialect] = 'frt'
++        env['SH%sFLAGS' % dialect] = SCons.Util.CLVar('$%sFLAGS -fPIC' % dialect)
++
++        env['INC%sPREFIX' % dialect] = "-I"
++        env['INC%sSUFFIX' % dialect] = ""
++
++    env['FORTRANMODDIRPREFIX'] = "-M"
++
++def exists(env):
++    return env.Detect('frt')
++
++# Local Variables:
++# tab-width:4
++# indent-tabs-mode:nil
++# End:
++# vim: set expandtab tabstop=4 shiftwidth=4:
+diff -u -r -N a/engine/SCons/Tool/__init__.py b/engine/SCons/Tool/__init__.py
+--- a/engine/SCons/Tool/__init__.py	2020-07-21 11:39:14.000000000 +0900
++++ b/engine/SCons/Tool/__init__.py	2020-07-21 16:30:54.000000000 +0900
+@@ -1259,10 +1259,10 @@
+     else:
+         "prefer GNU tools on all other platforms"
+         linkers = ['gnulink', 'ilink']
+-        c_compilers = ['gcc', 'intelc', 'icc', 'cc']
+-        cxx_compilers = ['g++', 'intelc', 'icc', 'cxx']
++        c_compilers = ['fcc', 'gcc', 'intelc', 'icc', 'cc']
++        cxx_compilers = ['fcc', 'g++', 'intelc', 'icc', 'cxx']
+         assemblers = ['gas', 'nasm', 'masm']
+-        fortran_compilers = ['gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
++        fortran_compilers = ['frt', 'gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
+         ars = ['ar', ]
+ 
+     if not str(platform) == 'win32':
+@@ -1282,7 +1282,7 @@
+         ar = None
+     else:
+         # Don't use g++ if the C compiler has built-in C++ support:
+-        if c_compiler in ('msvc', 'intelc', 'icc'):
++        if c_compiler in ('msvc', 'intelc', 'icc', 'fcc'):
+             cxx_compiler = None
+         else:
+             cxx_compiler = FindTool(cxx_compilers, env) or cxx_compilers[0]

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -25,14 +25,7 @@ class Scons(PythonPackage):
     depends_on('python@:2', when='@:2', type=('build', 'run'))
     depends_on('py-setuptools', when='@3.0.2:', type='build')
 
-    def patch(self):
-        if self.spec.satisfies('%fj'):
-            filter_file(
-                'env[\'FORTRANMODDIRPREFIX\'] = "-J"',
-                'env[\'FORTRANMODDIRPREFIX\'] = "-M"',
-                'engine/SCons/Tool/gfortran.py',
-                string=True
-            )
+    patch('fjcompiler.patch', when='%fj')
 
     # Prevent passing --single-version-externally-managed to
     # setup.py, which it does not support.


### PR DESCRIPTION
I added `frt.py` and `fcc.py` to recognize and support Fujitsu compilers 
as original compiler, not as `gcc` or `gfortran`.
Removed patch to `gfortran.py`