### PR TITLE
package preferences: allow specs to be configured buildable when their virtuals are not

### DIFF
--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -211,6 +211,7 @@ def is_spec_buildable(spec):
     spec_buildable = allpkgs.get(spec.name, {}).get("buildable", so_far)
     return spec_buildable
 
+
 def get_package_dir_permissions(spec):
     """Return the permissions configured for the spec.
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -195,24 +195,21 @@ def spec_externals(spec):
 
 def is_spec_buildable(spec):
     """Return true if the spec is configured as buildable"""
-
     allpkgs = spack.config.get("packages")
     all_buildable = allpkgs.get("all", {}).get("buildable", True)
+    so_far = all_buildable  # the default "so far"
 
     def _package(s):
         pkg_cls = spack.repo.path.get_pkg_class(s.name)
         return pkg_cls(s)
 
-    # Get the list of names for which all_buildable is overridden
-    reverse = [
-        name
-        for name, entry in allpkgs.items()
-        if entry.get("buildable", all_buildable) != all_buildable
-    ]
-    # Does this spec override all_buildable
-    spec_reversed = spec.name in reverse or any(_package(spec).provides(name) for name in reverse)
-    return not all_buildable if spec_reversed else all_buildable
+    # check whether any providers for this package override the default
+    if any(_package(spec).provides(name) and entry.get("buildable", so_far) != so_far
+           for name, entry in allpkgs.items()):
+        so_far = not so_far
 
+    spec_buildable = allpkgs.get(spec.name, {}).get("buildable", so_far)
+    return spec_buildable
 
 def get_package_dir_permissions(spec):
     """Return the permissions configured for the spec.

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -204,8 +204,10 @@ def is_spec_buildable(spec):
         return pkg_cls(s)
 
     # check whether any providers for this package override the default
-    if any(_package(spec).provides(name) and entry.get("buildable", so_far) != so_far
-           for name, entry in allpkgs.items()):
+    if any(
+        _package(spec).provides(name) and entry.get("buildable", so_far) != so_far
+        for name, entry in allpkgs.items()
+    ):
         so_far = not so_far
 
     spec_buildable = allpkgs.get(spec.name, {}).get("buildable", so_far)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -348,6 +348,21 @@ mpi:
         spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
+    def test_buildable_false_virtual_true_pacakge(self):
+        conf = syaml.load_config("""\
+mpi:
+  buildable: false
+mpich:
+  buildable: true
+""")
+        spack.config.set('packages', conf, scope='concretize')
+
+        spec = Spec('zmpi')
+        assert not spack.package_prefs.is_spec_buildable(spec)
+
+        spec = Spec('mpich')
+        assert spack.package_prefs.is_spec_buildable(spec)
+
     def test_config_permissions_from_all(self, configure_permissions):
         # Although these aren't strictly about concretization, they are
         # configured in the same file and therefore convenient to test here.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -349,18 +349,20 @@ mpi:
         assert spack.package_prefs.is_spec_buildable(spec)
 
     def test_buildable_false_virtual_true_pacakge(self):
-        conf = syaml.load_config("""\
+        conf = syaml.load_config(
+            """\
 mpi:
   buildable: false
 mpich:
   buildable: true
-""")
-        spack.config.set('packages', conf, scope='concretize')
+"""
+        )
+        spack.config.set("packages", conf, scope="concretize")
 
-        spec = Spec('zmpi')
+        spec = Spec("zmpi")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-        spec = Spec('mpich')
+        spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
     def test_config_permissions_from_all(self, configure_permissions):


### PR DESCRIPTION
This will allow users to specify a hard constraint on a single provider of a virtual packages:
```
packages:
  mpi:
    buildable: false
  mpich:
    buildable: true
```
or
```
$ spack config add packages:mpi:buildable:false
$ spack config add packages:mpich:buildable:true
```