### PR TITLE
Add variants to squashfs for different compression algorithms

### DIFF
--- a/var/spack/repos/builtin/packages/squashfs/package.py
+++ b/var/spack/repos/builtin/packages/squashfs/package.py
@@ -19,15 +19,43 @@ class Squashfs(MakefilePackage):
     version('4.1', sha256='3a870d065a25b3f5467bc6d9ed34340befab51a3f9e4b7e3792ea0ff4e06046a')
     version('4.0', sha256='18948edbe06bac2c4307eea99bfb962643e4b82e5b7edd541b4d743748e12e21')
 
+    variant('gzip', default=True, description='Enable gzip compression support')
+    variant('lz4', default=False, description='Enable LZ4 compression support')
+    variant('lzo', default=False, description='Enable LZO compression support')
+    variant('xz', default=False, description='Enable xz compression support')
+    variant('zstd', default=False, description='Enable Zstandard/zstd support')
+    variant('default_compression', default='gzip', values=('gzip', 'lz4', 'lzo', 'xz', 'zstd'), 
+            multi=False, description='Default compression algorithm')
+
+    conflicts('squashfs~gzip default_compression=gzip', msg='Cannot set default compression to missing algorithm')
+    conflicts('squashfs~lz4 default_compression=lz4', msg='Cannot set default compression to missing algorithm')
+    conflicts('squashfs~lzo default_compression=lzo', msg='Cannot set default compression to missing algorithm')
+    conflicts('squashfs~xz default_compression=xz', msg='Cannot set default compression to missing algorithm')
+    conflicts('squashfs~zstd default_compression=zstd', msg='Cannot set default compression to missing algorithm')
+
     depends_on('m4',       type='build')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('zlib')
+
+    depends_on('zlib', when='+gzip')
+    depends_on('lz4', when='+lz4')
+    depends_on('lzo', when='+lzo')
+    depends_on('xz', when='+xz')
+    depends_on('zstd', when='+zstd')
 
     def build(self, spec, prefix):
         with working_dir('squashfs-tools'):
-            make(parallel=False)
+            default = spec.variants['default_compression'].value
+            make(
+                'GZIP_SUPPORT={0}'.format(1 if '+gzip' in spec else 0),
+                'LZ4_SUPPORT={0}' .format(1 if '+lz4'  in spec else 0),
+                'LZO_SUPPORT={0}' .format(1 if '+lzo'  in spec else 0),
+                'XZ_SUPPORT={0}'  .format(1 if '+xz'   in spec else 0),
+                'ZSTD_SUPPORT={0}'.format(1 if '+zstd' in spec else 0),
+                'COMP_DEFAULT={0}'.format(default),
+                parallel=False
+            )
 
     def install(self, spec, prefix):
         with working_dir('squashfs-tools'):


### PR DESCRIPTION
Currently squashfs only provides `gzip`, but the default on e.g. Ubuntu 20.04 is to provide `gzip (default)`, `lzma`, `lzo`, `lz4`, `xz`, `zstd`. With this PR we have those available as well, but the user has to enable them with variants.
