### PR TITLE
fix buildcache create for environments with uninstalled root specs

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -239,8 +239,9 @@ def find_matching_specs(pkgs, allow_multiple_matches=False, env=None):
        concretized specs given from cli
 
     Args:
-        specs: list of specs to be matched against installed packages
-        allow_multiple_matches : if True multiple matches are admitted
+        pkgs (string): spec to be matched against installed packages
+        allow_multiple_matches (bool): if True multiple matches are admitted
+        env (Environment): active environment, or ``None`` if there is not one
 
     Return:
         list of specs

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -349,7 +349,7 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
 
     else:
         tty.die("build cache file creation requires at least one" +
-                " installed package spec, an activate environment," +
+                " installed package spec, an active environment," +
                 " or else a path to a yaml file containing a spec" +
                 " to install")
     specs = set()

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -371,11 +371,14 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
         else:
             lookup = spack.store.db.query_one(match)
 
-            if add_spec and lookup is not None:
+            if not add_spec:
+                tty.debug('skipping matching root spec %s' % match.format())
+            elif lookup is None:
+                tty.debug('skipping uninstalled matching spec %s' %
+                          match.format())
+            else:
                 tty.debug('adding matching spec %s' % match.format())
                 specs.add(match)
-            else:
-                tty.debug('skipping matching spec %s' % match.format())
 
             if not add_deps:
                 continue
@@ -390,8 +393,11 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
 
                 lookup = spack.store.db.query_one(node)
 
-                if node.external or node.virtual or lookup is None:
+                if node.external or node.virtual:
                     tty.debug('skipping external or virtual dependency %s' %
+                              node.format())
+                elif lookup is None:
+                    tty.debug('skipping uninstalled depenendency %s' %
                               node.format())
                 else:
                     tty.debug('adding dependency %s' % node.format())


### PR DESCRIPTION
Fixes #17858, where `spack buildcache create` does not work in an environment because a root-spec is uninstalled
