### PR TITLE
binutils: add build dep: diffutils (provides `cmp`)

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -44,6 +44,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     patch('update_symbol-2.26.patch', when='@2.26')
 
     depends_on('zlib')
+    depends_on('diffutils', type='build')
     depends_on('gettext', when='+nls')
 
     # Prior to 2.30, gold did not distribute the generated files and


### PR DESCRIPTION
`binutils` needs `cmp` for build. `cmp` is provided by `diffutils`. This PR makes this dependency explicit.

Fixes https://github.com/spack/spack/issues/18289