### PR TITLE
Build libtinfo.so --with-versioned-syms when it is enabled in ncurses.

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -73,7 +73,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
             opts.extend(('--with-termlib',
                          '--enable-termcap',
                          '--enable-getcap',
-                         '--enable-tcap-names'))
+                         '--enable-tcap-names',
+                         '--with-versioned-syms'))
 
         prefix = '--prefix={0}'.format(prefix)
 


### PR DESCRIPTION
Many system-installed binaries (at least in Debian) are built against a
libtinfo.so that has versioned symbols. If spack builds a version without this
functionality, and it winds up in the user's LD_LIBRARY_PATH via spack load,
system binaries will begin to complain.

```
$ less log.txt
less: /opt/spack/.../libtinfo.so.6: no version information available (required by less)
```