### PR TITLE
wcslib: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -11,8 +11,9 @@ class Wcslib(AutotoolsPackage):
     defined in the FITS WCS papers."""
 
     homepage = "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
-    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-6.4.tar.bz2"
+    url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-7.3.tar.bz2"
 
+    version('7.3', sha256='4b01cf425382a26ca4f955ed6841a5f50c55952a2994367f8e067e4183992961')
     version('6.4', sha256='13c11ff70a7725563ec5fa52707a9965fce186a1766db193d08c9766ea107000')
 
     variant('cfitsio', default=False, description='Include CFITSIO support')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 11.0.3.