### PR TITLE
Introduce virtual provider uuid

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -49,6 +49,7 @@ packages:
       unwind: [libunwind]
       yacc: [bison, byacc]
       flame: [libflame, amdlibflame]
+      uuid: [util-linux-uuid, libuuid]
     permissions:
       read: world
       write: user

--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -18,4 +18,4 @@ class Apr(AutotoolsPackage):
 
     patch('missing_includes.patch', when='@1.7.0')
 
-    depends_on('libuuid', type='link')
+    depends_on('uuid', type='link')

--- a/var/spack/repos/builtin/packages/babeltrace/package.py
+++ b/var/spack/repos/builtin/packages/babeltrace/package.py
@@ -17,5 +17,5 @@ class Babeltrace(AutotoolsPackage):
     version('1.2.4', sha256='666e3a1ad2dc7d5703059963056e7800f0eab59c8eeb6be2efe4f3acc5209eb1')
 
     depends_on('glib@2.22:', type=('build', 'link'))
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('popt')

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -19,6 +19,7 @@ class Bcache(MakefilePackage):
     version('1.0.5', sha256='1449294ef545b3dc6f715f7b063bc2c8656984ad73bcd81a0dc048cbba416ea9')
     version('1.0.4', sha256='102ffc3a8389180f4b491188c3520f8a4b1a84e5a7ca26d2bd6de1821f4d913d')
 
+    depends_on('uuid')
     depends_on('util-linux')
     depends_on('gettext')
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -71,7 +71,7 @@ class Cdo(AutotoolsPackage):
     depends_on('curl', when='+curl')
     depends_on('fftw@3:', when='+fftw3')
     depends_on('magics', when='+magics')
-    depends_on('libuuid')
+    depends_on('uuid')
 
     conflicts('grib2=eccodes', when='@:1.8',
               msg='Eccodes is supported starting version 1.9.0')

--- a/var/spack/repos/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/builtin/packages/coin3d/package.py
@@ -25,7 +25,7 @@ class Coin3d(AutotoolsPackage):
     depends_on('libsm', type='link')
     depends_on('libxext', type='link')
     depends_on('libice', type='link')
-    depends_on('libuuid', type='link')
+    depends_on('uuid', type='link')
     depends_on('libxcb', type='link')
     depends_on('libxau', type='link')
 

--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -21,11 +21,11 @@ class Cryptsetup(AutotoolsPackage):
     version('2.2.2', sha256='2af0ec9551ab9c870074cae9d3f68d82cab004f4095fa89db0e4413713424a46')
     version('2.2.1', sha256='94e79a31ed38bdb0acd9af7ccca1605a2ac62ca850ed640202876b1ee11c1c61')
 
-    depends_on('libuuid', type=('build', 'link'))
+    depends_on('uuid', type=('build', 'link'))
     depends_on('lvm2', type=('build', 'link'))
     depends_on('popt', type=('build', 'link'))
     depends_on('json-c', type=('build', 'link'))
