### PR TITLE
Make spack environment configurations writable from spack external and spack compiler find

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import collections
 import os
-import re
 import shutil
 
 import llnl.util.filesystem as fs

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -178,14 +178,6 @@ def config_list(args):
     print(' '.join(list(spack.config.section_schemas)))
 
 
-def set_config(args, section, new, scope):
-    if re.match(r'env.*', scope):
-        e = ev.get_env(args, 'config add')
-        e.set_config(section, new)
-    else:
-        spack.config.set(section, new, scope=scope)
-
-
 def config_add(args):
     """Add the given configuration to the specified config scope
 
@@ -217,7 +209,7 @@ def config_add(args):
                 existing = spack.config.get(section, scope=scope)
                 new = spack.config.merge_yaml(existing, value)
 
-                set_config(args, section, new, scope)
+                spack.config.set(section, new, scope)
 
     if args.path:
         components = spack.config.process_config_path(args.path)
@@ -261,7 +253,7 @@ def config_add(args):
 
         # merge value into existing
         new = spack.config.merge_yaml(existing, value)
-        set_config(args, path, new, scope)
+        spack.config.set(path, new, scope)
 
 
 def config_remove(args):
@@ -289,7 +281,7 @@ def config_remove(args):
         # This should be impossible to reach
         raise spack.config.ConfigError('Config has nested non-dict values')
 
-    set_config(args, path, existing, scope)
+    spack.config.set(path, existing, scope)
 
 
 def _can_update_config_file(scope_dir, cfg_file):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -188,8 +188,17 @@ class SingleFileScope(ConfigScope):
 
         Arguments:
             schema (dict): jsonschema for the file to read
-            yaml_path (list): list of dict keys in the schema where
-                config data can be found
+            yaml_path (list): path in the schema where config data can be
+                found.
+                If the schema accepts the following yaml data, the yaml_path
+                would be ['outer', 'inner']
+
+                .. code-block:: yaml
+
+                   outer:
+                     inner:
+                       config:
+                         install_tree: $spack/opt/spack
         """
         super(SingleFileScope, self).__init__(name, path)
         self._raw_data = None

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -259,7 +259,7 @@ class SingleFileScope(ConfigScope):
             with open(tmp, 'w') as f:
                 syaml.dump_config(full_obj, stream=f,
                                   default_flow_style=False)
-            os.replace(tmp, self.path)
+            os.rename(tmp, self.path)
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError(
                 "Error writing to config file: '%s'" % str(e))

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -272,8 +272,6 @@ class SingleFileScope(ConfigScope):
         for key, data in self.sections.items():
             data_update_pointer[key] = data[key]
 
-        # validate on a copy of the data so we don't add defaults
-        data_to_validate = copy.deepcopy(data_to_write)
         validate(data_to_write, self.schema)
         try:
             parent = os.path.dirname(self.path)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -234,11 +234,10 @@ class SingleFileScope(ConfigScope):
             if self._raw_data is None:
                 return None
 
-            section_data = copy.deepcopy(self._raw_data)
+            section_data = self._raw_data
             for key in self.yaml_path:
                 if section_data is None:
                     return None
-
                 section_data = section_data[key]
 
             for section_key, data in section_data.items():
@@ -246,15 +245,9 @@ class SingleFileScope(ConfigScope):
         return self.sections.get(section, None)
 
     def write_section(self, section):
-        data_to_write = copy.deepcopy(self._raw_data)
-        if syaml.markable(data_to_write):
-            setattr(data_to_write,
-                    yaml.comments.Comment.attrib,
-                    getattr(self._raw_data,
-                            yaml.comments.Comment.attrib,
-                            yaml.comments.Comment()))
+        data_to_write = self._raw_data
 
-        if data_to_write is None:
+        if not data_to_write:
             data_to_write = {}
             for key in self.yaml_path:
                 data_to_write = {key: data_to_write}

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -855,15 +855,6 @@ class Environment(object):
         """A list of all configuration scopes for this environment."""
         return self.included_config_scopes() + [self.env_file_config_scope()]
 
