### PR TITLE
trilinos: patch for cray cce fortran compiler

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/cray_secas.patch
+++ b/var/spack/repos/builtin/packages/trilinos/cray_secas.patch
@@ -1,0 +1,26 @@
+From f29f61e8ebcb8c887c271bc4a764192976910ca3 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <hppritcha@gmail.com>
+Date: Mon, 17 Aug 2020 16:05:47 -0600
+Subject: [PATCH] secas: patch FortranSettings for Cray fortran
+
+compiler.  This problem showed up in spack based builds of LANL LAP project dependencies
+on one of our cray systems using CCE.
+
+Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
+
+diff --git a/packages/seacas/cmake/FortranSettings.cmake b/packages/seacas/cmake/FortranSettings.cmake
+index c3447d57..7a73ce5f 100644
+--- a/packages/seacas/cmake/FortranSettings.cmake
++++ b/packages/seacas/cmake/FortranSettings.cmake
+@@ -8,6 +8,8 @@ IF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer -fdefault-real-8 -fdefault-integer-8 -fno-range-check")
+ ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "XL")
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -WF,-D__XLF__ -qintsize=8 -qrealsize=8 -qfixed")
++ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
++  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -sdefault64")
+ ELSE()
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -i8")
+ ENDIF()
+-- 
+2.18.4
+

--- a/var/spack/repos/builtin/packages/trilinos/cray_secas_12_12_1.patch
+++ b/var/spack/repos/builtin/packages/trilinos/cray_secas_12_12_1.patch
@@ -1,0 +1,16 @@
+diff --git a/packages/seacas/cmake/FortranSettings.cmake b/packages/seacas/cmake/FortranSettings.cmake
+index 02864ed3..4cb8f8b8 100644
+--- a/packages/seacas/cmake/FortranSettings.cmake
++++ b/packages/seacas/cmake/FortranSettings.cmake
+@@ -8,6 +8,8 @@ IF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer -fdefault-real-8 -fdefault-integer-8 -fno-range-check")
+ ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "XL")
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -WF,-D__XLF__ -qintsize=8 -qrealsize=8")
++ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
++  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -sdefault64")
+ ELSE()
+   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -i8")
+ ENDIF()
+-- 
+2.18.4
+

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -374,6 +374,8 @@ class Trilinos(CMakePackage):
     patch('xlf_tpetra.patch', when='@12.12.1%xl_r')
     patch('xlf_tpetra.patch', when='@12.12.1%clang')
     patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
+    patch('cray_secas_12_12_1.patch', when='@12.12.1%cce')
+    patch('cray_secas.patch', when='@12.14.1:12.18.1%cce')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"


### PR DESCRIPTION
two patchfiles needed since this file changed between 12.12.1 and 12.14.1

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>