### PR TITLE
[blaspp] Add an explicit dependency on CUDA

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Blaspp(CMakePackage):
+class Blaspp(CMakePackage, CudaPackage):
     """C++ API for the Basic Linear Algebra Subroutines. Developed by the
        Innovative Computing Laboratory at the University of Tennessee,
        Knoxville."""
@@ -29,9 +29,6 @@ class Blaspp(CMakePackage):
             default=False,
             description=('Use OpenMP threaded backend. '
                          'Default is sequential. (MKL & ESSL)'))
-    variant('cuda',
-            default=True,
-            description='Use CUDA.')
 
     depends_on('blas')
     depends_on('cuda', when='+cuda')

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -66,11 +66,11 @@ class Blaspp(CMakePackage):
         else:
             args.append('-DBLAS_LIBRARY_THREADING="sequential"')
 
-        # `blaspp` has an implicit CUDA detection. This disables it in cases
-        # where the `cuda` pacakge is external and marked as `buildable=false`.
-        # The issue occurs when cmake tries to find CUDA in e.g. /opt/cuda,
-        # certain paths are not are not properly set and lead to build issues.
-        # More info at [1].
+        # `blaspp` has an implicit CUDA detection mechanism. This disables it in
+        # cases where it may backfire. One such case is when `cuda` is external
+        # and marked with `buildable=false`. `blaspp`'s CMake CUDA detection
+        # mechanism finds CUDA but doesn't set certain paths properly which
+        # leads to a build issues [1].
         #
         # [1]: https://bitbucket.org/icl/blaspp/issues/6/compile-error-due-to-implicit-cuda
         if '~cuda' in spec:

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -31,7 +31,6 @@ class Blaspp(CMakePackage, CudaPackage):
                          'Default is sequential. (MKL & ESSL)'))
 
     depends_on('blas')
-    depends_on('cuda', when='+cuda')
 
     # 1) The CMake options exposed by `blaspp` allow for a value called `auto`.
     #    The value is not needed here as the choice of dependency in the spec
@@ -63,11 +62,11 @@ class Blaspp(CMakePackage, CudaPackage):
         else:
             args.append('-DBLAS_LIBRARY_THREADING="sequential"')
 
-        # `blaspp` has an implicit CUDA detection mechanism. This disables it in
-        # cases where it may backfire. One such case is when `cuda` is external
-        # and marked with `buildable=false`. `blaspp`'s CMake CUDA detection
-        # mechanism finds CUDA but doesn't set certain paths properly which
-        # leads to a build issues [1].
+        # `blaspp` has an implicit CUDA detection mechanism. This disables it
+        # in cases where it may backfire. One such case is when `cuda` is
+        # external and marked with `buildable=false`. `blaspp`'s CMake CUDA
+        # detection mechanism finds CUDA but doesn't set certain paths properly
+        # which leads to a build issues [1].
         #
         # [1]: https://bitbucket.org/icl/blaspp/issues/6/compile-error-due-to-implicit-cuda
         if '~cuda' in spec:


### PR DESCRIPTION
`blaspp` has an implicit CUDA detection. The PR introduces a variant which controls whether CUDA is enabled/disabled. This is important in cases where the implicit CUDA detection logic backfires. One such case is when `cuda` is external and marked as `buildable=false`. `blaspp`'s CMake CUDA detection logic finds an external cuda installations in default directories but certain paths are not properly set which leads to build [issues][1]. The explicit cuda dependency resolves this both with `+cuda` and `-cuda`. ~~The former is the default as the CUDA detection logic always runs unless explicitly disabled.~~

[1]: https://bitbucket.org/icl/blaspp/issues/6/compile-error-due-to-implicit-cuda 