### PR TITLE
MAGMA isn't compatible with CUDA 11

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -36,7 +36,7 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
-    depends_on('cuda@:10.2.89') # Incompatible with CUDA 11
+    depends_on('cuda@:10.2.89')  # Incompatible with CUDA 11
 
     conflicts('~cuda', msg='Magma requires cuda')
     conflicts('cuda_arch=none',

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -36,7 +36,7 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
-    depends_on('cuda@:10.2.89')  # Incompatible with CUDA 11
+    depends_on('cuda@:10.2.89', when='@:2.5.3')  # incompatible with CUDA 11
 
     conflicts('~cuda', msg='Magma requires cuda')
     conflicts('cuda_arch=none',

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -36,6 +36,7 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
+    depends_on('cuda@:10.2.89') # Incompatible with CUDA 11
 
     conflicts('~cuda', msg='Magma requires cuda')
     conflicts('cuda_arch=none',

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -36,7 +36,7 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
-    depends_on('cuda@:10.2.89', when='@:2.5.3')  # incompatible with CUDA 11
+    depends_on('cuda@:10', when='@:2.5.3')  # incompatible with CUDA 11
 
     conflicts('~cuda', msg='Magma requires cuda')
     conflicts('cuda_arch=none',


### PR DESCRIPTION
The upgrade from CUDA 10 to 11 has broken some packages.  This update will prevent magma from being built with cuda 11.