### PR TITLE
codecov: set project threshold to 0.2%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,8 @@ coverage:
   range: 60...90
   status:
     project:
-      default: yes
+      default:
+        threshold: 0.2%
 
 ignore:
   - lib/spack/spack/test/.*


### PR DESCRIPTION
Currently, we see a lot of spurious code coverage failures for very small changes in project coverage (especially when some tests are run on `develop` but not on PRs).