### PR TITLE
WIP: Binary installation improvements

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -809,6 +809,8 @@ def try_download_specs(urls=None, force=False):
                 # read the spec from the build cache file. All specs
                 # in build caches are concrete (as they are built) so
                 # we need to mark this spec concrete on read-in.
+                import pdb
+                pdb.set_trace()
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
                 print('Adding {0} (full_hash={1}) from {2}'.format(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -809,8 +809,6 @@ def try_download_specs(urls=None, force=False):
                 # read the spec from the build cache file. All specs
                 # in build caches are concrete (as they are built) so
                 # we need to mark this spec concrete on read-in.
-                import pdb
-                pdb.set_trace()
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
                 print('Adding {0} (full_hash={1}) from {2}'.format(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -811,6 +811,7 @@ def try_download_specs(urls=None, force=False):
                 # we need to mark this spec concrete on read-in.
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
+                spec._require_full_hash_match_for_equals(force)
                 print('Adding {0} (full_hash={1}) from {2}'.format(
                     spec, spec._full_hash, link))
                 _cached_specs.add(spec)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -812,7 +812,7 @@ def try_download_specs(urls=None, force=False):
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
                 print('Adding {0} (full_hash={1}) from {2}'.format(
-                    spec, spec.full_hash(), link))
+                    spec, spec._full_hash, link))
                 _cached_specs.add(spec)
 
     print('returning {0} cached specs'.format(len(_cached_specs)))

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -432,13 +432,13 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
         spec.prefix, spack.store.layout.root)
     buildinfo['relative_rpaths'] = rel
     spec_dict['buildinfo'] = buildinfo
-    spec_dict['full_hash'] = spec.full_hash()
+    # spec_dict['full_hash'] = spec.full_hash()
 
-    tty.debug('The full_hash ({0}) of {1} will be written into {2}'.format(
-        spec_dict['full_hash'],
-        spec.name,
-        url_util.format(remote_specfile_path)))
-    tty.debug(spec.tree())
+    # tty.debug('The full_hash ({0}) of {1} will be written into {2}'.format(
+    #     spec_dict['full_hash'],
+    #     spec.name,
+    #     url_util.format(remote_specfile_path)))
+    # tty.debug(spec.tree())
 
     with open(specfile_path, 'w') as outfile:
         outfile.write(syaml.dump(spec_dict))

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -811,8 +811,11 @@ def try_download_specs(urls=None, force=False):
                 # we need to mark this spec concrete on read-in.
                 spec = Spec.from_yaml(f)
                 spec._mark_concrete()
+                print('Adding {0} (full_hash={1}) from {2}'.format(
+                    spec, spec.full_hash(), link))
                 _cached_specs.add(spec)
 
+    print('returning {0} cached specs'.format(len(_cached_specs)))
     return _cached_specs
 
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1112,6 +1112,7 @@ class Database(object):
             # the original hash of concrete specs.
             new_spec._mark_concrete()
             new_spec._hash = key
+            new_spec._full_hash = spec._full_hash
 
         else:
             # If it is already there, mark it as installed.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1129,6 +1129,8 @@ class Database(object):
         # TODO: ensure that spec is concrete?
         # Entire add is transactional.
         with self.write_transaction():
+            print('Adding {0} to database, full_hash = {1}'.format(
+                spec.name, spec._full_hash))
             self._add(spec, directory_layout, explicit=explicit)
 
     def _get_matching_spec_key(self, spec, **kwargs):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -345,9 +345,11 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False):
     """
     pkg_id = package_id(pkg)
     tty.debug('Searching for binary cache of {0}'.format(pkg_id))
-    specs = binary_distribution.get_spec(pkg.spec, force=True)
+    full_hash_must_match = True
+    specs = binary_distribution.get_spec(pkg.spec, force=full_hash_must_match)
     binary_spec = spack.spec.Spec.from_dict(pkg.spec.to_dict())
     binary_spec._mark_concrete()
+    binary_spec._require_full_hash_match_for_equals(full_hash_must_match)
     if binary_spec not in specs:
         return False
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -351,9 +351,10 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False):
     if binary_spec not in specs:
         return False
 
-    print('Got spec list and it contains the target')
+    print('target spec: {0}-{1}'.format(binary_spec.name, binary_spec._full_hash))
+    print('list of matches:')
     for next_spec in specs:
-        print('  {0}'.format(next_spec))
+        print('  {0}-{1}'.format(next_spec.name, next_spec._full_hash))
 
     return _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -351,6 +351,10 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False):
     if binary_spec not in specs:
         return False
 
+    print('Got spec list and it contains the target')
+    for next_spec in specs:
+        print('  {0}'.format(next_spec))
+
     return _process_binary_cache_tarball(pkg, binary_spec, explicit, unsigned)
 
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -345,7 +345,7 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False):
     """
     pkg_id = package_id(pkg)
     tty.debug('Searching for binary cache of {0}'.format(pkg_id))
-    specs = binary_distribution.get_spec(pkg.spec, force=False)
+    specs = binary_distribution.get_spec(pkg.spec, force=True)
     binary_spec = spack.spec.Spec.from_dict(pkg.spec.to_dict())
     binary_spec._mark_concrete()
     if binary_spec not in specs:

