### PR TITLE
Explicit CUB dependency for CUDA <11

### DIFF
--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -67,7 +67,7 @@ class Dihydrogen(CMakePackage, CudaPackage):
 
     depends_on('cuda', when=('+cuda' or '+legacy'))
     depends_on('cudnn', when=('+cuda' or '+legacy'))
-    depends_on('cub', when=('+cuda' or '+legacy'))
+    depends_on('cub', when='^cuda@:10.99')
 
     # Note that #1712 forces us to enumerate the different blas variants
     depends_on('openblas', when='blas=openblas ~openmp_blas ~int64_blas')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -99,7 +99,7 @@ class Hydrogen(CMakePackage, CudaPackage):
     depends_on('mpfr', when='+mpfr')
 
     depends_on('cuda', when='+cuda')
-    depends_on('cub', when='+cuda')
+    depends_on('cub', when='^cuda@:10.99')
     depends_on('half', when='+half')
 
     conflicts('@0:0.98', msg="Hydrogen did not exist before v0.99. " +


### PR DESCRIPTION
Updated the dependency on CUB to be explict for CUDA versions less
than 11.  In CUDA 11, CUB is integratged into the CUDA library.