### PR TITLE
Make the build stage of OpenSSL parallel

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -78,8 +78,6 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
 
     depends_on('perl@5.14.0:', type=('build', 'test'))
 
-    parallel = False
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('version', output=str)
@@ -128,8 +126,10 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
 
         make()
         if self.run_tests:
-            make('test')            # 'VERBOSE=1'
-        make('install')
+            make('test', parallel=False)  # 'VERBOSE=1'
+
+        # See https://github.com/openssl/openssl/issues/7466#issuecomment-432148137
+        make('install', parallel=False)
 
     @run_after('install')
     def link_system_certs(self):


### PR DESCRIPTION
According to https://github.com/openssl/openssl/issues/7466#issuecomment-432148137 at least the build stage can be done in parallel, the install phase must maybe just be sequential

before
```
$ time spack install openssl %gcc@8.4.0

real    2m29.498s
user    2m10.120s
sys     0m19.587s
```

after
```
$ time spack install openssl %gcc@8.4.0

real    1m1.558s
user    2m52.794s
sys     0m24.173s
```