### PR TITLE
release procedure: add step to activate the documentation on readthedocs

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -620,12 +620,12 @@ for a major release, the steps to make the release are as follows:
 #. Bump the version in ``lib/spack/spack/__init__.py``. See `this example from 0.13.0
    <https://github.com/spack/spack/commit/8eeb64096c98b8a43d1c587f13ece743c864fba9>`_
 
-#. Updaate the release version lists in these files to include the new version:
+#. Update the release version lists in these files to include the new version:
 
    * ``lib/spack/spack/schema/container.py``
    * ``lib/spack/spack/container/images.json``
 
-   **TODO**: We should get rid of this step in some future release.
+.. TODO: We should get rid of this step in some future release.
 
 #. Update ``CHANGELOG.md`` with major highlights in bullet form. Use
    proper markdown formatting, like `this example from 0.15.0
@@ -634,6 +634,7 @@ for a major release, the steps to make the release are as follows:
 #. Push the release branch to GitHub.
 
 #. Make sure CI passes on the release branch, including:
+
    * Regular unit tests
    * Build tests
    * The E4S pipeline at `gitlab.spack.io <https://gitlab.spack.io>`_
@@ -794,6 +795,10 @@ Publishing a release on GitHub
       links. See the `releases
       page <https://api.github.com/repos/spack/spack/releases>`_ and search
       for ``download_count`` to see this.
+
+#. Go to `readthedocs.org <https://readthedocs.org/projects/spack>`_ and activate
+   the release tag. This builds the documentation and makes the released version
+   selectable in the versions menu.
 
 
 .. _merging-releases:


### PR DESCRIPTION
I noticed today that we didn't have handles for any of the v0.15.X versions. Activating the corresponding tags on readthedocs built the documentation and made it selectable:

![Screenshot from 2020-08-26 17-27-30](https://user-images.githubusercontent.com/4199709/91323685-740dfe80-e7c1-11ea-86ca-4eab9e1aac8b.png)


