### PR TITLE
macOS CI: Install OpenGL

### DIFF
--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -48,7 +48,7 @@ jobs:
         . .github/workflows/install_spack.sh
         brew install glfw
         spack external find opengl
-        spack install -v --fail-fast py-jupyter %apple-clang
+        spack install --fail-fast py-jupyter %apple-clang
 
   install_scipy_clang:
     name: scipy, mpl, pd

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -46,7 +46,8 @@ jobs:
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
-        spack config add packages:opengl:paths:opengl@4.1:/usr/X11R6
+        brew install glfw
+        spack external find opengl
         spack install -v --fail-fast py-jupyter %apple-clang
 
   install_scipy_clang:


### PR DESCRIPTION
Try to install OpenGL on macOS CI with brew.

Looks like the GitHub runner image removed OpenGL recently...?

Fixes #18370 