### PR TITLE
Update cray-libsci homepage and install error

### DIFF
--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack.concretize import NoBuildError
 from spack.util.module_cmd import module
 from spack.util.module_cmd import get_path_args_from_module_line
 
@@ -11,8 +10,8 @@ class CrayLibsci(Package):
     """The Cray Scientific Libraries package, LibSci, is a collection of
     numerical routines optimized for best performance on Cray systems."""
 
-    homepage = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
-    url      = "http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/"
+    homepage = "https://docs.nersc.gov/development/libraries/libsci/"
+    has_code = False    # Skip attempts to fetch source that is not available
 
     version("18.11.1.2")
     version("16.11.1")
@@ -78,4 +77,6 @@ class CrayLibsci(Package):
         return self.blas_libs
 
     def install(self, spec, prefix):
-        raise NoBuildError(spec)
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))


### PR DESCRIPTION
Fixes #17891 

This PR updates the home page to a valid link, removes the unneeded URL, and provides a meaningful error message.  The "fix" is based on the example set by the `lustre` package for addressing an attempt to install a package that needs to be configured as being external.  

Output before the fix:
```
==> Warning: Missing a source id for cray-libsci@18.11.1.2
==> Error: Unable to parse extension from http://www.nersc.gov/users/software/programming-libraries/math-libraries/libsci/.

If this URL is for a tarball but does not include the file extension
in the name, you can explicitly declare it with the following syntax:

    version('1.2.3', 'hash', extension='tar.gz')

If this URL is for a download like a .jar or .whl that does not need
to be expanded, or an uncompressed installation script, you can tell
Spack not to expand it with the following syntax:

    version('1.2.3', 'hash', expand=False)
```

Output with the fix in this PR:
```
==> Warning: Missing a source id for cray-libsci@18.11.1.2
==> Installing cray-libsci
==> No binary for cray-libsci found: installing from source
==> cray-libsci: Executing phase: 'install'
==> Error: InstallError: cray-libsci is not installable, you need to specify it as an external package in packages.yaml

/g/g21/dahlgren/spack/clean/spack/var/spack/repos/builtin/packages/cray-libsci/package.py:81, in install:
         79    def install(self, spec, prefix):
         80        raise InstallError(
  >>     81            self.spec.format('{name} is not installable, you need to specify '
         82                             'it as an external package in packages.yaml'))

See build log for details:
 $TMPDIR/spack-stage/spack-stage-cray-libsci-18.11.1.2-5momk4bz2owdilzhqw76nsnkftpnpglc/spack-build-out.txt
```