### PR TITLE
davix: Improve shared library building on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/davix/package.py
+++ b/var/spack/repos/builtin/packages/davix/package.py
@@ -33,4 +33,6 @@ class Davix(CMakePackage):
     def cmake_args(self):
         cmake_args = ['-DCMAKE_CXX_STANDARD={0}'.format(
                       self.spec.variants['cxxstd'].value)]
+        if 'darwin' in self.spec.architecture:
+            cmake_args.append('-DCMAKE_MACOSX_RPATH=ON')
         return cmake_args


### PR DESCRIPTION
Add -DCMAKE_MACOSX_RPATH=ON to cmake.