### PR TITLE
Rely on E4S project variable for SPACK_REPO

### DIFF
--- a/share/spack/gitlab/pr_pipeline.yml
+++ b/share/spack/gitlab/pr_pipeline.yml
@@ -2,7 +2,6 @@ pr_pipeline:
   only:
   - external_pull_requests
   variables:
-    SPACK_REPO: https://github.com/spack/spack.git
     SPACK_REF: ${CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME}
     SPACK_IS_PR_PIPELINE: "True"
   trigger:
@@ -13,7 +12,6 @@ merge_pipeline:
   only:
   - develop
   variables:
-    SPACK_REPO: https://github.com/spack/spack.git
     SPACK_REF: develop
   trigger:
     project: spack/e4s


### PR DESCRIPTION
Sending the `SPACK_REPO` variable from the multi-project trigger (like we were doing before this PR) overrode any value set in the project.  In order to get pipelines to clone spack from the gitlab mirror instead of github (hopefully reducing EC2 networking costs), we need to either set the cluster-internal gitlab url here or remove `SPACK_REPO` from here.  I went with removing `SPACK_REPO` since it seemed slightly cleaner.