### PR TITLE
Also allow --rpath as rpath linker flags

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -320,9 +320,13 @@ while [ -n "$1" ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
                 rp="${arg#-rpath=}"
+            elif [[ "$arg" = --rpath=* ]]; then
+                rp="${arg#--rpath=}"
             elif [[ "$arg" = -rpath,* ]]; then
                 rp="${arg#-rpath,}"
-            elif [[ "$arg" = -rpath ]]; then
+            elif [[ "$arg" = --rpath,* ]]; then
+                rp="${arg#--rpath,}"
+            elif [[ "$arg" = -rpath ]] || [[ "$arg" = --rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
@@ -339,7 +343,9 @@ while [ -n "$1" ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
                 rp="${arg#-rpath=}"
-            elif [[ "$arg" = -rpath ]]; then
+            elif [[ "$arg" = --rpath=* ]]; then
+                rp="${arg#--rpath=}"
+            elif [[ "$arg" = -rpath  ]] || [[ "$arg" = --rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Xlinker,* ]]; then
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -326,7 +326,7 @@ while [ -n "$1" ]; do
                 rp="${arg#-rpath,}"
             elif [[ "$arg" = --rpath,* ]]; then
                 rp="${arg#--rpath,}"
-            elif [[ "$arg" =~ "^-?-rpath$" ]]; then
+            elif [[ "$arg" =~ ^-?-rpath$ ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -326,7 +326,7 @@ while [ -n "$1" ]; do
                 rp="${arg#-rpath,}"
             elif [[ "$arg" = --rpath,* ]]; then
                 rp="${arg#--rpath,}"
-            elif [[ "$arg" = -rpath ]] || [[ "$arg" = --rpath ]]; then
+            elif [[ "$arg" =~ "^-?-rpath$" ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -28,6 +28,7 @@ test_args = [
     '-Wl,--end-group',
     '-Xlinker', '-rpath', '-Xlinker', '/third/rpath',
     '-Xlinker', '-rpath', '-Xlinker', '/fourth/rpath',
+    '-Wl,--rpath,/fifth/rpath', '-Wl,--rpath', '-Wl,/sixth/rpath',
     '-llib3', '-llib4',
     'arg5', 'arg6']
 
@@ -45,11 +46,13 @@ test_library_paths = [
 
 test_wl_rpaths = [
     '-Wl,-rpath,/first/rpath', '-Wl,-rpath,/second/rpath',
-    '-Wl,-rpath,/third/rpath', '-Wl,-rpath,/fourth/rpath']
+    '-Wl,-rpath,/third/rpath', '-Wl,-rpath,/fourth/rpath',
+    '-Wl,-rpath,/fifth/rpath', '-Wl,-rpath,/sixth/rpath']
 
 test_rpaths = [
     '-rpath', '/first/rpath', '-rpath', '/second/rpath',
-    '-rpath', '/third/rpath', '-rpath', '/fourth/rpath']
+    '-rpath', '/third/rpath', '-rpath', '/fourth/rpath',
+    '-rpath', '/fifth/rpath', '-rpath', '/sixth/rpath']
 
 test_args_without_paths = [
     'arg1',


### PR DESCRIPTION
When looking into what `hipcc` does, I found it adds `-Wl,--rpath=some/path`. Note the two dashes in `--rpath`. GCC is fine with this, but the Spack compiler wrapper is only looking for `-rpath`.

For example, this works:

```console
$ cat foo.c 
#include <stdio.h>
void foo(void) { puts("hi"); }
$ cat main.c 
extern void foo(void);
int main(void){ foo();return 0; }
$ gcc -c foo.c main.c
$ gcc -shared -o libfoo.so foo.o 
$ gcc -o main main.o -L. -lfoo -Wl,--rpath='$ORIGIN'
$ ./main 
hi
```

This PR makes the Spack compiler wrapper handle `--rpath` too. It rewrites arguments as follows now:

Before:

```console
$ gcc some.o file.o -Wl,--rpath -Wl,/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
some.o
file.o
-Wl,--rpath
-Wl,/some/path
$ gcc some.o file.o -Wl,--rpath=/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
some.o
file.o
-Wl,--rpath=/some/path
$ gcc some.o file.o -Wl,--rpath,/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
some.o
file.o
```

After:

```console
$ gcc some.o file.o -Wl,--rpath -Wl,/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
-Wl,-rpath,/some/path
some.o
file.o
$ gcc some.o file.o -Wl,--rpath=/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
-Wl,-rpath,/some/path
some.o
file.o
$ gcc some.o file.o -Wl,--rpath,/some/path
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
-Wl,-rpath,/some/path
some.o
file.o
```

Same for `-Xlinker`.