### PR TITLE
Clarify manual download required if unable to fetch package

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -577,7 +577,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     archive_files = []
 
     #: Boolean. Set to ``True`` for packages that require a manual download.
-    #: This is currently used by package sanity tests and fetching.
+    #: This is currently used by package sanity tests and generation of a
+    #: more meaningful fetch failure error.
     manual_download = False
 
     #: Set of additional options used when fetching package versions.
@@ -1244,7 +1245,10 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                                  self.spec.format('{name}{@version}'), ck_msg)
 
         self.stage.create()
-        self.stage.fetch(mirror_only, self.manual_download)
+        fetch_msg = None if not self.manual_download else \
+            ('Manual download is required for {0}. Refer to {1} for '
+             'directions.'.format(self.spec.name, self.spec.package.homepage))
+        self.stage.fetch(mirror_only, error_msg=fetch_msg)
         self._fetch_time = time.time() - start_time
 
         if checksum and self.version in self.versions:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1211,6 +1211,20 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         spack.store.layout.remove_install_directory(self.spec)
 
+    @property
+    def download_instr(self):
+        """
+        Defines the default manual download instructions.  Packages can
+        override the property to provide more information.
+
+        Returns:
+            (str):  default manual download instructions
+        """
+        required = ('Manual download is required for {0}. '
+                    .format(self.spec.name) if self.manual_download else '')
+        return ('{0}Refer to {1} for download instructions.'
+                .format(required, self.spec.package.homepage))
+
     def do_fetch(self, mirror_only=False):
         """
         Creates a stage directory and downloads the tarball for this package.
@@ -1245,10 +1259,8 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                                  self.spec.format('{name}{@version}'), ck_msg)
 
         self.stage.create()
-        fetch_msg = None if not self.manual_download else \
-            ('Manual download is required for {0}. Refer to {1} for '
-             'directions.'.format(self.spec.name, self.spec.package.homepage))
-        self.stage.fetch(mirror_only, error_msg=fetch_msg)
+        err_msg = None if not self.manual_download else self.download_instr
+        self.stage.fetch(mirror_only, err_msg=err_msg)
         self._fetch_time = time.time() - start_time
 
         if checksum and self.version in self.versions:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -577,7 +577,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
     archive_files = []
 
     #: Boolean. Set to ``True`` for packages that require a manual download.
-    #: This is currently only used by package sanity tests.
+    #: This is currently used by package sanity tests and fetching.
     manual_download = False
 
     #: Set of additional options used when fetching package versions.
@@ -1244,7 +1244,7 @@ class PackageBase(with_metaclass(PackageMeta, PackageViewMixin, object)):
                                  self.spec.format('{name}{@version}'), ck_msg)
 
         self.stage.create()
-        self.stage.fetch(mirror_only)
+        self.stage.fetch(mirror_only, self.manual_download)
         self._fetch_time = time.time() - start_time
 
         if checksum and self.version in self.versions:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -480,9 +480,12 @@ class Stage(object):
         else:
             print_errors(errors)
 
+            # Simplify the error name by removing the prefix when present
+            name = self.name if not self.name.startswith(stage_prefix) else \
+                self.name.replace(stage_prefix, '')
             err = 'Manual download is required' if manual_download else \
                 'All fetchers failed'
-            err_msg = '{0} for {1}'.format(err, self.name)
+            err_msg = '{0} for {1}'.format(err, name)
             self.fetcher = self.default_fetcher
             raise fs.FetchError(err_msg, None)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -400,8 +400,14 @@ class Stage(object):
         """Returns the well-known source directory path."""
         return os.path.join(self.path, _source_path_subdir)
 
-    def fetch(self, mirror_only=False, manual_download=False):
-        """Downloads an archive or checks out code from a repository."""
+    def fetch(self, mirror_only=False, error_msg=None):
+        """Retrieves the code or archive
+
+        Args:
+            mirror_only (bool): only fetch from a mirror
+            error_msg (str or None): error message to use if all fetchers fail
+                or ``None`` for the default message
+        """
         fetchers = []
         if not mirror_only:
             fetchers.append(self.default_fetcher)
@@ -480,14 +486,8 @@ class Stage(object):
         else:
             print_errors(errors)
 
-            # Simplify the error name by removing the prefix when present
-            name = self.name if not self.name.startswith(stage_prefix) else \
-                self.name.replace(stage_prefix, '')
-            err = 'Manual download is required' if manual_download else \
-                'All fetchers failed'
-            err_msg = '{0} for {1}'.format(err, name)
             self.fetcher = self.default_fetcher
-            raise fs.FetchError(err_msg, None)
+            raise fs.FetchError(error_msg or 'All fetchers failed', None)
 
         print_errors(errors)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -400,7 +400,7 @@ class Stage(object):
         """Returns the well-known source directory path."""
         return os.path.join(self.path, _source_path_subdir)
 
-    def fetch(self, mirror_only=False):
+    def fetch(self, mirror_only=False, manual_download=False):
         """Downloads an archive or checks out code from a repository."""
         fetchers = []
         if not mirror_only:
@@ -480,7 +480,9 @@ class Stage(object):
         else:
             print_errors(errors)
 
-            err_msg = 'All fetchers failed for {0}'.format(self.name)
+            err = 'Manual download is required' if manual_download else \
+                'All fetchers failed'
+            err_msg = '{0} for {1}'.format(err, self.name)
             self.fetcher = self.default_fetcher
             raise fs.FetchError(err_msg, None)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -400,13 +400,13 @@ class Stage(object):
         """Returns the well-known source directory path."""
         return os.path.join(self.path, _source_path_subdir)
 
-    def fetch(self, mirror_only=False, error_msg=None):
+    def fetch(self, mirror_only=False, err_msg=None):
         """Retrieves the code or archive
 
         Args:
             mirror_only (bool): only fetch from a mirror
