### PR TITLE
kim-api: add Fujitsu fortran options

### DIFF
--- a/var/spack/repos/builtin/packages/kim-api/fujitsu_add_link_flags.patch
+++ b/var/spack/repos/builtin/packages/kim-api/fujitsu_add_link_flags.patch
@@ -1,0 +1,21 @@
+diff -u -r -N a/cmake/Modules/DefaultCompilerFlags.cmake b/cmake/Modules/DefaultCompilerFlags.cmake
+--- a/cmake/Modules/DefaultCompilerFlags.cmake	2020-09-07 14:19:20.000000000 +0900
++++ b/cmake/Modules/DefaultCompilerFlags.cmake	2020-09-07 15:29:14.000000000 +0900
+@@ -51,7 +51,7 @@
+ endif()
+ #
+ #
+-set(CMAKE_EXE_LINKER_FLAGS "${KIM_API_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
++set(CMAKE_EXE_LINKER_FLAGS "--linkfortran ${KIM_API_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
+ #
+ 
+ # Set global compiler options
+@@ -107,7 +107,7 @@
+ endif()
+ set(KIM_API_Fortran_FLAGS "${KIM_API_Fortran_FLAGS}" CACHE STRING "KIM API Fortran compiler flags")
+ #
+-
++set(CMAKE_Fortran_MODDIR_FLAG -M)
+ # Update CMAKE variables
+ set(CMAKE_CXX_FLAGS "${KIM_API_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+ set(CMAKE_C_FLAGS "${KIM_API_C_FLAGS} ${CMAKE_C_FLAGS}")

--- a/var/spack/repos/builtin/packages/kim-api/package.py
+++ b/var/spack/repos/builtin/packages/kim-api/package.py
@@ -35,3 +35,6 @@ class KimApi(CMakePackage):
     version('2.1.1', sha256="25c4e83c6caa83a1c4ad480b430f1926fb44813b64f548fdaedc45e310b5f6b9")
     version('2.1.0', sha256="d6b154b31b288ec0a5643db176950ed71f1ca83a146af210a1d5d01cce8ce958")
     version('2.0.2', sha256="26e7cf91066692f316b8ba1548ccb7152bf56aad75902bce2338cff53e74e63d")
+    # The Fujitsu compiler requires the '--linkfortran'
+    # option to combine C++ and Fortran programs.
+    patch('fujitsu_add_link_flags.patch', when='%fj')


### PR DESCRIPTION
Cmake cannot recognize Fujitsu Fortran compiler now.
So I set Fortran compiler options manually.
Patch for Cmake to support Fujitsu Fortran compiler is working now, so this patch is tentative.