### PR TITLE
cray support: do not specify target args

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -332,7 +332,11 @@ def set_compiler_environment_variables(pkg, env):
         env.set("SPACK_DTAGS_TO_ADD", compiler.enable_new_dtags)
 
     # Set the target parameters that the compiler will add
-    isa_arg = spec.architecture.target.optimization_flags(compiler)
+    # Don't set on cray platform because the targeting module handles this
+    if spec.satisfies("platform=cray"):
+        isa_arg = ""
+    else:
+        isa_arg = spec.architecture.target.optimization_flags(compiler)
     env.set("SPACK_TARGET_ARGS", isa_arg)
 
     # Trap spack-tracked compiler flags as appropriate.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2755,7 +2755,9 @@ class Spec(object):
 
         # Check if we can produce an optimized binary (will throw if
         # there are declared inconsistencies)
-        self.architecture.target.optimization_flags(self.compiler)
+        # No need on platform=cray because of the targeting modules
+        if not self.satisfies("platform=cray"):
+            self.architecture.target.optimization_flags(self.compiler)
 
     def _patches_assigned(self):
         """Whether patches have been assigned to this spec by the concretizer."""


### PR DESCRIPTION
We already load the module associated with the target on Cray systems. Delegate to cray modules for targeting options for the compiler.

This is important because Cray compiler wrappers enable combinations of compilers that we otherwise cannot concretize for, such as `%gcc@8.1.0 target=zen2`. The Cray module gracefully backs up to zen1 for that install. We cannot solve the problem by backtracking the architecture in Spack as we do on other systems, because Cray does not always publish modules for all ancestors to a given architecture they support.

All necessary information is already on the spec, since the Cray platform is noted in the architecture.