### PR TITLE
audacious: Add gettext and iconv dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -22,10 +22,10 @@ class Audacious(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('gettext',  type=('build', 'link'))
+    depends_on('gettext')
     depends_on('iconv',    type='link')
     depends_on('glib',     type='link')
-    depends_on('qt',       type='link')
+    depends_on('qt')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -22,8 +22,10 @@ class Audacious(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('glib')
-    depends_on('qt')
+    depends_on('gettext',  type=('build', 'link'))
+    depends_on('iconv',    type='link')
+    depends_on('glib',     type='link')
+    depends_on('qt',       type='link')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')


### PR DESCRIPTION
audacious use gettext and iconv, but not dependency.
This PR add gettext and iconv dependency.