### PR TITLE
Smoke tests/bugfixes: Conform to new test stage directory plus consistency changes

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -5,24 +5,49 @@
 import base64
 import hashlib
 import os
+import re
 import shutil
 import sys
 
 import llnl.util.filesystem as fs
 
+from spack.spec import Spec
+
 import spack.error
 import spack.util.prefix
 import spack.util.spack_json as sjson
+
+
+def get_expected_output(filename):
+    """Retrieve the expected output from the file
+
+    Args:
+        filename (str): path to the file
+
+    Returns:
+        (list of str): escaped text lines read from the file
+    """
+    with open(filename, 'r') as f:
+        # Ensure special characters are escaped as needed
+        expected = f.read()
+
+    # Split the lines to make it easier to debug failures when there is
+    # a lot of output
+    return [re.escape(ln) for ln in expected.split('\n')]
+
 
 def get_test_stage_dir():
     return spack.util.path.canonicalize_path(
         spack.config.get('config:test_stage', '~/.spack/test'))
 
+
 def get_test_stage(name):
     return spack.util.prefix.Prefix(os.path.join(get_test_stage_dir(), name))
 
+
 def get_results_file(name):
     return get_test_stage(name).join('results.txt')
+
 
 def get_test_by_name(name):
     test_suite_file = get_test_stage(name).join('specs.lock')
@@ -92,7 +117,7 @@ class TestSuite(object):
                     # Create the test log file and report the error.
                     self.ensure_stage()
                     msg = 'Testing package {0}\n{1}'\
-                        .format(self.test_pkg_id(spec), str(err))
+                        .format(self.test_pkg_id(spec), str(exc))
                     _add_msg_to_file(self.log_file_for_spec(spec), msg)
 
                 self.write_test_result(spec, 'FAILED')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import shutil
 import sys
 
-import llnl.util.tty as tty
+import spack.install_test as sit
+
 from spack import *
 
 
@@ -387,31 +387,32 @@ HDF5 version {version} {version}
         ]
         use_short_opt = ['h52gif', 'h5repart', 'h5unjam']
         for exe in exes:
-            reason = 'test version of {0} is {1}'.format(exe, spec_vers_str)
+            reason = 'test: ensuring version of {0} is {1}' \
+                .format(exe, spec_vers_str)
             option = '-V' if exe in use_short_opt else '--version'
