### PR TITLE
Avoid accidental deletions of lock files on write errors

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1514,11 +1514,10 @@ class Environment(object):
             # write the lock file last
             with fs.write_tmp_and_move(self.lock_path) as f:
                 sjson.dump(self._to_lockfile_dict(), stream=f)
+            self._update_and_write_manifest(raw_yaml_dict, yaml_dict)
         else:
-            if os.path.exists(self.lock_path):
-                os.unlink(self.lock_path)
-
-        self._write_helper(raw_yaml_dict, yaml_dict)
+            with fs.safe_remove(self.lock_path):
+                self._update_and_write_manifest(raw_yaml_dict, yaml_dict)
 
         # TODO: rethink where this needs to happen along with
         # writing. For some of the commands (like install, which write
@@ -1529,13 +1528,9 @@ class Environment(object):
         if regenerate_views:
             self.regenerate_views()
 
-    def _write_helper(self, raw_yaml_dict, yaml_dict):
-        """Helper function to write an environment after all the prerequisite
-        checks have been successful.
-
-        Args:
-            raw_yaml_dict: raw YAML dictionary
-            yaml_dict: YAML dictionary
+    def _update_and_write_manifest(self, raw_yaml_dict, yaml_dict):
+        """Update YAML manifest for this environment based on changes to
+        spec lists and views and write it.
         """
         # invalidate _repo cache
         self._repo = None

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2217,7 +2217,9 @@ spack:
     def _write_helper_raise(self, x, y):
         raise RuntimeError('some error')
 
-    monkeypatch.setattr(ev.Environment, '_write_helper', _write_helper_raise)
+    monkeypatch.setattr(
+        ev.Environment, '_update_and_write_manifest', _write_helper_raise
+    )
     with ev.Environment(str(tmpdir)) as e:
         e.concretize(force=True)
         with pytest.raises(RuntimeError):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2189,3 +2189,38 @@ spack:
         libelf_second_hash = extract_build_hash(e)
 
     assert libelf_first_hash == libelf_second_hash
+
+
+@pytest.mark.regression('18441')
+def test_lockfile_not_deleted_on_write_error(tmpdir, monkeypatch):
+    raw_yaml = """
+spack:
+  specs:
+  - dyninst
+  packages:
+    libelf:
+      externals:
+      - spec: libelf@0.8.13
+        prefix: /usr
+"""
+    spack_yaml = tmpdir.join('spack.yaml')
+    spack_yaml.write(raw_yaml)
+    spack_lock = tmpdir.join('spack.lock')
+
+    # Concretize a first time and create a lockfile
+    with ev.Environment(str(tmpdir)):
+        concretize()
+    assert os.path.exists(str(spack_lock))
+
+    # If I run concretize again and there's an error during write,
+    # the spack.lock file shouldn't disappear from disk
+    def _write_helper_raise(self, x, y):
+        raise RuntimeError('some error')
+
+    monkeypatch.setattr(ev.Environment, '_write_helper', _write_helper_raise)
+    with ev.Environment(str(tmpdir)) as e:
+        e.concretize(force=True)
+        with pytest.raises(RuntimeError):
+            e.clear()
+            e.write()
+    assert os.path.exists(str(spack_lock))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -569,3 +569,22 @@ def test_safe_remove(files_or_dirs, tmpdir):
     # Assert that files are restored
     for entry in to_be_checked:
         assert os.path.exists(entry)
+
+
+@pytest.mark.regression('18441')
+def test_content_of_files_with_same_name(tmpdir):
+    # Create two subdirectories containing a file with the same name,
+    # differentiate the files by their content
+    file1 = tmpdir.ensure('myenv1/spack.lock')
+    file2 = tmpdir.ensure('myenv2/spack.lock')
+    file1.write('file1'), file2.write('file2')
+
+    # Use 'safe_remove' to remove the two files
+    with pytest.raises(RuntimeError):
+        with fs.safe_remove(str(file1), str(file2)):
+            raise RuntimeError('Mock a failure')
+
+    # Check both files have been restored correctly
+    # and have not been mixed
+    assert file1.read().strip() == 'file1'
+    assert file2.read().strip() == 'file2'

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Tests for ``llnl/util/filesystem.py``"""
-
-import pytest
 import os
 import shutil
 import stat
 import sys
