### PR TITLE
libcroco: fix depends on issue on Debian

### DIFF
--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -16,3 +16,4 @@ class Libcroco(AutotoolsPackage):
 
     depends_on('glib')
     depends_on('libxml2')
+    depends_on('pkgconfig', type='build')


### PR DESCRIPTION
We found so much `pkg-config` issue, maybe ask user to install a `pkg-config` package(from the distribution source) is a better choice then we add `pkgconfig` depends_on() one by one...

Fix compile error as below:
```
==> 10557: libcroco: Executing phase: 'autoreconf'
==> [2020-08-10-18:30:23.032579, 18307] FileNotFoundError: [Errno 2] No such file or directory: 'config.guess': 'config.guess'
==> [2020-08-10-18:30:23.063636, 18307] FileNotFoundError: [Errno 2] No such file or directory: 'config.sub': 'config.sub'
==> 10557: libcroco: Executing phase: 'configure'
==> [2020-08-10-18:30:23.077528, 18307] '/tmp/root/spack-stage/spack-stage-libcroco-0.6.12-zcmb2br7oeqmkhelvglmmpwrerac6jxt/spack-src/configure' '--prefix=/home/spack-develop/opt/spack/linux-debian10-aarch64/gcc-8.3.0/libcroco-0.6.12-zcmb2br7oeqmkhelvglmmpwrerac6jxt'
checking build system type... aarch64-unknown-linux-gnu
checking host system type... aarch64-unknown-linux-gnu
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether UID '0' is supported by ustar format... yes
checking whether GID '0' is supported by ustar format... yes
checking how to create a ustar tar archive... gnutar
checking whether to enable maintainer-specific portions of Makefiles... yes
checking whether make supports nested variables... (cached) yes
checking for gcc... /home/spack-develop/lib/spack/env/gcc/gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether /home/spack-develop/lib/spack/env/gcc/gcc accepts -g... yes
checking for /home/spack-develop/lib/spack/env/gcc/gcc option to accept ISO C89... none needed
checking whether /home/spack-develop/lib/spack/env/gcc/gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of /home/spack-develop/lib/spack/env/gcc/gcc... gcc3
checking how to run the C preprocessor... /home/spack-develop/lib/spack/env/gcc/gcc -E
checking whether make sets $(MAKE)... (cached) yes
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for library containing strerror... none required
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by /home/spack-develop/lib/spack/env/gcc/gcc... /home/spack-develop/lib/spack/env/ld
checking if the linker (/home/spack-develop/lib/spack/env/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert aarch64-unknown-linux-gnu file names to aarch64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert aarch64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /home/spack-develop/lib/spack/env/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from /home/spack-develop/lib/spack/env/gcc/gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if /home/spack-develop/lib/spack/env/gcc/gcc supports -fno-rtti -fno-exceptions... no
checking for /home/spack-develop/lib/spack/env/gcc/gcc option to produce PIC... -fPIC -DPIC
checking if /home/spack-develop/lib/spack/env/gcc/gcc PIC flag -fPIC -DPIC works... yes
checking if /home/spack-develop/lib/spack/env/gcc/gcc static flag -static works... yes
checking if /home/spack-develop/lib/spack/env/gcc/gcc supports -c -o file.o... yes
checking if /home/spack-develop/lib/spack/env/gcc/gcc supports -c -o file.o... (cached) yes
checking whether the /home/spack-develop/lib/spack/env/gcc/gcc linker (/home/spack-develop/lib/spack/env/ld) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for pkg-config... no
checking for gtk-doc... no
configure: WARNING:
  You will not be able to create source packages with 'make dist'
  because gtk-doc >= 1.0 is not found.
checking for gtkdoc-check... no
checking for gtkdoc-check... no
checking for gtkdoc-rebase... no
checking for gtkdoc-mkpdf... no
checking whether to build gtk-doc documentation... no
checking for GTKDOC_DEPS... no
checking for CROCO... no
configure: error: in `/tmp/root/spack-stage/spack-stage-libcroco-0.6.12-zcmb2br7oeqmkhelvglmmpwrerac6jxt/spack-src':
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.

Alternatively, you may set the environment variables CROCO_CFLAGS
and CROCO_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.

To get pkg-config, see <http://pkg-config.freedesktop.org/>.
See `config.log' for more details
```