### PR TITLE
h5py does not correctly recognize hdf5 version on Cray

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -50,8 +50,7 @@ class PyH5py(PythonPackage):
 
     def configure(self, spec, prefix):
         self.setup_py('configure', '--hdf5={0}'.format(spec['hdf5'].prefix),
-                      '--hdf5-version={0}.{1}.{2}'.format(
-                          *list(spec['hdf5'].version[:3])))
+                      '--hdf5-version={0}'.format(spec['hdf5'].version))
 
         if '+mpi' in spec:
             env['CC'] = spec['mpi'].mpicc

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -49,7 +49,9 @@ class PyH5py(PythonPackage):
     phases = ['configure', 'install']
 
     def configure(self, spec, prefix):
-        self.setup_py('configure', '--hdf5={0}'.format(spec['hdf5'].prefix))
+        self.setup_py('configure', '--hdf5={0}'.format(spec['hdf5'].prefix),
+                      '--hdf5-version={0}.{1}.{2}'.format(
+                          *list(spec['hdf5'].version[:3])))
 
         if '+mpi' in spec:
             env['CC'] = spec['mpi'].mpicc


### PR DESCRIPTION
`hdf5@1.10.5` on Cray is wrongly detected as `1.8.4`. Specify version explicitly using `--hdf5-version` flag.