-            self.run_test(exe, [option], spec_vers_str, installed=True,
+            self.run_test(exe, option, spec_vers_str, installed=True,
                           purpose=reason, skip_missing=True)
 
     def _test_example(self):
         """This test performs copy, dump, and diff on an example hdf5 file."""
-        h5_file = os.path.join(self.test_dir, 'data', 'spack.h5')
+        test_data_dir = self.test_suite.current_test_data_dir
 
-        reason = 'test: ensure h5dump produces expected output'
-        dump_file = os.path.join(self.test_dir, 'data', 'dump.out')
-        output = ''
-        with open(dump_file) as fd:
-            output == fd.read()
-        self.run_test('h5dump', [h5_file], output, installed=True,
-                      purpose=reason, skip_missing=True, work_dir='.')
+        filename = 'spack.h5'
+        h5_file = test_data_dir.join(filename)
 
-        reason = 'test: ensure h5copy runs'
+        reason = 'test: ensuring h5dump produces expected output'
+        expected = sit.get_expected_output(test_data_dir.join('dump.out'))
+        self.run_test('h5dump', filename, expected, installed=True,
+                      purpose=reason, skip_missing=True,
+                      work_dir=test_data_dir)
+
+        reason = 'test: ensuring h5copy runs'
         options = ['-i', h5_file, '-s', 'Spack', '-o', 'test.h5', '-d', 'Spack']
-        self.run_test('h5copy', options, installed=True,
+        self.run_test('h5copy', options, [], installed=True,
                       purpose=reason, skip_missing=True, work_dir='.')
 
-        reason = 'test: ensure h5diff shows no differences in orig and copy'
-        options = [h5_file, 'test.h5']
-        self.run_test('h5diff', options, installed=True,
+        reason = 'test: ensuring h5diff shows no differences between orig and copy'
+        self.run_test('h5diff', [h5_file, 'test.h5'], [], installed=True,
                       purpose=reason, skip_missing=True, work_dir='.')
 
     def test(self):

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import llnl.util.tty as tty
+
+import spack.install_test as sit
 
 from spack import *
 
@@ -38,7 +39,7 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
         """Build and run the added smoke (install) test."""
         data_dir = self.test_suite.current_test_data_dir
         prog = 'smoke_test'
-        src = data_dir.join('%s.c' % prog)
+        src = data_dir.join('{0}.c'.format(prog))
 
         options = [
             '-I{0}'.format(self.prefix.include),
@@ -48,18 +49,16 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
             '-L{0}'.format(self.prefix.lib),
             '-lsigsegv',
             '{0}{1}'.format(self.compiler.cc_rpath_arg, self.prefix.lib)]
-        reason = 'test ability to link to the library'
+        reason = 'test: checking ability to link to the library'
         self.run_test('cc', options, [], installed=False, purpose=reason)
 
         # Now run the program and confirm the output matches expectations
-        with open(data_dir.join('smoke_test.out'), 'r') as fd:
-            expected = fd.read()
-        reason = 'test ability to use the library'
+        expected = sit.get_expected_output(data_dir.join('smoke_test.out'))
+        reason = 'test: checking ability to use the library'
         self.run_test(prog, [], expected, purpose=reason)
 
     def _run_build_tests(self):
-        """Build and run selected tests pulled from the build."""
-        # Run the build tests to confirm the expected output
+        """Run selected build tests."""
         passed = 'Test passed'
         checks = {
             'sigsegv1': [passed],
@@ -70,8 +69,9 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
         }
 
         for exe, expected in checks.items():
-            reason = 'test {0} output'.format(exe)
-            self.run_test(exe, [], expected, purpose=reason, skip_missing=True)
+            reason = 'test: checking {0} output'.format(exe)
+            self.run_test(exe, [], expected, installed=True, purpose=reason,
+                          skip_missing=True)
 
     def test(self):
         """Perform smoke tests on the installed package."""

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -5,10 +5,7 @@
 
 import re
 
-import os
-import re
-
-import llnl.util.tty as tty
+import spack.install_test as sit
 
 
 class M4(AutotoolsPackage, GNUMirrorPackage):
@@ -83,22 +80,14 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         return args
 
     def test(self):
-        m4 = which('m4')
-        assert m4 is not None
+        spec_vers = str(self.spec.version)
+        reason = 'test: ensuring m4 version is {0}'.format(spec_vers)
+        self.run_test('m4', '--version', spec_vers, installed=True,
+                      purpose=reason, skip_missing=False)
 
-        tty.msg('test: Ensuring use of the installed executable')
-        m4_dir = os.path.dirname(m4.path)
-        assert m4_dir == self.prefix.bin
-
-        tty.msg('test: Checking version')
-        output = m4('--version', output=str.split, error=str.split)
-        version_regex = re.compile(r'm4(.+){0}'.format(self.spec.version))
-        assert version_regex.search(output)
-
-        tty.msg('test: Ensuring m4 runs')
-        data_dir = self.test_suite.current_test_data_dir
-        hello_file = data_dir.join('hello.m4')
-        output = m4(hello_file, output=str.split, error=str.split)
-        expected_file = data_dir.join('hello.out')
-        with open(expected_file) as fd:
-            assert output == fd.read()
+        reason = 'test: ensuring m4 example succeeds'
+        test_data_dir = self.test_suite.current_test_data_dir
+        hello_file = test_data_dir.join('hello.m4')
+        expected = sit.get_expected_output(test_data_dir.join('hello.out'))
+        self.run_test('m4', hello_file, expected, installed=True,
+                      purpose=reason, skip_missing=False)

--- a/var/spack/repos/builtin/packages/mpi/package.py
+++ b/var/spack/repos/builtin/packages/mpi/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+
 class Mpi(Package):
     """Virtual package for the Message Passing Interface."""
     homepage = 'https://www.mpi-forum.org/'
@@ -19,7 +20,7 @@ class Mpi(Package):
             compiler = os.environ[compiler_var]
 
             exe_name = 'mpi_hello_%s' % lang
-            mpirun = os.path.join(self.prefix.bin, 'mpirun')
+            mpirun = join_path(self.prefix.bin, 'mpirun')
 
             compiled = self.run_test(compiler,
                                      options=['-o', exe_name, filename])

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -743,14 +743,13 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             options, expected, status = checks[exe]
-            reason = 'test {0} output'.format(exe)
+            reason = 'test: checking {0} output'.format(exe)
             self.run_test(exe, options, expected, status, installed=True,
                           purpose=reason, skip_missing=True)
 
     def _test_check_versions(self):
         comp_vers = str(self.spec.compiler.version)
         spec_vers = str(self.spec.version)
-        bad_option = 'unknown option'
         checks = {
             # Binaries available in at least versions 2.0.0 through 4.0.3
             'mpiCC': ([comp_vers], 0),
@@ -762,15 +761,8 @@ class Openmpi(AutotoolsPackage):
             'mpif90': ([comp_vers], 0),
             'mpifort': ([comp_vers], 0),
             'mpirun': ([spec_vers], 0),
-            'ompi-clean': ([bad_option], 213),
-            'ompi-server': ([bad_option], 1),
             'ompi_info': ([spec_vers], 0),
-            'opal_wrapper': (['Cannot open configuration file'], 243),
-            'orte-clean': ([bad_option], 213),
-            'orte-info': (['did not have enough parameters'], 1),
-            'orte-server': ([bad_option], 1),
             'ortecc': ([comp_vers], 0),
-            'orted': ([bad_option], 213),
             'orterun': ([spec_vers], 0),
 
             # Binaries available in versions 2.0.0 through 2.1.6
@@ -779,11 +771,7 @@ class Openmpi(AutotoolsPackage):
 
             # Binaries available in versions 2.0.0 through 3.1.5
             'ompi-dvm': ([spec_vers], 0),
-            'ompi-ps': ([bad_option], 213),
-            'ompi-top': ([bad_option], 1),
             'orte-dvm': ([spec_vers], 0),
-            'orte-ps': ([bad_option], 213),
-            'orte-top': ([bad_option], 1),
             'oshcc': ([comp_vers], 0),
             'oshfort': ([comp_vers], 0),
             'oshmem_info': ([spec_vers], 0),
@@ -806,16 +794,17 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             expected, status = checks[exe]
-            purpose = 'test version of {0} is {1}'.format(exe, expected[0])
+            purpose = 'test: ensuring version of {0} is {1}' \
+                .format(exe, expected[0])
             self.run_test(exe, ['--version'], expected, status, installed=True,
                           purpose=purpose, skip_missing=True)
 
     def _test_examples(self):
         # First build the examples
-        work_dir = os.path.join(self.install_test_root,
-                                self.extra_install_tests)
         self.run_test('make', ['all'], [],
-                      purpose='test build the examples', work_dir=work_dir)
+                      purpose='test: ensuring ability to build the examples',
+                      work_dir=join_path(self.install_test_root,
+                                         self.extra_install_tests))
 
         # Now run those with known results
         have_spml = self.spec.satisfies('@2.0.0:2.1.6')
@@ -857,10 +846,9 @@ class Openmpi(AutotoolsPackage):
 
         for exe in checks:
             expected, status = checks[exe]
-            reason = 'test {0} output'.format(exe)
-            self.run_test(self.spec.prefix.bin.join(exe),
-                          [], expected, status, installed=True,
-                          purpose=reason, skip_missing=True, work_dir=work_dir)
+            reason = 'test: checking example {0} output'.format(exe)
+            self.run_test(exe, [], expected, status, installed=True,
+                          purpose=reason, skip_missing=True)
 
     def test(self):
         """Perform smoke tests on the installed package."""

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -20,20 +20,22 @@ class Patchelf(AutotoolsPackage):
     version('0.8',  sha256='14af06a2da688d577d64ff8dac065bb8903bbffbe01d30c62df7af9bf4ce72fe')
 
     def test(self):
-        # Check patchelf in prefix and reports correct version
-        purpose_str = 'test patchelf is in prefix and reports correct version'
+        # Check patchelf in prefix and reports the correct version
+        reason = 'test: ensuring patchelf version is {0}' \
+            .format(self.spec.version)
         self.run_test('patchelf',
-                      options=['--version'],
+                      options='--version',
                       expected=['patchelf %s' % self.spec.version],
                       installed=True,
-                      purpose=purpose_str)
+                      purpose=reason)
 
         # Check the rpath is changed
         currdir = os.getcwd()
-        hello_file = os.path.join(currdir, 'data', 'hello')
+        hello_file = self.test_suite.current_test_data_dir.join('hello')
         self.run_test('patchelf', ['--set-rpath', currdir, hello_file],
-                      purpose='test that patchelf can change rpath')
+                      purpose='test: ensuring that patchelf can change rpath')
+
         self.run_test('patchelf',
                       options=['--print-rpath', hello_file],
                       expected=[currdir],
-                      purpose='test that patchelf actually changed rpath')
+                      purpose='test: ensuring that patchelf changed rpath')

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -3,19 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
-import re
+import spack.install_test as sit
 
 from spack import *
 from spack import architecture
