### PR TITLE
oneDNN: add v1.6

### DIFF
--- a/var/spack/repos/builtin/packages/onednn/package.py
+++ b/var/spack/repos/builtin/packages/onednn/package.py
@@ -12,10 +12,11 @@ class Onednn(CMakePackage):
     Formerly known as Intel MKL-DNN and DNNL."""
 
     homepage = "https://01.org/dnnl"
-    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.6.tar.gz"
+    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.6.1.tar.gz"
 
     maintainers = ['adamjstewart']
 
+    version('1.6.1',  sha256='6686d01d9493905c9c8bcfabcf5b2cc9ced7de7a41c52bba99e569fd5b63464d')
     version('1.6',    sha256='f54893e487ccd99586725afdd19f526bb84e3251222586850782e3c7eedb7c4f')
     version('1.5.1',  sha256='aef4d2a726f76f5b98902491a1a4ac69954039aa8e5a1d67ef6ce58ed00e23a6')
     version('1.5',    sha256='2aacc00129418185e0bc1269d3ef82f93f08de2c336932989c0c360279129edb')

--- a/var/spack/repos/builtin/packages/onednn/package.py
+++ b/var/spack/repos/builtin/packages/onednn/package.py
@@ -12,10 +12,11 @@ class Onednn(CMakePackage):
     Formerly known as Intel MKL-DNN and DNNL."""
 
     homepage = "https://01.org/dnnl"
-    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.5.1.tar.gz"
+    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.6.tar.gz"
 
     maintainers = ['adamjstewart']
 
+    version('1.6',    sha256='f54893e487ccd99586725afdd19f526bb84e3251222586850782e3c7eedb7c4f')
     version('1.5.1',  sha256='aef4d2a726f76f5b98902491a1a4ac69954039aa8e5a1d67ef6ce58ed00e23a6')
     version('1.5',    sha256='2aacc00129418185e0bc1269d3ef82f93f08de2c336932989c0c360279129edb')
     version('1.4',    sha256='54737bcb4dc1961d32ee75da3ecc529fa48198f8b2ca863a079e19a9c4adb70f')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with GCC 9.3.0 (via WSL)

https://github.com/oneapi-src/oneDNN/releases/tag/v1.6