### PR TITLE
python: RPATH on fj

### DIFF
--- a/var/spack/repos/builtin/packages/python/fj-rpath-2.3.patch
+++ b/var/spack/repos/builtin/packages/python/fj-rpath-2.3.patch
@@ -1,0 +1,12 @@
+--- a/Lib/distutils/unixccompiler.py	2003-06-02 05:27:40.000000000 +1000
++++ b/Lib/distutils/unixccompiler.py	2017-05-13 13:52:45.554213616 +1000
+@@ -208,7 +208,8 @@
+         elif compiler[:3] == "gcc" or compiler[:3] == "g++":
+           return "-Wl,-R" + dir
+         else:
+-            return "-R" + dir
++            # Patched by spack to use GNU ld syntax by default:
++            return "-Wl,--enable-new-dtags,-R" + dir
+ 
+     def library_option(self, lib):
+         return "-l" + lib

--- a/var/spack/repos/builtin/packages/python/fj-rpath-3.1.patch
+++ b/var/spack/repos/builtin/packages/python/fj-rpath-3.1.patch
@@ -1,0 +1,15 @@
+--- a/Lib/distutils/unixccompiler.py	2009-05-09 21:55:12.000000000 +1000
++++ b/Lib/distutils/unixccompiler.py	2017-05-13 14:30:18.077518999 +1000
+@@ -299,10 +299,8 @@
+                 else:
+                     return "-Wl,-R" + dir
+             else:
+-                # No idea how --enable-new-dtags would be passed on to
+-                # ld if this system was using GNU ld.  Don't know if a
+-                # system like this even exists.
+-                return "-R" + dir
++                # Patched by spack to use GNU ld syntax by default:
++                return "-Wl,--enable-new-dtags,-R" + dir
+ 
+     def library_option(self, lib):
+         return "-l" + lib

--- a/var/spack/repos/builtin/packages/python/fj-rpath-3.1.patch
+++ b/var/spack/repos/builtin/packages/python/fj-rpath-3.1.patch
@@ -1,15 +1,13 @@
 --- a/Lib/distutils/unixccompiler.py	2009-05-09 21:55:12.000000000 +1000
 +++ b/Lib/distutils/unixccompiler.py	2017-05-13 14:30:18.077518999 +1000
-@@ -299,10 +299,8 @@
-                 else:
-                     return "-Wl,-R" + dir
-             else:
--                # No idea how --enable-new-dtags would be passed on to
--                # ld if this system was using GNU ld.  Don't know if a
--                # system like this even exists.
--                return "-R" + dir
-+                # Patched by spack to use GNU ld syntax by default:
-+                return "-Wl,--enable-new-dtags,-R" + dir
- 
-     def library_option(self, lib):
-         return "-l" + lib
+@@ -215,7 +211,8 @@
+         return "-L" + dir
+
+     def _is_gcc(self, compiler_name):
+-        return "gcc" in compiler_name or "g++" in compiler_name
++        return "gcc" in compiler_name or "g++" in compiler_name \
++        or "fcc" in compiler_name or "FCC" in compiler_name
+
+     def runtime_library_dir_option(self, dir):
+         # XXX Hackish, at the very least.  See Python bug #445902:
+

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -179,6 +179,10 @@ class Python(AutotoolsPackage):
     patch('cray-rpath-2.3.patch', when='@2.3:3.0.1 platform=cray')
     patch('cray-rpath-3.1.patch', when='@3.1:3.99  platform=cray')
 
+    # Ensure that distutils chooses correct compiler option for RPATH on fj:
+    patch('fj-rpath-2.3.patch', when='@2.3:3.0.1 %fj')
+    patch('fj-rpath-3.1.patch', when='@3.1:3.99  %fj')
+
     # Fixes an alignment problem with more aggressive optimization in gcc8
     # https://github.com/python/cpython/commit/0b91f8a668201fc58fa732b8acc496caedfdbae0
     patch('gcc-8-2.7.14.patch', when='@2.7.14 %gcc@8:')


### PR DESCRIPTION
See #4209 (Similar problem in Clay)
This patch patches `runtime_library_dir_option` function in distutils/unixccompiler.py
Fujitsu compiler use GNU LD. However, it recognized as "unknown compiler"
So I patched "unknown compiler" case to use GNU LD style options.

>    def runtime_library_dir_option(self, dir):
        compiler = os.path.basename(sysconfig.get_config_var("CC"))
        if sys.platform[:6] == "darwin":
            # MacOSX's linker doesn't understand the -R flag at all
            return "-L" + dir
        elif sys.platform[:7] == "freebsd":
            return "-Wl,-rpath=" + dir
        elif sys.platform[:5] == "hp-ux":
            if self._is_gcc(compiler):
                return ["-Wl,+s", "-L" + dir]
            return ["+s", "-L" + dir]
        else:
            if self._is_gcc(compiler):
                if sysconfig.get_config_var("GNULD") == "yes":
                    # GNU ld needs an extra option to get a RUNPATH
                    # instead of just an RPATH.
                    return "-Wl,--enable-new-dtags,-R" + dir
                else:
                    return "-Wl,-R" + dir
            else:
                # No idea how --enable-new-dtags would be passed on to
                # ld if this system was using GNU ld.  Don't know if a
                # system like this even exists.
                return "-R" + dir
