### PR TITLE
FFTW: "configure" script failed with Intel compilers on some systems.

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/intel-configure.patch
+++ b/var/spack/repos/builtin/packages/fftw/intel-configure.patch
@@ -1,0 +1,54 @@
+--- configure	2020-08-07 15:58:51.343052000 +0200
++++ configure	2020-08-07 16:03:16.202984102 +0200
+@@ -14858,51 +14858,6 @@
+ 
+ 
+ case "${ax_cv_c_compiler_vendor}" in
+-   intel) # Stop icc from defining __GNUC__, except on MacOS where this fails
+-        case "${host_os}" in
+-            *darwin*) ;; # icc -no-gcc fails to compile some system headers
+-            *)
+-	        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -no-gcc" >&5
+-$as_echo_n "checking whether C compiler accepts -no-gcc... " >&6; }
+-if ${ax_cv_c_flags__no_gcc+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-      ax_save_FLAGS=$CFLAGS
+-      CFLAGS="-no-gcc"
+-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  ax_cv_c_flags__no_gcc=yes
+-else
+-  ax_cv_c_flags__no_gcc=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-      CFLAGS=$ax_save_FLAGS
+-fi
+-
+-eval ax_check_compiler_flags=$ax_cv_c_flags__no_gcc
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_check_compiler_flags" >&5
+-$as_echo "$ax_check_compiler_flags" >&6; }
+-if test "x$ax_check_compiler_flags" = xyes; then
+-	CC="$CC -no-gcc"
+-else
+-	:
+-fi
+-
+-               ;;
+-        esac
+-        ;;
+-
+    hp) # must (sometimes) manually increase cpp limits to handle fftw3.h
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wp,-H128000" >&5
+ $as_echo_n "checking whether C compiler accepts -Wp,-H128000... " >&6; }

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -33,6 +33,7 @@ class Fftw(AutotoolsPackage):
     patch('pfft-3.3.5.patch', when="@3.3.5:+pfft_patches", level=0)
     patch('pfft-3.3.4.patch', when="@3.3.4+pfft_patches", level=0)
     patch('pgi-3.3.6-pl2.patch', when="@3.3.6-pl2%pgi", level=0)
+    patch('intel-configure.patch', when="@3:3.3.8%intel", level=0)
 
     variant(
         'precision', values=any_combination_of(


### PR DESCRIPTION
Next version of FFTW won't use `-no-gcc` so add a patch to backport the fix to older versions.

Fixes #17810.