### PR TITLE
Backport Mesa MR#6053

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/multiple-symbols_hash.patch
+++ b/var/spack/repos/builtin/packages/mesa/multiple-symbols_hash.patch
@@ -1,0 +1,22 @@
+--- a/src/gallium/auxiliary/util/u_debug_stack.c	2019-11-07 17:57:36.000000000 -0700
++++ b/src/gallium/auxiliary/util/u_debug_stack.c	2020-07-23 15:30:46.033145497 -0600
+@@ -46,7 +46,7 @@
+ #include "os/os_thread.h"
+ #include "u_hash_table.h"
+ 
+-struct util_hash_table* symbols_hash;
++static struct util_hash_table* symbols_hash;
+ static mtx_t symbols_mutex = _MTX_INITIALIZER_NP;
+ 
+ static unsigned hash_ptr(void* p)
+--- a/src/gallium/auxiliary/util/u_debug_symbol.c	2019-11-07 17:58:53.000000000 -0700
++++ b/src/gallium/auxiliary/util/u_debug_symbol.c	2020-07-23 15:31:06.400146072 -0600
+@@ -270,7 +270,7 @@
+    debug_printf("\t%s\n", buf);
+ }
+ 
+-struct util_hash_table* symbols_hash;
++static struct util_hash_table* symbols_hash;
+ static mtx_t symbols_mutex = _MTX_INITIALIZER_NP;
+ 
+ static unsigned hash_ptr(void* p)

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -79,6 +79,9 @@ class Mesa(AutotoolsPackage):
     # Prevent an unnecessary xcb-dri dependency
     patch('autotools-x11-nodri.patch')
 
+    # Backport Mesa MR#6053 to prevent multiply-defined symbols
+    patch('multiple-symbols_hash.patch', when='@:20.1.4%gcc@10:')
+
     def autoreconf(self, spec, prefix):
         which('autoreconf')('--force',  '--verbose', '--install')
 


### PR DESCRIPTION
This PR backports Mesa upstream MR#6053 which is needed to compile with `gcc@10` due to its default `-fno-common`.  This patch is slated for Mesa version 20.1.5.