### PR TITLE
environment-modules: fix version 4.5.2 install

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -64,11 +64,17 @@ class EnvironmentModules(Package):
             # It looks for tclConfig.sh
             "--with-tcl=" + tcl_lib_dir,
             "--with-tcl-ver={0}.{1}".format(*tcl.version.version[0:2]),
-            '--disable-dependency-tracking',
-            '--disable-silent-rules',
             '--disable-versioning',
             '--datarootdir=' + prefix.share
         ]
+
+        # ./configure script on version 4.5.2 breaks when specific options are
+        # set (see https://github.com/cea-hpc/modules/issues/354)
+        if not spec.satisfies('@4.5.2'):
+            config_args.extend([
+                '--disable-dependency-tracking',
+                '--disable-silent-rules'
+            ])
 
         if '~X' in spec:
             config_args = ['--without-x'] + config_args


### PR DESCRIPTION
`configure` script of Modules 4.5.2 is a bit too strict and breaks when
special options like `--disable-dependency-tracking` are set. This issue
will be fixed on Modules project starting version 4.5.3
(cea-hpc/modules#354).

This change adapts `configure` options set when installing version 4.5.2
to avoid options unrecognized on this version.

Fix #18420