### PR TITLE
Java: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.util.prefix import Prefix
-from spack import *
+import os
+import re
 
 import llnl.util.tty as tty
-import os
+from spack.util.prefix import Prefix
 
 
 class Jdk(Package):
@@ -78,6 +78,19 @@ class Jdk(Package):
     #    override how it is symlinked into a view prefix. Then, spack activate
     #    can symlink all *.jar files to `prefix.lib.ext`
     extendable = True
+
+    executables = ['^java$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('-version', output=str, error=str)
+
+        # Make sure this is actually Oracle JDK, not OpenJDK
+        if 'openjdk' in output:
+            return None
+
+        match = re.search(r'\(build (\S+)\)', output)
+        return match.group(1).replace('+', '_') if match else None
 
     @property
     def home(self):

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
 import platform
+import re
 
 
 # If you need to add a new version, please be aware that:
@@ -59,6 +59,19 @@ class Openjdk(Package):
     #    override how it is symlinked into a view prefix. Then, spack activate
     #    can symlink all *.jar files to `prefix.lib.ext`
     extendable = True
+
+    executables = ['^java$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('-version', output=str, error=str)
+
+        # Make sure this is actually OpenJDK, not Oracle JDK
+        if 'openjdk' not in output:
+            return None
+
+        match = re.search(r'\(build (\S+)\)', output)
+        return match.group(1).replace('+', '_') if match else None
 
     @property
     def home(self):


### PR DESCRIPTION
I noticed something very odd. The first time I run `spack external find jdk openjdk`, I get:
```yaml
  jdk:
    externals:
    - spec: jdk@14.0.2_12-46
      prefix: /Users/Adam/Downloads/jdk-14.0.2.jdk/Contents/Home
    - spec: jdk@12.0.1_12
      prefix: /usr
  openjdk:
    externals:
    - spec: openjdk@14.0.2_12-46
      prefix: /Users/Adam/Downloads/openjdk-14.0.2.jdk/Contents/Home
```
The second time I run it, without changing my `PATH` or anything, I see:
```yaml
  jdk:
    externals:
    - spec: jdk@12.0.1_12
      prefix: /usr
    - spec: jdk@14.0.2_12-46
      prefix: /Users/Adam/Downloads/jdk-14.0.2.jdk/Contents/Home
    - spec: jdk@12.0.1_12
      prefix: /Library/Java/JavaVirtualMachines/jdk-12.0.1.jdk/Contents/Home
    - spec: jdk@10.0.1_10
      prefix: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home
    - spec: jdk@1.8.0_231-b11
      prefix: /Library/Java/JavaVirtualMachines/jdk1.8.0_231.jdk/Contents/Home
    - spec: jdk@1.7.0_45-b18
      prefix: /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home
  openjdk:
    externals:
    - spec: openjdk@14.0.2_12-46
      prefix: /Users/Adam/Downloads/openjdk-14.0.2.jdk/Contents/Home
```
@alalazo @scheibelp is there any possible explanation for this non-deterministic behavior?