### PR TITLE
cassandra @ 3.11.6: checksum mismatch

### DIFF
--- a/var/spack/repos/builtin/packages/cassandra/package.py
+++ b/var/spack/repos/builtin/packages/cassandra/package.py
@@ -17,7 +17,7 @@ class Cassandra(Package):
 
     version('4.0-alpha2', sha256='6a8e99d8bc51efd500981c85c6aa547387b2fdbedecd692308f4632dbc1de3ba')
     version('4.0-alpha1', sha256='2fdf5e3d6c03a29d24a09cd52bb17575e5faccdc4c75a07edd63a9bf4f740105')
-    version('3.11.6',     sha256='ce34edebd1b6bb35216ae97bd06d3efc338c05b273b78267556a99f85d30e45b', preferred=True)
+    version('3.11.6',     sha256='a739ad036d58f95b5526c481b20773cfcc9ccf3c9dc0b50943d9f2306b56e824', preferred=True)
     version('3.11.5',     sha256='0ee3da12a2be86d7e03203fcc56c3589ddb38347b9cd031495a2b7fcf639fea6')
 
     depends_on('java', type=('build', 'run'))


### PR DESCRIPTION
…cksum

$ spack install cassandra @ 3.11.6 % gcc @ 10.2.1 arch=linux-fedora33-haswell
[+] /home/dantopa/spacktivity/fedora-33-spack/opt/spack/linux-fedora33-haswell/gcc-10.2.1/openjdk-11.0.2-3pxwapqxombrgvjc7cwnvix3unmj7mww
==> Installing cassandra
==> No binary for cassandra found: installing from source
==> Error: ChecksumError: sha256 checksum failed for /tmp/root/spack-stage/spack-stage-cassandra-3.11.6-vqjuwgq3p3ossomdlasraauqf4by2gr2/cassandra-3.11.6.tar.gz
    Expected ce34edebd1b6bb35216ae97bd06d3efc338c05b273b78267556a99f85d30e45b but got a739ad036d58f95b5526c481b20773cfcc9ccf3c9dc0b50943d9f2306b56e824

$ wget https://github.com/apache/cassandra/archive/cassandra-3.11.6.tar.gz

$ sha256sum cassandra-3.11.6.tar.gz
a739ad036d58f95b5526c481b20773cfcc9ccf3c9dc0b50943d9f2306b56e824  cassandra-3.11.6.tar.gz

Signed-off-by: Daniel Topa <dantopa@gmail.com>