### PR TITLE
Bugfix for #17999: use cudart instead of cuda.

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -132,7 +132,7 @@ class Cuda(Package):
 
     @property
     def libs(self):
-        libs = find_libraries('libcuda', root=self.prefix, shared=True,
+        libs = find_libraries('libcudart', root=self.prefix, shared=True,
                               recursive=True)
 
         filtered_libs = []


### PR DESCRIPTION
This is needed because libcuda is used by the driver,
whereas libcudart is used by the runtime. CMake searches
for cudart instead of cuda.

On LLNL LC systems, libcuda is only found in compat and
stubs directories, meaning that the lookup of libraries
fails.

Fixes #17999 