### PR TITLE
cpio: add --rtlib=compiler-rt for %fj

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -26,7 +26,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
             if '%intel' in spec:
                 flags.append('-no-gcc')
 
-            if '%clang' in spec or '%fj' in spec:
+            elif '%clang' in spec or '%fj' in spec:
                 flags.append('--rtlib=compiler-rt')
 
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -28,4 +28,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
         if '%clang' in spec and name == 'cflags':
             flags.append('--rtlib=compiler-rt')
 
+        if '%fj' in spec and name == 'cflags':
+            flags.append('--rtlib=compiler-rt')
+
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -22,13 +22,11 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
     def flag_handler(self, name, flags):
         spec = self.spec
 
-        if '%intel' in spec and name == 'cflags':
-            flags.append('-no-gcc')
+        if name == 'cflags':
+            if '%intel' in spec:
+                flags.append('-no-gcc')
 
-        if '%clang' in spec and name == 'cflags':
-            flags.append('--rtlib=compiler-rt')
-
-        if '%fj' in spec and name == 'cflags':
-            flags.append('--rtlib=compiler-rt')
+            if '%clang' in spec or '%fj' in spec:
+                flags.append('--rtlib=compiler-rt')
 
         return (flags, None, None)


### PR DESCRIPTION
Add compiler option equal to `%clang` to avoid this error.

> /tmp/n0026/spack-stage/spack-stage-cpio-2.13-ukb4ywnnxbksoxsu7vzn2zr5augx3t2k/spack-src/gnu/xalloc.h:107: undefined reference to `__muloti4'

line 107: `if (xalloc_oversized (n, s))`