### PR TITLE
py-sphinx-rtd-theme: add v0.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-rtd-theme/package.py
@@ -10,12 +10,16 @@ class PySphinxRtdTheme(PythonPackage):
     """ReadTheDocs.org theme for Sphinx."""
 
     homepage = "https://github.com/rtfd/sphinx_rtd_theme/"
-    url      = "https://pypi.io/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.10a0.tar.gz"
+    url      = "https://github.com/readthedocs/sphinx_rtd_theme/archive/0.5.0.tar.gz"
 
     import_modules = ['sphinx_rtd_theme']
 
-    version('0.4.3',  sha256='728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a')
-    version('0.2.5b1',  sha256='d99513e7f2f8b9da8fdc189ad83df926b83d7fb15ad7ed07f24665d1f29d38da')
-    version('0.1.10a0', sha256='1225df3fc8337b14d53779435381b7f7705b9f4819610f6b74e555684cee2ac4')
+    version('0.5.0',        sha256='f5c77e9026e2bd0b3d2530f9f8a6681808b216ba70195fe56e7ad89f641ac447')
+    version('0.4.3',        sha256='3412195caad06e4537ad741596d57706c3ed29073d1e0e6b46f25e344d0f393b')
+    version('0.2.5b1',      sha256='31924cdaa5232d1d573423ebebeb1e8f02c8b3cd8cd0662b8a91f3b12efbc12e')
+    version('0.1.10-alpha', sha256='a4c120c0d5c87a2541da9d5e48d3c43b96ea7d7867eacbd5dbf125cdeaa0b4f0')
 
     depends_on('py-setuptools', type='build')
+    depends_on('npm', when='@0.5.0:', type='build')
+    depends_on('py-sphinx', when='@0.4.1:', type=('build', 'run'))
+    depends_on('py-pytest', when='@0.5.0:', type='test')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.7.8 and GCC 9.3.0 (via WSL)

Had to switch from PyPI tarballs to GitHub tarballs, see: https://github.com/readthedocs/sphinx_rtd_theme/issues/990