### PR TITLE
Fix cpio clang build error

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -20,6 +20,12 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
     build_directory = 'spack-build'
 
     def flag_handler(self, name, flags):
-        if self.spec.satisfies('%intel') and name == 'cflags':
+        spec = self.spec
+
+        if '%intel' in spec and name == 'cflags':
             flags.append('-no-gcc')
+
+        if '%clang' in spec and name == 'cflags':
+            flags.append('--rtlib=compiler-rt')
+
         return (flags, None, None)


### PR DESCRIPTION
When building `cpio %clang` I'm getting `undefined reference to '__muloti4'`.

The fix according to https://bugs.llvm.org/show_bug.cgi?id=16404 is to add `--rtlib=compiler-rt`.

That works for me