### PR TITLE
Make finding of NetCDF and HDF5 more explicit.

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -52,6 +52,6 @@ class PyNetcdf4(PythonPackage):
         env.set('HDF5_DIR', self.spec['hdf5'].prefix)
         env.set('HDF5_INCDIR', self.spec['hdf5'].prefix.include)
         env.set('HDF5_LIBDIR', self.spec['hdf5'].prefix.lib)
+        env.set('NETCDF4_DIR', self.spec['netcdf-c'].prefix)
         env.set('NETCDF4_INCDIR', self.spec['netcdf-c'].prefix.include)
         env.set('NETCDF4_LIBDIR', self.spec['netcdf-c'].prefix.lib)
-        env.set('NETCDF4_DIR', self.spec['netcdf-c'].prefix)

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -46,8 +46,12 @@ class PyNetcdf4(PythonPackage):
         """Ensure installed netcdf and hdf5 libraries are used"""
         # Explicitly set these variables so setup.py won't erroneously pick up
         # system versions
+        # See: http://unidata.github.io/netcdf4-python
         env.set('USE_SETUPCFG', '0')
+        env.set('USE_NCCONFIG', '1')
+        env.set('HDF5_DIR', self.spec['hdf5'].prefix)
         env.set('HDF5_INCDIR', self.spec['hdf5'].prefix.include)
         env.set('HDF5_LIBDIR', self.spec['hdf5'].prefix.lib)
         env.set('NETCDF4_INCDIR', self.spec['netcdf-c'].prefix.include)
         env.set('NETCDF4_LIBDIR', self.spec['netcdf-c'].prefix.lib)
+        env.set('NETCDF4_DIR', self.spec['netcdf-c'].prefix)


### PR DESCRIPTION
@skosukhin @adamjstewart 

This is a follow-on to #16492 and #10885.  I ran into the same problem as #16492 and ended up coming up with the same solution (because I didn't have the latest Spack).  My solution had some additional env var settings that help make things more explicit, and hopefully more bulletproof.

@adamjstewart wrote:
> We should probably fix HDF5 to install pkg-config files so that this patch won't be needed forever

Not sure I agree.  `pkg-config` is a mess of automagic that never worked very well and, more often than not, conflicts with Spack.  As long as we've been explicit about where HDF5 is to be found (via the `HDF5_DIR` env var), then I think disabling `pkg-config` is the more robust approach.



