### PR TITLE
cp2k: Add depend on libxc@4.3.4.

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -97,6 +97,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     depends_on('libxc@2.2.2:', when='+libxc@:5.5999', type='build')
     depends_on('libxc@4.0.3:', when='+libxc@6.0:6.9', type='build')
     depends_on('libxc@4.0.3:', when='+libxc@7.0:')
+    depends_on('libxc@4.3.4', type='link')
 
     depends_on('mpi@2:', when='+mpi')
     depends_on('scalapack', when='+mpi')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -94,10 +94,9 @@ class Cp2k(MakefilePackage, CudaPackage):
         depends_on('libint@2.6.0:+fortran tune=cp2k-lmax-{0}'.format(lmax),
                    when='+libint@7.0: lmax={0}'.format(lmax))
 
-    depends_on('libxc@2.2.2:', when='+libxc@:5.5999', type='build')
-    depends_on('libxc@4.0.3:', when='+libxc@6.0:6.9', type='build')
-    depends_on('libxc@4.0.3:', when='+libxc@7.0:')
-    depends_on('libxc@4.3.4', type='link')
+    depends_on('libxc@2.2.2:3.99.0', when='+libxc@:5.5999', type='build')
+    depends_on('libxc@4.0.3:4.99.0', when='+libxc@6.0:6.9', type='build')
+    depends_on('libxc@4.0.3:4.99.0', when='+libxc@7.0:')
 
     depends_on('mpi@2:', when='+mpi')
     depends_on('scalapack', when='+mpi')


### PR DESCRIPTION
Since build error occurs in libxc@5.0.0, add depend on libxc@4.3.4.
This is a known issue.
　https://github.com/Homebrew/homebrew-core/pull/53077