### PR TITLE
Smoke tests: harden smoke tests to package syntax errors

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -444,6 +444,47 @@ class PackageViewMixin(object):
             view.remove_file(src, dst)
 
 
+def test_pkg_id(spec):
+    """Build the standard install test package identifier
+
+    Args:
+        spec (Spec): instance of the spec under test
+
+    Returns:
+        (str): the install test package identifier
+    """
+    return spec.format('{name}-{version}-{hash:7}')
+
+
+def test_log_pathname(test_stage, spec):
+    """Build the pathname of the test log file
+
+    Args:
+        test_stage (str): path to the test stage directory
+        spec (Spec): instance of the spec under test
+
+    Returns:
+        (str): the pathname of the test log file
+    """
+    return os.path.join(test_stage,
+                        'test-{0}-out.txt'.format(test_pkg_id(spec)))
+
+
+def setup_test_stage(test_name):
+    """Set up the test stage directory.
+
+    Args:
+        test_name (str):  the name of the test
+
+    Returns:
+        (str): the path to the test stage directory
+    """
+    test_stage = Prefix(spack.cmd.test.get_stage(test_name))
+    if not os.path.exists(test_stage):
+        fsys.mkdirp(test_stage)
+    return test_stage
+
+
 class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     """This is the superclass for all spack packages.
 
@@ -1638,16 +1679,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Clear test failures
         self.test_failures = []
 
-        self.test_stage = Prefix(spack.cmd.test.get_stage(name))
-        if not os.path.exists(self.test_stage):
-            fsys.mkdirp(self.test_stage)
-        self.test_log_file = os.path.join(self.test_stage, self.test_log_name)
+        self.test_stage = setup_test_stage(name)
+        self.test_log_file = test_log_pathname(self.test_stage, self.spec)
 
         def test_process():
             with tty.log.log_output(self.test_log_file) as logger:
                 with logger.force_echo():
-                    tty.msg('Testing package %s' %
-                            self.spec.format('{name}-{version}-{hash:7}'))
+                    tty.msg('Testing package {0}'
+                            .format(test_pkg_id(self.spec)))
 
                 # use debug print levels for log file to record commands
                 old_debug = tty.is_debug()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1077,7 +1077,8 @@ class Repo(object):
                 # manually construct the error message in order to give the
                 # user the correct package.py where the syntax error is located
                 raise SyntaxError('invalid syntax in {0:}, line {1:}'
-                                  ''.format(file_path, e.lineno))
+                                  .format(file_path, e.lineno))
+
             module.__package__ = self.full_namespace
             module.__loader__ = self
             self._modules[pkg_name] = module


### PR DESCRIPTION
This PR supports the following:

- changes smoke/install tests to catch and log `SyntaxError` failures;
- adds tests for new routines; and
- ensures existing test command tests use the mock test stage (to avoid "polluting" the standard test stage directory.

This PR has been tested manually using Python 2 *and* Python3 on the `m4` package with and without a syntax error.