### PR TITLE
Bazel: relax Java dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -96,14 +96,7 @@ class Bazel(Package):
 
     variant('nodepfail', default=True, description='Disable failing dependency checks due to injected absolute paths - required for most builds using bazel with spack')
 
-    # https://docs.bazel.build/versions/master/install-compile-source.html#bootstrap-bazel
-    # Until https://github.com/spack/spack/issues/14058 is fixed, use jdk to build bazel
-    # Strict dependency on java@8 as per
-    # https://docs.bazel.build/versions/master/install-compile-source.html#bootstrap-unix-prereq
-    if platform.machine() == 'aarch64':
-        depends_on('java@8:8.999', type=('build', 'run'))
-    else:
-        depends_on('jdk@1.8.0:1.8.999', type=('build', 'run'))
+    depends_on('java', type=('build', 'run'))
     depends_on('python', type=('build', 'run'))
     depends_on('zip', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-import platform
-
 
 class Bazel(Package):
     """Bazel is an open-source build and test tool similar to Make, Maven, and


### PR DESCRIPTION
I know we've gone back and forth with this before (see #14058, #14234, #16350, etc) but I wanted to reopen this discussion.

I propose we relax the Java dependency and let users build with whatever version of Java they want. Oracle JDK 8 can no longer be downloaded automatically, so that makes it problematic in many ways. I have OpenJDK 11.0.7 on my Ubuntu 20.04 instance and it builds Bazel just fine.

Pinging some interested parties: @lee218llnl @healther @coreyjadams @Sinan81 @s-sajid-ali @darmac 

Closes #14058