### PR TITLE
py-traitlets: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -10,20 +10,23 @@ class PyTraitlets(PythonPackage):
     """Traitlets Python config system"""
 
     homepage = "https://pypi.python.org/pypi/traitlets"
-    url      = "https://github.com/ipython/traitlets/archive/4.3.1.tar.gz"
+    url      = "https://pypi.io/packages/source/t/traitlets/traitlets-5.0.4.tar.gz"
 
-    version('4.3.3', sha256='b686c1aadf6ee5a9ee4c22df23bc5cd5bb7b5cfa18afe092e0a139cc2f05fe2e')
-    version('4.3.2', sha256='370f938ad730d52272ef74f96f831cb21138f6168e46fe582fe256c35cc656ce')
-    version('4.3.1', sha256='3d50b2968f2e1477bd0de4b9656df40fd5624fc85cd1fc15f6c885cd68a4f6a1')
-    version('4.3.0', sha256='2f6cbc367fb56cbde91b2585202ef0a5bd41ae205a70aeecca1aeb4cb5b64e66')
-    version('4.2.2', sha256='bc749e08dd89c6007eb70e98c958f16d41e9a1fa42fdc9e9ba24e67469efa0ef')
-    version('4.2.1', sha256='a9ea45313f7130c555d8c1832529bf3f522ffc584093436783bc4b9611e8c4a9')
-    version('4.2.0', sha256='923cbe84bef30c27d2083f014f23a5da0ebe7da2e67a683d97acb07002e2ce0d')
-    version('4.1.0', sha256='93ead8dbf7e9617c88b79620072bfc499e7f25613f3df2234e5fdf08348c0a83')
-    version('4.0.0', sha256='03f380cb2e47689ae55dbe9a5dccbdde5cad8c4637312d720f4c3a991fb15cd2')
+    version('5.0.4', sha256='86c9351f94f95de9db8a04ad8e892da299a088a64fd283f9f6f18770ae5eae1b')
+    version('4.3.3', sha256='d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7')
+    version('4.3.2', sha256='9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835')
+    version('4.3.1', sha256='ba8c94323ccbe8fd792e45d8efe8c95d3e0744cc8c085295b607552ab573724c')
+    version('4.3.0', sha256='8a33cb7b1ef47f2d6dc16e9cf971217d5a4882a3541c070e78a0e8e8edcb3f82')
+    version('4.2.2', sha256='7d7e3070484b2fe490fa55e0acf7023afc5ed9ddabec57405f25c355158e152a')
+    version('4.2.1', sha256='76eba33c89723b8fc024f950cacaf5bf2ef37999642cc9a61f4e7c1ca5cf0ac0')
+    version('4.2.0', sha256='e4c39210f2f2ff7361b86043b6512adbcf6f024b44b501f7b42fd9a23402dea9')
+    version('4.1.0', sha256='440e38dfa5d2a26c086d4b427cfb7aed17d0a2dca78bce90c33354da2592af5b')
+    version('4.0.0', sha256='0b140b4a94a4f1951887d9bce4650da211f79600fc9fdb422acc90c5bbe0233b')
 
+    depends_on('python@3.7:', when='@5:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
-    depends_on('py-six', type=('build', 'run'))
-    depends_on('py-decorator', type=('build', 'run'))
     depends_on('py-ipython-genutils', type=('build', 'run'))
+    depends_on('py-six', when='@:4', type=('build', 'run'))
+    depends_on('py-decorator', when='@:4', type=('build', 'run'))
     depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-pytest', type='test')


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Python 3.8.5 and Apple Clang 11.0.3.