### PR TITLE
coevp: use libquadmath only x86_64 and ppcle.

### DIFF
--- a/var/spack/repos/builtin/packages/coevp/package.py
+++ b/var/spack/repos/builtin/packages/coevp/package.py
@@ -61,6 +61,13 @@ class Coevp(MakefilePackage):
 
         return targets
 
+    def edit(self, spec, prefix):
+        # libquadmath is only available x86_64 and powerle
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85440
+        if self.spec.target.family not in ['x86_64', 'ppc64le']:
+            comps = join_path('LULESH', 'Makefile')
+            filter_file('-lquadmath', '', comps)
+
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         mkdir(prefix.doc)


### PR DESCRIPTION
When gcc compiler is used, coevp add libquadmath.
But libquadmath is enabled only x86_64 and ppc64le.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85440

This PR is removed -lquaddmath when target is not x86_64 or ppc64.
