### PR TITLE
Trilinos: Add Version 13.0.0 and PYTHONPATH for exodus.py

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -35,6 +35,7 @@ class Trilinos(CMakePackage):
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
     version('develop', branch='develop')
     version('master', branch='master')
+    version('13.0.0', commit='9fec35276d846a667bc668ff4cbdfd8be0dfea08')  # tag trilinos-release-13-0-0
     version('12.18.1', commit='55a75997332636a28afc9db1aee4ae46fe8d93e7')  # tag trilinos-release-12-8-1
     version('12.14.1', sha256='52a4406cca2241f5eea8e166c2950471dd9478ad6741cbb2a7fc8225814616f0')
     version('12.12.1', sha256='5474c5329c6309224a7e1726cf6f0d855025b2042959e4e2be2748bd6bb49e18')
@@ -768,3 +769,9 @@ class Trilinos(CMakePackage):
                         (r'\1\3'),
                         '%s/cmake/Trilinos/TrilinosConfig.cmake' %
                         self.prefix.lib)
+
+    def setup_run_environment(self, env):
+        if '+exodus' in self.spec:
+            env.prepend_path('PYTHONPATH',
+                             self.prefix.lib)
+

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -774,4 +774,3 @@ class Trilinos(CMakePackage):
         if '+exodus' in self.spec:
             env.prepend_path('PYTHONPATH',
                              self.prefix.lib)
-


### PR DESCRIPTION
Version 13.0.0 contains fixes for gcc-10 in SEACAS

SEACAS builds an exodus2.py and exodus3.py which are in the lib directory for interacting with exodus files through python