### PR TITLE
IOR package: added 3.3.0rc1 and develop version

### DIFF
--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -17,6 +17,9 @@ class Ior(AutotoolsPackage):
     version('3.2.0', sha256='91a766fb9c34b5780705d0997b71b236a1120da46652763ba11d9a8c44251852')
     version('3.0.1', sha256='0cbefbcdb02fb13ba364e102f9e7cc2dcf761698533dac25de446a3a3e81390d')
 
+    version('3.3.0rc1', sha256='0e42ebf5b5adae60625bf97989c8e2519d41ea2e3d18561d7d5b945625317aa5')
+    version('develop', git='https://github.com/hpc/ior.git', branch='master')
+
     variant('hdf5',  default=False, description='support IO with HDF5 backend')
     variant('ncmpi', default=False, description='support IO with NCMPI backend')
 

--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -13,12 +13,11 @@ class Ior(AutotoolsPackage):
     homepage = "https://github.com/hpc/ior"
     url      = "https://github.com/hpc/ior/archive/3.2.1.tar.gz"
 
-    version('3.2.1', sha256='ebcf2495aecb357370a91a2d5852cfd83bba72765e586bcfaf15fb79ca46d00e')
+    version('develop', git='https://github.com/hpc/ior.git', branch='master')
+    version('3.3.0rc1', sha256='0e42ebf5b5adae60625bf97989c8e2519d41ea2e3d18561d7d5b945625317aa5')
+    version('3.2.1', sha256='ebcf2495aecb357370a91a2d5852cfd83bba72765e586bcfaf15fb79ca46d00e', preferred=True)
     version('3.2.0', sha256='91a766fb9c34b5780705d0997b71b236a1120da46652763ba11d9a8c44251852')
     version('3.0.1', sha256='0cbefbcdb02fb13ba364e102f9e7cc2dcf761698533dac25de446a3a3e81390d')
-
-    version('3.3.0rc1', sha256='0e42ebf5b5adae60625bf97989c8e2519d41ea2e3d18561d7d5b945625317aa5')
-    version('develop', git='https://github.com/hpc/ior.git', branch='master')
 
     variant('hdf5',  default=False, description='support IO with HDF5 backend')
     variant('ncmpi', default=False, description='support IO with NCMPI backend')


### PR DESCRIPTION
I have added 3.3.0rc1 and develop version, current version have some issues working with hdf5 library.

```
     162      CC       libaiori_a-aiori.o
     163    aiori-HDF5.c:24: warning: "H5_USE_16_API" redefined
     164       24 | #define H5_USE_16_API
     165          |
     166    <command-line>: note: this is the location of the previous definition
     167    aiori-HDF5.c: In function 'HDF5_Open':
  >> 168    aiori-HDF5.c:232:20: error: 'IOR_param_t' {aka 'struct <anonymous>'} has no member named 'collective_md'; did you mean 'collective'?
     169      232 |         if (param->collective_md) {
     170          |                    ^~~~~~~~~~~~~
     171          |                    collective
     172    make[3]: *** [Makefile:1662: ior-aiori-HDF5.o] Error 1
     173    make[3]: *** Waiting for unfinished jobs....
     174    parse_options.c: In function 'ParseCommandLine':
```

Newer version 3.3.0rc1 have solved it.

-Nikolay
