### PR TITLE
Cython: add setuptools run-dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -39,7 +39,7 @@ class PyCython(PythonPackage):
 
     depends_on('python@2.6:2.8,3.3:', when='@0.23:', type=('build', 'run'))
     depends_on('python@:2', when='@:0.22', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('gdb@7.2:', type='test')
 
     @property


### PR DESCRIPTION
In older versions of Cython, the `cython` executable contains:
```python
from pkg_resources import load_entry_point
```
In newer versions of Cython, it contains:
```python
try:
    from importlib.metadata import distribution
except ImportError:
    try:
        from importlib_metadata import distribution
    except ImportError:
        from pkg_resources import load_entry_point
```
`importlib.metadata` was added in Python 3.8. `importlib_metadata` is the same library backported to older versions of Python. Instead of adding a new dependency, I figured it would be easier to fall back on `setuptools`, which provides `pkg_resources`.

Thanks to @ikitayama for reporting this bug over Slack.