### PR TITLE
brigand: fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/brigand/package.py
+++ b/var/spack/repos/builtin/packages/brigand/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Brigand(Package):
+class Brigand(CMakePackage):
     """Brigand Meta-programming library"""
 
     homepage = "https://github.com/edouarda/brigand"
@@ -19,6 +19,3 @@ class Brigand(Package):
     version('1.2.0', sha256='4287fa7278cc000a63e90f1a1b903952b7f606b1a3cf95c23a422d2fe96ca50d')
     version('1.1.0', sha256='afdcc6909ebff6994269d3039c31698c2b511a70280072f73382b26855221f64')
     version('1.0.0', sha256='8daf7686ff39792f851ef1977323808b80aab31c5f38ef0ba4e6a8faae491f8d')
-
-    def install(self, spec, prefix):
-        install_tree('include', prefix.include)


### PR DESCRIPTION
Error log:
```
==> Installing brigand
==> No binary for brigand found: installing from source
==> brigand: Executing phase: 'install'
==> [2020-08-19-20:18:42.563926] Installing include to /home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/brigand-1.3.0-ks2b22ax3ksjod3fnnzvud4pkrepnhqn/include
==> Error: FileNotFoundError: [Errno 2] No such file or directory: '/tmp/root/spack-stage/spack-stage-brigand-1.3.0-ks2b22ax3ksjod3fnnzvud4pkrepnhqn/spack-src/include/'

/home/xiaojun/spack/var/spack/repos/builtin/packages/brigand/package.py:24, in install:
         23    def install(self, spec, prefix):
  >>     24        install_tree('include', prefix.include)

See build log for details:
  /tmp/root/spack-stage/spack-stage-brigand-1.3.0-ks2b22ax3ksjod3fnnzvud4pkrepnhqn/spack-build-out.txt
```

There's no `include` dir in each version of `brigand`, and it's a `cmake package`.