### PR TITLE
nseg: add return 0; to void functions

### DIFF
--- a/var/spack/repos/builtin/packages/nseg/package.py
+++ b/var/spack/repos/builtin/packages/nseg/package.py
@@ -74,6 +74,16 @@ class Nseg(MakefilePackage):
                 res_path = join_path(res.fetcher.stage.source_path, res.name)
                 copy(res_path, join_path(self.build_directory, res_name))
 
+        if self.spec.satisfies('%fj'):
+            sfiles = ['genwin.c', 'nseg.c']
+            for s_name in sfiles:
+                filter_file(
+                    'return;',
+                    'return 0;',
+                    join_path(self.build_directory, s_name),
+                    string=True
+                )
+
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
             mkdirp(prefix.bin)


### PR DESCRIPTION
This patch is WIP, please wait.

There is no function declaration and all functions are implicit `int` type.
However, many functions are written as `void` and end with `return;`.
So I patched to  `return 0;` to avoid build error.