### PR TITLE
cvs: add a patch for segv issue

### DIFF
--- a/var/spack/repos/builtin/packages/cvs/package.py
+++ b/var/spack/repos/builtin/packages/cvs/package.py
@@ -14,4 +14,9 @@ class Cvs(AutotoolsPackage, GNUMirrorPackage):
 
     version('1.12.13', sha256='78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e')
 
+    # To avoid the problem: The use of %n in format strings in writable memory
+    # may crash the program on glibc2 systems from 2004-10-18 or newer.
+    patch('https://gentoofan.org/gentoo/poly-c_overlay/dev-vcs/cvs/files/cvs-1.12.13.1-fix-gnulib-SEGV-vasnprintf.patch',
+          sha256='e13db2acebad3ca5be5d8e0fa97f149b0f9661e4a9a731965c8226290c6413c0', when='@1.12.13')
+
     parallel = False


### PR DESCRIPTION
There is a bug when using `cvs checkout` on `Ubuntu 19.10`
![cvs_checkout_error](https://user-images.githubusercontent.com/29532367/92989089-f4dc3280-f503-11ea-9a2d-7961f966958e.png)
