### PR TITLE
libssh: add gssapi variant and include krb5 as a dependency accordingly

### DIFF
--- a/var/spack/repos/builtin/packages/libssh/package.py
+++ b/var/spack/repos/builtin/packages/libssh/package.py
@@ -15,10 +15,17 @@ class Libssh(CMakePackage):
     version('0.8.5', sha256='07d2c431240fc88f6b06bcb36ae267f9afeedce2e32f6c42f8844b205ab5a335')
     version('0.7.5', sha256='54e86dd5dc20e5367e58f3caab337ce37675f863f80df85b6b1614966a337095')
 
+    variant("gssapi", default=True, description="Build with gssapi support")
     depends_on('openssl@:1.0', when='@:0.7')
     depends_on('openssl')
     depends_on('zlib')
+    depends_on('krb5', when='+gssapi')
 
     def url_for_version(self, version):
         url = "https://www.libssh.org/files/{0}/libssh-{1}.tar.xz"
         return url.format(version.up_to(2), version)
+
+    def cmake_args(self):
+        args = ['-DWITH_GSSAPI=%s' %
+                ('ON' if '+gssapi' in self.spec else 'OFF')]
+        return args


### PR DESCRIPTION
See #18033

libssh seemed to detect and link to system krb5 libraries if found
to provide gssapi support, causing issues/system dependencies/etc.

We add a boolean variant gssapi

If +gssapi, the spack krb5 package is added as a dependency.
If ~gssapi, the Cmake flags are adjusted to not use gssapi so that
does not link to any krb5 package.