### PR TITLE
add py-llvmlite version 0.34

### DIFF
--- a/var/spack/repos/builtin/packages/py-llvmlite/package.py
+++ b/var/spack/repos/builtin/packages/py-llvmlite/package.py
@@ -12,6 +12,7 @@ class PyLlvmlite(PythonPackage):
     homepage = "http://llvmlite.readthedocs.io/en/latest/index.html"
     url = "https://pypi.io/packages/source/l/llvmlite/llvmlite-0.23.0.tar.gz"
 
+    version('0.34.0', sha256='f03ee0d19bca8f2fe922bb424a909d05c28411983b0c2bc58b020032a0d11f63')
     version('0.33.0', sha256='9c8aae96f7fba10d9ac864b443d1e8c7ee4765c31569a2b201b3d0b67d8fc596')
     version('0.31.0', sha256='22ab2b9d7ec79fab66ac8b3d2133347de86addc2e2df1b3793e523ac84baa3c8')
     version('0.29.0', sha256='3adb0d4c9a17ad3dca82c7e88118babd61eeee0ee985ce31fa43ec27aa98c963')
@@ -27,7 +28,8 @@ class PyLlvmlite(PythonPackage):
     depends_on('py-enum34', type=('build', 'run'), when='^python@:3.3.99')
 
     # llvmlite compatibility information taken from https://github.com/numba/llvmlite#compatibility
-    depends_on('llvm@9.0:9.0.99', when='@0.33.0:')
+    depends_on('llvm@10.0:', when='@0.34.0:')
+    depends_on('llvm@9.0:9.0.99', when='@0.33.0:0.33.99')
     depends_on('llvm@7.0:8.0.99', when='@0.29.0:0.32.99')
     depends_on('llvm@7.0:7.0.99', when='@0.27.0:0.28.99')
     depends_on('llvm@6.0:6.0.99', when='@0.23.0:0.26.99')


### PR DESCRIPTION
The llvmlite version for llvm@10. Tested on ubuntu 20.04. 