### PR TITLE
[WIP] Load external modules in environments

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -118,7 +118,7 @@ def env_activate(args):
     sys.stdout.write(cmds)
 
     if args.with_view:
-        ev.load_external_modules()
+        active_env.load_external_modules()
 
 #
 # env deactivate

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -117,6 +117,8 @@ def env_activate(args):
     )
     sys.stdout.write(cmds)
 
+    if args.with_view:
+        ev.load_external_modules()
 
 #
 # env deactivate

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -180,8 +180,6 @@ def activate(
         if add_view and default_view_name in env.views:
             with spack.store.db.read_transaction():
                 cmds += env.add_default_view_to_shell(shell)
-        if add_view:
-            load_external_modules(env)
     except (spack.repo.UnknownPackageError,
             spack.repo.UnknownNamespaceError) as e:
         tty.error(e)
@@ -194,11 +192,6 @@ def activate(
             '    spack -e {0} concretize --force'.format(env.name))
 
     return cmds
-
-
-def load_external_modules(env):
-    for spec in env.roots():
-        spack.build_environment.load_external_modules(spec)
 
 
 def deactivate(shell='sh'):
@@ -1229,6 +1222,10 @@ class Environment(object):
         env_mod.extend(mods)
 
         return env_mod.shell_modifications(shell)
+
+    def load_external_modules(self):
+        for spec in self.roots():
+            spack.build_environment.load_external_modules(spec)
 
     def _add_concrete_spec(self, spec, concrete, new=True):
         """Called when a new concretized spec is added to the environment.

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1225,7 +1225,7 @@ class Environment(object):
 
     def load_external_modules(self):
         for spec in self.roots():
-            spack.build_environment.load_external_modules(spec)
+            spack.build_environment.load_external_modules(spec.package)
 
     def _add_concrete_spec(self, spec, concrete, new=True):
         """Called when a new concretized spec is added to the environment.

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -30,6 +30,7 @@ import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.config
 import spack.user_environment as uenv
+import spack.build_environment
 from spack.filesystem_view import YamlFilesystemView
 import spack.util.environment
 import spack.architecture as architecture
@@ -179,6 +180,8 @@ def activate(
         if add_view and default_view_name in env.views:
             with spack.store.db.read_transaction():
                 cmds += env.add_default_view_to_shell(shell)
+        if add_view:
+            load_external_modules(env)
     except (spack.repo.UnknownPackageError,
             spack.repo.UnknownNamespaceError) as e:
         tty.error(e)
@@ -191,6 +194,11 @@ def activate(
             '    spack -e {0} concretize --force'.format(env.name))
 
     return cmds
+
+
+def load_external_modules(env):
+    for spec in env.roots():
+        spack.build_environment.load_external_modules(spec)
 
 
 def deactivate(shell='sh'):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -5,6 +5,7 @@
 
 import os
 from six import StringIO
+import re
 
 import pytest
 
@@ -1982,7 +1983,8 @@ def test_env_activate_default_view_root_unconditional(env_deactivate,
         viewdir = e.default_view.root
 
     out = env('activate', '--sh', 'test')
-    assert 'PATH=%s' % os.path.join(viewdir, 'bin') in out
+    pattern = r'PATH=[^:]*{0}'.format(os.path.join(viewdir, 'bin'))
+    assert re.search(pattern, out)
 
 
 def test_concretize_user_specs_together():


### PR DESCRIPTION
See: https://github.com/spack/spack/issues/16910

@quellyn does this resolve the problem you reported in #16910 (note that you should start a new shell, as this does not add corresponding cleanup functions)?

This loads every external module associated with each spec that was explicitly added to the environment or any of it's dependencies.

TODOs

- [ ] This doesn't have an "undo" operation right now (to get that precisely correct that may involve remembering the modules that were in place when the environment was activated, but maybe that's not important)
- [ ] We may want to make this optional