### PR TITLE
Add patches to make LLVM use spack zlib/ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/fix-system-zlib-ncurses-from-8.patch
+++ b/var/spack/repos/builtin/packages/llvm/fix-system-zlib-ncurses-from-8.patch
@@ -1,0 +1,60 @@
+From 7d55e46f8c991f74e3eff45ce2b35134b6817975 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Tue, 11 Aug 2020 14:10:39 +0200
+Subject: [PATCH] Use find_library for zlib and ncurses
+
+find_library makes it easier to use a non-system version of zlib and
+ncurses, since it respects *_ROOT and CMAKE_PREFIX_PATH.
+---
+ llvm/cmake/config-ix.cmake | 28 ++++++++++------------------
+ 1 file changed, 10 insertions(+), 18 deletions(-)
+
+diff --git a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+index 90e5d327c..61fa298c2 100644
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -120,15 +120,11 @@ endif()
+ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+   set(HAVE_LIBZ 0)
+   if(LLVM_ENABLE_ZLIB)
+-    foreach(library z zlib_static zlib)
+-      string(TOUPPER ${library} library_suffix)
+-      check_library_exists(${library} compress2 "" HAVE_LIBZ_${library_suffix})
+-      if(HAVE_LIBZ_${library_suffix})
+-        set(HAVE_LIBZ 1)
+-        set(ZLIB_LIBRARIES "${library}")
+-        break()
+-      endif()
+-    endforeach()
++    find_library(FIND_ZLIB NAMES z zlib_static zlib)
++    if(FIND_ZLIB)
++      set(HAVE_LIBZ 1)
++      set(ZLIB_LIBRARIES "${FIND_ZLIB}")
++    endif()
+   endif()
+ 
+   # Don't look for these libraries on Windows.
+@@ -141,15 +137,11 @@ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+     endif()
+     if(LLVM_ENABLE_TERMINFO)
+       set(HAVE_TERMINFO 0)
+-      foreach(library terminfo tinfo curses ncurses ncursesw)
+-        string(TOUPPER ${library} library_suffix)
+-        check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+-        if(HAVE_TERMINFO_${library_suffix})
+-          set(HAVE_TERMINFO 1)
+-          set(TERMINFO_LIBS "${library}")
+-          break()
+-        endif()
+-      endforeach()
++      find_library(FIND_TERMINFO NAMES terminfo tinfo curses ncurses ncursesw)
++      if(FIND_TERMINFO)
++        set(HAVE_TERMINFO 1)
++        set(TERMINFO_LIBS "${FIND_TERMINFO}")
++      endif()
+     else()
+       set(HAVE_TERMINFO 0)
+     endif()
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/llvm/fix-system-zlib-ncurses-pre-8.patch
+++ b/var/spack/repos/builtin/packages/llvm/fix-system-zlib-ncurses-pre-8.patch
@@ -1,0 +1,60 @@
+From 4878ef641cf94637dac682c02b9b054296caa818 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Tue, 11 Aug 2020 14:10:39 +0200
+Subject: [PATCH] Use find_library for zlib and ncurses
+
+find_library makes it easier to use a non-system version of zlib and
+ncurses, since it respects *_ROOT and CMAKE_PREFIX_PATH.
+---
+ llvm/cmake/config-ix.cmake | 28 ++++++++++------------------
+ 1 file changed, 10 insertions(+), 18 deletions(-)
+
+diff --git a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+index 18977d9950f..dce4ec78543 100644
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -107,15 +107,11 @@ endif()
+ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+   set(HAVE_LIBZ 0)
+   if(LLVM_ENABLE_ZLIB)
+-    foreach(library z zlib_static zlib)
+-      string(TOUPPER ${library} library_suffix)
+-      check_library_exists(${library} compress2 "" HAVE_LIBZ_${library_suffix})
+-      if(HAVE_LIBZ_${library_suffix})
+-        set(HAVE_LIBZ 1)
+-        set(ZLIB_LIBRARIES "${library}")
+-        break()
+-      endif()
+-    endforeach()
++    find_library(FIND_ZLIB NAMES z zlib_static zlib)
++    if(FIND_ZLIB)
++      set(HAVE_LIBZ 1)
++      set(ZLIB_LIBRARIES "${FIND_ZLIB}")
++    endif()
+   endif()
+ 
+   # Don't look for these libraries on Windows.
+@@ -128,15 +124,11 @@ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+     endif()
+     if(LLVM_ENABLE_TERMINFO)
+       set(HAVE_TERMINFO 0)
+-      foreach(library tinfo terminfo curses ncurses ncursesw)
+-        string(TOUPPER ${library} library_suffix)
+-        check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+-        if(HAVE_TERMINFO_${library_suffix})
+-          set(HAVE_TERMINFO 1)
+-          set(TERMINFO_LIBS "${library}")
+-          break()
+-        endif()
+-      endforeach()
++      find_library(FIND_TERMINFO NAMES tinfo terminfo curses ncurses ncursesw)
++      if(FIND_TERMINFO)
++        set(HAVE_TERMINFO 1)
++        set(TERMINFO_LIBS "${FIND_TERMINFO}")
++      endif()
+     else()
+       set(HAVE_TERMINFO 0)
+     endif()
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -205,8 +205,9 @@ class Llvm(CMakePackage, CudaPackage):
     patch("thread-p9.patch", when="@develop+libcxx")
 
     # patch for using spack's zlib and ncurses for LLVMExports.cmake
