### PR TITLE
py-jupyterlab-server: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab-server/package.py
@@ -3,16 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class PyJupyterlabServer(PythonPackage):
     """A set of server components for JupyterLab and JupyterLab
        like applications"""
 
     homepage = "https://pypi.org/project/jupyterlab-server/"
-    url      = "https://pypi.io/packages/source/j/jupyterlab_server/jupyterlab_server-1.1.0.tar.gz"
+    url      = "https://pypi.io/packages/source/j/jupyterlab_server/jupyterlab_server-1.2.0.tar.gz"
 
+    version('1.2.0', sha256='5431d9dde96659364b7cc877693d5d21e7b80cea7ae3959ecc2b87518e5f5d8c')
     version('1.1.0', sha256='bac27e2ea40f686e592d6429877e7d46947ea76c08c878081b028c2c89f71733')
 
     depends_on('python@3.5:', type=('build', 'run'))
@@ -23,3 +22,5 @@ class PyJupyterlabServer(PythonPackage):
     depends_on('py-jsonschema@3.0.1:', type=('build', 'run'))
     depends_on('py-notebook@4.2.0:', type=('build', 'run'))
     depends_on('py-jinja2@2.10:', type=('build', 'run'))
+
+    depends_on('py-pytest', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.8.5 and Apple Clang 11.0.3.