### PR TITLE
Qbox minor issues 18664

### DIFF
--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -67,6 +67,7 @@ class Qbox(MakefilePackage):
     def install(self, spec, prefix):
         mkdir(prefix.src)
         install('src/qb', prefix.src)
-        install_tree('test', prefix)
-        install_tree('xml', prefix)
-        install_tree('util', prefix)
+        install_tree('test', prefix.test)
+        install_tree('xml', prefix.xml)
+        install_tree('util', prefix.util)
+

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -46,7 +46,7 @@ class Qbox(MakefilePackage):
     depends_on('python@:2.999', type='run')
     depends_on('gnuplot', type='run')
 
-    #Change /usr/bin/python shebangs to /usr/bin/env python
+    # Change /usr/bin/python shebangs to /usr/bin/env python
     patch('qbox-python-shebang-path.patch')
 
     build_directory = 'src'

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -69,6 +69,9 @@ class Qbox(MakefilePackage):
             ))))
         filter_file('$(TARGET)', 'spack', 'src/Makefile', string=True)
 
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.util)
+
     def install(self, spec, prefix):
         mkdir(prefix.bin)
         install('src/qb', prefix.bin)

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -43,6 +43,8 @@ class Qbox(MakefilePackage):
     depends_on('scalapack')
     depends_on('fftw')
     depends_on('xerces-c')
+    depends_on('python@:2.999', type='run')
+    depends_on('gnuplot', type='run')
 
     #Change /usr/bin/python shebangs to /usr/bin/env python
     patch('qbox-python-shebang-path.patch')

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -65,8 +65,8 @@ class Qbox(MakefilePackage):
         filter_file('$(TARGET)', 'spack', 'src/Makefile', string=True)
 
     def install(self, spec, prefix):
-        mkdir(prefix.src)
-        install('src/qb', prefix.src)
+        mkdir(prefix.bin)
+        install('src/qb', prefix.bin)
         install_tree('test', prefix.test)
         install_tree('xml', prefix.xml)
         install_tree('util', prefix.util)

--- a/var/spack/repos/builtin/packages/qbox/package.py
+++ b/var/spack/repos/builtin/packages/qbox/package.py
@@ -44,6 +44,9 @@ class Qbox(MakefilePackage):
     depends_on('fftw')
     depends_on('xerces-c')
 
+    #Change /usr/bin/python shebangs to /usr/bin/env python
+    patch('qbox-python-shebang-path.patch')
+
     build_directory = 'src'
 
     def edit(self, spec, prefix):
@@ -70,4 +73,3 @@ class Qbox(MakefilePackage):
         install_tree('test', prefix.test)
         install_tree('xml', prefix.xml)
         install_tree('util', prefix.util)
-

