### PR TITLE
tutorial: Add boto3 installation to setup script

### DIFF
--- a/share/spack/setup-tutorial-env.sh
+++ b/share/spack/setup-tutorial-env.sh
@@ -58,6 +58,12 @@ until sudo apt-get install -y --no-install-recommends \
 done
 
 ####
+# Upgrade boto3 python package on AWS systems
+####
+pip3 install --upgrade boto3
+
+
+####
 # Spack configuration settings for tutorial
 ####
 


### PR DESCRIPTION
We seem to get spurious download errors if we use an old version of `boto3`.

- [x] Update the boto3 installation on tutorial EC2 instances in `setup-tutorial-env.sh`.