### PR TITLE
allow 4.08 and 4.09 to build with gcc10

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/fix-duplicate-defs.patch
+++ b/var/spack/repos/builtin/packages/ocaml/fix-duplicate-defs.patch
@@ -1,0 +1,41 @@
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Thu, 12 Dec 2019 16:41:17 +0100
+Subject: Avoid duplicate definitions of "common" global variables
+
+The variables are caml_debug_info and caml_atom_table.
+The multiple definitions look like a cut-and-paste error.
+They cause problems with C compilers that don't follow the "common" model.
+
+Bug: https://github.com/ocaml/ocaml/issues/9144
+Bug-Debian: https://bugs.debian.org/957623
+---
+ runtime/backtrace.c   | 3 ---
+ runtime/startup_nat.c | 1 -
+ 2 files changed, 4 deletions(-)
+
+diff --git a/runtime/backtrace.c b/runtime/backtrace.c
+index a3c2c08..ddf7af1 100644
+--- a/runtime/backtrace.c
++++ b/runtime/backtrace.c
+@@ -27,9 +27,6 @@
+ #include "caml/backtrace_prim.h"
+ #include "caml/fail.h"
+ 
+-/* The table of debug information fragments */
+-struct ext_table caml_debug_info;
+-
+ CAMLexport int32_t caml_backtrace_active = 0;
+ CAMLexport int32_t caml_backtrace_pos = 0;
+ CAMLexport backtrace_slot * caml_backtrace_buffer = NULL;
+diff --git a/runtime/startup_nat.c b/runtime/startup_nat.c
+index 43b85e3..5b20036 100644
+--- a/runtime/startup_nat.c
++++ b/runtime/startup_nat.c
+@@ -44,7 +44,6 @@
+ #endif
+ 
+ extern int caml_parser_trace;
+-CAMLexport header_t caml_atom_table[256];
+ char * caml_code_area_start, * caml_code_area_end;
+ struct ext_table caml_code_fragments_table;
+ 

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -12,9 +12,7 @@ class Ocaml(Package):
 
     homepage = "http://ocaml.org/"
     url      = "https://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz"
-
     maintainers = ['scemama']
-
     version('4.10.0', sha256='58d431dde66f5750ebe9b15d5a1c4872f80d283dec23448689b0d1a498b7e4c7')
     version('4.09.0', sha256='2b728f8a0e90da14f22fdc04660f2ab33819cdbb12bff0ceae3fdbb0133cf7a6')
     version('4.08.1', sha256='ee50118ee88472fd4b64311fa560f8f8ab66a1899f0117815c69a16070980f78')
@@ -27,8 +25,6 @@ class Ocaml(Package):
     patch('fix-duplicate-defs.patch', when="@4.08.0:4.09.0 %gcc@10.0:")
     depends_on('ncurses')
     sanity_check_file = ['bin/ocaml']
-
-
     variant(
         'force-safe-string', default=True,
         description='Enforce safe (immutable) strings'

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -12,7 +12,9 @@ class Ocaml(Package):
 
     homepage = "http://ocaml.org/"
     url      = "https://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz"
+
     maintainers = ['scemama']
+
     version('4.10.0', sha256='58d431dde66f5750ebe9b15d5a1c4872f80d283dec23448689b0d1a498b7e4c7')
     version('4.09.0', sha256='2b728f8a0e90da14f22fdc04660f2ab33819cdbb12bff0ceae3fdbb0133cf7a6')
     version('4.08.1', sha256='ee50118ee88472fd4b64311fa560f8f8ab66a1899f0117815c69a16070980f78')
@@ -22,9 +24,12 @@ class Ocaml(Package):
     version('4.06.1', sha256='0c38c6f531103e87fab1c218a7e76287d7cb4d7ee4dea64e7f85952af3b1b50e')
     version('4.06.0', sha256='c17578e243c4b889fe53a104d8927eb8749c7be2e6b622db8b3c7b386723bf50')
     version('4.03.0', sha256='7fdf280cc6c0a2de4fc9891d0bf4633ea417046ece619f011fd44540fcfc8da2')
+
     patch('fix-duplicate-defs.patch', when="@4.08.0:4.09.0 %gcc@10.0:")
     depends_on('ncurses')
+
     sanity_check_file = ['bin/ocaml']
+
     variant(
         'force-safe-string', default=True,
         description='Enforce safe (immutable) strings'

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -24,10 +24,10 @@ class Ocaml(Package):
     version('4.06.1', sha256='0c38c6f531103e87fab1c218a7e76287d7cb4d7ee4dea64e7f85952af3b1b50e')
     version('4.06.0', sha256='c17578e243c4b889fe53a104d8927eb8749c7be2e6b622db8b3c7b386723bf50')
     version('4.03.0', sha256='7fdf280cc6c0a2de4fc9891d0bf4633ea417046ece619f011fd44540fcfc8da2')
-
+    patch('fix-duplicate-defs.patch', when="@4.08.0:4.09.0 %gcc@10.0:")
     depends_on('ncurses')
-
     sanity_check_file = ['bin/ocaml']
+
 
     variant(
         'force-safe-string', default=True,


### PR DESCRIPTION
fixes #18228.  This patch doesn't cover all old versions but it
allows packages like whizard to build.