### PR TITLE
Docs: pkg list refer to current version, not latest release

### DIFF
--- a/lib/spack/docs/package_list.rst
+++ b/lib/spack/docs/package_list.rst
@@ -10,8 +10,8 @@ Package List
 ============
 
 This is a list of things you can install using Spack.  It is
-automatically generated based on the packages in the latest Spack
-release.
+automatically generated based on the packages in this Spack
+version.
 
 .. raw:: html
    :file: package_list.html


### PR DESCRIPTION
The package list at https://spack.readthedocs.io/en/latest/package_list.html where users automatically land, claims "it is automatically generated based on the packages in the latest Spack release" but it is actually based on the develop branch, not based on a release. Changing the language from "the latest Spack release" to "this Spack version" might make that clearer. Or maybe there's a more wordy alternative.