### PR TITLE
moab: delete -march=native

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -86,9 +86,8 @@ class Moab(AutotoolsPackage):
     patch('tools-492.patch', when='@4.9.2')
 
     @run_before('configure')
-    def filter_configure(self):
-        if self.spec.satisfies('%fj'):
-            filter_file('-march=native', '', 'configure', string=True)
+    def remove_march_native(self):
+        filter_file('-march=native', '', 'configure', string=True)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -85,6 +85,11 @@ class Moab(AutotoolsPackage):
 
     patch('tools-492.patch', when='@4.9.2')
 
+    @run_before('configure')
+    def filter_configure(self):
+        if self.spec.satisfies('%fj'):
+            filter_file('-march=native', '', 'configure', string=True)
+
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Fujitsu C compiler does not support `-march=native` option.
So I deleted this to use default arch. (See #17763 )

`configure`
> #GNU
EXTRA_GNU_CXXFLAGS="$EXTRA_GNU_CXXFLAGS -march=native"
EXTRA_GNU_FCFLAGS="$EXTRA_GNU_FCFLAGS -ffree-line-length-0 -march=native"
#CLANG
EXTRA_CLANG_CXXFLAGS="$EXTRA_CLANG_CXXFLAGS -march=native"
EXTRA_CLANG_FCFLAGS="$EXTRA_CLANG_FCFLAGS -ffree-line-length-0 -march=native"
