### PR TITLE
New package: ForTrilinos

### DIFF
--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -1,0 +1,53 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Fortrilinos(CMakePackage):
+    """ForTrilinos provides a set of Fortran-2003 wrappers to the Trilinos
+    solver library.
+
+    Note that most properties are *transitive* from the underlying Trilinos
+    configuration. For example, MPI is enabled if and only if the linked
+    Trilinos version has it, so this package does not provide an indepdent
+    variant. Instead, use ``fortrilinos ^trilinos~mpi`` to disable MPI support.
+
+    Since Trilinos enables a bunch of upstream dependencies by default, it
+    might be worthwhile to disable them::
+
+        spack install fortrilinos \
+            ^trilinos@12.18.1+nox+stratimikos \
+            ~boost~exodus~glm~gtest~hdf5~hypre~matio~metis~mumps~netcdf~suite-sparse
+    """
+
+    homepage = "https://trilinos.github.io/ForTrilinos/"
+    url      = "https://github.com/trilinos/ForTrilinos/archive/v2.0.0-dev1.tar.gz"
+
+    maintainers = ['sethrj', 'aprokop']
+
+    version('2.0.0-dev2', sha256='2a55c668b3fe986583658d272eab2dc076b291a5f2eb582a02602db86a32030b')
+    version('2.0.0-dev1', sha256='ab664ce2d7fe75c524d7ff6b1efffa3e459ab5739a916e6ea810ae40f39ca4f4')
+    version('master', branch='master')
+
+    variant('hl', default=True, description='Build high-level Trilinos wrappers')
+    variant('shared', default=True, description='Build shared libraries')
+
+    # Trilinos version dependencies
+    depends_on('trilinos@12.18.1', when='@2.0.0-dev2')
+    depends_on('trilinos@12.17.1', when='@2.0.0-dev1')
+
+    # Baseline trilinos dependencies
+    depends_on('trilinos+teuchos gotype=long_long')
+    # Full trilinos dependencies
+    depends_on('trilinos+amesos2+anasazi+belos+kokkos+ifpack2+muelu+nox+tpetra'
+               '+stratimikos', when='+hl')
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define('ForTrilinos_EXAMPLES', self.run_tests),
+            self.define('ForTrilinos_TESTING', self.run_tests),
+        ]

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -25,6 +25,7 @@ class Fortrilinos(CMakePackage):
 
     homepage = "https://trilinos.github.io/ForTrilinos/"
     url      = "https://github.com/trilinos/ForTrilinos/archive/v2.0.0-dev1.tar.gz"
+    git      = "https://github.com/trilinos/ForTrilinos.git"
 
     maintainers = ['sethrj', 'aprokop']
 

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -45,6 +45,14 @@ class Fortrilinos(CMakePackage):
     depends_on('trilinos+amesos2+anasazi+belos+kokkos+ifpack2+muelu+nox+tpetra'
                '+stratimikos', when='+hl')
 
+    @run_before('cmake')
+    def die_without_fortran(self):
+        # Until we can pass variants such as +fortran through virtual
+        # dependencies, require Fortran compiler to
+        # avoid delayed build errors in dependents.
+        if (self.compiler.f77 is None) or (self.compiler.fc is None):
+            raise InstallError('ForTrilinos requires a Fortran compiler')
+
     def cmake_args(self):
         return [
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -243,6 +243,7 @@ class Trilinos(CMakePackage):
     conflicts('+belos', when='~teuchos')
     conflicts('+epetraext', when='~epetra')
     conflicts('+epetraext', when='~teuchos')
+    conflicts('+exodus', when='~netcdf')
     conflicts('+ifpack2', when='~belos')
     conflicts('+ifpack2', when='~teuchos')
     conflicts('+ifpack2', when='~tpetra')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -198,8 +198,6 @@ class Trilinos(CMakePackage):
     # External package options
     variant('dtk',          default=False,
             description='Enable DataTransferKit')
-    variant('fortrilinos',  default=False,
-            description='Enable ForTrilinos')
     variant('mesquite',     default=False,
             description='Enable Mesquite')
 
@@ -220,11 +218,6 @@ class Trilinos(CMakePackage):
              placement='DataTransferKit',
              submodules=True,
              when='+dtk @develop')
-    resource(name='fortrilinos',
-             git='https://github.com/trilinos/ForTrilinos.git',
-             tag='develop',
-             placement='packages/ForTrilinos',
-             when='+fortrilinos')
     resource(name='mesquite',
              url='https://github.com/trilinos/mesquite/archive/trilinos-release-12-12-1.tar.gz',
              sha256='e0d09b0939dbd461822477449dca611417316e8e8d8268fd795debb068edcbb5',
@@ -297,9 +290,6 @@ class Trilinos(CMakePackage):
     conflicts('+dtk', when='~tpetra')
     # Only allow DTK with Trilinos 12.14 and develop
     conflicts('+dtk', when='@0:12.12.99,master')
-    conflicts('+fortrilinos', when='~fortran')
-    conflicts('+fortrilinos', when='@:99')
-    conflicts('+fortrilinos', when='@master')
     # Only allow Mesquite with Trilinos 12.12 and up, and develop
     conflicts('+mesquite', when='@0:12.10.99,master')
     # Can only use one type of SuperLU


### PR DESCRIPTION
Successfully installed and ran tests for ForTrilinos on mac:
```
-- darwin-catalina-x86_64 / apple-clang@11.0.0 ------------------
thsdvhq fortrilinos@2.0.0-dev2+hl+shared build_type=RelWithDebInfo
whhv6v4     trilinos@12.18.1~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos~boost~cgns~chaco~complex~debug~dtk+epetra+epetraext~exodus+explicit_template_instantiation~float+fortran~glm~gtest~hdf5~hypre+ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos~matio~mesquite~metis~minitensor+ml+mpi+muelu~mumps~netcdf+nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards+shared~shylu~stk+stratimikos~suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo gotype=long_long
gkdwhwe         openblas@0.3.10~consistent_fpcsr~ilp64+pic+shared threads=none
rq44ux2         openmpi@3.1.6~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none
d3sdlmx             hwloc@1.11.11~cairo~cuda~gl~libudev+libxml2~netloc~nvml~pci+shared
zd36xsu                 libxml2@2.9.10~python
dacit3k                     libiconv@1.16
27pku55                     xz@5.2.5
fwg66ug                     zlib@1.2.11+optimize+pic+shared
```
and successfully tested a downstream app against the installed ForTrilinos.

@keitat This removes the built-in `fortrilinos` variant (and resource) since ForTrilinos is now a separate library downstream of Trilinos.