### PR TITLE
Test package detection in a systematic way

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -34,6 +34,7 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           coverage run $(which spack) audit packages
+          coverage run $(which spack) audit externals        
           coverage combine
           coverage xml
     - name: Package audits (without coverage)
@@ -41,6 +42,7 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           $(which spack) audit packages
+          $(which spack) audit externals
     - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # @v2.1.0
       if: ${{ inputs.with_coverage == 'true' }}
       with:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6274,6 +6274,23 @@ package detection and checking that the outcome matches the expected
      - Any valid spec
      - Yes
 
+"""""""""""""""""""""""""""""""
+Reuse tests from other packages
+"""""""""""""""""""""""""""""""
+
+When using a custom repository, it is possible to customize a package that already exists in ``builtin``
+and reuse its external tests. To do so, just write a ``detection_tests.yaml`` alongside the customized
+``package.py`` with an ``includes`` attribute. For instance the ``detection_tests.yaml`` for
+``myrepo.llvm`` might look like:
+
+.. code-block:: yaml
+
+   includes:
+   - "builtin.llvm"
+
+This YAML file instructs Spack to run the detection tests defined in ``builtin.llvm`` in addition to
+those locally defined in the file.
+
 -----------------------------
 Style guidelines for packages
 -----------------------------

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6231,16 +6231,10 @@ the ``paths`` attribute:
 
    paths:
    - layout:
-     - subdir: [bin]
-       name: clang-3.9
-       output: |
-         echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
-         echo "Target: x86_64-pc-linux-gnu"
-         echo "Thread model: posix"
-         echo "InstalledDir: /usr/bin"
-     - subdir: [bin]
-       name: clang++-3.9
-       output: |
+     - executables:
+       - "bin/clang-3.9"
+       - "bin/clang++-3.9"
+       script: |
          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
          echo "Target: x86_64-pc-linux-gnu"
          echo "Thread model: posix"
@@ -6265,15 +6259,11 @@ package detection and checking that the outcome matches the expected
      - Specifies the filesystem tree used for the test
      - List of objects
      - Yes
-   * - ``layout:[0]:subdir``
-     - Subdirectory for this executable
+   * - ``layout:[0]:executables``
+     - Relative paths for the mock executables to be created
      - List of strings
      - Yes
-   * - ``layout:[0]:name``
-     - Name of the executable
-     - A valid filename
-     - Yes
-   * - ``layout:[0]:output``
+   * - ``layout:[0]:script``
      - Mock logic for the executable
      - Any valid shell script
      - Yes

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6202,15 +6202,15 @@ follows:
 Add detection tests to packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To ensure that a software is detected correctly for multiple configurations
+To ensure that software is detected correctly for multiple configurations
 and on different systems users can write a ``detection_test.yaml`` file and
-put it in the same directory as the corresponding ``package.py`` file.
+put it in the package directory alongside the ``package.py`` file.
 This YAML file contains enough information for Spack to mock an environment
 and try to check if the detection logic yields the results that are expected.
 
 As a general rule, attributes at the top-level of ``detection_test.yaml``
-represent search mechanisms and they all map to a list of tests that should confirm
-the validity of each package detection logic.
+represent search mechanisms and they each map to a list of tests that should confirm
+the validity of the package's detection logic.
 
 The detection tests can be run with the following command:
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6198,6 +6198,94 @@ follows:
 
 .. _package-lifecycle:
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Add detection tests to packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To ensure that a software is detected correctly for multiple configurations
+and on different systems users can write a ``detection_test.yaml`` file and
+put it in the same directory as the corresponding ``package.py`` file.
+This YAML file contains enough information for Spack to mock an environment
+and try to check if the detection logic yields the results that are expected.
+
+As a general rule, attributes at the top-level of ``detection_test.yaml``
+represent search mechanisms and they all map to a list of tests that should confirm
+the validity of each package detection logic.
+
+The detection tests can be run with the following command:
+
+.. code-block:: console
+
+   $ spack audit externals
+
+Errors that have been detected are reported to screen.
+
+""""""""""""""""""""""""""
+Tests for PATH inspections
+""""""""""""""""""""""""""
+
+Detection tests insisting on ``PATH`` inspections are listed under
+the ``paths`` attribute:
+
+.. code-block:: yaml
+
+   paths:
+   - layout:
+     - subdir: [bin]
+       name: clang-3.9
+       output: |
+         echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+         echo "Target: x86_64-pc-linux-gnu"
+         echo "Thread model: posix"
+         echo "InstalledDir: /usr/bin"
+     - subdir: [bin]
+       name: clang++-3.9
+       output: |
+         echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+         echo "Target: x86_64-pc-linux-gnu"
+         echo "Thread model: posix"
+         echo "InstalledDir: /usr/bin"
+     results:
+     - spec: 'llvm@3.9.1 +clang~lld~lldb'
+
+Each test is performed by first creating a temporary directory structure as
+specified in the corresponding ``layout`` and by then running
+package detection and checking that the outcome matches the expected
+``results``. The exact details on how to specify both the ``layout`` and the
+``results`` are reported in the table below:
+
+.. list-table:: Test based on PATH inspections
+   :header-rows: 1
+
+   * - Option Name
+     - Description
+     - Allowed Values
+     - Required Field
+   * - ``layout``
+     - Specifies the filesystem tree used for the test
+     - List of objects
+     - Yes
+   * - ``layout:[0]:subdir``
+     - Subdirectory for this executable
+     - List of strings
+     - Yes
+   * - ``layout:[0]:name``
+     - Name of the executable
+     - A valid filename
+     - Yes
+   * - ``layout:[0]:output``
+     - Mock logic for the executable
+     - Any valid shell script
+     - Yes
+   * - ``results``
+     - List of expected results
+     - List of objects (empty if no result is expected)
+     - Yes
+   * - ``results:[0]:spec``
+     - A spec that is expected from detection
+     - Any valid spec
+     - Yes
+
 -----------------------------
 Style guidelines for packages
 -----------------------------

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6196,8 +6196,6 @@ follows:
                "foo-package@{0}".format(version_str)
            )
 