+
+import pytest
 
 import llnl.util.filesystem as fs
 import spack.paths
@@ -484,3 +484,57 @@ def test_filter_files_multiple(tmpdir):
         assert '<malloc.h>' not in f.read()
         assert '<string.h>' not in f.read()
         assert '<stdio.h>' not in f.read()
+
+
+# Each test input is a tuple of entries which prescribe
+# - the 'subdirs' to be created from tmpdir
+# - the 'files' in that directory
+# - what is to be removed
+@pytest.mark.parametrize('files_or_dirs', [
+    # Remove a file over the two that are present
+    [{'subdirs': None,
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['spack.lock']}],
+    # Remove the entire directory where two files are stored
+    [{'subdirs': ['myenv'],
+      'files': ['spack.lock', 'spack.yaml'],
+     'remove': ['myenv']}],
+    # Combine a mix of directories and files
+    [{'subdirs': None,
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['spack.lock']},
+     {'subdirs': ['myenv'],
+      'files': ['spack.lock', 'spack.yaml'],
+     'remove': ['myenv']}]
+])
+@pytest.mark.regression('18441')
+def test_safe_remove(files_or_dirs, tmpdir):
+    # Create a fake directory structure as prescribed by test input
+    to_be_removed, to_be_checked = [], []
+    for entry in files_or_dirs:
+        # Create relative dir
+        subdirs = entry['subdirs']
+        dir = tmpdir if not subdirs else tmpdir.mkdir(*subdirs)
+
+        # Create files in the directory
+        files = entry['files']
+        for f in files:
+            abspath = str(dir.join(f))
+            to_be_checked.append(abspath)
+            fs.touch(abspath)
+
+        # List of things to be removed
+        for r in entry['remove']:
+            to_be_removed.append(str(tmpdir.join(r)))
+
+    # Assert that files are deleted in the context block,
+    # mock a failure by raising an exception
+    with pytest.raises(RuntimeError):
+        with fs.safe_remove(*to_be_removed):
+            for entry in to_be_removed:
+                assert not os.path.exists(entry)
+            raise RuntimeError('Mock a failure')
+
+    # Assert that files are restored
+    for entry in to_be_checked:
+        assert os.path.exists(entry)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -496,41 +496,45 @@ def test_filter_files_multiple(tmpdir):
       'files': ['spack.lock', 'spack.yaml'],
       'remove': ['spack.lock']}],
     # Remove the entire directory where two files are stored
-    [{'subdirs': ['myenv'],
+    [{'subdirs': 'myenv',
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['myenv']}],
+      'remove': ['myenv']}],
     # Combine a mix of directories and files
     [{'subdirs': None,
       'files': ['spack.lock', 'spack.yaml'],
       'remove': ['spack.lock']},
-     {'subdirs': ['myenv'],
+     {'subdirs': 'myenv',
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['myenv']}],
+      'remove': ['myenv']}],
     # Multiple subdirectories, remove root
