### PR TITLE
Add new package: tiptop

### DIFF
--- a/var/spack/repos/builtin/packages/tiptop/NR_perf_counter_open_aarch64.patch
+++ b/var/spack/repos/builtin/packages/tiptop/NR_perf_counter_open_aarch64.patch
@@ -1,0 +1,13 @@
+diff --git a/src/pmc.c b/src/pmc.c
+index 3467e1c..d20ad81 100644
+--- a/src/pmc.c
++++ b/src/pmc.c
+@@ -22,6 +22,8 @@
+ #define __NR_perf_counter_open	319
+ #elif defined(__ARM_EABI__)
+ #define __NR_perf_counter_open	364
++#elif defined(__aarch64__)
++#define __NR_perf_counter_open  241
+ #elif defined(__x86_64__)
+ #define __NR_perf_counter_open	298
+ #elif defined(__i386__)

--- a/var/spack/repos/builtin/packages/tiptop/package.py
+++ b/var/spack/repos/builtin/packages/tiptop/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Tiptop(AutotoolsPackage):
+    """Tiptop is a performance monitoring tool for Linux."""
+
+    homepage = "https://github.com/FeCastle/tiptop"
+    git      = "https://github.com/FeCastle/tiptop.git"
+
+    version('master', commit='529886d445ec32febad14246245372a8f244b3eb')
+
+    depends_on('papi')
+    depends_on('byacc', type='build')
+    depends_on('flex', type='build')
+
+    patch('NR_perf_counter_open_aarch64.patch',
+        sha256='024c2263108de2033a6017eb6fcf23bdd5e2293d83ce6a890fcb84454c7d79e1',
+        when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/tiptop/package.py
+++ b/var/spack/repos/builtin/packages/tiptop/package.py
@@ -18,4 +18,4 @@ class Tiptop(AutotoolsPackage):
     depends_on('byacc', type='build')
     depends_on('flex', type='build')
 
-    patch('NR_perf_counter_open_aarch64.patch', sha256='024c2263108de2033a6017eb6fcf23bdd5e2293d83ce6a890fcb84454c7d79e1', when='target=aarch64:')
+    patch('NR_perf_counter_open_aarch64.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/tiptop/package.py
+++ b/var/spack/repos/builtin/packages/tiptop/package.py
@@ -18,6 +18,4 @@ class Tiptop(AutotoolsPackage):
     depends_on('byacc', type='build')
     depends_on('flex', type='build')
 
-    patch('NR_perf_counter_open_aarch64.patch',
-        sha256='024c2263108de2033a6017eb6fcf23bdd5e2293d83ce6a890fcb84454c7d79e1',
-        when='target=aarch64:')
+    patch('NR_perf_counter_open_aarch64.patch', sha256='024c2263108de2033a6017eb6fcf23bdd5e2293d83ce6a890fcb84454c7d79e1', when='target=aarch64:')


### PR DESCRIPTION
`tiptop` need a patch to support `aarch64` platform,
but looks no one maintains the community now.
Anyway, I opened an issue for that: https://github.com/FeCastle/tiptop/issues/6
and give the reason why we modified it like that:
> And "#define __NR_perf_counter_open 241" comes from linux kernel code: include/uapi/asm-generic/unistd.h : "#define __NR_perf_event_open 241"