-.. _package-lifecycle:
-
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Add detection tests to packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -860,11 +860,6 @@ def _test_detection_by_executable(pkgs, error_cls):
             specs = test_runner.execute()
             expected_specs = test_runner.expected_specs
 
-            if not expected_specs and specs:
-                summary = pkg_name + ": detected a spec when expecting none"
-                details = [f'"{s}" was detected [test_id={idx}]' for s in specs]
-                errors.append(error_cls(summary=summary, details=details))
-
             not_detected = set(expected_specs) - set(specs)
             if not_detected:
                 summary = pkg_name + ": cannot detect some specs"

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -38,10 +38,14 @@ as input.
 import ast
 import collections
 import collections.abc
+import contextlib
+import glob
 import inspect
 import itertools
+import os.path
 import pickle
 import re
+import tempfile
 from urllib.request import urlopen
 
 import llnl.util.lang
@@ -796,5 +800,134 @@ def _analyze_variants_in_directive(pkg, constraint, directive, error_cls):
             err = error_cls(summary=summary, details=[error_msg, "in " + filename])
 
             errors.append(err)
+
+    return errors
+
+
+#: Sanity checks on package directives
+external_detection = AuditClass(
+    group="externals",
+    tag="PKG-EXTERNALS",
+    description="Sanity checks for external software detection",
+    kwargs=("pkgs",),
+)
+
+
+def packages_with_detection_tests():
+    """Return the list of packages with a corresponding detection_test.yaml file."""
+    import spack.config
+    import spack.util.path
+
+    # Directories where we have repositories
+    repo_dirs = [spack.util.path.canonicalize_path(x) for x in spack.config.get("repos")]
+
+    # Compute which files need to be tested
+    to_be_tested = []
+    for repo_dir in repo_dirs:
+        pattern = os.path.join(repo_dir, "packages", "**", "detection_test.yaml")
+        pkgs_with_tests = [os.path.basename(os.path.dirname(x)) for x in glob.glob(pattern)]
+        to_be_tested.extend(pkgs_with_tests)
+
+    return to_be_tested
+
+
+@external_detection
+def _test_detection_by_executable(pkgs, error_cls):
+    """Test drive external detection for packages"""
+    import jinja2
+
+    import llnl.util.filesystem
+
+    import spack.detection
+    import spack.repo
+    import spack.spec
+    import spack.util.spack_yaml
+
+    errors, tmpdir = [], tempfile.mkdtemp()
+
+    def mock_executable(name, output, subdir=("bin",)):
+        file_parts = list(subdir) + [name]
+        f = os.path.join(tmpdir, *file_parts)
+        llnl.util.filesystem.mkdirp(os.path.dirname(f))
+        t = jinja2.Template("#!/bin/bash\n{{ output }}\n")
+        with open(f, "w") as fs:
+            fs.write(t.render(output=output))
+        llnl.util.filesystem.set_executable(f)
+        return f
+
+    def detection_tests_for(pkg):
+        pkg_dir = os.path.dirname(spack.repo.PATH.filename_for_package_name(pkg))
+        detection_data = os.path.join(pkg_dir, "detection_test.yaml")
+        with open(detection_data) as f:
+            return spack.util.spack_yaml.load(f)
+
+    @contextlib.contextmanager
+    def setup_test_layout(layout):
+        hints, to_be_removed = set(), []
+        for binary in layout:
+            exe = mock_executable(binary["name"], binary["output"], subdir=binary["subdir"])
+            to_be_removed.append(exe)
+            hints.add(os.path.dirname(str(exe)))
+
+        yield list(hints)
+
+        for exe in to_be_removed:
+            os.unlink(exe)
+
+    # Filter the packages and retain only the ones with detection tests
+    pkgs_with_tests = packages_with_detection_tests()
+    selected_pkgs = list(sorted(set(pkgs).intersection(pkgs_with_tests)))
+
+    if not selected_pkgs:
+        summary = "no detection test to run"
+        details = ['"{0}" has no detection test'.format(p) for p in pkgs]
+        errors.append(error_cls(summary=summary, details=details))
+        return errors
+
+    for package_name in selected_pkgs:
+        # Retrieve detection test data for this package and cycle over each
+        # of the scenarios that are encoded
+        detection_tests = detection_tests_for(package_name)
+
+        # Detection by executable is under the "paths" keyword
+        if "paths" not in detection_tests:
+            continue
+
+        # Run all the tests in the YAML file for each package
+        for idx, test in enumerate(detection_tests["paths"]):
+            # The context sets up a mock layout for the detection test
+            # and cleans it on exit
+            with setup_test_layout(test["layout"]) as path_hints:
+                entries = spack.detection.by_executable(
+                    [spack.repo.PATH.get_pkg_class(package_name)], path_hints=path_hints
+                )
+                specs = set(x.spec for x in entries[package_name])
+                results = test["results"]
+
+                # If no result was expected, check that nothing was detected
+                if not results and specs:
+                    summary = package_name + ": detected a spec when expecting none"
+                    details = ['"{0}" was detected [test_id={1}]'.format(s, idx) for s in specs]
+                    errors.append(error_cls(summary=summary, details=details))
+
+                expected_specs = [spack.spec.Spec(r["spec"]) for r in results]
+
+                # Check wwe detect all the expected specs
+                not_detected = set(expected_specs) - set(specs)
+                if not_detected:
+                    summary = package_name + ": cannot detect some specs"
+                    details = [
+                        '"{0}" was not detected [test_id={1}]'.format(s, idx)
+                        for s in sorted(not_detected)
+                    ]
+                    errors.append(error_cls(summary=summary, details=details))
+
+                # Check that wwe didn't detect specs that were not expected
+                not_expected = set(specs) - set(expected_specs)
+                if not_expected:
+                    summary = package_name + ": detected unexpected specs"
+                    msg = '"{0}" was detected, but was not expected [test_id={1}]'
+                    details = [msg.format(s, idx) for s in sorted(not_expected)]
+                    errors.append(error_cls(summary=summary, details=details))
 
     return errors

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import llnl.util.tty as tty
+import llnl.util.tty.colify
 import llnl.util.tty.color as cl
 
 import spack.audit
