### PR TITLE
eagle: fix CC=gcc and delete march=native

### DIFF
--- a/var/spack/repos/builtin/packages/eagle/package.py
+++ b/var/spack/repos/builtin/packages/eagle/package.py
@@ -33,6 +33,13 @@ class Eagle(MakefilePackage):
         # add htslib link to ldflags
         filter_file('-lcurl', '-lcurl -lhts', 'Makefile', string=True)
 
+        # use spack C compiler
+        filter_file('CC=.*', 'CC={0}'.format(spack_cc), 'Makefile')
+
+        # remove march=native %fj
+        if self.spec.satisfies('%fj'):
+            filter_file('-march=native', '', 'Makefile', string=True)
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 


### PR DESCRIPTION
1. fix CC=gcc
In `Makefile`, `CC=gcc` is patched to use spack specified C compiler.
This is for all compiler.
2. delete march=native
Fujitsu C compiler does not support `-march=native` option.
So I deleted this to use default arch.