### PR TITLE
Increase db_lock_timeout

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -143,7 +143,7 @@ config:
   # when Spack needs to manage its own package metadata and all operations are
   # expected to complete within the default time limit. The timeout should
   # therefore generally be left untouched.
-  db_lock_timeout: 3
+  db_lock_timeout: 15
 
 
   # How long to wait when attempting to modify a package (e.g. to install it).


### PR DESCRIPTION
db_lock_timeout is currently set to 3 seconds. This is sometimes too short, even on a fast Xeon machine with an SSD.

When running "spack install cmake" and "spack install grpc" in parallel on a fresh install, then I needed to increase db_lock_timeout to at minimum 8 seconds to not hit the TimeoutError.

I propose to raise the timeout to 15 seconds (about double that value). This should be a good value to not hit the timeout too easily (at least on fast machines), and still have a reasonable time for erroring out.

possible label: defaults