### PR TITLE
ocaml: fix assembler to use spack_cc

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -44,6 +44,13 @@ class Ocaml(Package):
         if self.spec.satisfies('~force-safe-string'):
             base_args += ['--disable-force-safe-string']
 
+        if self.spec.satisfies('%fj'):
+            filter_file(
+                'clang -c -Wno-trigraphs',
+                spack_cc + ' -c -Wno-trigraphs',
+                'configure'
+            )
+
         configure(*(base_args))
 
         make('world.opt')

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -44,11 +44,15 @@ class Ocaml(Package):
         if self.spec.satisfies('~force-safe-string'):
             base_args += ['--disable-force-safe-string']
 
+        # This patch is aarch64-linux-fj only.
+        # However, similar patch is needed for other arch/OS/compiler
+        # to use correct assembler. (See #17918)
         if self.spec.satisfies('%fj'):
             filter_file(
-                'clang -c -Wno-trigraphs',
-                spack_cc + ' -c -Wno-trigraphs',
-                'configure'
+                '${toolpref}clang -c -Wno-trigraphs',
+                spack_cc + ' -c',
+                'configure',
+                string=True
             )
 
         configure(*(base_args))


### PR DESCRIPTION
Patch assembler setting to use `speck_cc`.

This patch is for aarch64-fj only.
However, similar patch is probably needed for other architectue/compiler.
From `configure`
>   amd64,*|arm,*|arm64,*|i386,*) :
    default_as="${toolpref}as"
    case $ocaml_cv_cc_vendor in #(
  clang-*) :
    default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #( // I patched this line
  *) :
    default_aspp="${toolpref}gcc -c" ;;