### PR TITLE
CMake: 3.18.2

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -15,6 +15,7 @@ class Cmake(Package):
 
     executables = ['^cmake$']
 
+    version('3.18.2',   sha256='5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e')
     version('3.18.1',   sha256='c0e3338bd37e67155b9d1e9526fec326b5c541f74857771b7ffed0c46ad62508')
     version('3.18.0',   sha256='83b4ffcb9482a73961521d2bafe4a16df0168f03f56e6624c419c461e5317e29')
     version('3.17.3',   sha256='0bd60d512275dc9f6ef2a2865426a184642ceb3761794e6b65bff233b91d8c40')


### PR DESCRIPTION
Adds the latest CMake release, which fixes a Spectrum-MPI + CUDA<10.2 regression, among others. Relevant for Summit.

https://blog.kitware.com/cmake-3-18-2-available-for-download/