### PR TITLE
OpenGL: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -38,7 +38,7 @@ class Opengl(Package):
 
     @classmethod
     def determine_version(cls, exe):
-        output = Executable(exe)(output=str)
+        output = Executable(exe)(output=str, error=str)
         match = re.search(r'OpenGL version string: (\S+)', output)
         return match.group(1) if match else None
 

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 import sys
-
-from spack import *
 
 
 class Opengl(Package):
@@ -34,6 +33,14 @@ class Opengl(Package):
 
     if sys.platform != 'darwin':
         provides('glx@1.4')
+
+    executables = ['^glxinfo$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)(output=str)
+        match = re.search(r'OpenGL version string: (\S+)', output)
+        return match.group(1) if match else None
 
     # Override the fetcher method to throw a useful error message;
     # fixes GitHub issue (#7061) in which this package threw a


### PR DESCRIPTION
```yaml
  opengl:
    externals:
    - spec: opengl@2.1
      prefix: /opt/X11
```
Should we update the fetcher message to say "just run `spack external find opengl`"?