### PR TITLE
nfs-utils: fix compile error on ubuntu

### DIFF
--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -26,9 +26,10 @@ class NfsUtils(AutotoolsPackage):
     depends_on('keyutils')
     depends_on('sqlite')
     depends_on('util-linux')
+    depends_on('gettext')
 
     def setup_build_environment(self, env):
-        env.append_flags('LDFLAGS', '-lintl')
+        env.append_flags('LIBS', '-lintl')
 
     def configure_args(self):
         args = ['--disable-gss', '--with-rpcgen=internal']


### PR DESCRIPTION
`nfs-utils` compile fail on `ubuntu`
the `configure` will check `libblkid` by using a mini c code, and check fail because an undefined symbol.
(that symbol realized in `libintl`).
So we need to add `libintl` dependency and export it in `LIBS` to make `configure` using it.
```
==> 84811: Installing nfs-utils
==> Finding buildcaches at http://172.19.16.223/spack_mirror/build_cache
==> Fetching http://172.19.16.223/spack_mirror/build_cache/linux-ubuntu19.10-aarch64-gcc-9.2.1-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6.spec.yaml

curl: (22) The requested URL returned error: 404 Not Found
==> Failed to fetch file from URL: http://172.19.16.223/spack_mirror/build_cache/linux-ubuntu19.10-aarch64-gcc-9.2.1-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6.spec.yaml
    URL http://172.19.16.223/spack_mirror/build_cache/linux-ubuntu19.10-aarch64-gcc-9.2.1-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6.spec.yaml was not found!
==> Fetching from http://172.19.16.223/spack_mirror/build_cache/linux-ubuntu19.10-aarch64-gcc-9.2.1-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6.spec.yaml failed.
==> Using cached archive: /home/spack-develop/var/spack/cache/_source-cache/archive/bb/bb08106cd7bd397c6cc34e2461bc7818a664450d2805da08b07e1ced88e5155f.tar.gz
==> Staging archive: /home/spack-stage/root/spack-stage-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6/download
==> Created stage in /home/spack-stage/root/spack-stage-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6
==> No patches needed for nfs-utils
==> 84811: nfs-utils: Building nfs-utils [AutotoolsPackage]
==> 84811: nfs-utils: Executing phase: 'autoreconf'
==> 84811: nfs-utils: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/home/spack-stage/root/spack-stage-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6/spack-src/configure' '--prefix=/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6' '--disable-gss' '--with-rpcgen=internal'

1 error found in build log:
     166    checking for dm_task_create in -ldevmapper... yes
     167    checking libdevmapper.h usability... yes
     168    checking libdevmapper.h presence... yes
     169    checking for libdevmapper.h... yes
     170    checking for sys/inotify.h... (cached) yes
     171    checking for blkid_get_library_version in -lblkid... no
  >> 172    configure: error: libblkid needed

See build log for details:
  /home/spack-stage/root/spack-stage-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6/spack-build-out.txt

==> Error: Failed to install nfs-utils due to ChildError: ProcessError: Command exited with status 1:
    '/home/spack-stage/root/spack-stage-nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6/spack-src/configure' '--prefix=/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/nfs-utils-2.4.2-crushuawerxtkgimcc2kqwp42yopr4y6' '--disable-gss' '--with-rpcgen=internal'
1 error found in build log:
     166    checking for dm_task_create in -ldevmapper... yes
     167    checking libdevmapper.h usability... yes
     168    checking libdevmapper.h presence... yes
     169    checking for libdevmapper.h... yes
     170    checking for sys/inotify.h... (cached) yes
     171    checking for blkid_get_library_version in -lblkid... no
  >> 172    configure: error: libblkid needed
```