### PR TITLE
deptypes: move deptype formatting code from Spec.format to dependency.py

### DIFF
--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -17,6 +17,26 @@ all_deptypes = ('build', 'link', 'run', 'test')
 default_deptype = ('build', 'link')
 
 
+def deptype_chars(*type_tuples):
+    """Create a string representing deptypes for many dependencies.
+
+    The string will be some subset of 'blrt', like 'bl ', 'b t', or
+    ' lr ' where each letter in 'blrt' stands for 'build', 'link',
+    'run', and 'test' (the dependency types).
+
+    For a single dependency, this just indicates that the dependency has
+    the indicated deptypes. For a list of dependnecies, this shows
+    whether ANY dpeendency in the list has the deptypes (so the deptypes
+    are merged).
+    """
+    types = set()
+    for t in type_tuples:
+        if t:
+            types.update(t)
+
+    return ''.join(t[0] if t in types else ' ' for t in all_deptypes)
+
+
 def canonical_deptype(deptype):
     """Convert deptype to a canonical sorted tuple, or raise ValueError.
 
@@ -108,3 +128,8 @@ class Dependency(object):
                 self.patches[cond].extend(other.patches[cond])
             else:
                 self.patches[cond] = other.patches[cond]
+
+    def __repr__(self):
+        types = deptype_chars(self.type)
+        return '<Dependency: %s -> %s [%s]>' % (
+            self.pkg.name, self.spec, types)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3877,22 +3877,18 @@ class Spec(object):
                     '@K{%s}  ', color=color) % node.dag_hash(hlen)
 
             if show_types:
-                types = set()
                 if cover == 'nodes':
                     # when only covering nodes, we merge dependency types
                     # from all dependents before showing them.
-                    for name, ds in node.dependents_dict().items():
-                        if ds.deptypes:
-                            types.update(set(ds.deptypes))
-                elif dep_spec.deptypes:
+                    types = [
+                        ds.deptypes for ds in node.dependents_dict().values()]
+                else:
                     # when covering edges or paths, we show dependency
                     # types only for the edge through which we visited
-                    types = set(dep_spec.deptypes)
+                    types = [dep_spec.deptypes]
 
-                out += '['
-                for t in dp.all_deptypes:
-                    out += ''.join(t[0] if t in types else ' ')
-                out += ']  '
+                type_chars = dp.deptype_chars(*types)
+                out += '[%s]  ' % type_chars
 
             out += ("    " * d)
             if d > 0:


### PR DESCRIPTION
- [x] Pull deptype formatting (e.g., '[blrt]' for build/link/test/run) out into `dependency.py`
  - This simplifies `Spec.format()`
  - Allows this code to be reused in other places