### PR TITLE
py-charm4py: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -34,8 +34,12 @@ class PyCharm4py(PythonPackage):
             ' communication layer')
 
     # Builds its own charm++, so no charmpp dependency
-    depends_on('py-greenlet')
-    depends_on('py-cython')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-cython', type='build')
+    depends_on('py-cffi@1.7:', type='build')
+    depends_on('py-numpy@1.10.0:', type=('build', 'run'))
+    depends_on('py-greenlet', type=('build', 'run'))
     depends_on('cuda')
     depends_on('mpi', when='+mpi')
 

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -61,13 +61,9 @@ class PyCharm4py(PythonPackage):
     # This sets the SPACK_CHARM4PY_EXTRALIBS env var which the
     # py-charm4py.makefile.patch adds to the build/link command for
     # libcharm.so.
-    def setup_environment(self, spack_env, run_env):
-        if '^cuda' in self.spec:
-            cudalib = self.spec['cuda'].prefix.lib
-            if not os.path.isdir(cudalib):
-                cudalib = self.spec['cuda'].prefix.lib64
-            spack_env.set('SPACK_CHARM4PY_EXTRALIBS',
-                          '-L{} -lcudart'.format(cudalib))
+    def setup_build_environment(self, env):
+        env.set('SPACK_CHARM4PY_EXTRALIBS',
+                self.spec['cuda'].libs.ld_flags)
 
     def install_args(self, spec, prefix):
         # Have the parent class version set prefix

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-import os.path
 
 
 class PyCharm4py(PythonPackage):

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -1,0 +1,73 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+import os.path
+
+
+class PyCharm4py(PythonPackage):
+    """Charm4py (Charm++ for Python) is a distributed computing and parallel
+    programming framework for Python, for the productive development of fast,
+    parallel and scalable applications. It is built on top of Charm++, a C++
+    adaptive runtime system that has seen extensive use in the scientific and
+    high-performance computing (HPC) communities across many disciplines, and
+    has been used to develop applications that run on a wide range of devices:
+    from small multi-core devices up to the largest supercomputers."""
+
+    homepage = "https://charmpy.readthedocs.io"
+    url = "https://pypi.io/packages/source/c/charm4py/charm4py-1.0.tar.gz"
+
+    # Add a list of GitHub accounts to
+    # notify when the package is updated.
+    maintainers = ['payerle']
+
+    # Get errors passing --mpi to build* phases of setup.py
+    phases = ['install']
+
+    version('1.0', sha256='8ddb9f021b7379fde94b28c31f4ab6a60ced2c2a207a2d75ce57cb91b6be92bc')
+
+    variant('mpi', default=True,
+            description='build Charm++ library with the MPI instead of TCP'
+            ' communication layer')
+
+    # Builds its own charm++, so no charmpp dependency
+    depends_on('py-greenlet')
+    depends_on('py-cython')
+    depends_on('cuda')
+    depends_on('mpi', when='+mpi')
+
+    # setup.py builds its own charm++, but libcharm.so
+    # ends up with a cuda dependency causing unresolved symbol errors
+    # when setup.py tries to load it to get version.  We need to explicitly
+    # link libcudart when building the charm++ library.
+    # To do this, the following patch:
+    # 1) hacks setup.py to apply a patch to the charm++ Makefile
+    # causing the Makefile to include libcudart when building libcharm.so
+    # 2) inserts the patchfile needed to do so.
+    # This is convoluted, but best way I see since setup.py untars the
+    # charm++ sources and we need to patch a file that is in the tarball.
+    #
+    # The patch to the Makefile adds SPACK_CHARM4PY_EXTRALIBS to the link
+    # arguments.  This needs to be set in the environment to be effective.
+    patch('py-charm4py.makefile.patch', when='@1.0')
+
+    # This sets the SPACK_CHARM4PY_EXTRALIBS env var which the
+    # py-charm4py.makefile.patch adds to the build/link command for
+    # libcharm.so.
+    def setup_environment(self, spack_env, run_env):
+        if '^cuda' in self.spec:
+            cudalib = self.spec['cuda'].prefix.lib
+            if not os.path.isdir(cudalib):
+                cudalib = self.spec['cuda'].prefix.lib64
+            spack_env.set('SPACK_CHARM4PY_EXTRALIBS',
+                          '-L{} -lcudart'.format(cudalib))
+
+    def install_args(self, spec, prefix):
+        # Have the parent class version set prefix
+        args = super().install_args(spec, prefix)
+        if '+mpi' in spec:
+            args.append('--mpi')
+        return args

