### PR TITLE
fermi: support for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/fermi/ksw_for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/fermi/ksw_for_aarch64.patch
@@ -1,0 +1,11 @@
+--- spack-src/ksw.c.bak	2012-08-23 03:32:38.000000000 +0900
++++ spack-src/ksw.c	2020-09-03 13:42:23.495232913 +0900
+@@ -25,7 +25,7 @@
+ 
+ #include <stdlib.h>
+ #include <stdint.h>
+-#include <emmintrin.h>
++#include <SSE2NEON.h>
+ #include "ksw.h"
+ 
+ #ifdef __GNUC__

--- a/var/spack/repos/builtin/packages/fermi/package.py
+++ b/var/spack/repos/builtin/packages/fermi/package.py
@@ -16,6 +16,9 @@ class Fermi(MakefilePackage):
 
     depends_on('zlib')
     depends_on('perl', type='run')
+    depends_on('sse2neon', when='target=aarch64:')
+
+    patch('ksw_for_aarch64.patch', when='target=aarch64:')
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)


### PR DESCRIPTION
I modified it with reference to the following PR.
https://github.com/spack/spack/pull/17473