-    depends_on('util-linux~libuuid', type=('build', 'link'))
+    depends_on('util-linux', type=('build', 'link'))
     depends_on('gettext', type=('build', 'link'))
 
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/czmq/package.py
+++ b/var/spack/repos/builtin/packages/czmq/package.py
@@ -19,7 +19,7 @@ class Czmq(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('pkgconfig', type='build')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libzmq')
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -27,7 +27,7 @@ class Davix(CMakePackage):
 
     depends_on('pkgconfig', type='build')
     depends_on('libxml2')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('openssl')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/dia/package.py
+++ b/var/spack/repos/builtin/packages/dia/package.py
@@ -21,7 +21,7 @@ class Dia(Package):
     depends_on('python')
     depends_on('swig')
     depends_on('libsm')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libxinerama')
     depends_on('libxrender')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -37,7 +37,7 @@ class FluxSched(AutotoolsPackage):
     depends_on("py-pyyaml", when="@0.7.0:")
     depends_on("libxml2@2.9.1:", when="@0.6.0")
     depends_on("yaml-cpp", when="@0.7.0:")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("pkgconfig")
 
     depends_on("flux-core", type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -21,7 +21,7 @@ class Fontconfig(AutotoolsPackage):
     depends_on('libxml2')
     depends_on('pkgconfig', type='build')
     depends_on('font-util')
-    depends_on('libuuid', when='@2.13.1:')
+    depends_on('uuid', when='@2.13.1:')
 
     def configure_args(self):
         font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -48,7 +48,7 @@ class Gaudi(CMakePackage):
     depends_on('cppgsl')
     depends_on('fmt', when='@33.2:')
     depends_on('intel-tbb')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('nlohmann-json', when="@35.0:")
     depends_on('python', type=('build', 'run'))
     depends_on('python@:3.7.99', when='@32.2:34.99', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -60,6 +60,7 @@ class Glib(Package):
     depends_on('perl', type=('build', 'run'))
     depends_on('python', type=('build', 'run'), when='@2.53.4:')
     depends_on('pcre+utf', when='@2.48:')
+    depends_on('uuid', when='+libmount')
     depends_on('util-linux', when='+libmount')
     depends_on('iconv')
 

--- a/var/spack/repos/builtin/packages/glusterfs/package.py
+++ b/var/spack/repos/builtin/packages/glusterfs/package.py
@@ -31,7 +31,7 @@ class Glusterfs(AutotoolsPackage):
     depends_on('bison',    type='build')
     depends_on('rpcsvc-proto')
     depends_on('acl')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libtirpc')
     depends_on('userspace-rcu')
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -30,7 +30,7 @@ class Libdap4(AutotoolsPackage):
     depends_on('flex')
     depends_on('curl')
     depends_on('libxml2')
-    depends_on('libuuid')
+    depends_on('uuid')
 
     def configure_args(self):
         # libxml2 exports ./include/libxml2/ instead of ./include/, which we

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -16,10 +16,9 @@ class Libsm(AutotoolsPackage, XorgPackage):
     version('1.2.2', sha256='14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4')
 
     depends_on('libice@1.0.5:')
-    depends_on('libuuid')
+    depends_on('uuid')
 
     depends_on('xproto', type='build')
     depends_on('xtrans', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
-    depends_on('libuuid')

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -13,3 +13,5 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
     sourceforge_mirror_path = "libuuid/libuuid-1.0.3.tar.gz"
 
     version('1.0.3', sha256='46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644')
+
+    provides('uuid')

--- a/var/spack/repos/builtin/packages/netdata/package.py
+++ b/var/spack/repos/builtin/packages/netdata/package.py
@@ -19,4 +19,4 @@ class Netdata(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('libuv')
-    depends_on('libuuid')
+    depends_on('uuid')

--- a/var/spack/repos/builtin/packages/nfs-utils/package.py
+++ b/var/spack/repos/builtin/packages/nfs-utils/package.py
@@ -25,6 +25,7 @@ class NfsUtils(AutotoolsPackage):
     depends_on('lvm2')
     depends_on('keyutils')
     depends_on('sqlite')
+    depends_on('uuid')
     depends_on('util-linux')
     depends_on('gettext')
 

--- a/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
+++ b/var/spack/repos/builtin/packages/oci-systemd-hook/package.py
@@ -23,6 +23,7 @@ class OciSystemdHook(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('gettext')
     depends_on('yajl')
+    depends_on('uuid')
     depends_on('util-linux')
     depends_on('go-md2man')
 

--- a/var/spack/repos/builtin/packages/open-iscsi/package.py
+++ b/var/spack/repos/builtin/packages/open-iscsi/package.py
@@ -20,6 +20,7 @@ class OpenIscsi(MakefilePackage):
     version('2.0.876', sha256='9f01327d5e100ed794dc5083fc18dc4a06a0c29c77b252e21abd1b8f56edd9a7')
 
     depends_on('gettext')
+    depends_on('uuid')
     depends_on('util-linux+libmount')
     depends_on('kmod')
     depends_on('open-isns')

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Uuid(AutotoolsPackage):
+class OsspUuid(AutotoolsPackage):
     """OSSP uuid is a ISO-C:1999 application programming interface (API) and
     corresponding command line interface (CLI) for the generation of DCE 1.1,
     ISO/IEC 11578:1996 and RFC 4122 compliant Universally Unique Identifier
@@ -16,3 +16,13 @@ class Uuid(AutotoolsPackage):
     url = "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz"
 
     version('1.6.2', sha256='11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0')
+
+    provides('uuid')
+
+    @property
+    def libs(self):
+        return find_libraries('libuuid', self.prefix, recursive=True)
+
+    @property
+    def headers(self):
+        return find_headers('uuid', self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/psm/package.py
+++ b/var/spack/repos/builtin/packages/psm/package.py
@@ -18,7 +18,7 @@ class Psm(MakefilePackage):
 
     conflicts('%gcc@6:', when='@3.3')
 
-    depends_on('libuuid')
+    depends_on('uuid')
 
     def edit(self, spec, prefix):
         makefile = FileFilter('Makefile')

--- a/var/spack/repos/builtin/packages/pulseaudio/package.py
+++ b/var/spack/repos/builtin/packages/pulseaudio/package.py
@@ -42,7 +42,7 @@ class Pulseaudio(AutotoolsPackage):
     depends_on('libsndfile@1.0.18:')
     depends_on('libtool@2.4:')  # links to libltdl.so
     depends_on('libsm', when='+x11')
-    depends_on('libuuid', when='+x11')
+    depends_on('uuid', when='+x11')
     depends_on('libx11', when='+x11')
     depends_on('libxcb', when='+x11')
     depends_on('libxau', when='+x11')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -172,7 +172,7 @@ class Python(AutotoolsPackage):
         # system-provided version is sufficient to build Python's UUID support,
         # the easy solution is to only depend on Spack's libuuid when *not* on
         # a Mac.
-        depends_on('libuuid', when='+uuid')
+        depends_on('uuid', when='+uuid')
 
     # Python needs to be patched to build extensions w/ mixed C/C++ code:
     # https://github.com/NixOS/nixpkgs/pull/19585/files

--- a/var/spack/repos/builtin/packages/rsyslog/package.py
+++ b/var/spack/repos/builtin/packages/rsyslog/package.py
@@ -23,7 +23,7 @@ class Rsyslog(AutotoolsPackage):
     depends_on('libestr')
     depends_on('libfastjson')
     depends_on('zlib')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libgcrypt')
     depends_on('curl')
     depends_on('byacc', type='build')

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -48,7 +48,7 @@ class Singularity(MakefilePackage):
 
     depends_on('pkgconfig', type='build')
     depends_on('go')
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libgpg-error')
     depends_on('libseccomp')
     depends_on('squashfs', type='run')

--- a/var/spack/repos/builtin/packages/task/package.py
+++ b/var/spack/repos/builtin/packages/task/package.py
@@ -16,6 +16,6 @@ class Task(CMakePackage):
 
     depends_on('cmake@2.8:', type='build')
     depends_on('gnutls')
-    depends_on('libuuid')
+    depends_on('uuid')
 
     conflicts('%gcc@:4.7')

--- a/var/spack/repos/builtin/packages/taskd/package.py
+++ b/var/spack/repos/builtin/packages/taskd/package.py
@@ -14,7 +14,7 @@ class Taskd(CMakePackage):
 
     version('1.1.0', sha256='7b8488e687971ae56729ff4e2e5209ff8806cf8cd57718bfd7e521be130621b4')
 
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('gnutls')
     depends_on('cmake@2.8:', type='build')
 

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class UtilLinuxUuid(AutotoolsPackage):
+    """Util-linux is a suite of essential utilities for any Linux system."""
+
+    homepage = "https://github.com/karelzak/util-linux"
+    url      = "https://www.kernel.org/pub/linux/utils/util-linux/v2.29/util-linux-2.29.2.tar.gz"
+    list_url = "https://www.kernel.org/pub/linux/utils/util-linux"
+    list_depth = 1
+
+    version('2.36', sha256='82942cd877a989f6d12d4ce2c757fb67ec53d8c5cd9af0537141ec5f84a2eea3')
+
+    depends_on('pkgconfig', type='build')
+
+    provides('uuid')
+
+    def url_for_version(self, version):
+        url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
+        return url.format(version.up_to(2), version)
+
+    @property
+    def libs(self):
+        return find_libraries('libuuid', self.prefix, recursive=True)
+
+    @property
+    def headers(self):
+        return find_headers('uuid', self.prefix, recursive=True)
+
+    def configure_args(self):
+        config_args = [
+            '--disable-use-tty-group',
+            '--disable-makeinstall-chown',
+            '--without-systemd',
+            '--disable-all-programs',
+            '--without-python',
+            '--enable-libuuid'
+        ]
+        return config_args

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -15,6 +15,7 @@ class UtilLinux(AutotoolsPackage):
     list_url = "https://www.kernel.org/pub/linux/utils/util-linux"
     list_depth = 1
 
+    version('2.36', sha256='82942cd877a989f6d12d4ce2c757fb67ec53d8c5cd9af0537141ec5f84a2eea3')
     version('2.35.1', sha256='37ac05d82c6410d89bc05d43cee101fefc8fe6cf6090b3ce7a1409a6f35db606')
     version('2.35',   sha256='98acab129a8490265052e6c1e033ca96d68758a13bb7fcd232c06bf16cc96238')
     version('2.34',   sha256='b62c92e5e1629642113cd41cec1ee86d1ee7e36b8ffe8ec3ac89c11797e9ac25')
@@ -24,12 +25,9 @@ class UtilLinux(AutotoolsPackage):
     version('2.29.1', sha256='a6a7adba65a368e6dad9582d9fbedee43126d990df51266eaee089a73c893653')
     version('2.25',   sha256='7e43273a9e2ab99b5a54ac914fddf5d08ba7ab9b114c550e9f03474672bd23a1')
 
-    depends_on('python@2.7:')
-    depends_on('pkgconfig')
+    depends_on('python@2.7:', type='build')
+    depends_on('pkgconfig', type='build')
 
-    # Make it possible to disable util-linux's libuuid so that you may
-    # reliably depend_on(`libuuid`).
-    variant('libuuid', default=True, description='Build libuuid')
     variant('bash', default=False, description='Install bash completion scripts')
 
     depends_on('bash', when="+bash", type='run')
@@ -43,6 +41,7 @@ class UtilLinux(AutotoolsPackage):
             '--disable-use-tty-group',
             '--disable-makeinstall-chown',
             '--without-systemd',
+            '--disable-libuuid',
         ]
         if "+bash" in self.spec:
             config_args.extend(
@@ -52,7 +51,6 @@ class UtilLinux(AutotoolsPackage):
                      "share", "bash-completion", "completions")])
         else:
             config_args.append('--disable-bash-completion')
-        config_args.extend(self.enable_or_disable('libuuid'))
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/xeus/package.py
+++ b/var/spack/repos/builtin/packages/xeus/package.py
@@ -29,7 +29,7 @@ class Xeus(CMakePackage):
     depends_on('xtl@0.4.0:')
     depends_on('nlohmann-json@3.2.0', when='@develop,0.15.0:')
     depends_on('nlohmann-json@3.1.1', when='@0.14.1')
-    depends_on('libuuid')
+    depends_on('uuid')
 
     # finds cryptopp not built with cmake, removes c++17 attribute
     # in check_cxx_source_compiles

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -19,6 +19,7 @@ class Xfsprogs(AutotoolsPackage):
     version('4.20.0', sha256='beafdfd080352a8c9d543491e0874d0e8809cb643a3b9d352d5feed38d77022a')
 
     depends_on('gettext')
+    depends_on('uuid')
     depends_on('util-linux')
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -56,7 +56,7 @@ class Xrootd(CMakePackage):
     depends_on('bzip2')
     depends_on('cmake@2.6:', type='build')
     depends_on('libxml2', when='+http')
-    depends_on('libuuid', when="@4.11.0:")
+    depends_on('uuid', when="@4.11.0:")
     depends_on('openssl')
     depends_on('python', when='+python')
     depends_on('readline', when='+readline')

--- a/var/spack/repos/builtin/packages/zfs/package.py
+++ b/var/spack/repos/builtin/packages/zfs/package.py
@@ -20,7 +20,7 @@ class Zfs(AutotoolsPackage):
     version('0.8.1', sha256='0af79fde44b7b8ecb94d5166ce2e4fff7409c20ed874c2d759db92909e6c2799')
     version('0.8.0', sha256='0fd92e87f4b9df9686f18e2ac707c16b2eeaf00f682d41c20ea519f3a0fe4705')
 
-    depends_on('libuuid')
+    depends_on('uuid')
     depends_on('libtirpc')
     depends_on('util-linux')
 


### PR DESCRIPTION
libuuid is currently contained in util-linux, libuuid and uuid. This change introduces a new virtual provider `uuid` and renames the existing `uuid` package to `ossp-uuid`.

util-linux's libuuid is provided in the form of a separate package util-linux-uuid to make sure that packages depending on uuid and util-linux can use a separate uuid implementation, which the concretizer does not allow if libuuid is contained in util-linux.

Fixes #10812