### PR TITLE
py-cartopy: add v0.18.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cartopy/package.py
+++ b/var/spack/repos/builtin/packages/py-cartopy/package.py
@@ -10,7 +10,7 @@ class PyCartopy(PythonPackage):
     """Cartopy - a cartographic python library with matplotlib support."""
 
     homepage = "https://scitools.org.uk/cartopy/docs/latest/"
-    url      = "https://github.com/SciTools/cartopy/archive/v0.17.0.tar.gz"
+    url      = "https://github.com/SciTools/cartopy/archive/v0.18.0.tar.gz"
 
     maintainers = ['adamjstewart']
     import_modules = [
@@ -18,33 +18,35 @@ class PyCartopy(PythonPackage):
         'cartopy.examples', 'cartopy.mpl', 'cartopy.feature',
     ]
 
+    version('0.18.0', sha256='493ced4698361ffabec1a213d2b711dc836117242c304f3b93f5406182fd8bc2')
     version('0.17.0', sha256='137642e63952404ec0841fa0333ad14c58fbbf19cca2a5ac6a38498c4b4998fb')
     version('0.16.0', sha256='cadf62434492c965220b37f0548bc58180466ad6894a1db57dbc51cd43467e5c')
-
-    # https://scitools.org.uk/cartopy/docs/latest/installing.html#installing
-    depends_on('python@2.7:', type=('build', 'run'))
-    depends_on('py-setuptools@0.7.2:', type='build')
-    depends_on('py-cython@0.15.1:',    type='build')
-    depends_on('py-numpy@1.10.0:',  type=('build', 'run'))
-    depends_on('py-shapely@1.5.6:', type=('build', 'run'))
-    depends_on('py-pyshp@1.1.4:',   type=('build', 'run'))
-    depends_on('py-six@1.3.0:',     type=('build', 'run'))
-    depends_on('geos@3.3.3:')
-    depends_on('proj@4.9.0:5', when='@0.16.0')
-    depends_on('proj@4.9:',    when='@0.17.0')
 
     variant('epsg', default=False, description='Add support for epsg.io')
     variant('ows', default=False, description='Add support for Open Geospatial Consortium (OGC) web service')
     variant('plotting', default=False, description='Add plotting functionality')
 
+    # https://scitools.org.uk/cartopy/docs/latest/installing.html#installing
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('py-setuptools@0.7.2:', type='build')
+    depends_on('py-cython@0.28:',    type='build')
+    depends_on('py-numpy@1.10.0:',  type=('build', 'run'))
+    depends_on('py-shapely@1.5.6:', type=('build', 'run'))
+    depends_on('py-pyshp@1.1.4:',   type=('build', 'run'))
+    depends_on('py-six@1.3.0:',     type=('build', 'run'))
+    depends_on('py-futures', when='^python@:2', type=('build', 'run'))
+    depends_on('geos@3.3.3:')
+    depends_on('proj@4.9.0:5', when='@:0.16.0')
+    depends_on('proj@4.9:',    when='@0.17.0:')
+
     # Optional dependecies
+    depends_on('py-pyepsg@0.4.0:',     type=('build', 'run'), when='+epsg')
+    depends_on('py-owslib@0.8.11:',    type=('build', 'run'), when='+ows')
+    depends_on('py-pillow@1.7.8:',     type=('build', 'run'), when='+ows')
     depends_on('py-matplotlib@1.5.1:', type=('build', 'run'), when='+plotting')
     depends_on('gdal@1.10.0:+python',  type=('build', 'run'), when='+plotting')
-    depends_on('py-pillow@1.7.8:',     type=('build', 'run'), when='+ows')
     depends_on('py-pillow@1.7.8:',     type=('build', 'run'), when='+plotting')
-    depends_on('py-pyepsg@0.2.0:',     type=('build', 'run'), when='+epsg')
     depends_on('py-scipy@0.10:',       type=('build', 'run'), when='+plotting')
-    depends_on('py-owslib@0.8.11:',    type=('build', 'run'), when='+ows')
 
     # Testing dependencies
     depends_on('py-filelock',      type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.7.8 and Apple Clang 11.0.3.