### PR TITLE
Autotools packages: modify ACLOCAL_PATH to build dependent packages

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -16,6 +16,7 @@ import llnl.util.tty as tty
 import llnl.util.filesystem as fs
 from llnl.util.filesystem import working_dir, force_remove
 from spack.package import PackageBase, run_after, run_before
+from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 
 
@@ -239,6 +240,14 @@ class AutotoolsPackage(PackageBase):
     def delete_configure_to_force_update(self):
         if self.force_autoreconf:
             force_remove(self.configure_abs_path)
+
+    @run_before('autoreconf')
+    def add_aclocal_path(self):
+        env = EnvironmentModifications()
+        for dep in self.spec.dependencies(deptype='build'):
+            if os.path.exists(dep.prefix.share.aclocal):
+                env.append_path('ACLOCAL_PATH', dep.prefix.share.aclocal)
+        env.apply_modifications()
 
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -98,3 +98,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
                 "libintl"],
             root=self.prefix, recursive=True
         )
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        """Adds the ACLOCAL path for autotools."""
+        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -98,7 +98,3 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
                 "libintl"],
             root=self.prefix, recursive=True
         )
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        """Adds the ACLOCAL path for autotools."""
-        env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)


### PR DESCRIPTION
closes #19258 

gettext has m4 files for aclocal (for example, gettext.m4, iconv.m4).
But gettext package dose not set ACLOCAL_PATH.
This PR set ACLOCAL_PATH.