### PR TITLE
Add new package: fastdb

### DIFF
--- a/var/spack/repos/builtin/packages/fastdb/fastdb-fmax-fmin.patch
+++ b/var/spack/repos/builtin/packages/fastdb/fastdb-fmax-fmin.patch
@@ -1,0 +1,26 @@
+diff --git a/examples/testtimeseries.cpp b/examples/testtimeseries.cpp
+index 1f57bac..e3ed88e 100644
+--- a/examples/testtimeseries.cpp
++++ b/examples/testtimeseries.cpp
+@@ -47,8 +47,8 @@ REGISTER_TEMPLATE(DailyBlock);
+ REGISTER(Stock);
+ 
+ inline int random(unsigned mod) { return rand() % mod; }
+-inline float fmax(float x, float y) { return x > y ? x : y; }
+-inline float fmin(float x, float y) { return x < y ? x : y; }
++inline float my_fmax(float x, float y) { return x > y ? x : y; }
++inline float my_fmin(float x, float y) { return x < y ? x : y; }
+ 
+ int main(int argc, char* argv[])
+ {
+@@ -66,8 +66,8 @@ int main(int argc, char* argv[])
+             quote.timestamp = i;
+             quote.open = (float)random(10000)/100;
+             quote.close = (float)random(10000)/100;
+-            quote.high = fmax(quote.open, quote.close);
+-            quote.low = fmin(quote.open, quote.close);
++            quote.high = my_fmax(quote.open, quote.close);
++            quote.low = my_fmin(quote.open, quote.close);
+             quote.volume = random(1000);
+             proc.add(stockId, quote); // add new element in time series
+         }

--- a/var/spack/repos/builtin/packages/fastdb/package.py
+++ b/var/spack/repos/builtin/packages/fastdb/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Fastdb(MakefilePackage):
+    """Object-Relational Main-Memory Embedded Database system
+       tightly integrated with C++ language."""
+
+    homepage = "https://sourceforge.net/projects/fastdb/"
+    url      = "https://sourceforge.net/projects/fastdb/files/fastdb/3.75/fastdb-3.75.tar.gz"
+
+    version('3.75', sha256='eeafdb2ad01664c29e2d4053a305493bdedc8e91612ab25f1d36ad2f95b0dad6')
+    version('3.74', sha256='4d0c9a165a1031860d4853d7084b8fe4627f0004861e6070927d3b6c594af889')
+
+    patch('fastdb-fmax-fmin.patch')
+
+    def install(self, spec, prefix):
+        make('PREFIX=%s' % prefix, 'install')


### PR DESCRIPTION
According to fastdb@3.75 fix bugs in fastdb@3.73
![image](https://user-images.githubusercontent.com/29532367/91421386-75eec500-e888-11ea-931c-f276c39baca2.png)
We used a similar patch for the error:

```
examples/testtimeseries.cpp:50:35: error: 'float fmax(float, float)' conflicts with a previous declaration
 inline float fmax(float x, float y) { return x > y ? x : y; }
                                   ^
In file included from /usr/include/c++/8/math.h:36,
                 from examples/testtimeseries.cpp:15:
/usr/include/c++/8/cmath:1418:3: note: previous declaration 'constexpr float std::fmax(float, float)'
   fmax(float __x, float __y)
   ^~~~
examples/testtimeseries.cpp:51:35: error: 'float fmin(float, float)' conflicts with a previous declaration
 inline float fmin(float x, float y) { return x < y ? x : y; }
                                   ^
In file included from /usr/include/c++/8/math.h:36,
                 from examples/testtimeseries.cpp:15:
/usr/include/c++/8/cmath:1438:3: note: previous declaration 'constexpr float std::fmin(float, float)'
   fmin(float __x, float __y)
   ^~~~
examples/testtimeseries.cpp: In function 'int main(int, char**)':
examples/testtimeseries.cpp:69:54: error: call of overloaded 'fmax(float&, float&)' is ambiguous
             quote.high = fmax(quote.open, quote.close);
                                                      ^
In file included from /usr/include/features.h:428,
                 from /usr/include/sys/stat.h:25,
                 from inc/stdtp.h:64,
                 from inc/class.h:14,
                 from inc/database.h:14,
                 from inc/fastdb.h:19,
                 from examples/testtimeseries.cpp:11:
/usr/include/bits/mathcalls.h:329:1: note: candidate: 'double fmax(double, double)'
 __MATHCALLX (fmax,, (_Mdouble_ __x, _Mdouble_ __y), (__const__));
 ^~~~~~~~~~~
examples/testtimeseries.cpp:50:14: note: candidate: 'float fmax(float, float)'
 inline float fmax(float x, float y) { return x > y ? x : y; }
              ^~~~
In file included from /usr/include/c++/8/math.h:36,
                 from examples/testtimeseries.cpp:15:
/usr/include/c++/8/cmath:1429:5: note: candidate: 'constexpr typename __gnu_cxx::__promote_2<_Tp, _Up>::__type std::fmax(_Tp, _Up) [with _Tp = float; _Up = float; typename __gnu_cxx::__promote_2<_Tp, _Up>::__type = float]'
     fmax(_Tp __x, _Up __y)
     ^~~~
/usr/include/c++/8/cmath:1422:3: note: candidate: 'constexpr long double std::fmax(long double, long double)'
   fmax(long double __x, long double __y)
   ^~~~
/usr/include/c++/8/cmath:1418:3: note: candidate: 'constexpr float std::fmax(float, float)'
   fmax(float __x, float __y)
   ^~~~
examples/testtimeseries.cpp:70:53: error: call of overloaded 'fmin(float&, float&)' is ambiguous
             quote.low = fmin(quote.open, quote.close);
                                                     ^
In file included from /usr/include/features.h:428,
                 from /usr/include/sys/stat.h:25,
                 from inc/stdtp.h:64,
                 from inc/class.h:14,
                 from inc/database.h:14,
                 from inc/fastdb.h:19,
                 from examples/testtimeseries.cpp:11:
/usr/include/bits/mathcalls.h:332:1: note: candidate: 'double fmin(double, double)'
 __MATHCALLX (fmin,, (_Mdouble_ __x, _Mdouble_ __y), (__const__));
 ^~~~~~~~~~~
examples/testtimeseries.cpp:51:14: note: candidate: 'float fmin(float, float)'
 inline float fmin(float x, float y) { return x < y ? x : y; }
              ^~~~
In file included from /usr/include/c++/8/math.h:36,
                 from examples/testtimeseries.cpp:15:
/usr/include/c++/8/cmath:1449:5: note: candidate: 'constexpr typename __gnu_cxx::__promote_2<_Tp, _Up>::__type std::fmin(_Tp, _Up) [with _Tp = float; _Up = float; typename __gnu_cxx::__promote_2<_Tp, _Up>::__type = float]'
     fmin(_Tp __x, _Up __y)
     ^~~~
/usr/include/c++/8/cmath:1442:3: note: candidate: 'constexpr long double std::fmin(long double, long double)'
   fmin(long double __x, long double __y)
   ^~~~
/usr/include/c++/8/cmath:1438:3: note: candidate: 'constexpr float std::fmin(float, float)'
   fmin(float __x, float __y)
   ^~~~
rm -f libfastdb_r.a
ar -cru libfastdb_r.a  class.o compiler.o database.o xml.o hashtab.o file.o symtab.o ttree.o rtree.o container.o cursor.o query.o wwwapi.o unisock.o sync.o localcli.o stdtp.o server.o
true libfastdb_r.a
make: *** [makefile:355: testtimeseries.o] Error 1
make: *** Waiting for unfinished jobs....
```