### PR TITLE
sirius, q-e-sirius

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -57,7 +57,7 @@ class QESirius(Package):
     depends_on('blas')
     depends_on('lapack')
     depends_on('fftw-api@3')
-    depends_on('sirius+fortran')
+    depends_on('sirius+fortran+shared')
     depends_on('mpi', when='+mpi')
     depends_on('scalapack', when='+scalapack+mpi')
     depends_on('elpa+openmp', when='+elpa+openmp')
@@ -172,7 +172,6 @@ class QESirius(Package):
         options = ['-prefix={0}'.format(prefix_path)]
 
         sirius = spec['sirius']
-
         options.append('LIBS={0}'.format(sirius.libs[0]))
         options.append('LD_LIBS={0}'.format(sirius.libs[0]))
 
@@ -203,7 +202,7 @@ class QESirius(Package):
         f90flags = 'F90FLAGS=-cpp -I {0}/sirius'.format(header_dir)
 
         if self.spec.satisfies('%gcc@10:'):
-            f90flags += '-fallow-argument-mismatch'
+            f90flags += ' -fallow-argument-mismatch'
 
         options.append(f90flags)
 

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -44,7 +44,7 @@ class Sirius(CMakePackage, CudaPackage):
         'gfx1011', 'gfx1012'
     )
 
-    variant('shared', default=False, description="Build shared libraries")
+    variant('shared', default=True, description="Build shared libraries")
     variant('openmp', default=True, description="Build with OpenMP support")
     variant('fortran', default=False, description="Build Fortran bindings")
     variant('python', default=False, description="Build Python bindings")
@@ -161,8 +161,7 @@ class Sirius(CMakePackage, CudaPackage):
             _def('+rocm')
         ]
 
-        if '@:6.2.999' in self.spec:
-            args += [_def('+shared', 'BUILD_SHARED_LIBS')]
+        args += [_def('+shared', 'BUILD_SHARED_LIBS')]
 
         lapack = spec['lapack']
         blas = spec['blas']


### PR DESCRIPTION
- sirius: fix bug `~/+shared` (`~shared` was not properly passed to cmake)
- sirius: make `+shared` the default
- q-e-sirius: explicitly depend on `sirius+shared`, fix gcc@10 workaround