### PR TITLE
Add setuptools as a direct dependency for py-fenics-dolfinx

### DIFF
--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -17,6 +17,7 @@ class PyFenicsDolfinx(PythonPackage):
     version("master", branch="master")
 
     depends_on("cmake@3.9:", type="build")
+    depends_on("py-setuptools", type="build")
     depends_on("fenics-dolfinx@master")
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-petsc4py", type=("build", "run"))


### PR DESCRIPTION
* ensures that install is done with `--single-version-externally-managed` flag