### PR TITLE
Add more updates for kokkos 3.2 release, particularly nvcc-wrapper

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -15,10 +15,12 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     version('develop', branch='develop')
     version('master',  branch='master')
+    version('3.2.00', sha256="8ac20ee28ae7813ce1bda461918800ad57fdbac2af86ef5d1ba74e83e10956de")
     version('3.1.00', sha256="27fea241ae92f41bd5b070b1a590ba3a56a06aca750207a98bea2f64a4a40c89")
     version('3.0.00', sha256="e4b832aed3f8e785de24298f312af71217a26067aea2de51531e8c1e597ef0e6")
 
     depends_on("kokkos")
+    depends_on("kokkos@master", when="@master")
     depends_on("kokkos@develop", when="@develop")
     depends_on("cmake@3.10:", type='build')
 

--- a/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
@@ -6,17 +6,22 @@ from spack import *
 import os
 
 
-class KokkosNvccWrapper(CMakePackage):
+class KokkosNvccWrapper(MakefilePackage):
     """The NVCC wrapper provides a wrapper around NVCC to make it a
        'full' C++ compiler that accepts all flags"""
 
+    # We no longer maintain this as a separate repo
+    # Download the Kokkos repo and install from there
     homepage = "https://github.com/kokkos/kokkos"
-    git = "https://github.com/kokkos/nvcc_wrapper.git"
+    git = "git@github.com:kokkos/kokkos.git"
+    url = "https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz"
 
-    version('3.1', url='https://github.com/kokkos/nvcc_wrapper/archive/3.1.tar.gz',
-            sha256="5171530763bb2845aa70651f3a8e5dc95b6eed76379323fde3205f97ed28ec8c",
-            default=True)
-    version('master', branch='master')
+    version('3.2.00', sha256='05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9')
+    version('3.1.01', sha256='ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd')
+    version('3.1.00', sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878")
+    version('3.0.00', sha256="c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b")
+    version('master',  branch='master')
+    version('develop', branch='develop')
 
     variant("mpi", default=True,
             description="use with MPI as the underlying compiler")
@@ -24,19 +29,23 @@ class KokkosNvccWrapper(CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("cmake@3.10:", type='build')
 
-    def cmake_args(self):
-        options = [
-            "-DCMAKE_CXX_COMPILER=%s" % os.environ["SPACK_CXX"],
-            "-DCMAKE_CUDA_HOST_COMPILER=%s" % os.environ["SPACK_CXX"],
-            "-DCMAKE_C_COMPILER=%s" % os.environ["SPACK_CC"],
-        ]
-        return options
+    def build(self, spec, prefix):
+        # This is not actually a Makefile, but I don't know how
+        # else to do this in Spack
+        pass
+
+    def install(self, spec, prefix):
+        src = os.path.join("bin", "nvcc_wrapper")
+        mkdir(prefix.bin)
+        install(src, prefix.bin)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         wrapper = join_path(self.prefix.bin, "nvcc_wrapper")
+        env.set('CUDA_ROOT', dependent_spec["cuda"].prefix)
+        env.set('NVCC_WRAPPER_DEFAULT_COMPILER', self.compiler.cxx)
+        env.set('KOKKOS_CXX', self.compiler.cxx)
         env.set('MPICH_CXX', wrapper)
         env.set('OMPI_CXX', wrapper)
-        env.set('KOKKOS_CXX', spack_cxx)
 
     def setup_dependent_package(self, module, dependent_spec):
         wrapper = join_path(self.prefix.bin, "nvcc_wrapper")

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -172,6 +172,8 @@ class Kokkos(CMakePackage, CudaPackage):
     variant("wrapper", default=False,
             description="Use nvcc-wrapper for CUDA build")
     depends_on("kokkos-nvcc-wrapper", when="+wrapper")
+    depends_on("kokkos-nvcc-wrapper@develop", when="@develop+wrapper")
+    depends_on("kokkos-nvcc-wrapper@master", when="@master+wrapper")
     conflicts("+wrapper", when="~cuda")
 
     variant("std", default="11", values=["11", "14", "17", "20"], multi=False)


### PR DESCRIPTION
This adds some missing pieces for the Kokkos and Kokkos Kernels 3.2 release.
The nvcc-wrapper repo has also been deprecated in favor of just maintaining it inside the Kokkos repo.
For Spack purposes, kokkos-nvcc-wrapper must still be a separate package. This adds some workarounds to get nvcc-wrapper working from within the Kokkos repo.