### PR TITLE
bml: Add build dependency on python (#18489)

### DIFF
--- a/var/spack/repos/builtin/packages/bml/package.py
+++ b/var/spack/repos/builtin/packages/bml/package.py
@@ -30,6 +30,7 @@ class Bml(CMakePackage):
     depends_on("blas")
     depends_on("lapack")
     depends_on('mpi', when='+mpi')
+    depends_on('python', type='build')
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
At some point in the build phase a script
spack-src/scripts/convert-template
has a shebang looking for python in the path.

Currently this picks up system python if in invoker's path, but should
be using python from spack, so add a build dependency on python.