### PR TITLE
[libdrm] AutotoolsPackage; %gcc@10.0.0 requires CFLAGS=-fcommon

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -7,7 +7,7 @@ from spack import *
 import sys
 
 
-class Libdrm(Package):
+class Libdrm(AutotoolsPackage):
     """A userspace library for accessing the DRM, direct rendering manager,
     on Linux, BSD and other systems supporting the ioctl interface."""
 
@@ -25,11 +25,10 @@ class Libdrm(Package):
     depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
     depends_on('libpthread-stubs')
 
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(prefix),
-                  '--enable-static',
-                  'LIBS=-lrt')  # This fixes a bug with `make check`
-
-        make()
-        make('check')
-        make('install')
+    def configure_args(self):
+        args = []
+        args.append('--enable-static')
+        args.append('LIBS=-lrt') # This fixes a bug with `make check`
+        if self.spec.satisfies('%gcc@10.0.0:'):
+            args.append('CFLAGS=-fcommon')
+        return args

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -28,7 +28,7 @@ class Libdrm(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.append('--enable-static')
-        args.append('LIBS=-lrt') # This fixes a bug with `make check`
+        args.append('LIBS=-lrt')  # This fixes a bug with `make check`
         if self.spec.satisfies('%gcc@10.0.0:'):
             args.append('CFLAGS=-fcommon')
         return args


### PR DESCRIPTION
### Bugfix for `gcc@10.0.0:`

`libdrm %gcc@10.2.0` fails to compile on `linux-ubuntu20.04-skylake_avx512` in `develop` with the following error ([spack-build-out.txt](https://github.com/spack/spack/files/5145785/spack-build-out.txt)):
```console
==> Installing libdrm
==> No binary for libdrm found: installing from source
==> Using cached archive: /data/spack/var/spack/cache/_source-cache/archive/6a/6a5337c054c0c47bc16607a21efa2b622e08030be4101ef4a241c5eb05b6619b.tar.gz
==> libdrm: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

1 error found in build log:
     308      CC       bufctx.lo
     309      CC       abi16.lo
     310      CCLD     libdrm_nouveau.la
     311    /usr/bin/ld: .libs/pushbuf.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/spack-src/nouveau/private.h:1
            3: multiple definition of `nouveau_debug'; .libs/nouveau.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2
            /spack-src/nouveau/private.h:13: first defined here
     312    /usr/bin/ld: .libs/bufctx.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/spack-src/nouveau/private.h:13
            : multiple definition of `nouveau_debug'; .libs/nouveau.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/
            spack-src/nouveau/private.h:13: first defined here
     313    /usr/bin/ld: .libs/abi16.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/spack-src/nouveau/private.h:13:
             multiple definition of `nouveau_debug'; .libs/nouveau.o:/tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/s
            pack-src/nouveau/private.h:13: first defined here
  >> 314    collect2: error: ld returned 1 exit status
     315    make[2]: *** [Makefile:657: libdrm_nouveau.la] Error 1
     316    make[1]: *** [Makefile:859: all-recursive] Error 1
     317    make: *** [Makefile:618: all] Error 2

See build log for details:
  /tmp/wdconinc/spack-stage/spack-stage-libdrm-2.4.100-maf3nidkjafqyjfc66y4yvzxq6my4zl2/spack-build-out.txt
```

This PR adds `CFLAGS=-fcommon` to the `configure` phase when `%gcc@10.0.0:`, which allows the compilation to succeed on my `%gcc@10.2.0:` ([spack-build-out.txt](https://github.com/spack/spack/files/5145819/spack-build-out.txt)).

### Rewrite to use `AutotoolsPackage`

Furthermore, anticipating the request, this is an autotools package, so it was rewritten to use AutotoolsPackage. The compiled versions on `%gcc@9.3.0` before and after the change were compared. The libraries had identical md5sum hashes. The only difference is that the previous version explicitly included the `make('check')` step, which is only included with `spack install --test all` in the AutotoolsPackage (as in the successful build output linked above).

### Newer versions

Finally, no attempt was made to support newer versions 2.4.101 or 2.4.102, which are distributed only as `tar.xz` files and use meson as the build system.