-    def set_config(self, path, value):
-        """Set configuration for this environment"""
-        yaml = config_dict(self.yaml)
-        keys = spack.config.process_config_path(path)
-        for key in keys[:-1]:
-            yaml = yaml[key]
-        yaml[keys[-1]] = value
-        self.write()
-
     def destroy(self):
         """Remove this environment from Spack entirely."""
         shutil.rmtree(self.path)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -844,10 +844,12 @@ class Environment(object):
     def env_file_config_scope(self):
         """Get the configuration scope for the environment's manifest file."""
         config_name = self.env_file_config_scope_name()
-        return spack.config.SingleFileScope(config_name,
-                                            self.manifest_path,
-                                            spack.schema.env.schema,
-                                            [spack.schema.env.keys])
+        return spack.config.SingleFileScope(
+            config_name,
+            self.manifest_path,
+            spack.schema.env.schema,
+            [spack.config.first_existing(self.raw_yaml,
+                                         spack.schema.env.keys)])
 
     def config_scopes(self):
         """A list of all configuration scopes for this environment."""

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -399,7 +399,8 @@ def test_remove_list(mutable_empty_config):
 
 def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
     env = ev.create('test')
-    with env:
+    env.write()  # We can only preserve comments on a written environment
+    with ev.read('test'):
         config('add', 'config:dirty:true')
         output = config('get')
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -399,7 +399,7 @@ def test_remove_list(mutable_empty_config):
 
 def test_config_add_to_env_preserve_comments(mutable_empty_config,
                                              mutable_mock_env_path):
-    env = ev.create('test')
+    ev.create('test')
     with ev.read('test'):
         config('add', 'config:dirty:true')
         output = config('get')

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -413,11 +413,11 @@ def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
 def test_config_add_to_env_preserve_comments(mutable_empty_config,
                                              mutable_mock_env_path,
                                              tmpdir):
-    filepath = tmpdir.join('spack.yaml')
+    filepath = str(tmpdir.join('spack.yaml'))
     manifest = '# Added a comment\n' + ev.default_manifest_yaml
     with open(filepath, 'w') as f:
         f.write(manifest)
-    env = ev.create('test', str(filepath))
+    env = ev.create('test', filepath)
     env.write()  # We can only preserve comments on a written environment
     with ev.read('test'):
         config('add', 'config:dirty:true')

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -414,12 +414,23 @@ def test_config_add_to_env_preserve_comments(mutable_empty_config,
                                              mutable_mock_env_path,
                                              tmpdir):
     filepath = str(tmpdir.join('spack.yaml'))
-    manifest = '# Added a comment\n' + ev.default_manifest_yaml
+    manifest = """# comment
+spack:  # comment
+  # comment
+  specs:  # comment
+    - foo  # comment
+  # comment
+  view: true  # comment
+  packages:  # comment
+    # comment
+    all: # comment
+      # comment
+      compiler: [gcc] # comment
+"""
     with open(filepath, 'w') as f:
         f.write(manifest)
-    env = ev.create('test', filepath)
-    env.write()  # We can only preserve comments on a written environment
-    with ev.read('test'):
+    env = ev.Environment(str(tmpdir))
+    with env:
         config('add', 'config:dirty:true')
         output = config('get')
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -397,6 +397,20 @@ def test_remove_list(mutable_empty_config):
 """
 
 
+def test_config_add_to_env_preserve_comments(mutable_empty_config,
+                                             mutable_mock_env_path):
+    env = ev.create('test')
+    with ev.read('test'):
+        config('add', 'config:dirty:true')
+        output = config('get')
+
+    expected = """  config:
+    dirty: true
+
+"""
+    assert expected in output
+
+
 def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
     env = ev.create('test')
     env.write()  # We can only preserve comments on a written environment

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -397,8 +397,7 @@ def test_remove_list(mutable_empty_config):
 """
 
 
-def test_config_add_to_env_preserve_comments(mutable_empty_config,
-                                             mutable_mock_env_path):
+def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
     ev.create('test')
     with ev.read('test'):
         config('add', 'config:dirty:true')
