### PR TITLE
Use configure-release instead of configure for UCX

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -36,7 +36,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     variant('thread_multiple', default=False,
             description='Enable thread support in UCP and UCT')
-    variant('optimizations', default=False,
+    variant('optimizations', default=True,
             description='Enable optimizations')
     variant('logging', default=False,
             description='Enable logging')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Ucx(AutotoolsPackage, CudaPackage):
@@ -16,6 +17,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     maintainers = ['hppritcha']
 
     # Current
+    version('1.8.1', sha256='a48820cb8d0761b5ccf3e7ba03a7c8c1dde6276017657178829e07ffc35b556a')
     version('1.8.0', sha256='e400f7aa5354971c8f5ac6b881dc2846143851df868088c37d432c076445628d')
     version('1.7.0', sha256='6ab81ee187bfd554fe7e549da93a11bfac420df87d99ee61ffab7bb19bdd3371')
     version('1.6.1', sha256='1425648aa03f5fa40e4bc5c4a5a83fe0292e2fe44f6054352fbebbf6d8f342a1')
@@ -58,6 +60,15 @@ class Ucx(AutotoolsPackage, CudaPackage):
     depends_on('gdrcopy@1.3', when='+gdrcopy')
     conflicts('+gdrcopy', when='~cuda',
               msg='gdrcopy currently requires cuda support')
+
+    @property
+    def configure_abs_path(self):
+        # UCX docs recommend using configure-release
+        configure_abs_path = os.path.join(
+            os.path.abspath(self.configure_directory),
+            'contrib/configure-release'
+        )
+        return configure_abs_path
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -61,14 +61,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     conflicts('+gdrcopy', when='~cuda',
               msg='gdrcopy currently requires cuda support')
 
-    @property
-    def configure_abs_path(self):
-        # UCX docs recommend using configure-release
-        configure_abs_path = os.path.join(
-            os.path.abspath(self.configure_directory),
-            'contrib/configure-release'
-        )
-        return configure_abs_path
+    configure_abs_path = 'contrib/configure-release'
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -53,6 +53,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     variant('gdrcopy', default=False,
             description='Enable gdrcopy support')
 
+    depends_on('binutils')
     depends_on('numactl')
     depends_on('rdma-core')
     depends_on('java@8', when='+java')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Ucx(AutotoolsPackage, CudaPackage):
@@ -17,7 +16,6 @@ class Ucx(AutotoolsPackage, CudaPackage):
     maintainers = ['hppritcha']
 
     # Current
-    version('1.8.1', sha256='a48820cb8d0761b5ccf3e7ba03a7c8c1dde6276017657178829e07ffc35b556a')
     version('1.8.0', sha256='e400f7aa5354971c8f5ac6b881dc2846143851df868088c37d432c076445628d')
     version('1.7.0', sha256='6ab81ee187bfd554fe7e549da93a11bfac420df87d99ee61ffab7bb19bdd3371')
     version('1.6.1', sha256='1425648aa03f5fa40e4bc5c4a5a83fe0292e2fe44f6054352fbebbf6d8f342a1')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -51,7 +51,6 @@ class Ucx(AutotoolsPackage, CudaPackage):
     variant('gdrcopy', default=False,
             description='Enable gdrcopy support')
 
-    depends_on('binutils')
     depends_on('numactl')
     depends_on('rdma-core')
     depends_on('java@8', when='+java')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -45,7 +45,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     variant('assertions', default=False,
             description='Enable assertions')
     variant('parameter_checking', default=False,
-            description='Enable paramter checking')
+            description='Enable parameter checking')
     variant('pic', default=True,
             description='Builds with PIC support')
     variant('java', default=False,


### PR DESCRIPTION
Also add UCX version 1.8.1 and set `optimizations` variant default to `True`. This fulfills recommendations by Mellanox here https://docs.mellanox.com/display/hpcxv24/Unified+Communication+-+X+Framework+Library#UnifiedCommunicationXFrameworkLibrary-ConfiguringUCX :

```
When UCX is compiled from sources, it should be optimized for the best performance. 
To accomplish this, please compile UCX with:
./contrib/configure-release --enable-optimizations
```