### PR TITLE
Bugfix: Terminate if a spack.yaml include path does not exist

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -826,12 +826,16 @@ class Environment(object):
                 config_name = 'env:%s:%s' % (
                     self.name, os.path.basename(config_path))
                 scope = spack.config.ConfigScope(config_name, config_path)
-            else:
+            elif os.path.exists(config_path):
                 # files are assumed to be SingleFileScopes
                 base, ext = os.path.splitext(os.path.basename(config_path))
                 config_name = 'env:%s:%s' % (self.name, base)
                 scope = spack.config.SingleFileScope(
                     config_name, config_path, spack.schema.merged.schema)
+            else:
+                tty.warn('Ignoring non-existent include {0}'
+                         .format(config_path))
+                continue
 
             scopes.append(scope)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -812,6 +812,7 @@ class Environment(object):
         # load config scopes added via 'include:', in reverse so that
         # highest-precedence scopes are last.
         includes = config_dict(self.yaml).get('include', [])
+        missing = []
         for i, config_path in enumerate(reversed(includes)):
             # allow paths to contain spack config/environment variables, etc.
             config_path = substitute_path_variables(config_path)
@@ -833,11 +834,15 @@ class Environment(object):
                 scope = spack.config.SingleFileScope(
                     config_name, config_path, spack.schema.merged.schema)
             else:
-                tty.warn('Ignoring non-existent include {0}'
-                         .format(config_path))
+                missing.append(config_path)
                 continue
 
             scopes.append(scope)
+
+        if missing:
+            msg = 'Detected {0} missing include path(s):'.format(len(missing))
+            msg += '\n   {0}'.format('\n   '.join(missing))
+            tty.die('{0}\nPlease correct and try again.'.format(msg))
 
         return scopes
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -525,6 +525,25 @@ env:
                for x in e._get_environment_specs())
 
 
+def test_with_config_bad_include(capfd):
+    test_config = """\
+spack:
+  include:
+  - /no/such/directory
+  - no/such/file.yaml
+"""
+    _env_create('test', StringIO(test_config))
+
+    e = ev.read('test')
+    with e:
+        e.concretize()
+
+    _, err = capfd.readouterr()
+    assert 'Ignoring' in err
+    assert 'include /no/such/directory' in err
+    assert 'no/such/file.yaml' in err
+
+
 def test_env_with_included_config_file():
     test_config = """\
 env:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -525,22 +525,25 @@ env:
                for x in e._get_environment_specs())
 
 
-def test_with_config_bad_include(capfd):
+def test_with_config_bad_include(env_deactivate, capfd):
+    env_name = 'test_bad_include'
     test_config = """\
 spack:
   include:
   - /no/such/directory
   - no/such/file.yaml
 """
-    _env_create('test', StringIO(test_config))
+    _env_create(env_name, StringIO(test_config))
 
-    e = ev.read('test')
-    with e:
-        e.concretize()
+    e = ev.read(env_name)
+    with pytest.raises(SystemExit):
+        with e:
+            e.concretize()
 
-    _, err = capfd.readouterr()
-    assert 'Ignoring' in err
-    assert 'include /no/such/directory' in err
+    out, err = capfd.readouterr()
+
+    assert 'missing include' in err
+    assert '/no/such/directory' in err
     assert 'no/such/file.yaml' in err
 
 


### PR DESCRIPTION
There is no error or warning by environments if the `spack.yaml` file has an `include` entry that does not exist.  The reason is the missing entries are treated as if they are files and assumed to specify `SingleFileScopes`.  

This PR terminates execution with an error that includes the missing path(s).  For example, the output with this PR is:

```
==> Error: Detected 2 missing include path(s):
   $HOME/spack/clean/spacktest/A
   $HOME/spack/clean/spacktest/B
Please correct and try again.
```

when the two include paths do not exist.

(Note: Adrien Bernede requested a fix to this issue in the `#environments` slack channel.  )