### PR TITLE
py-torchvision: cuda prefix determined by user's PATH

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -86,5 +86,6 @@ class PyTorchvision(PythonPackage):
 
         if '+cuda' in self.spec['py-torch']:
             env.set('FORCE_CUDA', 1)
+            env.set('CUDA_HOME', self.spec['cuda'].prefix)
         else:
             env.set('FORCE_CUDA', 0)


### PR DESCRIPTION
CUDA_HOME needs to be set, or CUDA is found based on user's PATH.

Fixes #18474