### PR TITLE
openscenegraph: remove dependency on Qt for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -25,7 +25,8 @@ class Openscenegraph(CMakePackage):
     variant('ffmpeg', default=False, description='Builds ffmpeg plugin for audio encoding/decoding')
 
     depends_on('cmake@2.8.7:', type='build')
-    depends_on('qt+opengl')
+    depends_on('gl')
+    depends_on('qt+opengl', when='@:3.5.4')  # Qt windowing system was moved into separate osgQt project
     depends_on('qt@4:', when='@3.2:')
     depends_on('qt@:4', when='@:3.1')
     depends_on('libxinerama')


### PR DESCRIPTION
Starting with OpenSceneGraph 3.5.5, support for windows managed by Qt
has been moved to the seperate project osgQt. Hence, a dependency on Qt
is not needed any longer for version 3.5.5 or newer.
In order to still satisfy the dependency on OpenGL, a depends_on('gl')
has been added.