### PR TITLE
conduit: dont use cmake >= 3.18 because of FindHDF5 bug

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -85,7 +85,7 @@ class Conduit(Package):
     # CMake
     #######################
     # cmake 3.8.2 or newer
-    depends_on("cmake@3.8.2:", type='build')
+    depends_on("cmake@3.8.2:3.17.9999", type='build')
 
     #######################
     # Python


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/17846