### PR TITLE
py-torchvision: fix linking to -lavcodec

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -104,6 +104,16 @@ class Ffmpeg(AutotoolsPackage):
     conflicts('+libssh', when='@2.0.999:')
     conflicts('+libzmq', when='@:1.999.999')
 
+    @property
+    def libs(self):
+        return find_libraries('*', self.prefix, recursive=True)
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix.include)
+        headers.directories = self.prefix.include
+        return headers
+
     def enable_or_disable_meta(self, variant, options):
         switch = 'enable' if '+{0}'.format(variant) in self.spec else 'disable'
         return ['--{0}-{1}'.format(switch, option) for option in options]

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -195,6 +195,22 @@ class PyTorch(PythonPackage, CudaPackage):
     # Only run once to speed up build times
     phases = ['install']
 
+    @property
+    def libs(self):
+        root = join_path(
+            self.prefix, self.spec['python'].package.site_packages_dir,
+            'torch', 'lib')
+        return find_libraries('libtorch', root)
+
+    @property
+    def headers(self):
+        root = join_path(
+            self.prefix, self.spec['python'].package.site_packages_dir,
+            'torch', 'include')
+        headers = find_all_headers(root)
+        headers.directories = root
+        return headers
+
     def setup_build_environment(self, env):
         def enable_or_disable(variant, keyword='USE', var=None, newer=False):
             """Set environment variable to enable or disable support for a


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.7.8 and Apple Clang 11.0.3.

@xjrc can you take a look at the changes to `ffmpeg`?