### PR TITLE
new package: dbus-glib

### DIFF
--- a/var/spack/repos/builtin/packages/dbus-glib/package.py
+++ b/var/spack/repos/builtin/packages/dbus-glib/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class DbusGlib(AutotoolsPackage):
+    """dbus-glib package provides GLib interface for D-Bus API."""
+
+    homepage = "https://dbus.freedesktop.org"
+    url      = "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.110.tar.gz"
+
+    version('0.110', sha256='7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825')
+
+    depends_on('pkgconfig', type='build')
+    depends_on('expat')
+    depends_on('glib')
+    depends_on('dbus')


### PR DESCRIPTION
New package to support missing dependencies of `gconf`

>     # TODO: add missing dependencies
    # gio-2.0 >= 2.31.0
    # gthread-2.0
    # gmodule-2.0 >= 2.7.0
    # gobject-2.0 >= 2.7.0
    # dbus-1 >= 1.0.0
    # dbus-glib-1 >= 0.74 // This