### PR TITLE
Fix loading of compiler modules on CRAY

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -642,7 +642,7 @@ def get_rpaths(pkg):
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
-        rpaths.append(path_from_modules(pkg.compiler.modules[1]))
+        rpaths.append(path_from_modules([pkg.compiler.modules[1]]))
     return list(dedupe(filter_system_paths(rpaths)))
 
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -145,6 +145,8 @@ def path_from_modules(modules):
     Returns:
         Guess of the prefix path where the package
     """
+    assert isinstance(modules, list), 'the "modules" argument must be a list'
+
     best_choice = None
     for module_name in modules:
         # Read the current module and return a candidate path


### PR DESCRIPTION
The modifications in 193e8333fa23a2e9b44d44a80e153d9a27033860 introduced a bug in the loading of compiler modules, since a function that was expecting a list of strings was just getting a string.

This commit fixes the bug and adds an assertion to verify the prerequisite of the function.