### PR TITLE
Bash: add v5.0.18, external package detection

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import re
 
 
 class Bash(AutotoolsPackage, GNUMirrorPackage):
     """The GNU Project's Bourne Again SHell."""
 
     homepage = "https://www.gnu.org/software/bash/"
-    gnu_mirror_path = "bash/bash-4.4.tar.gz"
+    gnu_mirror_path = "bash/bash-5.0.tar.gz"
 
     version('5.0',    sha256='b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d')
     version('4.4.12', sha256='57d8432be54541531a496fd4904fdc08c12542f43605a9202594fa5d5f9f2331')
@@ -38,6 +38,8 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
         ('5.0', '014', '5d6eee6514ee6e22a87bba8d22be0a8621a0ae119246f1c5a9a35db1f72af589'),
         ('5.0', '015', 'a517df2dda93b26d5cbf00effefea93e3a4ccd6652f152f4109170544ebfa05e'),
         ('5.0', '016', 'ffd1d7a54a99fa7f5b1825e4f7e95d8c8876bc2ca151f150e751d429c650b06d'),
+        ('5.0', '017', '4cf3b9fafb8a66d411dd5fc9120032533a4012df1dc6ee024c7833373e2ddc31'),
+        ('5.0', '018', '7c314e375a105a6642e8ed44f3808b9def89d15f7492fe2029a21ba9c0de81d3'),
     ]
 
     # TODO: patches below are not managed by the GNUMirrorPackage base class
@@ -45,6 +47,14 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
         ver = Version(ver)
         patch('https://ftpmirror.gnu.org/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),
               level=0, when='@{0}'.format(ver), sha256=checksum)
+
+    executables = ['^bash$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'GNU bash, version ([\d.]+)', output)
+        return match.group(1) if match else None
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Successfully builds and passes all unit tests on macOS 10.15.6 with Apple Clang 11.0.3.

```yaml
  bash:
    externals:
    - spec: bash@5.0.16
      prefix: /Users/Adam/.spack/darwin/.spack-env/view
    - spec: bash@3.2.57
      prefix: /
```
Bash is weird in the sense that they don't release a tarball for 5.0.18, they release a tarball for 5.0 and 18 consecutive patches to apply. I'm not sure if there's an easy way to sync Spack's version representation and our external package version detection.