### PR TITLE
[new version] Draco package

### DIFF
--- a/var/spack/repos/builtin/packages/draco/d770-nocuda.patch
+++ b/var/spack/repos/builtin/packages/draco/d770-nocuda.patch
@@ -1,0 +1,38 @@
+diff --git a/config/compilerEnv.cmake b/config/compilerEnv.cmake
+index a4996822..413f6836 100644
+--- a/config/compilerEnv.cmake
++++ b/config/compilerEnv.cmake
+@@ -741,6 +741,18 @@ macro(dbsSetupCuda)
+     # User option to disable Cuda, even when it is available.
+     option(USE_CUDA "Use Cuda?" ON)
+ 
++  endif()
++
++  # Save the results
++  set( HAVE_CUDA ${HAVE_CUDA} CACHE BOOL
++    "Should we build CUDA portions of this project?" FORCE )
++  if( HAVE_CUDA AND USE_CUDA )
++
++    # Use this string in 'project(foo ${CUDA_DBS_STRING})' commands to enable
++    # cuda per project.
++    set( CUDA_DBS_STRING "CUDA" CACHE STRING
++      "If CUDA is available, this variable is 'CUDA'")
++
+     # Use this string as a toggle when calling add_component_library or
+     # add_scalar_tests to force compiling with nvcc.
+     set( COMPILE_WITH_CUDA LINK_LANGUAGE CUDA )
+@@ -752,14 +764,7 @@ macro(dbsSetupCuda)
+       message(FATAL_ERROR "Build system does not support "
+         "CUDACXX=${CMAKE_CUDA_COMPILER}")
+     endif()
+-  endif()
+ 
+-  # Save the results
+-  set( HAVE_CUDA ${HAVE_CUDA} CACHE BOOL
+-    "Should we build CUDA portions of this project?" FORCE )
+-  if( ${HAVE_CUDA} )
+-    set( CUDA_DBS_STRING "CUDA" CACHE STRING
+-      "If CUDA is available, this variable is 'CUDA'")
+   endif()
+ 
+ endmacro()

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -18,6 +18,7 @@ class Draco(CMakePackage):
     maintainers = ['KineticTheory']
 
     version('develop', branch='develop')
+    version('7.7.0',  sha256='eb7fffbcba48e16524f619d261192ead129f968c59f3581f3217b89590812ddf')
     version('7.6.0',  sha256='c2c6b329620d7bcb0f2fc14371f105dfb80a84e7c5adbb34620777034b15c7c9')
     version('7.5.0',  sha256='0bb12b5f5ff60ba3087310c07da42e8d4f481ec4259daaa24ec240815a2e9dec')
     version('7.4.0',  sha256='61da2c3feace0e92c5410c9e9e613708fdf8954b1367cdc62c415329b0ddab6e')
