### PR TITLE
fenics: split 'parmetis' dependency definition.

### DIFF
--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -61,7 +61,8 @@ class Fenics(CMakePackage):
     # FIXME: next line fixes concretization with petsc
     depends_on('hdf5+hl+fortran', when='+hdf5+petsc')
     depends_on('hdf5+hl', when='+hdf5~petsc')
-    depends_on('parmetis@4.0.2:^metis+real64', when='+parmetis')
+    depends_on('parmetis@4.0.2:', when='+parmetis')
+    depends_on('metis+real64', when='+parmetis')
     depends_on('scotch~metis', when='+scotch~mpi')
     depends_on('scotch+mpi~metis', when='+scotch+mpi')
     depends_on('petsc@3.4:', when='+petsc')


### PR DESCRIPTION
I got a following error.
```
$ spack install fenics
==> Error: Package metis does not depend on p, k, g, c, o, n, or f
```
The definition of dependency of `parmetis` may not be correctly divided.
In addition, there are the following restrictions.
```
depends_on statements can’t include ^
```
Therefore, the dependency is defined separately.
