### PR TITLE
Smoke tests: Preliminary berkeley-db install tests

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -32,3 +32,15 @@ class BerkeleyDb(AutotoolsPackage):
 
     def configure_args(self):
         return ['--disable-static', '--enable-cxx', '--enable-stl']
+
+    def test(self):
+        """Perform smoke tests on the installed package binaries."""
+        exes = [
+            'db_checkpoint', 'db_deadlock', 'db_dump', 'db_load',
+            'db_printlog', 'db_stat', 'db_upgrade', 'db_verify'
+        ]
+        for exe in exes:
+            reason = 'test version of {0} is {1}'.format(exe,
+                                                         self.spec.version)
+            self.run_test(exe, ['-V'], [self.spec.version.string], None,
+                          installed=True, purpose=reason, skip_missing=True)


### PR DESCRIPTION
This PR adds version checks of a subset of the installed binaries build by berkeley-db.

It has been tested using versions: `6.2.32` (explicitly installed) and `18.1.40` (implicitly installed).