### PR TITLE
sbang: add support for php

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -71,6 +71,17 @@
 #     3
 #     4    print "success!"
 #
+# For php, scripts the second line can't start with #!, as # is not
+# the comment character in php (even though php ignores #! on the
+# *first* line of a script).  So, instrument a php script like this,
+# using -- instead of # on the second line:
+#
+#     1    #!/bin/bash /path/to/sbang
+#     2    <?php  #/long/path/to/lua with arguments
+#     3    >?
+#     3
+#     4    <?php echo "success!" ?>
+#
 # How it works
 # -----------------------------
 # `sbang` is a very simple bash script. It looks at the first two
@@ -90,6 +101,8 @@ while read line && ((lines < 2)) ; do
         interpreter="${line#//!}"
     elif [[ "$line" = '--!'*lua* ]]; then
         interpreter="${line#--!}"
+    elif [[ "$line" = '<?php #!'*php* ]]; then
+        interpreter="${line#<?php\ \#}"
     fi
     lines=$((lines+1))
 done < "$script"

--- a/bin/sbang
+++ b/bin/sbang
@@ -61,26 +61,23 @@
 # Obviously, for this to work, `sbang` needs to have a short enough
 # path that *it* will run without hitting OS limits.
 #
-# For Lua, scripts the second line can't start with #!, as # is not
-# the comment character in lua (even though lua ignores #! on the
-# *first* line of a script).  So, instrument a lua script like this,
-# using -- instead of # on the second line:
+# For Lua, node, and php scripts, the second line can't start with #!, as
+# # is not the comment character in these languages (though they all
+# ignore #! on the *first* line of a script). So, instrument such scripts
+# like this, using --, //, or <?php ... ?> instead of # on the second
+# line, e.g.:
 #
 #     1    #!/bin/bash /path/to/sbang
 #     2    --!/long/path/to/lua with arguments
-#     3
-#     4    print "success!"
-#
-# For php, scripts the second line can't start with #!, as # is not
-# the comment character in php (even though php ignores #! on the
-# *first* line of a script).  So, instrument a php script like this,
-# using -- instead of # on the second line:
+#     3    print "success!"
 #
 #     1    #!/bin/bash /path/to/sbang
-#     2    <?php  #/long/path/to/lua with arguments
-#     3    >?
-#     3
-#     4    <?php echo "success!" ?>
+#     2    //!/long/path/to/node with arguments
+#     3    print "success!"
+#
+#     1    #!/bin/bash /path/to/sbang
+#     2    <?php #/long/path/to/php with arguments ?>
+#     3    <?php echo "success!\n"; ?>
 #
 # How it works
 # -----------------------------
@@ -102,7 +99,8 @@ while read line && ((lines < 2)) ; do
     elif [[ "$line" = '--!'*lua* ]]; then
         interpreter="${line#--!}"
     elif [[ "$line" = '<?php #!'*php* ]]; then
-        interpreter="${line#<?php\ \#}"
+        interpreter="${line#<?php\ \#!}"
+        interpreter="${interpreter%\ ?>}"
     fi
     lines=$((lines+1))
 done < "$script"
@@ -111,7 +109,7 @@ done < "$script"
 # #!/<spack-long-path>/perl -w
 # this is the interpreter line with all the parameters as a vector
 interpreter_v=(${interpreter})
-# this is the single interpreter path 
+# this is the single interpreter path
 interpreter_f="${interpreter_v[0]}"
 
 # Invoke any interpreter found, or raise an error if none was found.

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -64,6 +64,10 @@ def filter_shebang(path):
     if re.search(r'^#!(/[^/\n]*)*lua\b', original):
         original = re.sub(r'^#', '--', original)
 
+    # Use <?php #! instead of #! on second line for php.
+    if re.search(r'^#!(/[^/\n]*)*php\b', original):
+        original = re.sub(r'^#', '<?php #', original) + '\n?>'
+
     # Use //! instead of #! on second line for node.js.
     if re.search(r'^#!(/[^/\n]*)*node\b', original):
         original = re.sub(r'^#', '//', original)

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -66,7 +66,7 @@ def filter_shebang(path):
 
     # Use <?php #! instead of #! on second line for php.
     if re.search(r'^#!(/[^/\n]*)*php\b', original):
-        original = re.sub(r'^#', '<?php #', original) + '\n?>'
+        original = re.sub(r'^#', '<?php #', original) + ' ?>'
 
     # Use //! instead of #! on second line for node.js.
     if re.search(r'^#!(/[^/\n]*)*node\b', original):

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -30,6 +30,11 @@ node_line         = "#!/this/" + ('x' * 200) + "/is/node\n"
 node_in_text      = ("line\n") * 100 + "lua\n" + ("line\n" * 100)
 node_line_patched = "//!/this/" + ('x' * 200) + "/is/node\n"
 sbang_line        = '#!/bin/bash %s/bin/sbang\n' % spack.store.layout.root
+php_line         = "#!/this/" + ('x' * 200) + "/is/php\n"
+php_in_text      = ("line\n") * 100 + "php\n" + ("line\n" * 100)
+php_line_patched = "<?php #!/this/" + ('x' * 200) + "/is/php\n"
+php_line_patched2 = "?>\n"
+sbang_line        = '#!/bin/bash %s/bin/sbang\n' % spack.store.layout.root
 last_line         = "last!\n"
 
 
