### PR TITLE
sundials: add github url as backup

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -13,7 +13,8 @@ class Sundials(CMakePackage):
     Solvers)"""
 
     homepage = "https://computing.llnl.gov/projects/sundials"
-    url = "https://computing.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"
+    urls = ["https://computing.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz",
+            "https://github.com/LLNL/sundials/releases/download/v2.7.0/sundials-2.7.0.tar.gz"]
     git = "https://github.com/llnl/sundials.git"
     maintainers = ['cswoodward', 'gardner48', 'balos1']
 


### PR DESCRIPTION
Fixes #17241 