### PR TITLE
Handle updates to packages.yaml with empty attributes

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -128,6 +128,14 @@ def update(data):
     changed = False
     for cfg_object in data.values():
         externals = []
+
+        # If we don't have these deprecated attributes, continue
+        if not any(x in cfg_object for x in ('paths', 'modules')):
+            continue
+
+        # If we arrive here we need to make some changes i.e.
+        # we need to remove and eventually convert some attributes
+        changed = True
         paths = cfg_object.pop('paths', {})
         for spec, prefix in paths.items():
             externals.append({
@@ -141,6 +149,6 @@ def update(data):
                 'modules': [str(module)]
             })
         if externals:
-            changed = True
             cfg_object['externals'] = externals
+
     return changed

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -551,6 +551,27 @@ packages:
     assert '# Another comment after the outdated section' in text
 
 
+@pytest.mark.regression('18050')
+def test_config_update_works_for_empty_paths(mutable_config):
+    # Create an outdated config file with empty "paths" and "modules"
+    scope = spack.config.default_modify_scope()
+    cfg_file = spack.config.config.get_config_filename(scope, 'packages')
+    with open(cfg_file, mode='w') as f:
+        f.write("""
+packages:
+  cmake:
+    paths: {}
+    modules: {}
+    buildable: False
+""")
+
+    # Try to update it, it should not raise errors
+    output = config('update', '-y', 'packages')
+
+    # This ensures that we updated the configuration
+    assert '[backup=' in output
+
+
 def check_update(data):
     """Check that the data from the packages_yaml_v015
     has been updated.


### PR DESCRIPTION
fixes #18050

Before this PR `packages.yaml` files that contained empty "paths" or "modules" attribute were not updated correctly, since the update function was not reporting them as changed after the update.

This PR fixes that issue and adds a unit test to avoid regression.