### PR TITLE
lcio: changes to install and CPATH for python bindings

### DIFF
--- a/var/spack/repos/builtin/packages/lcio/package.py
+++ b/var/spack/repos/builtin/packages/lcio/package.py
@@ -76,3 +76,14 @@ class Lcio(CMakePackage):
     def setup_run_environment(self, env):
         env.set('LCIO', self.prefix)
         env.prepend_path('PYTHONPATH', self.prefix.python)
+        # needed for the python bindings to find "Exceptions.h"
+        env.prepend_path('CPATH', self.prefix)
+
+    @run_after('install')
+    def install_source(self):
+        # these files are needed for the python bindings and root to
+        # find the headers
+        install_tree('src/cpp/include/pre-generated/',
+                     self.prefix.include + '/pre-generated')
+        install('src/cpp/include/IOIMPL/LCEventLazyImpl.h',
+                self.prefix.include + '/IOIMPL/')


### PR DESCRIPTION
As far as I can tell, these are the minimal changes to the spack recipe to allow one to run 
```
$ python -c "import pylcio"
Loading LCIO ROOT dictionaries ...
```
with a spack installed LCIO. See also https://github.com/iLCSoft/LCIO/issues/106 

@vvolkl I am open for any tweaks to this of course.