### PR TITLE
[root] add dataframe cmake option

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -347,6 +347,7 @@ class Root(CMakePackage):
                 ['chirp', False],
                 ['cling', True],
                 ['cocoa', 'aqua'],
+                ['dataframe', True],
                 ['davix'],
                 ['dcache', False],
                 ['fftw3', 'fftw'],

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -15,7 +15,7 @@ class Root(CMakePackage):
     homepage = "https://root.cern.ch"
     url      = "https://root.cern/download/root_v6.16.00.source.tar.gz"
 
-    maintainers = ['chissg', 'HadrienG2', 'drbenmorgan']
+    maintainers = ['chissg', 'HadrienG2', 'drbenmorgan', 'vvolkl']
 
     # ###################### Versions ##########################
 


### PR DESCRIPTION
@chissg @HadrienG2  @drbenmorgan


This has been a separate cmake option starting v6-19 I believe: https://github.com/root-project/root/commit/31292b90826fbb1aaf0694c445f5996cdde3f358
It should default to true -- not sure why, but this recipe sets it to off.

I could add a variant too, but since it has become an integral part of root and doesn't introduce extra dependencies, I'd propose to just set it to true like I do here.