### PR TITLE
fish: add dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/fish/codesign.patch
+++ b/var/spack/repos/builtin/packages/fish/codesign.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2020-04-28 21:54:40.000000000 -0500
++++ b/CMakeLists.txt	2020-09-09 08:25:54.000000000 -0500
+@@ -183,7 +183,6 @@
+ # Define a function to link dependencies.
+ FUNCTION(FISH_LINK_DEPS_AND_SIGN target)
+   TARGET_LINK_LIBRARIES(${target} fishlib)
+-  CODESIGN_ON_MAC(${target})
+ ENDFUNCTION(FISH_LINK_DEPS_AND_SIGN)
+ 
+ # Define libfish.a.

--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -30,6 +30,9 @@ class Fish(CMakePackage):
     depends_on('python@3.3:', type='test')
     depends_on('py-pexpect', type='test')
 
+    # https://github.com/fish-shell/fish-shell/issues/7310
+    patch('codesign.patch', when='@3.1.2 platform=darwin')
+
     executables = ['^fish$']
 
     @classmethod

--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class Fish(CMakePackage):
     """fish is a smart and user-friendly command line shell for OS X, Linux, and
@@ -12,10 +10,45 @@ class Fish(CMakePackage):
     """
 
     homepage = "https://fishshell.com/"
-    url      = "https://github.com/fish-shell/fish-shell/releases/download/2.7.1/fish-2.7.1.tar.gz"
-    list_url = "https://fishshell.com/"
+    url      = "https://github.com/fish-shell/fish-shell/releases/download/3.1.2/fish-3.1.2.tar.gz"
+    git      = "https://github.com/fish-shell/fish-shell.git"
+    list_url = homepage
 
-    depends_on('ncurses')
-
+    version('master', branch='master')
+    version('3.1.2', sha256='d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed')
     version('3.1.0', sha256='e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368')
     version('3.0.0', sha256='ea9dd3614bb0346829ce7319437c6a93e3e1dfde3b7f6a469b543b0d2c68f2cf')
+
+    variant('docs', default=False, description='Build documentation')
+
+    # https://github.com/fish-shell/fish-shell#dependencies-1
+    depends_on('cmake@3.2:', type='build')
+    depends_on('ncurses~termlib')
+    depends_on('pcre2@10.21:')
+    depends_on('gettext')
+    depends_on('py-sphinx', when='+docs', type='build')
+    depends_on('python@3.3:', type='test')
+    depends_on('py-pexpect', type='test')
+
+    executables = ['^fish$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'fish, version (\S+)', output)
+        return match.group(1) if match else None
+
+    def cmake_args(self):
+        args = [
+            '-DBUILD_SHARED_LIBS=ON',
+            '-DMAC_CODESIGN_ID=OFF',
+            '-DPCRE2_LIB=' + self.spec['pcre2'].libs[0],
+            '-DPCRE2_INCLUDE_DIR=' + self.spec['pcre2'].headers.directories[0],
+        ]
+
+        if '+docs' in self.spec:
+            args.append('-DBUILD_DOCS=ON')
+        else:
+            args.append('-DBUILD_DOCS=OFF')
+
+        return args


### PR DESCRIPTION
Also add external package detection, master version, and a variant to enable/disable documentation.

I'm able to successfully build master on macOS 10.15.6 with Apple Clang 11.0.3. ~3.1.2 has a few build issues on macOS related to code signing: https://github.com/fish-shell/fish-shell/issues/7310~ 3.1.2 also builds and passes all unit tests.

Depends on #18524 
Depends on #18525