### PR TITLE
Likwid versions >= 5.0.0 depend on Lua 5.2.

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -38,8 +38,8 @@ class Likwid(Package):
     # The reason is that the internal hwloc is patched to contain extra
     # functionality and functions are prefixed with "likwid_".
 
-    depends_on('lua', when='@4.2.0:4.9.9')
-    depends_on('lua@5.2.0', when='@5.0.0:')
+    depends_on('lua', when='@:4')
+    depends_on('lua@5.2:', when='@5:')
 
     # TODO: check
     # depends_on('gnuplot', type='run')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -38,7 +38,8 @@ class Likwid(Package):
     # The reason is that the internal hwloc is patched to contain extra
     # functionality and functions are prefixed with "likwid_".
 
-    depends_on('lua', when='@4.2.0:')
+    depends_on('lua', when='@4.2.0:4.9.9')
+    depends_on('lua@5.2.0', when='@5.0.0:')
 
     # TODO: check
     # depends_on('gnuplot', type='run')


### PR DESCRIPTION
According to https://github.com/RRZE-HPC/likwid/issues/324 recent versions of Likwid require Lua 5.2.