### PR TITLE
ParaView: add -no-ipo for builds using intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -276,6 +276,11 @@ class Paraview(CMakePackage, CudaPackage):
         if name == 'ldflags' and self.spec.satisfies('%intel'):
             flags.append('-shared-intel')
             return(None, flags, None)
+        # -no-ipo prevents internal compiler error from multi-file
+        # optimization (https://github.com/spack/spack/issues/18192)
+        if (name == 'cflags' or name == 'cxxflags') and self.spec.satisfies('%intel'):
+            flags.append('-no-ipo')
+            return(None, None, flags)
         return(flags, None, None)
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
@chuckatkins fixes #18192 

-no-ipo allows paraview to be built with intel/19.0.4 and not get the internal compiler error as shown in the issue.