@@ -77,6 +82,19 @@ class ScriptDirectory(object):
         with open(self.node_textbang, 'w') as f:
             f.write(short_line)
             f.write(node_in_text)
+            f.write(last_line)
+
+        # php script with long shebang
+        self.php_shebang = os.path.join(self.tempdir, 'php')
+        with open(self.php_shebang, 'w') as f:
+            f.write(php_line)
+            f.write(last_line)
+
+        # php script with long shebang
+        self.php_textbang = os.path.join(self.tempdir, 'php_in_text')
+        with open(self.php_textbang, 'w') as f:
+            f.write(short_line)
+            f.write(php_in_text)
             f.write(last_line)
 
         # Script already using sbang.

--- a/var/spack/repos/builtin/packages/php/package.py
+++ b/var/spack/repos/builtin/packages/php/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+import spack.hooks.sbang as sbang
+
 
 class Php(AutotoolsPackage):
     """
@@ -49,7 +51,7 @@ class Php(AutotoolsPackage):
         if len(self.prefix.bin.php) + 2 <= shebang_limit:
             return
 
-        new_sbang_line = '#!/bin/bash %s/bin/sbang' % spack.paths.prefix
+        new_sbang_line = '#!/bin/bash %s' % sbang.sbang_install_path()
         original_bang = '-b "$(PHP_PHARCMD_BANG)"'
         makefile = join_path('ext', 'phar', 'Makefile.frag')
         filter_file(

--- a/var/spack/repos/builtin/packages/php/sbang.patch
+++ b/var/spack/repos/builtin/packages/php/sbang.patch
@@ -1,0 +1,42 @@
+--- spack-src/ext/phar/phar/pharcommand.inc.org	2019-12-18 01:35:53.000000000 +0900
++++ spack-src/ext/phar/phar/pharcommand.inc	2020-08-20 12:26:16.207347572 +0900
+@@ -68,6 +68,12 @@
+ 				'inf' => '<bang>   Hash-bang line to start the archive (e.g. #!/usr/bin/php). The hash '
+ 						 .'         mark itself \'#!\' and the newline character are optional.'
+ 			),
++			'z' => array(
++				'typ' => 'any',
++				'val' => NULL,
++				'inf' => '<bang>   Hash-bang line to start the archive for spack. The hash '
++						 .'         mark itself \'#!\' and the newline character are optional.'
++			),
+ 			'c' => array(
+ 				'typ' => 'compalg',
+ 				'val' => NULL,
+@@ -455,7 +461,7 @@
+ 	 */
+ 	static function cli_cmd_arg_pack()
+ 	{
+-		$args = self::phar_args('abcFhilpsxy', 'pharnew');
++		$args = self::phar_args('azbcFhilpsxy', 'pharnew');
+ 
+ 		$args[''] = array(
+ 			'typ'     => 'any',
+@@ -560,6 +566,7 @@
+ 		}
+ 
+ 		$alias    = $this->args['a']['val'];
++		$spack_hb = $this->args['z']['val'];
+ 		$hashbang = $this->args['b']['val'];
+ 		$archive  = $this->args['f']['val'];
+ 		$hash     = $this->args['h']['val'];
+@@ -571,6 +578,9 @@
+ 		$invregex = $this->args['x']['val'];
+ 		$input    = $this->args['']['val'];
+ 
++		if (isset($spack_hb)) {
++			$hashbang = "$spack_hb\n<?php #!$hashbang\n?>";
++		}
+ 		$hash = self::phar_check_hash($hash, $privkey);
+ 
+ 		$phar  = new Phar($archive, 0, $alias);

--- a/var/spack/repos/builtin/packages/php/sbang.patch
+++ b/var/spack/repos/builtin/packages/php/sbang.patch
@@ -19,12 +19,12 @@
  	{
 -		$args = self::phar_args('abcFhilpsxy', 'pharnew');
 +		$args = self::phar_args('azbcFhilpsxy', 'pharnew');
- 
+
  		$args[''] = array(
  			'typ'     => 'any',
 @@ -560,6 +566,7 @@
  		}
- 
+
  		$alias    = $this->args['a']['val'];
 +		$spack_hb = $this->args['z']['val'];
  		$hashbang = $this->args['b']['val'];
@@ -33,10 +33,10 @@
 @@ -571,6 +578,9 @@
  		$invregex = $this->args['x']['val'];
  		$input    = $this->args['']['val'];
- 
+
 +		if (isset($spack_hb)) {
-+			$hashbang = "$spack_hb\n<?php #!$hashbang\n?>";
++			$hashbang = "$spack_hb\n<?php #!$hashbang ?>";
 +		}
  		$hash = self::phar_check_hash($hash, $privkey);
- 
+
  		$phar  = new Phar($archive, 0, $alias);


### PR DESCRIPTION
fixed #15543

php script is processed only inside from `<?php` to `?>`.
another part is output to stdout.
The PR change `<?php #!` to sbang line.

php package installed phar script written by php.
But phar include binary, and phar embeded own sh1 checksum.
This PR insert sbang when generate phar script if it is needed.