### PR TITLE
New package: kassiopeia

### DIFF
--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -46,12 +46,20 @@ class Kassiopeia(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if self.spec.variants['vtk']:
+        if self.spec.satisfies('+vtk'):
             args.extend(['-DKASPER_USE_VTK=ON'])
-        if self.spec.variants['tbb']:
+        else:
+            args.extend(['-DKASPER_USE_VTK=OFF'])
+        if self.spec.satisfies('+tbb'):
             args.extend(['-DKASPER_USE_TBB=ON'])
-        if self.spec.variants['mpi']:
+        else:
+            args.extend(['-DKASPER_USE_TBB=OFF'])
+        if self.spec.satisfies('+mpi'):
             args.extend(['-DKEMField_USE_MPI=ON'])
-        if self.spec.variants['vtk']:
+        else:
+            args.extend(['-DKEMField_USE_MPI=OFF'])
+        if self.spec.satisfies('+opencl'):
             args.extend(['-DKEMField_USE_OPENCL=ON'])
+        else:
+            args.extend(['-DKEMField_USE_OPENCL=OFF'])
         return args

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -15,7 +15,6 @@ class Kassiopeia(CMakePackage):
 
     maintainers = ['wdconinc']
 
-    version('master',  branch='master')
     version('3.7.5', sha256='8f28d08c7ef51e64221e0a4705f3cee3a5d738b8cdde5ce9fa58a3a0dd14ae05')
     version('3.7.4', sha256='c1514163a084530930be10dbe487fb1950ccbc9662a4a190bdecffbd84a71fd4')
     version('3.7.3', sha256='a8753585b9fa0903e1f5f821c4ced3cddd72792ad7e6075a7e25318f81ad9eaa')
@@ -37,10 +36,10 @@ class Kassiopeia(CMakePackage):
     variant("opencl", default=False,
             description="Include OpenCL support for field calculations")
 
-    depends_on('cmake@3.2:', type='build')
+    depends_on('cmake@3.13:', type='build')
     depends_on('zlib')
-    depends_on('root', when='+root')
-    depends_on('vtk', when='+vtk')
+    depends_on('root@6.0.0:', when='+root')
+    depends_on('vtk@6.1:', when='+vtk')
     depends_on('openmpi', when='+mpi')
     depends_on('intel-tbb', when='+tbb')
     depends_on('opencl', when='+opencl')

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -1,0 +1,58 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Kassiopeia(CMakePackage):
+    """Simulation of electric and magnetic fields and particle tracking."""
+
+    homepage = "https://katrin-experiment.github.io/Kassiopeia/"
+    url      = "https://github.com/KATRIN-Experiment/Kassiopeia/archive/v3.6.1.tar.gz"
+    git      = "https://github.com/KATRIN-Experiment/Kassiopeia.git"
+
+    maintainers = ['wdconinc']
+
+    version('master',  branch='master')
+    version('3.7.5', sha256='8f28d08c7ef51e64221e0a4705f3cee3a5d738b8cdde5ce9fa58a3a0dd14ae05')
+    version('3.7.4', sha256='c1514163a084530930be10dbe487fb1950ccbc9662a4a190bdecffbd84a71fd4')
+    version('3.7.3', sha256='a8753585b9fa0903e1f5f821c4ced3cddd72792ad7e6075a7e25318f81ad9eaa')
+    version('3.7.2', sha256='bdfdf8c26fa5ad19e8b9c6eb600dfbd3c8218cd695ce067f10633b63bd192f92')
+    version('3.7.1', sha256='b22ae2fe5c2271bdf6aaf65d9ecf57ff0d6a88d28ad26d176e1129f0e58faea4')
+    version('3.7.0', sha256='32a3e98c77d1b97fe9862cf1d8c6ba8e6c82fb9295a6a217c7ce77cbec751046')
+    version('3.6.1', sha256='30193d5384ad81b8570fdcd1bb35b15cc365ab84712819ac0d989c6f5cf6f790')
+    version('3.5.0', sha256='b704d77bd182b2806dc8323f642d3197ce21dba3d456430f594b19a7596bda22')
+    version('3.4.0', sha256='4e2bca61011e670186d49048aea080a06c3c95dacf4b79e7549c36960b4557f4')
+
+    variant("root", default=False,
+            description="Include support for writing ROOT files")
+    variant("vtk", default=False,
+            description="Include visualization support through VTK")
+    variant("mpi", default=False,
+            description="Include MPI support for field calculations")
+    variant("tbb", default=False,
+            description="Include Intel TBB support for field calculations")
+    variant("opencl", default=False,
+            description="Include OpenCL support for field calculations")
+
+    depends_on('cmake@3.2:', type='build')
+    depends_on('zlib')
+    depends_on('root', when='+root')
+    depends_on('vtk', when='+vtk')
+    depends_on('openmpi', when='+mpi')
+    depends_on('intel-tbb', when='+tbb')
+    depends_on('opencl', when='+opencl')
+
+    def cmake_args(self):
+        args = []
+        if self.spec.variants['vtk']:
+            args.extend(['-DKASPER_USE_VTK=ON'])
+        if self.spec.variants['tbb']:
+            args.extend(['-DKASPER_USE_TBB=ON'])
+        if self.spec.variants['mpi']:
+            args.extend(['-DKEMField_USE_MPI=ON'])
+        if self.spec.variants['vtk']:
+            args.extend(['-DKEMField_USE_OPENCL=ON'])
+        return args

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -47,19 +47,19 @@ class Kassiopeia(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies('+vtk'):
-            args.extend(['-DKASPER_USE_VTK=ON'])
+            args.append('-DKASPER_USE_VTK=ON')
         else:
-            args.extend(['-DKASPER_USE_VTK=OFF'])
+            args.append('-DKASPER_USE_VTK=OFF')
         if self.spec.satisfies('+tbb'):
-            args.extend(['-DKASPER_USE_TBB=ON'])
+            args.append('-DKASPER_USE_TBB=ON')
         else:
-            args.extend(['-DKASPER_USE_TBB=OFF'])
+            args.append('-DKASPER_USE_TBB=OFF')
         if self.spec.satisfies('+mpi'):
-            args.extend(['-DKEMField_USE_MPI=ON'])
+            args.append('-DKEMField_USE_MPI=ON')
         else:
-            args.extend(['-DKEMField_USE_MPI=OFF'])
+            args.append('-DKEMField_USE_MPI=OFF')
         if self.spec.satisfies('+opencl'):
-            args.extend(['-DKEMField_USE_OPENCL=ON'])
+            args.append('-DKEMField_USE_OPENCL=ON')
         else:
-            args.extend(['-DKEMField_USE_OPENCL=OFF'])
+            args.append('-DKEMField_USE_OPENCL=OFF')
         return args

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -41,7 +41,7 @@ class Kassiopeia(CMakePackage):
     depends_on('root@6.0.0:', when='+root')
     depends_on('vtk@6.1:', when='+vtk')
     depends_on('openmpi', when='+mpi')
-    depends_on('intel-tbb', when='+tbb')
+    depends_on('tbb', when='+tbb')
     depends_on('opencl', when='+opencl')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -40,7 +40,7 @@ class Kassiopeia(CMakePackage):
     depends_on('zlib')
     depends_on('root@6.0.0:', when='+root')
     depends_on('vtk@6.1:', when='+vtk')
-    depends_on('openmpi', when='+mpi')
+    depends_on('mpi', when='+mpi')
     depends_on('tbb', when='+tbb')
     depends_on('opencl', when='+opencl')
 


### PR DESCRIPTION
Kassiopeia allows to run highly customizable particle tracking simulations along with calculations of electric and magnetic fields. 

Link: https://github.com/KATRIN-Experiment/Kassiopeia

(Part of an effort to contribute spack packages from the Electron-Ion Collider repository to the broader NP and HEP community.)
