### PR TITLE
Streamline key management for build caches

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -293,7 +293,8 @@ def generate_package_index(cache_prefix):
     file_list = (
         entry
         for entry in web_util.list_url(cache_prefix)
-        if entry.endswith('.yaml'))
+        if entry.endswith('.yaml')
+        and os.sep not in entry)
 
     tty.debug('Retrieving spec.yaml files from {0} to build index'.format(
         cache_prefix))
@@ -911,10 +912,12 @@ def get_keys(install=False, trust=False, force=False):
     keys = set()
 
     for mirror in mirror_collection.values():
+        fetch_url = mirror.fetch_url
         fetch_url_build_cache = url_util.join(
-            mirror.fetch_url, _build_cache_relative_path)
+            fetch_url, _build_cache_relative_path)
 
-        tty.debug('Finding public keys in {0}'.format(url_util.format(mirror)))
+        tty.debug('Finding public keys in {0}'.format(
+            url_util.format(fetch_url)))
 
         for file in web_util.list_url(fetch_url_build_cache):
             if file.endswith('.key') or file.endswith('.pub'):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -913,15 +913,13 @@ def get_keys(install=False, trust=False, force=False):
 
     for mirror in mirror_collection.values():
         fetch_url = mirror.fetch_url
-        fetch_url_build_cache = url_util.join(
-            fetch_url, _build_cache_relative_path)
 
         tty.debug('Finding public keys in {0}'.format(
             url_util.format(fetch_url)))
 
-        for file in web_util.list_url(fetch_url_build_cache):
+        for file in web_util.list_url(fetch_url):
             if file.endswith('.key') or file.endswith('.pub'):
-                link = url_util.join(fetch_url_build_cache, file)
+                link = url_util.join(fetch_url, file)
                 keys.add(link)
 
         for link in keys:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -957,10 +957,11 @@ def get_specs():
     return _cached_specs
 
 
-def get_keys(install=False, trust=False, force=False):
+def get_keys(install=False, trust=False, force=False, mirrors=None):
     """Get pgp public keys available on mirror with suffix .pub
     """
-    mirror_collection = spack.mirror.MirrorCollection()
+    mirror_collection = (mirrors or spack.mirror.MirrorCollection())
+
     if not mirror_collection:
         tty.die("Please add a spack mirror to allow " +
                 "download of build caches.")

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -290,7 +290,7 @@ def generate_package_index(cache_prefix):
     """Create the build cache index page.
 
     Creates (or replaces) the "index.json" page at the location given in
-    cache_prefix.  This page contains a link for each binary package (*.yaml)
+    cache_prefix.  This page contains a link for each binary package (.yaml)
     under cache_prefix.
     """
     tmpdir = tempfile.mkdtemp()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -965,8 +965,6 @@ def get_keys(install=False, trust=False, force=False):
         tty.die("Please add a spack mirror to allow " +
                 "download of build caches.")
 