-
-
-def _read_file(filepath):
-    """Read and clean up the expected output from the specified file."""
-    output = ''
-    with open(filepath, 'r') as fd:
-        output = fd.read()
-    return [re.escape(ln) for ln in output.split('\n')]
 
 
 class Sqlite(AutotoolsPackage):
@@ -142,21 +133,23 @@ class Sqlite(AutotoolsPackage):
 
     def _test_example(self):
         """Ensure a sequence of commands on example db are successful."""
-        data_dir = self.test_suite.current_test_data_dir
+
+        test_data_dir = self.test_suite.current_test_data_dir
+        db_filename = test_data_dir.join('packages.db')
+        exe = 'sqlite3'
 
         # Ensure the database only contains one table
-        reason = 'test to ensure only table is "packages"'
-        opts = [data_dir.join('packages.db'), '.tables']
-        self.run_test('sqlite3', opts, 'packages', installed=True,
+        expected = 'packages'
+        reason = 'test: ensuring only table is "{0}"'.format(expected)
+        self.run_test(exe, [db_filename, '.tables'], expected, installed=True,
                       purpose=reason, skip_missing=False)
 
         # Ensure the database dump matches expectations, where special
         # characters are replaced with spaces in the expected and actual
         # output to avoid pattern errors.
-        reason = 'test dump output'
-        opts = [data_dir.join('packages.db'), '.dump']
-        expected = _read_file(data_dir.join('dump.out'))
-        self.run_test('sqlite3', opts, expected, installed=True,
+        reason = 'test: checking dump output'
+        expected = sit.get_expected_output(test_data_dir.join('dump.out'))
+        self.run_test(exe, [db_filename, '.dump'], expected, installed=True,
                       purpose=reason, skip_missing=False)
 
     def _test_version(self):
@@ -164,15 +157,12 @@ class Sqlite(AutotoolsPackage):
         exe = 'sqlite3'
         vers_str = str(self.spec.version)
 
-        reason = 'test version of {0} is {1}'.format(exe, vers_str)
+        reason = 'test: ensuring version of {0} is {1}'.format(exe, vers_str)
         self.run_test(exe, '-version', vers_str, installed=True,
                       purpose=reason, skip_missing=False)
 
     def test(self):
         """Perform smoke tests on the installed package."""
-        tty.debug('Expected results currently based on simple {0} builds'
-                  .format(self.name))
-
         # Perform a simple version check
         self._test_version()
 


### PR DESCRIPTION
Closes #18210 

This PR addresses install test bugs and consistency changes from #18210 that were not subsumed by #18277.  These changes include:

- Provide function for reading and converting (`re.escape`) expected output from a file
- Provide consistent test part purpose/reason: `test: <verb> <description>`
- Change `m4` to use the (newer) `run_test` method
- Use of Spack's `join_path` (versus `os.path.join`)
- Leverage (newer) ability to pass a string to `options`
- Remove remaining version checks for executables that do not support the option
- Fix `flake8` errors in the modified code and packages