### PR TITLE
Boost: Update conflicts for version 1.73.0.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -183,7 +183,7 @@ class Boost(Package):
     conflicts('+numpy', when='~python')
 
     # boost-python in 1.72.0 broken with cxxstd=98
-    conflicts('cxxstd=98', when='+mpi+python @1.72.0:')
+    conflicts('cxxstd=98', when='+mpi+python @1.72.0')
 
     # Container's Extended Allocators were not added until 1.56.0
     conflicts('+container', when='@:1.55.99')


### PR DESCRIPTION
Variant "+mpi+python cxxstd=98" is fixed in 1.73.0.