### PR TITLE
petsc: add explicit build dependency: diffutils

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -159,6 +159,8 @@ class Petsc(Package):
 
     patch('xlf_fix-dup-petscfecreate.patch', when='@3.11.0')
 
+    depends_on('diffutils', type='build')
+
     # Virtual dependencies
     # Git repository needs sowing to build Fortran interface
     depends_on('sowing', when='@develop')


### PR DESCRIPTION
Makes `petsc`'s dependency on `diffutils` for build explicit. Configure phase of `petsc` requires `diff` from `diffutils`

See discussion starting here: https://github.com/spack/spack/pull/17973#issuecomment-671550375

@balay @BarrySmith @jedbrown 