### PR TITLE
gcc+nvptx: fix cuda driver linking once more

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -123,6 +123,20 @@ class Cuda(Package):
     def setup_run_environment(self, env):
         env.set('CUDA_HOME', self.prefix)
 
+    def setup_dependent_package(self, module, dependent_spec):
+        # define the path to the driver lib separately.
+        libs = find_libraries('libcuda', root=self.prefix,
+                              shared=True, recursive=True)
+        filtered_libs = []
+
+        # Filter out compat libs
+        for lib in libs:
+            parts = lib.split(os.sep)
+            if 'compat' not in parts:
+                filtered_libs.append(lib)
+
+        self.spec.driver_libs = LibraryList(filtered_libs)
+
     def install(self, spec, prefix):
         if os.path.exists('/tmp/cuda-installer.log'):
             try:
@@ -168,24 +182,6 @@ class Cuda(Package):
             os.remove('/tmp/cuda-installer.log')
         except OSError:
             pass
-
-    @property
-    def driver_libs(self):
-        """
-        List of driver libraries, which are shipped as a stub library.
-        Note: typically you want to use runtime libs instead.
-        """
-        libs = find_libraries('libcuda', root=self.prefix,
-                              shared=True, recursive=True)
-        filtered_libs = []
-
-        # Filter out compat libs
-        for lib in libs:
-            parts = lib.split(os.sep)
-            if 'compat' not in parts:
-                filtered_libs.append(lib)
-
-        return LibraryList(filtered_libs)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -170,15 +170,27 @@ class Cuda(Package):
             pass
 
     @property
-    def libs(self):
-        libs = find_libraries('libcudart', root=self.prefix, shared=True,
-                              recursive=True)
-
+    def driver_libs(self):
+        """
+        List of driver libraries, which are shipped as a stub library.
+        Note: typically you want to use runtime libs instead.
+        """
+        libs = find_libraries('libcuda', root=self.prefix,
+                              shared=True, recursive=True)
         filtered_libs = []
-        # CUDA 10.0 provides Compatability libraries for running newer versions
-        # of CUDA with older drivers. These do not work with newer drivers.
+
+        # Filter out compat libs
         for lib in libs:
             parts = lib.split(os.sep)
-            if 'compat' not in parts and 'stubs' not in parts:
+            if 'compat' not in parts:
                 filtered_libs.append(lib)
+
         return LibraryList(filtered_libs)
+
+    @property
+    def libs(self):
+        """
+        List of runtime libraries
+        """
+        return find_libraries('libcudart', root=self.prefix,
+                              shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -510,7 +510,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                             '--with-cuda-driver-include={0}'.format(
                                 spec['cuda'].prefix.include),
                             '--with-cuda-driver-lib={0}'.format(
-                                spec['cuda'].libs.directories[0]),
+                                spec['cuda'].driver_libs.directories[0]),
                             '--disable-bootstrap',
                             '--disable-multilib'])
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -510,7 +510,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                             '--with-cuda-driver-include={0}'.format(
                                 spec['cuda'].prefix.include),
                             '--with-cuda-driver-lib={0}'.format(
-                                spec['cuda'].driver_libs.directories[0]),
+                                spec['cuda:cuda'].libs.directories[0]),
                             '--disable-bootstrap',
                             '--disable-multilib'])
 


### PR DESCRIPTION
Attempted fix for #18444 

GCC actually needs the CUDA driver lib (libcuda.so) instead of the runtime lib (libcudart.so).

This is an attempt to properly fix https://github.com/spack/spack/pull/17619 / https://github.com/spack/spack/pull/18000.

Currently I cannot really test it, since GCC +nvptx fails because of other reasons now :) they use sm_30 somewhere in their defaults, which my CUDA driver does not support.

--

I guess the `libs` property is special in spack, whereas my `driver_libs` property is custom. Can someone comment on whether this is a good idea or not? At any rate, there's two things: (a) we don't want the stub lib to end up in the rpaths, so we shouldn't add driver libs to `libs`, and (b) some packages actually need the driver lib.