### PR TITLE
SLOCCount: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/sloccount/package.py
+++ b/var/spack/repos/builtin/packages/sloccount/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Sloccount(MakefilePackage):
+    """SLOCCount is a set of tools for counting physical Source Lines of Code
+    (SLOC) in a large number of languages of a potentially large set of
+    programs."""
+
+    homepage = "https://dwheeler.com/sloccount/"
+    url      = "https://dwheeler.com/sloccount/sloccount-2.26.tar.gz"
+
+    version('2.26', sha256='fa7fa2bbf2f627dd2d0fdb958bd8ec4527231254c120a8b4322405d8a4e3d12b')
+
+    # md5sum needed at run-time
+    depends_on('coreutils', type=('build', 'run'))
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter('makefile')
+        makefile.filter('^PREFIX=.*', 'PREFIX=' + prefix)
+        makefile.filter('^CC=.*', 'CC=' + spack_cc)
+
+        # Needed for `make test` to pass
+        makefile.filter('PATH=.:${PATH}', 'PATH=$(CURDIR):${PATH}',
+                        string=True)
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        make('install')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 11.0.3.

For the record, the output for `spack` is:
```console
$ sloccount .
...
SLOC	Directory	SLOC-by-Language (Sorted)
114063  var             python=113220,sh=609,ansic=205,cpp=29
104986  lib             python=103355,ansic=1225,sh=402,tcl=4
2310    share           sh=2112,csh=129,tcl=69
53      bin             sh=53
0       etc             (none)
0       top_dir         (none)


Totals grouped by language (dominant language first):
python:      216575 (97.82%)
sh:            3176 (1.43%)
ansic:         1430 (0.65%)
csh:            129 (0.06%)
tcl:             73 (0.03%)
cpp:             29 (0.01%)




Total Physical Source Lines of Code (SLOC)                = 221,412
Development Effort Estimate, Person-Years (Person-Months) = 58.01 (696.10)
 (Basic COCOMO model, Person-Months = 2.4 * (KSLOC**1.05))
Schedule Estimate, Years (Months)                         = 2.51 (30.07)
 (Basic COCOMO model, Months = 2.5 * (person-months**0.38))
Estimated Average Number of Developers (Effort/Schedule)  = 23.15
Total Estimated Cost to Develop                           = $ 7,836,152
 (average salary = $56,286/year, overhead = 2.40).
```