### PR TITLE
[delphes] align env var with lcg release

### DIFF
--- a/var/spack/repos/builtin/packages/delphes/package.py
+++ b/var/spack/repos/builtin/packages/delphes/package.py
@@ -62,4 +62,4 @@ class Delphes(CMakePackage):
 
     def setup_run_environment(self, env):
         # make the cards distributed with delphes more easily accessible
-        env.set('DELPHESCARDS', self.prefix.cards)
+        env.set('DELPHES_DIR', self.prefix)


### PR DESCRIPTION
This seems to be a more widely used runtime env variable.