### PR TITLE
Added specific "@master" version specifier for SCR dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -29,6 +29,12 @@ class Scr(CMakePackage):
     depends_on('zlib')
     depends_on('mpi')
 
+    # As of mid-2020, develop requires the "master" branch
+    # of a few component libraries
+    depends_on('axl@master', when="@develop")
+    depends_on('kvtree@master', when="@develop")
+    depends_on('redset@master', when="@develop")
+
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later
     depends_on('er', when="@3:")


### PR DESCRIPTION
Recent changes to the SCR develop branch requires the master branch of several component library dependencies. The dependencies for building the default version of spack are unchanged.