### PR TITLE
Binary Distribution: Relocate RPATH on Cray

### DIFF
--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -233,10 +233,14 @@ class Platform(object):
         Will return a instance of it once it is returned.
     """
 
-    priority        = None  # Subclass sets number. Controls detection order
+    priority        = None   # Subclass sets number. Controls detection order
+
+    #: binary formats used on this platform; used by relocation logic
+    binary_formats  = ['elf']
+
     front_end       = None
     back_end        = None
-    default         = None  # The default back end target. On cray ivybridge
+    default         = None   # The default back end target. On cray ivybridge
 
     front_os        = None
     back_os         = None

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -11,7 +11,6 @@ import shutil
 import tempfile
 import hashlib
 import glob
-import platform
 
 from contextlib import closing
 import ruamel.yaml as yaml
@@ -520,17 +519,16 @@ def make_package_relative(workdir, spec, allow_root):
     for filename in buildinfo['relocate_binaries']:
         orig_path_names.append(os.path.join(prefix, filename))
         cur_path_names.append(os.path.join(workdir, filename))
-    if (spec.architecture.platform == 'darwin' or
-        spec.architecture.platform == 'test' and
-            platform.system().lower() == 'darwin'):
-        relocate.make_macho_binaries_relative(cur_path_names, orig_path_names,
-                                              old_layout_root)
-    if (spec.architecture.platform == 'linux' or
-        spec.architecture.platform == 'cray' or
-        spec.architecture.platform == 'test' and
-            platform.system().lower() == 'linux'):
-        relocate.make_elf_binaries_relative(cur_path_names, orig_path_names,
-                                            old_layout_root)
+
+    platform = spack.architecture.get_platform(spec.platform)
+    if 'macho' in platform.binary_formats:
+        relocate.make_macho_binaries_relative(
+            cur_path_names, orig_path_names, old_layout_root)
+
+    if 'elf' in platform.binary_formats:
+        relocate.make_elf_binaries_relative(
+            cur_path_names, orig_path_names, old_layout_root)
+
     relocate.raise_if_not_relocatable(cur_path_names, allow_root)
     orig_path_names = list()
     cur_path_names = list()
@@ -610,19 +608,16 @@ def relocate_package(spec, allow_root):
                              ]
         # If the buildcache was not created with relativized rpaths
         # do the relocation of path in binaries
-        if (spec.architecture.platform == 'darwin' or
-            spec.architecture.platform == 'test' and
-                platform.system().lower() == 'darwin'):
+        platform = spack.architecture.get_platform(spec.platform)
+        if 'macho' in platform.binary_formats:
             relocate.relocate_macho_binaries(files_to_relocate,
                                              old_layout_root,
                                              new_layout_root,
                                              prefix_to_prefix, rel,
                                              old_prefix,
                                              new_prefix)
-        if (spec.architecture.platform == 'linux' or
-            spec.architecture.platform == 'cray' or
-            spec.architecture.platform == 'test' and
-                platform.system().lower() == 'linux'):
+
+        if 'elf' in platform.binary_formats:
             relocate.relocate_elf_binaries(files_to_relocate,
                                            old_layout_root,
                                            new_layout_root,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -620,6 +620,7 @@ def relocate_package(spec, allow_root):
                                              old_prefix,
                                              new_prefix)
         if (spec.architecture.platform == 'linux' or
+            spec.architecture.platform == 'cray' or
             spec.architecture.platform == 'test' and
                 platform.system().lower() == 'linux'):
             relocate.relocate_elf_binaries(files_to_relocate,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -526,6 +526,7 @@ def make_package_relative(workdir, spec, allow_root):
         relocate.make_macho_binaries_relative(cur_path_names, orig_path_names,
                                               old_layout_root)
     if (spec.architecture.platform == 'linux' or
+        spec.architecture.platform == 'cray' or
         spec.architecture.platform == 'test' and
             platform.system().lower() == 'linux'):
         relocate.make_elf_binaries_relative(cur_path_names, orig_path_names,

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -12,6 +12,8 @@ from spack.operating_systems.mac_os import MacOs
 class Darwin(Platform):
     priority    = 89
 
+    binary_formats = ['macho']
+
     def __init__(self):
         super(Darwin, self).__init__('darwin')
 

--- a/lib/spack/spack/platforms/test.py
+++ b/lib/spack/spack/platforms/test.py
@@ -3,12 +3,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
 from spack.architecture import Platform, Target
 from spack.architecture import OperatingSystem
 
 
 class Test(Platform):
     priority    = 1000000
+
+    if platform.system().lower() == 'darwin':
+        binary_formats = ['macho']
+
     front_end   = 'x86'
     back_end    = 'x86_64'
     default     = 'x86_64'


### PR DESCRIPTION
Do RPATH relocation on Cray as part of
* `spack buildcache create -r ...`
* `spack install` when installation is from binary cache

@scottwittenburg @shahzebsiddiqui @becker33 