### PR TITLE
py-rasterio: add v1.1.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -14,28 +14,31 @@ class PyRasterio(PythonPackage):
     arrays."""
 
     homepage = "https://github.com/mapbox/rasterio"
-    url      = "https://pypi.io/packages/source/r/rasterio/rasterio-1.0.24.tar.gz"
+    url      = "https://pypi.io/packages/source/r/rasterio/rasterio-1.1.5.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = ['rasterio', 'rasterio.rio']
 
+    version('1.1.5',  sha256='ebe75c71f9257c780615caaec8ef81fa4602702cf9290a65c213e1639284acc9')
     version('1.0.24', sha256='4839479621045211f66868ec49625979693450bc2e476f23e7e8ac4804eaf452')
     version('1.0a12', sha256='47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c')
 
-    depends_on('python@3:', type=('build', 'run'), when='@1.1:')
+    depends_on('python@3.5:', type=('build', 'link', 'run'), when='@1.2:')
+    depends_on('python@2.7:2.8,3.5:3.8', type=('build', 'link', 'run'), when='@1.1.0:1.1.999')
+    depends_on('python@2.7:2.8,3.5:3.7', type=('build', 'link', 'run'), when='@:1.0')
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython', type='build')
     depends_on('py-affine', type=('build', 'run'))
     depends_on('py-attrs', type=('build', 'run'))
     depends_on('py-click@4:7', type=('build', 'run'))
     depends_on('py-cligj@0.5:', type=('build', 'run'))
-    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'link', 'run'))
     depends_on('py-snuggs@1.4.1:', type=('build', 'run'))
     depends_on('py-click-plugins', type=('build', 'run'))
     depends_on('py-enum34', type='run', when='^python@:3.3')
-    depends_on('gdal@1.11:')
-    depends_on('jpeg')
+    depends_on('gdal@1.11:3.0', when='@1.0.25:')
+    depends_on('gdal@1.11:2', when='@:1.0.24')
     depends_on('py-pytest@2.8.2:', type='test')
+    depends_on('py-pytest-cov@2.2.0:', type='test')
     depends_on('py-boto3@1.2.4:', type='test')
     depends_on('py-packaging', type='test')
     depends_on('py-hypothesis', type='test')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.8 and GCC 9.3.0 (via WSL)