### PR TITLE
MAGMA package: Fixing problems caused by a confused spack concretizer

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -36,7 +36,9 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
-    depends_on('cuda@:10', when='@:2.5.3')  # incompatible with CUDA 11
+    depends_on('cuda@:10.99999')  # incompatible with CUDA 11
+    # The previous line would ideally include "when='@:2.5.3'", but this
+    # doesn't work due to a problem with the concretizer.
 
     conflicts('~cuda', msg='Magma requires cuda')
     conflicts('cuda_arch=none',


### PR DESCRIPTION
Needed to remove the "when" constraint on the cuda dependency due to a problem in the concretizer. It would only match the version in the constraint when the version was included on the command-line.