### PR TITLE
Smoke tests: Preliminary binutils install tests

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -129,3 +129,32 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             if self.spec.satisfies('@:2.34 %gcc@10:'):
                 flags.append('-fcommon')
         return (flags, None, None)
+
+    def _test_check_versions(self):
+        spec_vers = str(self.spec.version)
+
+        checks = {
+            'ar': spec_vers,
+            'c++filt': spec_vers,
+            'coffdump': spec_vers,
+            'dlltool': spec_vers,
+            'elfedit': spec_vers,
+            'gprof': spec_vers,
+            'ld': spec_vers,
+            'nm': spec_vers,
+            'objdump': spec_vers,
+            'ranlib': spec_vers,
+            'readelf': spec_vers,
+            'size': spec_vers,
+            'strings': spec_vers,
+        }
+
+        for exe in checks:
+            expected = checks[exe]
+            reason = 'test: ensuring version of {0} is {1}' \
+                .format(exe, expected)
+            self.run_test(exe, '--version', expected, installed=True,
+                          purpose=reason, skip_missing=True)
+
+    def test(self):
+        self._test_check_versions()


### PR DESCRIPTION
This PR provides preiminary `binutils` smoke/install tests in the form of version checks on a subset of the installed binaries.