### PR TITLE
PROJ: add v7.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -13,13 +13,17 @@ class Proj(AutotoolsPackage):
     transformations."""
 
     homepage = "https://proj.org/"
-    url      = "https://download.osgeo.org/proj/proj-6.2.0.tar.gz"
+    url      = "https://download.osgeo.org/proj/proj-7.1.0.tar.gz"
 
     maintainers = ['adamjstewart']
 
     # Version 6 removes projects.h, while version 7 removes proj_api.h.
     # Many packages that depend on proj do not yet support the newer API.
     # See https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
+    version('7.1.0', sha256='876151e2279346f6bdbc63bd59790b48733496a957bccd5e51b640fdd26eaa8d')
+    version('7.0.1', sha256='a7026d39c9c80d51565cfc4b33d22631c11e491004e19020b3ff5a0791e1779f')
+    version('7.0.0', sha256='ee0e14c1bd2f9429b1a28999240304c0342ed739ebaea3d4ff44c585b1097be8')
+    version('6.3.2', sha256='cb776a70f40c35579ae4ba04fb4a388c1d1ce025a1df6171350dc19f25b80311')
     version('6.3.1', sha256='6de0112778438dcae30fcc6942dee472ce31399b9e5a2b67e8642529868c86f8')
     version('6.2.0', sha256='b300c0f872f632ad7f8eb60725edbf14f0f8f52db740a3ab23e7b94f1cd22a50')
     version('6.1.0', sha256='676165c54319d2f03da4349cbd7344eb430b225fe867a90191d848dc64788008')
@@ -33,20 +37,54 @@ class Proj(AutotoolsPackage):
     version('4.7.0', sha256='fc5440002a496532bfaf423c28bdfaf9e26cc96c84ccefcdefde911efbd98986')
     version('4.6.1', sha256='76d174edd4fdb4c49c1c0ed8308a469216c01e7177a4510b1b303ef3c5f97b47')
 
-    # https://github.com/OSGeo/proj.4#distribution-files-and-format
+    variant('tiff', default=True, description='Enable TIFF support')
+    variant('curl', default=True, description='Enable curl support')
+
+    # https://github.com/OSGeo/PROJ#distribution-files-and-format
+    # https://github.com/OSGeo/PROJ-data
+    resource(
+        name='proj-data',
+        url='https://download.osgeo.org/proj/proj-data-1.1.tar.gz',
+        sha256='df7c57e60f9e1d5bcc724f1def71d2a7cd33bd83c28f4b4bb71dbb2d8849c84a',
+        placement='nad',
+        when='@7:',
+    )
+
+    # https://github.com/OSGeo/PROJ#distribution-files-and-format
     # https://github.com/OSGeo/proj-datumgrid
     resource(
         name='proj-datumgrid',
         url='https://download.osgeo.org/proj/proj-datumgrid-1.8.tar.gz',
         sha256='3ff6618a0acc9f0b9b4f6a62e7ff0f7bf538fb4f74de47ad04da1317408fcc15',
-        placement='nad'
+        placement='nad',
+        when='@:6',
     )
 
-    # @6 appears to be the first version with dependencies
+    # https://proj.org/install.html#build-requirements
     depends_on('pkgconfig@0.9.0:', type='build', when='@6:')
-    depends_on('sqlite@3.7:', when='@6:')
+    depends_on('googletest', when='@6:')
+    depends_on('sqlite@3.11:', when='@6:')
+    depends_on('libtiff@4.0:', when='@7:+tiff')
+    depends_on('curl@7.29.0:', when='@7:+curl')
 
     def configure_args(self):
-        return [
+        args = [
             'PROJ_LIB={0}'.format(join_path(self.stage.source_path, 'nad'))
         ]
+
+        if self.spec.satisfies('@6:'):
+            args.append('--with-external-gtest')
+
+        if self.spec.satisfies('@7:'):
+            if '+tiff' in self.spec:
+                args.append('--enable-tiff')
+            else:
+                args.append('--disable-tiff')
+
+            if '+curl' in self.spec:
+                args.append('--with-curl=' + self.spec['curl'].prefix.bin.join(
+                    'curl-config'))
+            else:
+                args.append('--without-curl')
+
+        return args


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 11.0.3.

I'm hoping that this will be a less painful version bump than when we added PROJ 5 or PROJ 6. Originally the PROJ developers planned on dropping `proj_api.h` in PROJ 7, but they decided to punt this to PROJ 8. I tested this with GDAL, cartopy, and libgeotiff and all build fine with PROJ 7.