### PR TITLE
berkeley-db: add version 18.1.40, update build options in package

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -9,10 +9,11 @@ from spack import *
 class BerkeleyDb(AutotoolsPackage):
     """Oracle Berkeley DB"""
 
-    homepage = "http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
-    url      = "http://download.oracle.com/berkeley-db/db-5.3.28.tar.gz"
+    homepage = "https://www.oracle.com/database/technologies/related/berkeleydb.html"
+    url      = "http://download.oracle.com/berkeley-db/db-18.1.40.tar.gz"
 
     version("18.1.40", sha256="0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8")
+    version('18.1.32', sha256='fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654')
     version('6.2.32', sha256='a9c5e2b004a5777aa03510cfe5cd766a4a3b777713406b02809c17c8e0e7a8fb')
     version('6.1.29', sha256='b3c18180e4160d97dd197ba1d37c19f6ea2ec91d31bbfaf8972d99ba097af17d')
     version('6.0.35', sha256='24421affa8ae436fe427ae4f5f2d1634da83d3d55a5ad6354a98eeedb825de55')
@@ -22,16 +23,20 @@ class BerkeleyDb(AutotoolsPackage):
     build_directory = 'build_unix'
 
     def patch(self):
-        # some of the docs are missing in at least 18.1.40
-        filter_file(r'bdb-sql', '', 'dist/Makefile.in')
-        filter_file(r'gsg_db_server', '', 'dist/Makefile.in')
+        # some of the docs are missing in 18.1.40
+        if self.spec.satisfies("@18.1.40"):
+            filter_file(r'bdb-sql', '', 'dist/Makefile.in')
+            filter_file(r'gsg_db_server', '', 'dist/Makefile.in')
 
     def configure_args(self):
-        args = [
+        return [
             '--disable-static',
             '--enable-cxx',
             '--enable-dbm',
             '--enable-stl',
-            "--enable-compat185",  # compat with system berkeley-db on darwin
+            # compat with system berkeley-db on darwin
+            "--enable-compat185",
+            # SSL support requires OpenSSL, but OpenSSL depends on Perl, which
+            # depends on Berkey DB, creating a circular dependency
+            '--with-repmgr-ssl=no',
         ]
-        return args

--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -12,23 +12,26 @@ class BerkeleyDb(AutotoolsPackage):
     homepage = "http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
     url      = "http://download.oracle.com/berkeley-db/db-5.3.28.tar.gz"
 
+    version("18.1.40", sha256="0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8")
     version('6.2.32', sha256='a9c5e2b004a5777aa03510cfe5cd766a4a3b777713406b02809c17c8e0e7a8fb')
     version('6.1.29', sha256='b3c18180e4160d97dd197ba1d37c19f6ea2ec91d31bbfaf8972d99ba097af17d')
     version('6.0.35', sha256='24421affa8ae436fe427ae4f5f2d1634da83d3d55a5ad6354a98eeedb825de55')
     version('5.3.28', sha256='e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628')
 
     configure_directory = 'dist'
-    build_directory = 'spack-build'
+    build_directory = 'build_unix'
 
-# TODO: Gentoo's website removed the BerkeleyDB archives.
-#       Please update the function bellow with a valid mirror.
-#       Right now this package will fetch from the Oracle website,
-#       and versions 5.3.28 and 6.0.35 will fail to download.
-#
-#    def url_for_version(self, version):
-#        # newer version need oracle login, so get them from gentoo mirror
-#        url_fmt = 'http://distfiles.gentoo.org/distfiles/db-{0}.tar.gz'
-#        return url_fmt.format(version)
+    def patch(self):
+        # some of the docs are missing in at least 18.1.40
+        filter_file(r'bdb-sql', '', 'dist/Makefile.in')
+        filter_file(r'gsg_db_server', '', 'dist/Makefile.in')
 
     def configure_args(self):
-        return ['--disable-static', '--enable-cxx', '--enable-stl']
+        args = [
+            '--disable-static',
+            '--enable-cxx',
+            '--enable-dbm',
+            '--enable-stl',
+            "--enable-compat185",  # compat with system berkeley-db on darwin
+        ]
+        return args


### PR DESCRIPTION
Closes #17833.

This fixes the `berkeley-db` build on OS X and updates the version to 18.1.40.