### PR TITLE
bugfix: fix spack buildcache list --allarch

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -436,6 +436,12 @@ class Arch(object):
             ('target', self.target.to_dict_or_value())])
         return syaml_dict([('arch', d)])
 
+    def to_spec(self):
+        """Convert this Arch to an anonymous Spec with architecture defined."""
+        spec = spack.spec.Spec()
+        spec.architecture = spack.spec.ArchSpec(str(self))
+        return spec
+
     @staticmethod
     def from_dict(d):
         spec = spack.spec.ArchSpec.from_dict(d)
@@ -518,6 +524,14 @@ def platform():
 
 
 @memoized
+def default_arch():
+    """Default ``Arch`` object for this machine.
+
+    See ``sys_type()``.
+    """
+    return Arch(platform(), 'default_os', 'default_target')
+
+
 def sys_type():
     """Print out the "default" platform-os-target tuple for this machine.
 
@@ -530,8 +544,7 @@ def sys_type():
     architectures.
 
     """
-    arch = Arch(platform(), 'default_os', 'default_target')
-    return str(arch)
+    return str(default_arch())
 
 
 @memoized

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -36,7 +36,6 @@ import spack.util.web as web_util
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.gpg import Gpg
-import spack.architecture as architecture
 
 _build_cache_relative_path = 'build_cache'
 
@@ -856,13 +855,11 @@ def get_spec(spec=None, force=False):
     return try_download_specs(urls=urls, force=force)
 
 
-def get_specs(allarch=False):
+def get_specs():
     """
     Get spec.yaml's for build caches available on mirror
     """
     global _cached_specs
-    arch = architecture.Arch(architecture.platform(),
-                             'default_os', 'default_target')
 
     if not spack.mirror.MirrorCollection():
         tty.debug("No Spack mirrors are currently configured")
@@ -882,8 +879,7 @@ def get_specs(allarch=False):
                 index_url, 'application/json')
             index_object = codecs.getreader('utf-8')(file_stream).read()
         except (URLError, web_util.SpackWebError) as url_err:
-            tty.error('Failed to read index {0}'.format(index_url))
-            tty.debug(url_err)
+            tty.debug('Failed to read index {0}'.format(index_url), url_err, 1)
             # Continue on to the next mirror
             continue
 
@@ -900,9 +896,7 @@ def get_specs(allarch=False):
         spec_list = db.query_local(installed=False)
 
         for indexed_spec in spec_list:
-            spec_arch = architecture.arch_for_spec(indexed_spec.architecture)
-            if (allarch is True or spec_arch == arch):
-                _cached_specs.add(indexed_spec)
+            _cached_specs.add(indexed_spec)
 
     return _cached_specs
 


### PR DESCRIPTION
Fixes #17469.
    
`spack buildcache list` was trying to construct an `Arch` object and compare it to `arch_for_spec(<spec>)`. for each spec in the buildcache.  `Arch` objects are only intended to be constructed for the machine they describe. The `ArchSpec` object (part of the `Spec`) is the descriptor that lets us talk about architectures anywhere.
    
- [x] Make it easier to get a `Spec` with a proper `ArchSpec` from an `Arch` object via new `Arch.to_spec()` method.
    
- [x] Pull `spack.architecture.default_arch()` out of `spack.architecture.sys_type()` so we can get an `Arch` instead of a string.
    
- [x] Modify `spack buildcache list` and `spack buildcache install` to filter with `Spec` matching instead of using `Arch`.

- [x] regression test