### PR TITLE
Spec: fix multiple generator iteration in satisfies_dependencies (#18527)

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3009,8 +3009,9 @@ class Spec(object):
             if not self._dependencies:
                 return False
 
-            selfdeps = self.traverse(root=False)
-            otherdeps = other.traverse(root=False)
+            # use list to prevent double-iteration
+            selfdeps = list(self.traverse(root=False))
+            otherdeps = list(other.traverse(root=False))
             if not all(any(d.satisfies(dep, strict=True) for d in selfdeps)
                        for dep in otherdeps):
                 return False

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1014,6 +1014,13 @@ class TestSpecSematics(object):
         with pytest.raises(UnknownVariantError, match=r'package has no such'):
             s.concretize()
 
+    @pytest.mark.regression('18527')
+    def test_satisfies_dependencies_ordered(self):
+        d = Spec('zmpi ^fake')
+        s = Spec('mpileaks')
+        s._add_dependency(d, ())
+        assert s.satisfies('mpileaks ^zmpi ^fake', strict=True)
+
 
 @pytest.mark.regression('3887')
 @pytest.mark.parametrize('spec_str', [


### PR DESCRIPTION
A saved instanced of `Spec.traverse()` was iterated multiple times, resulting in incorrect behavior, particularly around database searches. We should ensure that this fix doesn't break other use cases of `Spec.satisfies_dependencies` or `Spec.satisfies`.

Fixes #18527.