### PR TITLE
trigger ascent e4s pipeline on merge to spack develop

### DIFF
--- a/share/spack/gitlab/ascent_pipeline.yml
+++ b/share/spack/gitlab/ascent_pipeline.yml
@@ -1,0 +1,6 @@
+merge_pipeline:
+  only:
+  - develop
+  trigger:
+    project: ecpcitest/ascent-e4s
+    strategy: depend

--- a/share/spack/gitlab/ascent_pipeline.yml
+++ b/share/spack/gitlab/ascent_pipeline.yml
@@ -2,5 +2,5 @@ merge_pipeline:
   only:
   - develop
   trigger:
-    project: ecpcitest/ascent-e4s
+    project: ecpcitest/e4s
     strategy: depend


### PR DESCRIPTION
@eugeneswalker @mpbelhorn @tgamblin 
This pipeline will be used in spack mirror at ORNL https://code.ornl.gov/ecpcitest/spack to trigger ascent e4s pipeline https://code.ornl.gov/ecpcitest/e4s

Once this is merged, i will configure the spack mirror and then we can wait for subsequent merge to see if we get spack pipeline triggered at Ascent. 