### PR TITLE
Added FFLAGS for apple-clang:11

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -181,7 +181,7 @@ spack package at this time.''',
         # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
         if self.spec.satisfies('%gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
-        # Same fix but for max - avoids issue #
+        # Same fix but for max - avoids issue #17934
         if self.spec.satisfies('%apple-clang@11:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -181,6 +181,9 @@ spack package at this time.''',
         # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
         if self.spec.satisfies('%gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+        # Same fix but for max - avoids issue #
+        if self.spec.satisfies('%apple-clang@11:'):
+            env.set('FFLAGS', '-fallow-argument-mismatch')
 
     def setup_run_environment(self, env):
         # Because MPI implementations provide compilers, they have to add to

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -181,7 +181,7 @@ spack package at this time.''',
         # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
         if self.spec.satisfies('%gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
-        # Same fix but for max - avoids issue #17934
+        # Same fix but for macOS - avoids issue #17934
         if self.spec.satisfies('%apple-clang@11:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
 


### PR DESCRIPTION
This is a small PR is to try to Fix #17934 .

Tested successfully on my macOS machine:
```console
$ spack debug report
* **Spack:** 0.15.3-421-c83236d3a
* **Python:** 3.7.3
* **Platform:** darwin-catalina-skylake
```

* clang version: 11.0.3
* gcc (gfortran) version: 10.2.0
* cmake version: 3.18.1

This fix is valid for when `gfortran` is coming from `gcc@10:`, which I achieved using:
```console
$ % cat ~/.spack/darwin/compilers.yaml 
compilers:
- compiler:
    spec: apple-clang@11.0.3
    paths:
      cc: /usr/bin/clang
      cxx: /usr/bin/clang++
      f77: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/gfortran
      fc: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/gfortran
    flags: {}
    operating_system: catalina
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
- compiler:
    spec: gcc@10.2.0
    paths:
      cc: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/gcc
      cxx: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/g++
      f77: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/gfortran
      fc: /Users/LDianaAmorim/Documents/opt/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/gcc-10.2.0-phyqkhktab6nxd2noi3kklzjxsnku5le/bin/gfortran
    flags: {}
    operating_system: catalina
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
```