### PR TITLE
Bugfix/Smoke tests: Added test data dir property and use plus escaped compares

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1635,6 +1635,10 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         return self.test_stage.join(
             self.spec.format('{name}-{version}-{hash}'))
 
+    @property
+    def test_data_dir(self):
+        return self.test_dir.data.join(self.spec.name)
+
     def cache_extra_test_sources(self, srcs):
         """Copy relative source paths to the corresponding install test subdir
 
@@ -1722,7 +1726,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                             except spack.repo.UnknownPackageError:
                                 continue
 
-                            # copy test data into testdir/data
+                            # copy test data into testdir/data/spec.name
                             data_source = Prefix(spec_pkg.package_dir).test
                             data_dir = os.path.join(testdir.data, spec.name)
                             if os.path.isdir(data_source):
@@ -1874,9 +1878,11 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 raise
 
         for check in expected:
+            check = re.escape(check)
             cmd = ' '.join([runner.name] + options)
-            msg = "Expected '{0}' to match output of `{1}`".format(check, cmd)
-            msg += '\n\nOutput: {0}'.format(output)
+            msg = "Expected:\n'{0}'\nto match the output of `{1}`" \
+                .format(check, cmd)
+            msg += '\nOutput:\n\'{0}\''.format(output)
             assert re.search(check, output), msg
 
     def unit_test_check(self):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import shutil
 import sys
 
@@ -387,31 +386,32 @@ HDF5 version {version} {version}
         ]
         use_short_opt = ['h52gif', 'h5repart', 'h5unjam']
         for exe in exes:
-            reason = 'test version of {0} is {1}'.format(exe, spec_vers_str)
+            reason = 'test: checking version of {0} is {1}' \
+                .format(exe, spec_vers_str)
             option = '-V' if exe in use_short_opt else '--version'
-            self.run_test(exe, [option], spec_vers_str, installed=True,
+            self.run_test(exe, option, spec_vers_str, installed=True,
                           purpose=reason, skip_missing=True)
 
     def _test_example(self):
         """This test performs copy, dump, and diff on an example hdf5 file."""
-        h5_file = os.path.join(self.test_dir, 'data', 'spack.h5')
+        filename = 'spack.h5'
+        h5_file = join_path(self.test_data_dir, filename)
 
-        reason = 'test: ensure h5dump produces expected output'
-        dump_file = os.path.join(self.test_dir, 'data', 'dump.out')
-        output = ''
-        with open(dump_file) as fd:
-            output == fd.read()
-        self.run_test('h5dump', [h5_file], output, installed=True,
-                      purpose=reason, skip_missing=True, work_dir='.')
+        reason = 'test: ensuring h5dump produces expected output'
+        dump_file = join_path(self.test_data_dir, 'dump.out')
+        with open(dump_file, 'r') as fd:
+            expected = fd.read()
+        self.run_test('h5dump', filename, expected, installed=True,
+                      purpose=reason, skip_missing=True,
+                      work_dir=self.test_data_dir)
 
-        reason = 'test: ensure h5copy runs'
+        reason = 'test: ensuring h5copy runs'
         options = ['-i', h5_file, '-s', 'Spack', '-o', 'test.h5', '-d', 'Spack']
-        self.run_test('h5copy', options, installed=True,
+        self.run_test('h5copy', options, [], installed=True,
                       purpose=reason, skip_missing=True, work_dir='.')
 
-        reason = 'test: ensure h5diff shows no differences in orig and copy'
-        options = [h5_file, 'test.h5']
-        self.run_test('h5diff', options, installed=True,
+        reason = 'test: ensuring h5diff shows no differences in orig and copy'
+        self.run_test('h5diff', [h5_file, 'test.h5'], [], installed=True,
                       purpose=reason, skip_missing=True, work_dir='.')
 
     def test(self):

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import llnl.util.tty as tty
 
 from spack import *
@@ -36,30 +35,29 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
 
     def _run_smoke_tests(self):
         """Build and run the added smoke (install) test."""
-        prog = 'data/smoke_test'
+        prog = 'smoke_test'
+        src = join_path(self.test_data_dir, '{0}.c'.format(prog))
 
         options = [
             '-I{0}'.format(self.prefix.include),
-            '{0}.c'.format(prog),
+            src,
             '-o',
             prog,
             '-L{0}'.format(self.prefix.lib),
             '-lsigsegv',
             '-Wl,-R{0}'.format(self.prefix.lib)]
-        reason = 'test ability to link to the library'
+        reason = 'test: checking ability to link to the library'
         self.run_test('cc', options, [], None, False, purpose=reason)
 
         # Now run the program and confirm the output matches expectations
-        with open('./data/smoke_test.out', 'r') as fd:
+        outfn = join_path(self.test_data_dir, 'smoke_test.out')
+        with open(outfn, 'r') as fd:
             expected = fd.read()
-        reason = 'test ability to use the library'
+        reason = 'test: checking ability to use the library'
         self.run_test(prog, [], expected, purpose=reason)
 
     def _run_build_tests(self):
         """Build and run selected tests pulled from the build."""
-        work_dir = os.path.join(self.install_test_root,
-                                self.extra_install_tests)
-
         # Run the build tests to confirm the expected output
         passed = 'Test passed'
         checks = {
@@ -71,15 +69,12 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
         }
 
         for exe, expected in checks.items():
-            reason = 'test {0} output'.format(exe)
-            self.run_test(exe, [], expected, installed=True,
-                          purpose=reason, skip_missing=True, work_dir=work_dir)
+            reason = 'test: checking {0} output'.format(exe)
+            self.run_test(exe, [], expected, installed=True, purpose=reason,
+                          skip_missing=True)
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        tty.debug('Expected results currently based on simple {0} builds'
-                  .format(self.name))
-
         if not self.spec.satisfies('@2.10:2.12'):
             tty.debug('Expected results have not been confirmed for {0} {1}'
                       .format(self.name, self.spec.version))

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -78,23 +78,21 @@ class Libxml2(AutotoolsPackage):
         self.import_module_test()
 
         # Now run defined tests based on expected executables
-        dtd_path = './data/info.dtd'
+        dtd_path = join_path(self.test_data_dir, 'info.dtd')
+        info_path = join_path(self.test_data_dir, 'info.xml')
         test_fn = 'test.xml'
         exec_checks = {
             'xml2-config': [
-                (['--version'], [str(self.spec.version)], None)],
+                ('--version', [str(self.spec.version)], None)],
             'xmllint': [
-                (['--version'],
-                 ['using libxml', str(self.spec.version).replace('.', '0')],
-                 None),
                 (['--auto', '-o', test_fn], [], None),
                 (['--postvalid', test_fn],
                  ['validity error', 'no DTD found', 'does not validate'], 3),
                 (['--dtdvalid', dtd_path, test_fn],
                  ['validity error', 'does not follow the DTD'], 3),
-                (['--dtdvalid', dtd_path, './data/info.xml'], [], None)],
+                (['--dtdvalid', dtd_path, info_path], [], None)],
             'xmlcatalog': [
-                (['--create'], ['<catalog xmlns', 'catalog"/>'], None)],
+                ('--create', ['<catalog xmlns', 'catalog"/>'], None)],
         }
         for exe in exec_checks:
             for options, expected, status in exec_checks[exe]:

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -5,11 +5,6 @@
 
 import re
 
-import os
-import re
-
-import llnl.util.tty as tty
-
 
 class M4(AutotoolsPackage, GNUMirrorPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
@@ -83,22 +78,14 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         return args
 
     def test(self):
-        m4 = which('m4')
-        assert m4 is not None
+        spec_vers = str(self.spec.version)
+        reason = 'test: checking m4 version is {0}'.format(spec_vers)
+        self.run_test('m4', '--version', spec_vers, installed=True,
+                      purpose=reason, skip_missing=False)
 
-        tty.msg('test: Ensuring use of the installed executable')
-        m4_dir = os.path.dirname(m4.path)
-        assert m4_dir == self.prefix.bin
-
-        tty.msg('test: Checking version')
-        output = m4('--version', output=str.split, error=str.split)
-        version_regex = re.compile(r'm4(.+){0}'.format(self.spec.version))
-        assert version_regex.search(output)
-
-        tty.msg('test: Ensuring m4 runs')
-        currdir = os.getcwd()
-        hello_file = os.path.join(currdir, 'data', 'hello.m4')
-        output = m4(hello_file, output=str.split, error=str.split)
-        expected_file = os.path.join(currdir, 'data', 'hello.out')
-        with open(expected_file) as fd:
-            assert output == fd.read()
+        reason = 'test: ensuring m4 example succeeds'
+        hello_file = join_path(self.test_data_dir, 'hello.m4')
+        with open(join_path(self.test_data_dir, 'hello.out'), 'r') as fd:
+            expected = fd.read()
+        self.run_test('m4', hello_file, expected, installed=True,
+                      purpose=reason, skip_missing=False)

--- a/var/spack/repos/builtin/packages/mpi/package.py
+++ b/var/spack/repos/builtin/packages/mpi/package.py
@@ -5,23 +5,27 @@
 
 import os
 
+
 class Mpi(Package):
     """Virtual package for the Message Passing Interface."""
     homepage = 'https://www.mpi-forum.org/'
     virtual = True
 
     def test(self):
+        mpi_test_data_dir = self.test_dir.data.join('mpi')
+
         for lang in ('c', 'f'):
             filename = 'mpi_hello.' + lang
-            filepath = os.path.join(self.test_dir, 'data', 'mpi')
+            filepath = join_path(mpi_test_data_dir, filename)
 
             compiler_var = 'MPI%sC' % lang.upper()
             compiler = os.environ[compiler_var]
 
             exe_name = 'mpi_hello_%s' % lang
-            mpirun = os.path.join(self.prefix.bin, 'mpirun')
+            mpirun = join_path(self.prefix.bin, 'mpirun')
 
-            compiled = self.run_test(compiler, options=['-o', exe_name])
+            compiled = self.run_test(compiler,
+                                     options=['-o', exe_name, filepath])
             if compiled:
                 self.run_test(mpirun,
                               options=['-np', '1', exe_name],

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -743,7 +743,7 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             options, expected, status = checks[exe]
-            reason = 'test {0} output'.format(exe)
+            reason = 'test: checking {0} output'.format(exe)
             self.run_test(exe, options, expected, status, installed=True,
                           purpose=reason, skip_missing=True)
 
@@ -806,16 +806,17 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             expected, status = checks[exe]
-            purpose = 'test version of {0} is {1}'.format(exe, expected[0])
+            purpose = 'test: checking version of {0} is {1}' \
+                .format(exe, expected[0])
             self.run_test(exe, ['--version'], expected, status, installed=True,
                           purpose=purpose, skip_missing=True)
 
     def _test_examples(self):
         # First build the examples
-        work_dir = os.path.join(self.install_test_root,
-                                self.extra_install_tests)
         self.run_test('make', ['all'], [],
-                      purpose='test build the examples', work_dir=work_dir)
+                      purpose='test: ensuring ability to build the examples',
+                      work_dir=join_path(self.install_test_root,
+                                         self.extra_install_tests))
 
         # Now run those with known results
         have_spml = self.spec.satisfies('@2.0.0:2.1.6')
@@ -857,9 +858,9 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             expected, status = checks[exe]
-            reason = 'test {0} output'.format(exe)
+            reason = 'test: checking example {0} output'.format(exe)
             self.run_test(exe, [], expected, status, installed=True,
-                          purpose=reason, skip_missing=True, work_dir=work_dir)
+                          purpose=reason, skip_missing=True)
 
     def test(self):
         """Perform smoke tests on the installed package."""

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -29,8 +29,8 @@ class Patchelf(AutotoolsPackage):
                       purpose=purpose_str)
 
         # Check the rpath is changed
+        hello_file = join_path(self.test_data_dir, 'hello')
         currdir = os.getcwd()
-        hello_file = os.path.join(currdir, 'data', 'hello')
         self.run_test('patchelf', ['--set-rpath', currdir, hello_file],
                       purpose='test that patchelf can change rpath')
         self.run_test('patchelf',


### PR DESCRIPTION
This PR fixes existing smoke tests relying on  test data to use the new `test_data_dir` property and regular expression comparisons for output that needs escaped characters.

It also makes the layout of test part purposes consistent; uses `join_path` instead of `os.path.join`; and eliminates `xmllint`'s version test since the version `.` replacement isn't as simple as originally thought.