### PR TITLE
charliecloud: add 0.18

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -15,26 +15,16 @@ class Charliecloud(AutotoolsPackage):
     git      = "https://github.com/hpc/charliecloud.git"
 
     version('master', branch='master')
-    version('0.17',   sha256='9ccb34243e17cbb9c65e44fba66293ed65c39db0422c7d9bd6d1c314c3896723')
-    version('0.16',   sha256='6cdc21d414b6173090ac0a4c2c62a2a038c81659a75ae8f837b332bb7e6e9090')
-    version('0.15',   sha256='2163420d43c934151c4f44a188313bdb7f79e576d5a86ba64b9ea45f784b9921')
-    version('0.14',   sha256='4ae23c2d6442949e16902f9d5604dbd1d6059aeb5dd461b11fc5c74d49dcb194')
-    version('0.13',   sha256='5740bff6e410ca99484c1bdf3dbe834c0f753c846d55c19d6162967a3e2718e0')
+    version('0.18',   sha256='15ce63353afe1fc6bcc10979496a54fcd5628f997cb13c827c9fc7afb795bdc5')
 
     depends_on('m4',       type='build')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
 
-    # Use skopeo and umoci for older (unsupported) ch-grow versions.
-    depends_on('skopeo',         type='run', when='@0.10:0.13')
-    depends_on('umoci',          type='run', when='@0.10:0.13')
-    depends_on('python+libxml2', type='run', when='@0.10:0.13')
-
-    # Use python for ch-grow 0.14 and above version dependencies.
-    depends_on('python@3.5:',    type='run', when='@0.14:')
-    depends_on('py-lark-parser', type='run', when='@0.14:')
-    depends_on('py-requests',    type='run', when='@0.14:')
+    depends_on('python@3.5:',    type='run')
+    depends_on('py-lark-parser', type='run')
+    depends_on('py-requests',    type='run')
 
     # Man pages and html docs variant.
     variant('docs', default=False, description='Build man pages and html docs')
@@ -47,27 +37,18 @@ class Charliecloud(AutotoolsPackage):
 
     # Bash automated testing harness (bats).
     depends_on('bats@0.4.0', type='test')
-    depends_on('python@3.5:', type='test')
 
     def configure_args(self):
 
         args = []
         py_path = self.spec['python'].command.path
-
-        if (self.spec.satisfies('@0.13')):
-            args.append('--with-python-shebang={0}'.format(py_path))
-        else:
-            args.append('--with-python={0}'.format(py_path))
+        args.append('--with-python={0}'.format(py_path))
 
         if '+docs' in self.spec:
             sphinx_bin = '{0}'.format(self.spec['py-sphinx'].prefix.bin)
-            if (self.spec.satisfies('@0.13')):
-                # 0.13 fails when we try to build it with html.
-                args.append('--disable-html')
-            else:
-                args.append('--enable-html')
-                args.append('--with-sphinx-build={0}'.format(sphinx_bin.join(
-                                                             'sphinx-build')))
+            args.append('--enable-html')
+            args.append('--with-sphinx-build={0}'.format(sphinx_bin.join(
+                                                         'sphinx-build')))
         else:
             args.append('--disable-html')
 

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -11,7 +11,7 @@ class Charliecloud(AutotoolsPackage):
 
     maintainers = ['j-ogas', 'reidpr']
     homepage = "https://hpc.github.io/charliecloud"
-    url      = "https://github.com/hpc/charliecloud/releases/download/v0.14/charliecloud-0.18.tar.gz"
+    url      = "https://github.com/hpc/charliecloud/releases/download/v0.18/charliecloud-0.18.tar.gz"
     git      = "https://github.com/hpc/charliecloud.git"
 
     version('master', branch='master')

--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -11,7 +11,7 @@ class Charliecloud(AutotoolsPackage):
 
     maintainers = ['j-ogas', 'reidpr']
     homepage = "https://hpc.github.io/charliecloud"
-    url      = "https://github.com/hpc/charliecloud/releases/download/v0.14/charliecloud-0.14.tar.gz"
+    url      = "https://github.com/hpc/charliecloud/releases/download/v0.14/charliecloud-0.18.tar.gz"
     git      = "https://github.com/hpc/charliecloud.git"
 
     version('master', branch='master')


### PR DESCRIPTION
This PR adds 0.18 and removes older versions susceptible to a symlink bug in `ch-tug` and `ch-grow`. From the release notes:

> This release fixes an important symlink handling bug in ch-tug and ch-grow ([#819](https://github.com/hpc/charliecloud/issues/819)). Prior to version 0.18, if a pulled image contained a symlink in one layer and then a regular file at the same path in a subsequent layer, the target of the symlink would be overwritten even if it was not within the image; i.e., unpacking inappropriately followed the symlink. This allows a crafted image to overwrite any file writeable by the invoking user.
>
> (The underlying cause is a known bug in Python's tarfile module, e.g. https://bugs.python.org/issue35483, https://bugs.python.org/issue19974.)
