### PR TITLE
python: switch to +uuid by default

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -129,7 +129,7 @@ class Python(AutotoolsPackage):
     variant('pyexpat',  default=True,  description='Build pyexpat module')
     variant('ctypes',   default=True,  description='Build ctypes module')
     variant('tkinter',  default=False, description='Build tkinter module')
-    variant('uuid',     default=False, description='Build uuid module')
+    variant('uuid',     default=True,  description='Build uuid module')
     variant('tix',      default=False, description='Build Tix module')
 
     depends_on('pkgconfig@0.9.0:', type='build')


### PR DESCRIPTION
Spack uses Python's `uuid` module if it is available. On macOS, `+uuid` adds no extra dependencies. I think we should enable this module by default for the best Spack experience.