### PR TITLE
external find: add arch to spec.

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -30,7 +30,7 @@ from typing import Optional, List, Dict, Any, Callable  # novm
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
-import llnl.util.cpu as cpu
+import archspec.cpu as cpu
 import spack.architecture as architecture
 import spack.compilers
 import spack.config

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -30,7 +30,8 @@ from typing import Optional, List, Dict, Any, Callable  # novm
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
-
+import llnl.util.cpu as cpu
+import spack.architecture as architecture
 import spack.compilers
 import spack.config
 import spack.dependency
@@ -172,6 +173,10 @@ class DetectablePackageMeta(object):
                 filter_fn = getattr(cls, 'filter_detected_exes',
                                     lambda x, exes: exes)
                 exes_in_prefix = filter_fn(prefix, exes_in_prefix)
+                arch = architecture.Arch(
+                    architecture.platform(),
+                    'default_os', cpu.host().family)
+                archstr = 'arch={0}'.format(arch)
                 for exe in exes_in_prefix:
                     try:
                         version_str = cls.determine_version(exe)
@@ -193,8 +198,8 @@ class DetectablePackageMeta(object):
                         if isinstance(variant, six.string_types):
                             variant = (variant, {})
                         variant_str, extra_attributes = variant
-                        spec_str = '{0}@{1} {2}'.format(
-                            cls.name, version_str, variant_str
+                        spec_str = '{0}@{1} {2} {3}'.format(
+                            cls.name, version_str, variant_str, archstr
                         )
 
                         # Pop a few reserved keys from extra attributes, since

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -289,7 +289,7 @@ def test_overriding_arch2(mock_executable, mutable_config, monkeypatch):
 
     # Check entries in 'packages.yaml'
     packages_yaml = spack.config.get('packages')
-    archstr = 'arch=test-centos7-core2'.format(architecture.platform())
+    archstr = 'arch=test-centos7-core2'
     assert 'gcc' in packages_yaml
     assert 'externals' in packages_yaml['gcc']
     externals = packages_yaml['gcc']['externals']

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -12,7 +12,7 @@ from spack.spec import Spec
 from spack.cmd.external import ExternalPackageEntry
 from spack.main import SpackCommand
 import spack.architecture as architecture
-import llnl.util.cpu as cpu
+import archspec.cpu as cpu
 
 target = cpu.host()
 arch = architecture.Arch(architecture.platform(), 'default_os', target.family)

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -239,6 +239,35 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
     assert externals[0]['prefix'] == '/opt/gcc/bin'
 
 
+def test_overriding_arch(mock_executable, mutable_config, monkeypatch):
+    # Prepare an environment to detect a fake gcc that
+    # override its external prefix
+    gcc_exe = mock_executable('gcc', output="echo 4.2.1")
+    prefix = os.path.dirname(gcc_exe)
+    monkeypatch.setenv('PATH', prefix)
+
+    @classmethod
+    def _determine_variants(cls, exes, version_str):
+        return 'os=centos6 target=core2 languages=c', {
+            'compilers': {'c': exes[0]}
+        }
+
+    gcc_cls = spack.repo.path.get_pkg_class('gcc')
+    monkeypatch.setattr(gcc_cls, 'determine_variants', _determine_variants)
+
+    # Find the external spec
+    external('find', 'gcc')
+
+    # Check entries in 'packages.yaml'
+    packages_yaml = spack.config.get('packages')
+    archstr = 'arch={0}-centos6-core2'.format(architecture.platform())
+    assert 'gcc' in packages_yaml
+    assert 'externals' in packages_yaml['gcc']
+    externals = packages_yaml['gcc']['externals']
+    assert len(externals) == 1
+    assert archstr in externals[0]['spec']
+
+
 def test_new_entries_are_reported_correctly(
         mock_executable, mutable_config, monkeypatch
 ):


### PR DESCRIPTION
`spack external find` search packages and add them to `packages.yaml`.
But this command search only one architecture to run te spack.
Other architectures may have different versions of the package in the same path.

This PR add architecture to spec when generate `spack external find`.