### PR TITLE
libimagequant: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/libimagequant/package.py
+++ b/var/spack/repos/builtin/packages/libimagequant/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Libimagequant(Package):
+    """Small, portable C library for high-quality conversion of RGBA images to
+    8-bit indexed-color (palette) images."""
+
+    homepage = "https://pngquant.org/lib/"
+    url      = "https://github.com/ImageOptim/libimagequant/archive/2.12.6.tar.gz"
+
+    version('2.12.6', sha256='b34964512c0dbe550c5f1b394c246c42a988cd73b71a76c5838aa2b4a96e43a0')
+
+    phases = ['configure', 'build', 'install']
+
+    def configure(self, spec, prefix):
+        configure('--prefix=' + prefix)
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        make('install')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 11.0.3.