### PR TITLE
Remove unmatched triple quotes

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -70,6 +70,6 @@ def python(parser, args, unknown_args):
         # Provides readline support, allowing user to use arrow keys
         console.push('import readline')
 
-        console.interact("Spack version %s\nPython %s, %s %s"""
+        console.interact("Spack version %s\nPython %s, %s %s"
                          % (spack.spack_version, platform.python_version(),
                             platform.system(), platform.machine()))

--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -11,7 +11,7 @@ class Pcre2(AutotoolsPackage):
        libraries. These are useful for implementing regular expression
        pattern matching using the same syntax and semantics as Perl 5."""
 
-    homepage = "http://www.pcre.org"""
+    homepage = "http://www.pcre.org"
     url      = "https://ftp.pcre.org/pub/pcre/pcre2-10.31.tar.bz2"
 
     version('10.35', sha256='9ccba8e02b0ce78046cdfb52e5c177f0f445e421059e43becca4359c669d4613')

--- a/var/spack/repos/builtin/packages/py-snuggs/package.py
+++ b/var/spack/repos/builtin/packages/py-snuggs/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PySnuggs(PythonPackage):
     """Snuggs are s-expressions for Numpy"""
 
-    homepage = "https://github.com/mapbox/snuggs"""
+    homepage = "https://github.com/mapbox/snuggs"
     url      = "https://github.com/mapbox/snuggs/archive/1.4.1.zip"
 
     version('1.4.1', sha256='b37ed4e11c5f372695dc6fe66fce6cede124c90a920fe4726c970c9293b71233')


### PR DESCRIPTION
Somehow this isn't a syntax error in Python, and flake8 doesn't catch it either, but SLOCCount warned me about it.