### PR TITLE
Revert "openmpi: Update hwloc version bounds"

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -260,7 +260,9 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc')
     # ompi@:3.0.0 doesn't support newer hwloc releases:
     # "configure: error: OMPI does not currently support hwloc v2 API"
-    depends_on('hwloc@:1.999', when='@:3.999.999')
+    # Future ompi releases may support it, needs to be verified.
+    # See #7483 for context.
+    depends_on('hwloc@:1.999')
 
     depends_on('hwloc +cuda', when='+cuda')
     depends_on('java', when='+java')


### PR DESCRIPTION
Reverts spack/spack#18040

```
$ spack spec openmpi
Input spec
--------------------------------
openmpi

Concretized
--------------------------------
==> Error: An unsatisfiable version constraint has been detected for spec:

    hwloc@2.2.0%gcc@8.4.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-skylake


while trying to concretize the partial spec:

    openmpi@3.1.6%gcc@8.4.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-skylake
        ^numactl@2.0.12%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^autoconf@2.69%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                ^m4@1.4.18%gcc@8.4.0+sigsegv arch=linux-ubuntu18.04-skylake
                    ^libsigsegv
                ^perl@5.30.3%gcc@8.4.0+cpanm+shared+threads arch=linux-ubuntu18.04-skylake
                    ^berkeley-db@18.1.40%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                    ^gdbm@1.18.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                        ^readline@8.0%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                            ^ncurses@6.2%gcc@8.4.0~symlinks+termlib arch=linux-ubuntu18.04-skylake
                                ^pkgconf@1.7.3%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^automake@1.16.2%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^libtool@2.4.6%gcc@8.4.0 arch=linux-ubuntu18.04-skylake


openmpi requires hwloc version :1.999, but spec asked for 2.2.0
```

ping @eschnett 

bisected to this commit:

```
$ git bisect good 
488d8ae747b9e9151c38a959243755ddc768bb84 is the first bad commit
commit 488d8ae747b9e9151c38a959243755ddc768bb84
Author: Erik Schnetter <schnetter@gmail.com>
Date:   Sat Aug 22 14:10:11 2020 -0400

    openmpi: Update hwloc version bounds (#18040)
    
    `openmpi @4:` can use `hwloc @2:`.

:040000 040000 930f51f2f25507e6225ef1b500a8e44a3a119c35 115fc1dcf87716e58b2b69f451e9b1bd83037fc3 M	var
```