### PR TITLE
Timemory: Fix python dependencies + NCCL

### DIFF
--- a/var/spack/repos/builtin/packages/timemory/package.py
+++ b/var/spack/repos/builtin/packages/timemory/package.py
@@ -25,7 +25,10 @@ class Timemory(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
     variant('static', default=False, description='Build static libraries')
     variant('python', default=False, description='Enable Python support')
-    variant('mpi', default=False, description='Enable MPI support')
+    variant('mpi', default=False, 
+            description='Enable support for MPI aggregation')
+    variant('nccl', default=False, 
+            description='Enable support for wrapping NCCL functions')
     variant('tau', default=False, description='Enable TAU support')
     variant('papi', default=False, description='Enable PAPI support')
     variant('cuda', default=False, description='Enable CUDA support')
@@ -92,7 +95,11 @@ class Timemory(CMakePackage):
     depends_on('py-numpy', when='+python', type=('run'))
     depends_on('py-pillow', when='+python', type=('run'))
     depends_on('py-matplotlib', when='+python', type=('run'))
+    depends_on('py-mpi4py', when='+python+mpi', type=('run'))
+    depends_on('py-cython', when='+python', type=('build'))
+    depends_on('py-ipython', when='+python', type=('run'))
     depends_on('mpi', when='+mpi')
+    depends_on('nccl', when='+nccl')
     depends_on('tau', when='+tau')
     depends_on('papi', when='+papi')
     depends_on('cuda', when='+cuda')
@@ -123,6 +130,8 @@ class Timemory(CMakePackage):
               msg='+python require tls_model=global-dynamic')
     conflicts('tls_model=local-exec', when='+python',
               msg='+python require tls_model=global-dynamic')
+    conflicts('+nccl', when='~gotcha',
+              msg='+nccl requires +gotcha')
     conflicts('+mpip_library', when='~mpi', msg='+mpip_library requires +mpi')
     conflicts('+mpip_library', when='~gotcha',
               msg='+mpip_library requires +gotcha')
@@ -160,6 +169,10 @@ class Timemory(CMakePackage):
         if '+python' in spec:
             args.append('-DPYTHON_EXECUTABLE={0}'.format(
                 spec['python'].command.path))
+
+        if '+nccl' in spec:
+            args.append('-DTIMEMORY_USE_NCCL=ON')
+            args.append('-DTIMEMORY_BUILD_NCCLP_LIBRARY=ON')
 
         if '+mpi' in spec:
             args.append('-DTIMEMORY_USE_MPI_LINK_FLAGS=OFF')

--- a/var/spack/repos/builtin/packages/timemory/package.py
+++ b/var/spack/repos/builtin/packages/timemory/package.py
@@ -25,9 +25,9 @@ class Timemory(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
     variant('static', default=False, description='Build static libraries')
     variant('python', default=False, description='Enable Python support')
-    variant('mpi', default=False, 
+    variant('mpi', default=False,
             description='Enable support for MPI aggregation')
-    variant('nccl', default=False, 
+    variant('nccl', default=False,
             description='Enable support for wrapping NCCL functions')
     variant('tau', default=False, description='Enable TAU support')
     variant('papi', default=False, description='Enable PAPI support')


### PR DESCRIPTION
- Python extensions require Cython
- Added options for enabling NCCL