### PR TITLE
Add new MavenPackage build system base class

### DIFF
--- a/lib/spack/docs/build_systems.rst
+++ b/lib/spack/docs/build_systems.rst
@@ -29,6 +29,7 @@ on these ideas for each distinct build system that Spack supports:
    :maxdepth: 1
    :caption: Make-incompatible
 
+   build_systems/mavenpackage
    build_systems/sconspackage
    build_systems/wafpackage
 

--- a/lib/spack/docs/build_systems/mavenpackage.rst
+++ b/lib/spack/docs/build_systems/mavenpackage.rst
@@ -1,0 +1,84 @@
+.. Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _mavenpackage:
+
+----------
+MavenPackage
+----------
+
+Apache Maven is a general-purpose build system that does not rely
+on Makefiles to build software. It is designed for building and
+managing and Java-based project.
+
+^^^^^^
+Phases
+^^^^^^
+
+The ``MavenPackage`` base class comes with the following phases:
+
+#. ``build`` - compile code and package into a JAR file
+#. ``install`` - copy to installation prefix
+
+By default, these phases run:
+
+.. code-block:: console
+
+   $ mvn package
+   $ install . <prefix>
+
+
+^^^^^^^^^^^^^^^
+Important files
+^^^^^^^^^^^^^^^
+
+Maven packages can be identified by the presence of a ``pom.xml`` file.
+This file lists dependencies and other metadata about the project.
+There may also be configuration files in the ``.mvn`` directory.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Build system dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Maven requires the ``mvn`` executable to build the project. It also
+requires Java at both build- and run-time. Because of this, the base
+class automatically adds the following dependencies:
+
+.. code-block:: python
+
+   depends_on('java', type=('build', 'run'))
+   depends_on('maven', type='build')
+
+
+In the ``pom.xml`` file, you may see sections like:
+
+.. code-block:: xml
+
+   <requireJavaVersion>
+      <version>[1.7,)</version>
+   </requireJavaVersion>
+   <requireMavenVersion>
+      <version>[3.5.4,)</version>
+   </requireMavenVersion>
+
+
+This specifies the versions of Java and Maven that are required to
+build the package. See
+https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402
+for a description of this version range syntax. In this case, you
+should add:
+
+.. code-block:: python
+
+   depends_on('java@7:', type='build')
+   depends_on('maven@3.5.4:', type='build')
+
+
+^^^^^^^^^^^^^^^^^^^^^^
+External documentation
+^^^^^^^^^^^^^^^^^^^^^^
+
+For more information on the Maven build system, see:
+https://maven.apache.org/index.html

--- a/lib/spack/docs/build_systems/mavenpackage.rst
+++ b/lib/spack/docs/build_systems/mavenpackage.rst
@@ -5,9 +5,9 @@
 
 .. _mavenpackage:
 
-----------
+------------
 MavenPackage
-----------
+------------
 
 Apache Maven is a general-purpose build system that does not rely
 on Makefiles to build software. It is designed for building and

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from llnl.util.filesystem import install_tree, working_dir
+from spack.directives import depends_on
+from spack.package import PackageBase, run_after
+from spack.util.executable import which
+
+
+class MavenPackage(PackageBase):
+    """Specialized class for packages that are built using the
+    Maven build system. See https://maven.apache.org/index.html
+    for more information.
+
+    This class provides the following phases that can be overridden:
+
+    * build
+    * install
+    """
+    # Default phases
+    phases = ['build', 'install']
+
+    # To be used in UI queries that require to know which
+    # build-system class we are using
+    build_system_class = 'MavenPackage'
+
+    depends_on('java', type=('build', 'run'))
+    depends_on('maven', type='build')
+
+    @property
+    def build_directory(self):
+        """The directory containing the ``pom.xml`` file."""
+        return self.stage.source_path
+
+    def build(self, spec, prefix):
+        """Compile code and package into a JAR file."""
+
+        with working_dir(self.build_directory):
+            mvn = which('mvn')
+            if self.run_tests:
+                mvn('verify')
+            else:
+                mvn('package', '-DskipTests')
+
+    def install(self, spec, prefix):
+        """Copy to installation prefix."""
+
+        with working_dir(self.build_directory):
+            install_tree('.', prefix)
+
+    # Check that self.prefix is there after installation
+    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -204,6 +204,16 @@ class QMakePackageTemplate(PackageTemplate):
         return args"""
 
 
+class MavenPackageTemplate(PackageTemplate):
+    """Provides appropriate overrides for Maven-based packages"""
+
+    base_class_name = 'MavenPackage'
+
+    body_def = """\
+    def build(self, spec, prefix):
+        # FIXME: If not needed delete this function"""
+
+
 class SconsPackageTemplate(PackageTemplate):
     """Provides appropriate overrides for SCons-based packages"""
 
