### PR TITLE
spectrum-mpi: external support, compiler detection

### DIFF
--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -78,7 +78,10 @@ class SpectrumMpi(Package):
                     variant = "%" + str(compiler_spec)
                 else:
                     variant = ''
-                results.append((variant, {'compilers': compilers_found}))
+                # Use this variant when you need to define the compilers explicitly
+                #results.append((variant, {'compilers': compilers_found}))
+                # Otherwise, use this simpler attribute
+                results.append(variant)
             else:
                 results.append('')
         return results

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -48,7 +48,6 @@ class SpectrumMpi(Package):
         def get_spack_compiler_spec(compilers_found):
             # check using cc for now, as everyone should have that defined.
             path = os.path.dirname(compilers_found['cc'])
-            print("path:", path)
             spack_compilers = spack.compilers.find_compilers([path])
             actual_compiler = None
             # check if the compiler actually matches the one we want
@@ -74,7 +73,6 @@ class SpectrumMpi(Package):
                 if compilers_found:
                     break
             if compilers_found:
-                print(compilers_found)
                 compiler_spec = get_spack_compiler_spec(compilers_found)
                 if compiler_spec:
                     variant = "%" + str(compiler_spec)

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -27,46 +27,47 @@ class SpectrumMpi(Package):
     @classmethod
     def determine_variants(cls, exes, version):
         compiler_suites = {
-            'xl' : { 'cc' : 'mpixlc',
-                     'cxx' : 'mpixlC',
-                     'f77' : 'mpixlf',
-                     'fc'  : 'mpixlf'},
-            'pgi' : { 'cc' : 'mpipgicc',
-                      'cxx' : 'mpipgic++',
-                      'f77' : 'mpipgifort',
-                      'fc'  : 'mpipgifort'},
-            'default' : { 'cc' : 'mpicc',
-                          'cxx' : 'mpicxx',
-                          'f77' : 'mpif77',
-                          'fc'  : 'mpif90'}}
+            'xl': {'cc': 'mpixlc',
+                   'cxx': 'mpixlC',
+                   'f77': 'mpixlf',
+                   'fc': 'mpixlf'},
+            'pgi': {'cc': 'mpipgicc',
+                    'cxx': 'mpipgic++',
+                    'f77': 'mpipgifort',
+                    'fc': 'mpipgifort'},
+            'default': {'cc': 'mpicc',
+                        'cxx': 'mpicxx',
+                        'f77': 'mpif77',
+                        'fc': 'mpif90'}}
+
         def get_host_compiler(exe):
             output = Executable(exe)("--showme", output=str, error=str)
             match = re.search(r'^(\S+)', output)
             return match.group(1) if match else None
 
         def get_spack_compiler_spec(compilers_found):
-            #check using cc for now, as everyone should have that defined.
+            # check using cc for now, as everyone should have that defined.
             path = os.path.dirname(compilers_found['cc'])
             print("path:", path)
             spack_compilers = spack.compilers.find_compilers([path])
             actual_compiler = None
-            #check if the compiler actually matches the one we want
+            # check if the compiler actually matches the one we want
             for spack_compiler in spack_compilers:
                 if os.path.dirname(spack_compiler.cc) == path:
                     actual_compiler = spack_compiler
                     break
             return actual_compiler.spec if actual_compiler else None
-        
+
         results = []
         for exe in exes:
             dirname = os.path.dirname(exe)
             siblings = os.listdir(dirname)
             compilers_found = {}
             for compiler_suite in compiler_suites.values():
-                for (compiler_class,compiler_name) in compiler_suite.items():
+                for (compiler_class, compiler_name) in compiler_suite.items():
                     if compiler_name in siblings:
-                        #Get the real name of the compiler
-                        full_exe = os.path.join(dirname,compiler_name)
+                        # Get the real name of the compiler
+                        full_exe = os.path.join(dirname, compiler_name)
                         host_exe = get_host_compiler(full_exe)
                         if host_exe:
                             compilers_found[compiler_class] = host_exe
@@ -76,14 +77,14 @@ class SpectrumMpi(Package):
                 print(compilers_found)
                 compiler_spec = get_spack_compiler_spec(compilers_found)
                 if compiler_spec:
-                    variant = "%"+str(compiler_spec)
+                    variant = "%" + str(compiler_spec)
                 else:
                     variant = ''
-                results.append((variant , {'compilers' : compilers_found}))
+                results.append((variant, {'compilers': compilers_found}))
             else:
                 results.append('')
         return results
