### PR TITLE
Add setuptools run-time dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-babel/package.py
+++ b/var/spack/repos/builtin/packages/py-babel/package.py
@@ -22,7 +22,7 @@ class PyBabel(PythonPackage):
     version('2.3.4', sha256='c535c4403802f6eb38173cd4863e419e2274921a01a8aad8a5b497c131c62875')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-pytz@2015.7:', type=('build', 'run'))
     depends_on('py-pytest', type='test')
     depends_on('py-freezegun', type='test')

--- a/var/spack/repos/builtin/packages/py-chardet/package.py
+++ b/var/spack/repos/builtin/packages/py-chardet/package.py
@@ -16,7 +16,7 @@ class PyChardet(PythonPackage):
     version('3.0.2', sha256='4f7832e7c583348a9eddd927ee8514b3bf717c061f57b21dbe7697211454d9bb')
     version('2.3.0', sha256='e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-pytest-runner', type='build')
     depends_on('py-pytest', type='test')
     depends_on('py-hypothesis', type='test')

--- a/var/spack/repos/builtin/packages/py-codecov/package.py
+++ b/var/spack/repos/builtin/packages/py-codecov/package.py
@@ -16,7 +16,7 @@ class PyCodecov(PythonPackage):
 
     version('2.0.15', sha256='8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-requests@2.7.9:', type=('build', 'run'))
     depends_on('py-coverage', type=('build', 'run'))
     depends_on('py-argparse', when='^python@:2.6', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-coverage/package.py
+++ b/var/spack/repos/builtin/packages/py-coverage/package.py
@@ -18,4 +18,4 @@ class PyCoverage(PythonPackage):
     version('4.0a6', sha256='85c7f3efceb3724ab066a3fcccc05b9b89afcaefa5b669a7e2222d31eac4728d')
 
     depends_on('python@2.6:2.8,3.3:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-json5/package.py
+++ b/var/spack/repos/builtin/packages/py-json5/package.py
@@ -16,4 +16,4 @@ class PyJson5(PythonPackage):
 
     version('0.9.4', sha256='2ebfad1cd502dca6aecab5b5c36a21c732c3461ddbc412fb0e9a52b07ddfe586')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -85,7 +85,7 @@ class PyNumpy(PythonPackage):
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@1.16:')
     depends_on('python@3.5:', type=('build', 'run'), when='@1.17:')
     depends_on('python@3.6:', type=('build', 'run'), when='@1.19:')
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     # Check pyproject.toml for updates to the required cython version
     depends_on('py-cython@0.29.13:', when='@1.18.0:', type='build')
     depends_on('py-cython@0.29.14:', when='@1.18.1:', type='build')

--- a/var/spack/repos/builtin/packages/py-pkginfo/package.py
+++ b/var/spack/repos/builtin/packages/py-pkginfo/package.py
@@ -14,6 +14,6 @@ class PyPkginfo(PythonPackage):
 
     version('1.5.0.1', sha256='7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-nose', type='test')
     depends_on('py-coverage', type='test')

--- a/var/spack/repos/builtin/packages/py-pyinstrument/package.py
+++ b/var/spack/repos/builtin/packages/py-pyinstrument/package.py
@@ -15,7 +15,7 @@ class PyPyinstrument(PythonPackage):
     version('3.1.3', sha256='ca4571775caa06444cd7e832056afc21175130271fe3f3481e3ab1bf67f96c8b')
     version('3.1.0', sha256='02319607daf65110e246085f5e2ee111f565f213eed1991229f2d58e9a7657a5')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-pytest-runner', type='build')
     depends_on('npm', type='build')
     depends_on('py-pyinstrument-cext@0.2.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -33,7 +33,7 @@ class PyTables(PythonPackage):
     depends_on('python@3.4:', when='@3.6.0:', type=('build', 'run'))
     depends_on('python@2.6:', type=('build', 'run'))
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-cython@0.21:', type='build')
     depends_on('py-numpy@1.9.3:', type=('build', 'run'))
     depends_on('py-numexpr@2.6.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -125,7 +125,7 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('python@3.6.1:', when='@1.6:', type=('build', 'run'))
     depends_on('python@3.5:', when='@1.5:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-future', when='@1.1: ^python@:2', type='build')
     depends_on('py-pyyaml', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tox/package.py
+++ b/var/spack/repos/builtin/packages/py-tox/package.py
@@ -15,7 +15,7 @@ class PyTox(PythonPackage):
     version('3.14.2', sha256='7efd010a98339209f3a8292f02909b51c58417bfc6838ab7eca14cf90f96117a')
 
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-importlib-metadata@1.1.0:', when='^python@:3.7', type=('build', 'run'))
     depends_on('py-packaging@14:', type=('build', 'run'))
     depends_on('py-pluggy@0.12.0:0.999', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tqdm/package.py
+++ b/var/spack/repos/builtin/packages/py-tqdm/package.py
@@ -17,7 +17,7 @@ class PyTqdm(PythonPackage):
     version('4.8.4',  sha256='bab05f8bb6efd2702ab6c532e5e6a758a66c0d2f443e09784b73e4066e6b3a37')
 
     depends_on('python@2.6:2.8,3.2:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-nose', type='test')
     depends_on('py-flake8', type='test')
     depends_on('py-coverage', type='test')

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -23,7 +23,7 @@ class Scons(PythonPackage):
 
     # Python 3 support was added in SCons 3.0.0
     depends_on('python@:2', when='@:2', type=('build', 'run'))
-    depends_on('py-setuptools', when='@3.0.2:', type='build')
+    depends_on('py-setuptools', when='@3.0.2:', type=('build', 'run'))
 
     patch('fjcompiler.patch', when='%fj')
 


### PR DESCRIPTION
All of these packages install executables into `prefix.bin` that import `pkg_resources`, which is provided by `setuptools`. Unfortunately none of them properly documented this dependency.