### PR TITLE
py-sphinx: add v3.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -9,8 +9,8 @@ from spack import *
 class PySphinx(PythonPackage):
     """Sphinx Documentation Generator."""
 
-    homepage = "http://sphinx-doc.org"
-    url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-3.0.0.tar.gz"
+    homepage = "https://sphinx-doc.org/"
+    url      = "https://pypi.io/packages/source/S/Sphinx/Sphinx-3.2.0.tar.gz"
 
     import_modules = [
         'sphinx', 'sphinx.testing', 'sphinx.ext', 'sphinx.pycode',
@@ -22,6 +22,7 @@ class PySphinx(PythonPackage):
         'sphinx.environment.collectors', 'sphinx.environment.adapters'
     ]
 
+    version('3.2.0', sha256='cf2d5bc3c6c930ab0a1fbef3ad8a82994b1bf4ae923f8098a05c7e5516f07177')
     version('3.0.0', sha256='6a099e6faffdc3ceba99ca8c2d09982d43022245e409249375edf111caf79ed3')
     version('2.2.0', sha256='0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845')
     version('1.8.4', sha256='c1c00fc4f6e8b101a0d037065043460dffc2d507257f2f11acaed71fd2b0c83c')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.8 and GCC 9.3.0 (via WSL)