### PR TITLE
minizip: support minizip and miniunz building

### DIFF
--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -22,15 +22,15 @@ class Minizip(AutotoolsPackage):
     depends_on('m4', type='build')
     depends_on('zlib')
 
+    # build minizip and miniunz
     @run_before('autoreconf')
     def build_minizip_binary(self):
-        print(self)
-        bash = which('bash')
-        bash('./configure')
+        configure()
         make()
         with working_dir(self.configure_directory):
             make()
 
+    # install minizip and miniunz
     @run_after('install')
     def install_minizip_binary(self):
         mkdirp(self.prefix.bin)

--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -21,3 +21,21 @@ class Minizip(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
     depends_on('zlib')
+
+    # build minizip and miniunz
+    @run_before('autoreconf')
+    def build_minizip_binary(self):
+        print(self)
+        bash = which('bash')
+        bash('./configure')
+        make()
+        with working_dir(self.configure_directory):
+            make()
+
+    # install minizip and miniunz
+    @run_after('install')
+    def install_minizip_binary(self):
+        mkdirp(self.prefix.bin)
+        with working_dir(self.configure_directory):
+            install('minizip', self.prefix.bin)
+            install('miniunz', self.prefix.bin)

--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -22,7 +22,6 @@ class Minizip(AutotoolsPackage):
     depends_on('m4', type='build')
     depends_on('zlib')
 
-    # build minizip and miniunz
     @run_before('autoreconf')
     def build_minizip_binary(self):
         print(self)
@@ -32,7 +31,6 @@ class Minizip(AutotoolsPackage):
         with working_dir(self.configure_directory):
             make()
 
-    # install minizip and miniunz
     @run_after('install')
     def install_minizip_binary(self):
         mkdirp(self.prefix.bin)


### PR DESCRIPTION
`minizip` has two `configure` file, the first is in root dir, the second is in `contrib/minizip`.
when you run `contrib/minizip/configure` the `contrib/minizip/Makefile` will be completely rewrite as a minizip-lib makefile.
while the raw `contrib/minizip/Makefile` is used to generate `minizip` and `miniunz` binary.

So, I insert a new flow before `contrib/minizip/configule` build flow, to make sure we can get `minizip` and `miniunz` binary.
I'm not sure is that method is matching `spack coding style` or not.