### PR TITLE
Update texlive/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -172,6 +172,9 @@ class Texlive(AutotoolsPackage):
         else:
             pass
 
+    def setup_build_environment(self, env):
+        env.prepend_path('PATH', join_path(self.prefix.bin, self.tex_arch()))
+
     def setup_run_environment(self, env):
         env.prepend_path('PATH', join_path(self.prefix.bin, self.tex_arch()))
 


### PR DESCRIPTION
without setting the build enviroment, the installation (on ubuntu18 system) fails with

```
1 error found in build log:
     35946    fmtutil [INFO]: /usr/local/pkg/Installs/linux-ubuntu18.04-skylake_avx512/gcc7.4.0/texlive/20190410/rgs2nakycorkgzno/t
              exmf-var/web2c/pdftex/pdfcslatex.fmt installed.
     35947    fmtutil [INFO]: Disabled formats: 6
     35948    fmtutil [INFO]: Successfully rebuilt formats: 45
     35949    fmtutil [INFO]: Total formats: 51
     35950    fmtutil [INFO]: exiting with status 0
     35951    ==> [2020-09-07-21:23:21.482745] '/usr/local/pkg/Installs/linux-ubuntu18.04-skylake_avx512/gcc7.4.0/texlive/20190410/
              rgs2nakycorkgzno/bin/x86_64-linux/mtxrun' '--generate'
  >> 35952    /usr/bin/env: 'texlua': No such file or directory
```

This helps, but may be there is a better way...