### PR TITLE
libvdwxc: unbreak concretization, request fftw-api

### DIFF
--- a/var/spack/repos/builtin/packages/libvdwxc/package.py
+++ b/var/spack/repos/builtin/packages/libvdwxc/package.py
@@ -19,13 +19,13 @@ class Libvdwxc(AutotoolsPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("pfft", default=False, description="Enable support for PFFT")
 
-    depends_on("fftw@3:", when="~mpi")
+    depends_on("fftw-api@3")
     depends_on("mpi@2:", when="+mpi")
-    depends_on("fftw@3:+mpi", when="+mpi")
     depends_on("pfft", when="+pfft")
 
     # pfft needs MPI
     conflicts("~mpi", "+pfft")
+    conflicts("^fftw~mpi", "+mpi")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
mixing both fftw and fftw-api in a dependency tree can trigger the
following:

```
$ spack spec cp2k@master +sirius
==> [2020-09-16-12:36:06.552981] sirius applying constraint gsl
==> [2020-09-16-12:36:06.554270] sirius applying constraint openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-opensuse_leap15-sandybridge
Traceback (most recent call last):
  File "./bin/spack", line 64, in <module>
    sys.exit(spack.main.main())
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/main.py", line 762, in main
    return _invoke_command(command, parser, args, unknown)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/main.py", line 490, in _invoke_command
    return_val = command(parser, args)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/cmd/spec.py", line 103, in spec
    spec.concretize()
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2228, in concretize
    user_spec_deps=user_spec_deps),
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2716, in normalize
    visited, all_spec_deps, provider_index, tests)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2654, in _normalize_helper
    dep, visited, spec_deps, provider_index, tests)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2613, in _merge_dependency
    visited, spec_deps, provider_index, tests)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2654, in _normalize_helper
    dep, visited, spec_deps, provider_index, tests)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2554, in _merge_dependency
    provider = self._find_provider(dep, provider_index)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/spec.py", line 2489, in _find_provider
    providers = provider_index.providers_for(vdep)
  File "/data/tiziano/debug-spack/spack2/lib/spack/spack/provider_index.py", line 80, in providers_for
    return sorted(s.copy() for s in result)
  File "/data/tiziano/debug-spack/spack2/lib/spack/llnl/util/lang.py", line 249, in <lambda>
    lambda s, o: o is not None and s._cmp_key() < o._cmp_key())
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

while at the same point disallowing MKL as a fftw provider.
Solving this by depending on `fftw-api@3` instead and a runtime check on
`^fftw+mpi` if `fftw` is used as provider for the `fftw-api`.