### PR TITLE
Modules: Deduplicate suffixes but don't sort them.

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -36,6 +36,7 @@ import os.path
 import re
 
 import llnl.util.filesystem
+from llnl.util.lang import dedupe
 import llnl.util.tty as tty
 import spack.build_environment as build_environment
 import spack.error
@@ -442,7 +443,7 @@ class BaseConfiguration(object):
         for constraint, suffix in self.conf.get('suffixes', {}).items():
             if constraint in self.spec:
                 suffixes.append(suffix)
-        suffixes = sorted(set(suffixes))
+        suffixes = list(dedupe(suffixes))
         if self.hash:
             suffixes.append(self.hash)
         return suffixes

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -16,7 +16,6 @@ import xml.etree.ElementTree
 
 import py
 import pytest
-import ruamel.yaml as yaml
 
 from llnl.util.filesystem import mkdirp, remove_linked_tree
 
@@ -35,6 +34,7 @@ import spack.repo
 import spack.stage
 import spack.util.executable
 import spack.util.gpg
+import spack.util.spack_yaml as syaml
 
 from spack.util.pattern import Bunch
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
@@ -748,7 +748,7 @@ def module_configuration(monkeypatch, request):
 
         file = os.path.join(root_for_conf, filename + '.yaml')
         with open(file) as f:
-            configuration = yaml.load(f)
+            configuration = syaml.load_config(f)
 
         def mock_config_function():
             return configuration

--- a/lib/spack/spack/test/data/modules/tcl/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix.yaml
@@ -3,6 +3,7 @@ enable:
 tcl:
   mpileaks:
     suffixes:
+      '+opt': baz
       '+debug': foo
-      '~debug': bar
       '^mpich': foo
+      '~debug': bar

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -272,7 +272,11 @@ class TestTcl(object):
         assert 'foo-foo' not in writer.layout.use_name
 
         writer, spec = factory('mpileaks~debug arch=x86-linux')
-        assert 'bar-foo' in writer.layout.use_name
+        assert 'foo-bar' in writer.layout.use_name
+        assert 'baz' not in writer.layout.use_name
+
+        writer, spec = factory('mpileaks~debug+opt arch=x86-linux')
+        assert 'baz-foo-bar' in writer.layout.use_name
 
     def test_setup_environment(self, modulefile_content, module_configuration):
         """Tests the internal set-up of run-time environment."""


### PR DESCRIPTION
PR #14920 changed the behavior to sorting the suffixes. That change is causing some issues with our modules.

`foo/X.Y.Z-cuda-mpi` becomes `foo/X.Y.Z-cuda-mpi` for example, which we aren't really happy about because it is causing duplicated modules if we don't pay attention and we cannot have consistent module naming without breaking existing submission scripts.

The documentation (https://spack.readthedocs.io/en/latest/module_file_support.html#selection-by-anonymous-specs) currently states:
> Order does matter
> The modifications associated with the all keyword are always evaluated first, no matter where they appear in the configuration file. All the other spec constraints are instead evaluated top to bottom.

I think that it makes sense that "modifications" also apply to `suffixes`. As far as I can tell, the suffixes' ordering is indeed guaranteed to follow the ordering of configuration files (except for `all` which is considered first, as already noted in the documentation).
