### PR TITLE
subread: Support version 2.0.0 for aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -33,7 +33,7 @@ class Subread(MakefilePackage):
                 )
                 if spec.target.family == 'aarch64':
                     filter_file('-mtune=core2', '', 'Makefile.Linux')
-                    if spec.satisfies('@1.6.2:1.6.4'):
+                    if spec.satisfies('@1.6.2:2.0.0'):
                         filter_file(
                             '-mtune=core2',
                             '',


### PR DESCRIPTION
This PR modifies the processing of aarch64 with the support of version 2.0.0.