### PR TITLE
soapdenovo-trans: build on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -23,6 +23,8 @@ class Samtools(Package):
     version('1.4', sha256='9aae5bf835274981ae22d385a390b875aef34db91e6355337ca8b4dd2960e3f4')
     version('1.3.1', sha256='6c3d74355e9cf2d9b2e1460273285d154107659efa36a155704b1e4358b7d67e')
     version('1.2', sha256='420e7a4a107fe37619b9d300b6379452eb8eb04a4a9b65c3ec69de82ccc26daa')
+    version('0.1.8', sha256='343daf96f035c499c5b82dce7b4d96b10473308277e40c435942b6449853815b',
+            url="https://github.com/samtools/samtools/archive/0.1.8.tar.gz")
 
     depends_on('zlib')
     depends_on('ncurses')
@@ -55,7 +57,10 @@ class Samtools(Package):
         else:
             make('prefix={0}'.format(prefix),
                  'LIBCURSES={0}'.format(curses_lib))
-            make('prefix={0}'.format(prefix), 'install')
+            if self.spec.version == Version('0.1.8'):
+                make('prefix={0}'.format(prefix))
+            else:
+                make('prefix={0}'.format(prefix), 'install')
 
         # Install dev headers and libs for legacy apps depending on them
         mkdir(prefix.include)

--- a/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
@@ -16,8 +16,8 @@ class SoapdenovoTrans(MakefilePackage):
 
     version('1.0.4', sha256='378a54cde0ebe240fb515ba67197c053cf95393645c1ae1399b3a611be2a9795')
 
-    depends_on('zlib', type='link', when='target=aarch64:')
-    depends_on('samtools@0.1.8', type='link', when='target=aarch64:')
+    depends_on('zlib', type='link')
+    depends_on('samtools@0.1.8', type='link')
 
     build_directory = 'src'
 

--- a/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
@@ -16,6 +16,9 @@ class SoapdenovoTrans(MakefilePackage):
 
     version('1.0.4', sha256='378a54cde0ebe240fb515ba67197c053cf95393645c1ae1399b3a611be2a9795')
 
+    depends_on('zlib', type='link', when='target=aarch64:')
+    depends_on('samtools@0.1.8', type='link', when='target=aarch64:')
+
     build_directory = 'src'
 
     def edit(self, spec, prefix):
@@ -23,6 +26,8 @@ class SoapdenovoTrans(MakefilePackage):
             makefile = FileFilter('Makefile')
             makefile.filter('CFLAGS=         -O3 -fomit-frame-pointer -static',
                             'CFLAGS=         -O3 -fomit-frame-pointer')
+            if spec.target.family == 'aarch64':
+                makefile.filter('ppc64 ia64', 'ppc64 ia64 aarch64')
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):


### PR DESCRIPTION
soapdenovo-trans has the library (zlib,libbam.a) built with x86_64 inside.
When I checked libbam.a with the string command, the version was 0.1.8.
This PR is to modify samtools and add depend on soapdenovo-trans.
