### PR TITLE
gromacs: add support for opencl  build

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -59,6 +59,7 @@ class Gromacs(CMakePackage):
         description='Produces a double precision version of the executables')
     variant('plumed', default=False, description='Enable PLUMED support')
     variant('cuda', default=False, description='Enable CUDA support')
+    variant('opencl', default=False, description='Enable OpenCL support')
     variant('nosuffix', default=False, description='Disable default suffixes')
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
@@ -130,12 +131,17 @@ class Gromacs(CMakePackage):
         else:
             options.append('-DGMX_HWLOC:BOOL=OFF')
 
-        if '+cuda' in self.spec:
+        if '+cuda' in self.spec or '+opencl' in self.spec:
             options.append('-DGMX_GPU:BOOL=ON')
-            options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
-                           self.spec['cuda'].prefix)
         else:
             options.append('-DGMX_GPU:BOOL=OFF')
+
+        if '+cuda' in self.spec:
+            options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
+                           self.spec['cuda'].prefix)
+
+        if '+opencl' in self.spec:
+            options.append('-DGMX_USE_OPENCL=on')
 
         # Activate SIMD based on properties of the target
         target = self.spec.target


### PR DESCRIPTION
This adds support for building for opencl targets, such as AMD ROCm supported GPUs