### PR TITLE
freetype: Add custom headers property

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -32,6 +32,12 @@ class Freetype(AutotoolsPackage):
 
     patch('windows.patch', when='@2.9.1')
 
+    @property
+    def headers(self):
+        headers = find_headers('*', self.prefix.include, recursive=True)
+        headers.directories = [self.prefix.include.freetype2]
+        return headers
+
     def configure_args(self):
         args = ['--with-harfbuzz=no']
         if self.spec.satisfies('@2.9.1:'):

--- a/var/spack/repos/builtin/packages/glvis/package.py
+++ b/var/spack/repos/builtin/packages/glvis/package.py
@@ -114,8 +114,8 @@ class Glvis(MakefilePackage):
         args.append('USE_FREETYPE={0}'.format(yes_no('+fonts')))
         if '+fonts' in spec:
             args += [
-                'FT_OPTS=-DGLVIS_USE_FREETYPE -I{0} -I{1}'.format(
-                    spec['freetype'].prefix.include.freetype2,
+                'FT_OPTS=-DGLVIS_USE_FREETYPE {0} -I{1}'.format(
+                    spec['freetype'].headers.include_flags,
                     spec['fontconfig'].prefix.include),
                 'FT_LIBS={0} {1}'.format(
                     spec['freetype'].libs.ld_flags,

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -239,8 +239,7 @@ class Ncl(Package):
             self.spec['bzip2'].prefix.lib + '\n',
             # Enter local include search path(s) :
             # All other paths will be passed by the Spack wrapper.
-            join_path(self.spec['freetype'].prefix.include, 'freetype2') +
-            '\n',
+            self.spec['freetype'].headers.directories[0] + '\n',
             # Go back and make more changes or review?
             'n\n',
             # Save current configuration?

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -376,9 +376,11 @@ class Qt(Package):
 
         if self.spec.variants['freetype'].value == 'spack':
             config_args.extend([
-                '-system-freetype',
-                '-I{0}/freetype2'.format(self.spec['freetype'].prefix.include)
+                '-system-freetype'
             ])
+            config_args.extend(
+                self.spec['freetype'].headers.include_flags.split()
+            )
             if not MACOS_VERSION:
                 config_args.append('-fontconfig')
 


### PR DESCRIPTION
freetype's headers are installed in the `freetype2` subdirectory, use a custom headers property to fix this in dependent packages.