-    
+
     def install(self, spec, prefix):
         raise InstallError('IBM MPI is not installable; it is vendor supplied')
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -78,8 +78,11 @@ class SpectrumMpi(Package):
                     variant = "%" + str(compiler_spec)
                 else:
                     variant = ''
-                # Use this variant when you need to define the compilers explicitly
-                #results.append((variant, {'compilers': compilers_found}))
+                # Use this variant when you need to define the
+                # compilers explicitly
+                #
+                # results.append((variant, {'compilers': compilers_found}))
+                #
                 # Otherwise, use this simpler attribute
                 results.append(variant)
             else:

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
+import os
 import re
 
 
@@ -19,8 +19,71 @@ class SpectrumMpi(Package):
     def determine_version(cls, exe):
         output = Executable(exe)(output=str, error=str)
         match = re.search(r'Spectrum MPI: (\S+)', output)
-        return match.group(1) if match else None
+        if not match:
+            return None
+        version = match.group(1)
+        return version
 
+    @classmethod
+    def determine_variants(cls, exes, version):
+        compiler_suites = {
+            'xl' : { 'cc' : 'mpixlc',
+                     'cxx' : 'mpixlC',
+                     'f77' : 'mpixlf',
+                     'fc'  : 'mpixlf'},
+            'pgi' : { 'cc' : 'mpipgicc',
+                      'cxx' : 'mpipgic++',
+                      'f77' : 'mpipgifort',
+                      'fc'  : 'mpipgifort'},
+            'default' : { 'cc' : 'mpicc',
+                          'cxx' : 'mpicxx',
+                          'f77' : 'mpif77',
+                          'fc'  : 'mpif90'}}
+        def get_host_compiler(exe):
+            output = Executable(exe)("--showme", output=str, error=str)
+            match = re.search(r'^(\S+)', output)
+            return match.group(1) if match else None
+
+        def get_spack_compiler_spec(compilers_found):
+            #check using cc for now, as everyone should have that defined.
+            path = os.path.dirname(compilers_found['cc'])
+            print("path:", path)
+            spack_compilers = spack.compilers.find_compilers([path])
+            actual_compiler = None
+            #check if the compiler actually matches the one we want
+            for spack_compiler in spack_compilers:
+                if os.path.dirname(spack_compiler.cc) == path:
+                    actual_compiler = spack_compiler
+                    break
+            return actual_compiler.spec if actual_compiler else None
+        
+        results = []
+        for exe in exes:
+            dirname = os.path.dirname(exe)
+            siblings = os.listdir(dirname)
+            compilers_found = {}
+            for compiler_suite in compiler_suites.values():
+                for (compiler_class,compiler_name) in compiler_suite.items():
+                    if compiler_name in siblings:
+                        #Get the real name of the compiler
+                        full_exe = os.path.join(dirname,compiler_name)
+                        host_exe = get_host_compiler(full_exe)
+                        if host_exe:
+                            compilers_found[compiler_class] = host_exe
+                if compilers_found:
+                    break
+            if compilers_found:
+                print(compilers_found)
+                compiler_spec = get_spack_compiler_spec(compilers_found)
+                if compiler_spec:
+                    variant = "%"+str(compiler_spec)
+                else:
+                    variant = ''
+                results.append((variant , {'compilers' : compilers_found}))
+            else:
+                results.append('')
+        return results
+    
     def install(self, spec, prefix):
         raise InstallError('IBM MPI is not installable; it is vendor supplied')
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
+import re
 
 
 class SpectrumMpi(Package):
@@ -12,11 +13,11 @@ class SpectrumMpi(Package):
 
     provides('mpi')
 
-    executables = ['ompi_info']
+    executables = ['^ompi_info$']
 
     @classmethod
     def determine_version(cls, exe):
-        output = Executable(exe)('', output=str, error=str)
+        output = Executable(exe)(output=str, error=str)
         match = re.search(r'Spectrum MPI: (\S+)', output)
         return match.group(1) if match else None
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -12,6 +12,14 @@ class SpectrumMpi(Package):
 
     provides('mpi')
 
+    executables = ['ompi_info']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('', output=str, error=str)
+        match = re.search(r'Spectrum MPI: (\S+)', output)
+        return match.group(1) if match else None
+
     def install(self, spec, prefix):
         raise InstallError('IBM MPI is not installable; it is vendor supplied')
 


### PR DESCRIPTION
This is the easiest MPI to add as it has no variants.  Tested on LLNL Lassen.

The selection criteria for finding the correct compiler was taken with advice from @becker33.