### PR TITLE
Support config variables in upstreams.yaml paths

### DIFF
--- a/lib/spack/docs/chain.rst
+++ b/lib/spack/docs/chain.rst
@@ -54,6 +54,11 @@ Other details about upstream installations:
    includes the upstream functionality (i.e. if its commit is after March
    27, 2019).
 
+.. note::
+
+   Upstream install_tree path supports :ref:`config variables
+   <config-file-variables>`.
+
 ---------------------------------------
 Using Multiple Upstream Spack Instances
 ---------------------------------------
@@ -94,3 +99,8 @@ corresponding command for the type of module they intend to use).
    Spack can generate modules that :ref:`automatically load
    <autoloading-dependencies>` the modules of dependency packages. Spack cannot
    currently do this for modules in upstream packages.
+
+.. note::
+
+   Upstream module path configs support :ref:`config variables
+   <config-file-variables>`.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -818,6 +818,7 @@ def print_setup_info(*info):
             (k, v) for k, v in upstream_module_roots.items() if k in module_to_roots
         )
         for module_type, root in upstream_module_roots.items():
+            root = spack.util.path.canonicalize_path(root)
             module_to_roots[module_type].append(root)
 
     for name, paths in module_to_roots.items():

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -324,6 +324,7 @@ def read_module_indices():
         module_type_to_index = {}
         module_type_to_root = install_properties.get("modules", {})
         for module_type, root in module_type_to_root.items():
+            root = spack.util.path.canonicalize_path(root)
             module_type_to_index[module_type] = read_module_index(root)
         module_indices.append(module_type_to_index)
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -265,7 +265,9 @@ def retrieve_upstream_dbs():
 
     install_roots = []
     for install_properties in other_spack_instances.values():
-        install_roots.append(install_properties["install_tree"])
+        root = install_properties["install_tree"]
+        root = spack.util.path.canonicalize_path(root)
+        install_roots.append(root)
 
     return _construct_upstream_dbs_from_install_roots(install_roots)
 


### PR DESCRIPTION
This PR adds [Config File Variables](https://spack.readthedocs.io/en/latest/configuration.html#config-file-variables) to `upstreams.yaml`'s `install_tree` and `modules` paths.

I'd like to see it  cherry-picked on `v0.15`, if you don't mind, because it looked like a bug the first time I tried to use variables there, especially since `configs.yaml`'s `install_tree` and `module_roots` support them.
