### PR TITLE
Smoke tests: Rename and make escaped file text utility available to packages

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -18,8 +18,8 @@ import spack.util.prefix
 import spack.util.spack_json as sjson
 
 
-def get_expected_output(filename):
-    """Retrieve the expected output from the file
+def get_escaped_text_output(filename):
+    """Retrieve and escape the expected text output from the file
 
     Args:
         filename (str): path to the file

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -57,6 +57,7 @@ from spack.package import \
 
 from spack.installer import \
     ExternalPackageError, InstallError, InstallLockError, UpstreamPackageError
+from spack.install_test import get_escaped_text_output
 
 from spack.variant import any_combination_of, auto_or_any_combination_of
 from spack.variant import disjoint_sets

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -6,8 +6,6 @@
 import sys
 import os
 
-import spack.install_test as sit
-
 
 class Hdf(AutotoolsPackage):
     """HDF4 (also known as HDF) is a library and multi-object
@@ -201,9 +199,9 @@ class Hdf(AutotoolsPackage):
         test_data_dir = self.test_suite.current_test_data_dir
         work_dir = '.'
 
-        reason = 'test: ensuring hdfls produces expected output'
+        reason = 'test: checking hdfls output'
         details_file = os.path.join(test_data_dir, 'storm110.out')
-        expected = sit.get_expected_output(details_file)
+        expected = get_escaped_text_output(details_file)
         self.run_test('hdfls', [storm_fn], expected, installed=True,
                       purpose=reason, skip_missing=True, work_dir=work_dir)
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -6,10 +6,6 @@
 import shutil
 import sys
 
-import spack.install_test as sit
-
-from spack import *
-
 
 class Hdf5(AutotoolsPackage):
     """HDF5 is a data model, library, and file format for storing and managing
@@ -401,7 +397,7 @@ HDF5 version {version} {version}
         h5_file = test_data_dir.join(filename)
 
         reason = 'test: ensuring h5dump produces expected output'
-        expected = sit.get_expected_output(test_data_dir.join('dump.out'))
+        expected = get_escaped_text_output(test_data_dir.join('dump.out'))
         self.run_test('h5dump', filename, expected, installed=True,
                       purpose=reason, skip_missing=True,
                       work_dir=test_data_dir)

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -5,10 +5,6 @@
 
 import llnl.util.tty as tty
 
-import spack.install_test as sit
-
-from spack import *
-
 
 class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
     """GNU libsigsegv is a library for handling page faults in user mode."""
@@ -53,7 +49,7 @@ class Libsigsegv(AutotoolsPackage, GNUMirrorPackage):
         self.run_test('cc', options, [], installed=False, purpose=reason)
 
         # Now run the program and confirm the output matches expectations
-        expected = sit.get_expected_output(data_dir.join('smoke_test.out'))
+        expected = get_escaped_text_output(data_dir.join('smoke_test.out'))
         reason = 'test: checking ability to use the library'
         self.run_test(prog, [], expected, purpose=reason)
 

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -5,8 +5,6 @@
 
 import re
 
-import spack.install_test as sit
-
 
 class M4(AutotoolsPackage, GNUMirrorPackage):
     """GNU M4 is an implementation of the traditional Unix macro processor."""
@@ -88,6 +86,6 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         reason = 'test: ensuring m4 example succeeds'
         test_data_dir = self.test_suite.current_test_data_dir
         hello_file = test_data_dir.join('hello.m4')
-        expected = sit.get_expected_output(test_data_dir.join('hello.out'))
+        expected = get_escaped_text_output(test_data_dir.join('hello.out'))
         self.run_test('m4', hello_file, expected, installed=True,
                       purpose=reason, skip_missing=False)

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.install_test as sit
-
-from spack import *
 from spack import architecture
 
 
@@ -148,7 +145,7 @@ class Sqlite(AutotoolsPackage):
         # characters are replaced with spaces in the expected and actual
         # output to avoid pattern errors.
         reason = 'test: checking dump output'
-        expected = sit.get_expected_output(test_data_dir.join('dump.out'))
+        expected = get_escaped_text_output(test_data_dir.join('dump.out'))
         self.run_test(exe, [db_filename, '.dump'], expected, installed=True,
                       purpose=reason, skip_missing=False)
 


### PR DESCRIPTION
This PR renames the smoke test utility for reading and escaping expected smoke test output from a file *and* makes it available to packages.  It also updates the five packages currently making use of the utility to use the new name.

I also removed the unnecessary imports of Spack and "standardized" the test purpose for one test case/part/whatever it's called in this context.

This feature was requested in #18337 .