### PR TITLE
erlang: add depends_on('ncurses', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/erlang/package.py
+++ b/var/spack/repos/builtin/packages/erlang/package.py
@@ -27,3 +27,4 @@ class Erlang(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('m4', type='build')
     depends_on('libtool', type='build')
+    depends_on('ncurses', type='link')


### PR DESCRIPTION
The following errors occurred.
An ncurses dependency needs to be added.
```
==> Error: ProcessError: Command exited with status 1:
    '/tmp/spack-test2/spack-stage/spack-stage-erlang-23.0-vo4qhpa7yrxjqf5dbmoe4ntf6qruv6vh/spack-src/configure' '--prefix=/data/test-2/20200707/spack/opt/spack/linux-rhel8-haswell/gcc-8.3.1/erlang-23.0-vo4qhpa7yrxjqf5dbmoe4ntf6qruv6vh'

1 error found in build log:
     186    checking for kstat_open in -lkstat... (cached) no
     187    checking for tgetent in -ltinfo... no
     188    checking for tgetent in -lncurses... no
     189    checking for tgetent in -lcurses... no
     190    checking for tgetent in -ltermcap... no
     191    checking for tgetent in -ltermlib... no
  >> 192    configure: error: No curses library functions found
     193    ERROR: /tmp/spack-test2/spack-stage/spack-stage-erlang-23.0-vo4qhpa7yrxjqf5dbmoe4ntf6qruv6vh/spack-src
            /erts/configure failed!
     194    /tmp/spack-test2/spack-stage/spack-stage-erlang-23.0-vo4qhpa7yrxjqf5dbmoe4ntf6qruv6vh/spack-src/config
            ure: line 353: kill: (-2120122) - No such process

See build log for details:
  /tmp/spack-test2/spack-stage/spack-stage-erlang-23.0-vo4qhpa7yrxjqf5dbmoe4ntf6qruv6vh/spack-build-out.txt
```