### PR TITLE
Updated Hugo package

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 from spack import *
 from spack.util.executable import which
 
@@ -13,6 +14,9 @@ class Hugo(Package):
     homepage = "https://gohugo.io"
     url      = "https://github.com/gohugoio/hugo/archive/v0.53.tar.gz"
 
+    executables = ['^hugo$']
+
+    version('0.74.3', sha256='9b296fa0396c20956fa6a1f7afadaa78739af62c277b6c0cfae79a91b0fe823f')
     version('0.68.3', sha256='38e743605e45e3aafd9563feb9e78477e72d79535ce83b56b243ff991d3a2b6e')
     version('0.53', sha256='48e65a33d3b10527101d13c354538379d9df698e5c38f60f4660386f4232e65c')
 
@@ -21,6 +25,15 @@ class Hugo(Package):
     depends_on('go@1.11:', when='@0.48:', type='build')
 
     variant('extended', default=False, description="Enable extended features")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('version', output=str, error=str)
+        match = re.search(r'Hugo Static Site Generator v(\S+)', output)
+        return match.group(1) if match else None
+
+    def setup_build_environment(self, env):
+        env.prepend_path('GOPATH', self.stage.path)
 
     def install(self, spec, prefix):
         go_args = ['build']


### PR DESCRIPTION
Set GOPATH in build environment to avoid creating files in the user's
default GOPATH (e.g. ~/go).
* This should fix https://github.com/spack/spack/issues/16916

```shell
$ spack install hugo
...
[+] /spack/spack/opt/spack/linux-debian10-haswell/gcc-8.3.0/hugo-0.74.3-6tuuviroruqzvlomvpaxaiitosu4e4t2
$  ls $GOPATH
bin  src
```

* Note, I saw the `self.stage.path` also being used in Singularity so it seemed like a good solution.

Support for external find.

```shell
$ spack external find hugo
==> The following specs have been detected on this system and added to /Users/pbryant/.spack/packages.yaml
hugo@0.74.3
$ cat ~/.spack/packages.yaml
packages:
  ...
  hugo:
    externals:
    - spec: hugo@0.74.3
      prefix: /Users/pbryant/go
```

* Added latest releease 0.74.3.