### PR TITLE
hpctoolkit: fix commit hash for version 2020.08.03

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -20,7 +20,7 @@ class Hpctoolkit(AutotoolsPackage):
 
     version('develop', branch='develop')
     version('master',  branch='master')
-    version('2020.08.03', commit='f5853882147d18bed81127dfeeef2f68b5c58db0')
+    version('2020.08.03', commit='d9d13c705d81e5de38e624254cf0875cce6add9a')
     version('2020.07.21', commit='4e56c780cffc53875aca67d6472a2fb3678970eb')
     version('2020.06.12', commit='ac6ae1156e77d35596fea743ed8ae768f7222f19')
     version('2020.03.01', commit='94ede4e6fa1e05e6f080be8dc388240ea027f769')


### PR DESCRIPTION
In the previous commit for hpctoolkit 2020.08.03, I picked the wrong
commit hash (an "off-by-one" error, my bad).  The bits are the same,
except --version reports the wrong answer.