### PR TITLE
lesstif: Dependency is not enough.

### DIFF
--- a/var/spack/repos/builtin/packages/lesstif/package.py
+++ b/var/spack/repos/builtin/packages/lesstif/package.py
@@ -20,6 +20,7 @@ class Lesstif(AutotoolsPackage):
     depends_on('libice')
     depends_on('libsm')
     depends_on('libxt')
+    depends_on('libxext')
 
     def patch(self):
         filter_file("ACLOCALDIR=.*",


### PR DESCRIPTION
The following error occurred during the installation of lesstif.
We found out that the dependency of libxext is missing.

```
<pack/repos/builtin/packages/lesstif/package.py" 52L, 1842C written

     1038              ^~~~~~~~~~~~~~~~~~~~~~~~
     1039    compilation terminated.
  >> 1040    decorate.c:44:10: fatal error: X11/extensions/shape.h: No such file or directory
     1041     #include <X11/extensions/shape.h>
     1042              ^~~~~~~~~~~~~~~~~~~~~~~~
     1043    compilation terminated.
     1044    make[3]: *** [Makefile:385: icons.o] Error 1
     1045    make[3]: *** Waiting for unfinished jobs....
     1046    make[3]: *** [Makefile:385: decorate.o] Error 1
  >> 1047    events.c:59:10: fatal error: X11/extensions/shape.h: No such file or directory
     1048     #include <X11/extensions/shape.h>
     1049              ^~~~~~~~~~~~~~~~~~~~~~~~
```