-    [{'subdirs': ['work', 'myenv1'],
+    [{'subdirs': 'work/myenv1',
       'files': ['spack.lock', 'spack.yaml'],
       'remove': []},
-     {'subdirs': ['work', 'myenv2'],
+     {'subdirs': 'work/myenv2',
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['work']}],
+      'remove': ['work']}],
     # Multiple subdirectories, remove each one
-    [{'subdirs': ['work', 'myenv1'],
+    [{'subdirs': 'work/myenv1',
       'files': ['spack.lock', 'spack.yaml'],
       'remove': ['work/myenv1']},
-     {'subdirs': ['work', 'myenv2'],
+     {'subdirs': 'work/myenv2',
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['work/myenv2']}],
+      'remove': ['work/myenv2']}],
     # Remove files with the same name in different directories
-    [{'subdirs': ['work', 'myenv1'],
+    [{'subdirs': 'work/myenv1',
       'files': ['spack.lock', 'spack.yaml'],
       'remove': ['work/myenv1/spack.lock']},
-     {'subdirs': ['work', 'myenv2'],
+     {'subdirs': 'work/myenv2',
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['work/myenv2/spack.lock']}],
+      'remove': ['work/myenv2/spack.lock']}],
     # Remove first the directory, then a file within the directory
-    [{'subdirs': ['myenv'],
+    [{'subdirs': 'myenv',
       'files': ['spack.lock', 'spack.yaml'],
       'remove': ['myenv', 'myenv/spack.lock']}],
+    # Remove first a file within a directory, then the directory
+    [{'subdirs': 'myenv',
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['myenv/spack.lock', 'myenv']}],
 ])
 @pytest.mark.regression('18441')
 def test_safe_remove(files_or_dirs, tmpdir):
@@ -539,7 +543,9 @@ def test_safe_remove(files_or_dirs, tmpdir):
     for entry in files_or_dirs:
         # Create relative dir
         subdirs = entry['subdirs']
-        dir = tmpdir if not subdirs else tmpdir.ensure(*subdirs, dir=True)
+        dir = tmpdir if not subdirs else tmpdir.ensure(
+            *subdirs.split('/'), dir=True
+        )
 
         # Create files in the directory
         files = entry['files']

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -505,7 +505,32 @@ def test_filter_files_multiple(tmpdir):
       'remove': ['spack.lock']},
      {'subdirs': ['myenv'],
       'files': ['spack.lock', 'spack.yaml'],
-     'remove': ['myenv']}]
+     'remove': ['myenv']}],
+    # Multiple subdirectories, remove root
+    [{'subdirs': ['work', 'myenv1'],
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': []},
+     {'subdirs': ['work', 'myenv2'],
+      'files': ['spack.lock', 'spack.yaml'],
+     'remove': ['work']}],
+    # Multiple subdirectories, remove each one
+    [{'subdirs': ['work', 'myenv1'],
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['work/myenv1']},
+     {'subdirs': ['work', 'myenv2'],
+      'files': ['spack.lock', 'spack.yaml'],
+     'remove': ['work/myenv2']}],
+    # Remove files with the same name in different directories
+    [{'subdirs': ['work', 'myenv1'],
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['work/myenv1/spack.lock']},
+     {'subdirs': ['work', 'myenv2'],
+      'files': ['spack.lock', 'spack.yaml'],
+     'remove': ['work/myenv2/spack.lock']}],
+    # Remove first the directory, then a file within the directory
+    [{'subdirs': ['myenv'],
+      'files': ['spack.lock', 'spack.yaml'],
+      'remove': ['myenv', 'myenv/spack.lock']}],
 ])
 @pytest.mark.regression('18441')
 def test_safe_remove(files_or_dirs, tmpdir):
@@ -514,7 +539,7 @@ def test_safe_remove(files_or_dirs, tmpdir):
     for entry in files_or_dirs:
         # Create relative dir
         subdirs = entry['subdirs']
-        dir = tmpdir if not subdirs else tmpdir.mkdir(*subdirs)
+        dir = tmpdir if not subdirs else tmpdir.ensure(*subdirs, dir=True)
 
         # Create files in the directory
         files = entry['files']


### PR DESCRIPTION
fixes #18441

Modifications:

- [x] Added a context manager to ensure that files or dirs are safely removed only if the block in the context executes successfully
- [x] Employ that context manager in `Environment.write` to avoid accidental deletions of `spack.lock`
- [x] Add unit tests to stress the context manager and avoid regressions