### PR TITLE
detatch binutils usage from static stage1 libs in gcc variants

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -95,9 +95,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('nvptx',
             default=False,
             description='Target nvptx offloading to NVIDIA GPUs')
-    variant('static_stage1',
+    variant('enable_bootstrap',
             default=False,
-            description='Use static libstdc++,libstdc for stage1')
+            description='add --enable-bootstrap flag for stage3 build')
 
     depends_on('flex', type='build', when='@master')
 
@@ -476,13 +476,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                 '--with-gnu-as',
                 '--with-as=' + binutils.join('as'),
             ])
-        if spec.satisfies('+static_stage1'):
-            stage1_ldflags = str(self.rpath_args)
-            boot_ldflags = stage1_ldflags + ' -static-libstdc++ -static-libgcc'
+
+        # enable_bootstrap
+        if spec.satisfies('+enable_bootstrap'):
             options.extend([
-                '--with-sysroot=/',
-                '--with-stage1-ldflags=' + stage1_ldflags,
-                '--with-boot-ldflags=' + boot_ldflags,
                 '--enable-bootstrap',
             ])
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -95,6 +95,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('nvptx',
             default=False,
             description='Target nvptx offloading to NVIDIA GPUs')
+    variant('static_stage1',
+            default=False,
+            description='Use sysroot=/ and static libstdc++,libstdc for stage1')
 
     depends_on('flex', type='build', when='@master')
 
@@ -468,11 +471,20 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         if spec.satisfies('+binutils'):
             binutils = spec['binutils'].prefix.bin
             options.extend([
-                '--with-sysroot=/',
                 '--with-gnu-ld',
                 '--with-ld=' + binutils.ld,
                 '--with-gnu-as',
                 '--with-as=' + binutils.join('as'),
+            ])
+        if spec.satisfies('+static_stage1'):
+            stage1_ldflags = str(self.rpath_args)
+            boot_ldflags = stage1_ldflags + ' -static-libstdc++ -static-libgcc'
+            if '%gcc' in spec:
+                stage1_ldflags = boot_ldflags
+            options.extend([
+                '--with-sysroot=/',
+                '--with-stage1-ldflags=' + stage1_ldflags,
+                '--with-boot-ldflags=' + boot_ldflags,
                 '--enable-bootstrap',
             ])
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -97,7 +97,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             description='Target nvptx offloading to NVIDIA GPUs')
     variant('static_stage1',
             default=False,
-            description='Use sysroot=/ and static libstdc++,libstdc for stage1')
+            description='Use static libstdc++,libstdc for stage1')
 
     depends_on('flex', type='build', when='@master')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -95,7 +95,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('nvptx',
             default=False,
             description='Target nvptx offloading to NVIDIA GPUs')
-    variant('enable_bootstrap',
+    variant('bootstrap',
             default=False,
             description='add --enable-bootstrap flag for stage3 build')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -479,8 +479,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         if spec.satisfies('+static_stage1'):
             stage1_ldflags = str(self.rpath_args)
             boot_ldflags = stage1_ldflags + ' -static-libstdc++ -static-libgcc'
-            if '%gcc' in spec:
-                stage1_ldflags = boot_ldflags
             options.extend([
                 '--with-sysroot=/',
                 '--with-stage1-ldflags=' + stage1_ldflags,

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -478,7 +478,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             ])
 
         # enable_bootstrap
-        if spec.satisfies('+enable_bootstrap'):
+        if spec.satisfies('+bootstrap'):
             options.extend([
                 '--enable-bootstrap',
             ])


### PR DESCRIPTION
The current gcc recipe convolves using a Spack-built binutils with  several unrelated flags about using a
static libstdc++ and libstdc in stage1 of the bootstrap.   This patch makes a separate variant (+static_stage1) 
for those static bootstrap flags, and makes +binutils just specify an alternate "ld" and "as" from the specified
binutils.

