### PR TITLE
dbus: Add libsm dependency (fix for issue #18267)

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -30,6 +30,7 @@ class Dbus(Package):
     depends_on('pkgconfig', type='build')
     depends_on('expat')
     depends_on('glib')
+    depends_on('libsm')
 
     def install(self, spec, prefix):
         configure(


### PR DESCRIPTION
dbus has a dependency on libSM which was not being declared (and would
normally be satisfied by using system libraries).

Fixes #18267