### PR TITLE
BLAS and LAPACK package properties for CMake FindBLAS/FindLAPACK (#18372)

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -24,6 +24,7 @@ from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 from spack.util.prefix import Prefix
 from spack.build_environment import dso_suffix
+from spack.build_systems.cmake import CMakePackage
 
 # A couple of utility functions that might be useful in general. If so, they
 # should really be defined elsewhere, unless deemed heretical.
@@ -849,6 +850,23 @@ class IntelPackage(PackageBase):
         # near the end phase of a client package's build phase.
 
         return sca_libs
+
+    @property
+    def blas_cmake_args(self):
+        vendor = 'Intel10'
+        vendor += '_64ilp' if '+ilp64' in self.spec else '_64lp'
+        if self.spec.satisfies('threads=none'):
+            vendor += '_seq'
+        elif self.spec.satisfies('threads=tbb'):
+            raise_lib_error('CMake FindBLAS doesn\'t support MKL with TBB')
+        return [
+            CMakePackage.define('BLA_STATIC', '~shared' in self.spec),
+            CMakePackage.define('BLA_VENDOR', vendor),
+        ]
+
+    @property
+    def lapack_cmake_args(self):
+        return self.blas_cmake_args
 
     # ---------------------------------------------------------------------
     # Support for virtual 'mpi'

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -882,6 +882,25 @@ def _libs_default_handler(descriptor, spec, cls):
     raise spack.error.NoLibrariesError(msg.format(spec.name, spec.prefix))
 
 
+def _cmake_args_default_handler(descriptor, spec, cls):
+    """Default handler when looking for the 'cmake_args' attribute.
+
+    Packages that don't use or support CMake don't have a cmake_args attribute,
+    so just returns an empty list.
+
+    Parameters:
+        descriptor (ForwardQueryToPackage): descriptor that triggered the call
+        spec (Spec): spec that is being queried
+        cls (type(spec)): type of spec, to match the signature of the
+            descriptor ``__get__`` method
+
+    Returns:
+        list: the nonexistant CMake arguments
+    """
+
+    return []
+
+
 class ForwardQueryToPackage(object):
     """Descriptor used to forward queries from Spec to Package"""
 
@@ -1013,6 +1032,11 @@ class SpecBuildInterface(lang.ObjectWrapper):
     libs = ForwardQueryToPackage(
         'libs',
         default_handler=_libs_default_handler
+    )
+
+    cmake_args = ForwardQueryToPackage(
+        'cmake_args',
+        default_handler=_cmake_args_default_handler
     )
 
     def __init__(self, spec, name, query_parameters):

--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -7,6 +7,7 @@ import os
 
 from spack import *
 from spack.package_test import compile_c_and_execute, compare_output_file
+from spack.build_systems.cmake import CMakePackage
 
 
 class Atlas(Package):
@@ -147,6 +148,17 @@ class Atlas(Package):
         return find_libraries(
             to_find, root=self.prefix, shared=shared, recursive=True
         )
+
+    @property
+    def blas_cmake_args(self):
+        return [
+            CMakePackage.define('BLA_STATIC', '~shared' in self.spec),
+            CMakePackage.define('BLA_VENDOR', 'ATLAS'),
+        ]
+
+    @property
+    def lapack_cmake_args(self):
+        return self.blas_cmake_args
 
     def install_test(self):
         source_file = join_path(os.path.dirname(self.module.__file__),

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -8,6 +8,8 @@
 # https://github.com/flame/blis/issues/195
 # https://github.com/flame/blis/issues/197
 
+from spack.build_systems.cmake import CMakePackage
+
 
 class BlisBase(Package):
     """Base class for building BLIS, shared with the AMD optimized version
@@ -117,6 +119,14 @@ class BlisBase(Package):
             shared='+shared' in self.spec,
             recursive=True
         )
+
+    @property
+    def blas_cmake_args(self):
+        static = '~shared' in self.spec or '+static' in self.spec
+        return [
+            CMakePackage.define('BLA_STATIC', static),
+            CMakePackage.define('BLA_VENDOR', 'FLAME'),
+        ]
 
 
 class Blis(BlisBase):

--- a/var/spack/repos/builtin/packages/essl/package.py
+++ b/var/spack/repos/builtin/packages/essl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.build_systems.cmake import CMakePackage
 
 
 class Essl(Package):
@@ -59,6 +60,13 @@ class Essl(Package):
         )
 
         return essl_libs
+
+    @property
+    def blas_cmake_args(self):
+        return [
+            CMakePackage.define('BLA_STATIC', False),
+            CMakePackage.define('BLA_VENDOR', 'IBMESSL'),
+        ]
 
     def install(self, spec, prefix):
         raise InstallError('IBM ESSL is not installable;'

--- a/var/spack/repos/builtin/packages/flexiblas/package.py
+++ b/var/spack/repos/builtin/packages/flexiblas/package.py
@@ -19,3 +19,14 @@ class Flexiblas(CMakePackage):
     # virtual dependency
     provides('blas')
     provides('lapack')
+
+    @property
+    def blas_cmake_args(self):
+        return [
+            CMakePackage.define('BLA_STATIC', False),
+            CMakePackage.define('BLA_VENDOR', 'FlexiBLAS'),
+        ]
+
+    @property
+    def lapack_cmake_args(self):
+        return self.blas_cmake_args

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.build_systems.cmake import CMakePackage
 
 
 class LibflameBase(AutotoolsPackage):
@@ -106,6 +107,14 @@ class LibflameBase(AutotoolsPackage):
         # The shared library is not installed correctly on Darwin; fix this
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(self.prefix.lib)
+
+    @property
+    def lapack_cmake_args(self):
+        static = '~shared' in self.spec or '+static' in self.spec
+        return [
+            CMakePackage.define('BLA_STATIC', static),
+            CMakePackage.define('BLA_VENDOR', 'FLAME'),
+        ]
 
 
 class Libflame(LibflameBase):

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.build_systems.cmake import CMakePackage
 
 
 class NetlibLapack(CMakePackage):
@@ -132,6 +133,17 @@ class NetlibLapack(CMakePackage):
         cblas_h = join_path(include_dir, 'cblas.h')
         lapacke_h = join_path(include_dir, 'lapacke.h')
         return HeaderList([cblas_h, lapacke_h])
+
+    @property
+    def blas_cmake_args(self):
+        return [
+            CMakePackage.define('BLA_STATIC', '~shared' in self.spec),
+            CMakePackage.define('BLA_VENDOR', 'Generic'),
+        ]
+
+    @property
+    def lapack_cmake_args(self):
+        return self.blas_cmake_args
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -8,6 +8,7 @@ import re
 
 from spack import *
 from spack.package_test import compare_output_file, compile_c_and_execute
+from spack.build_systems.cmake import CMakePackage
 
 
 class Openblas(MakefilePackage):
@@ -325,6 +326,17 @@ class Openblas(MakefilePackage):
         # one of the source files implementing functions declared in these
         # headers.
         return find_headers(['cblas', 'lapacke'], self.prefix.include)
+
+    @property
+    def blas_cmake_args(self):
+        return [
+            CMakePackage.define('BLA_STATIC', '~shared' in self.spec),
+            CMakePackage.define('BLA_VENDOR', 'OpenBLAS'),
+        ]
+
+    @property
+    def lapack_cmake_args(self):
+        return self.blas_cmake_args
 
     @property
     def build_targets(self):


### PR DESCRIPTION
FindBLAS and FindLAPACK expect `BLA_STATIC` and `BLA_VENDOR` to be set to find the correct BLAS and LAPACK libraries. New `blas_cmake_args` and `lapack_cmake_args` allow CMake consumers to add these arguments to their CMake configuration arguments in a similar manner to the existing use of `blas_libs` and `lapack_libs`.

Currently has support for:
* BLAS:
  * amdblis
  * atlas
  * blis
  * essl
  * intel-mkl
  * intel-parallel-studio
  * openblas
* LAPACK:
  * atlas
  * intel-mkl
  * intel-parallel-studio
  * libflame
  * netlib-lapack
  * openblas

cray-libsci isn't currently supported by FindBLAS/FindLAPACK and while Apple Accelerate/vecLib _is_ supported, I couldn't figure out a way to add the veclibfort library to it. The other currently unsupported providers are flexiblas and netlib-xblas.