### PR TITLE
kaldi:refine dependency openfst

### DIFF
--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -38,9 +38,8 @@ class Kaldi(Package):    # Does not use Autotools
     depends_on('openfst@1.4.1-patch', when='@2015-10-07')
     depends_on('openfst@1.6.0:', when='@2018-07-11')
     depends_on('openfst@1.6.0:', when='@2019-07-29')
-    depends_on('openfst@1.6.7:', when='@2019-09-29')
+    depends_on('openfst@1.6.7:1.7.3', when='@2019-09-29:')
     depends_on('cub', when='@2019-07-29:')
-    depends_on('openfst')
 
     patch('openfst-1.4.1.patch', when='@2015-10-07')
 


### PR DESCRIPTION
```
depends_on('openfst')
```
will overwrite the other version of `openfst`
And I found that kaldi will build fail with `openfst@1.7.4 & @1.7.9` but build pass with `openfst@1.7.3`.