### PR TITLE
Fix openmpi concretization

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -257,7 +257,7 @@ class Openmpi(AutotoolsPackage):
 
     depends_on('pkgconfig', type='build')
 
-    depends_on('hwloc')
+    depends_on('hwloc', when='@4:')
     # ompi@:3.0.0 doesn't support newer hwloc releases:
     # "configure: error: OMPI does not currently support hwloc v2 API"
     depends_on('hwloc@:1.999', when='@:3.999.999')


### PR DESCRIPTION
Closes #18232 

This fixes `spack spec openmpi` concretization:

```
$ spack spec openmpi
Input spec
--------------------------------
openmpi

Concretized
--------------------------------
openmpi@3.1.6%gcc@8.4.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-skylake
    ^hwloc@1.11.11%gcc@8.4.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-skylake
        ^libpciaccess@0.16%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^libtool@2.4.6%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                ^m4@1.4.18%gcc@8.4.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-skylake
                    ^libsigsegv@2.12%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^pkgconf@1.7.3%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^util-macros@1.19.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
        ^libxml2@2.9.10%gcc@8.4.0~python arch=linux-ubuntu18.04-skylake
            ^libiconv@1.16%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^xz@5.2.5%gcc@8.4.0~pic arch=linux-ubuntu18.04-skylake
            ^zlib@1.2.11%gcc@8.4.0+optimize+pic+shared arch=linux-ubuntu18.04-skylake
        ^numactl@2.0.12%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^autoconf@2.69%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                ^perl@5.30.3%gcc@8.4.0+cpanm+shared+threads arch=linux-ubuntu18.04-skylake
                    ^berkeley-db@18.1.40%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                    ^gdbm@1.18.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                        ^readline@8.0%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                            ^ncurses@6.2%gcc@8.4.0~symlinks+termlib arch=linux-ubuntu18.04-skylake
            ^automake@1.16.2%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
```

```
$ spack spec openmpi@4:
Input spec
--------------------------------
openmpi@4:

Concretized
--------------------------------
openmpi@4.0.4%gcc@8.4.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-skylake
    ^hwloc@2.2.0%gcc@8.4.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-skylake
        ^libpciaccess@0.16%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^libtool@2.4.6%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                ^m4@1.4.18%gcc@8.4.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-skylake
                    ^libsigsegv@2.12%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^pkgconf@1.7.3%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^util-macros@1.19.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
        ^libxml2@2.9.10%gcc@8.4.0~python arch=linux-ubuntu18.04-skylake
            ^libiconv@1.16%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^xz@5.2.5%gcc@8.4.0~pic arch=linux-ubuntu18.04-skylake
            ^zlib@1.2.11%gcc@8.4.0+optimize+pic+shared arch=linux-ubuntu18.04-skylake
    ^numactl@2.0.12%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
        ^autoconf@2.69%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
            ^perl@5.30.3%gcc@8.4.0+cpanm+shared+threads arch=linux-ubuntu18.04-skylake
                ^berkeley-db@18.1.40%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                ^gdbm@1.18.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                    ^readline@8.0%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
                        ^ncurses@6.2%gcc@8.4.0~symlinks+termlib arch=linux-ubuntu18.04-skylake
        ^automake@1.16.2%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
```