### PR TITLE
Add C99 flag for older GCC versions

### DIFF
--- a/var/spack/repos/builtin/packages/hpcc/package.py
+++ b/var/spack/repos/builtin/packages/hpcc/package.py
@@ -205,3 +205,9 @@ class Hpcc(MakefilePackage):
         mkdirp(self.prefix.doc.hpcc)
         install('README.html', self.prefix.doc.hpcc)
         install('README.txt', self.prefix.doc.hpcc)
+
+    def flag_handler(self, name, flags):
+        # old GCC defaults to -std=c90 but C99 is required for "restrict"
+        if self.spec.satisfies('%gcc@:5.1') and name == 'cflags':
+            flags.append(self.compiler.c99_flag)
+        return (flags, None, None)


### PR DESCRIPTION
I use `restrict` keyword in STREAM loops to improve vectorization. Older GCC defaults to C90 and fails to compile which happens on CentOS 7 and RedHat servers that ship with GCC 4.8.5. Adding C99 flag fixes the problem for these old compilers and has no effect for the new ones.