### PR TITLE
add     depends_on('zlib',      type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/advancecomp/package.py
+++ b/var/spack/repos/builtin/packages/advancecomp/package.py
@@ -22,3 +22,4 @@ class Advancecomp(AutotoolsPackage):
     depends_on('automake',  type='build')
     depends_on('libtool',   type='build')
     depends_on('m4',        type='build')
+    depends_on('zlib',      type='link')


### PR DESCRIPTION
The following error occurred during the installation
We need to add an zlib dependency.

```
==> Error: ProcessError: Command exited with status 1:
    '/tmp/denpo/spack-stage/spack-stage-advancecomp-2.1-e6ptazkjzun72jcsspy5izvmamxeyjir/spack-src/configure' '--prefix=/home/denpo/develop/spack/opt/spack/linux-rhel8-haswell/gcc-8.3.1/advancecomp-2.1-e6ptazkjzun72jcsspy5izvmamxeyjir'

1 error found in build log:
     71    checking for valgrind... valgrind --leak-check=full --track-fds=yes --error-exitcode=1
     72    checking for wine... no
     73    checking for advd2... no
     74    checking for special C compiler options needed for large files... no
     75    checking for _FILE_OFFSET_BITS value needed for large files... no
     76    checking for adler32 in -lz... no
  >> 77    configure: error: the libz library is missing

```
