### PR TITLE
darshan-util: remove return(-1) from void function

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -31,6 +31,8 @@ class DarshanUtil(Package):
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
 
+    patch('retvoid.patch')
+
     def install(self, spec, prefix):
 
         options = ['CC=%s' % self.compiler.cc,

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -31,7 +31,7 @@ class DarshanUtil(Package):
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
 
-    patch('retvoid.patch')
+    patch('retvoid.patch', when='@:3.2.1')
 
     def install(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -31,7 +31,7 @@ class DarshanUtil(Package):
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
 
-    patch('retvoid.patch', when='@:3.2.1')
+    patch('retvoid.patch', when='@3.2.0:3.2.1')
 
     def install(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/darshan-util/retvoid.patch
+++ b/var/spack/repos/builtin/packages/darshan-util/retvoid.patch
@@ -1,0 +1,12 @@
+diff -u -r -N a/darshan-util/darshan-logutils.c b/darshan-util/darshan-logutils.c
+--- a/darshan-util/darshan-logutils.c	2020-09-04 15:02:21.000000000 +0900
++++ b/darshan-util/darshan-logutils.c	2020-09-04 15:07:44.000000000 +0900
+@@ -1915,7 +1915,7 @@
+     if(ret < 0)
+     {
+         darshan_log_close(fd);
+-        return(-1);
++        return;
+     }
+ 
+     int num = HASH_CNT(hlink, name_hash);


### PR DESCRIPTION
> void darshan_log_get_name_records(darshan_fd fd,
                              struct darshan_name_record_info **name_records,
                              int* count)
{
...
    if(ret < 0)
    {
        darshan_log_close(fd);
        return(-1);
    }

`return(-1);` in void function causes error in Fujitsu C compiler.
So I fixed to `return;` .