### PR TITLE
looptools: skip UNDERSCORE check and add -Fwide

### DIFF
--- a/var/spack/repos/builtin/packages/looptools/conf.patch
+++ b/var/spack/repos/builtin/packages/looptools/conf.patch
@@ -1,0 +1,45 @@
+diff -u -r -N a/configure b/configure
+--- a/configure	2020-08-18 12:07:36.000000000 +0900
++++ b/configure	2020-08-18 12:52:34.000000000 +0900
+@@ -243,30 +243,8 @@
+ 
+ ## does Fortran append underscores to symbols?
+ 
+-echo -n "does $CONF_FC append underscores... " 1>&3
+-
+-tee $test-c.c << _EOF_ 1>&2
+-int uscore_ = 95;
+-int uscore = 59;
+-_EOF_
+-
+-for CONF_BITS in ${CONF_BITS:--m64 -m32} "" ; do
+-  eval $CONF_CC$CONF_CFLAGS $CONF_BITS -c $test-c.c 1>&2 || continue
+-  eval $CONF_FC$CONF_FFLAGS -o $test$CONF_EXE $test.f $test-c.o $CONF_LDFLAGS 1>&2 && break
+-done
+-
+-./$test$CONF_EXE
+-case $? in
+-95)
+-  echo "yes" 1>&3
+-  CONF_NOUNDERSCORE=0 ;;
+-59)
+-  echo "no" 1>&3
+-  CONF_NOUNDERSCORE=1 ;;
+-*)
+-  echo "error linking Fortran and C" 1>&3
+-  exit 1 ;;
+-esac
++CONF_BITS=""
++CONF_NOUNDERSCORE=0
+ 
+ CONF_CFLAGS+=" $CONF_BITS"
+ CONF_CXXFLAGS+=" $CONF_BITS"
+@@ -426,7 +404,7 @@
+ QUADSIZE = $CONF_QUADSIZE
+ 
+ FC = $CONF_FC
+-FFLAGS =$CONF_FFLAGS \\
++FFLAGS =-Fwide $CONF_FFLAGS \\
+   \$(DEF)QUAD=\$(QUAD) \$(DEF)QUADSIZE=\$(QUADSIZE) \\
+   \$(DEF)U77EXT=$CONF_U77EXT
+ 

--- a/var/spack/repos/builtin/packages/looptools/package.py
+++ b/var/spack/repos/builtin/packages/looptools/package.py
@@ -19,6 +19,8 @@ class Looptools(AutotoolsPackage):
     version('2.15', sha256='a065ffdc4fe6882aa3bb926134ba8ec875d6c0a633c3d4aa5f70db26542713f2')
     version('2.8', sha256='2395518d0eac9b0883a2c249b9a5ba80df443929c520c45e60f5a4284166eb42')
 
+    patch('conf.patch', when='%fj')
+
     def configure_args(self):
         args = ["FFLAGS=" + self.compiler.f77_pic_flag,
                 "CFLAGS=" + self.compiler.cc_pic_flag]


### PR DESCRIPTION
1. does Fortran append underscores to symbols?
In `configure` script, these files is build to check underscores.

test-c.c
> int uscore_ = 95;
int uscore = 59;

test.f
> 	program test
	integer i
	common /uscore/ i
	call exit(i)
	end

These source seems GCC specific.
So I patched these real check as below.

> CONF_BITS=""
CONF_NOUNDERSCORE=0

(2020/08/24)
I didn't submit upstream. Because this problem seems compiler specific.
I tried to link C and fortran. Warning occurred and  `$?` was 0.
>  [n0026@apollo13 spack-src]$ fcc -c testc.c
[n0026@apollo13 spack-src]$ frt -o teste test.f testc.o
/usr/bin/ld: Warning: alignment 4 of symbol `uscore_' in testc.o is smaller than 16 in /tmp/frtd78w7e.o

Result of `looptools%fj` was same as `looptools%gcc(x86_64)` . So linking in real looptools seems OK.
 
2. Long line
After 1, Fortran error occured due to long line.
So I added `-Fwide` option for Fujitsu compiler directly to `configure` script.