### PR TITLE
ADIOS: Fix no-MPI Build

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -106,7 +106,7 @@ class Adios(AutotoolsPackage):
     patch('zfp051.patch', when='@1.11.0:1.13.1')
 
     # Fix a bug in configure.ac that causes automake issues on RHEL 7.7
-    patch('https://github.com/ornladios/ADIOS/pull/207.patch', when='@1.12.0:',
+    patch('https://github.com/ornladios/ADIOS/pull/207.patch', when='@1.12.0: +mpi',
           sha256='01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640')
 
     def validate(self, spec):


### PR DESCRIPTION
Do not apply this patch in no-MPI builds. I think this autotools check logic is generally borked, this will just set it manually to on/off now.

Fixes `spack install adios ~mpi` builds.

Regression introduced in: #17465 / https://github.com/ornladios/ADIOS/pull/207#issuecomment-685096681

cc @germasch 