### PR TITLE
CMake: Update GCC on macOS Conflict message

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -101,11 +101,13 @@ class Cmake(Package):
     variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
     # Tries to build an Objective-C file from libuv with GCC's C frontend
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/20620
     # https://github.com/libuv/libuv/issues/2805
-    conflicts('%gcc platform=darwin',
-              msg='CMake does not compile with GCC on macOS yet, use clang. '
-                  'See: https://gitlab.kitware.com/cmake/cmake/-/issues/20620')
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4687
+    _msg_gcc_macOS = 'CMake<3.18.0 does not compile with GCC on macOS, ' \
+                     'use %apple-clang.'
+    conflicts('@:3.17.99 %gcc +ownlibs platform=darwin', msg=_msg_gcc_macOS)
+    conflicts('%gcc ~ownlibs ^libuv@:1.37.99 platform=darwin',
+              msg=_msg_gcc_macOS)
 
     # Really this should conflict since it's enabling or disabling openssl for
     # CMake's internal copy of curl.  Ideally we'd want a way to have the

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -100,14 +100,11 @@ class Cmake(Package):
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
     variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
-    # Tries to build an Objective-C file from libuv with GCC's C frontend
-    # https://github.com/libuv/libuv/issues/2805
-    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4687
-    _msg_gcc_macOS = 'CMake<3.18.0 does not compile with GCC on macOS, ' \
-                     'use %apple-clang.'
-    conflicts('@:3.17.99 %gcc +ownlibs platform=darwin', msg=_msg_gcc_macOS)
-    conflicts('%gcc ~ownlibs ^libuv@:1.37.99 platform=darwin',
-              msg=_msg_gcc_macOS)
+    # Does not compile and is not covered in upstream CI (yet).
+    conflicts('%gcc platform=darwin',
+              msg='CMake does not compile with GCC on macOS yet, '
+                  'please use %apple-clang. '
+                  'See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135')
 
     # Really this should conflict since it's enabling or disabling openssl for
     # CMake's internal copy of curl.  Ideally we'd want a way to have the


### PR DESCRIPTION
The latest release of CMake updates libuv, which fixes ObjC code usage on macOS. Passing ObjC code to non apple-clang compilers crashed the build before #16249.

But there are further issues to address before this conflict can be removed.

Refs.:
- https://gitlab.kitware.com/cmake/cmake/-/issues/20620 (fixed)
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4687 (merged)
- https://gitlab.kitware.com/cmake/cmake/-/issues/21135 (open)