### PR TITLE
util-linux: remove libintl link

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -24,21 +24,14 @@ class UtilLinux(AutotoolsPackage):
 
     depends_on('python@2.7:')
     depends_on('pkgconfig')
-    depends_on('gettext', when='+libmount')
 
     # Make it possible to disable util-linux's libuuid so that you may
     # reliably depend_on(`libuuid`).
     variant('libuuid', default=True, description='Build libuuid')
-    variant('libmount', default=False, description='Build libmount.so with gettext')
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
         return url.format(version.up_to(2), version)
-
-    def setup_build_environment(self, env):
-        if '+libmount' in self.spec:
-            env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
-                self.spec['gettext'].prefix.lib))
 
     def configure_args(self):
         config_args = [


### PR DESCRIPTION
I found that the `libmount` variant I added in https://github.com/spack/spack/pull/15631 is totally a wrong way to link `libintl`.
I added this variant just because `nfs-utils` will link to `libblkid`, and some API in `libblkid` called another API in `libintl`.

I want to fix this error by removing `libintl` link in `util-linux`, then add the `LIBS` or `LDFLAGS` in `nfs-utils` package.