### PR TITLE
TensorFlow: add v2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -11,11 +11,12 @@ class PyTensorflow(Package, CudaPackage):
     """
 
     homepage = "https://www.tensorflow.org"
-    url      = "https://github.com/tensorflow/tensorflow/archive/v2.2.0.tar.gz"
+    url      = "https://github.com/tensorflow/tensorflow/archive/v2.3.0.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = ['tensorflow']
 
+    version('2.3.0',  sha256='2595a5c401521f20a2734c4e5d54120996f8391f00bb62a57267d930bce95350')
     version('2.2.0',  sha256='69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3')
     version('2.1.1',  sha256='a200bc16e4b630db3ac7225bcb6f239a76841967b0aec1d7d7bbe44dc5661318')
     version('2.1.0',  sha256='638e541a4981f52c69da4a311815f1e7989bf1d67a41d204511966e1daed14f7')
@@ -94,7 +95,8 @@ class PyTensorflow(Package, CudaPackage):
     # Need to investigate further.
 
     # See _TF_MIN_BAZEL_VERSION and _TF_MAX_BAZEL_VERSION in configure.py
-    depends_on('bazel@2.0.0',         type='build', when='@2.2:')
+    depends_on('bazel@3.1.0:3.99.0',  type='build', when='@2.3:')
+    depends_on('bazel@2.0.0',         type='build', when='@2.2.0:2.2.999')
     depends_on('bazel@0.27.1:0.29.1', type='build', when='@2.1.0:2.1.999')
     depends_on('bazel@0.24.1:0.26.1', type='build', when='@1.15:2.0')
     # See call to check_bazel_version in configure.py
@@ -138,6 +140,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-keras-applications@1.0.8:', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-keras-applications@1.0.6:', type=('build', 'run'), when='@1.12:1.14')
     depends_on('py-keras-applications@1.0.5:', type=('build', 'run'), when='@1.11.0:1.11.999')
+    depends_on('py-keras-preprocessing@1.1.1:1.999', type=('build', 'run'), when='@2.3:')
     depends_on('py-keras-preprocessing@1.1.0:', type=('build', 'run'), when='@2.1:')
     depends_on('py-keras-preprocessing@1.0.5:', type=('build', 'run'), when='@1.12:')
     depends_on('py-keras-preprocessing@1.0.3:', type=('build', 'run'), when='@1.11:')
@@ -152,6 +155,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-numpy@1.8.2:',        type=('build', 'run'), when='@0.6:')
     depends_on('py-numpy@1.9.2:',        type=('build', 'run'), when='@0.5.0')
     depends_on('py-opt-einsum@2.3.2:', type=('build', 'run'), when='@1.15:')
+    depends_on('py-protobuf@3.9.2:', type=('build', 'run'), when='@2.3:')
     depends_on('py-protobuf@3.8.0:', type=('build', 'run'), when='@2.1:')
     depends_on('py-protobuf@3.6.1:', type=('build', 'run'), when='@1.12:')
     depends_on('py-protobuf@3.6.0:', type=('build', 'run'), when='@1.10:')
@@ -522,7 +526,7 @@ class PyTensorflow(Package, CudaPackage):
         mkdirp(tmp_path)
         env.set('TEST_TMPDIR', tmp_path)
 
-        env.set('TF_SYSTEM_LIBS', 'com_google_protobuf')
+        #env.set('TF_SYSTEM_LIBS', 'com_google_protobuf')
         # NOTE: INCLUDEDIR is not just relevant to protobuf
         # see third_party/systemlibs/jsoncpp.BUILD
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -532,7 +532,7 @@ class PyTensorflow(Package, CudaPackage):
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)
 
     def patch(self):
-        if spec.satisfies('@2.3.0'):
+        if self.spec.satisfies('@2.3.0'):
             filter_file('deps = protodeps + well_known_proto_libs(),',
                         'deps = protodeps,',
                         'tensorflow/core/platform/default/build_config.bzl',

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -526,10 +526,17 @@ class PyTensorflow(Package, CudaPackage):
         mkdirp(tmp_path)
         env.set('TEST_TMPDIR', tmp_path)
 
-        #env.set('TF_SYSTEM_LIBS', 'com_google_protobuf')
+        env.set('TF_SYSTEM_LIBS', 'com_google_protobuf')
         # NOTE: INCLUDEDIR is not just relevant to protobuf
         # see third_party/systemlibs/jsoncpp.BUILD
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)
+
+    def patch(self):
+        if spec.satisfies('@2.3.0'):
+            filter_file('deps = protodeps + well_known_proto_libs(),',
+                        'deps = protodeps,',
+                        'tensorflow/core/platform/default/build_config.bzl',
+                        string=True)
 
     def configure(self, spec, prefix):
         # NOTE: configure script is interactive. If you set the appropriate


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.7 and GCC 9.3.0 (via WSL)

https://github.com/tensorflow/tensorflow/releases/tag/v2.3.0

@aweits I had to disable the change made in #16258 in order to get this to compile. I'll post the exact error message soon. We should figure this out before merging this PR.

Depends on #17735