### PR TITLE
slate package: resolve issues with cuda version and fortran compiler name

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -25,7 +25,7 @@ class Slate(Package):
     variant('mpi',    default=True, description='Build with MPI support.')
     variant('openmp', default=True, description='Build with OpenMP support.')
 
-    depends_on('cuda@9:10.2.89', when='+cuda')
+    depends_on('cuda@9:10', when='+cuda')
     depends_on('intel-mkl')
     depends_on('mpi', when='+mpi')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -25,7 +25,7 @@ class Slate(Package):
     variant('mpi',    default=True, description='Build with MPI support.')
     variant('openmp', default=True, description='Build with OpenMP support.')
 
-    depends_on('cuda@9:', when='+cuda')
+    depends_on('cuda@9:10.2.89', when='+cuda')
     depends_on('intel-mkl')
     depends_on('mpi', when='+mpi')
 
@@ -41,10 +41,13 @@ class Slate(Package):
         f_mpi = "1" if spec.variants['mpi'].value else "0"
         f_openmp = "1" if spec.variants['openmp'].value else "0"
 
-        compiler = 'mpicxx' if spec.variants['mpi'].value else ''
+        comp_cxx = comp_for = ''
+        if spec.variants['mpi'].value:
+            comp_cxx = 'mpicxx'
+            comp_for = 'mpif90'
 
         make('mpi=' + f_mpi, 'mkl=1', 'cuda=' + f_cuda, 'openmp=' + f_openmp,
-             'CXX=' + compiler)
+             'CXX=' + comp_cxx, 'FC=' + comp_for)
         install_tree('lib', prefix.lib)
         install_tree('test', prefix.test)
         mkdirp(prefix.include)

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -42,7 +42,7 @@ class Slate(Package):
         f_openmp = "1" if spec.variants['openmp'].value else "0"
 
         comp_cxx = comp_for = ''
-        if spec.variants['mpi'].value:
+        if '+mpi' in spec:
             comp_cxx = 'mpicxx'
             comp_for = 'mpif90'
 


### PR DESCRIPTION
This change sets the compatible CUDA version (disallows use of CUDA 11) and adds a required build parameter "FC=".

@becker33 @ax3l 