### PR TITLE
Add standard `ipo` variant for CMakePackage

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -12,7 +12,7 @@ import re
 import spack.build_environment
 from llnl.util.filesystem import working_dir
 from spack.util.environment import filter_system_paths
-from spack.directives import depends_on, variant
+from spack.directives import depends_on, variant, conflicts
 from spack.package import PackageBase, InstallError, run_after
 
 # Regex to extract the primary generator from the CMake generator
@@ -94,6 +94,14 @@ class CMakePackage(PackageBase):
             description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_INTERPROCEDURAL_OPTIMIZATION.html
+    variant('ipo', default=False,
+            description='CMake interprocedural optimization')
+    # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
+    conflicts('+ipo', when='^cmake@:3.8',
+              msg='CMAKE_INTERPROCEDURAL_OPTIMIZATION cannot be used with '
+                  'CMake < 3.9')
+
     depends_on('cmake', type='build')
 
     @property
@@ -147,12 +155,21 @@ class CMakePackage(PackageBase):
         except KeyError:
             build_type = 'RelWithDebInfo'
 
+        try:
+            ipo = pkg.spec.variants['ipo'].value
+        except KeyError:
+            ipo = False
+
         define = CMakePackage.define
         args = [
             '-G', generator,
             define('CMAKE_INSTALL_PREFIX', pkg.prefix),
             define('CMAKE_BUILD_TYPE', build_type),
         ]
+
+        # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
+        if pkg.spec.satisfies('^cmake@3.9:'):
+            args.append(define('CMAKE_INTERPROCEDURAL_OPTIMIZATION', ipo))
 
         if primary_generator == 'Unix Makefiles':
             args.append(define('CMAKE_VERBOSE_MAKEFILE', True))

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -99,8 +99,7 @@ class CMakePackage(PackageBase):
             description='CMake interprocedural optimization')
     # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
     conflicts('+ipo', when='^cmake@:3.8',
-              msg='CMAKE_INTERPROCEDURAL_OPTIMIZATION cannot be used with '
-                  'CMake < 3.9')
+              msg='+ipo is not supported by CMake < 3.9')
 
     depends_on('cmake', type='build')
 


### PR DESCRIPTION
Due to CMake's handling of compilers, linkers, archivers, etc., it can be harder to enable IPO/LTO by simply manipulating `CFLAGS`, `AR`, `RANLIB`, etc. than in autotools-based projects. The variable `CMAKE_INTERPROCEDURAL_OPTIMIZATION` has existed since CMake 3.9 to allow compilation with IPO/LTO more easily.

This PR adds a standard `ipo` variant to CMake packages, defaulting to `False`, that allows users to control this variable. Enabling it possibly breaks some packages, but it defaults to off, so I don't think it should cause any problems.

Closes #18373.