### PR TITLE
Support external find for gpgme.

### DIFF
--- a/var/spack/repos/builtin/packages/gpgme/package.py
+++ b/var/spack/repos/builtin/packages/gpgme/package.py
@@ -13,8 +13,14 @@ class Gpgme(AutotoolsPackage):
     homepage = "https://www.gnupg.org/software/gpgme/index.html"
     url      = "https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.12.0.tar.bz2"
 
+    executables = ['^gpgme-config$']
+
     version('1.12.0', sha256='b4dc951c3743a60e2e120a77892e9e864fb936b2e58e7c77e8581f4d050e8cd8')
 
     depends_on('gnupg', type='build')
     depends_on('libgpg-error', type='build')
     depends_on('libassuan', type='build')
+
+    @classmethod
+    def determine_version(cls, exe):
+        return Executable(exe)('--version', output=str, error=str).rstrip()


### PR DESCRIPTION
Adding support for `external find` command to the `gpgme` package:

```console
$ spack external find gpgme
==> The following specs have been detected on this system and added to /root/.spack/packages.yaml
gpgme@1.12.0
$ cat ~/.spack/packages.yaml 
packages:
  gpgme:
    externals:
    - spec: gpgme@1.12.0
      prefix: /usr
```