### PR TITLE
py-notebook: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-notebook/package.py
@@ -3,15 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class PyNotebook(PythonPackage):
     """Jupyter Interactive Notebook"""
 
     homepage = "https://github.com/jupyter/notebook"
-    url      = "https://pypi.io/packages/source/n/notebook/notebook-4.2.3.tar.gz"
+    url      = "https://pypi.io/packages/source/n/notebook/notebook-6.1.4.tar.gz"
 
+    version('6.1.4', sha256='687d01f963ea20360c0b904ee7a37c3d8cda553858c8d6e33fd0afd13e89de32')
     version('6.0.3', sha256='47a9092975c9e7965ada00b9a20f0cf637d001db60d241d479f53c0be117ad48')
     version('6.0.1', sha256='660976fe4fe45c7aa55e04bf4bccb9f9566749ff637e9020af3422f9921f9a5d')
     version('5.7.8', sha256='573e0ae650c5d76b18b6e564ba6d21bf321d00847de1d215b418acb64f056eb8')
@@ -26,40 +25,29 @@ class PyNotebook(PythonPackage):
 
     depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
     depends_on('python@3.5:',         type=('build', 'run'), when='@6:')
-
     depends_on('py-setuptools',       type=('build', 'run'), when='@5:')
     depends_on('py-jinja2',           type=('build', 'run'))
-    depends_on('py-ipython-genutils', type=('build', 'run'))
-    depends_on('py-nbformat',         type=('build', 'run'))
-    depends_on('py-nbconvert',        type=('build', 'run'))
-    depends_on('py-ipykernel',        type=('build', 'run'))
-
-    depends_on('py-ipywidgets',        type=('build', 'run'), when="+terminal")
-    depends_on('py-prometheus-client', type=('build', 'run'), when='@5.7.0:')
-    depends_on('py-send2trash',        type=('build', 'run'), when='@6:')
-    depends_on('py-pyzmq@17:',         type=('build', 'run'), when='@6:')
-    depends_on('py-traitlets@4.2.1:',  type=('build', 'run'), when='@6:')
-    depends_on('py-ipaddress',         type=('build', 'run'), when='@5.7.0: ^python@:2.8')
-
-    depends_on('py-terminado@0.3.3:', type=('build', 'run'), when='@:5.7.0')
-    depends_on('py-terminado@0.8.1:', type=('build', 'run'), when='@5.7.0:')
-
-    depends_on('py-ipykernel@5.1.0:', type=('build', 'run'), when='@4.2.0: ^python@3.3:')
-    depends_on('py-ipykernel@:5.0.0', type=('build', 'run'), when='@4.2.0: ^python@:2.8')
-
     depends_on('py-tornado@4.0:6.999', type=('build', 'run'), when='@:5.7.4')
     depends_on('py-tornado@4.1:6.999', type=('build', 'run'), when='@5.7.5:5.999')
-    depends_on('py-tornado@5.0:',      type=('build', 'run'), when='@6.0.0:')
-
+    depends_on('py-tornado@5.0:',      type=('build', 'run'), when='@6:')
+    depends_on('py-pyzmq@17:',         type=('build', 'run'), when='@6:')
+    depends_on('py-argon2-cffi',       type=('build', 'run'), when='@6.1:')
+    depends_on('py-ipython-genutils', type=('build', 'run'))
+    depends_on('py-traitlets',        type=('build', 'run'))
+    depends_on('py-traitlets@4.2.1:', type=('build', 'run'), when='@5:')
     depends_on('py-jupyter-core',        type=('build', 'run'))
     depends_on('py-jupyter-core@4.4.0:', type=('build', 'run'), when='@5.7.0:6.0.1')
     depends_on('py-jupyter-core@4.6.0:', type=('build', 'run'), when='@6.0.2')
     depends_on('py-jupyter-core@4.6.1:', type=('build', 'run'), when='@6.0.3:')
-
     depends_on('py-jupyter-client',        type=('build', 'run'))
     depends_on('py-jupyter-client@5.2.0:', type=('build', 'run'), when='@5.7.0:5.999')
     depends_on('py-jupyter-client@5.3.1:', type=('build', 'run'), when='@6.0.0:6.0.1')
     depends_on('py-jupyter-client@5.3.4:', type=('build', 'run'), when='@6.0.2:')
-
-    depends_on('py-traitlets',        type=('build', 'run'))
-    depends_on('py-traitlets@4.2.1:', type=('build', 'run'), when='@5:')
+    depends_on('py-nbformat',         type=('build', 'run'))
+    depends_on('py-nbconvert',        type=('build', 'run'))
+    depends_on('py-ipykernel',        type=('build', 'run'))
+    depends_on('py-send2trash',        type=('build', 'run'), when='@6:')
+    depends_on('py-terminado@0.3.3:', type=('build', 'run'), when='@:5.7.0')
+    depends_on('py-terminado@0.8.1:', type=('build', 'run'), when='@5.7.0:')
+    depends_on('py-terminado@0.8.3:', type=('build', 'run'), when='@6.1:')
+    depends_on('py-prometheus-client', type=('build', 'run'), when='@5.7.0:')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.8.5 and Apple Clang 11.0.3.