### PR TITLE
clamcv: Add curl dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/clamav/package.py
+++ b/var/spack/repos/builtin/packages/clamav/package.py
@@ -22,6 +22,7 @@ class Clamav(AutotoolsPackage):
     depends_on('yara')
     depends_on('zlib')
     depends_on('bzip2')
+    depends_on('curl', type='link')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
clamav use libcurl, but curl dependency is not found.
This PR add dependency to curl.