### PR TITLE
Smoke tests: Preliminary tests for the HDF package

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+import os
 
 
 class Hdf(AutotoolsPackage):
@@ -150,3 +151,67 @@ class Hdf(AutotoolsPackage):
     def check(self):
         with working_dir(self.build_directory):
             make('check', parallel=False)
+
+    extra_install_tests = 'hdf/util/testfiles'
+
+    @run_after('install')
+    def setup_build_tests(self):
+        """Copy the build test files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(self.extra_install_tests)
+
+    def _test_check_versions(self):
+        """Perform version checks on selected installed package binaries."""
+        spec_vers_str = 'Version {0}'.format(self.spec.version.up_to(2))
+
+        exes = ['hdfimport', 'hrepack', 'ncdump', 'ncgen']
+        for exe in exes:
+            reason = 'test version of {0} is {1}'.format(exe, spec_vers_str)
+            self.run_test(exe, ['-V'], spec_vers_str, installed=True,
+                          purpose=reason, skip_missing=True)
+
+    def _test_gif_converters(self):
+        """This test performs an image conversion sequence and diff."""
+        work_dir = '.'
+        storm_fn = os.path.join(self.install_test_root,
+                                self.extra_install_tests, 'storm110.hdf')
+        gif_fn = 'storm110.gif'
+        new_hdf_fn = 'storm110gif.hdf'
+
+        # Convert a test HDF file to a gif
+        self.run_test('hdf2gif', [storm_fn, gif_fn], '', installed=True,
+                      purpose="test: hdf-to-gif", work_dir=work_dir)
+
+        # Convert the gif to an HDF file
+        self.run_test('gif2hdf', [gif_fn, new_hdf_fn], '', installed=True,
+                      purpose="test: gif-to-hdf", work_dir=work_dir)
+
+        # Compare the original and new HDF files
+        self.run_test('hdiff', [new_hdf_fn, storm_fn], '', installed=True,
+                      purpose="test: compare orig to new hdf",
+                      work_dir=work_dir)
+
+    def _test_list(self):
+        """This test compares low-level HDF file information to expected."""
+        storm_fn = os.path.join(self.install_test_root,
+                                self.extra_install_tests, 'storm110.hdf')
+        work_dir = '.'
+
+        reason = 'test: ensure hdfls produces expected output'
+        details_file = os.path.join(self.test_dir.data.hdf, 'storm110.out')
+        output = ''
+        with open(details_file, 'r') as fd:
+            output == fd.read()
+        self.run_test('hdfls', [storm_fn], output, installed=True,
+                      purpose=reason, skip_missing=True, work_dir=work_dir)
+
+    def test(self):
+        """Perform smoke tests on the installed package."""
+        # Simple version check tests on subset of known binaries that respond
+        self._test_check_versions()
+
+        # Run gif converter sequence test
+        self._test_gif_converters()
+
+        # Run gif converter sequence test
+        self._test_list()

--- a/var/spack/repos/builtin/packages/hdf/test/storm110.out
+++ b/var/spack/repos/builtin/packages/hdf/test/storm110.out
@@ -1,0 +1,17 @@
+File library version: Major= 0, Minor=0, Release=0
+String=
+
+Number type                   : (tag 106)
+	Ref nos: 110
+Machine type                  : (tag 107)
+	Ref nos: 4369
+Image Dimensions-8            : (tag 200)
+	Ref nos: 110
+Raster Image-8                : (tag 202)
+	Ref nos: 110
+Image Dimensions              : (tag 300)
+	Ref nos: 110
+Raster Image Data             : (tag 302)
+	Ref nos: 110
+Raster Image Group            : (tag 306)
+	Ref nos: 110


### PR DESCRIPTION
Added preliminary HDF smoke tests consisting of:
- version checks for a small subset of installed binaries;
- sequence of image conversion and differences commands; and
- output checks from the `hdfls` command."

This PR has been tested against versions 4.2.11, 4.2.13, and 4.2.15.