### PR TITLE
express: add cast for %fj

### DIFF
--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -27,6 +27,7 @@ class Express(CMakePackage):
     # patch from the debian package repo:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859
     patch('gcc-6.patch', when='%gcc@6.0.0:')
+    patch('gcc-6.patch', when='%fj')
 
     def patch(self):
         with working_dir('src'):


### PR DESCRIPTION
Cast for old gcc(gcc-6.patch, see below) is also needed for Fujitsu C compiler.

> --- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -113,12 +113,12 @@
   double ll = LOG_1;
   double tot_mass = mass(with_pseudo);
 -double tot_eff_len = cached_effective_length(lib.bias_table); 
 +double tot_eff_len = cached_effective_length(static_cast<bool>(lib.bias_table));
   if (neighbors) {
     foreach (const Target* neighbor, *neighbors) {
       tot_mass = log_add(tot_mass, neighbor->mass(with_pseudo));
       tot_eff_len = log_add(tot_eff_len,
-neighbor->cached_effective_length(lib.bias_table));
+neighbor->cached_effective_length(static_cast<bool>(lib.bias_table)));
     }
   }
   ll += tot_mass - tot_eff_len;