### PR TITLE
NetCDF: Fix non-mpi hdf5 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -104,7 +104,7 @@ class NetcdfC(AutotoolsPackage):
     # HDF5 without mpi support to disable parallel I/O:
     depends_on('hdf5~mpi', when='@:4.3~mpi')
 
-    # We need HDF5 with mpi support to enable parallel I/O. 
+    # We need HDF5 with mpi support to enable parallel I/O.
     # And HDF5 without mpi on a non-parallel build
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -104,7 +104,8 @@ class NetcdfC(AutotoolsPackage):
     # HDF5 without mpi support to disable parallel I/O:
     depends_on('hdf5~mpi', when='@:4.3~mpi')
 
-    # We need HDF5 with mpi support to enable parallel I/O. And HDF5 without mpi on a non-parallel build
+    # We need HDF5 with mpi support to enable parallel I/O. 
+    # And HDF5 without mpi on a non-parallel build
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')
 

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -104,8 +104,9 @@ class NetcdfC(AutotoolsPackage):
     # HDF5 without mpi support to disable parallel I/O:
     depends_on('hdf5~mpi', when='@:4.3~mpi')
 
-    # We need HDF5 with mpi support to enable parallel I/O.
+    # We need HDF5 with mpi support to enable parallel I/O. And HDF5 without mpi on a non-parallel build
     depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5~mpi', when='~mpi')
 
     # NetCDF 4.4.0 and prior have compatibility issues with HDF5 1.10 and later
     # https://github.com/Unidata/netcdf-c/issues/250


### PR DESCRIPTION
If building `netcdf-c~mpi`, the downstream HDF5 dependency was taking the default value for `mpi` and building a parallel HDF5 which is not correct.  Need to explicitly override the default `mpi` variant in HDF5 for an `netcdf-c~mpi` build.   This was broken in #9fdb94