### PR TITLE
dcmtk: fixed type error

### DIFF
--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -37,6 +37,16 @@ class Dcmtk(CMakePackage):
     variant('cxx11', default=False, description="Enable c++11 features")
     variant('stl', default=True, description="Use native STL implementation")
 
+    def patch(self):
+        # Backport 3.6.4
+        if self.spec.satisfies('%fj') and self.spec.satisfies('@:3.6.3'):
+            filter_file(
+                'OFintegral_constant<size_t,-1>',
+                'OFintegral_constant<size_t,~OFstatic_cast(size_t,0)>',
+                'ofstd/include/dcmtk/ofstd/variadic/helpers.h',
+                string=True
+            )
+
     def cmake_args(self):
         args = ["-DDCMTK_WITH_OPENSSL={0}".format(
             'ON' if '+ssl' in self.spec else 'OFF')]

--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -39,7 +39,7 @@ class Dcmtk(CMakePackage):
 
     def patch(self):
         # Backport 3.6.4
-        if self.spec.satisfies('%fj') and self.spec.satisfies('@:3.6.3'):
+        if self.spec.satisfies('@:3.6.3 %fj'):
             filter_file(
                 'OFintegral_constant<size_t,-1>',
                 'OFintegral_constant<size_t,~OFstatic_cast(size_t,0)>',


### PR DESCRIPTION
Backport DCMTK 3.6.4 changes
https://github.com/DCMTK/dcmtk/commits/master/ofstd/include/dcmtk/ofstd/variadic/helpers.h

- Re-fixed the clang conversion issue from yesterday.
- Fixed a compile time type conversion issue on clang.

These changes are already merged after 3.6.4. 
So I added `self.spec.satisfies('@:3.6.3')`