### PR TITLE
Enforce the type of Spec.external_modules

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1007,6 +1007,14 @@ class Spec(object):
         # have package.py files for.
         self._normal = normal
         self._concrete = concrete
+
+        # Normalize external modules, to ensure they are never set from
+        # anything that is not a built-in Python list. This is needed
+        # because when hashes are computed there can be discrepancies
+        # depending on the type use to represent a sequence and round trip
+        # to YAML representation. See #18338
+        if external_modules:
+            external_modules = list(external_modules)
         self.external_path = external_path
         self.external_modules = external_modules
         self._full_hash = full_hash
@@ -1383,8 +1391,8 @@ class Spec(object):
         """
         # TODO: curently we strip build dependencies by default.  Rethink
         # this when we move to using package hashing on all specs.
-        yaml_text = syaml.dump(
-            self.to_node_dict(hash=hash), default_flow_style=True)
+        node_dict = self.to_node_dict(hash=hash)
+        yaml_text = syaml.dump(node_dict, default_flow_style=True)
         sha = hashlib.sha1(yaml_text.encode('utf-8'))
         b32_hash = base64.b32encode(sha.digest()).lower()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1007,14 +1007,6 @@ class Spec(object):
         # have package.py files for.
         self._normal = normal
         self._concrete = concrete
-
-        # Normalize external modules, to ensure they are never set from
-        # anything that is not a built-in Python list. This is needed
-        # because when hashes are computed there can be discrepancies
-        # depending on the type use to represent a sequence and round trip
-        # to YAML representation. See #18338
-        if external_modules:
-            external_modules = list(external_modules)
         self.external_path = external_path
         self.external_modules = external_modules
         self._full_hash = full_hash
@@ -1534,9 +1526,18 @@ class Spec(object):
             d['parameters'] = params
 
         if self.external:
+            # Normalize external modules, to ensure they are never set from
+            # anything that is not a built-in Python list. This is needed
+            # because when hashes are computed there can be discrepancies
+            # depending on the type use to represent a sequence and round trip
+            # to YAML representation. See #18338
+            external_modules = self.external_modules
+            if external_modules:
+                external_modules = list(external_modules)
+
             d['external'] = syaml.syaml_dict([
                 ('path', self.external_path),
-                ('module', self.external_modules),
+                ('module', external_modules),
                 ('extra_attributes', self.extra_attributes)
             ])
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2132,3 +2132,38 @@ spack:
 
     # Check that an update does not raise
     env('update', '-y', str(abspath.dirname))
+
+
+@pytest.mark.regression('18338')
+def test_newline_in_commented_sequence_is_not_an_issue(tmpdir):
+    spack_yaml = """
+spack:
+  specs:
+  - dyninst
+  packages:
+    libelf:
+      externals:
+      - spec: libelf@0.8.13
+        modules:
+        - libelf/3.18.1
+
+  concretization: together
+"""
+    abspath = tmpdir.join('spack.yaml')
+    abspath.write(spack_yaml)
+
+    def extract_build_hash(environment):
+        _, dyninst = next(iter(environment.specs_by_hash.items()))
+        return dyninst['libelf'].build_hash()
+
+    # Concretize a first time and create a lockfile
+    with ev.Environment(str(tmpdir)) as e:
+        concretize()
+        libelf_first_hash = extract_build_hash(e)
+
+    # Check that a second run won't error
+    with ev.Environment(str(tmpdir)) as e:
+        concretize()
+        libelf_second_hash = extract_build_hash(e)
+
+    assert libelf_first_hash == libelf_second_hash


### PR DESCRIPTION
fixes #18338
closes #18368

Having `Spec.external_modules` attributes not of type `list` might cause issues when passing to YAML representation and computing the build-hash. 

In particular, if specs are constructed directly from a YAML `CommentedSeq` vs. a Python `list` the build-hash might differ for the same spec.