### PR TITLE
nfs-ganesha: fix compile error on debian

### DIFF
--- a/var/spack/repos/builtin/packages/nfs-ganesha/package.py
+++ b/var/spack/repos/builtin/packages/nfs-ganesha/package.py
@@ -20,10 +20,10 @@ class NfsGanesha(CMakePackage):
 
     depends_on('bison', type='build')
     depends_on('flex',  type='build')
+    depends_on('py-stsci-distutils', type='build')
     depends_on('userspace-rcu')
     depends_on('ntirpc')
     depends_on('krb5')
-    depends_on('py-stsci-distutils')
 
     root_cmakelists_dir = 'src'
 

--- a/var/spack/repos/builtin/packages/nfs-ganesha/package.py
+++ b/var/spack/repos/builtin/packages/nfs-ganesha/package.py
@@ -22,6 +22,8 @@ class NfsGanesha(CMakePackage):
     depends_on('flex',  type='build')
     depends_on('userspace-rcu')
     depends_on('ntirpc')
+    depends_on('krb5')
+    depends_on('py-stsci-distutils')
 
     root_cmakelists_dir = 'src'
 


### PR DESCRIPTION
There are 2 errors in nfs-ganesha compile phase:
```
/home/spack-develop/opt/spack/linux-debian10-aarch64/gcc-8.3.0/ntirpc-3.2-j7uutos3svixgkhzm23v2fnsxw64xujo/include/ntirpc/rpc/gss_internal.h:121: undefined reference to `svcauth_gss_destroy'
collect2: error: ld returned 1 exit status
make[2]: *** [MainNFSD/CMakeFiles/ganesha_nfsd.dir/build.make:601: MainNFSD/libganesha_nfsd.so.3.2] Error 1
```
=> need `krb5`

```
ModuleNotFoundError: No module named 'distutils.core'
```
=> need `py-stsci-distutils`