### PR TITLE
add `PYTHONPATH` to the variables to be passed down to `spconfig.py` from `spack setup`

### DIFF
--- a/lib/spack/spack/cmd/setup.py
+++ b/lib/spack/spack/cmd/setup.py
@@ -55,6 +55,7 @@ def write_spconfig(package, dirty):
     env['CC'] = os.environ['SPACK_CC']
     env['CXX'] = os.environ['SPACK_CXX']
     env['FC'] = os.environ['SPACK_FC']
+    env['PYTHONPATH'] = os.environ['PYTHONPATH']
 
     setup_fname = 'spconfig.py'
     with open(setup_fname, 'w') as fout:


### PR DESCRIPTION
Currently a CMake package that requires `PYTHONPATH` will not work with the `spack setup` workflow. This patch adds `PYTHONPATH` to the variables that are setup in `spconfig.py`. 

I don't see any tests currently for `spack setup` so I haven't written one here. And I wouldn't really know where to start in writing a test for this kind of use case. However I hope this patch is simple and pretty obvious... 