### PR TITLE
Avoid update and upgrades to brew to avoid conflicting formulae

### DIFF
--- a/.github/workflows/macos_unit_tests.yaml
+++ b/.github/workflows/macos_unit_tests.yaml
@@ -26,8 +26,6 @@ jobs:
           pip install --upgrade flake8 pep8-naming
     - name: Setup Homebrew packages
       run: |
-        brew update
-        brew upgrade
         brew install gcc gnupg2 dash kcov
     - name: Run unit tests
       run: |


### PR DESCRIPTION
Ci is currently failing on `brew update` with the error:
```console
Error: Cannot install bazelisk because conflicting formulae are installed.
  bazel: because Bazelisk replaces the bazel binary

Please `brew unlink bazel` before continuing.

Unlinking removes a formula's symlinks from /usr/local. You can
link the formula again after the install finishes. You can --force this
install, but the build may fail or cause obscure side effects in the
resulting software.
```
Try to avoid:
```
$ brew update
$ brew upgrade
```
to check if it solves the issue