### PR TITLE
Detecting changed files: don't use version range for detached commit

### DIFF
--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -103,7 +103,7 @@ def changed_files(base=None, untracked=True, all_files=False):
 
     git_args = [
         # Add changed files committed since branching off of develop
-        ['diff', '--name-only', '--diff-filter=ACMR', base],
+        ['diff', '--name-only', '--diff-filter=ACMR', str(base)],
         # Add changed files that have been staged but not yet committed
         ['diff', '--name-only', '--diff-filter=ACMR', '--cached'],
         # Add changed files that are unstaged

--- a/lib/spack/spack/cmd/flake8.py
+++ b/lib/spack/spack/cmd/flake8.py
@@ -101,11 +101,9 @@ def changed_files(base=None, untracked=True, all_files=False):
     if base is None:
         base = os.environ.get('TRAVIS_BRANCH', 'develop')
 
-    range = "{0}...".format(base)
-
     git_args = [
         # Add changed files committed since branching off of develop
-        ['diff', '--name-only', '--diff-filter=ACMR', range],
+        ['diff', '--name-only', '--diff-filter=ACMR', base],
         # Add changed files that have been staged but not yet committed
         ['diff', '--name-only', '--diff-filter=ACMR', '--cached'],
         # Add changed files that are unstaged


### PR DESCRIPTION
(EDIT: this is better resolved by https://github.com/spack/spack/pull/17732/files although it summarizes the issue, so I've added a close tag to that PR and this will be automatically closed when that is merged)

See also: https://github.com/spack/spack/pull/17738

From https://git-scm.com/docs/git-diff

> `git diff [<options>] <commit>...<commit> [--] [<path>…​]`
> `This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>. "git diff A...B" is equivalent to "git diff $(git merge-base A B) B". You can omit any one of <commit>, which has the same effect as using HEAD instead.`

`spack.cmd.flake8.changed_files` runs 

`'/usr/local/bin/git' 'diff' '--name-only' '--diff-filter=ACMR' 'develop...'`

Which (from the linked documentation) will involve calling `git merge-base develop...HEAD`

However, the commands which set up the git repository result in a detached head with no discernable merge-base, e.g. from  https://github.com/spack/spack/pull/17733/checks?check_run_id=920605207:

```
git init test1
git remote add origin https://github.com/spack/spack
git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +893837c02773b007384c0de343baa43223cda865:refs/remotes/pull/17733/merge
git checkout --progress --force refs/remotes/pull/17733/merge
```

For some reason, Git versions before 2.28.0 on Mac OS (and including that on Ubuntu) tolerate the fact that `git merge-base develop...HEAD` returns nothing. However, 2.28.0 on Mac OS rejects `git diff develop...HEAD` with:

`fatal: HEAD...develop: no merge base`

To resolve this, the PR uses the `git diff` format which compares two arbitrary commits, for example: `git diff develop`
