### PR TITLE
depends_on cannot handle ^ sigil

### DIFF
--- a/lib/spack/docs/known_issues.rst
+++ b/lib/spack/docs/known_issues.rst
@@ -14,7 +14,7 @@ problems if you encounter them.
 Variants are not properly forwarded to dependencies
 ---------------------------------------------------
 
-**Status:** Expected to be fixed in the next release
+**Status:** Expected to be fixed by Spack's new concretizer
 
 Sometimes, a variant of a package can also affect how its dependencies are
 built. For example, in order to build MPI support for a package, it may
@@ -48,3 +48,30 @@ A workaround is to explicitly activate the variants of dependencies as well:
 
 See https://github.com/spack/spack/issues/267 and
 https://github.com/spack/spack/issues/2546 for further details.
+
+-----------------------------------------------
+depends_on cannot handle recursive dependencies
+-----------------------------------------------
+
+**Status:** Not yet a work in progress
+
+Although ``depends_on`` can handle any aspect of Spack's spec syntax,
+it currently cannot handle recursive dependencies. If the ``^`` sigil
+appears in a ``depends_on`` statement, the concretizer will hang.
+For example, something like:
+
+.. code-block:: python
+
+   depends_on('mfem+cuda ^hypre+cuda', when='+cuda')
+
+
+should be rewritten as:
+
+.. code-block:: python
+
+   depends_on('mfem+cuda', when='+cuda')
+   depends_on('hypre+cuda', when='+cuda')
+
+
+See https://github.com/spack/spack/issues/17660 and
+https://github.com/spack/spack/issues/11160 for more details.

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1897,6 +1897,25 @@ command line to find installed packages or to install packages with
 particular constraints, and package authors can use specs to describe
 relationships between packages.
 
+.. warning::
+
+   Although ``depends_on`` can handle any aspect of Spack's spec syntax,
+   it currently cannot handle recursive dependencies. If the ``^`` sigil
+   appears in a ``depends_on`` statement, the concretizer will hang.
+   For example, something like:
+
+   .. code-block:: python
+
+      depends_on('mfem+cuda ^hypre+cuda', when='+cuda')
+
+   should be rewritten as:
+
+   .. code-block:: python
+
+      depends_on('mfem+cuda', when='+cuda')
+      depends_on('hypre+cuda', when='+cuda')
+
+
 ^^^^^^^^^^^^^^
 Version ranges
 ^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1897,25 +1897,6 @@ command line to find installed packages or to install packages with
 particular constraints, and package authors can use specs to describe
 relationships between packages.
 
-.. warning::
-
-   Although ``depends_on`` can handle any aspect of Spack's spec syntax,
-   it currently cannot handle recursive dependencies. If the ``^`` sigil
-   appears in a ``depends_on`` statement, the concretizer will hang.
-   For example, something like:
-
-   .. code-block:: python
-
-      depends_on('mfem+cuda ^hypre+cuda', when='+cuda')
-
-   should be rewritten as:
-
-   .. code-block:: python
-
-      depends_on('mfem+cuda', when='+cuda')
-      depends_on('hypre+cuda', when='+cuda')
-
-
 ^^^^^^^^^^^^^^
 Version ranges
 ^^^^^^^^^^^^^^

--- a/var/spack/repos/builtin/packages/cardioid/package.py
+++ b/var/spack/repos/builtin/packages/cardioid/package.py
@@ -26,6 +26,7 @@ class Cardioid(CMakePackage):
     depends_on('mpi')
     depends_on('cuda', when="+cuda")
     depends_on('mfem+mpi+superlu-dist+lapack', when="+mfem")
+    depends_on('hypre+cuda', when="+mfem+cuda")
     depends_on('cmake@3.1:', type='build')
     depends_on('perl', type='build')
 

--- a/var/spack/repos/builtin/packages/cardioid/package.py
+++ b/var/spack/repos/builtin/packages/cardioid/package.py
@@ -25,8 +25,7 @@ class Cardioid(CMakePackage):
     depends_on('lapack')
     depends_on('mpi')
     depends_on('cuda', when="+cuda")
-    depends_on('mfem+mpi+superlu-dist+lapack', when="+mfem~cuda")
-    depends_on('mfem+mpi+superlu-dist+lapack^hypre+cuda', when="+mfem+cuda")
+    depends_on('mfem+mpi+superlu-dist+lapack', when="+mfem")
     depends_on('cmake@3.1:', type='build')
     depends_on('perl', type='build')
 

--- a/var/spack/repos/builtin/packages/parmetis/package.py
+++ b/var/spack/repos/builtin/packages/parmetis/package.py
@@ -22,10 +22,13 @@ class Parmetis(CMakePackage):
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
     variant('gdb', default=False, description='Enables gdb support.')
+    variant('int64', default=False, description='Sets the bit width of METIS\'s index type to 64.')
 
     depends_on('cmake@2.8:', type='build')
     depends_on('mpi')
     depends_on('metis@5:')
+    depends_on('metis+int64', when='+int64')
+    depends_on('metis~int64', when='~int64')
 
     patch('enable_external_metis.patch')
     # bug fixes from PETSc developers

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -118,7 +118,8 @@ class Phist(CMakePackage):
     depends_on('ghost', when='kernel_lib=ghost')
 
     depends_on('trilinos+anasazi+belos+teuchos', when='+trilinos')
-    depends_on('parmetis', when='+parmetis')
+    depends_on('parmetis+int64', when='+parmetis+int64')
+    depends_on('parmetis~int64', when='+parmetis~int64')
 
     # Fortran 2003 bindings were included in version 1.7, previously they
     # required a separate package

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -118,8 +118,7 @@ class Phist(CMakePackage):
     depends_on('ghost', when='kernel_lib=ghost')
 
     depends_on('trilinos+anasazi+belos+teuchos', when='+trilinos')
-    depends_on('parmetis ^metis+int64', when='+parmetis +int64')
-    depends_on('parmetis ^metis~int64', when='+parmetis ~int64')
+    depends_on('parmetis', when='+parmetis')
 
     # Fortran 2003 bindings were included in version 1.7, previously they
     # required a separate package

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -51,7 +51,7 @@ class Warpx(MakefilePackage):
     depends_on('openpmd-api +mpi', when='+openpmd +mpi')
     depends_on('ascent', when='+ascent')
     depends_on('ascent +cuda', when='+ascent backend=cuda')
-    depends_on('ascent +mpi ^conduit~hdf5', when='+ascent +mpi')
+    depends_on('ascent +mpi', when='+ascent +mpi')
 
     resource(name='amrex',
              git='https://github.com/AMReX-Codes/amrex.git',


### PR DESCRIPTION
Spack's `depends_on` directive cannot handle dependencies of dependencies at the moment. For example, the following specs hang forever:

* `spack spec cardioid+mfem+cuda`
* `spack spec phist+parmetis`
* `spack spec warpx+ascent+mpi`

Also pinging package maintainers: @MaxThevenet @RemiLehe @ax3l @dpgrote @jthies @rblake-llnl