### PR TITLE
conduit: add Fujitsu fortran options

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/fj_flags.patch
+++ b/var/spack/repos/builtin/packages/conduit/fj_flags.patch
@@ -1,0 +1,14 @@
+diff -u -r -N a/src/blt/cmake/SetupCompilerOptions.cmake b/src/blt/cmake/SetupCompilerOptions.cmake
+--- a/src/blt/cmake/SetupCompilerOptions.cmake	2020-08-26 11:58:24.000000000 +0900
++++ b/src/blt/cmake/SetupCompilerOptions.cmake	2020-08-26 13:31:04.000000000 +0900
+@@ -206,7 +206,9 @@
+ 
+ endif()
+ 
+-
++set(CMAKE_Fortran_MODDIR_FLAG -M)
++set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
++set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "--linkfortran")
+ 
+ ################################
+ # RPath Settings

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -85,7 +85,7 @@ class Conduit(Package):
     # CMake
     #######################
     # cmake 3.8.2 or newer
-    depends_on("cmake@3.8.2:3.17.9999", type='build')
+    depends_on("cmake@3.8.2:", type='build')
 
     #######################
     # Python
@@ -144,6 +144,10 @@ class Conduit(Package):
     depends_on("py-sphinx", when="+python+doc", type='build')
     depends_on("py-sphinx-rtd-theme", when="+python+doc", type='build')
     depends_on("doxygen", when="+doc+doxygen")
+
+    # Tentative patch for fj compiler
+    # Cmake will support fj compiler and this patch will be removed
+    patch('fj_flags.patch', when='%fj')
 
     # build phases used by this package
     phases = ["configure", "build", "install"]


### PR DESCRIPTION
1. Cmake version
`cmake@3.8.2:3.17.9999` is not equal to `# cmake 3.8.2 or newer`
So I fixed version specification.

2. Fujitsu Fortran options
Cmake cannot recognize Fujitsu Fortran compiler now.
So set Fortran compiler options manually. 
Patch for Cmake is working now, so this patch is tentative.