### PR TITLE
viennarna: fixed build on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Viennarna(AutotoolsPackage):
@@ -41,5 +42,9 @@ class Viennarna(AutotoolsPackage):
 
         if 'python@3:' in self.spec:
             args.append('--with-python3')
+
+        d = find('src', 'config.guess', recursive=True)
+        target = os.path.dirname(d[0])
+        copy(join_path('.', 'config.guess'), join_path(target))
 
         return args

--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Viennarna(AutotoolsPackage):
@@ -43,8 +42,6 @@ class Viennarna(AutotoolsPackage):
         if 'python@3:' in self.spec:
             args.append('--with-python3')
 
-        d = find('src', 'config.guess', recursive=True)
-        target = os.path.dirname(d[0])
-        copy(join_path('.', 'config.guess'), join_path(target))
+        copy('config.guess', 'src/RNAforester/g2-0.72/config.guess')
 
         return args


### PR DESCRIPTION
copy config.guess /src/RNAforester/g2-0.72/
Due to an old config.guess in /src/RNAforester/g2-0.72/
```
3 errors found in build log:
     387    /usr/convex/getsysinfo =
     388    
     389    UNAME_MACHINE = aarch64
     390    UNAME_RELEASE = 4.18.0-147.3.1.el8_1.aarch64
     391    UNAME_SYSTEM  = Linux
     392    UNAME_VERSION = #1 SMP Wed Nov 27 01:58:10 UTC 2019
  >> 393    configure: error: cannot guess build type; you must specify one
  >> 394    configure: error: ./configure failed for g2-0.72
  >> 395    configure: error: ./configure failed for src/RNAforester
```