### PR TITLE
Add run-time dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/scalasca/package.py
+++ b/var/spack/repos/builtin/packages/scalasca/package.py
@@ -30,7 +30,8 @@ class Scalasca(AutotoolsPackage):
 
     # version 2.4+
     depends_on('scorep@6.0:', when='@2.4:', type=('build', 'run') )
-    depends_on('cubew@4.4:', when='@2.4:', type=('build', 'run') )
+    depends_on('cube@4.4:', when='@2.4:', type=('build', 'run') )
+    depends_on('cubew@4.4:', when='@2.4:')
 
     # version 2.3+
     depends_on('otf2@2:', when='@2.3:')

--- a/var/spack/repos/builtin/packages/scalasca/package.py
+++ b/var/spack/repos/builtin/packages/scalasca/package.py
@@ -29,7 +29,8 @@ class Scalasca(AutotoolsPackage):
     depends_on("mpi")
 
     # version 2.4+
-    depends_on('cubew@4.4:', when='@2.4:')
+    depends_on('scorep@6.0:', when='@2.4:', type=('build', 'run') )
+    depends_on('cubew@4.4:', when='@2.4:', type=('build', 'run') )
 
     # version 2.3+
     depends_on('otf2@2:', when='@2.3:')


### PR DESCRIPTION
Two packages ```cube``` and ```scorep``` are needed when Scalasca runs.