### PR TITLE
openmpi: Update hwloc version bounds

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -260,9 +260,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc')
     # ompi@:3.0.0 doesn't support newer hwloc releases:
     # "configure: error: OMPI does not currently support hwloc v2 API"
-    # Future ompi releases may support it, needs to be verified.
-    # See #7483 for context.
-    depends_on('hwloc@:1.999')
+    depends_on('hwloc@:1.999', when='@:3.999.999')
 
     depends_on('hwloc +cuda', when='+cuda')
     depends_on('java', when='+java')


### PR DESCRIPTION
`openmpi @4:` can use `hwloc @2:`.