### PR TITLE
[acts] Add version 0.32 and adapt to latest master changes

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -157,7 +157,7 @@ class Acts(CMakePackage, CudaPackage):
         integration_tests_label = "INTEGRATIONTESTS"
         unit_tests_label = "UNITTESTS"
         legacy_plugin_label = "LEGACY_PLUGIN"
-        if spec.satisfies('@:0.15.99'):
+        if spec.satisfies('@:0.15'):
             integration_tests_label = "INTEGRATION_TESTS"
             unit_tests_label = "TESTS"
         if spec.satisfies('@:0.32'):

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -35,6 +35,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version('master', branch='master')
+    version('0.32.0', commit='a4cedab7e727e1327f2835db29d147cc86b21054')
     version('0.31.0', commit='cfbd901555579a2f32f4efe2b76a7048442b42c3')
     version('0.30.0', commit='a71ef0a9c742731611645214079884585a92b15e')
     version('0.29.0', commit='33aa3e701728112e8908223c4a7fd521907c8ea4')

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -192,7 +192,7 @@ class Acts(CMakePackage, CudaPackage):
 
         if spec.satisfies('@0.33: +json'):
             args.append("-DACTS_USE_SYSTEM_NLOHMANN_JSON=ON")
-        else if spec.satisfies('@0.14.0: +json'):
+        elif spec.satisfies('@0.14.0: +json'):
             args.append("-DACTS_USE_BUNDLED_NLOHMANN_JSON=OFF")
 
         return args

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -92,6 +92,7 @@ class Acts(CMakePackage, CudaPackage):
     variant('identification', default=False, description='Build the Identification plugin')
     variant('json', default=False, description='Build the Json plugin')
     variant('legacy', default=False, description='Build the Legacy package')
+    # FIXME: Cannot build SyCL plugin yet as Spack doesn't have SyCL support
     variant('tgeo', default=False, description='Build the TGeo plugin')
 
     # Variants that only affect Acts examples for now

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -101,8 +101,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Build dependencies
     depends_on('boost @1.62:1.69.99 +program_options +test', when='@:0.10.3')
-    depends_on('boost @1.69: +filesystem +program_options +test', when='@0.10.4:0.25')
-    depends_on('boost @1.69: +program_options +test', when='@0.26:')
+    depends_on('boost @1.69: +filesystem +program_options +test', when='@0.10.4')
     depends_on('cmake @3.11:', type='build')
     depends_on('dd4hep @1.10:', when='+dd4hep')
     depends_on('dd4hep @1.10: +geant4', when='+dd4hep +geant4')

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -145,29 +145,41 @@ class Acts(CMakePackage, CudaPackage):
             enabled = spec.satisfies('+examples +' + spack_variant)
             return "-DACTS_BUILD_EXAMPLES_{0}={1}".format(cmake_label, enabled)
 
+        def plugin_label(plugin_name):
+            if spec.satisfies('@0.33:'):
+                return "PLUGIN_" + plugin_name
+            else:
+                return plugin_name + "_PLUGIN"
+
+        def plugin_cmake_variant(plugin_name, spack_variant):
+            return cmake_variant(plugin_label(plugin_name), spack_variant)
+
         integration_tests_label = "INTEGRATIONTESTS"
         unit_tests_label = "UNITTESTS"
+        legacy_plugin_label = "LEGACY_PLUGIN"
         if spec.satisfies('@:0.15.99'):
             integration_tests_label = "INTEGRATION_TESTS"
             unit_tests_label = "TESTS"
+        if spec.satisfies('@:0.32'):
+            legacy_plugin_label = "LEGACY"
 
         args = [
             cmake_variant("BENCHMARKS", "benchmarks"),
-            cmake_variant("CUDA_PLUGIN", "cuda"),
-            cmake_variant("DD4HEP_PLUGIN", "dd4hep"),
-            cmake_variant("DIGITIZATION_PLUGIN", "digitization"),
+            plugin_cmake_variant("CUDA", "cuda"),
+            plugin_cmake_variant("DD4HEP", "dd4hep"),
+            plugin_cmake_variant("DIGITIZATION", "digitization"),
             cmake_variant("EXAMPLES", "examples"),
             example_cmake_variant("DD4HEP", "dd4hep"),
             example_cmake_variant("GEANT4", "geant4"),
             example_cmake_variant("HEPMC3", "hepmc3"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             cmake_variant("FATRAS", "fatras"),
-            cmake_variant("IDENTIFICATION_PLUGIN", "identification"),
+            plugin_cmake_variant("IDENTIFICATION", "identification"),
             cmake_variant(integration_tests_label, "integration_tests"),
-            cmake_variant("JSON_PLUGIN", "json"),
+            plugin_cmake_variant("JSON", "json"),
             cmake_variant(unit_tests_label, "unit_tests"),
-            cmake_variant("LEGACY", "legacy"),
-            cmake_variant("TGEO_PLUGIN", "tgeo")
+            cmake_variant(legacy_plugin_label, "legacy"),
+            plugin_cmake_variant("TGEO", "tgeo")
         ]
 
         cuda_arch = spec.variants['cuda_arch'].value
@@ -178,7 +190,9 @@ class Acts(CMakePackage, CudaPackage):
             cxxstd = spec['root'].variants['cxxstd'].value
             args.append("-DCMAKE_CXX_STANDARD={0}".format(cxxstd))
 
-        if spec.satisfies('@0.14.0: +json'):
+        if spec.satisfies('@0.33: +json'):
+            args.append("-DACTS_USE_SYSTEM_NLOHMANN_JSON=ON")
+        else if spec.satisfies('@0.14.0: +json'):
             args.append("-DACTS_USE_BUNDLED_NLOHMANN_JSON=OFF")
 
         return args


### PR DESCRIPTION
This allows spack to build acts version 0.32, along with the latest master.