@@ -20,6 +21,15 @@ def setup_parser(subparser):
     # Audit configuration files
     sp.add_parser("configs", help="audit configuration files")
 
+    # Audit package recipes
+    external_parser = sp.add_parser("externals", help="check external detection in packages")
+    external_parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_externals",
+        help="if passed, list which packages have detection tests",
+    )
+
     # Https and other linting
     https_parser = sp.add_parser("packages-https", help="check https in packages")
     https_parser.add_argument(
@@ -29,7 +39,7 @@ def setup_parser(subparser):
     # Audit package recipes
     pkg_parser = sp.add_parser("packages", help="audit package recipes")
 
-    for group in [pkg_parser, https_parser]:
+    for group in [pkg_parser, https_parser, external_parser]:
         group.add_argument(
             "name",
             metavar="PKG",
@@ -62,6 +72,18 @@ def packages_https(parser, args):
     _process_reports(reports)
 
 
+def externals(parser, args):
+    if args.list_externals:
+        msg = "@*{The following packages have detection tests:}"
+        tty.msg(cl.colorize(msg))
+        llnl.util.tty.colify.colify(spack.audit.packages_with_detection_tests(), indent=2)
+        return
+
+    pkgs = args.name or spack.repo.PATH.all_package_names()
+    reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)
+    _process_reports(reports)
+
+
 def list(parser, args):
     for subcommand, check_tags in spack.audit.GROUPS.items():
         print(cl.colorize("@*b{" + subcommand + "}:"))
@@ -78,6 +100,7 @@ def list(parser, args):
 def audit(parser, args):
     subcommands = {
         "configs": configs,
+        "externals": externals,
         "packages": packages,
         "packages-https": packages_https,
         "list": list,

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -5,6 +5,7 @@
 import argparse
 import errno
 import os
+import re
 import sys
 from typing import List, Optional
 
@@ -156,11 +157,20 @@ def packages_to_search_for(
 ):
     result = []
     for current_tag in tags:
-        result.extend(spack.repo.PATH.packages_with_tags(current_tag))
+        result.extend(spack.repo.PATH.packages_with_tags(current_tag, full=True))
+
     if names:
-        result = [x for x in result if x in names]
+        # Match both fully qualified and unqualified
+        parts = [rf"(^{x}$|[.]{x}$)" for x in names]
+        select_re = re.compile("|".join(parts))
+        result = [x for x in result if select_re.search(x)]
+
     if exclude:
-        result = [x for x in result if x not in exclude]
+        # Match both fully qualified and unqualified
+        parts = [rf"(^{x}$|[.]{x}$)" for x in exclude]
+        select_re = re.compile("|".join(parts))
+        result = [x for x in result if not select_re.search(x)]
+
     return result
 
 

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from .common import DetectedPackage, executable_prefix, update_configuration
 from .path import by_path, executables_in_path
+from .test import detection_tests
 
 __all__ = [
     "DetectedPackage",
@@ -11,4 +12,5 @@ __all__ = [
     "executables_in_path",
     "executable_prefix",
     "update_configuration",
+    "detection_tests",
 ]

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Detection of software installed in the system based on paths inspections
+"""Detection of software installed in the system, based on paths inspections
 and running executables.
 """
 import collections

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -322,12 +322,14 @@ def by_path(
     path_hints: Optional[List[str]] = None,
     max_workers: Optional[int] = None,
 ) -> Dict[str, List[DetectedPackage]]:
-    """Return the list of packages that have been detected on the system,
-    searching by path.
+    """Return the list of packages that have been detected on the system, keyed by
+    unqualified package name.
 
     Args:
-        packages_to_search: list of package classes to be detected
+        packages_to_search: list of packages to be detected. Each package can be either unqualified
+            of fully qualified
         path_hints: initial list of paths to be searched
+        max_workers: maximum number of workers to search for packages in parallel
     """
     # TODO: Packages should be able to define both .libraries and .executables in the future
     # TODO: determine_spec_details should get all relevant libraries and executables in one call
@@ -355,7 +357,8 @@ def by_path(
                 try:
                     detected = future.result(timeout=DETECTION_TIMEOUT)
                     if detected:
-                        result[pkg_name].extend(detected)
+                        _, unqualified_name = spack.repo.partition_package_name(pkg_name)
+                        result[unqualified_name].extend(detected)
                 except Exception:
                     llnl.util.tty.debug(
                         f"[EXTERNAL DETECTION] Skipping {pkg_name}: timeout reached"

--- a/lib/spack/spack/detection/test.py
+++ b/lib/spack/spack/detection/test.py
@@ -17,7 +17,7 @@ import spack.repo
 import spack.spec
 from spack.util import spack_yaml
 
-from .path import by_executable
+from .path import by_path
 
 
 class MockExecutables(NamedTuple):
@@ -65,9 +65,7 @@ class Runner:
         have been detected.
         """
         with self._mock_layout() as path_hints:
-            entries = by_executable(
-                [self.repository.get_pkg_class(self.test.pkg_name)], path_hints=path_hints
-            )
+            entries = by_path([self.test.pkg_name], path_hints=path_hints)
             _, unqualified_name = spack.repo.partition_package_name(self.test.pkg_name)
             specs = set(x.spec for x in entries[unqualified_name])
         return list(specs)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -744,10 +744,18 @@ class RepoPath:
         for name in self.all_package_names():
             yield self.package_path(name)
 
-    def packages_with_tags(self, *tags):
+    def packages_with_tags(self, *tags, full=False):
+        """Returns a list of packages matching any of the tags in input.
+
+        Args:
+            full: if True the package names in the output are fully-qualified
+        """
         r = set()
         for repo in self.repos:
-            r |= set(repo.packages_with_tags(*tags))
+            current = repo.packages_with_tags(*tags)
+            if full:
+                current = [f"{repo.namespace}.{x}" for x in current]
+            r |= set(current)
         return sorted(r)
 
     def all_package_classes(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -24,7 +24,7 @@ import sys
 import traceback
 import types
 import uuid
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.lang
@@ -1123,7 +1123,8 @@ class Repo:
     def dirname_for_package_name(self, pkg_name):
         """Get the directory name for a particular package.  This is the
         directory that contains its package.py file."""
-        return os.path.join(self.packages_path, pkg_name)
+        _, unqualified_name = self.partition_package_name(pkg_name)
+        return os.path.join(self.packages_path, unqualified_name)
 
     def filename_for_package_name(self, pkg_name):
         """Get the filename for the module we should load for a particular
@@ -1221,15 +1222,10 @@ class Repo:
         package. Then extracts the package class from the module
         according to Spack's naming convention.
         """
-        namespace, _, pkg_name = pkg_name.rpartition(".")
-        if namespace and (namespace != self.namespace):
-            raise InvalidNamespaceError(
-                "Invalid namespace for %s repo: %s" % (self.namespace, namespace)
-            )
-
+        namespace, pkg_name = self.partition_package_name(pkg_name)
         class_name = nm.mod_to_class(pkg_name)
+        fullname = f"{self.full_namespace}.{pkg_name}"
 
-        fullname = "{0}.{1}".format(self.full_namespace, pkg_name)
         try:
             module = importlib.import_module(fullname)
         except ImportError:
@@ -1240,7 +1236,7 @@ class Repo:
 
         cls = getattr(module, class_name)
         if not inspect.isclass(cls):
-            tty.die("%s.%s is not a class" % (pkg_name, class_name))
+            tty.die(f"{pkg_name}.{class_name} is not a class")
 
         new_cfg_settings = (
             spack.config.get("packages").get(pkg_name, {}).get("package_attributes", {})
@@ -1279,6 +1275,15 @@ class Repo:
 
         return cls
 
+    def partition_package_name(self, pkg_name: str) -> Tuple[str, str]:
+        namespace, pkg_name = partition_package_name(pkg_name)
+        if namespace and (namespace != self.namespace):
+            raise InvalidNamespaceError(
+                f"Invalid namespace for the '{self.namespace}' repo: {namespace}"
+            )
+
+        return namespace, pkg_name
+
     def __str__(self):
         return "[Repo '%s' at '%s']" % (self.namespace, self.root)
 
@@ -1290,6 +1295,20 @@ class Repo:
 
 
 RepoType = Union[Repo, RepoPath]
+
+
+def partition_package_name(pkg_name: str) -> Tuple[str, str]:
+    """Given a package name that might be fully-qualified, returns the namespace part,
+    if present and the unqualified package name.
+
+    If the package name is unqualified, the namespace is an empty string.
+
+    Args:
+        pkg_name: a package name, either unqualified like "llvl", or
+            fully-qualified, like "builtin.llvm"
+    """
+    namespace, _, pkg_name = pkg_name.rpartition(".")
+    return namespace, pkg_name
 
 
 def create_repo(root, namespace=None, subdir=packages_dir_name):

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -120,8 +120,9 @@ def test_find_external_cmd_not_buildable(mutable_config, working_env, mock_execu
     "names,tags,exclude,expected",
     [
         # find --all
-        (None, ["detectable"], [], ["find-externals1"]),
+        (None, ["detectable"], [], ["builtin.mock.find-externals1"]),
         # find --all --exclude find-externals1
+        (None, ["detectable"], ["builtin.mock.find-externals1"], []),
         (None, ["detectable"], ["find-externals1"], []),
         # find cmake (and cmake is not detectable)
         (["cmake"], ["detectable"], [], []),

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -181,3 +181,15 @@ def test_repository_construction_doesnt_use_globals(nullify_globals, repo_paths,
     repo_path = spack.repo.RepoPath(*repo_paths)
     assert len(repo_path.repos) == len(namespaces)
     assert [x.namespace for x in repo_path.repos] == namespaces
+
+
+@pytest.mark.parametrize("method_name", ["dirname_for_package_name", "filename_for_package_name"])
+def test_path_computation_with_names(method_name, mock_repo_path):
+    """Tests that repositories can compute the correct paths when using both fully qualified
+    names and unqualified names.
+    """
+    repo_path = spack.repo.RepoPath(mock_repo_path)
+    method = getattr(repo_path, method_name)
+    unqualified = method("mpileaks")
+    qualified = method("builtin.mock.mpileaks")
+    assert qualified == unqualified

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -423,12 +423,21 @@ _spack_audit() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="configs packages-https packages list"
+        SPACK_COMPREPLY="configs externals packages-https packages list"
     fi
 }
 
 _spack_audit_configs() {
     SPACK_COMPREPLY="-h --help"
+}
+
+_spack_audit_externals() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --list"
+    else
+        SPACK_COMPREPLY=""
+    fi
 }
 
 _spack_audit_packages_https() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -508,6 +508,7 @@ complete -c spack -n '__fish_spack_using_command arch' -s b -l backend -d 'print
 # spack audit
 set -g __fish_spack_optspecs_spack_audit h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 audit' -f -a configs -d 'audit configuration files'
+complete -c spack -n '__fish_spack_using_command_pos 0 audit' -f -a externals -d 'check external detection in packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 audit' -f -a packages-https -d 'check https in packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 audit' -f -a packages -d 'audit package recipes'
 complete -c spack -n '__fish_spack_using_command_pos 0 audit' -f -a list -d 'list available checks and exits'
@@ -518,6 +519,14 @@ complete -c spack -n '__fish_spack_using_command audit' -s h -l help -d 'show th
 set -g __fish_spack_optspecs_spack_audit_configs h/help
 complete -c spack -n '__fish_spack_using_command audit configs' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command audit configs' -s h -l help -d 'show this help message and exit'
+
+# spack audit externals
+set -g __fish_spack_optspecs_spack_audit_externals h/help list
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 audit externals' -f -a '(__fish_spack_packages)'
+complete -c spack -n '__fish_spack_using_command audit externals' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command audit externals' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command audit externals' -l list -f -a list_externals
+complete -c spack -n '__fish_spack_using_command audit externals' -l list -d 'if passed, list which packages have detection tests'
 
 # spack audit packages-https
 set -g __fish_spack_optspecs_spack_audit_packages_https h/help all

--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -1,0 +1,46 @@
+paths:
+  # Ubuntu 18.04, system compilers without Fortran
+  - layout:
+      - subdir: [bin]
+        name: gcc
+        output: "echo 7.5.0"
+      - subdir: [bin]
+        name: g++
+        output: "echo 7.5.0"
+    results:
+      - spec: "gcc@7.5.0 languages=c,c++"
+  # Mock a version < 7 of GCC that requires -dumpversion and
+  # errors with -dumpfullversion
+  - layout:
+      - subdir: [bin]
+        name: gcc-5
+        output: |
+          if [[ "$1" == "-dumpversion" ]] ; then
+            echo "5.5.0"
+          else
+            echo "gcc-5: fatal error: no input files"
+            echo "compilation terminated."
+            exit 1
+          fi
+      - subdir: [bin]
+        name: g++-5
+        output: "echo 5.5.0"
+      - subdir: [bin]
+        name: gfortran-5
+        output: "echo 5.5.0"
+    results:
+      - spec: "gcc@5.5.0 languages=c,c++,fortran"
+  # Multiple compilers present at the same time
+  - layout:
+      - subdir: [bin]
+        name: x86_64-linux-gnu-gcc-6
+        output: 'echo 6.5.0'
+      - subdir: [bin]
+        name: x86_64-linux-gnu-gcc-10
+        output: "echo 10.1.0"
+      - subdir: [bin]
+        name: x86_64-linux-gnu-g++-10
+        output: "echo 10.1.0"
+    results:
+      - spec: "gcc@6.5.0 languages=c"
+      - spec: "gcc@10.1.0 languages=c,c++"

--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -1,20 +1,20 @@
 paths:
   # Ubuntu 18.04, system compilers without Fortran
   - layout:
-      - subdir: [bin]
-        name: gcc
-        output: "echo 7.5.0"
-      - subdir: [bin]
-        name: g++
-        output: "echo 7.5.0"
+      - executables:
+        - "bin/gcc"
+        - "bin/g++"
+        script: "echo 7.5.0"
     results:
       - spec: "gcc@7.5.0 languages=c,c++"
   # Mock a version < 7 of GCC that requires -dumpversion and
   # errors with -dumpfullversion
   - layout:
-      - subdir: [bin]
-        name: gcc-5
-        output: |
+      - executables:
+        - "bin/gcc-5"
+        - "bin/g++-5"
+        - "bin/gfortran-5"
+        script: |
           if [[ "$1" == "-dumpversion" ]] ; then
             echo "5.5.0"
           else
@@ -22,25 +22,17 @@ paths:
             echo "compilation terminated."
             exit 1
           fi
-      - subdir: [bin]
-        name: g++-5
-        output: "echo 5.5.0"
-      - subdir: [bin]
-        name: gfortran-5
-        output: "echo 5.5.0"
     results:
       - spec: "gcc@5.5.0 languages=c,c++,fortran"
   # Multiple compilers present at the same time
   - layout:
-      - subdir: [bin]
-        name: x86_64-linux-gnu-gcc-6
-        output: 'echo 6.5.0'
-      - subdir: [bin]
-        name: x86_64-linux-gnu-gcc-10
-        output: "echo 10.1.0"
-      - subdir: [bin]
-        name: x86_64-linux-gnu-g++-10
-        output: "echo 10.1.0"
+      - executables:
+        - "bin/x86_64-linux-gnu-gcc-6"
+        script: 'echo 6.5.0'
+      - executables:
+        - "bin/x86_64-linux-gnu-gcc-10"
+        - "bin/x86_64-linux-gnu-g++-10"
+        script: "echo 10.1.0"
     results:
       - spec: "gcc@6.5.0 languages=c"
       - spec: "gcc@10.1.0 languages=c,c++"

--- a/var/spack/repos/builtin/packages/intel/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/intel/detection_test.yaml
@@ -1,0 +1,19 @@
+paths:
+  - layout:
+      - subdir: [bin, intel64]
+        name: icc
+        output: |
+          echo "icc (ICC) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+      - subdir: [bin, intel64]
+        name: icpc
+        output: |
+          echo "icpc (ICC) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+      - subdir: [bin, intel64]
+        name: ifort
+        output: |
+          echo "ifort (IFORT) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+    results:
+      - spec: 'intel@18.0.5'

--- a/var/spack/repos/builtin/packages/intel/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/intel/detection_test.yaml
@@ -1,18 +1,18 @@
 paths:
   - layout:
-      - subdir: [bin, intel64]
-        name: icc
-        output: |
+      - executables:
+        - "bin/intel64/icc"
+        script: |
           echo "icc (ICC) 18.0.5 20180823"
           echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
-      - subdir: [bin, intel64]
-        name: icpc
-        output: |
+      - executables:
+        - "bin/intel64/icpc"
+        script: |
           echo "icpc (ICC) 18.0.5 20180823"
           echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
-      - subdir: [bin, intel64]
-        name: ifort
-        output: |
+      - executables:
+        - "bin/intel64/ifort"
+        script: |
           echo "ifort (IFORT) 18.0.5 20180823"
           echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
     results:

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -1,0 +1,74 @@
+paths:
+  - layout:
+      - subdir: [bin]
+        name: clang-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+    results:
+      - spec: 'llvm@3.9.1 +clang~lld~lldb'
+  # Multiple LLVM packages in the same prefix
+  - layout:
+      - subdir: [bin]
+        name: clang-8
+        output: |
+          echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-8
+        output: |
+          echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: ld.lld-8
+        output: 'echo "LLD 8.0.0 (compatible with GNU linkers)"'
+      - subdir: [bin]
+        name: lldb
+        output: 'echo "lldb version 8.0.0"'
+      - subdir: [bin]
+        name: clang-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+    results:
+      - spec: 'llvm@8.0.0+clang+lld+lldb'
+      - spec: 'llvm@3.9.1+clang~lld~lldb'
+  # Apple Clang should not be detected
+  - layout:
+    - subdir: [bin]
+      name: clang
+      output: |
+        echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+        echo "Target: x86_64-apple-darwin19.5.0"
+        echo "Thread model: posix"
+        echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    - subdir: [bin]
+      name: 'clang++'
+      output: |
+        echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+        echo "Target: x86_64-apple-darwin19.5.0"
+        echo "Thread model: posix"
+        echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    results: []

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -1,15 +1,15 @@
 paths:
   - layout:
-      - subdir: [bin]
-        name: clang-3.9
-        output: |
+      - executables:
+        - "bin/clang-3.9"
+        script: |
           echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
           echo "Target: x86_64-pc-linux-gnu"
           echo "Thread model: posix"
           echo "InstalledDir: /usr/bin"
-      - subdir: [bin]
-        name: clang++-3.9
-        output: |
+      - executables:
+        - "bin/clang++-3.9"
+        script: |
           echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
           echo "Target: x86_64-pc-linux-gnu"
           echo "Thread model: posix"
@@ -18,36 +18,24 @@ paths:
       - spec: 'llvm@3.9.1 +clang~lld~lldb'
   # Multiple LLVM packages in the same prefix
   - layout:
-      - subdir: [bin]
-        name: clang-8
-        output: |
+      - executables:
+        - "bin/clang-8"
+        - "bin/clang++-8"
+        script: |
           echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
           echo "Target: x86_64-pc-linux-gnu"
           echo "Thread model: posix"
           echo "InstalledDir: /usr/bin"
-      - subdir: [bin]
-        name: clang++-8
-        output: |
-          echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
-          echo "Target: x86_64-pc-linux-gnu"
-          echo "Thread model: posix"
-          echo "InstalledDir: /usr/bin"
-      - subdir: [bin]
-        name: ld.lld-8
-        output: 'echo "LLD 8.0.0 (compatible with GNU linkers)"'
-      - subdir: [bin]
-        name: lldb
-        output: 'echo "lldb version 8.0.0"'
-      - subdir: [bin]
-        name: clang-3.9
-        output: |
-          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
-          echo "Target: x86_64-pc-linux-gnu"
-          echo "Thread model: posix"
-          echo "InstalledDir: /usr/bin"
-      - subdir: [bin]
-        name: clang++-3.9
-        output: |
+      - executables:
+        - "bin/ld.lld-8"
+        script: 'echo "LLD 8.0.0 (compatible with GNU linkers)"'
+      - executables:
+        - "bin/lldb"
+        script: 'echo "lldb version 8.0.0"'
+      - executables:
+        - "bin/clang-3.9"
+        - "bin/clang++-3.9"
+        script: |
           echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
           echo "Target: x86_64-pc-linux-gnu"
           echo "Thread model: posix"
@@ -57,16 +45,10 @@ paths:
       - spec: 'llvm@3.9.1+clang~lld~lldb'
   # Apple Clang should not be detected
   - layout:
-    - subdir: [bin]
-      name: clang
-      output: |
-        echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
-        echo "Target: x86_64-apple-darwin19.5.0"
-        echo "Thread model: posix"
-        echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
-    - subdir: [bin]
-      name: 'clang++'
-      output: |
+    - executables:
+      - "bin/clang"
+      - "bin/clang++"
+      script: |
         echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
         echo "Target: x86_64-apple-darwin19.5.0"
         echo "Thread model: posix"


### PR DESCRIPTION
closes #21343 
closes #28092 
fixes #39633

This PR adds a new audit sub-command to check that detection of relevant packages is performed correctly in a few scenarios mocking real use-cases. The data for each package being tested is in a YAML file called `detection_test.yaml` alongside the corresponding `package.py` file. 

This is to allow encoding detection tests for compilers and other widely used tools, in preparation for compilers as dependencies.

The audit can be run with:
```console
$ spack -d audit externals 
==> [2023-08-29-15:43:35.481713] Imported audit from built-in commands
==> [2023-08-29-15:43:35.483244] Imported audit from built-in commands
==> [2023-08-29-15:43:35.483774] Reading config from file /home/culpo/PycharmProjects/spack/etc/spack/defaults/repos.yaml
==> [2023-08-29-15:43:35.546046] Reading config from file /home/culpo/PycharmProjects/spack/etc/spack/defaults/config.yaml
==> [2023-08-29-15:43:35.566903] Reading config from file /home/culpo/.spack/config.yaml
==> [2023-08-29-15:43:35.636355] Reading config from file /home/culpo/PycharmProjects/spack/etc/spack/defaults/packages.yaml
==> [2023-08-29-15:43:36.100078] '/tmp/tmpmvgxs0xq/bin/g++' '--version'
==> [2023-08-29-15:43:36.101754] '/tmp/tmpmvgxs0xq/bin/g++' '-dumpfullversion'
==> [2023-08-29-15:43:36.103053] '/tmp/tmpmvgxs0xq/bin/gcc' '--version'
==> [2023-08-29-15:43:36.104154] '/tmp/tmpmvgxs0xq/bin/gcc' '-dumpfullversion'
==> [2023-08-29-15:43:36.108037] '/tmp/tmpwfh68a7_/bin/g++-5' '--version'
==> [2023-08-29-15:43:36.109346] '/tmp/tmpwfh68a7_/bin/g++-5' '-dumpfullversion'
==> [2023-08-29-15:43:36.110537] '/tmp/tmpwfh68a7_/bin/g++-5' '-dumpversion'
==> [2023-08-29-15:43:36.111552] '/tmp/tmpwfh68a7_/bin/gcc-5' '--version'
==> [2023-08-29-15:43:36.112801] '/tmp/tmpwfh68a7_/bin/gcc-5' '-dumpfullversion'
==> [2023-08-29-15:43:36.113896] '/tmp/tmpwfh68a7_/bin/gcc-5' '-dumpversion'
==> [2023-08-29-15:43:36.114965] '/tmp/tmpwfh68a7_/bin/gfortran-5' '--version'
==> [2023-08-29-15:43:36.115915] '/tmp/tmpwfh68a7_/bin/gfortran-5' '-dumpfullversion'
==> [2023-08-29-15:43:36.116910] '/tmp/tmpwfh68a7_/bin/gfortran-5' '-dumpversion'
==> [2023-08-29-15:43:36.121359] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-gcc-10' '--version'
==> [2023-08-29-15:43:36.122565] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-gcc-10' '-dumpfullversion'
==> [2023-08-29-15:43:36.123825] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-gcc-6' '--version'
==> [2023-08-29-15:43:36.124894] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-gcc-6' '-dumpfullversion'
==> [2023-08-29-15:43:36.125865] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-g++-10' '--version'
==> [2023-08-29-15:43:36.127096] '/tmp/tmp2_x568wi/bin/x86_64-linux-gnu-g++-10' '-dumpfullversion'
==> [2023-08-29-15:43:36.138709] '/tmp/tmp1w5upxqk/bin/intel64/icpc' '--version'
==> [2023-08-29-15:43:36.140950] '/tmp/tmp1w5upxqk/bin/intel64/ifort' '--version'
==> [2023-08-29-15:43:36.142114] '/tmp/tmp1w5upxqk/bin/intel64/icc' '--version'
==> [2023-08-29-15:43:36.206720] '/tmp/tmpkujzcakc/bin/clang-3.9' '--version'
==> [2023-08-29-15:43:36.208211] '/tmp/tmpkujzcakc/bin/clang++-3.9' '--version'
==> [2023-08-29-15:43:36.213159] '/tmp/tmpv5s6fkek/bin/clang++-8' '--version'
==> [2023-08-29-15:43:36.214300] '/tmp/tmpv5s6fkek/bin/clang++-3.9' '--version'
==> [2023-08-29-15:43:36.215466] '/tmp/tmpv5s6fkek/bin/clang-3.9' '--version'
==> [2023-08-29-15:43:36.216532] '/tmp/tmpv5s6fkek/bin/clang-8' '--version'
==> [2023-08-29-15:43:36.217426] '/tmp/tmpv5s6fkek/bin/ld.lld-8' '--version'
==> [2023-08-29-15:43:36.218345] '/tmp/tmpv5s6fkek/bin/lldb' '--version'
==> [2023-08-29-15:43:36.222536] '/tmp/tmpl0yvyr1h/bin/clang++' '--version'
==> [2023-08-29-15:43:36.224217] '/tmp/tmpl0yvyr1h/bin/clang' '--version'
==> [2023-08-29-15:43:36.225956] The following executables in /tmp/tmpl0yvyr1h/bin were decidedly not part of the package llvm: /tmp/tmpl0yvyr1h/bin/clang++, /tmp/tmpl0yvyr1h/bin/clang
PKG-EXTERNALS: 0 issues found.
```

Modifications:

- [x] Added an audit to check that detection for packages is performed correctly
- [x] Added documentation on how to write detection tests for each package
- [x] Added detection tests for `gcc`, `llvm` and `intel`
- [x] Run detection audits in CI