### PR TITLE
Made lua dependency on ncurses+termlib explicit

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -32,7 +32,7 @@ class Lua(Package):
 
     extendable = True
 
-    depends_on('ncurses')
+    depends_on('ncurses+termlib')
     depends_on('readline')
     # luarocks needs unzip for some packages (e.g. lua-luaposix)
     depends_on('unzip', type='run')


### PR DESCRIPTION
Semi-recently the lua spackage was updated to explicitly add libtinfow
to the lua build line. Ncurses provides this but only when the +termlib
variant is enabled