### PR TITLE
vdt: Removed the -mfpu=neon option for aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/vdt/CMakeLists.txt.patch
+++ b/var/spack/repos/builtin/packages/vdt/CMakeLists.txt.patch
@@ -1,0 +1,11 @@
+--- spack-src/CMakeLists.txt.bak	2019-02-05 19:20:28.000000000 +0900
++++ spack-src/CMakeLists.txt	2020-08-17 16:54:33.476417139 +0900
+@@ -51,7 +51,7 @@
+ # SIMD and FMA instructions set-------------------------------------------------
+ if (NEON)
+   message(STATUS "Using NEON instructions!")
+-  set(PACKED_INSTR "-mfpu=neon ")
++  set(PACKED_INSTR " ")
+ else()
+   if (SSE AND (NOT (AVX OR AVX2) ))
+     message(STATUS "Using SSE instructions!")

--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -18,6 +18,8 @@ class Vdt(CMakePackage):
     version('0.3.7', sha256='713a7e6d76d98f3b2b56b5216e7d5906e30f17865a5c7c889968e9a0b0664949')
     version('0.3.6', sha256='fb8f6386f2cd1eeb03db43f2b5c83a172107949bb5e5e8d4dfa603660a9757b0')
 
+    patch('CMakeLists.txt.patch', when='target=aarch64:')
+
     @property
     def build_directory(self):
         d = join_path(self.stage.path, 'spack-build')


### PR DESCRIPTION
The command line option to use Advanced SIMD (aka NEON) is not needed in aarch64, so remove the option.