### PR TITLE
GDAL: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -169,7 +169,7 @@ class Gdal(AutotoolsPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        return Executable(exe)('--version', output=str).rstrip()
+        return Executable(exe)('--version', output=str, error=str).rstrip()
 
     def setup_build_environment(self, env):
         # Needed to install Python bindings to GDAL installation

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -165,6 +165,12 @@ class Gdal(AutotoolsPackage):
 
     conflicts('+mdb', when='~java', msg='MDB driver requires Java')
 
+    executables = ['^gdal-config$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        return Executable(exe)('--version', output=str).rstrip()
+
     def setup_build_environment(self, env):
         # Needed to install Python bindings to GDAL installation
         # prefix instead of Python installation prefix.


### PR DESCRIPTION
```yaml
  gdal:
    externals:
    - spec: gdal@3.1.0
      prefix: /Users/Adam/.spack/darwin/.spack-env/view
```
It shouldn't be too hard to add variant detection, but I'll do that another time.