### PR TITLE
r-ff: support for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/r-ff/package.py
+++ b/var/spack/repos/builtin/packages/r-ff/package.py
@@ -19,3 +19,5 @@ class RFf(RPackage):
 
     depends_on('r@2.10.1:', type=('build', 'run'))
     depends_on('r-bit@1.1-13:', type=('build', 'run'))
+
+    patch('utk_platform_macros.hpp.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/r-ff/utk_platform_macros.hpp.patch
+++ b/var/spack/repos/builtin/packages/r-ff/utk_platform_macros.hpp.patch
@@ -1,0 +1,11 @@
+--- spack-src/src/utk_platform_macros.hpp.bak	2017-04-09 00:25:51.000000000 +0900
++++ spack-src/src/utk_platform_macros.hpp	2020-08-26 09:43:04.464838833 +0900
+@@ -136,6 +136,8 @@
+     #define UTK__Arch_ARM_THUMB
+   #elif defined(__sh__)
+     #define UTK__Arch_SuperH
++  #elif defined(__aarch64__)
++    #define UTK__Arch_ARM64
+   #else
+     #error Architecture not supported.
+   #endif


### PR DESCRIPTION
This PR is a fix for building on aarch64.
No response, but I did upstream on 8/27.
