### PR TITLE
readline: fix build with ncurses~termlib

### DIFF
--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -29,8 +29,11 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
 
     def build(self, spec, prefix):
         options = [
-            'SHLIB_LIBS=-L{0} -lncursesw -ltinfo'.format(
+            'SHLIB_LIBS=-L{0} -lncursesw'.format(
                 spec['ncurses'].prefix.lib)
         ]
+
+        if '+termlib' in spec['ncurses']:
+            options[0] += ' -ltinfo'
 
         make(*options)


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 11.0.3.