### PR TITLE
Bcache

### DIFF
--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -22,6 +22,7 @@ class Bcache(MakefilePackage):
     depends_on('libuuid')
     depends_on('util-linux')
     depends_on('gettext')
+    depends_on('pkgconfig', type='build')
 
     def setup_build_environment(self, env):
         env.append_flags('LDFLAGS', '-lintl')

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -19,7 +19,6 @@ class Bcache(MakefilePackage):
     version('1.0.5', sha256='1449294ef545b3dc6f715f7b063bc2c8656984ad73bcd81a0dc048cbba416ea9')
     version('1.0.4', sha256='102ffc3a8389180f4b491188c3520f8a4b1a84e5a7ca26d2bd6de1821f4d913d')
 
-    depends_on('libuuid')
     depends_on('util-linux')
     depends_on('gettext')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
There is no need for `bcache` depends on `package: libuuid`.
`util-linux` will generator `libuuid` too.
So, there is a bug when we build `bcache`. 
`libuuid` and `util-linux` path will both in `PKG_CONFIG_PATH`, and there will be 2 `libuuid.so` with different content. It will come to build error on `Ubuntu19` when `libuuid` order before `util-linux` with this log:
```
/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/util-linux-2.35.1-6yj5fgsmr4aezijujdnmv3qudnlblwhz/lib/libblkid.so: undefined reference to `libintl_gettext'
```