### PR TITLE
Support config variables in config.yaml extensions paths

### DIFF
--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -38,8 +38,7 @@ obtained by cloning the corresponding git repository:
 
 .. code-block:: console
 
-   $ pwd
-   /home/user
+   $ cd ~/
    $ mkdir tmp && cd tmp
    $ git clone https://github.com/alalazo/spack-scripting.git
    Cloning into 'spack-scripting'...
@@ -62,7 +61,7 @@ paths to ``config.yaml``. In the case of our example this means ensuring that:
 
    config:
      extensions:
-     - /home/user/tmp/spack-scripting
+     - ~/tmp/spack-scripting
 
 is part of your configuration file. Once this is setup any command that the extension provides
 will be available from the command line:

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -202,7 +202,7 @@ def unit_test(parser, args, unknown_args):
     pytest_root = spack.paths.spack_root
     if args.extension:
         target = args.extension
-        extensions = spack.config.get('config:extensions')
+        extensions = spack.extensions.get_extension_paths()
         pytest_root = spack.extensions.path_for_extension(target, *extensions)
 
     # pytest.ini lives in the root of the spack repository.

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -15,6 +15,7 @@ import llnl.util.lang
 
 import spack.config
 import spack.error
+import spack.util.path
 
 _extension_regexp = re.compile(r'spack-(\w[-\w]*)$')
 
@@ -105,10 +106,19 @@ def load_command_extension(command, path):
     return module
 
 
+def get_extension_paths():
+    """Return the list of canonicalized extension paths from config:extensions.
+
+    """
+    extension_paths = spack.config.get('config:extensions') or []
+    paths = [spack.util.path.canonicalize_path(p) for p in extension_paths]
+    return paths
+
+
 def get_command_paths():
     """Return the list of paths where to search for command files."""
     command_paths = []
-    extension_paths = spack.config.get('config:extensions') or []
+    extension_paths = get_extension_paths()
 
     for path in extension_paths:
         extension = _python_name(extension_name(path))
@@ -145,7 +155,7 @@ def get_module(cmd_name):
     """
     # If built-in failed the import search the extension
     # directories in order
-    extensions = spack.config.get('config:extensions') or []
+    extensions = get_extension_paths()
     for folder in extensions:
         module = load_command_extension(cmd_name, folder)
         if module:
@@ -158,7 +168,7 @@ def get_template_dirs():
     """Returns the list of directories where to search for templates
     in extensions.
     """
-    extension_dirs = spack.config.get('config:extensions') or []
+    extension_dirs = get_extension_paths()
     extensions = [os.path.join(x, 'templates') for x in extension_dirs]
     return extensions
 

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -257,6 +257,19 @@ def test_get_command_paths(config):
         assert spack.extensions.get_command_paths() == expected_cmd_paths
 
 
+def test_variable_in_extension_path(config, working_env):
+    """Test variables in extension paths."""
+    os.environ['_MY_VAR'] = "my/var"
+    ext_paths = [
+        os.path.join("~", "${_MY_VAR}", "spack-extension-1")
+    ]
+    expected_ext_paths = [
+        os.path.join(os.environ['HOME'], os.environ['_MY_VAR'], "spack-extension-1")
+    ]
+    with spack.config.override('config:extensions', ext_paths):
+        assert spack.extensions.get_extension_paths() == expected_ext_paths
+
+
 @pytest.mark.parametrize('command_name,contents,exception',
                          [('bad-cmd', 'from oopsie.daisy import bad\n',
                            ImportError),

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -249,9 +249,9 @@ def test_get_command_paths(config):
     for ext in extensions:
         ext_path = os.path.join('my', 'path', 'to', 'spack-' + ext)
         ext_paths.append(ext_path)
-        expected_cmd_paths.append(os.path.join(ext_path,
-                                               spack.cmd.python_name(ext),
-                                               'cmd'))
+        path = os.path.join(ext_path, spack.cmd.python_name(ext), 'cmd')
+        path = os.path.abspath(path)
+        expected_cmd_paths.append(path)
 
     with spack.config.override('config:extensions', ext_paths):
         assert spack.extensions.get_command_paths() == expected_cmd_paths


### PR DESCRIPTION
This PR adds [Config File Variables](https://spack.readthedocs.io/en/latest/configuration.html#config-file-variables) to `config.yaml:extensions` paths.

I'd like to see it cherry-picked for v0.15, if you don't mind, because it looked like a bug the first time I tried to use variables there.

I did my best to find all the places where the 'extensions' config was used. And factorized it.

I arbitrarily used `spack.util.path.canonicalize_path` instead of `substitute_path_variables`: not sure which is best.



