### PR TITLE
Mfem: Fix transitive hdf5 static libs

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -494,10 +494,16 @@ class Mfem(Package):
                 ld_flags_from_dirs([spec['gslib'].prefix.lib], ['gs'])]
 
         if '+netcdf' in spec:
+            lib_flags = ld_flags_from_dirs([spec['netcdf-c'].prefix.lib],
+                                           ['netcdf'])
+            hdf5 = spec['hdf5:hl']
+            if hdf5.satisfies('~shared'):
+                hdf5_libs = hdf5.libs
+                hdf5_libs += LibraryList(find_system_libraries('libdl'))
+                lib_flags += " " + ld_flags_from_library_list(hdf5_libs)
             options += [
                 'NETCDF_OPT=-I%s' % spec['netcdf-c'].prefix.include,
-                'NETCDF_LIB=%s' %
-                ld_flags_from_dirs([spec['netcdf-c'].prefix.lib], ['netcdf'])]
+                'NETCDF_LIB=%s' % lib_flags]
 
         if '+zlib' in spec:
             if "@:3.3.2" in spec:

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -181,6 +181,8 @@ class NetcdfC(AutotoolsPackage):
         hdf5_hl = self.spec['hdf5:hl']
         cppflags.append(hdf5_hl.headers.cpp_flags)
         ldflags.append(hdf5_hl.libs.search_flags)
+        if hdf5_hl.satisfies('~shared'):
+            libs.append(hdf5_hl.libs.link_flags)
 
         if '+parallel-netcdf' in self.spec:
             config_args.append('--enable-pnetcdf')


### PR DESCRIPTION
When building mfem+netcdf~shared, I ran into a lot of missing symbols from hdf5 (netcdf depends on hdf5).  This fixes this and is tested via Serac on Toss3.