### PR TITLE
MacOS nightly builds: use Python 3.7 in CI

### DIFF
--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
@@ -37,6 +40,9 @@ jobs:
     timeout-minutes: 700
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
@@ -48,6 +54,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
@@ -60,6 +69,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh


### PR DESCRIPTION
Closes #17806.

#14102 isn't ready yet, @alalazo's on vacation, and #17806 is in draft, so I'm de-drafting it while we wait for #14102 

Nightly builds with MacOS started failing again due to an upgrade of the default virtual environment that now uses Python 3.8

This makes us hit #14102 and every build fails. This commit should be reverted along with the fix to #14102.