### PR TITLE
"spack config update" can handle comments in YAML files

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -363,7 +363,7 @@ def config_update(args):
             scope.name, args.section
         )
         with open(cfg_file) as f:
-            data = syaml.load(f) or {}
+            data = syaml.load_config(f) or {}
             data = data.pop(args.section, {})
         update_fn(data)
 


### PR DESCRIPTION
fixes #18031

With this fix "spack config update" can update YAML files that contain comments, while previously it couldn't.

**Before this PR:**
```console
$ cat ~/.spack/packages.yaml
packages:
  # system cmake in /usr
  cmake:
    paths:
      cmake@3.11.0:  /usr
    buildable: False

$ spack -d config update packages -y
==> [2020-08-13-08:29:36.695023] Imported config from built-in commands
==> [2020-08-13-08:29:36.700339] Imported config from built-in commands
==> [2020-08-13-08:29:36.701393] Reading config file /home/culpo/PycharmProjects/spack/etc/spack/defaults/packages.yaml
==> [2020-08-13-08:29:36.724921] Reading config file /home/culpo/.spack/packages.yaml
==> [2020-08-13-08:29:36.728661] Warning: the attribute "paths" in the "packages" section of the configuration has been deprecated [entry=CommentedMap([('cmake@3.11.0', '/usr')])]
==> [2020-08-13-08:29:36.728953] OUTDATED CONFIGURATION FILE [section=packages, scope=user, dir=/home/culpo/.spack]
==> [2020-08-13-08:29:36.730702] Reading config file /home/culpo/PycharmProjects/spack/etc/spack/defaults/config.yaml
Traceback (most recent call last):
  File "/home/culpo/PycharmProjects/spack/bin/spack", line 64, in <module>
    sys.exit(spack.main.main())
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 762, in main
    return _invoke_command(command, parser, args, unknown)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 490, in _invoke_command
    return_val = command(parser, args)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/cmd/config.py", line 455, in config
    action[args.config_command](args)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/cmd/config.py", line 374, in config_update
    args.section, data, scope=scope.name, force=True
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/config.py", line 490, in update_config
    comments)
AttributeError: 'dict' object has no attribute '_yaml_comment'
```

**After this PR:**
```console
$ cat ~/.spack/packages.yaml
packages:
  # system cmake in /usr
  cmake:
    paths:
      cmake@3.11.0:  /usr
    # Comment after updated section
    buildable: False

$ spack config update -y packages 
==> Warning: the attribute "paths" in the "packages" section of the configuration has been deprecated [entry=CommentedMap([('cmake@3.11.0', '/usr')])]
==> File "/home/culpo/.spack/packages.yaml" updated [backup=/home/culpo/.spack/packages.yaml.bkp]

$ cat ~/.spack/packages.yaml
packages:
  # system cmake in /usr
  cmake:
    # Comment after updated section
    buildable: false
    externals:
    - spec: cmake@3.11.0
      prefix: /usr

```