### PR TITLE
autotools: patch all config.guess and config.sub

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -5,7 +5,6 @@
 import inspect
 import os
 import os.path
-import sys
 import re
 from subprocess import PIPE
 from subprocess import check_call


### PR DESCRIPTION
fixes #18098
fixes #18064
closes #10785

On aarch64 and ppc64le, config.guess and config.sub is updated.
But only each only one file is updated.
This PR updates all config.guess and config.sub files.