### PR TITLE
activeharmony: support version 4.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/activeharmony/fix_logical_bug_in_slave_list_parsing.patch
+++ b/var/spack/repos/builtin/packages/activeharmony/fix_logical_bug_in_slave_list_parsing.patch
@@ -1,0 +1,29 @@
+diff --git a/code-server/code_generator.cxx b/code-server/code_generator.cxx
+index df25400..1c213f7 100644
+--- a/code-server/code_generator.cxx
++++ b/code-server/code_generator.cxx
+@@ -574,13 +574,13 @@ int parse_slave_list(const char* hostlist)
+         }
+ 
+         // Skip leading whitespace.
+-        while (head < tail && (head == '\0' || isspace(*head))) {
++        while (head < tail && (*head == '\0' || isspace(*head))) {
+             ++head;
+         }
+         host_ptr = head;
+ 
+         // Find host boundary whitespace.
+-        while (head < tail && (head != '\0' && !isspace(*head))) {
++        while (head < tail && (*head != '\0' && !isspace(*head))) {
+             ++head;
+         }
+         host = string(host_ptr, head++);
+@@ -596,7 +596,7 @@ int parse_slave_list(const char* hostlist)
+         }
+ 
+         // Skip trailing whitespace.
+-        while (head < tail && (head == '\0' || isspace(*head))) {
++        while (head < tail && (*head == '\0' || isspace(*head))) {
+             ++head;
+         }
+ 

--- a/var/spack/repos/builtin/packages/activeharmony/package.py
+++ b/var/spack/repos/builtin/packages/activeharmony/package.py
@@ -6,14 +6,31 @@
 from spack import *
 
 
-class Activeharmony(Package):
+class Activeharmony(MakefilePackage):
     """Active Harmony: a framework for auto-tuning (the automated search for
-       values to improve the performance of a target application)."""
+    values to improve the performance of a target application)."""
+
     homepage = "http://www.dyninst.org/harmony"
     url      = "http://www.dyninst.org/sites/default/files/downloads/harmony/ah-4.5.tar.gz"
 
-    version('4.5', sha256='31d9990c8dd36724d336707d260aa4d976e11eaa899c4c7cc11f80a56cdac684')
+    version('4.6.0', sha256='9ce5009cfd8e2f4cf5f3536e1fea9993414fc25920fc90d0a2cb56f044787dbb')
+    version('4.5',   sha256='31d9990c8dd36724d336707d260aa4d976e11eaa899c4c7cc11f80a56cdac684')
 
-    def install(self, spec, prefix):
+    patch('fix_logical_bug_in_slave_list_parsing.patch', sha256='3e000616f84de80b262efcae7559d65eed0efcd53e915580dab63b0ffbbb8bf2', when='@4.6.0')
+
+    def build(self, spec, prefix):
         make("CFLAGS=-O3")
+
+    @when('@:4.5')
+    def install(self, spec, prefix):
         make("install", 'PREFIX=%s' % prefix)
+
+    @when('@4.6.0:')
+    def install(self, spec, prefix):
+        make("install")
+        install_tree("./bin", prefix.bin)
+        install("./src/harmony.cfg", prefix.bin)
+        install_tree("./lib", prefix.lib)
+        install_tree("./libexec", prefix.libexec)
+        install_tree("./include", prefix.include)
+        install_tree("./doc", prefix.doc)

--- a/var/spack/repos/builtin/packages/activeharmony/package.py
+++ b/var/spack/repos/builtin/packages/activeharmony/package.py
@@ -18,8 +18,10 @@ class Activeharmony(MakefilePackage):
 
     patch('fix_logical_bug_in_slave_list_parsing.patch', sha256='3e000616f84de80b262efcae7559d65eed0efcd53e915580dab63b0ffbbb8bf2', when='@4.6.0')
 
-    def build(self, spec, prefix):
-        make("CFLAGS=-O3")
+    cflags = ['-O3', '-fPIC']
+
+    def setup_build_environment(self, spack_env):
+        spack_env.set('CFLAGS', ' '.join(self.cflags))
 
     @when('@:4.5')
     def install(self, spec, prefix):


### PR DESCRIPTION
The patch "fix_logical_bug_in_slave_list_parsing.patch" is merged to `4.6.0-dev` branch.
The patch is come from here:
https://github.com/ActiveHarmony/harmony/commit/f4bbc840ccbdc94746b57d5dc3910f69824d99bc