### PR TITLE
Allow configuring spack load from modules.yaml

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -5,6 +5,7 @@
 import sys
 import os
 
+import spack.config
 import spack.util.prefix as prefix
 import spack.util.environment as environment
 import spack.build_environment as build_env
@@ -25,6 +26,10 @@ def prefix_inspections(platform):
         A dictionary mapping subdirectory names to lists of environment
             variables to modify with that directory if it exists.
     """
+    inspections = spack.config.get('modules:prefix_inspections', None)
+    if inspections is not None:
+        return inspections
+
     inspections = {
         'bin': ['PATH'],
         'lib': ['LD_LIBRARY_PATH', 'LIBRARY_PATH'],


### PR DESCRIPTION
`spack load` didn't use the `prefix_inspections` from modules.yaml at all. All the other module systems use this mechanism to allow the user to configure those inspections.

Let's take the prefix_inspections from modules.yaml configuration. If that is not available fall back to the old behaviour.