### PR TITLE
libxmms: add python build dependency (#18566)

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -60,6 +60,7 @@ class Libxsmm(MakefilePackage):
             description='With generator executable(s)')
     conflicts('+header-only', when='@:1.6.2',
               msg='Header-only is available since v1.6.2!')
+    depends_on('python', type='build')
 
     @property
     def libs(self):


### PR DESCRIPTION
Build of libxmms requires python, but not in spack dependency list.
Fixes  #18566