### PR TITLE
use github for download

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -10,7 +10,7 @@ class Glew(Package):
     """The OpenGL Extension Wrangler Library."""
 
     homepage = "http://glew.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0.tgz/download"
+    url      = "https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz"
 
     version('2.1.0',  sha256='04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95')
     version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')


### PR DESCRIPTION
This downloads the packages from github which has more bandwidth than sourceforge.