-            error_msg (str or None): error message to use if all fetchers fail
-                or ``None`` for the default message
+            err_msg (str or None): the error message to display if all fetchers
+                fail or ``None`` for the default fetch failure message
         """
         fetchers = []
         if not mirror_only:
@@ -487,7 +487,7 @@ class Stage(object):
             print_errors(errors)
 
             self.fetcher = self.default_fetcher
-            raise fs.FetchError(error_msg or 'All fetchers failed', None)
+            raise fs.FetchError(err_msg or 'All fetchers failed', None)
 
         print_errors(errors)
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -560,3 +560,52 @@ def test_macho_make_paths():
                    '/Users/Shared/spack/pkgB/libB.dylib',
                    '/usr/local/lib/libloco.dylib':
                    '/usr/local/lib/libloco.dylib'}
+
+
+@pytest.fixture()
+def mock_download():
+    """Mock a failing download strategy."""
+    class FailedDownloadStrategy(spack.fetch_strategy.FetchStrategy):
+        def mirror_id(self):
+            return None
+
+        def fetch(self):
+            raise spack.fetch_strategy.FailedDownloadError(
+                "<non-existent URL>", "This FetchStrategy always fails")
+
+    fetcher = FetchStrategyComposite()
+    fetcher.append(FailedDownloadStrategy())
+
+    @property
+    def fake_fn(self):
+        return fetcher
+
+    orig_fn = spack.package.PackageBase.fetcher
+    spack.package.PackageBase.fetcher = fake_fn
+    yield
+    spack.package.PackageBase.fetcher = orig_fn
+
+
+@pytest.mark.parametrize("manual,instr", [(False, False), (False, True),
+                                          (True, False), (True, True)])
+@pytest.mark.disable_clean_stage_check
+def test_manual_download(install_mockery, mock_download, monkeypatch, manual,
+                         instr):
+    """
+    Ensure expected fetcher fail message based on manual download and instr.
+    """
+    @property
+    def _instr(pkg):
+        return 'Download instructions for {0}'.format(pkg.spec.name)
+
+    spec = Spec('a').concretized()
+    pkg = spec.package
+
+    pkg.manual_download = manual
+    if instr:
+        monkeypatch.setattr(spack.package.PackageBase, 'download_instr',
+                            _instr)
+
+    expected = pkg.download_instr if manual else 'All fetchers failed'
+    with pytest.raises(spack.fetch_strategy.FetchError, match=expected):
+        pkg.do_fetch()

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -530,15 +530,14 @@ class TestStage(object):
         check_destroy(stage, self.stage_name)
 
     def test_search_if_default_fails(self, failing_fetch_strategy, search_fn):
+        err = 'All fetchers failed'
         stage = Stage(failing_fetch_strategy,
                       name=self.stage_name,
                       search_fn=search_fn)
+
         with stage:
-            try:
+            with pytest.raises(spack.fetch_strategy.FetchError, match=err):
                 stage.fetch(mirror_only=False)
-                assert False, 'Expected fetch to fail'
-            except spack.fetch_strategy.FetchError as err:
-                assert 'All fetchers failed' in str(err)
 
         check_destroy(stage, self.stage_name)
         assert search_fn.performed_search
@@ -547,13 +546,11 @@ class TestStage(object):
         stage = Stage(failing_fetch_strategy,
                       name=self.stage_name,
                       search_fn=search_fn)
+
         msg = 'Manual download is required for test'
         with stage:
-            try:
+            with pytest.raises(spack.fetch_strategy.FetchError, match=msg):
                 stage.fetch(mirror_only=False, error_msg=msg)
-                assert False, 'Expected fetch to fail'
-            except spack.fetch_strategy.FetchError as err:
-                assert 'Manual download is required' in str(err)
 
     def test_ensure_one_stage_entry(self, mock_stage_archive):
         archive = mock_stage_archive()

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -547,9 +547,10 @@ class TestStage(object):
         stage = Stage(failing_fetch_strategy,
                       name=self.stage_name,
                       search_fn=search_fn)
+        msg = 'Manual download is required for test'
         with stage:
             try:
-                stage.fetch(mirror_only=False, manual_download=True)
+                stage.fetch(mirror_only=False, error_msg=msg)
                 assert False, 'Expected fetch to fail'
             except spack.fetch_strategy.FetchError as err:
                 assert 'Manual download is required' in str(err)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -529,28 +529,23 @@ class TestStage(object):
                 pass
         check_destroy(stage, self.stage_name)
 
-    def test_search_if_default_fails(self, failing_fetch_strategy, search_fn):
-        err = 'All fetchers failed'
+    @pytest.mark.parametrize(
+        "err_msg,expected", [('Fetch from fetch.test.com',
+                              'Fetch from fetch.test.com'),
+                             (None, 'All fetchers failed')])
+    def test_search_if_default_fails(self, failing_fetch_strategy, search_fn,
+                                     err_msg, expected):
         stage = Stage(failing_fetch_strategy,
                       name=self.stage_name,
                       search_fn=search_fn)
 
         with stage:
-            with pytest.raises(spack.fetch_strategy.FetchError, match=err):
-                stage.fetch(mirror_only=False)
+            with pytest.raises(spack.fetch_strategy.FetchError,
+                               match=expected):
+                stage.fetch(mirror_only=False, err_msg=err_msg)
 
         check_destroy(stage, self.stage_name)
         assert search_fn.performed_search
-
-    def test_search_manual_download(self, failing_fetch_strategy, search_fn):
-        stage = Stage(failing_fetch_strategy,
-                      name=self.stage_name,
-                      search_fn=search_fn)
-
-        msg = 'Manual download is required for test'
-        with stage:
-            with pytest.raises(spack.fetch_strategy.FetchError, match=msg):
-                stage.fetch(mirror_only=False, error_msg=msg)
 
     def test_ensure_one_stage_entry(self, mock_stage_archive):
         archive = mock_stage_archive()

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -536,10 +536,23 @@ class TestStage(object):
         with stage:
             try:
                 stage.fetch(mirror_only=False)
-            except spack.fetch_strategy.FetchError:
-                pass
+                assert False, 'Expected fetch to fail'
+            except spack.fetch_strategy.FetchError as err:
+                assert 'All fetchers failed' in str(err)
+
         check_destroy(stage, self.stage_name)
         assert search_fn.performed_search
+
+    def test_search_manual_download(self, failing_fetch_strategy, search_fn):
+        stage = Stage(failing_fetch_strategy,
+                      name=self.stage_name,
+                      search_fn=search_fn)
+        with stage:
+            try:
+                stage.fetch(mirror_only=False, manual_download=True)
+                assert False, 'Expected fetch to fail'
+            except spack.fetch_strategy.FetchError as err:
+                assert 'Manual download is required' in str(err)
 
     def test_ensure_one_stage_entry(self, mock_stage_archive):
         archive = mock_stage_archive()


### PR DESCRIPTION
This PR addresses an issue raised in #18043 regarding outputting something more meaningful when fetching fails for packages marked as `manual_download`.

Output before this PR for `matlab` (since it has no dependencies):
```
==> Installing matlab
==> No binary for matlab found: installing from source
==> Error: FetchError: All fetchers failed for spack-stage-matlab-R2019b-2ur3qt5ocgetpzcnxp7wc4lylgddd4rz
<traceback>
```

And using this PR:
```
==> Installing matlab
==> No binary for matlab found: installing from source
==> Error: FetchError: Manual download is required for matlab. Refer to https://www.mathworks.com/products/matlab.html for directions.
<traceback>
```