### PR TITLE
adios: relax libtool restriction

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -68,7 +68,7 @@ class Adios(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('m4', type='build')
-    depends_on('libtool@:2.4.2', type='build')
+    depends_on('libtool', type='build')
     depends_on('python', type='build')
 
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
While I believe there must have been a reason to restrict libtool to <=
2.4.2, adios compiles just fine with libtool 2.4.6 for me.

In fact, without this change, I'm getting this error:

```
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from libtool 2.4.2.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
```

This doesn't make much sense, since spack did build libtool@2.4.2 as a
dependency, and was supposedly trying to use it. My guess is that on
this system (NERSC's cori) the system libtool in /usr/bin, which is
2.4.6 somehow got picked up partially.