--- a/var/spack/repos/builtin/packages/qbox/qbox-python-shebang-path.patch
+++ b/var/spack/repos/builtin/packages/qbox/qbox-python-shebang-path.patch
@@ -1,0 +1,108 @@
+diff -Nuar spack-src/util/qbox_angle.py spack-src.patched/util/qbox_angle.py
+--- spack-src/util/qbox_angle.py	2016-07-05 00:43:50.000000000 -0400
++++ spack-src.patched/util/qbox_angle.py	2020-09-11 17:48:34.381997541 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_angle.py
+ # extract angle defined by three atoms from Qbox output
+ # use: qbox_angle.py name1 name2 name3 file.r
+diff -Nuar spack-src/util/qbox_distance.py spack-src.patched/util/qbox_distance.py
+--- spack-src/util/qbox_distance.py	2016-07-05 00:43:50.000000000 -0400
++++ spack-src.patched/util/qbox_distance.py	2020-09-11 17:48:40.733188691 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_distance.py
+ # extract distance between two atoms from Qbox output
+ # use: qbox_distance.py name1 name2 file.r
+diff -Nuar spack-src/util/qbox_dos.py spack-src.patched/util/qbox_dos.py
+--- spack-src/util/qbox_dos.py	2014-01-10 15:39:02.000000000 -0500
++++ spack-src.patched/util/qbox_dos.py	2020-09-11 17:48:46.141351461 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_dos.py: extract electronic DOS from Qbox output
+ # generate DOS plot in gnuplot format
+ # use: qbox_dos.py [-last] emin emax width file.r
+diff -Nuar spack-src/util/qbox_eig.py spack-src.patched/util/qbox_eig.py
+--- spack-src/util/qbox_eig.py	2016-09-06 19:47:51.000000000 -0400
++++ spack-src.patched/util/qbox_eig.py	2020-09-11 17:49:00.811792982 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_eig.py: extract eigenvalues from Qbox output
+ # use: qbox_eig.py kpoint n ispin file.r
+ # extracts eigenvalue n at (ispin,kpoint)
+diff -Nuar spack-src/util/qbox_maxforce.py spack-src.patched/util/qbox_maxforce.py
+--- spack-src/util/qbox_maxforce.py	2016-09-06 19:47:51.000000000 -0400
++++ spack-src.patched/util/qbox_maxforce.py	2020-09-11 17:49:05.763942033 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # Copyright 2016 The Regents of the University of California
+ # This file is part of Qbox
+ #
+diff -Nuar spack-src/util/qbox_msd.py spack-src.patched/util/qbox_msd.py
+--- spack-src/util/qbox_msd.py	2014-04-24 16:30:49.000000000 -0400
++++ spack-src.patched/util/qbox_msd.py	2020-09-11 17:49:11.751122219 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_msd.py: compute mean-square displacement in an MD simulation
+ # generate plot of <r^2>(t) in gnuplot format
+ # use: qbox_msd.py species file.r [file.r ...]
+diff -Nuar spack-src/util/qbox_repair_h2o.py spack-src.patched/util/qbox_repair_h2o.py
+--- spack-src/util/qbox_repair_h2o.py	2013-12-05 15:28:06.000000000 -0500
++++ spack-src.patched/util/qbox_repair_h2o.py	2020-09-11 17:49:16.467264160 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_repair_h2o.py: repair broken h2o molecules in a Qbox sys file
+ # move hydrogen atoms across periodic boundaries to repair molecules
+ # use: qbox_repair_h2o.py file.sys
+diff -Nuar spack-src/util/qbox_torsion.py spack-src.patched/util/qbox_torsion.py
+--- spack-src/util/qbox_torsion.py	2017-03-10 14:46:12.000000000 -0500
++++ spack-src.patched/util/qbox_torsion.py	2020-09-11 17:49:21.469414705 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # qbox_torsion.py
+ # extract torsion angle defined by four atoms from Qbox output
+ # use: qbox_torsion.py name1 name2 name3 name4 file.r
+diff -Nuar spack-src/util/qbox_xyz.py spack-src.patched/util/qbox_xyz.py
+--- spack-src/util/qbox_xyz.py	2016-05-31 13:23:45.000000000 -0400
++++ spack-src.patched/util/qbox_xyz.py	2020-09-11 17:49:26.550567625 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # Copyright 2016 The Regents of the University of California
+ # This file is part of Qbox
+ #
+diff -Nuar spack-src/util/qso2qbox.py spack-src.patched/util/qso2qbox.py
+--- spack-src/util/qso2qbox.py	2016-05-31 13:23:45.000000000 -0400
++++ spack-src.patched/util/qso2qbox.py	2020-09-11 17:49:31.049703037 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # Convert <atomset> elements from quantum-simulation.org (QSO) format 
+ # to Qbox input file
+ # use: qso2qbox.py [-last] {file|URL}
+diff -Nuar spack-src/util/qso2qe.py spack-src.patched/util/qso2qe.py
+--- spack-src/util/qso2qe.py	2016-05-31 13:23:45.000000000 -0400
++++ spack-src.patched/util/qso2qe.py	2020-09-11 17:49:36.099855027 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ # Convert from quantum-simulation.org format to QuantumEspresso input format
+ # use: env ECUT=ecut qso2qe.py [-last] {file|URL}
+ 
+diff -Nuar spack-src/util/qso.py spack-src.patched/util/qso.py
+--- spack-src/util/qso.py	2016-05-31 13:23:45.000000000 -0400
++++ spack-src.patched/util/qso.py	2020-09-11 17:49:42.412045000 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ import xml.sax
+ # quantum-simulation.org (QSO) definitions
+ class Atom:


### PR DESCRIPTION
Fixes #18664

I have applied as several commits, as I am not 100% sure of the proper fix

1) install to proper subdirs (this should match qbox online docs, and fix issues with broken
symlinks in install prefix)
2) place the qb exectutable into bin subdir. This seems to also fix issue with PATH not being set.
3) Add a patch to change shebangs for python scripts to use python from user's PATH.
4) Add run dependencies on python2 and gnuplot (for utilities)

In particular, I am unsure about (4) --- I am not a qbox user, but from the online docs, etc. it seems like the main user interaction is with the qb command, and I believe pyhon2 and gnuplot are _only_ required for the utility scripts.  Is that a sufficient requirement for a spack runtime dependency --- I would use "recommends" or "suggests" dependencies if available, but  spack does not have such (at least to my knowledge).  

Also, I do not know how to have spack add the utils subdir to the PATH environmental module in modulefiles, so that is currently missing
