### PR TITLE
lmod: change variant defaults to match Lmod's defaults

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -46,8 +46,8 @@ class Lmod(AutotoolsPackage):
     depends_on('lua-luafilesystem', type=('build', 'run'))
     depends_on('tcl', type=('build', 'link', 'run'))
 
-    variant('auto_swap', default=False, description='Enable auto swapping conflicting modules')
-    variant('redirect', default=True, description='Enables redirect instead of pager')
+    variant('auto_swap', default=True, description='Auto swapping of compilers, etc.')
+    variant('redirect', default=False, description='Redirect messages to stdout (instead of stderr)')
 
     patch('fix_tclsh_paths.patch', when='@:6.4.3')
     patch('0001-fix-problem-with-MODULESHOME-and-issue-271.patch', when='@7.3.28:7.4.10')


### PR DESCRIPTION
This changes the default variant values introduced in #15682 to match LMod's defaults