### PR TITLE
Add numactl dependency to hip dependents

### DIFF
--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -15,6 +15,9 @@ class Hipblas(CMakePackage):
     url      = "https://github.com/ROCmSoftwarePlatform/hipBLAS/archive/rocm-3.5.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
+
+    depends_on('numactl', when='^hip@3.7.0')
+
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocsolver@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -20,7 +20,7 @@ class Hipcub(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('numactl', when='@3.7.0')
+    depends_on('numactl', when='^hip@3.7.0')
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -21,6 +21,7 @@ class Hipsparse(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('git', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
 
     for ver in ['3.5.0', '3.7.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -21,6 +21,8 @@ class Rccl(CMakePackage):
     version('3.5.0', sha256='290b57a66758dce47d0bfff3f5f8317df24764e858af67f60ddcdcadb9337253')
 
     depends_on('cmake@3:', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
+
     for ver in ['3.5.0', '3.7.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -12,7 +12,7 @@ class Rccl(CMakePackage):
     implementing all-reduce, all-gather, reduce, broadcast,
     and reduce-scatter."""
 
-    homepage = "https://github.com/RadeonOpenCompute/rccl"
+    homepage = "https://github.com/ROCmSoftwarePlatform/rccl"
     url      = "https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-3.7.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -23,6 +23,8 @@ class Rocalution(CMakePackage):
     version('3.5.0', sha256='be2f78c10c100d7fd9df5dd2403a44700219c2cbabaacf2ea50a6e2241df7bfe')
 
     depends_on('cmake@3.5.2', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
+
     for ver in ['3.5.0']:
         depends_on('hip@' + ver,  when='@' + ver)
         depends_on('rocblas@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -23,6 +23,7 @@ class Rocblas(CMakePackage):
     variant('amdgpu_target', default='all', multi=True, values=amdgpu_targets)
 
     depends_on('cmake@3:', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
 
     for ver in ['3.5.0', '3.7.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -28,6 +28,7 @@ class Rocfft(CMakePackage):
     variant('amdgpu_target', default='gfx701', multi=True, values=amdgpu_targets)
 
     depends_on('cmake@3:', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
 
     for ver in ['3.5.0', '3.7.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -20,7 +20,7 @@ class Rocprim(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('numactl', when='@3.7.0')
+    depends_on('numactl', when='^hip@3.7.0')
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -20,7 +20,7 @@ class Rocrand(CMakePackage):
     version('3.5.0', sha256='592865a45e7ef55ad9d7eddc8082df69eacfd2c1f3e9c57810eb336b15cd5732')
 
     depends_on('cmake@3.5.1:', type='build')
-    depends_on('numactl', when='@3.7.0')
+    depends_on('numactl', when='^hip@3.7.0')
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -20,7 +20,7 @@ class Rocsolver(CMakePackage):
     version('3.5.0', sha256='d655e8c762fb9e123b9fd7200b4258512ceef69973de4d0588c815bc666cb358')
 
     depends_on('cmake@3:', type='build')
-    depends_on('numactl', when='@3.7.0')
+    depends_on('numactl', when='^hip@3.7.0')
     depends_on('hsa-rocr-dev@3.7.0', type='build', when='@3.7.0')
 
     for ver in ['3.5.0', '3.7.0']:

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -22,6 +22,7 @@ class Rocsparse(CMakePackage):
     version('3.5.0', sha256='9ca6bae7da78abbb47143c3d77ff4a8cd7d63979875fc7ebc46b400769fd9cb5')
 
     depends_on('cmake@3:', type='build')
+    depends_on('numactl', when='^hip@3.7.0')
 
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -24,7 +24,7 @@ class Rocthrust(CMakePackage):
             description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('numactl', when='@3.7.0')
+    depends_on('numactl', when='^hip@3.7.0')
     for ver in ['3.5.0', '3.7.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -106,6 +106,7 @@ class Sirius(CMakePackage, CudaPackage):
 
     # rocm
     depends_on('hip', when='+rocm')
+    depends_on('numactl', when='^hip@3.7.0')
     depends_on('hsakmt-roct', when='+rocm', type='link')
     depends_on('hsa-rocr-dev', when='+rocm', type='link')
     depends_on('rocblas', when='+rocm')

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -47,6 +47,7 @@ class Spfft(CMakePackage, CudaPackage):
 
     depends_on('rocfft', when='+rocm')
     depends_on('hip', when='+rocm')
+    depends_on('numactl', when='^hip@3.7.0')
     depends_on('hsakmt-roct', when='+rocm', type='link')
     depends_on('hsa-rocr-dev', when='+rocm', type='link')
     variant('amdgpu_target', default=('gfx803', 'gfx900', 'gfx906'), multi=True, values=amdgpu_targets)

--- a/var/spack/repos/builtin/packages/spla/package.py
+++ b/var/spack/repos/builtin/packages/spla/package.py
@@ -34,6 +34,7 @@ class Spla(CMakePackage):
     depends_on('cuda', when='+cuda')
     depends_on('rocblas', when='+rocm')
     depends_on('hip', when='+rocm')
+    depends_on('numactl', when='^hip@3.7.0')
     depends_on('hsakmt-roct', when='+rocm', type='link')
     depends_on('hsa-rocr-dev', when='+rocm', type='link')
 


### PR DESCRIPTION
hipcc 3.7.0 always adds an `-lnuma` linker flag, meaning that numactl
should be a link dependency of all packages using it.