### PR TITLE
PCRE2: fix libs property

### DIFF
--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -37,7 +37,9 @@ class Pcre2(AutotoolsPackage):
 
     @property
     def libs(self):
-        libs = find_libraries('libpcre2*',
-                              root=self.prefix.lib,
-                              recursive=False)
-        return libs
+        if '+multibyte' in self.spec:
+            name = 'libpcre2-32'
+        else:
+            name = 'libpcre2-8'
+
+        return find_libraries(name, root=self.prefix, recursive=True)


### PR DESCRIPTION
No Spack packages currently use `spec['pcre2'].libs` so this change won't break anything. This change was necessary for the `fish` package, which I will update soon.