### PR TITLE
gcc: fixed compilation on OpenSUSE

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -448,9 +448,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             '--enable-languages={0}'.format(
                 ','.join(spec.variants['languages'].value)),
             # Drop gettext dependency
-            '--disable-nls',
-            '--with-mpfr={0}'.format(spec['mpfr'].prefix),
-            '--with-gmp={0}'.format(spec['gmp'].prefix),
+            '--disable-nls'
         ]
 
         # Use installed libz
@@ -476,13 +474,23 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                 '--enable-bootstrap',
             ])
 
-        # MPC
-        if 'mpc' in spec:
-            options.append('--with-mpc={0}'.format(spec['mpc'].prefix))
+        # Configure include and lib directories explicitly for these
+        # dependencies since the short GCC option assumes that libraries
+        # are installed in "/lib" which might not be true on all OS
+        # (see #10842)
+        #
+        # More info at: https://gcc.gnu.org/install/configure.html
+        for dep_str in ('mpfr', 'gmp', 'mpc', 'isl'):
+            if dep_str not in spec:
+                continue
 
-        # ISL
-        if 'isl' in spec:
-            options.append('--with-isl={0}'.format(spec['isl'].prefix))
+            dep_spec = spec[dep_str]
+            include_dir = dep_spec.headers.directories[0]
+            lib_dir = dep_spec.libs.directories[0]
+            options.extend([
+                '--with-{0}-include={1}'.format(dep_str, include_dir),
+                '--with-{0}-lib={1}'.format(dep_str, lib_dir)
+            ])
 
         # nvptx-none offloading for host compiler
         if spec.satisfies('+nvptx'):


### PR DESCRIPTION
fixes #17556
fixes #10842
closes #18150

Set location for dependencies specifying explicitly both the include and lib path. This permits to handle cases where the libraries are installed in `lib64` instead of `lib`