### PR TITLE
ParaView, LLVM: add -shared-intel to solve intel linking failures

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -362,7 +362,7 @@ class Llvm(CMakePackage, CudaPackage):
     def setup_build_environment(self, env):
         env.append_flags("CXXFLAGS", self.compiler.cxx11_flag)
         if self.spec.satisfies('%intel'):
-            env.set('LDFLAGS', "-shared-intel")
+            env.append_flags('LDFLAGS', "-shared-intel")
 
     def setup_run_environment(self, env):
         if "+clang" in self.spec:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -359,10 +359,14 @@ class Llvm(CMakePackage, CudaPackage):
                         'create this identity.'
                     )
 
-    def setup_build_environment(self, env):
-        env.append_flags("CXXFLAGS", self.compiler.cxx11_flag)
-        if self.spec.satisfies('%intel'):
-            env.append_flags('LDFLAGS', "-shared-intel")
+    def flag_handler(self, name, flags):
+        if name == 'cxxflags':
+            flags.append(self.compiler.cxx11_flag)
+            return(None, flags, None)
+        elif name == 'ldflags' and self.spec.satisfies('%intel'):
+            flags.append('-shared-intel')
+            return(None, flags, None)
+        return(flags, None, None)
 
     def setup_run_environment(self, env):
         if "+clang" in self.spec:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -361,6 +361,8 @@ class Llvm(CMakePackage, CudaPackage):
 
     def setup_build_environment(self, env):
         env.append_flags("CXXFLAGS", self.compiler.cxx11_flag)
+        if self.spec.satisfies('%intel'):
+            env.set('LDFLAGS', "-shared-intel")
 
     def setup_run_environment(self, env):
         if "+clang" in self.spec:

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -181,6 +181,12 @@ class Paraview(CMakePackage, CudaPackage):
             env.set('PARAVIEW_VTK_DIR',
                     join_path(lib_dir, 'cmake', self.paraview_subdir, 'vtk'))
 
+    def flag_handler(self, name, flags):
+        if name == 'ldflags' and self.spec.satisfies('%intel'):
+            flags.append('-shared-intel')
+            return(None, flags, None)
+        return(flags, None, None)
+
     def setup_run_environment(self, env):
         # paraview 5.5 and later
         # - cmake under lib/cmake/paraview-5.5
@@ -372,10 +378,5 @@ class Paraview(CMakePackage, CudaPackage):
         # arises.
         if '%intel' in spec and spec.version >= Version('5.6'):
             cmake_args.append('-DPARAVIEW_ENABLE_MOTIONFX:BOOL=OFF')
-
-        if '%intel' in spec:
-            cmake_args.extend([
-                '-DCMAKE_EXE_LINKER_FLAGS:STRING=-shared-intel'
-            ])
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -373,4 +373,9 @@ class Paraview(CMakePackage, CudaPackage):
         if '%intel' in spec and spec.version >= Version('5.6'):
             cmake_args.append('-DPARAVIEW_ENABLE_MOTIONFX:BOOL=OFF')
 
+        if '%intel' in spec:
+            cmake_args.extend([
+                '-DCMAKE_EXE_LINKER_FLAGS:STRING=-shared-intel'
+            ])
+
         return cmake_args


### PR DESCRIPTION
@chuckatkins fixes #18194 

This PR adds -shared-intel to the linking flags for LLVM, Mesa, and ParaView when using the intel compiler. This adds the flag specifically for each package. There may be a more general solution.