### PR TITLE
fraggenescan: Modify build_targets for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/fraggenescan/package.py
+++ b/var/spack/repos/builtin/packages/fraggenescan/package.py
@@ -16,7 +16,7 @@ class Fraggenescan(MakefilePackage):
 
     version('1.31', sha256='cd3212d0f148218eb3b17d24fcd1fc897fb9fee9b2c902682edde29f895f426c')
 
-    build_targets = ['fgs']
+    build_targets = ['clean', 'hmm.obj']
 
     def edit(self, spec, prefix):
         filter_file('gcc', spack_cc, 'Makefile', string=True)


### PR DESCRIPTION
I failed to build on aarch64. 
Because FragGeneScan1.31.tar.gz includes an object file created with x86_64.
I was able to build on aarch64 by changing build_targets.