### PR TITLE
clp : fixed build on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/clp/package.py
+++ b/var/spack/repos/builtin/packages/clp/package.py
@@ -16,3 +16,21 @@ class Clp(AutotoolsPackage):
     version('1.16.11', sha256='b525451423a9a09a043e6a13d9436e13e3ee7a7049f558ad41a110742fa65f39')
 
     build_directory = 'spack-build'
+
+    def configure_args(self):
+        args = []
+        for d in [join_path('BuildTools', 'config.guess'),
+                  join_path('Clp', 'config.guess'),
+                  join_path('ThirdParty', 'ASL', 'config.guess'),
+                  join_path('ThirdParty', 'Blas', 'config.guess'),
+                  join_path('ThirdParty', 'Lapack', 'config.guess'),
+                  join_path('ThirdParty', 'Metis', 'config.guess'),
+                  join_path('ThirdParty', 'Mumps', 'config.guess'),
+                  join_path('ThirdParty', 'Glpk', 'config.guess'),
+                  join_path('Data', 'Netlib', 'config.guess'),
+                  join_path('Data', 'Sample', 'config.guess'),
+                  join_path('CoinUtils', 'config.guess'),
+                  join_path('Osi', 'config.guess')]:
+            copy('config.guess', d)
+
+        return args


### PR DESCRIPTION
I can't build on ARM because of the old version of config.guess.
Copy config.guess to the subdirectories.

```
2 errors found in build log:
     164    /usr/convex/getsysinfo =
     165
     166    UNAME_MACHINE = aarch64
     167    UNAME_RELEASE = 4.18.0-147.el8.aarch64
     168    UNAME_SYSTEM  = Linux
     169    UNAME_VERSION = #1 SMP Wed Dec 4 21:57:21 UTC 2019
  >> 170    configure: error: cannot guess build type; you must specify one
  >> 171    configure: error: /bin/sh '/home/denpo/spack-stage/spack-stage-clp-1.16.11-f54xhsuxirlzroehrziy6gpk2rinvyne/spac
            k-src/Data/Sample/configure' failed for Data/Sample

```