### PR TITLE
Update to CCTools 7.1.7

### DIFF
--- a/var/spack/repos/builtin/packages/cctools/package.py
+++ b/var/spack/repos/builtin/packages/cctools/package.py
@@ -15,6 +15,7 @@ class Cctools(AutotoolsPackage):
     homepage = "https://cctools.readthedocs.io"
     url      = "https://ccl.cse.nd.edu/software/files/cctools-7.1.5-source.tar.gz"
 
+    version('7.1.7', sha256='63cbfabe52591d41a1b27040bf27700d2a11b2f30cb2e25132e0016fb1aade03')
     version('7.1.5', sha256='c01415fd47a1d9626b6c556e0dc0a6b0d3cd67224fa060cabd44ff78eede1d8a')
     version('7.1.3', sha256='b937878ab429dda31bc692e5d9ffb402b9eb44bb674c07a934bb769cee4165ba')
     version('7.1.2', sha256='ca871e9fe245d047d4c701271cf2b868e6e3a170e8834c1887157ed855985131')


### PR DESCRIPTION
This is a bug release with some new features and bug fixes. Among them:

[Batch] Set number of MPI processes for SLURM. (Ben Tovar)
[General] Use the right signature when overriding gettimeofday.
(Tim Shaffer)
[Resource Monitor] Add context-switch count to final summary.
(Ben Tovar)
[Resource Monitor] Fix kbps to Mbps typo in final summary. (Ben Tovar)
[WorkQueue] Update example apps to python3. (Douglas Thain)