### PR TITLE
dpdk: Avoid option conflicts between spack wrappers and Makefiles on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/dpdk/package.py
+++ b/var/spack/repos/builtin/packages/dpdk/package.py
@@ -21,6 +21,14 @@ class Dpdk(MakefilePackage):
 
     depends_on('numactl')
 
+    @when('%gcc target=aarch64:')
+    def patch(self):
+        filter_file(
+            r'^MACHINE_CFLAGS',
+            '#MACHINE_CFLAGS',
+            join_path('mk', 'machine', 'armv8a', 'rte.vars.mk')
+        )
+
     def build(self, spec, prefix):
         make('defconfig')
         make()


### PR DESCRIPTION
dpdk package add `-marmv8-a+crc` option to build on aarch64 and gcc.
spack on thunderx2 add '-mthunderx2t99p1' (armv8.1-a).
when we build dpdk on thunderX2, gcc conflicts for both options.
To avoid this, the PR delete adding machine options when gcc and aarch64.