### PR TITLE
r-rcppparallel: Fujitsu compiler as clang

### DIFF
--- a/var/spack/repos/builtin/packages/r-rcppparallel/asclang.patch
+++ b/var/spack/repos/builtin/packages/r-rcppparallel/asclang.patch
@@ -1,0 +1,12 @@
+diff -u -r -N a/src/Makevars.in b/src/Makevars.in
+--- a/src/Makevars.in	2020-08-06 09:31:48.000000000 +0900
++++ b/src/Makevars.in	2020-08-06 09:34:01.000000000 +0900
+@@ -87,6 +87,8 @@
+ 	cd tbb/src; \
+ 	if [ -n "$(shell echo $(CC) | grep clang)" ]; then \
+ 	   $(MAKE_CMD) stdver=@STDVER@ compiler=clang $(MAKE_ARGS); \
++	elif [ -n "$(shell echo $(CC) | grep fcc)" ]; then \
++	   $(MAKE_CMD) stdver=@STDVER@ compiler=clang $(MAKE_ARGS); \
+ 	elif [ -n "$(shell echo $(CC) | grep gcc)" ]; then \
+ 	   $(MAKE_CMD) stdver=@STDVER@ compiler=gcc $(MAKE_ARGS); \
+ 	else \

--- a/var/spack/repos/builtin/packages/r-rcppparallel/package.py
+++ b/var/spack/repos/builtin/packages/r-rcppparallel/package.py
@@ -20,3 +20,5 @@ class RRcppparallel(RPackage):
 
     depends_on('r@3.0.2:', type=('build', 'run'))
     depends_on('gmake', type='build')
+
+    patch('asclang.patch', when='%fj')


### PR DESCRIPTION
Fujitsu compiler was recognized as `gcc` and bad compiler options were added.
So I patched `src/Makevars.in` to be recognized as `clang`