### PR TITLE
Make spack compiler find respect $PATH order

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -576,9 +576,7 @@ def arguments_to_detect_version_fn(operating_system, paths):
                         )
                         command_arguments.append(detect_version_args)
 
-        # Reverse it here so that the dict creation (last insert wins)
-        # does not spoil the intended precedence.
-        return reversed(command_arguments)
+        return command_arguments
 
     fn = getattr(
         operating_system, 'arguments_to_detect_version_fn', _default


### PR DESCRIPTION
On my system I have the gcc compiler located in both `/usr/bin/gcc` and `/bin/gcc`. 

`which gcc` points to `/usr/bin/gcc`, and indeed `/usr/bin` occurs before `/bin` in my `$PATH`.

Spack however adds `/bin/gcc` as a gcc compiler when I run `spack compiler find`.

I guess historically there was some reason to return the list of compilers in a reversed order in `arguments_to_detect_version_fn`, but the current logic in `find_compilers` keeps a flat list and filters that, passes it to `make_compiler_list` which does a stable sort, and then takes the first working compiler from the list. So that means the order should not be reversed.

This problem came up in https://github.com/spack/spack/issues/17932