### PR TITLE
namd: added patching charmrun location, as it stored in prefix.bin

### DIFF
--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -142,6 +142,15 @@ class Namd(MakefilePackage):
 
         config(self.build_directory, *opts)
 
+        # patch Make.config if needed
+        # spack install charmpp straight to prefix
+        # (not to $(CHARMBASE)/$(CHARMARCH))
+        if not os.path.exists(join_path(
+                self.spec['charmpp'].prefix, self.spec['charmpp'].charmarch)):
+            filter_file(r"^CHARM = \$\(CHARMBASE\)/\$\(CHARMARCH\)",
+                        "CHARM = $(CHARMBASE)",
+                        join_path(self.build_directory, "Make.config"))
+
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
             mkdirp(prefix.bin)


### PR DESCRIPTION
Hello,

Fixed the location of charmrun during namd compilation.

Namd used to fail because it was looking for charmrun in $(CHARMBASE)/$(CHARMARCH) while with current charmpp setup it is in spec['charmpp'].prefix:

```
make: *** No rule to make target 
'/home/nikolays/spack/opt/spack/linux-ubuntu20.04-skylake_avx512/gcc-10.2.0/
charmpp-6.10.2-mf5vqdyi3q7mzqiofevjf42fehcuwvwv/netlrts-linux-x86_64/bin/charmrun', 
needed by 'charmrun'.  Stop. 
```

I am not sure is charm++ architecture is now per one installed package or it still can combine multiple within single installed package. So  I added conditional patching if there is no spec['charmpp'].charmarch in spec['charmpp'].prefix then set CHARM to $(CHARMBASE) in Make.config.

Best,
Nikolay