### PR TITLE
Add new STRUMPACK version 4.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Strumpack(CMakePackage):
+class Strumpack(CMakePackage, CudaPackage):
     """STRUMPACK -- STRUctured Matrix PACKage - provides linear solvers
     for sparse matrices and for dense rank-structured matrices, i.e.,
     matrices that exhibit some kind of low-rank property. It provides a
@@ -18,32 +18,31 @@ class Strumpack(CMakePackage):
     iterative solvers."""
 
     homepage = "http://portal.nersc.gov/project/sparse/strumpack"
-    url      = "https://github.com/pghysels/STRUMPACK/archive/v3.3.0.tar.gz"
+    url      = "https://github.com/pghysels/STRUMPACK/archive/v4.0.0.tar.gz"
     git      = "https://github.com/pghysels/STRUMPACK.git"
 
     maintainers = ['pghysels']
 
     version('master', branch='master')
+    version('4.0.0', sha256='a3629f1f139865c74916f8f69318f53af6319e7f8ec54e85c16466fd7d256938')
     version('3.3.0', sha256='499fd3b58656b4b6495496920e5372895861ebf15328be8a7a9354e06c734bc7')
     version('3.2.0', sha256='34d93e1b2a3b8908ef89804b7e08c5a884cbbc0b2c9f139061627c0d2de282c1')
     version('3.1.1', sha256='c1c3446ee023f7b24baa97b24907735e89ce4ae9f5ef516645dfe390165d1778')
-    version('3.1.0', sha256='b4f91b7d433955518b04538be1c726afc5de4bffb163e982ef8844d391b26fa7')
-    version('3.0.3', sha256='2bd2a40d9585b769ae4ba461de02c6e36433bf2b21827f824a50f2fdf73389f7')
-    version('3.0.2', sha256='828e5ec59019b2c74e008745b04ceebbb7ef1313fb4e3ac01fa8ff350799df38')
-    version('3.0.1', sha256='b4a4d870c589937e22e77a6c4b52a96fd808f0b564e363f826ae5ffc94b9d000')
-    version('3.0.0', sha256='7acd9b4653b8b11380de733c80b164348ca00f9226904f5dc166a8e3db88cd20')
-    version('2.2.0', sha256='8fe73875cbbb29ed1faf714e3bf13ad538eb062e39d7d5e73cb9c4aafb571e24')
 
     variant('shared', default=False, description='Build shared libraries')
     variant('mpi', default=True, description='Use MPI')
     variant('openmp', default=True,
             description='Enable thread parallellism via tasking with OpenMP')
-    variant('parmetis', default=False,
+    variant('cuda', default=True,
+            description='Enable CUDA support')
+    variant('parmetis', default=True,
             description='Enable use of ParMetis')
     variant('scotch', default=False,
             description='Enable use of Scotch')
     variant('butterflypack', default=True,
             description='Enable use of ButterflyPACK')
+    variant('zfp', default=True,
+            description='Build with support for compression using ZFP')
     variant('c_interface', default=True,
             description='Enable C interface')
     variant('count_flops', default=False,
@@ -55,7 +54,9 @@ class Strumpack(CMakePackage):
     variant('build_tests', default=False,
             description='Build test routines')
 
-    depends_on('cmake@3.2:', type='build')
+    # TODO: add a slate variant
+
+    depends_on('cmake@3.11:', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('blas')
     depends_on('lapack')
@@ -64,11 +65,16 @@ class Strumpack(CMakePackage):
     depends_on('parmetis', when='+parmetis')
     depends_on('scotch~metis', when='+scotch')
     depends_on('scotch~metis+mpi', when='+scotch+mpi')
-    depends_on('butterflypack@1.1.0:', when='+butterflypack+mpi')
+    depends_on('butterflypack@1.1.0', when='@3.3.0:3.9.999 +butterflypack+mpi')
+    depends_on('butterflypack@1.2.0:', when='@4.0.0: +butterflypack+mpi')
+    depends_on('cuda', when='@4.0.0: +cuda')
+    depends_on('zfp', when='+zfp')
 
     conflicts('+parmetis', when='~mpi')
     conflicts('+butterflypack', when='~mpi')
-    conflicts('+butterflypack', when='strumpack@:3.2.0')
+    conflicts('+butterflypack', when='@:3.2.0')
+    conflicts('+cuda', when='@:3.9.999')
+    conflicts('+zfp', when='@:3.9.999')
 
     patch('intel-19-compile.patch', when='@3.1.1')
 
@@ -78,33 +84,32 @@ class Strumpack(CMakePackage):
         def on_off(varstr):
             return 'ON' if varstr in spec else 'OFF'
 
-        if '+mpi' in spec:
-            args = ['-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
-                    '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
-                    '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-                    '-DSTRUMPACK_USE_MPI=ON']
-        else:
-            args = ['-DSTRUMPACK_USE_MPI=OFF']
-
-        args.extend([
+        args = [
+            '-DSTRUMPACK_USE_MPI=%s' % on_off('+mpi'),
             '-DSTRUMPACK_USE_OPENMP=%s' % on_off('+openmp'),
-            '-DSTRUMPACK_C_INTERFACE=%s' % on_off('+c_interface'),
+            '-DTPL_ENABLE_PARMETIS=%s' % on_off('+parmetis'),
+            '-DTPL_ENABLE_SCOTCH=%s' % on_off('+scotch'),
+            '-DTPL_ENABLE_BPACK=%s' % on_off('+butterflypack'),
             '-DSTRUMPACK_COUNT_FLOPS=%s' % on_off('+count_flops'),
             '-DSTRUMPACK_TASK_TIMERS=%s' % on_off('+task_timers'),
             '-DSTRUMPACK_DEV_TESTING=%s' % on_off('+build_dev_tests'),
             '-DSTRUMPACK_BUILD_TESTS=%s' % on_off('+build_tests')
-        ])
+        ]
 
-        if spec.satisfies('@3.0.4:'):
+        if spec.satisfies('@:3.9.999'):
+            if '+mpi' in spec:
+                args.extend([
+                    '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
+                    '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
+                    '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc
+                ])
             args.extend([
-                '-DTPL_ENABLE_PARMETIS=%s' % on_off('+parmetis'),
-                '-DTPL_ENABLE_SCOTCH=%s' % on_off('+scotch'),
-                '-DTPL_ENABLE_BPACK=%s' % on_off('+butterflypack')
+                '-DSTRUMPACK_C_INTERFACE=%s' % on_off('+c_interface'),
             ])
-        else:
+
+        if spec.satisfies('@4.0.0:'):
             args.extend([
-                '-DSTRUMPACK_USE_PARMETIS=%s' % on_off('+parmetis'),
-                '-DSTRUMPACK_USE_SCOTCH=%s' % on_off('+scotch')
+                '-DSTRUMPACK_USE_CUDA=%s' % on_off('+cuda')
             ])
 
         args.extend([


### PR DESCRIPTION
- add cuda variant, enabled by default, but conflicting with
  strumpack@:3.9.999
- add zfp variant, enabled by default, but conflicting with
  strumpack@:3.9.999
- update minimum CMake version to 3.11
- for version 4.0.0:, do not use mpi wrappers. v4.0.0 uses CMake
  MPI targets
- for version 4.0.0, add dependency on butterflypack@1.2.0:
- remove versions 3.1.0 and older
- make parmetis variant True by default
- add TODO for slate variant (spack package not ready yet)