### PR TITLE
py-pyinstrument: add v3.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyinstrument/package.py
+++ b/var/spack/repos/builtin/packages/py-pyinstrument/package.py
@@ -10,8 +10,9 @@ class PyPyinstrument(PythonPackage):
     """Call stack profiler for Python. Shows you why your code is slow!"""
 
     homepage = "https://github.com/joerick/pyinstrument"
-    url      = "https://github.com/joerick/pyinstrument/archive/v3.1.0.tar.gz"
+    url      = "https://github.com/joerick/pyinstrument/archive/v3.1.3.tar.gz"
 
+    version('3.1.3', sha256='ca4571775caa06444cd7e832056afc21175130271fe3f3481e3ab1bf67f96c8b')
     version('3.1.0', sha256='02319607daf65110e246085f5e2ee111f565f213eed1991229f2d58e9a7657a5')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.8 and GCC 9.3.0 (via WSL)