### PR TITLE
Bugfix/cppzmq versions

### DIFF
--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -24,3 +24,4 @@ class Cppzmq(CMakePackage):
 
     depends_on('cmake@3.0.0:', type='build')
     depends_on('libzmq')
+    depends_on('libzmq@4.2.2', when='@4.2.2:4.2.3')

--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -13,7 +13,7 @@ class Cppzmq(CMakePackage):
     url      = "https://github.com/zeromq/cppzmq/archive/v4.2.2.tar.gz"
     git      = "https://github.com/zeromq/cppzmq.git"
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('4.6.0', sha256='e9203391a0b913576153a2ad22a2dc1479b1ec325beb6c46a3237c669aef5a52')
     version('4.5.0', sha256='64eb4e58eaf0c77505391c6c9a606cffcb57c6086f3431567a1ef4a25b01fa36')
     version('4.4.1', sha256='117fc1ca24d98dbe1a60c072cde13be863d429134907797f8e03f654ce679385')

--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -14,9 +14,13 @@ class Cppzmq(CMakePackage):
     git      = "https://github.com/zeromq/cppzmq.git"
 
     version('develop', branch='master')
+    version('4.6.0', sha256='e9203391a0b913576153a2ad22a2dc1479b1ec325beb6c46a3237c669aef5a52')
+    version('4.5.0', sha256='64eb4e58eaf0c77505391c6c9a606cffcb57c6086f3431567a1ef4a25b01fa36')
+    version('4.4.1', sha256='117fc1ca24d98dbe1a60c072cde13be863d429134907797f8e03f654ce679385')
+    version('4.4.0', sha256='118b9ff117f07d1aabadfb905d7227362049d7940d16b7863b3dd3cebd28be85')
     version('4.3.0', sha256='27d1f56406ba94ee779e639203218820975cf68174f92fbeae0f645df0fcada4')
+    version('4.2.3', sha256='3e6b57bf49115f4ae893b1ff7848ead7267013087dc7be1ab27636a97144d373')
     version('4.2.2', sha256='3ef50070ac5877c06c6bb25091028465020e181bbfd08f110294ed6bc419737d')
 
     depends_on('cmake@3.0.0:', type='build')
-    depends_on('libzmq@4.2.5', when='@4.3.0')
-    depends_on('libzmq@4.2.2', when='@4.2.2')
+    depends_on('libzmq')


### PR DESCRIPTION
Added newer versions for cppzmq (4.3.0 was 2+ years old). All new versions were tested on gcc@9.3.0 (ubuntu 20.04) against current release/v0.15 (v0.15.4).

For cppzmq@4.3.0:, cppzmq runs unit tests at the end of the build. Each of these versions has been confirmed to build against each of the libzmq@4.2.5: versions in release/v0.15 (and develop, for that matter). That has allowed the relaxing of depends_on('libzmq@4.2.5', when='@4.3.0'), which were the most recent versions at the time cppzmq@4.3.0 was added (#9682).

For cppzmq@4.2.2:4.2.3 there are no unit tests, and I elected to leave the version pinning unchanged. In addition to not being able to rely on unit tests, since libzmq@4.2.2 conflicts with %gcc@8: I was also unable to easily test whether cppzmq@4.2.2:4.2.3 compiles with any newer libzmq.

Note: This PR accompanies bug report #18086 in the dependency resolution for which this is a workaround.