--- a/lib/spack/spack/schema/buildcache_spec.py
+++ b/lib/spack/spack/schema/buildcache_spec.py
@@ -26,7 +26,6 @@ schema = {
                 'relative_rpaths': {'type': 'boolean'},
             },
         },
-        'full_hash': {'type': 'string'},
         'spec': {
             'type': 'array',
             'items': spack.schema.spec.properties,

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -81,6 +81,7 @@ properties = {
         ],
         'properties': {
             'hash': {'type': 'string'},
+            'full_hash': {'type': 'string'},
             'version': {
                 'oneOf': [
                     {'type': 'string'},

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -959,7 +959,8 @@ class Spec(object):
 
     def __init__(self, spec_like=None,
                  normal=False, concrete=False, external_path=None,
-                 external_modules=None, full_hash=None):
+                 external_modules=None, full_hash=None,
+                 full_hash_match_for_equals=False):
         """Create a new Spec.
 
         Arguments:
@@ -1010,6 +1011,7 @@ class Spec(object):
         self.external_path = external_path
         self.external_modules = external_modules
         self._full_hash = full_hash
+        self._match_full_hash = full_hash_match_for_equals
 
         # This attribute is used to store custom information for
         # external specs. None signal that it was not set yet.
@@ -2360,6 +2362,9 @@ class Spec(object):
             s._normal = value
             s._concrete = value
 
+    def _require_full_hash_match_for_equals(self, value=True):
+        self._match_full_hash = True
+
     def concretized(self):
         """This is a non-destructive version of concretize().  First clones,
            then returns a concrete version of this package without modifying
@@ -3352,7 +3357,9 @@ class Spec(object):
             (d.spec.name, hash(d.spec), tuple(sorted(d.deptypes)))
             for name, d in sorted(self._dependencies.items()))
 
-        key = (self._full_hash, self._cmp_node(), dep_tuple)
+        comp_one = self._full_hash if self._match_full_hash else None
+
+        key = (comp_one, self._cmp_node(), dep_tuple)
         if self._concrete:
             self._cmp_key_cache = key
         return key

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1534,6 +1534,8 @@ class Spec(object):
 
         if not self._concrete:
             d['concrete'] = False
+        else:
+            d['full_hash'] = self._full_hash
 
         if 'patches' in self.variants:
             variant = self.variants['patches']
@@ -1716,6 +1718,7 @@ class Spec(object):
 
         # specs read in are concrete unless marked abstract
         spec._concrete = node.get('concrete', True)
+        spec._full_hash = node.get('full_hash', None)
 
         if 'patches' in node:
             patches = node['patches']

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3352,7 +3352,7 @@ class Spec(object):
             (d.spec.name, hash(d.spec), tuple(sorted(d.deptypes)))
             for name, d in sorted(self._dependencies.items()))
 
-        key = (self._cmp_node(), dep_tuple)
+        key = (self._full_hash, self._cmp_node(), dep_tuple)
         if self._concrete:
             self._cmp_key_cache = key
         return key

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1443,6 +1443,7 @@ class Spec(object):
 
         TODO: investigate whether to include build deps here.
         """
+        print(' @@@@@@@@@ Someone asked to compute full_hash for {0} @@@@@@@@@ '.format(self.name))
         return self._cached_hash(ht.full_hash, length)
 
     def dag_hash_bit_prefix(self, bits):

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -38,6 +38,7 @@ class Zlib(Package):
         )
 
     def setup_build_environment(self, env):
+        env.append_flags('CFLAGS', '-Wall')
         if '+pic' in self.spec:
             env.append_flags('CFLAGS', self.compiler.cc_pic_flag)
         if '+optimize' in self.spec:


### PR DESCRIPTION
The goal of this PR is to support an option to `spack install`, something shorter than `--require-full-hash-match-on-binary-install`, but which might convey that idea.  Use of the option would cause spack to compare the full hash of the local spec to install against full hashes stored in the `spec.yaml` files on any remote mirrors until it found a match, and only install from binary if it finds one with a matching full hash, otherwise, it would install from source.  When the option is not provided, the current behavior would remain, i.e. spack will install the binary version of the first remote spec it finds with a matching DAG hash.

This new behavior will support PR build pipelines in several ways:

1. The goal of the pipeline is to compare the full hash of a local spec against that of a built spec on a remote mirror, and rebuild/push the updated package to the remote mirror.  When running a pipeline for a PR, we want to configure a temporary "PR mirror" for each PR so that untrusted binaries could be re-used by subsequent runs of the pipeline when possible.  This would improve developer experience, for example, when the first push on a PR branch requires a rebuild of a long job, but subsequent pushes do not.  With the feature added by this PR, subsequent pipelines on the same PR could potentially re-use binaries created in earlier pipelines.  The current two-pass install approach required in the pipeline prevents this possibility.

2. This PR would get rid of the need for the pipeline to do package installation in two passes.  Due to how spack will install any binary it finds with a matching DAG hash, the pipeline code currently has to do a lot of gymnastics.   First it has to manually determine whether the package needs to be rebuilt by comparing the locally computed full hash of the spec against the full hash stored with the binary on the remote mirror.  If a rebuild is required due to a full hash mismatch, pipeline code has to coerce spack to rebuild the package from source using the "two-pass install" workaround: first we install only our dependencies with `--cache-only` option, and then install only the package with the `--no-cache` option.  If `spack install` could manage all of this for us, we could remove a lot of code from the `spack ci rebuild` command.