### PR TITLE
Fix a typo in test/concretize.py

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -70,7 +70,7 @@ def check_concretize(abstract_spec):
         # with virtual
         'mpileaks ^mpi', 'mpileaks ^mpi@:1.1', 'mpileaks ^mpi@2:',
         'mpileaks ^mpi@2.1', 'mpileaks ^mpi@2.2', 'mpileaks ^mpi@2.2',
-        'mpileaks ^mpi@:1', 'mpileaks ^mpi@1.2:2'
+        'mpileaks ^mpi@:1', 'mpileaks ^mpi@1.2:2',
         # conflict not triggered
         'conflict',
         'conflict%clang~foo',


### PR DESCRIPTION
There is a missing comma in a fixture, so we are testing a wrong spec instead of the two that were meant to be tested.