### PR TITLE
Work around MacOS failures on Github Actions

### DIFF
--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -137,7 +137,7 @@ def test_all_packages_use_sha256_checksums():
                 if bad_digest:
                     errors.append(
                         "All packages must use sha256 checksums."
-                        "Resource in %s uses %s." % (name, v, bad_digest)
+                        "Resource in %s@%s uses %s." % (name, v, bad_digest)
                     )
 
     assert [] == errors

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -6,6 +6,7 @@
 """This test does sanity checks on Spack's builtin package database."""
 import os.path
 import re
+import sys
 
 import pytest
 
@@ -163,6 +164,9 @@ def test_api_for_build_and_run_environment():
 
 @pytest.mark.skipif(
     not executable.which('git'), reason='requires git to be installed'
+)
+@pytest.mark.xfail(
+    sys.platform == 'darwin', reason='started failing on Github Actions'
 )
 def test_prs_update_old_api():
     """Ensures that every package modified in a PR doesn't contain


### PR DESCRIPTION
There's a test that started failing consistently around yesterday on MacOS. The issue is a `git diff` command that can't find the merge base to compute the list of files which changed in a PR:
```console
'/usr/local/bin/git' 'diff' '--name-only' '--diff-filter=ACMR' 'develop...'
fatal: develop...HEAD: no merge base
```
Oddly enough the same command succeeds on linux for the same merge commit and repository. An example of a failure can be found [here](https://github.com/spack/spack/pull/17732/checks?check_run_id=919374994).