-    # see https://github.com/spack/spack/issues/17981
     # patch might also work before 6, but not tested.
+    # See https://reviews.llvm.org/D79219 for upstream support for non-system zlib
+    # and https://reviews.llvm.org/D85820 for ncurses
     patch("fix-system-zlib-ncurses-from-8.patch", when="@8:")
     patch("fix-system-zlib-ncurses-pre-8.patch", when="@6:7")
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -204,6 +204,12 @@ class Llvm(CMakePackage, CudaPackage):
     # https://bugs.llvm.org/show_bug.cgi?id=39696
     patch("thread-p9.patch", when="@develop+libcxx")
 
+    # patch for using spack's zlib and ncurses for LLVMExports.cmake
+    # see https://github.com/spack/spack/issues/17981
+    # patch might also work before 6, but not tested.
+    patch("fix-system-zlib-ncurses-from-8.patch", when="@8:")
+    patch("fix-system-zlib-ncurses-pre-8.patch", when="@6:7")
+
     @run_before('cmake')
     def codesign_check(self):
         if self.spec.satisfies("+code_signing"):


### PR DESCRIPTION
This should fix https://github.com/spack/spack/issues/17981 for LLVM 6 and above, e.g.:

```
harmen-desktop spack-stage $ grep "libz" ./spack-stage-llvm-10.0.0-kmr2veey2khsmolq5izpz2jsrb2oya5b/spack-build/lib/cmake/llvm/LLVMExports.cmake 
  INTERFACE_LINK_LIBRARIES "/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/zlib-1.2.11-2pwsgfxppopolmjj6tf34k5jsaqzpodo/lib/libz.so;rt;dl;/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/ncurses-6.2-l4seuemvhefwetlot2dbcnlaxtncqzqd/lib/libtinfo.so;-lpthread;m;/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/z3-4.8.7-qiwh5wxz2mdknzv4gef7lwxxdnlf5ycx/lib/libz3.so;LLVMDemangle"
harmen-desktop spack-stage $ grep "libz" ./spack-stage-llvm-7.0.1-u4vs4lbw3bt664lzzm66rigz2detyduh/spack-build/lib/cmake/llvm/LLVMExports.cmake
  INTERFACE_LINK_LIBRARIES "/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/zlib-1.2.11-2pwsgfxppopolmjj6tf34k5jsaqzpodo/lib/libz.so;rt;dl;/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/ncurses-6.2-l4seuemvhefwetlot2dbcnlaxtncqzqd/lib/libtinfo.so;-lpthread;m;LLVMDemangle"

```

I'll try to submit the same patch upstream as well