### PR TITLE
openmpi: external detection support

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -368,11 +368,12 @@ class Openmpi(AutotoolsPackage):
                 variants += "+static"
             elif re.search(r'--disable-static', output):
                 variants += "~static"
-            elif re.search(r'\bMCA (?:coll|oca|pml): monitoring', output):
-                #Built multiple variants of openmpi and ran diff.
-                #This seems to be the distinguishing feature.
+            elif re.search(r'\bMCA (?:coll|oca|pml): monitoring',
+                           output):
+                # Built multiple variants of openmpi and ran diff.
+                # This seems to be the distinguishing feature.
                 variants += "~static"
-            if re.search(r'--with-sqlite3', output):
+            if re.search(r'\bMCA db: sqlite', output):
                 variants += "+sqlite3"
             if re.search(r'--enable-contrib-no-build=vt', output):
                 variants += '+vt'

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -411,7 +411,8 @@ class Openmpi(AutotoolsPackage):
             fabrics = get_options_from_variant(cls, "fabrics")
             used_fabrics = []
             for fabric in fabrics:
-                match = re.search(r'\bMCA (?:mtl|btl|pml): %s\b' % fabric, output)
+                match = re.search(r'\bMCA (?:mtl|btl|pml): %s\b' % fabric,
+                                  output)
                 if match:
                     used_fabrics.append(fabric)
             if used_fabrics:
@@ -420,7 +421,8 @@ class Openmpi(AutotoolsPackage):
             schedulers = get_options_from_variant(cls, "schedulers")
             used_schedulers = []
             for scheduler in schedulers:
-                match = re.search(r'\bMCA (?:prrte|ras): %s\b' % scheduler, output)
+                match = re.search(r'\bMCA (?:prrte|ras): %s\b' % scheduler,
+                                  output)
                 if match:
                     used_schedulers.append(scheduler)
             if used_schedulers:

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -368,6 +368,10 @@ class Openmpi(AutotoolsPackage):
                 variants += "+static"
             elif re.search(r'--disable-static', output):
                 variants += "~static"
+            elif re.search(r'\bMCA (?:coll|oca|pml): monitoring', output):
+                #Built multiple variants of openmpi and ran diff.
+                #This seems to be the distinguishing feature.
+                variants += "~static"
             if re.search(r'--with-sqlite3', output):
                 variants += "+sqlite3"
             if re.search(r'--enable-contrib-no-build=vt', output):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -397,7 +397,7 @@ class Openmpi(AutotoolsPackage):
             match = re.search(r'Memory debugging support: (\S+)', output)
             if match and is_enabled(match.group(1)):
                 variants += '+memchecker'
-            if re.search(r'\bMCA ess: pmi', output):
+            if re.search(r'\bMCA (?:ess|prrte): pmi', output):
                 variants += '+pmi'
 
             # This code gets all the fabric names from the variants list
@@ -411,7 +411,7 @@ class Openmpi(AutotoolsPackage):
             fabrics = get_options_from_variant(cls, "fabrics")
             used_fabrics = []
             for fabric in fabrics:
-                match = re.search(r'\bMCA mtl: %s\b' % fabric, output)
+                match = re.search(r'\bMCA (?:mtl|btl|pml): %s\b' % fabric, output)
                 if match:
                     used_fabrics.append(fabric)
             if used_fabrics:
@@ -420,7 +420,7 @@ class Openmpi(AutotoolsPackage):
             schedulers = get_options_from_variant(cls, "schedulers")
             used_schedulers = []
             for scheduler in schedulers:
-                match = re.search(r'\bMCA ras: %s\b' % scheduler, output)
+                match = re.search(r'\bMCA (?:prrte|ras): %s\b' % scheduler, output)
                 if match:
                     used_schedulers.append(scheduler)
             if used_schedulers:

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -339,21 +339,6 @@ class Openmpi(AutotoolsPackage):
 
     @classmethod
     def determine_variants(cls, exes, version):
-        def get_spack_compiler_spec(path):
-            spack_compilers = spack.compilers.find_compilers([path])
-            actual_compiler = None
-            # check if the compiler actually matches the one we want
-            for spack_compiler in spack_compilers:
-                if os.path.dirname(spack_compiler.cc) == path:
-                    actual_compiler = spack_compiler
-                    break
-            return actual_compiler.spec if actual_compiler else None
-
-        def is_enabled(text):
-            if text in set(['t', 'true', 'enabled', 'yes', '1']):
-                return True
-            return False
-
         results = []
         for exe in exes:
             variants = ''
@@ -837,3 +822,20 @@ class Openmpi(AutotoolsPackage):
                     tty.debug("File not present: " + exe)
                 else:
                     copy(script_stub, exe)
