### PR TITLE
Restore curl progress output

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -295,6 +295,9 @@ class URLFetchStrategy(FetchStrategy):
         url = None
         errors = []
         for url in self.candidate_urls:
+            if not self._existing_url(url):
+                continue
+
             try:
                 partial_file, save_file = self._fetch_from_url(url)
                 if save_file:
@@ -309,13 +312,22 @@ class URLFetchStrategy(FetchStrategy):
         if not self.archive_file:
             raise FailedDownloadError(url)
 
+    def _existing_url(self, url):
+        tty.debug('Checking existence of {0}'.format(url))
+        curl = self.curl
+        # Telling curl to fetch the first byte (-r 0-0) is supposed to be
+        # portable.
+        curl_args = ['--stderr', '-', '-s', '-f', '-r', '0-0', url]
+        _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
+        return curl.returncode == 0
+
     def _fetch_from_url(self, url):
         save_file = None
         partial_file = None
         if self.stage.save_filename:
             save_file = self.stage.save_filename
             partial_file = self.stage.save_filename + '.part'
-        tty.debug('Fetching {0}'.format(url))
+        tty.msg('Fetching {0}'.format(url))
         if partial_file:
             save_args = ['-C',
                          '-',  # continue partial downloads
@@ -330,8 +342,6 @@ class URLFetchStrategy(FetchStrategy):
             '-',  # print out HTML headers
             '-L',  # resolve 3xx redirects
             url,
-            '--stderr',  # redirect stderr output
-            '-',         # redirect to stdout
         ]
 
         if not spack.config.get('config:verify_ssl'):
@@ -340,7 +350,7 @@ class URLFetchStrategy(FetchStrategy):
         if sys.stdout.isatty() and tty.msg_enabled():
             curl_args.append('-#')  # status bar when using a tty
         else:
-            curl_args.append('-sS')  # just errors when not.
+            curl_args.append('-sS')  # show errors if fail
 
         connect_timeout = spack.config.get('config:connect_timeout', 10)
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -579,7 +579,7 @@ class CacheURLFetchStrategy(URLFetchStrategy):
                 raise
 
         # Notify the user how we fetched.
-        tty.debug('Using cached archive: {0}'.format(path))
+        tty.msg('Using cached archive: {0}'.format(path))
 
 
 class VCSFetchStrategy(FetchStrategy):

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -6,8 +6,10 @@
 import collections
 import os
 import pytest
+import sys
 
 from llnl.util.filesystem import working_dir, is_exe
+import llnl.util.tty as tty
 
 import spack.repo
 import spack.config
@@ -171,6 +173,22 @@ def test_hash_detection(checksum_type):
 def test_unknown_hash(checksum_type):
     with pytest.raises(ValueError):
         crypto.Checker('a')
+
+
+def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch):
+    """Ensure a fetch with status bar option."""
+    def is_true():
+        return True
+
+    testpath = str(tmpdir)
+
+    monkeypatch.setattr(sys.stdout, 'isatty', is_true)
+    monkeypatch.setattr(tty, 'msg_enabled', is_true)
+
+    fetcher = fs.URLFetchStrategy(mock_archive.url)
+    with Stage(fetcher, path=testpath) as stage:
+        assert fetcher.archive_file is None
+        stage.fetch()
 
 
 def test_url_extra_fetch(tmpdir, mock_archive):

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -175,8 +175,8 @@ def test_unknown_hash(checksum_type):
         crypto.Checker('a')
 
 
-def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch):
-    """Ensure a fetch with status bar option."""
+def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch, capfd):
+    """Ensure fetch with status bar option succeeds."""
     def is_true():
         return True
 
@@ -189,6 +189,9 @@ def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch):
     with Stage(fetcher, path=testpath) as stage:
         assert fetcher.archive_file is None
         stage.fetch()
+
+    status = capfd.readouterr()[1]
+    assert '##### 100.0%' in status
 
 
 def test_url_extra_fetch(tmpdir, mock_archive):


### PR DESCRIPTION
Fixes #18016 

The `curl` progress bar was removed, along with other verbose output, to address #17464 and add debug levels in #17546 .

This PR restores the `curl` fetching output/progress bar while honoring the request to avoid fetch failures per #17464 .

Results for installing `m4` after the change for `m4` (where `libsigsegv` is already installed), for example, appear as follows:
```
$ spack install m4
[+] $HOME/spack/clean/spack/opt/spack/linux-rhel7-broadwell/gcc-8.1.0/libsigsegv-2.12-ifc2oc4r34po2jokvyjhbl4kewmne6d4
==> Installing m4
==> No binary for m4 found: installing from source
==> Fetching https://spack-llnl-mirror.s3-us-west-2.amazonaws.com/_source-cache/archive/ab/ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab.tar.gz
######################################################################## 100.0%
==> Fetching https://spack-llnl-mirror.s3-us-west-2.amazonaws.com/_source-cache/archive/fc/fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8
######################################################################## 100.0%
==> m4: Executing phase: 'autoreconf'
==> m4: Executing phase: 'configure'
==> m4: Executing phase: 'build'
==> m4: Executing phase: 'install'
[+] $HOME/spack/clean/spack/opt/spack/linux-rhel7-broadwell/gcc-8.1.0/m4-1.4.18-axouc4ppwhnv6ulvuof7766ihxlbakyz
57.398u 30.557s 2:14.41 65.4%	0+0k 5744+191448io 0pf+0w
```