--- a/var/spack/repos/builtin/packages/py-charm4py/py-charm4py.makefile.patch
+++ b/var/spack/repos/builtin/packages/py-charm4py/py-charm4py.makefile.patch
@@ -1,0 +1,35 @@
+#This patchfile 
+#	1) patches setup.py to patch the Makefile for charm++ (which it untars) using
+#		spack-charm4py-setup.py.patch
+#	2) creates the spack-charm4py-setup.py.patch file
+diff -Naur spack-src/setup.py spack-src.patched/setup.py
+--- spack-src/setup.py	2019-09-08 20:33:25.000000000 -0400
++++ spack-src.patched/setup.py	2020-09-10 18:09:10.714772095 -0400
+@@ -112,6 +112,11 @@
+             rc = p.wait()
+             if rc != 0:
+                 raise DistutilsSetupError('An error occured while building charm library')
++            cmd = [ 'patch', 'charm/src/scripts/Makefile' , 'spack-charm4py-setup.py.patch' ]
++            p = subprocess.Popen(cmd, cwd=charm_src_dir, shell=False)
++            rc = p.wait()
++            if rc != 0:
++                raise DistutilsSetupError('An error occured while patching charm++ Makefile')
+ 
+         # divide by 2 to not hog the system. On systems with hyperthreading, this will likely
+         # result in using same # cores as physical cores (therefore not all the logical cores)
+diff -Naur spack-src/charm_src/spack-charm4py-setup.py.patch spack-src.patched/charm_src/spack-charm4py-setup.py.patch
+--- spack-src/charm_src/spack-charm4py-setup.py.patch	1969-12-31 19:00:00.000000000 -0500
++++ spack-src.patched/charm_src/spack-charm4py-setup.py.patch	2020-09-10 18:04:58.935191477 -0400
+@@ -0,0 +1,12 @@
++diff -Naur charm_src.orig/charm/src/scripts/Makefile charm_src/charm/src/scripts/Makefile
++--- charm_src.orig/charm/src/scripts/Makefile	2020-09-10 17:52:36.402834986 -0400
+++++ charm_src/charm/src/scripts/Makefile	2020-09-10 17:49:49.514810102 -0400
++@@ -87,7 +87,7 @@
++ f90charm: charm++ $(L)/libf90charm.a
++ 
++ libcharm: charm++
++-	cd $(L) ; $(CHARMC) -standalone -whole-archive -c++stl -shared -o libcharm.so $(LIBCHARM_LIBS)
+++	cd $(L) ; $(CHARMC) -standalone -whole-archive -c++stl -shared -o libcharm.so $(LIBCHARM_LIBS) $(SPACK_CHARM4PY_EXTRALIBS)
++ 
++ charmpy: libcharm
++ 


### PR DESCRIPTION
Charm++ for python

Installation notes:

1) charm4py ships with its own charm++ tarball.  It really wants
to use the version it ships with. It also builds charm++ in a special way to
produce libcharm.so (but not charmc, etc), so it does not seem
worthwhile to try to hack to build using a spack installed charmpp.

2) Originally, the installation was failing due to unresolved cuda
symbols when setup.py was doing a ctypes.CDLL of libcharm.so (in order
to verify version?).  This appears to be due to the fact that
libcharm.so had undefined cuda symbols, but did not show libcudart.so as
a dependency (in e.g. ldd output).  To fix this, I had to add
libcudart.so explicitly when linking libcharm.so, but since setup.py
untars a tarball to build libcharm, the solution was a tad convoluted:
2a) Add a patch in spack to py-charm4py which creates a patchfile
"spack-charm4py-setup.py.patch" which will modify a Makefile file (after it
is untarred) to add the flags in env var SPACK_CHARM4PY_EXTRALIBS to
the link command for libcharm.so
2b) The spack patch file also patches setup.py to run patch using the
aforementioned patchfile to patch the Makefile after it is untarred, and
sets the SPACK_CHARM4PY_EXTRALIBS variable appropriately in the setup
environment.