### PR TITLE
HPX: fix wrong method name and use define/define_from_variant methods

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -174,7 +174,7 @@ class Hpx(CMakePackage, CudaPackage):
 
         # HPX_WITH_GENERIC_CONTEXT_COROUTINES
         args.append(
-            self.define_with_variant(
+            self.define_from_variant(
                 'HPX_WITH_GENERIC_CONTEXT_COROUTINES', 'generic_coroutines')
         )
 

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -117,14 +117,14 @@ class Hpx(CMakePackage, CudaPackage):
 
             condition = 'instrumentation={0}'.format(value)
             yield self.define(
-                'HPX_WITH_{}'.format(value.upper()), condition in self.spec)
+                'HPX_WITH_{0}'.format(value.upper()), condition in self.spec)
 
     def cmake_args(self):
         spec, args = self.spec, []
 
         args += [
             self.define(
-                'HPX_WITH_CXX{}'.format(spec.variants['cxxstd'].value), True),
+                'HPX_WITH_CXX{0}'.format(spec.variants['cxxstd'].value), True),
 
             self.define_from_variant('HPX_WITH_MALLOC', 'malloc'),
             self.define_from_variant('HPX_WITH_CUDA', 'cuda'),

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -110,85 +110,50 @@ class Hpx(CMakePackage, CudaPackage):
     # Patches APEX
     patch('git_external.patch', when='@1.3.0 instrumentation=apex')
 
-    def cxx_standard(self):
-        value = self.spec.variants['cxxstd'].value
-        return '-DHPX_WITH_CXX{0}=ON'.format(value)
-
     def instrumentation_args(self):
         for value in self.variants['instrumentation'].values:
             if value == 'none':
                 continue
 
             condition = 'instrumentation={0}'.format(value)
-            yield '-DHPX_WITH_{0}={1}'.format(
-                str(value).upper(), 'ON' if condition in self.spec else 'OFF'
-            )
+            yield self.define(
+                    'HPX_WITH_{0}'.format(str(value).upper()), condition in self.spec)
 
     def cmake_args(self):
         spec, args = self.spec, []
 
-        # CXX Standard
-        args.append(self.cxx_standard())
+        args += [
+            self.define(
+                'HPX_WITH_CXX{0}'.format(self.spec.variants['cxxstd'].value), True),
 
-        # Malloc
-        selected_malloc = spec.variants['malloc'].value
-        args.append('-DHPX_WITH_MALLOC={0}'.format(selected_malloc))
+            self.define_from_variant('HPX_WITH_MALLOC', 'malloc'),
+            self.define_from_variant('HPX_WITH_CUDA', 'cuda'),
+            self.define_from_variant('HPX_WITH_TOOLS', 'tools'),
+            self.define_from_variant('HPX_WITH_EXAMPLES', 'examples'),
+            self.define('HPX_WITH_TESTS', self.run_tests),
+
+            self.define('HPX_WITH_NETWORKING', 'networking=none' not in spec),
+            self.define('HPX_WITH_PARCELPORT_TCP', 'networking=tcp' in spec),
+            self.define('HPX_WITH_PARCELPORT_MPI', 'networking=mpi' in spec),
+
+            self.define_from_variant('HPX_WITH_MAX_CPU_COUNT', 'max_cpu_count'),
+            self.define_from_variant(
+                'HPX_WITH_GENERIC_CONTEXT_COROUTINES', 'generic_coroutines'),
+
+            self.define('BOOST_ROOT', spec['boost'].prefix),
+            self.define('HWLOC_ROOT', spec['hwloc'].prefix),
+            self.define('HPX_WITH_BOOST_ALL_DYNAMIC_LINK', True),
+            self.define('BUILD_SHARED_LIBS', True),
+            self.define('HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE', False),
+        ]
 
         # Instrumentation
-        args.extend(self.instrumentation_args())
+        args += self.instrumentation_args()
 
         if 'instrumentation=apex' in spec:
