### PR TITLE
bwa: fix CC=gcc

### DIFF
--- a/var/spack/repos/builtin/packages/bwa/package.py
+++ b/var/spack/repos/builtin/packages/bwa/package.py
@@ -36,6 +36,8 @@ class Bwa(Package):
                         zlib_inc_path, 'Makefile')
         filter_file(r'^LIBS=', "LIBS=-L%s " % spec['zlib'].prefix.lib,
                     'Makefile')
+        # use spack C compiler
+        filter_file('^CC=.*', 'CC={0}'.format(spack_cc), 'Makefile')
         make()
 
         mkdirp(prefix.bin)


### PR DESCRIPTION
In ‘Makefile`, `CC=gcc` is patched to use spack specified C compiler.
This is for all compiler.