### PR TITLE
bcache:add pkg-config to find blkid.h in linux-utils

### DIFF
--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -22,6 +22,7 @@ class Bcache(MakefilePackage):
     depends_on('libuuid')
     depends_on('util-linux')
     depends_on('gettext')
+    depends_on('pkgconfig', type='build')
 
     def setup_build_environment(self, env):
         env.append_flags('LDFLAGS', '-lintl')


### PR DESCRIPTION
fix build error on `bcache`