### PR TITLE
ALSA-lib only works on Linux

### DIFF
--- a/var/spack/repos/builtin/packages/alsa-lib/package.py
+++ b/var/spack/repos/builtin/packages/alsa-lib/package.py
@@ -12,9 +12,10 @@ class AlsaLib(AutotoolsPackage):
     space library that developers compile ALSA applications against."""
 
     homepage = "https://www.alsa-project.org"
-    url      = "ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.2.2.tar.bz2"
+    url      = "ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.2.3.2.tar.bz2"
 
-    version('1.2.2', sha256='d8e853d8805574777bbe40937812ad1419c9ea7210e176f0def3e6ed255ab3ec')
+    version('1.2.3.2', sha256='e81fc5b7afcaee8c9fd7f64a1e3043e88d62e9ad2c4cff55f578df6b0a9abe15')
+    version('1.2.2',   sha256='d8e853d8805574777bbe40937812ad1419c9ea7210e176f0def3e6ed255ab3ec')
     version('1.1.4.1', sha256='91bb870c14d1c7c269213285eeed874fa3d28112077db061a3af8010d0885b76')
 
     variant('python', default=False, description='enable python')
@@ -22,6 +23,8 @@ class AlsaLib(AutotoolsPackage):
     patch('python.patch', when='@1.1.4:1.1.5 +python')
 
     depends_on('python', type=('link', 'run'), when='+python')
+
+    conflicts('platform=darwin', msg='ALSA only works for Linux')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/brltty/package.py
+++ b/var/spack/repos/builtin/packages/brltty/package.py
@@ -24,7 +24,7 @@ class Brltty(AutotoolsPackage):
     depends_on('libtool',   type='build')
     depends_on('m4',        type='build')
     depends_on('expat')
-    depends_on('alsa-lib',        type='link')
+    depends_on('alsa-lib', when='platform=linux', type='link')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -63,7 +63,7 @@ class Ffmpeg(AutotoolsPackage):
     variant('sdl2', default=False, description='sdl2 support')
     variant('shared', default=True, description='build shared libraries')
 
-    depends_on('alsa-lib')
+    depends_on('alsa-lib', when='platform=linux')
     depends_on('libiconv')
     depends_on('yasm@1.2.0:')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -66,7 +66,7 @@ class Icedtea(AutotoolsPackage):
     depends_on('jpeg')
     depends_on('lcms')
     depends_on('zlib')
-    depends_on('alsa-lib')
+    depends_on('alsa-lib', when='platform=linux')
 
     provides('java@8', when='@3.4.0:3.99.99')
 


### PR DESCRIPTION
Tried building `ffmpeg` on macOS and it crashed when trying to compile `alsa-lib`:
```
In file included from cards.c:35:
In file included from ./control_local.h:22:
../../include/local.h:47:2: error: Header defining endianness not defined
#error Header defining endianness not defined
 ^
In file included from tlv.c:36:
In file included from ./control_local.h:22:
../../include/local.h:47:2: error: Header defining endianness not defined
#error Header defining endianness not defined
 ^
In file included from namehint.c:28:
../../include/local.h:47:2: error: Header defining endianness not defined
#error Header defining endianness not defined
 ^
In file included from cards.c:35:
In file included from ./control_local.h:22:
In file included from ../../include/local.h:146:
In file included from ../../include/sound/asound.h:11:
../../include/alsa/sound/uapi/asound.h:31:10: fatal error: 'endian.h' file not found
In file included from namehint.c:28:
In file included from ../../include/local.h:146:
In file included from ../../include/sound/asound.h:11:
#include <endian.h>../../include/alsa/sound/uapi/asound.h
:         ^~~~~~~~~~31
:10: fatal error: 'endian.h' file not found
#include <endian.h>
In file included from tlv.c:36:
In file included from ./control_local.h:22:
In file included from ../../include/local.h:146:
In file included from ../../include/sound/asound.h:11:
../../include/alsa/sound/uapi/asound.h:31:10: fatal error: 'endian.h' file not found
#include <endian.h>
         ^~~~~~~~~~
         ^~~~~~~~~~
In file included from hcontrol.c:51:
In file included from ./control_local.h:22:
../../include/local.h:47:2: error: Header defining endianness not defined
#error Header defining endianness not defined
 ^
In file included from hcontrol.c:51:
In file included from ./control_local.h:22:
In file included from ../../include/local.h:146:
In file included from ../../include/sound/asound.h:11:
../../include/alsa/sound/uapi/asound.h:31:10: fatal error: 'endian.h' file not found
#include <endian.h>
         ^~~~~~~~~~
2 errors generated.
2 errors generated.
2 errors generated.
make[2]: *** [cards.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [tlv.lo] Error 1
make[2]: *** [namehint.lo] Error 1
2 errors generated.
make[2]: *** [hcontrol.lo] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```
Based on https://alsa-user.narkive.com/aY89FcbT/alsa-lib-on-mac-os-x it seems like `alsa-lib` is only intended for Linux.

@xjrc 