### PR TITLE
Buildcache: Need to check the binary is not a Mach-o binary in a linux package or an ELF binary in a macOS package.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -180,7 +180,11 @@ def write_buildinfo_file(spec, workdir, rel=False):
                         tty.warn(msg)
 
             if relocate.needs_binary_relocation(m_type, m_subtype):
-                if not filename.endswith('.o'):
+                if ((m_subtype in ('x-executable', 'x-sharedlib')
+                    and platform.sys != 'Darwin') or
+                   (m_subtype in ('x-mach-binary')
+                    and platform.sys == 'Darwin') or
+                   (not filename.endswith('.o'))):
                     rel_path_name = os.path.relpath(path_name, prefix)
                     binary_to_relocate.append(rel_path_name)
             if relocate.needs_text_relocation(m_type, m_subtype):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -6,6 +6,7 @@
 import codecs
 import os
 import re
+import sys
 import tarfile
 import shutil
 import tempfile
@@ -181,9 +182,9 @@ def write_buildinfo_file(spec, workdir, rel=False):
 
             if relocate.needs_binary_relocation(m_type, m_subtype):
                 if ((m_subtype in ('x-executable', 'x-sharedlib')
-                    and platform.sys != 'Darwin') or
+                    and sys.platform != 'Darwin') or
                    (m_subtype in ('x-mach-binary')
-                    and platform.sys == 'Darwin') or
+                    and sys.platform == 'Darwin') or
                    (not filename.endswith('.o'))):
                     rel_path_name = os.path.relpath(path_name, prefix)
                     binary_to_relocate.append(rel_path_name)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -182,9 +182,9 @@ def write_buildinfo_file(spec, workdir, rel=False):
 
             if relocate.needs_binary_relocation(m_type, m_subtype):
                 if ((m_subtype in ('x-executable', 'x-sharedlib')
-                    and sys.platform != 'Darwin') or
+                    and sys.platform != 'darwin') or
                    (m_subtype in ('x-mach-binary')
-                    and sys.platform == 'Darwin') or
+                    and sys.platform == 'darwin') or
                    (not filename.endswith('.o'))):
                     rel_path_name = os.path.relpath(path_name, prefix)
                     binary_to_relocate.append(rel_path_name)


### PR DESCRIPTION
Reported on Spack slack that installing cmake from buildcache produces this warning on a macho binary share/cmake-3.16/Modules/Internal/CPack/CPack.OSXScriptLauncher.in that is included with cmake.
```
'/global/cscratch1/sd/kavaluav/spack-AgSMOlED/spack_/cray-cnl7-haswell/intel-19.1.2.254/patchelf-0.10-3m6lh5l2ezt6nis5iqethdwf3mmzzmic/bin/patchelf' '--print-rpath' '/global/cscratch1/sd/kavaluav/spack_/cray-cnl7-haswell/intel-19.1.2.254/cmake-3.16.5-zmyp2sa4rgaccfjjs5o6atzakxvzxsrk/share/cmake-3.16/Modules/Internal/CPack/CPack.OSXScriptLauncher.in'
patchelf: not an ELF executable: Cannot allocate memory
```
