### PR TITLE
amrvis: use libquadmath only x86_64 and ppcle.

### DIFF
--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -73,6 +73,17 @@ class Amrvis(MakefilePackage):
              placement='amrex')
 
     def edit(self, spec, prefix):
+        # libquadmath is only available x86_64 and powerle
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85440
+        if self.spec.target.family not in ['x86_64', 'ppc64le']:
+            comps = join_path('amrex', 'Tools', 'GNUMake', 'comps')
+            maks = [
+                join_path(comps, 'gnu.mak'),
+                join_path(comps, 'llvm.mak'),
+            ]
+            for mak in maks:
+                filter_file('-lquadmath', '', mak)
+
         # Set all available makefile options to values we want
         makefile = FileFilter('GNUmakefile')
         makefile.filter(


### PR DESCRIPTION
When gcc compiler is used, armvis add libquadmath.
But libquadmath is enabled only x86_64 and ppc64le.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85440

This PR is removed -lquaddmath when target is not x86_64 or ppc64.