-            args += ['-DAPEX_WITH_OTF2=ON',
-                     '-DOTF2_ROOT={0}'.format(spec['otf2'].prefix)]
-
-        # Networking
-        args.append('-DHPX_WITH_NETWORKING={0}'.format(
-            'OFF' if 'networking=none' in spec else 'ON'
-        ))
-        args.append('-DHPX_WITH_PARCELPORT_TCP={0}'.format(
-            'ON' if 'networking=tcp' in spec else 'OFF'
-        ))
-        args.append('-DHPX_WITH_PARCELPORT_MPI={0}'.format(
-            'ON' if 'networking=mpi' in spec else 'OFF'
-        ))
-
-        # Cuda support
-        args.append('-DHPX_WITH_CUDA={0}'.format(
-            'ON' if '+cuda' in spec else 'OFF'
-        ))
-
-        # Tests
-        args.append('-DHPX_WITH_TESTS={0}'.format(
-            'ON' if self.run_tests else 'OFF'
-        ))
-
-        # Tools
-        args.append('-DHPX_WITH_TOOLS={0}'.format(
-            'ON' if '+tools' in spec else 'OFF'
-        ))
-
-        # MAX_CPU_COUNT
-        args.append('-DHPX_WITH_MAX_CPU_COUNT={0}'.format(
-            spec.variants['max_cpu_count'].value
-        ))
-
-        # HPX_WITH_GENERIC_CONTEXT_COROUTINES
-        args.append(
-            self.define_from_variant(
-                'HPX_WITH_GENERIC_CONTEXT_COROUTINES', 'generic_coroutines')
-        )
-
-        # Examples
-        args.append('-DHPX_WITH_EXAMPLES={0}'.format(
-            'ON' if '+examples' in spec else 'OFF'
-        ))
-
-        args.extend([
-            '-DBOOST_ROOT={0}'.format(spec['boost'].prefix),
-            '-DHWLOC_ROOT={0}'.format(spec['hwloc'].prefix),
-            '-DHPX_WITH_BOOST_ALL_DYNAMIC_LINK=ON',
-            '-DBUILD_SHARED_LIBS=ON',
-            '-DHPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE=OFF'
-        ])
+            args += [
+                self.define('APEX_WITH_OTF2', True),
+                self.define('OTF2_ROOT', spec['otf2'].prefix),
+            ]
 
         return args

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -117,14 +117,14 @@ class Hpx(CMakePackage, CudaPackage):
 
             condition = 'instrumentation={0}'.format(value)
             yield self.define(
-                    'HPX_WITH_{0}'.format(str(value).upper()), condition in self.spec)
+                'HPX_WITH_{}'.format(value.upper()), condition in self.spec)
 
     def cmake_args(self):
         spec, args = self.spec, []
 
         args += [
             self.define(
-                'HPX_WITH_CXX{0}'.format(self.spec.variants['cxxstd'].value), True),
+                'HPX_WITH_CXX{}'.format(spec.variants['cxxstd'].value), True),
 
             self.define_from_variant('HPX_WITH_MALLOC', 'malloc'),
             self.define_from_variant('HPX_WITH_CUDA', 'cuda'),
@@ -136,7 +136,8 @@ class Hpx(CMakePackage, CudaPackage):
             self.define('HPX_WITH_PARCELPORT_TCP', 'networking=tcp' in spec),
             self.define('HPX_WITH_PARCELPORT_MPI', 'networking=mpi' in spec),
 
-            self.define_from_variant('HPX_WITH_MAX_CPU_COUNT', 'max_cpu_count'),
+            self.define_from_variant(
+                'HPX_WITH_MAX_CPU_COUNT', 'max_cpu_count'),
             self.define_from_variant(
                 'HPX_WITH_GENERIC_CONTEXT_COROUTINES', 'generic_coroutines'),
 


### PR DESCRIPTION
In the last PR I used `define_from_variant` with the wrong name, moreover I preferred to keep the "refactoring" of the script in a separate PR.

Here it is. I quickly tested it, but it is not so easy to test all the variants. An additional eye check would be very useful.

Thanks in advance!