### PR TITLE
use specified freetype libs for fontconfig

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -23,7 +23,7 @@ class Fontconfig(AutotoolsPackage):
     depends_on('font-util')
     depends_on('libuuid', when='@2.13.1:')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, spack_env):
         spack_env.set("FREETYPE_CFLAGS", "-I{0}/include/freetype2".format( self.spec['freetype'].prefix))
         spack_env.set("FREETYPE_LIBS", "-L{0}/lib -lfreetype".format(self.spec['freetype'].prefix))
 

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -26,12 +26,10 @@ class Fontconfig(AutotoolsPackage):
     def setup_build_environment(self, spack_env):
         spack_env.set(
             "FREETYPE_CFLAGS",
-            "-I{0}/include/freetype2".format(
-                self.spec['freetype'].prefix))
+            self.spec['freetype'].headers.include_flags)
         spack_env.set(
             "FREETYPE_LIBS",
-            "-L{0}/lib -lfreetype".format(
-                self.spec['freetype'].prefix))
+            self.spec['freetype'].libs.ld_flags)
 
     def configure_args(self):
         font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -23,6 +23,10 @@ class Fontconfig(AutotoolsPackage):
     depends_on('font-util')
     depends_on('libuuid', when='@2.13.1:')
 
+    def setup_environment(self, spack_env, run_env):
+        spack_env.set("FREETYPE_CFLAGS", "-I{0}/include/freetype2".format( self.spec['freetype'].prefix))
+        spack_env.set("FREETYPE_LIBS", "-L{0}/lib -lfreetype".format(self.spec['freetype'].prefix))
+
     def configure_args(self):
         font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')
 

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -26,7 +26,7 @@ class Fontconfig(AutotoolsPackage):
     def setup_build_environment(self, spack_env):
         spack_env.set(
             "FREETYPE_CFLAGS",
-            self.spec['freetype'].headers.include_flags)
+            self.spec['freetype'].headers.include_flags + "/freetype2")
         spack_env.set(
             "FREETYPE_LIBS",
             self.spec['freetype'].libs.ld_flags)

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Fontconfig(AutotoolsPackage):
     """Fontconfig is a library for configuring/customizing font access"""
     homepage = "http://www.freedesktop.org/wiki/Software/fontconfig/"
-    url      = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.3.tar.gz"
+    url = "http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.3.tar.gz"
 
     version('2.13.1', sha256='9f0d852b39d75fc655f9f53850eb32555394f36104a044bb2b2fc9e66dbbfa7f')
     version('2.12.3', sha256='ffc3cbf6dd9fcd516ee42f48306a715e66698b238933d6fa7cef02ea8b3b818e')
@@ -24,8 +24,14 @@ class Fontconfig(AutotoolsPackage):
     depends_on('libuuid', when='@2.13.1:')
 
     def setup_build_environment(self, spack_env):
-        spack_env.set("FREETYPE_CFLAGS", "-I{0}/include/freetype2".format( self.spec['freetype'].prefix))
-        spack_env.set("FREETYPE_LIBS", "-L{0}/lib -lfreetype".format(self.spec['freetype'].prefix))
+        spack_env.set(
+            "FREETYPE_CFLAGS",
+            "-I{0}/include/freetype2".format(
+                self.spec['freetype'].prefix))
+        spack_env.set(
+            "FREETYPE_LIBS",
+            "-L{0}/lib -lfreetype".format(
+                self.spec['freetype'].prefix))
 
     def configure_args(self):
         font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')


### PR DESCRIPTION
When building fontconfig, it uses the system freetype library even if you have built it.
This patch corrects this.