### PR TITLE
spack test: no gpg sign

### DIFF
--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -55,7 +55,8 @@ def mock_pkg_git_repo(tmpdir_factory):
         git('add', '.')
         git('config', 'user.email', 'testing@spack.io')
         git('config', 'user.name', 'Spack Testing')
-        git('commit', '-m', 'initial mock repo commit')
+        git('-c', 'commit.gpgsign=false', 'commit',
+            '-m', 'initial mock repo commit')
 
         # add commit with pkg-a, pkg-b, pkg-c packages
         mkdirp('pkg-a', 'pkg-b', 'pkg-c')
@@ -66,7 +67,8 @@ def mock_pkg_git_repo(tmpdir_factory):
         with open('pkg-b/package.py', 'w') as f:
             f.write(pkg_template.format(name='PkgC'))
         git('add', 'pkg-a', 'pkg-b', 'pkg-c')
-        git('commit', '-m', 'add pkg-a, pkg-b, pkg-c')
+        git('-c', 'commit.gpgsign=false', 'commit',
+            '-m', 'add pkg-a, pkg-b, pkg-c')
 
         # remove pkg-c, add pkg-d
         with open('pkg-b/package.py', 'a') as f:
@@ -77,7 +79,8 @@ def mock_pkg_git_repo(tmpdir_factory):
             f.write(pkg_template.format(name='PkgD'))
         git('add', 'pkg-d')
         git('rm', '-rf', 'pkg-c')
-        git('commit', '-m', 'change pkg-b, remove pkg-c, add pkg-d')
+        git('-c', 'commit.gpgsign=false', 'commit',
+            '-m', 'change pkg-b, remove pkg-c, add pkg-d')
 
     with spack.repo.swap(mock_repo):
         yield mock_repo_packages

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -867,7 +867,8 @@ def mock_git_repository(tmpdir_factory):
             submodule_file = 'r0_file_{0}'.format(submodule_count)
             repodir.ensure(submodule_file)
             git('add', submodule_file)
-            git('commit', '-m', 'mock-git-repo r0 {0}'.format(submodule_count))
+            git('-c', 'commit.gpgsign=false', 'commit',
+                '-m', 'mock-git-repo r0 {0}'.format(submodule_count))
 
     tmpdir = tmpdir_factory.mktemp('mock-git-repo-dir')
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
@@ -887,7 +888,7 @@ def mock_git_repository(tmpdir_factory):
         r0_file = 'r0_file'
         repodir.ensure(r0_file)
         git('add', r0_file)
-        git('commit', '-m', 'mock-git-repo r0')
+        git('-c', 'commit.gpgsign=false', 'commit', '-m', 'mock-git-repo r0')
 
         branch = 'test-branch'
         branch_file = 'branch_file'
@@ -901,13 +902,13 @@ def mock_git_repository(tmpdir_factory):
         git('checkout', branch)
         repodir.ensure(branch_file)
         git('add', branch_file)
-        git('commit', '-m' 'r1 test branch')
+        git('-c', 'commit.gpgsign=false', 'commit', '-m' 'r1 test branch')
 
         # Check out a second branch and tag it
         git('checkout', tag_branch)
         repodir.ensure(tag_file)
         git('add', tag_file)
-        git('commit', '-m' 'tag test branch')
+        git('-c', 'commit.gpgsign=false', 'commit', '-m' 'tag test branch')
 
         tag = 'test-tag'
         git('tag', tag)


### PR DESCRIPTION
In my `~/.gitconfig`, I have the following logic:
```
[commit]
    # Automatically sign using GPG keys
    gpgsign = true
```
This allows me to automatically sign all git commits. However, when I run `spack test`, tests that involve git commits stall with the following message:
```console
$ spack test lib/spack/spack/test/mirror.py
...
Please enter the passphrase to unlock the OpenPGP secret key:
"Adam J. Stewart <ajstewart426@gmail.com>"
4096-bit RSA key, ID C66C0675661156FC,
created 2020-03-07.

Passphrase: 
```
This PR removes that message. Another possible solution would be to pass some flag to git to ignore all local configurations.