### PR TITLE
bugfix: fix spack -V with releases/latest and shallow clones

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -128,8 +128,8 @@ def get_version():
         git = exe.which("git")
         if git:
             with fs.working_dir(spack.paths.prefix):
-                desc = git(
-                    "describe", "--tags", output=str, fail_on_error=False)
+                desc = git("describe", "--tags", "--match", "v*",
+                           output=str, error=os.devnull, fail_on_error=False)
 
             if git.returncode == 0:
                 match = re.match(r"v([^-]+)-([^-]+)-g([a-f\d]+)", desc)


### PR DESCRIPTION
`spack -V` stopped working when we added the `releases/latest` tag to track the most recent release. It started just reporting the version, even on a `develop` checkout. We need to tell it to *only* search for tags that start with `v`, so that it will ignore `releases/latest`.

`spack -V` also would print out unwanted git eror output on a shallow clone.

- [x] add `--match 'v*'` to `git describe` arguments
- [x] route error output to `os.devnull`