### PR TITLE
Prefer dynamic linking for Python in vim when +python

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -91,11 +91,11 @@ class Vim(AutotoolsPackage):
 
         if '+python' in spec:
             if 'python@3:' in self.spec:
-                configure_args.append("--enable-python3interp=yes")
+                configure_args.append("--enable-python3interp=dynamic")
                 configure_args.append("--enable-pythoninterp=no")
             else:
                 configure_args.append("--enable-python3interp=no")
-                configure_args.append("--enable-pythoninterp=yes")
+                configure_args.append("--enable-pythoninterp=dynamic")
         else:
             configure_args.append("--enable-python3interp=no")
 


### PR DESCRIPTION
Previously the python package for vim used static linking, and depending
on what system libraries were available and linked against could cause
symbol conflicts for python leading to segfaults in loading c modules in
the standard library (i.e. heapq).  This patch address this issue by
dynamically linking them.