### PR TITLE
libsm: new version, depends_on libuuid

### DIFF
--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -12,9 +12,12 @@ class Libsm(AutotoolsPackage, XorgPackage):
     homepage = "http://cgit.freedesktop.org/xorg/lib/libSM"
     xorg_mirror_path = "lib/libSM-1.2.2.tar.gz"
 
+    version('1.2.3', sha256='1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320')
     version('1.2.2', sha256='14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4')
 
+
     depends_on('libice@1.0.5:')
+    depends_on('libuuid')
 
     depends_on('xproto', type='build')
     depends_on('xtrans', type='build')

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -15,7 +15,6 @@ class Libsm(AutotoolsPackage, XorgPackage):
     version('1.2.3', sha256='1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320')
     version('1.2.2', sha256='14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4')
 
-
     depends_on('libice@1.0.5:')
     depends_on('libuuid')
 


### PR DESCRIPTION
libsm depends on libuuid, but the dependency was missing from the recipe