@@ -411,14 +410,20 @@ def test_config_add_to_env_preserve_comments(mutable_empty_config,
     assert expected in output
 
 
-def test_config_add_to_env(mutable_empty_config, mutable_mock_env_path):
-    env = ev.create('test')
+def test_config_add_to_env_preserve_comments(mutable_empty_config,
+                                             mutable_mock_env_path,
+                                             tmpdir):
+    filepath = tmpdir.join('spack.yaml')
+    manifest = '# Added a comment\n' + ev.default_manifest_yaml
+    with open(filepath, 'w') as f:
+        f.write(manifest)
+    env = ev.create('test', str(filepath))
     env.write()  # We can only preserve comments on a written environment
     with ev.read('test'):
         config('add', 'config:dirty:true')
         output = config('get')
 
-    expected = ev.default_manifest_yaml
+    expected = manifest
     expected += """  config:
     dirty: true
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -58,7 +58,8 @@ def test_find_external_update_config(mutable_config):
     ]
     pkg_to_entries = {'cmake': entries}
 
-    spack.cmd.external._update_pkg_config(pkg_to_entries, False)
+    scope = spack.config.default_modify_scope('packages')
+    spack.cmd.external._update_pkg_config(scope, pkg_to_entries, False)
 
     pkgs_cfg = spack.config.get('packages')
     cmake_cfg = pkgs_cfg['cmake']
@@ -154,7 +155,8 @@ def test_find_external_merge(mutable_config, mutable_mock_repo):
         )
     ]
     pkg_to_entries = {'find-externals1': entries}
-    spack.cmd.external._update_pkg_config(pkg_to_entries, False)
+    scope = spack.config.default_modify_scope('packages')
+    spack.cmd.external._update_pkg_config(scope, pkg_to_entries, False)
 
     pkgs_cfg = spack.config.get('packages')
     pkg_cfg = pkgs_cfg['find-externals1']

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -791,6 +791,15 @@ env:
             '/x/y/z', '$spack/var/spack/repos/builtin']
 
 
+def test_write_empty_single_file_scope(tmpdir):
+    env_schema = spack.schema.env.schema
+    scope = spack.config.SingleFileScope(
+        'test', str(tmpdir.ensure('config.yaml')), env_schema, ['spack'])
+    scope.write_section('config')
+    # confirm we can write empty config
+    assert scope.get_section('config') is None
+
+
 def check_schema(name, file_contents):
     """Check a Spack YAML schema against some data"""
     f = StringIO(file_contents)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -797,7 +797,7 @@ def test_write_empty_single_file_scope(tmpdir):
         'test', str(tmpdir.ensure('config.yaml')), env_schema, ['spack'])
     scope.write_section('config')
     # confirm we can write empty config
-    assert scope.get_section('config') is None
+    assert not scope.get_section('config')
 
 
 def check_schema(name, file_contents):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -791,15 +791,6 @@ env:
             '/x/y/z', '$spack/var/spack/repos/builtin']
 
 
-def test_write_empty_single_file_scope(tmpdir):
-    env_schema = spack.schema.env.schema
-    scope = spack.config.SingleFileScope(
-        'test', str(tmpdir.ensure('config.yaml')), env_schema, ['spack'])
-    scope.write_section('config')
-    # confirm we can write empty config
-    assert scope.get_section('config') is None
-
-
 def check_schema(name, file_contents):
     """Check a Spack YAML schema against some data"""
     f = StringIO(file_contents)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -860,7 +860,7 @@ _spack_external() {
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --not-buildable"
+        SPACK_COMPREPLY="-h --help --not-buildable --scope"
     else
         _all_packages
     fi


### PR DESCRIPTION
This is a change in default behavior for these routines, but better
matches the mental model for an environment taking precedence over
the user's default packages.yaml file.

When I'm setting up a new user environment, I'd like to keep a record of what things I've pulled in from the system environment. Both `spack compiler find` and `spack external find` modify things in my user directory, but if I have an environment active then I'd like those changes reflected in my environment.

The code to do this was mostly already there. From what I could put together by reading the code and talking to @becker33, `write_section()` for `SingleFileConfig` was untested and many of the internals of `spack.config` were coded before environments were created.  

This is a minor cleanup in code quality that none-the-less has a huge impact on the default behavior of `spack external find`, `spack compiler find` and any other routine that relies on `default_modify_scope()` .  The change better reflects the mental model that environments take higher precedence compared to user configurations.