+
+
+def get_spack_compiler_spec(path):
+    spack_compilers = spack.compilers.find_compilers([path])
+    actual_compiler = None
+    # check if the compiler actually matches the one we want
+    for spack_compiler in spack_compilers:
+        if os.path.dirname(spack_compiler.cc) == path:
+            actual_compiler = spack_compiler
+            break
+    return actual_compiler.spec if actual_compiler else None
+
+
+def is_enabled(text):
+    if text in set(['t', 'true', 'enabled', 'yes', '1']):
+        return True
+    return False

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -349,6 +349,8 @@ class Openmpi(AutotoolsPackage):
             match = re.search(r'\bJava bindings: (\S+)', output)
             if match and is_enabled(match.group(1)):
                 variants += "+java"
+            else:
+                variants += "~java"
             if re.search(r'--enable-static', output):
                 variants += "+static"
             elif re.search(r'--disable-static', output):
@@ -360,26 +362,38 @@ class Openmpi(AutotoolsPackage):
                 variants += "~static"
             if re.search(r'\bMCA db: sqlite', output):
                 variants += "+sqlite3"
+            else:
+                variants += "~sqlite3"
             if re.search(r'--enable-contrib-no-build=vt', output):
                 variants += '+vt'
             match = re.search(r'MPI_THREAD_MULTIPLE: (\S+?),?', output)
             if match and is_enabled(match.group(1)):
                 variants += '+thread_multiple'
+            else:
+                variants += '~thread_multiple'
             match = re.search(
                 r'parameter "mpi_built_with_cuda_support" ' +
                 r'\(current value: "(\S+)"',
                 output)
             if match and is_enabled(match.group(1)):
                 variants += '+cuda'
+            else:
+                variants += '~cuda'
             match = re.search(r'\bWrapper compiler rpath: (\S+)', output)
             if match and is_enabled(match.group(1)):
                 variants += '+wrapper-rpath'
+            else:
+                variants += '~wrapper-rpath'
             match = re.search(r'\bC\+\+ bindings: (\S+)', output)
             if match and match.group(1) == 'yes':
                 variants += '+cxx'
+            else:
+                variants += '~cxx'
             match = re.search(r'\bC\+\+ exceptions: (\S+)', output)
             if match and match.group(1) == 'yes':
                 variants += '+cxx_exceptions'
+            else:
+                variants += '~cxx_exceptions'
             if re.search(r'--with-singularity', output):
                 variants += '+singularity'
             if re.search(r'--with-lustre', output):
@@ -387,16 +401,12 @@ class Openmpi(AutotoolsPackage):
             match = re.search(r'Memory debugging support: (\S+)', output)
             if match and is_enabled(match.group(1)):
                 variants += '+memchecker'
+            else:
+                variants += '~memchecker'
             if re.search(r'\bMCA (?:ess|prrte): pmi', output):
                 variants += '+pmi'
-
-            # This code gets all the fabric names from the variants list
-            # Idea taken from the AutotoolsPackage source.
-            def get_options_from_variant(self, name):
-                values = self.variants[name].values
-                if getattr(values, 'feature_values', None):
-                    values = values.feature_values
-                return values
+            else:
+                variants += '~pmi'
 
             fabrics = get_options_from_variant(cls, "fabrics")
             used_fabrics = []
@@ -425,7 +435,6 @@ class Openmpi(AutotoolsPackage):
             if compiler_spec:
                 variants += "%" + str(compiler_spec)
             results.append(variants)
-        print(results)
         return results
 
     def url_for_version(self, version):
@@ -839,3 +848,12 @@ def is_enabled(text):
     if text in set(['t', 'true', 'enabled', 'yes', '1']):
         return True
     return False
+
+
+# This code gets all the fabric names from the variants list
+# Idea taken from the AutotoolsPackage source.
+def get_options_from_variant(self, name):
+    values = self.variants[name].values
+    if getattr(values, 'feature_values', None):
+        values = values.feature_values
+    return values

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -343,6 +343,11 @@ class Openmpi(AutotoolsPackage):
         for exe in exes:
             variants = ''
             output = Executable(exe)("-a", output=str, error=str)
+            # Some of these options we have to find by hoping the
+            # configure string is in the ompi_info output. While this
+            # is usually true, it's not guaranteed.  For anything that
+            # begins with --, we want to use the defaults as provided
+            # by the openmpi package in the absense of any other info.
 
             if re.search(r'--enable-builtin-atomics', output):
                 variants += "+atomics"


### PR DESCRIPTION
@hppritcha , can you have a look at this PR please?

I'm trying to add `spack external find` support to the openmpi package.  I've been trying to understand the output of `ompi_info`, but I'm having trouble parsing some of it:

1.) By default, I don't see any way to get access to all the configure command line flags within `ompi_info.`  Therefore, my ability to detect the following variants is limited to the occasional leak of command line arguments:
  * atomics
  * static
  * sqlite3
  * vt
  * singularity
  * lustre

Do you have a better way of detecting the use of these variants from the output of `ompi_info` ?

2.) Have I handled parsing the following options from ompi_correctly?
  * Are fabrics always found in the mtl framework?
  * Are schedulers always found in the ras framework?
  * Am I right to use pmi from the ess framework?
  * Have I understood the +memchecker variant correctly?

3.) Right now I don't have a good way of detecting the 'legacylaunchers' variant, do you have any ideas?