@@ -402,6 +412,7 @@ templates = {
     'cmake':      CMakePackageTemplate,
     'bundle':     BundlePackageTemplate,
     'qmake':      QMakePackageTemplate,
+    'maven':      MavenPackageTemplate,
     'scons':      SconsPackageTemplate,
     'waf':        WafPackageTemplate,
     'bazel':      BazelPackageTemplate,
@@ -482,6 +493,7 @@ class BuildSystemGuesser:
             (r'/configure$',          'autotools'),
             (r'/configure\.(in|ac)$', 'autoreconf'),
             (r'/Makefile\.am$',       'autoreconf'),
+            (r'/pom.xml$',            'maven'),
             (r'/SConstruct$',         'scons'),
             (r'/waf$',                'waf'),
             (r'/setup\.py$',          'python'),

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -494,7 +494,7 @@ class BuildSystemGuesser:
             (r'/configure$',          'autotools'),
             (r'/configure\.(in|ac)$', 'autoreconf'),
             (r'/Makefile\.am$',       'autoreconf'),
-            (r'/pom.xml$',            'maven'),
+            (r'/pom\.xml$',           'maven'),
             (r'/SConstruct$',         'scons'),
             (r'/waf$',                'waf'),
             (r'/setup\.py$',          'python'),

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -211,7 +211,8 @@ class MavenPackageTemplate(PackageTemplate):
 
     body_def = """\
     def build(self, spec, prefix):
-        # FIXME: If not needed delete this function"""
+        # FIXME: If not needed delete this function
+        pass"""
 
 
 class SconsPackageTemplate(PackageTemplate):

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -21,6 +21,7 @@ from spack.build_systems.autotools import AutotoolsPackage
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.cuda import CudaPackage
 from spack.build_systems.qmake import QMakePackage
+from spack.build_systems.maven import MavenPackage
 from spack.build_systems.scons import SConsPackage
 from spack.build_systems.waf import WafPackage
 from spack.build_systems.octave import OctavePackage

--- a/lib/spack/spack/test/build_system_guess.py
+++ b/lib/spack/spack/test/build_system_guess.py
@@ -16,6 +16,7 @@ import spack.stage
         ('configure',      'autotools'),
         ('CMakeLists.txt', 'cmake'),
         ('project.pro',    'qmake'),
+        ('pom.xml',        'maven'),
         ('SConstruct',     'scons'),
         ('waf',            'waf'),
         ('setup.py',       'python'),

--- a/var/spack/repos/builtin/packages/accumulo/package.py
+++ b/var/spack/repos/builtin/packages/accumulo/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Accumulo(Package):
+class Accumulo(MavenPackage):
     """Apache Accumulo is a sorted, distributed key/value store that
     provides robust, scalable data storage and retrieval."""
 
@@ -17,10 +15,5 @@ class Accumulo(Package):
     version('1.9.3', sha256='d9548d5b9cf9f494f027f0fe59d5d6d45d09064359d7761cade62991ce2a5d0c')
     version('1.9.2', sha256='11ab028143ad6313cd5fc701b36b4c35e46a4a3fa2ce663869860b9f6bf5ee4d')
 
-    depends_on('maven', type='build')
-    depends_on('java', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('java@8:', type=('build', 'run'))
+    depends_on('maven@3.5.0:', type='build')

--- a/var/spack/repos/builtin/packages/canal/package.py
+++ b/var/spack/repos/builtin/packages/canal/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Canal(Package):
+class Canal(MavenPackage):
     """Alibaba MySQL binlog incremental subscription & consumer components."""
 
     homepage = "https://github.com/alibaba/canal/wiki"
@@ -15,11 +13,3 @@ class Canal(Package):
     version('1.1.4', sha256='740e0adac56d7f281cba21eca173eef3e8d42aa3e0fb49709f92cb6a1451dfbc')
     version('1.1.3', sha256='3fe75ca5eb5cb97eb35818426c1427542ccddb0de052cf154e948ef321822cbc')
     version('1.1.2', sha256='097190f952bdf09b835ed68966f5a98fa8308322a6aab11c1bfd16cec1800cf2')
-
-    depends_on('maven', type='build')
-    depends_on('java', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('install', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/giraph/package.py
+++ b/var/spack/repos/builtin/packages/giraph/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Giraph(Package):
+class Giraph(MavenPackage):
     """Apache Giraph is an iterative graph processing system built
     for high scalability."""
 
@@ -16,14 +14,12 @@ class Giraph(Package):
     list_depth = 1
 
     version('1.2.0', sha256='6206f4ad220ea42aa0c4abecce343e36026cf9c6e0a2853f1eb08543da452ad1')
-    version('1.1.0', sha256='181d94b8198c0f312d4611e24b0056b5181c8358a7ec89b0393661736cd19a4c') 
+    version('1.1.0', sha256='181d94b8198c0f312d4611e24b0056b5181c8358a7ec89b0393661736cd19a4c')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
+    depends_on('java@7:', type=('build', 'run'))
+    depends_on('maven@3.0.0:', type='build')
 
     def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('clean', 'package', '-DskipTests')
         giraph_path = join_path(self.stage.source_path,
                                 'giraph-dist', 'target',
                                 'giraph-{0}-for-hadoop-1.2.1-bin'

--- a/var/spack/repos/builtin/packages/h2database/package.py
+++ b/var/spack/repos/builtin/packages/h2database/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class H2database(Package):
+class H2database(MavenPackage):
     """H2 is an embeddable RDBMS written in Java."""
 
     homepage = "https://h2database.com"
@@ -23,15 +21,4 @@ class H2database(Package):
     version('1.4.192', sha256='b5f370d7256cf816696a28acd282ed10bf8a05e09b814bf79d4527509846c977')
     version('1.4.191', sha256='9890adc66979647b131242e87ad1498b906c0dcc041d25fcb24ff304b86b4f98')
 
-    depends_on('maven', type='build')
-    depends_on('java', type=('build', 'run'))
-
-    @property
-    def build_directory(self):
-        return 'h2'
-
-    def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            mvn = which('mvn')
-            mvn('install', '-DskipTests')
-            install_tree('.', prefix)
+    build_directory = 'h2'

--- a/var/spack/repos/builtin/packages/hazelcast/package.py
+++ b/var/spack/repos/builtin/packages/hazelcast/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Hazelcast(Package):
+class Hazelcast(MavenPackage):
     """Hazelcast is an open-source distributed in-memory data
      store and computation platform. It provides a wide variety
      of distributed data structures and concurrency primitives."""
@@ -20,10 +18,4 @@ class Hazelcast(Package):
     version('3.12.7', sha256='0747de968082bc50202f825b4010be28a3885b3dbcee4b83cbe21b2f8b26a7e0')
     version('3.11.7', sha256='c9f636b8813027d4cc24459bd27740549f89b4f11f62a868079bcb5b41d9b2bb')
 
-    depends_on('maven', type='build')
-    depends_on('java', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('java@8:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/hibench/package.py
+++ b/var/spack/repos/builtin/packages/hibench/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Hibench(Package):
+class Hibench(MavenPackage):
     """HiBench is a big data benchmark suite that helps evaluate different big
     data frameworks in terms of speed, throughput and system resource
     utilizations. It contains a set of Hadoop,Spark and streaming workloads,
@@ -25,11 +23,3 @@ class Hibench(Package):
     version('3.0.0',   sha256='869771e73593caac3a9b2fb14a10041a485d248074ba38cca812c934897db63d')
     version('2.2.1',   sha256='f8531cbaff8d93bfd1c0742fec5dbb375bfeeb9ec1b39b4e857120e933a2c9ec')
     version('2.2',     sha256='5f68e22339cdd141b846d8b1d7134b2b8ff5fbd5e847e406214dc845f5d005cf')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/hudi/package.py
+++ b/var/spack/repos/builtin/packages/hudi/package.py
@@ -12,3 +12,5 @@ class Hudi(MavenPackage):
     url      = "https://github.com/apache/hudi/archive/release-0.5.3.tar.gz"
 
     version('0.5.3', sha256='8cbf52007fddd07eebd20c8962cd630b05a8ae4c597523fd63db837a45a0b227')
+
+    depends_on('java@8', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/hudi/package.py
+++ b/var/spack/repos/builtin/packages/hudi/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Hudi(Package):
+class Hudi(MavenPackage):
     """Apache Hudi stands for Hadoop Upserts Deletes and Incrementals.
     Hudi manages the storage of large analytical datasets on DFS."""
 
@@ -14,11 +12,3 @@ class Hudi(Package):
     url      = "https://github.com/apache/hudi/archive/release-0.5.3.tar.gz"
 
     version('0.5.3', sha256='8cbf52007fddd07eebd20c8962cd630b05a8ae4c597523fd63db837a45a0b227')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/interproscan/package.py
+++ b/var/spack/repos/builtin/packages/interproscan/package.py
@@ -46,7 +46,10 @@ class Interproscan(Package):
 
     def install(self, spec, prefix):
         with working_dir('core'):
-            which('mvn')('clean', 'install')
+            if self.run_tests:
+                which('mvn')('verify')
+            else:
+                which('mvn')('package', '-DskipTests')
 
         install_tree('.', prefix)
 

--- a/var/spack/repos/builtin/packages/kinesis/package.py
+++ b/var/spack/repos/builtin/packages/kinesis/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Kinesis(Package):
+class Kinesis(MavenPackage):
     """The Amazon Kinesis Client Library for Java (Amazon KCL) enables Java
     developers to easily consume and process data from Amazon Kinesis."""
 
@@ -17,11 +15,3 @@ class Kinesis(Package):
     version('2.2.9', sha256='8d743c2dae127ce7c08627e7944aad4ccf025b4d71aa5486b57469c32daf20e6')
     version('2.2.8', sha256='0753d6c84247fa58c09749ca7d258a11c658b64eb65286eff74a2115613183a8')
     version('2.2.7', sha256='1838ef2327920d1df6f41db1de55318d6935d16ddde90b6e65ec65d374993177')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('clean', 'install', '-Dgpg.skip=true', '-DskipITs')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/kinesis/package.py
+++ b/var/spack/repos/builtin/packages/kinesis/package.py
@@ -15,3 +15,5 @@ class Kinesis(MavenPackage):
     version('2.2.9', sha256='8d743c2dae127ce7c08627e7944aad4ccf025b4d71aa5486b57469c32daf20e6')
     version('2.2.8', sha256='0753d6c84247fa58c09749ca7d258a11c658b64eb65286eff74a2115613183a8')
     version('2.2.7', sha256='1838ef2327920d1df6f41db1de55318d6935d16ddde90b6e65ec65d374993177')
+
+    depends_on('java@8', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/mahout/package.py
+++ b/var/spack/repos/builtin/packages/mahout/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Mahout(Package):
+class Mahout(MavenPackage):
     """The Apache Mahout project's goal is to build an environment for
     quickly creating scalable performant machine learning applications."""
 
@@ -20,10 +18,5 @@ class Mahout(Package):
     version('0.12.1', sha256='32e334115e4b2bfa21ba58e888fc47cdde2ca32c915d1694ed6761bda3b05dbb')
     version('0.12.0', sha256='65f340072131b1178b7bf4da115782254bdb20d6abd9789f10fc6dfe1ea7e7ad')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('java@8:', type=('build', 'run'))
+    depends_on('maven@3.3.3:', type='build')

--- a/var/spack/repos/builtin/packages/maven/package.py
+++ b/var/spack/repos/builtin/packages/maven/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import re
 
 
 class Maven(Package):
@@ -19,7 +19,15 @@ class Maven(Package):
     version('3.5.0', sha256='beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034')
     version('3.3.9', sha256='6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82')
 
-    depends_on('java')
+    depends_on('java', type='run')
+
+    executables = ['^mvn$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'Apache Maven (\S+)', output)
+        return match.group(1) if match else None
 
     def install(self, spec, prefix):
         # install pre-built distribution

--- a/var/spack/repos/builtin/packages/mongodb-async-driver/package.py
+++ b/var/spack/repos/builtin/packages/mongodb-async-driver/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class MongodbAsyncDriver(Package):
+class MongodbAsyncDriver(MavenPackage):
     """The MongoDB Asynchronous Java Driver."""
 
     homepage = "http://www.allanbank.com/mongodb-async-driver/"
@@ -14,11 +12,3 @@ class MongodbAsyncDriver(Package):
 
     version('2.0.1', sha256='87f22c16f3744a847eeb8276ed132bf235f025db0b7dee0d0f239d5cdcab720c')
     version('2.0.0', sha256='8cffe4c960d42550be30c27d66f5de6df4edb5ee7a094c50519986dc5cbcf9b8')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/mrbench/package.py
+++ b/var/spack/repos/builtin/packages/mrbench/package.py
@@ -3,21 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Mrbench(Package):
+class Mrbench(MavenPackage):
     """A simple Java tool for SMTP server benchmarking."""
 
     homepage = "https://github.com/marcorosi/mrbench"
     git      = "https://github.com/marcorosi/mrbench.git"
 
     version('master', branch='master')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/mrbench/package.py
+++ b/var/spack/repos/builtin/packages/mrbench/package.py
@@ -11,3 +11,5 @@ class Mrbench(MavenPackage):
     git      = "https://github.com/marcorosi/mrbench.git"
 
     version('master', branch='master')
+
+    depends_on('java@8', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/neo4j/package.py
+++ b/var/spack/repos/builtin/packages/neo4j/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Neo4j(Package):
+class Neo4j(MavenPackage):
     """Neo4j is the world's leading Graph Database. It is a high performance
     graph store with all the features expected of a mature and robust
     database, like a friendly query language and ACID transactions. The
@@ -23,9 +21,4 @@ class Neo4j(Package):
     version('4.0.0',  sha256='7173b97baf53be82b46f95fa52f99af591606a318e03915917ddd7141936fec5')
     version('3.5.16', sha256='1304fcd56b0f08f35b05d8b546fd844637ba1ffa5e00bb1e9a81a06b6242cb88')
 
-    depends_on('maven', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        maven = which('mvn')
-        maven('clean', 'install', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('maven@3.5.4:', type='build')

--- a/var/spack/repos/builtin/packages/phoenix/package.py
+++ b/var/spack/repos/builtin/packages/phoenix/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Phoenix(Package):
+class Phoenix(MavenPackage):
     """Apache Phoenix is a SQL skin over HBase delivered as a client-embedded
     JDBC driver targeting low latency queries over HBase data."""
 
@@ -14,11 +12,3 @@ class Phoenix(Package):
     git      = "https://github.com/apache/phoenix.git"
 
     version('master', branch='master')
-
-    depends_on('java@8:', type=('build', 'run'))
-    depends_on('maven', type='build')
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/presto/package.py
+++ b/var/spack/repos/builtin/packages/presto/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Presto(Package):
+class Presto(MavenPackage):
     """Presto is a distributed SQL query engine for big data."""
 
     homepage = "https://prestodb.io/"
@@ -22,11 +20,3 @@ class Presto(Package):
     version('0.236.1', sha256='571c74c0b84ee515750c129eb5de1fbac09cd4d028943d9df99c8e89909c83f4')
     version('0.236',   sha256='6d4c1d79216d2530b64a7737a54c35e698ca738e42d77d086f036224b42b508e')
     version('0.235.1', sha256='1353b2b8526bc2a365f70e9af7005e294cfff11d53285279b2f67048bb5511a0')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('install', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/slf4j/package.py
+++ b/var/spack/repos/builtin/packages/slf4j/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Slf4j(Package):
+class Slf4j(MavenPackage):
     """The Simple Logging Facade for Java (SLF4J) serves as a simple facade
     or abstraction for various logging frameworks (e.g. java.util.logging,
     logback,log4j) allowing the end user to plug in the desired logging
@@ -15,16 +13,10 @@ class Slf4j(Package):
     homepage = "http://www.slf4j.org/"
     url      = "https://github.com/qos-ch/slf4j/archive/v_1.7.30.tar.gz"
 
-    version('1.7.30',       sha256='217519588d0dd1f85cee2357ca31afdd7c0a1a8a6963953b3bf455cf5174633e')
-    version('1.7.29',       sha256='e584f1f380d8c64ed8a45944cec3c2fb4d6b850783fd5bc166a9246bc8b6ac56')
-    version('1.7.28',       sha256='14063bfcbc942bda03e07759e64307163c1646d70a42c632f066812a8630eec7')
-    version('1.7.27',       sha256='238883cab9808a5cd58cf5245f9f13ac645c9fca878b60d959e00fc4ac588231')
-    version('1.7.26',       sha256='dc422820f92e581241c4cfe796d01531d12bad3dc04225bdb315761871156942')
+    version('1.7.30', sha256='217519588d0dd1f85cee2357ca31afdd7c0a1a8a6963953b3bf455cf5174633e')
+    version('1.7.29', sha256='e584f1f380d8c64ed8a45944cec3c2fb4d6b850783fd5bc166a9246bc8b6ac56')
+    version('1.7.28', sha256='14063bfcbc942bda03e07759e64307163c1646d70a42c632f066812a8630eec7')
+    version('1.7.27', sha256='238883cab9808a5cd58cf5245f9f13ac645c9fca878b60d959e00fc4ac588231')
+    version('1.7.26', sha256='dc422820f92e581241c4cfe796d01531d12bad3dc04225bdb315761871156942')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('java@5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/slf4j/package.py
+++ b/var/spack/repos/builtin/packages/slf4j/package.py
@@ -19,4 +19,4 @@ class Slf4j(MavenPackage):
     version('1.7.27', sha256='238883cab9808a5cd58cf5245f9f13ac645c9fca878b60d959e00fc4ac588231')
     version('1.7.26', sha256='dc422820f92e581241c4cfe796d01531d12bad3dc04225bdb315761871156942')
 
-    depends_on('java@5:', type=('build', 'run'))
+    depends_on('java@8', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/slider/package.py
+++ b/var/spack/repos/builtin/packages/slider/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Slider(Package):
+class Slider(MavenPackage):
     """Slider is a framework for deployment and management of these
     long-running data access applications in Hadoop."""
 
@@ -19,16 +17,13 @@ class Slider(Package):
     version('0.91.0', sha256='212a5cde6de60060c9a081f553d66940b70af4bccb469072febb554c4005bcef')
     version('0.90.2', sha256='410941f772d29f564c4bb90ca0631f29dc895f509048cb6052f8695302e3f944')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
+    depends_on('java@7:', type=('build', 'run'))
     depends_on('python@2.7.0:2.7.99', type='run')
 
     def url_for_version(self, version):
         return "http://archive.apache.org/dist/incubator/slider/{0}-incubating/apache-slider-{0}-incubating-source-release.tar.gz".format(version)
 
     def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('clean', 'package', '-DskipTests')
         slider_path = join_path(self.stage.source_path,
                                 'slider-assembly', 'target',
                                 'slider-{0}-incubating-all'

--- a/var/spack/repos/builtin/packages/slider/package.py
+++ b/var/spack/repos/builtin/packages/slider/package.py
@@ -17,7 +17,7 @@ class Slider(MavenPackage):
     version('0.91.0', sha256='212a5cde6de60060c9a081f553d66940b70af4bccb469072febb554c4005bcef')
     version('0.90.2', sha256='410941f772d29f564c4bb90ca0631f29dc895f509048cb6052f8695302e3f944')
 
-    depends_on('java@7:', type=('build', 'run'))
+    depends_on('java@8', type=('build', 'run'))
     depends_on('python@2.7.0:2.7.99', type='run')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/sqoop/package.py
+++ b/var/spack/repos/builtin/packages/sqoop/package.py
@@ -15,3 +15,5 @@ class Sqoop(MavenPackage):
     list_depth = 1
 
     version('1.99.7', sha256='caca533554235d9e999435be59a13b5ecae514b3c914ca3b54868fca43a3b74a')
+
+    depends_on('java@8', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/sqoop/package.py
+++ b/var/spack/repos/builtin/packages/sqoop/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Sqoop(Package):
+class Sqoop(MavenPackage):
     """Apache Sqoop is a tool designed for efficiently transferring bulk
     data between Apache Hadoop and structured datastores such as relational
     databases."""
@@ -17,11 +15,3 @@ class Sqoop(Package):
     list_depth = 1
 
     version('1.99.7', sha256='caca533554235d9e999435be59a13b5ecae514b3c914ca3b54868fca43a3b74a')
-
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('clean', 'install', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/testdfsio/package.py
+++ b/var/spack/repos/builtin/packages/testdfsio/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Testdfsio(Package):
+class Testdfsio(MavenPackage):
     """A corrected and enhanced version of Apache Hadoop TestDFSIO"""
 
     homepage = "https://github.com/tthx/testdfsio"
@@ -14,11 +12,4 @@ class Testdfsio(Package):
 
     version('0.0.1', sha256='fe8cc47260ffb3e3ac90e0796ebfe73eb4dac64964ab77671e5d32435339dd09')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
     depends_on('hadoop@3.2.1:', type='run')
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('clean', 'package', '-Dmaven.test.skip=true')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/ycsb/package.py
+++ b/var/spack/repos/builtin/packages/ycsb/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Ycsb(Package):
+class Ycsb(MavenPackage):
     """Yahoo! Cloud Serving Benchmark."""
 
     homepage = "https://research.yahoo.com/news/yahoo-cloud-serving-benchmark/"
@@ -19,11 +17,10 @@ class Ycsb(Package):
     version('0.14.0', sha256='456bcc9fa3d5d66d76fffa9cec34afd4528d9f02aa8a8d1135f511650516d5cb')
     version('0.13.0', sha256='21cb8078a0fe2d8d909145744ca15848dbb6757e98a7fdc97fb4049f82f4afbc')
 
-    depends_on('maven', type='build')
-    depends_on('java@8', type=('build', 'run'))
+    depends_on('maven@3.1.0:', type='build')
     depends_on('mongodb-async-driver', type='build')
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         mvn = which('mvn')
         jar_name = 'target/mongodb-async-driver-' + \
             spec['mongodb-async-driver'].version.string + '.jar'
@@ -32,4 +29,3 @@ class Ycsb(Package):
             '-DgroupId=com.allanbank', '-DartifactId=mongodb-async-driver',
             '-Dversion=2.0.1', '-Dpackaging=jar')
         mvn('package', '-DskipTests')
-        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/zipkin/package.py
+++ b/var/spack/repos/builtin/packages/zipkin/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Zipkin(Package):
+class Zipkin(MavenPackage):
     """Zipkin is a distributed tracing system. It helps gather timing
     data needed to troubleshoot latency problems in service
     architectures. Features include both the collection and lookup
@@ -19,10 +17,4 @@ class Zipkin(Package):
     version('2.21.4', sha256='ee7b0110b3852479c925b6429ff278aa38b1d5da27f4762891b1f863e67bdad5')
     version('2.21.3', sha256='02526e2ba4de85938b510cb2db01865ec46cdad53157862c39fa5e9b6cbd15b6')
 
-    depends_on('maven', type='build')
-    depends_on('java', type=('build', 'run'))
-
-    def install(self, spec, prefix):
-        mvn = which('mvn')
-        mvn('package', '-DskipTests')
-        install_tree('.', prefix)
+    depends_on('maven@1.8:14', type='build')

--- a/var/spack/repos/builtin/packages/zookeeper-benchmark/package.py
+++ b/var/spack/repos/builtin/packages/zookeeper-benchmark/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class ZookeeperBenchmark(Package):
+class ZookeeperBenchmark(MavenPackage):
     """It is designed to measure the per-request latency of a ZooKeeper
     ensemble for a predetermined length of time"""
 
@@ -15,11 +13,9 @@ class ZookeeperBenchmark(Package):
 
     version('master', branch='master')
 
-    depends_on('maven', type='build')
     depends_on('zookeeper', type=('build', 'run'))
 
-    def install(self, spec, prefix):
+    def build(self, spec, prefix):
         zookeeper_version = self.spec['zookeeper'].version.string
         mvn = which('mvn')
         mvn('-DZooKeeperVersion=' + zookeeper_version, 'package')
-        install_tree('.', prefix)


### PR DESCRIPTION
We've seen a lot of new packages lately using the Maven build system. This PR adds a new `MavenPackage` base class to enforce uniformity between these packages and make it easier to write new packages.

According to https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#a-build-lifecycle-is-made-up-of-phases, Maven packages have a series of lifecycle phases. I tried adding all of these to the base class as separate phases, but from what I can tell it re-runs all prior stages of the lifecycle.

Note that all of these packages pull in dozens to hundreds of dependencies from the internet. At some point, we should find a way to enforce offline builds and add packages for all of the dependencies, but I don't care enough about Maven to be the person to do that.

@darmac I believe you added many of these packages. Can you review this PR and make sure I didn't break any packages you care about?