### PR TITLE
r-boot: checksum mismatch @1.3-23

### DIFF
--- a/var/spack/repos/builtin/packages/r-boot/package.py
+++ b/var/spack/repos/builtin/packages/r-boot/package.py
@@ -15,7 +15,7 @@ class RBoot(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/boot_1.3-18.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/boot"
 
-    version('1.3-23', sha256='30c89e19dd6490b943233e87dfe422bfef92cfbb7a7dfb5c17dfd9b2d63fa02f')
+    version('1.3-23', sha256='79236a5a770dc8bf5ce25d9aa303c5dc0574d94aa043fd00b8b4c8ccc877357f')
     version('1.3-22', sha256='cf1f0cb1e0a7a36dcb6ae038f5d0211a0e7a009c149bc9d21acb9c58c38b4dfc')
     version('1.3-20', sha256='adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a')
     version('1.3-18', sha256='12fd237f810a69cc8d0a51a67c57eaf9506bf0341c764f8ab7c1feb73722235e')


### PR DESCRIPTION
Update checksum of `r-boot@1.3-23`
We already confirmed this change is harmless.
Closes #18409