-    keys = set()
-
     for mirror in mirror_collection.values():
         fetch_url = mirror.fetch_url
         keys_url = url_util.join(fetch_url,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -339,7 +339,7 @@ def generate_key_index(key_prefix, tmpdir=None):
     """Create the key index page.
 
     Creates (or replaces) the "index.json" page at the location given in
-    key_prefix.  This page contains an entry for each key (*.pub) under
+    key_prefix.  This page contains an entry for each key (.pub) under
     key_prefix.
     """
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -26,8 +26,8 @@ import spack.cmd
 import spack.config as config
 import spack.database as spack_db
 import spack.fetch_strategy as fs
-import spack.util.gpg
 import spack.relocate as relocate
+import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.mirror
 import spack.util.url as url_util
@@ -37,6 +37,7 @@ from spack.stage import Stage
 from spack.util.gpg import Gpg
 
 _build_cache_relative_path = 'build_cache'
+_build_cache_keys_relative_path = '_pgp'
 
 BUILD_CACHE_INDEX_TEMPLATE = '''
 <html>
@@ -249,7 +250,7 @@ def checksum_tarball(file):
 
 def sign_tarball(key, force, specfile_path):
     # Sign the packages if keys available
-    if spack.util.gpg.Gpg.gpg() is None:
+    if Gpg.gpg() is None:
         raise NoGpgException(
             "gpg2 is not available in $PATH .\n"
             "Use spack install gnupg and spack load gnupg.")
@@ -282,7 +283,7 @@ def generate_package_index(cache_prefix):
 
     Creates (or replaces) the "index.json" page at the location given in
     cache_prefix.  This page contains a link for each binary package (*.yaml)
-    and public key (*.key) under cache_prefix.
+    under cache_prefix.
     """
     tmpdir = tempfile.mkdtemp()
     db_root_dir = os.path.join(tmpdir, 'db_root')
@@ -324,6 +325,45 @@ def generate_package_index(cache_prefix):
             extra_args={'ContentType': 'application/json'})
     finally:
         shutil.rmtree(tmpdir)
+
+
+def generate_key_index(key_prefix, tmpdir=None):
+    """Create the key index page.
+
+    Creates (or replaces) the "index.json" page at the location given in
+    key_prefix.  This page contains an entry for each key (*.pub) under
+    key_prefix.
+    """
+
+    tty.debug(' '.join(('Retrieving key.pub files from',
+                        url_util.format(key_prefix),
+                        'to build key index')))
+
+    fingerprints = (
+        entry[:-4]
+        for entry in web_util.list_url(key_prefix, recursive=False)
+        if entry.endswith('.pub'))
+
+    keys_local = url_util.local_file_path(key_prefix)
+    if keys_local:
+        target = os.path.join(keys_local, 'index.json')
+    else:
+        target = os.path.join(tmpdir, 'index.json')
+
+    index = {
+        'keys': dict(
+            (fingerprint, {}) for fingerprint
+            in sorted(set(fingerprints)))
+    }
+    with open(target, 'w') as f:
+        sjson.dump(index, f)
+
+    if not keys_local:
+        web_util.push_to_url(
+            target,
+            url_util.join(key_prefix, 'index.json'),
+            keep_original=False,
+            extra_args={'ContentType': 'application/json'})
 
 
 def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
@@ -469,7 +509,15 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
               .format(spec, remote_spackfile_path))
 
     try:
-        # create an index.html for the build_cache directory so specs can be
+        # push the key to the build cache's _pgp directory so it can be
+        # imported
+        if not unsigned:
+            push_keys(outdir,
+                      keys=[key],
+                      regenerate_index=regenerate_index,
+                      tmpdir=tmpdir)
+
+        # create an index.json for the build_cache directory so specs can be
         # found
         if regenerate_index:
             generate_package_index(url_util.join(
@@ -900,9 +948,7 @@ def get_specs():
 
 
 def get_keys(install=False, trust=False, force=False):
-    """
-    Get pgp public keys available on mirror
-    with suffix .key or .pub
+    """Get pgp public keys available on mirror with suffix .pub
     """
     mirror_collection = spack.mirror.MirrorCollection()
     if not mirror_collection:
@@ -913,16 +959,35 @@ def get_keys(install=False, trust=False, force=False):
 
     for mirror in mirror_collection.values():
         fetch_url = mirror.fetch_url
+        keys_url = url_util.join(fetch_url,
+                                 _build_cache_relative_path,
+                                 _build_cache_keys_relative_path)
+        keys_index = url_util.join(keys_url, 'index.json')
 
         tty.debug('Finding public keys in {0}'.format(
             url_util.format(fetch_url)))
 
-        for file in web_util.list_url(fetch_url):
-            if file.endswith('.key') or file.endswith('.pub'):
-                link = url_util.join(fetch_url, file)
-                keys.add(link)
+        try:
+            _, _, json_file = web_util.read_from_url(keys_index)
+            json_index = sjson.load(codecs.getreader('utf-8')(json_file))
+        except (URLError, web_util.SpackWebError) as url_err:
+            if web_util.url_exists(keys_index):
+                err_msg = [
+                    'Unable to find public keys in {0},',
+                    ' caught exception attempting to read from {1}.',
+                ]
 
-        for link in keys:
+                tty.error(''.join(err_msg).format(
+                    url_util.format(fetch_url),
+                    url_util.format(keys_index)))
+
+                tty.debug(url_err)
+
+            continue
+
+        for fingerprint, key_attributes in json_index['keys'].items():
+            link = os.path.join(keys_url, fingerprint + '.pub')
+
             with Stage(link, name="build_cache", keep=True) as stage:
                 if os.path.exists(stage.save_filename) and force:
                     os.remove(stage.save_filename)
@@ -931,7 +996,8 @@ def get_keys(install=False, trust=False, force=False):
                         stage.fetch()
                     except fs.FetchError:
                         continue
-            tty.debug('Found key {0}'.format(link))
+
+            tty.debug('Found key {0}'.format(fingerprint))
             if install:
                 if trust:
                     Gpg.trust(stage.save_filename)
@@ -939,6 +1005,64 @@ def get_keys(install=False, trust=False, force=False):
                 else:
                     tty.debug('Will not add this key to trusted keys.'
                               'Use -t to install all downloaded keys')
+
+
+def push_keys(*mirrors, keys=None, regenerate_index=False, tmpdir=None):
+    """
+    Upload pgp public keys to the given mirrors
+    """
+
+    keys = Gpg.public_keys(*(keys or []))
+
+    try:
+        for mirror in mirrors:
+            push_url = getattr(mirror, 'push_url', mirror)
+            keys_url = url_util.join(push_url,
+                                     _build_cache_relative_path,
+                                     _build_cache_keys_relative_path)
+            keys_local = url_util.local_file_path(keys_url)
+
+            verb = 'Writing' if keys_local else 'Uploading'
+            tty.debug('{0} public keys to {1}'.format(
+                verb, url_util.format(push_url)))
+
+            if keys_local:  # mirror is local, don't bother with the tmpdir
+                prefix = keys_local
+                mkdirp(keys_local)
+            else:
+                # A tmp dir is created for the first mirror that is non-local.
+                # On the off-hand chance that all the mirrors are local, then
+                # we can avoid the need to create a tmp dir.
+                if tmpdir is None:
+                    tmpdir = tempfile.mkdtemp()
+                prefix = tmpdir
+
+            for fingerprint in keys:
+                tty.debug('    ' + fingerprint)
+                filename = fingerprint + '.pub'
+
+                export_target = os.path.join(prefix, filename)
+                Gpg.export_keys(export_target, fingerprint)
+
+                # If mirror is local, the above export writes directly to the
+                # mirror (export_target points directly to the mirror).
+                #
+                # If not, then export_target is a tmpfile that needs to be
+                # uploaded to the mirror.
+                if not keys_local:
+                    spack.util.web.push_to_url(
+                        export_target,
+                        url_util.join(keys_url, filename),
+                        keep_original=False)
+
+            if regenerate_index:
+                if keys_local:
+                    generate_key_index(keys_url)
+                else:
+                    generate_key_index(keys_url, tmpdir)
+    finally:
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir)
 
 
 def needs_rebuild(spec, mirror_url, rebuild_on_errors=False):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -292,8 +292,7 @@ def generate_package_index(cache_prefix):
     file_list = (
         entry
         for entry in web_util.list_url(cache_prefix)
-        if entry.endswith('.yaml')
-        and os.sep not in entry)
+        if entry.endswith('.yaml'))
 
     tty.debug('Retrieving spec.yaml files from {0} to build index'.format(
         cache_prefix))

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1007,10 +1007,13 @@ def get_keys(install=False, trust=False, force=False):
                               'Use -t to install all downloaded keys')
 
 
-def push_keys(*mirrors, keys=None, regenerate_index=False, tmpdir=None):
+def push_keys(*mirrors, **kwargs):
     """
     Upload pgp public keys to the given mirrors
     """
+    keys = kwargs.get('keys')
+    regenerate_index = kwargs.get('regenerate_index', False)
+    tmpdir = kwargs.get('tmpdir')
 
     keys = Gpg.public_keys(*(keys or []))
 

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -101,11 +101,12 @@ def setup_parser(subparser):
                         help="URL of the mirror where " +
                              "keys will be published.")
     publish.add_argument('--rebuild-index', action='store_true',
-                        default=False, help="Regenerate buildcache key index " +
-                                            "after publishing key(s)")
+                         default=False, help=(
+                             "Regenerate buildcache key index "
+                             "after publishing key(s)"))
     publish.add_argument('keys', nargs='*',
-                        help='the keys to publish; '
-                             'all public keys if unspecified')
+                         help='the keys to publish; '
+                              'all public keys if unspecified')
     publish.set_defaults(func=gpg_publish)
 
 

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -9,7 +9,7 @@ import argparse
 import spack.binary_distribution
 import spack.cmd.common.arguments as arguments
 import spack.paths
-from spack.util.gpg import Gpg
+import spack.util.gpg
 
 description = "handle GPG actions for spack"
 section = "packaging"
@@ -113,33 +113,33 @@ def setup_parser(subparser):
 def gpg_create(args):
     """create a new key"""
     if args.export:
-        old_sec_keys = Gpg.signing_keys()
-    Gpg.create(name=args.name, email=args.email,
-               comment=args.comment, expires=args.expires)
+        old_sec_keys = spack.util.gpg.signing_keys()
+    spack.util.gpg.create(name=args.name, email=args.email,
+                          comment=args.comment, expires=args.expires)
     if args.export:
-        new_sec_keys = set(Gpg.signing_keys())
+        new_sec_keys = set(spack.util.gpg.signing_keys())
         new_keys = new_sec_keys.difference(old_sec_keys)
-        Gpg.export_keys(args.export, *new_keys)
+        spack.util.gpg.export_keys(args.export, *new_keys)
 
 
 def gpg_export(args):
     """export a secret key"""
     keys = args.keys
     if not keys:
-        keys = Gpg.signing_keys()
-    Gpg.export_keys(args.location, *keys)
+        keys = spack.util.gpg.signing_keys()
+    spack.util.gpg.export_keys(args.location, *keys)
 
 
 def gpg_list(args):
     """list keys available in the keyring"""
-    Gpg.list(args.trusted, args.signing)
+    spack.util.gpg.list(args.trusted, args.signing)
 
 
 def gpg_sign(args):
     """sign a package"""
     key = args.key
     if key is None:
-        keys = Gpg.signing_keys()
+        keys = spack.util.gpg.signing_keys()
         if len(keys) == 1:
             key = keys[0]
         elif not keys:
@@ -151,12 +151,12 @@ def gpg_sign(args):
     if not output:
         output = args.spec[0] + '.asc'
     # TODO: Support the package format Spack creates.
-    Gpg.sign(key, ' '.join(args.spec), output, args.clearsign)
+    spack.util.gpg.sign(key, ' '.join(args.spec), output, args.clearsign)
 
 
 def gpg_trust(args):
     """add a key to the keyring"""
-    Gpg.trust(args.keyfile)
+    spack.util.gpg.trust(args.keyfile)
 
 
 def gpg_init(args):
@@ -169,12 +169,12 @@ def gpg_init(args):
         for filename in filenames:
             if not filename.endswith('.key'):
                 continue
-            Gpg.trust(os.path.join(root, filename))
+            spack.util.gpg.trust(os.path.join(root, filename))
 
 
 def gpg_untrust(args):
     """remove a key from the keyring"""
-    Gpg.untrust(args.signing, *args.keys)
+    spack.util.gpg.untrust(args.signing, *args.keys)
 
 
 def gpg_verify(args):
@@ -183,7 +183,7 @@ def gpg_verify(args):
     signature = args.signature
     if signature is None:
         signature = args.spec[0] + '.asc'
-    Gpg.verify(signature, ' '.join(args.spec))
+    spack.util.gpg.verify(signature, ' '.join(args.spec))
 
 
 def gpg_publish(args):

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -473,8 +473,8 @@ def test_relative_rpaths_install_nondefault(tmpdir,
     mirror.mirror(mparser, margs)
 
 
-def test_push_and_fetch_keys(tmpdir):
-    testpath = str(tmpdir)
+def test_push_and_fetch_keys(mock_gnupghome):
+    testpath = str(mock_gnupghome)
 
     mirror = os.path.join(testpath, 'mirror')
     mirrors = {'test-mirror': mirror}

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -53,15 +53,8 @@ def test_urlencode_string():
     assert(s_enc == 'Spack+Test+Project')
 
 
-def has_gpg():
-    try:
-        gpg = spack.util.gpg.Gpg.gpg()
-    except spack.util.gpg.SpackGPGError:
-        gpg = None
-    return bool(gpg)
-
-
-@pytest.mark.skipif(not has_gpg(), reason='This test requires gpg')
+@pytest.mark.skipif(not spack.util.gpg.has_gpg(),
+                    reason='This test requires gpg')
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, 'package-signing-key')

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -35,14 +35,6 @@ buildcache_cmd = SpackCommand('buildcache')
 git = exe.which('git', required=True)
 
 
-def has_gpg():
-    try:
-        gpg = spack.util.gpg.Gpg.gpg()
-    except spack.util.gpg.SpackGPGError:
-        gpg = None
-    return bool(gpg)
-
-
 @pytest.fixture()
 def env_deactivate():
     yield
@@ -668,7 +660,8 @@ spack:
 
 
 @pytest.mark.disable_clean_stage_check
-@pytest.mark.skipif(not has_gpg(), reason='This test requires gpg')
+@pytest.mark.skipif(not spack.util.gpg.has_gpg(),
+                    reason='This test requires gpg')
 def test_push_mirror_contents(tmpdir, mutable_mock_env_path, env_deactivate,
                               install_mockery, mock_packages, mock_fetch,
                               mock_stage, mock_gnupghome):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -29,39 +29,35 @@ gpg = SpackCommand('gpg')
     ('gpg2', 'gpg (GnuPG) 2.2.19'),  # gpg2 command
 ])
 def test_find_gpg(cmd_name, version, tmpdir, mock_gnupghome, monkeypatch):
+    TEMPLATE = ('#!/bin/sh\n'
+                'echo "{version}"\n')
+
     with tmpdir.as_cwd():
-        with open(cmd_name, 'w') as f:
-            f.write("""\
-#!/bin/sh
-echo "{version}"
-""".format(version=version))
-        fs.set_executable(cmd_name)
+        for fname in (cmd_name, 'gpgconf'):
+            with open(fname, 'w') as f:
+                f.write(TEMPLATE.format(version=version))
+            fs.set_executable(fname)
 
     monkeypatch.setitem(os.environ, "PATH", str(tmpdir))
     if version == 'undetectable' or version.endswith('1.3.4'):
         with pytest.raises(spack.util.gpg.SpackGPGError):
-            exe = spack.util.gpg.Gpg.gpg()
+            spack.util.gpg.ensure_gpg(reevaluate=True)
     else:
-        exe = spack.util.gpg.Gpg.gpg()
-        assert isinstance(exe, spack.util.executable.Executable)
+        spack.util.gpg.ensure_gpg(reevaluate=True)
+        gpg_exe = spack.util.gpg.get_global_gpg_instance().gpg_exe
+        assert isinstance(gpg_exe, spack.util.executable.Executable)
+        gpgconf_exe = spack.util.gpg.get_global_gpg_instance().gpgconf_exe
+        assert isinstance(gpgconf_exe, spack.util.executable.Executable)
 
 
 def test_no_gpg_in_path(tmpdir, mock_gnupghome, monkeypatch):
     monkeypatch.setitem(os.environ, "PATH", str(tmpdir))
     with pytest.raises(spack.util.gpg.SpackGPGError):
-        spack.util.gpg.Gpg.gpg()
-
-
-def has_gpg():
-    try:
-        gpg = spack.util.gpg.Gpg.gpg()
-    except spack.util.gpg.SpackGPGError:
-        gpg = None
-    return bool(gpg)
+        spack.util.gpg.ensure_gpg(reevaluate=True)
 
 
 @pytest.mark.maybeslow
-@pytest.mark.skipif(not has_gpg(),
+@pytest.mark.skipif(not spack.util.gpg.has_gpg(),
                     reason='These tests require gnupg2')
 def test_gpg(tmpdir, mock_gnupghome):
     # Verify a file with an empty keyring.
@@ -103,7 +99,7 @@ def test_gpg(tmpdir, mock_gnupghome):
         '--export', str(keypath),
         'Spack testing 1',
         'spack@googlegroups.com')
-    keyfp = spack.util.gpg.Gpg.signing_keys()[0]
+    keyfp = spack.util.gpg.signing_keys()[0]
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -122,7 +122,8 @@ def test_pkg_add(mock_pkg_git_repo):
     with working_dir(mock_pkg_git_repo):
         try:
             assert ('A  pkg-e/package.py' in
-                    git('status', '--short', output=str))
+                    git('-c', 'color.status=off',
+                        'status', '--short', output=str))
         finally:
             shutil.rmtree('pkg-e')
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -122,8 +122,7 @@ def test_pkg_add(mock_pkg_git_repo):
     with working_dir(mock_pkg_git_repo):
         try:
             assert ('A  pkg-e/package.py' in
-                    git('-c', 'color.status=off',
-                        'status', '--short', output=str))
+                    git('status', '--short', output=str))
         finally:
             shutil.rmtree('pkg-e')
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -782,7 +782,7 @@ def mock_gnupghome(monkeypatch):
     # pytest makes them longer.
     short_name_tmpdir = tempfile.mkdtemp()
     with spack.util.gpg.gnupg_home_override(short_name_tmpdir):
-        yield
+        yield short_name_tmpdir
 
     # clean up, since we are doing this manually
     shutil.rmtree(short_name_tmpdir)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -781,10 +781,8 @@ def mock_gnupghome(monkeypatch):
     # This comes up because tmp paths on macOS are already long-ish, and
     # pytest makes them longer.
     short_name_tmpdir = tempfile.mkdtemp()
-    monkeypatch.setattr(spack.util.gpg, 'GNUPGHOME', short_name_tmpdir)
-    monkeypatch.setattr(spack.util.gpg.Gpg, '_gpg', None)
-
-    yield
+    with spack.util.gpg.gnupg_home_override(short_name_tmpdir):
+        yield
 
     # clean up, since we are doing this manually
     shutil.rmtree(short_name_tmpdir)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -834,8 +834,7 @@ class TestStage(object):
 
                 # Make sure cached stage path value was changed appropriately
                 assert spack.stage._stage_root in (
-                        test_path,
-                        os.path.join(test_path, getpass.getuser()))
+                    test_path, os.path.join(test_path, getpass.getuser()))
 
                 # Make sure the directory exists
                 assert os.path.isdir(spack.stage._stage_root)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -833,7 +833,9 @@ class TestStage(object):
                 assert 'spack' in path.split(os.path.sep)
 
                 # Make sure cached stage path value was changed appropriately
-                assert spack.stage._stage_root == test_path
+                assert spack.stage._stage_root in (
+                        test_path,
+                        os.path.join(test_path, getpass.getuser()))
 
                 # Make sure the directory exists
                 assert os.path.isdir(spack.stage._stage_root)

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -70,7 +70,7 @@ def test_really_long_gnupg_home_dir(tmpdir):
         tdir = os.path.join(tdir, 'filler')
 
     tdir = tdir[:N].rstrip(os.sep)
-    tdir += '0'*(N - len(tdir))
+    tdir += '0' * (N - len(tdir))
 
     with spack.util.gpg.gnupg_home_override(tdir):
         spack.util.gpg.create(name='Spack testing 1',

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import pytest
 
 import spack.util.gpg
 
@@ -62,6 +63,8 @@ fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
     assert keys[1] == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 
 
+@pytest.mark.skipif(not spack.util.gpg.GpgConstants.user_run_dir,
+                    reason='This test requires /var/run/user/$(id -u)')
 def test_really_long_gnupg_home_dir(tmpdir):
     N = 1000
 

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -17,7 +17,7 @@ fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
 """
-    keys = gpg.parse_keys_output(output)
+    keys = gpg.parse_secret_keys_output(output)
 
     assert len(keys) == 2
     assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
@@ -34,7 +34,7 @@ ssb:-:2048:1:AAAAAAAAA::::::esa:::+:::23:
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
 """
-    keys = gpg.parse_keys_output(output)
+    keys = gpg.parse_secret_keys_output(output)
 
     assert len(keys) == 1
     assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
@@ -53,7 +53,7 @@ uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
 ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
 fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
 
-    keys = gpg.parse_keys_output(output)
+    keys = gpg.parse_secret_keys_output(output)
 
     assert len(keys) == 2
     assert keys[0] == 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -66,7 +66,7 @@ fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
 @pytest.mark.skipif(not spack.util.gpg.GpgConstants.user_run_dir,
                     reason='This test requires /var/run/user/$(id -u)')
 def test_really_long_gnupg_home_dir(tmpdir):
-    N = 1000
+    N = 960
 
     tdir = str(tmpdir)
     while len(tdir) < N:

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -167,3 +167,31 @@ def test_get_header():
     # If there isn't even a fuzzy match, raise KeyError
     with pytest.raises(KeyError):
         spack.util.web.get_header(headers, 'ContentLength')
+
+
+def test_list_url(tmpdir):
+    testpath = str(tmpdir)
+
+    os.mkdir(os.path.join(testpath, 'dir'))
+
+    with open(os.path.join(testpath, 'file-0.txt'), 'w'):
+        pass
+    with open(os.path.join(testpath, 'file-1.txt'), 'w'):
+        pass
+    with open(os.path.join(testpath, 'file-2.txt'), 'w'):
+        pass
+
+    with open(os.path.join(testpath, 'dir', 'another-file.txt'), 'w'):
+        pass
+
+    list_url = lambda recursive: list(sorted(
+        spack.util.web.list_url(testpath, recursive=recursive)))
+
+    assert list_url(False) == ['file-0.txt',
+                               'file-1.txt',
+                               'file-2.txt']
+
+    assert list_url(True) == ['dir/another-file.txt',
+                              'file-0.txt',
+                              'file-1.txt',
+                              'file-2.txt']

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -145,6 +145,13 @@ class GpgConstants(object):
         if spack.version.Version(match.group(2)) < self.target_version:
             raise SpackGPGError(no_gpgconf_msg)
 
+        # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
+        try:
+            exe('--dry-run', '--create-socketdir')
+        except spack.util.executable.ProcessError:
+            # no dice
+            exe_str = None
+
         return exe_str
 
     @cached_property
@@ -175,34 +182,50 @@ class GpgConstants(object):
 
     @cached_property
     def user_run_dir(self):
-        # Try to ensure that /run/user/$(id -u) exists so that
+        # Try to ensure that (/var)/run/user/$(id -u) exists so that
         #  `gpgconf --create-socketdir` can be run later.
         #
         # NOTE(opadron): This action helps prevent a large class of
         #                "file-name-too-long" errors in gpg.
-        var_run_user = '/run/user'
-        result = os.path.join(var_run_user, str(os.getuid()))
-        try:
-            mkdir = (os.path.isdir(var_run_user) and
-                     not os.path.exists(result))
-            if mkdir:
-                os.mkdir(result)
-                os.chmod(result, 0o700)
 
-        # If the above operation fails due to lack of permissions, then just
-        # carry on without running gpgconf and hope for the best.
-        #
-        # NOTE(opadron): Without a dir in which to create a socket for IPC,
-        #                gnupg may fail if GNUPGHOME is set to a path that is
-        #                too long, where "too long" in this context is actually
-        #                quite short; somewhere in the neighborhood of more
-        #                than 100 characters.
-        #
-        # TODO(opadron): Maybe a warning should be printed in this case?
-        except OSError as exc:
-            if exc.errno not in (errno.EPERM, errno.EACCES):
-                raise
-            result = None
+        try:
+            has_suitable_gpgconf = bool(GpgConstants.gpgconf_string)
+        except SpackGPGError:
+            has_suitable_gpgconf = False
+
+        # If there is no suitable gpgconf, don't even bother trying to
+        # precreate a user run dir.
+        if not has_suitable_gpgconf:
+            return None
+
+        result = None
+        for var_run_user in ('/run/user', '/var/run/user'):
+            user_dir = os.path.join(var_run_user, str(os.getuid()))
+            try:
+                mkdir = (os.path.isdir(var_run_user) and
+                         not os.path.exists(user_dir))
+                if mkdir:
+                    os.mkdir(user_dir)
+                    os.chmod(user_dir, 0o700)
+
+            # If the above operation fails due to lack of permissions, then
+            # just carry on without running gpgconf and hope for the best.
+            #
+            # NOTE(opadron): Without a dir in which to create a socket for IPC,
+            #                gnupg may fail if GNUPGHOME is set to a path that
+            #                is too long, where "too long" in this context is
+            #                actually quite short; somewhere in the
+            #                neighborhood of more than 100 characters.
+            #
+            # TODO(opadron): Maybe a warning should be printed in this case?
+            except OSError as exc:
+                if exc.errno not in (errno.EPERM, errno.EACCES):
+                    raise
+                user_dir = None
+
+            # return the last iteration that provides a usable user run dir
+            if user_dir is not None:
+                result = user_dir
 
         return result
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -237,8 +237,12 @@ class Gpg(object):
 
         # Make sure that the GNUPGHOME exists
         if not os.path.exists(self.gnupg_home):
-            os.makedirs(os.path.dirname(self.gnupg_home), exist_ok=True)
-            os.mkdir(self.gnupg_home, mode=0o700)
+            os.makedirs(self.gnupg_home)
+
+        if not os.path.isdir(self.gnupg_home):
+            raise SpackGPGError(
+                'GNUPGHOME "{0}" exists and is not a directory'.format(
+                    self.gnupg_home))
 
         # Try to ensure that /var/run/user/$(id -u) exists and run gpgconf
         # --create-socketdir.
@@ -251,7 +255,8 @@ class Gpg(object):
             mkdir = (os.path.isdir(var_run_user) and
                      not os.path.exists(user_run_dir))
             if mkdir:
-                os.mkdir(user_run_dir, mode=0o700)
+                os.mkdir(user_run_dir)
+                os.chmod(user_run_dir, 0o700)
 
         # If the above operation fails due to lack of permissions, then just
         # carry on without running gpgconf and hope for the best.

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -175,12 +175,12 @@ class GpgConstants(object):
 
     @cached_property
     def user_run_dir(self):
-        # Try to ensure that /var/run/user/$(id -u) exists and run gpgconf
-        # --create-socketdir.
+        # Try to ensure that /run/user/$(id -u) exists so that
+        #  `gpgconf --create-socketdir` can be run later.
         #
         # NOTE(opadron): This action helps prevent a large class of
         #                "file-name-too-long" errors in gpg.
-        var_run_user = '/var/run/user'
+        var_run_user = '/run/user'
         result = os.path.join(var_run_user, str(os.getuid()))
         try:
             mkdir = (os.path.isdir(var_run_user) and

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -199,12 +199,19 @@ class GpgConstants(object):
             return None
 
         result = None
-        for var_run_user in ('/run/user', '/var/run/user'):
+        for var_run in ('/run', '/var/run'):
+            if not os.path.exists(var_run):
+                continue
+
+            var_run_user = os.path.join(var_run, 'user')
+            if not os.path.exists(var_run_user):
+                os.mkdir(var_run_user)
+                os.chmod(var_run_user, 0o777)
+
             user_dir = os.path.join(var_run_user, str(os.getuid()))
+
             try:
-                mkdir = (os.path.isdir(var_run_user) and
-                         not os.path.exists(user_dir))
-                if mkdir:
+                if not os.path.exists(user_dir):
                     os.mkdir(user_dir)
                     os.chmod(user_dir, 0o700)
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -303,6 +303,7 @@ class Gpg(object):
         # Make sure that the GNUPGHOME exists
         if not os.path.exists(self.gnupg_home):
             os.makedirs(self.gnupg_home)
+            os.chmod(self.gnupg_home, 0o700)
 
         if not os.path.isdir(self.gnupg_home):
             raise SpackGPGError(

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -343,6 +343,8 @@ class SpackGPGError(spack.error.SpackError):
 #         with gpg.gnupg_home_override('...'):
 #             ...
 def _make_wrapped_callables(namespace):
+    global wrap
+
     def _make_wrapped_callable(func, name):
         if func.__name__ == '__call__':
             @functools.wraps(func)
@@ -360,6 +362,7 @@ def _make_wrapped_callables(namespace):
 
     for func, name in wrap:
         namespace[name] = _make_wrapped_callable(func, name)
+
 
 _make_wrapped_callables(globals())
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -204,13 +204,13 @@ class GpgConstants(object):
                 continue
 
             var_run_user = os.path.join(var_run, 'user')
-            if not os.path.exists(var_run_user):
-                os.mkdir(var_run_user)
-                os.chmod(var_run_user, 0o777)
-
-            user_dir = os.path.join(var_run_user, str(os.getuid()))
-
             try:
+                if not os.path.exists(var_run_user):
+                    os.mkdir(var_run_user)
+                    os.chmod(var_run_user, 0o777)
+
+                user_dir = os.path.join(var_run_user, str(os.getuid()))
+
                 if not os.path.exists(user_dir):
                     os.mkdir(user_dir)
                     os.chmod(user_dir, 0o700)

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -132,7 +132,6 @@ class Gpg(object):
         cls.gpg()('--batch', '--yes', '--delete-keys',
                   *cls.public_keys(*keys))
 
-
     @classmethod
     def sign(cls, key, file, output, clearsign=False):
         args = [

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -279,35 +279,46 @@ def _list_s3_objects(client, bucket, prefix, num_entries, start_after=None):
     return iter, last_key
 
 
-def list_url(url):
+def _iter_s3_prefix(client, url, num_entries=1024):
+    key = None
+    bucket = url.netloc
+    prefix = re.sub(r'^/*', '/', url.path)
+
+    while True:
+        contents, key = _list_s3_objects(
+            client, bucket, prefix, num_entries, start_after=key)
+
+        for x in contents:
+            yield x
+
+        if not key:
+            break
+
+
+def _iter_local_prefix(path):
+    for root, _, files in os.walk(path):
+        for f in files:
+            yield os.path.relpath(os.path.join(root, f), path)
+
+
+def list_url(url, recursive=False):
     url = url_util.parse(url)
 
     local_path = url_util.local_file_path(url)
     if local_path:
-        for dirname, _, filenames in os.walk(local_path):
-            relative_dirname = os.path.relpath(dirname, local_path)
-            if relative_dirname == '.':
-                relative_dirname = ''
-
-            for filename in filenames:
-                yield os.path.join(relative_dirname, filename)
+        if recursive:
+            return list(_iter_local_prefix(local_path))
+        return [subpath for subpath in os.listdir(local_path)
+                if os.path.isfile(os.path.join(local_path, subpath))]
 
     if url.scheme == 's3':
         s3 = s3_util.create_s3_session(url)
+        if recursive:
+            return list(_iter_s3_prefix(s3, url))
 
-        key = None
-        bucket = url.netloc
-        prefix = re.sub(r'^/*', '/', url.path)
-
-        while True:
-            contents, key = _list_s3_objects(
-                s3, bucket, prefix, num_entries=1024, start_after=key)
-
-            for x in contents:
-                yield x
-
-            if not key:
-                break
+        return list(set(
+            key.split('/', 1)[0]
+            for key in _iter_s3_prefix(s3, url)))
 
 
 def spider(root_urls, depth=0, concurrency=32):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -224,7 +224,7 @@ def url_exists(url):
     try:
         read_from_url(url)
         return True
-    except URLError:
+    except (SpackWebError, URLError):
         return False
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -906,7 +906,7 @@ _spack_gpg() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="verify trust untrust sign create list init export"
+        SPACK_COMPREPLY="verify trust untrust sign create list init export publish"
     fi
 }
 
@@ -967,6 +967,15 @@ _spack_gpg_export() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help"
+    else
+        _keys
+    fi
+}
+
+_spack_gpg_publish() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -d --directory -m --mirror-name --mirror-url --rebuild-index"
     else
         _keys
     fi


### PR DESCRIPTION
Fixes the logic Spack uses when getting keys from a mirror, which was broken after merging #15002 and #15361.

- ~Update `spack.util.web.list_url()` to iterate recursively over all files~
   - ~Changed to be more consistent across `s3://` and `file://` URLs.~

 - ~Changed `bindist.get_keys()` so that it no longer depends on an index.~
   - ~Instead, it will find *all* files under the prefix URL that end
     with .key or .pub~

 - Simplified `bindist.get_keys()` so that it uses the web/url abstraction
   instead of separate code paths for `s3://` and `file://` resources.

TODO:

- [x] Fix tests
- [x] Confirm getting keys from mirror is working
- [x] Add new tests covering changes

EDIT: Crossed out parts of this PR that has since changed.  See discussion for details.