### PR TITLE
qt: fix build with ~ssl.

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -363,7 +363,6 @@ class Qt(Package):
     @property
     def common_config_args(self):
         # incomplete list is here http://doc.qt.io/qt-5/configure-options.html
-        openssl = self.spec['openssl']
         config_args = [
             '-prefix', self.prefix,
             '-v',
@@ -389,6 +388,7 @@ class Qt(Package):
             config_args.append('-no-freetype')
 
         if '+ssl' in self.spec:
+            openssl = self.spec['openssl']
             config_args.extend([
                 '-openssl-linked',
                 openssl.libs.search_flags,


### PR DESCRIPTION
OpenSSL was pulled from the spec too early, leading to failures when
attempting to build with ~ssl.