### PR TITLE
allow libfoo.so.3 libraries for dependency check

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1534,6 +1534,11 @@ def find_libraries(libraries, root, shared=True, recursive=False):
         suffix = 'a'
     # List of libraries we are searching with suffixes
     libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
+    if suffix == 'so':
+        # if we're installing buildcache images, we only need runtimes
+        # runtimes on Linux are libfoo.so.n for some integer n
+        librariesn = ['{0}.{1}'.format(lib,str(n)) for n in range(20) for lib in libraries]
+        libraries = libraries + librariesn
 
     if not recursive:
         # If not recursive, look for the libraries directly in root

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1537,7 +1537,7 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     if suffix == 'so':
         # if we're installing buildcache images, we only need runtimes
         # runtimes on Linux are libfoo.so.n for some integer n
-        librariesn = ['{0}.{1}'.format(lib, str(n)) 
+        librariesn = ['{0}.{1}'.format(lib, str(n))
                       for n in range(20) for lib in libraries]
         libraries = libraries + librariesn
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1537,7 +1537,8 @@ def find_libraries(libraries, root, shared=True, recursive=False):
     if suffix == 'so':
         # if we're installing buildcache images, we only need runtimes
         # runtimes on Linux are libfoo.so.n for some integer n
-        librariesn = ['{0}.{1}'.format(lib,str(n)) for n in range(20) for lib in libraries]
+        librariesn = ['{0}.{1}'.format(lib, str(n)) 
+                      for n in range(20) for lib in libraries]
         libraries = libraries + librariesn
 
     if not recursive:


### PR DESCRIPTION
When you're installing packages from buildcache, you really only need the runtime libraries for the
dependencies.  However, Spack insists on having, for example libfred.so (from a fred-devel RPM) 
and not just libfred.so.3 (from fred RPM).  This patch lets the libfred.so.3 existence for the dependency
allow the package install.