### PR TITLE
Added spackage for cosmoflow-benchmark proxy app

### DIFF
--- a/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
+++ b/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class CosmoflowBenchmark(Package):
+class CosmoflowBenchmark(Package, CudaPackage):
     """This is a an implementation of the CosmoFlow 3D convolutional neural
     network for benchmarking. It is written in TensorFlow with the Keras API
     and uses Horovod for distributed training."""
@@ -20,13 +20,19 @@ class CosmoflowBenchmark(Package):
     version('master', branch='master')
 
     depends_on('python@3:', type=('build', 'run'))
-    depends_on('py-tensorflow')
+
     depends_on('py-h5py')
     depends_on('py-numpy')
     depends_on('py-pandas')
     depends_on('py-pyyaml')
     depends_on('py-horovod')
     depends_on('py-mpi4py')
+
+    depends_on('py-tensorflow+cuda', when='+cuda')
+    depends_on('py-tensorflow~cuda~nccl', when='~cuda')
+    depends_on('py-torch+cuda', when='+cuda')
+    depends_on('py-torch~cuda~cudnn~nccl', when='~cuda')
+    depends_on('py-horovod tensor_ops=mpi', when='~cuda')
 
     def install(self, spec, prefix):
         # Mostly  about providing an environment so just copy everything

--- a/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
+++ b/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class CosmoflowBenchmark(Package):
+    """This is a an implementation of the CosmoFlow 3D convolutional neural
+    network for benchmarking. It is written in TensorFlow with the Keras API
+    and uses Horovod for distributed training."""
+
+    homepage = "https://github.com/sparticlesteve/cosmoflow-benchmark"
+    url      = "hhttps://github.com/sparticlesteve/cosmoflow-benchmark/archive/master.zip"
+    git      = "https://github.com/sparticlesteve/cosmoflow-benchmark.git"
+
+    tags = ['proxy-app']
+
+    version('master', branch='master')
+
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-tensorflow')
+    depends_on('py-h5py')
+    depends_on('py-numpy')
+    depends_on('py-pandas')
+    depends_on('py-pyyaml')
+    depends_on('py-horovod')
+    depends_on('py-mpi4py')
+
+    def install(self, spec, prefix):
+        # Mostly  about providing an environment so just copy everything
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
+++ b/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
@@ -12,7 +12,6 @@ class CosmoflowBenchmark(Package, CudaPackage):
     and uses Horovod for distributed training."""
 
     homepage = "https://github.com/sparticlesteve/cosmoflow-benchmark"
-    url      = "hhttps://github.com/sparticlesteve/cosmoflow-benchmark/archive/master.zip"
     git      = "https://github.com/sparticlesteve/cosmoflow-benchmark.git"
 
     tags = ['proxy-app']
@@ -21,18 +20,18 @@ class CosmoflowBenchmark(Package, CudaPackage):
 
     depends_on('python@3:', type=('build', 'run'))
 
-    depends_on('py-h5py')
-    depends_on('py-numpy')
-    depends_on('py-pandas')
-    depends_on('py-pyyaml')
-    depends_on('py-horovod')
-    depends_on('py-mpi4py')
+    depends_on('py-h5py', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-pandas', type=('build', 'run'))
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-horovod', type=('build', 'run'))
+    depends_on('py-mpi4py', type=('build', 'run'))
 
-    depends_on('py-tensorflow+cuda', when='+cuda')
-    depends_on('py-tensorflow~cuda~nccl', when='~cuda')
-    depends_on('py-torch+cuda', when='+cuda')
-    depends_on('py-torch~cuda~cudnn~nccl', when='~cuda')
-    depends_on('py-horovod tensor_ops=mpi', when='~cuda')
+    depends_on('py-tensorflow+cuda', when='+cuda', type=('build', 'run'))
+    depends_on('py-tensorflow~cuda~nccl', when='~cuda', type=('build', 'run'))
+    depends_on('py-torch+cuda', when='+cuda', type=('build', 'run'))
+    depends_on('py-torch~cuda~cudnn~nccl', when='~cuda', type=('build', 'run'))
+    depends_on('py-horovod tensor_ops=mpi', when='~cuda', type=('build', 'run'))
 
     def install(self, spec, prefix):
         # Mostly  about providing an environment so just copy everything


### PR DESCRIPTION
Added spackage for cosmoflow-benchmark proxy app.

Needed to provide additional constraints for ```~cuda``` variant due to downstream spackages. Eventually that should be relaxed in a future PR