### PR TITLE
py-shapely: add v1.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -12,7 +12,7 @@ class PyShapely(PythonPackage):
     """
 
     homepage = "https://github.com/Toblerity/Shapely"
-    url      = "https://pypi.io/packages/source/S/Shapely/Shapely-1.7.0.tar.gz"
+    url      = "https://pypi.io/packages/source/S/Shapely/Shapely-1.7.1.tar.gz"
     git      = "https://github.com/Toblerity/Shapely.git"
 
     maintainers = ['adamjstewart']
@@ -22,8 +22,8 @@ class PyShapely(PythonPackage):
     ]
 
     version('master', branch='master')
+    version('1.7.1', sha256='1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129')
     version('1.7.0', sha256='e21a9fe1a416463ff11ae037766fe410526c95700b9e545372475d2361cc951e')
-    version('1.6.4.post2', sha256='c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f')
     version('1.6.4', sha256='b10bc4199cfefcf1c0e5d932eac89369550320ca4bdf40559328d85f1ca4f655')
 
     depends_on('python@3.5:', when='@1.8:', type=('build', 'run'))
@@ -40,7 +40,7 @@ class PyShapely(PythonPackage):
     # https://github.com/Toblerity/Shapely/pull/891
     patch('https://github.com/Toblerity/Shapely/commit/98f6b36710bbe05b4ab59231cb0e08b06fe8b69c.patch',
           sha256='4984cd0590beb5091f213948a953f70cea08ea11c5db1de07ba98c19e3d13f06',
-          when='@:1.7')
+          when='@:1.7.0')
 
     @when('^python@3.7:')
     def patch(self):


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.7.8 and Apple Clang 11.0.3.