@@ -33,6 +34,7 @@ class Draco(CMakePackage):
 
     variant('build_type', default='Release', description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+    variant('cuda',     default=False, description='Enable Cuda/GPU support')
     variant('eospac',   default=True, description='Enable EOSPAC support')
     variant('lapack',   default=True, description='Enable LAPACK wrapper')
     variant('libquo',   default=True, description='Enable Quo wrapper')
@@ -41,28 +43,35 @@ class Draco(CMakePackage):
     variant('superlu_dist', default=True, description='Enable SuperLU-DIST support')
 
     depends_on('gsl')
-    depends_on('mpi@3:',      type=('build', 'link', 'run'))
-    depends_on('numdiff',     type='build')
-    depends_on('python@2.7:', type=('build', 'run'))
-    depends_on('random123',   type='build')
+    depends_on('mpi@3:',                            type=('build', 'link', 'run'))
+    depends_on('numdiff',                           type='build')
+    depends_on('python@2.7:', when='@:7.6.99',      type=('build', 'run'))
+    depends_on('python@3.5:', when='@7.7.0:',       type=('build', 'run', 'test'))
+    depends_on('random123@1.09',                    type='build')
 
     depends_on('cmake@3.9:',  when='@:6.99',        type='build')
     depends_on('cmake@3.11:', when='@7.0.0:7.1.99', type='build')
-    depends_on('cmake@3.14:', when='@7.2:',         type='build')
+    depends_on('cmake@3.14:', when='@7.2:7.6.99',   type='build')
+    depends_on('cmake@3.17:', when='@7.7:',         type='build')
+    depends_on('cuda@10.1:',  when='+cuda')
     depends_on('eospac@6.3:', when='+eospac')
     depends_on('lapack',      when='+lapack')
-    depends_on('libquo',      when='@7.4.0:+libquo')
+    depends_on('libquo@1.3.1:', when='@7.4.0:+libquo')
     depends_on('metis',       when='+parmetis')
     depends_on('parmetis',    when='+parmetis')
     depends_on('qt',          when='+qt',
                type=('build', 'link', 'run'))
-    depends_on('superlu-dist@:5.99', when='+superlu_dist')
+    depends_on('superlu-dist@:5.99', when='@:7.6.99+superlu_dist')
+
+    conflicts('+cuda', when='@:7.6.99')
 
     # Fix python discovery.
     patch('d710.patch', when='@7.1.0^python@3:')
     patch('d710-python2.patch', when='@7.1.0^python@2.7:2.99')
     patch('d730.patch', when='@7.3.0:7.3.99')
     patch('d740.patch', when='@7.4.0:7.4.99')
+    patch('smpi.patch', when='@:7.6.99')
+    patch('d770-nocuda.patch', when='@7.7.0')
 
     def url_for_version(self, version):
         url = "https://github.com/lanl/Draco/archive/draco-{0}.zip"
@@ -74,4 +83,13 @@ class Draco(CMakePackage):
             '-Wno-dev',
             '-DBUILD_TESTING={0}'.format('ON' if self.run_tests else 'OFF')
         ])
+        if '~cuda' in self.spec:
+            options.extend(['-DUSE_CUDA=OFF'])
         return options
+
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
+    def check(self):
+        """Run ctest after building project."""
+        with working_dir(self.build_directory):
+            ctest('--output-on-failure')

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -87,8 +87,6 @@ class Draco(CMakePackage):
             options.extend(['-DUSE_CUDA=OFF'])
         return options
 
-    @run_after('build')
-    @on_package_attributes(run_tests=True)
     def check(self):
         """Run ctest after building project."""
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/draco/smpi.patch
+++ b/var/spack/repos/builtin/packages/draco/smpi.patch
@@ -1,0 +1,12 @@
+The LANL Darwin platform calls the IBM Spectrum modules "smpi".
+diff -up config/setupMPI.cmake.smpi config/setupMPI.cmake
+--- a/config/setupMPI.cmake.smpi	2020-05-28 11:54:17.851957957 -0600
++++ b/config/setupMPI.cmake	2020-05-28 11:55:35.018332601 -0600
+@@ -46,6 +46,7 @@ function( setMPIflavorVer )
+   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "mvapich2")
+     set( MPI_FLAVOR "mvapich2" )
+   elseif( "${MPIEXEC_EXECUTABLE}" MATCHES "spectrum-mpi" OR
++      "${MPIEXEC_EXECUTABLE}" MATCHES "smpi" OR
+       "${MPIEXEC_EXECUTABLE}" MATCHES "jsrun" )
+     set( MPI_FLAVOR "spectrum")
+   endif()


### PR DESCRIPTION
+ Add support for `draco-7.7.0`.
  + Introduces new `+cuda` variant.  This variant is only allowed in version `7.7.0:`.
  + Restrict `random123` to compatible versions.
  + Restrict `libquo` to compatible versions.
  + Moving forward, require `python@3:`
  + Moving forward, the `+superlu_dist` variant is no longer supported.
+ Improve printed output for `--test` mode by adding `ctest` option `--output-on-failure`
+ Provide a patch to support for IBM Spectrum-MPI in version `7.7.0:`
+ Provide a patch to allow variant `~cuda` to actually disable GPU portions of the code when a GPU is discovered on the local system (for version `7.7.0` only).