### PR TITLE
Ninja: prepend `misc` to PYTHONPATH in run environment

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -40,6 +40,9 @@ class Ninja(Package):
         ninja_test = Executable('./ninja_test')
         ninja_test()
 
+    def setup_run_environment(self, env):
+        env.prepend_path('PYTHONPATH', self.prefix.misc)
+
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install('ninja', prefix.bin)


### PR DESCRIPTION
Prepends `${NINJA_ROOT}/misc` to `PYTHONPATH` in run environment.

@coti @junghans 