### PR TITLE
Updated FZF package for newer versions.

### DIFF
--- a/var/spack/repos/builtin/packages/fzf/package.py
+++ b/var/spack/repos/builtin/packages/fzf/package.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-import inspect
 
 from spack import *
 
@@ -16,6 +15,9 @@ class Fzf(MakefilePackage):
     homepage = "https://github.com/junegunn/fzf"
     url      = "https://github.com/junegunn/fzf/archive/0.17.5.tar.gz"
 
+    executables = ['^fzf$']
+
+    version('0.22.0',   sha256='3090748bb656333ed98490fe62133760e5da40ba4cd429a8142b4a0b69d05586')
     version('0.17.5',   sha256='de3b39758e01b19bbc04ee0d5107e14052d3a32ce8f40d4a63d0ed311394f7ee')
     version('0.17.4',   sha256='a4b009638266b116f422d159cd1e09df64112e6ae3490964db2cd46636981ff0')
     version('0.17.3',   sha256='e843904417adf926613431e4403fded24fade56269446e92aac6ff1db86af81e')
@@ -27,26 +29,31 @@ class Fzf(MakefilePackage):
     version('0.16.9',   sha256='dd9434576c68313481613a5bd52dbf623eee37a5c87f7bb66ca71ac8add5ff94')
     version('0.16.8',   sha256='daef99f67cff3dad261dbcf2aef995bb78b360bcc7098d7230cb11674e1ee1d4')
 
-    depends_on('go@1.11:')
+    depends_on('go@1.11:', type='build')
 
     variant('vim', default=False, description='Install vim plugins for fzf')
 
-    patch("github_mirrors.patch")
+    patch("github_mirrors.patch", when='@:0.17.5')
 
-    def build(self, spec, prefix):
+    @classmethod
+    def determine_version(cls, exe):
+        return Executable(exe)('--version', output=str, error=str).rstrip()
+
+    @when('@:0.17.5')
+    def patch(self):
         glide_home = os.path.join(self.build_directory, 'glide_home')
         os.environ['GLIDE_HOME'] = glide_home
         shutil.rmtree(glide_home, ignore_errors=True)
         os.mkdir(glide_home)
-        super(Fzf, self).build(spec, prefix)
 
     def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            inspect.getmodule(self).make(*self.install_targets)
+        make('install')
 
         mkdir(prefix.bin)
         install('bin/fzf', prefix.bin)
 
-        if '+vim' in spec:
-            mkdir(prefix.plugin)
-            install('plugin/fzf.vim', prefix.plugin)
+    @run_after('install')
+    def post_install(self):
+        if '+vim' in self.spec:
+            mkdir(self.prefix.plugin)
+            install('plugin/fzf.vim', self.prefix.plugin)


### PR DESCRIPTION
Support for external find:

```shell
$ spack external find fzf
==> The following specs have been detected on this system and added to /home/paul/.spack/packages.yaml
fzf@0.20.0
$ cat ~/.spack/packages.yaml 
packages:
  fzf:
    externals:
    - spec: fzf@0.20.0
      prefix: /usr
```

Added latest version (0.22.0) and conditions to package to continue support for older versions. With `go mod` there is no longer a need for Glide that was relied upon in the previous installs.