### PR TITLE
external packages: do not check for conflicts

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2330,6 +2330,10 @@ class Spec(object):
         # TODO: internal configuration conflicts within one package.
         matches = []
         for x in self.traverse():
+            if x.external:
+                # external specs are already built, don't worry about whether
+                # it's possible to build that configuration with Spack
+                continue
             for conflict_spec, when_list in x.package_class.conflicts.items():
                 if x.satisfies(conflict_spec, strict=True):
                     for when_spec, msg in when_list:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -500,6 +500,12 @@ class TestConcretize(object):
             with pytest.raises(exc_type):
                 s.concretize()
 
+    def test_no_conflixt_in_external_specs(self, conflict_spec):
+        # clear deps because external specs cannot depend on anything
+        ext = Spec(conflict_spec).copy(deps=False)
+        ext.external_path = '/fake/path'
+        ext.concretize()  # failure raises exception
+
     def test_regression_issue_4492(self):
         # Constructing a spec which has no dependencies, but is otherwise
         # concrete is kind of difficult. What we will do is to concretize


### PR DESCRIPTION
Users may have one-off, hacked externals for combinations that are otherwise impossible. This allows spack to make use of those.

It also fixes a bug (reported by @rblake on slack) with cmake externals on macos for users who set their default compiler to gcc. Previously, those users would get concretization every time a package depended on cmake, because the default cmake was %gcc, which is a conflict on macos.