### PR TITLE
py-argon2-cffi: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-argon2-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-argon2-cffi/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyArgon2Cffi(PythonPackage):
+    """The secure Argon2 password hashing algorithm.."""
+
+    homepage = "https://argon2-cffi.readthedocs.io/"
+    url      = "https://pypi.io/packages/source/a/argon2-cffi/argon2-cffi-20.1.0.tar.gz"
+
+    version('20.1.0', sha256='d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-cffi@1.0.0:', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-coverage@5.0.2:+toml', type='test')
+    depends_on('py-hypothesis', type='test')
+    depends_on('py-pytest', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.8.5 and Apple Clang 11.0.3.