### PR TITLE
Allow system gettext on RedHat/Centos/SL

### DIFF
--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,7 +27,8 @@ class Acl(AutotoolsPackage):
     depends_on('gettext')
 
     def setup_build_environment(self, env):
-        env.append_flags('LDFLAGS', '-lintl')
+        if self.spec['gettext'].prefix != '/usr':
+            env.append_flags('LDFLAGS', '-lintl')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -25,7 +25,8 @@ class Bcache(MakefilePackage):
     depends_on('pkgconfig', type='build')
 
     def setup_build_environment(self, env):
-        env.append_flags('LDFLAGS', '-lintl')
+        if self.spec['gettext'].prefix != '/usr':
+            env.append_flags('LDFLAGS', '-lintl')
 
     patch('func_crc64.patch', sha256='558b35cadab4f410ce8f87f0766424a429ca0611aa2fd247326ad10da115737d')
 

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -91,7 +91,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
         if '+nls' in spec:
             configure_args.append('--enable-nls')
-            configure_args.append('LDFLAGS=-lintl')
+            if self.spec['gettext'].prefix != '/usr':
+                configure_args.append('LDFLAGS=-lintl')
         else:
             configure_args.append('--disable-nls')
 

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -87,8 +87,9 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
         if '+nls' in spec:
             # configure doesn't use LIBS correctly
-            args.append('LDFLAGS=-Wl,--no-as-needed -L%s -lintl' %
-                        spec['gettext'].prefix.lib)
+            if self.spec['gettext'].prefix != '/usr':
+                args.append('LDFLAGS=-Wl,--no-as-needed -L%s -lintl' %
+                            spec['gettext'].prefix.lib)
         else:
             args.append('--disable-nls')
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -88,7 +88,8 @@ class Extrae(AutotoolsPackage):
 
         # This was added due to configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
-        args.append('LDFLAGS=-lintl')
+        if self.spec['gettext'].prefix != '/usr':
+            args.append('LDFLAGS=-lintl')
 
         return(args)
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -245,8 +245,9 @@ class Git(AutotoolsPackage):
         # In that case the node in the DAG gets truncated and git DOES NOT
         # have a gettext dependency.
         if 'gettext' in self.spec:
-            env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
-                self.spec['gettext'].prefix.lib))
+            if self.spec['gettext'].prefix != '/usr':
+                env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
+                    self.spec['gettext'].prefix.lib))
             env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
 

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -31,5 +31,6 @@ class Libxpm(AutotoolsPackage, XorgPackage):
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
         if 'gettext' in self.spec:
-            env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
-                self.spec['gettext'].prefix.lib))
+            if self.spec['gettext'].prefix != '/usr':
+                env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+                    self.spec['gettext'].prefix.lib))

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -29,7 +29,8 @@ class NfsUtils(AutotoolsPackage):
     depends_on('gettext')
 
     def setup_build_environment(self, env):
-        env.append_flags('LIBS', '-lintl')
+        if self.spec['gettext'].prefix != '/usr':
+            env.append_flags('LIBS', '-lintl')
 
     def configure_args(self):
         args = ['--disable-gss', '--with-rpcgen=internal']

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -17,4 +17,5 @@ class RpcsvcProto(AutotoolsPackage):
     depends_on('gettext')
 
     def configure_args(self):
-        return ['LIBS=-lintl']
+        if self.spec['gettext'].prefix != '/usr':
+            return ['LIBS=-lintl']

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -32,7 +32,8 @@ class Xfd(AutotoolsPackage, XorgPackage):
     # correctly, so add it here.
     def flag_handler(self, name, flags):
         if name == 'ldlibs':
-            flags.append('-lintl')
+            if self.spec['gettext'].prefix != '/usr':
+                flags.append('-lintl')
 
         return (flags, None, None)
 


### PR DESCRIPTION
On RedHat/Centos/SL the system gettext is installed as /usr/lib64/preloadable_libintl.so

so adding -lintl to various LDFLAGS breaks builds trying to use the system gettext, whereas most packages
using pkg-config, etc. do find it using the system pkgconfig info.
 
So we shouldn't specify -lintl when gettext's prefix is /usr.