### PR TITLE
remove hypre variant from mfem and all references to it

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -124,7 +124,7 @@ class Axom(CMakePackage, CudaPackage):
         depends_on('umpire cuda_arch={0}'.format(sm_),
                    when='+umpire cuda_arch={0}'.format(sm_))
 
-    depends_on("mfem~mpi~hypre~metis~zlib", when="+mfem")
+    depends_on("mfem~mpi~metis~zlib", when="+mfem")
 
     depends_on("python", when="+python")
 

--- a/var/spack/repos/builtin/packages/cardioid/package.py
+++ b/var/spack/repos/builtin/packages/cardioid/package.py
@@ -25,8 +25,8 @@ class Cardioid(CMakePackage):
     depends_on('lapack')
     depends_on('mpi')
     depends_on('cuda', when="+cuda")
-    depends_on('mfem+hypre+superlu-dist+lapack', when="+mfem~cuda")
-    depends_on('mfem+hypre+superlu-dist+lapack^hypre+cuda', when="+mfem+cuda")
+    depends_on('mfem+mpi+superlu-dist+lapack', when="+mfem~cuda")
+    depends_on('mfem+mpi+superlu-dist+lapack^hypre+cuda', when="+mfem+cuda")
     depends_on('cmake@3.1:', type='build')
     depends_on('perl', type='build')
 

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -92,12 +92,6 @@ class Mfem(Package):
     # Can we make the default value for 'metis' to depend on the 'mpi' value?
     variant('metis', default=True,
             description='Enable METIS support')
-    # TODO: The 'hypre' variant is the same as 'mpi', we may want to remove it.
-    #       For now, keep the 'hypre' variant while ignoring its setting. This
-    #       is done to preserve compatibility with other packages that refer to
-    #       it, e.g. xSDK.
-    variant('hypre', default=True,
-            description='Required for MPI parallelism')
     variant('openmp', default=False,
             description='Enable OpenMP parallelism')
     variant('cuda', default=False, description='Enable CUDA support')


### PR DESCRIPTION
This is following up on a long-standing TODO in the mfem package.