### PR TITLE
[dd4hep]: add variant lcio

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -40,6 +40,7 @@ class Dd4hep(CMakePackage):
     variant('geant4', default=False, description="Enable the simulation part based on Geant4")
     variant('assimp', default=False, description="Enable CAD interface based on Assimp")
     variant('hepmc3', default=False, description="Enable build with hepmc3")
+    variant('lcio', default=False, description="Enable build with lcio")
 
     depends_on('cmake @3.12:', type='build')
     depends_on('boost @1.49:')
@@ -49,6 +50,7 @@ class Dd4hep(CMakePackage):
     depends_on('geant4@10.2.2:', when='+geant4')
     depends_on('assimp', when='+assimp')
     depends_on('hepmc3', when="+hepmc3")
+    depends_on('lcio', when="+lcio")
 
     def cmake_args(self):
         spec = self.spec
@@ -60,6 +62,7 @@ class Dd4hep(CMakePackage):
             "-DCMAKE_CXX_STANDARD={0}".format(cxxstd),
             "-DDD4HEP_USE_XERCESC={0}".format(spec.satisfies('+xercesc')),
             "-DDD4HEP_USE_GEANT4={0}".format(spec.satisfies('+geant4')),
+            "-DDD4HEP_USE_LCIO={0}".format(spec.satisfies('+lcio')),
             "-DDD4HEP_LOAD_ASSIMP={0}".format(spec.satisfies('+assimp')),
             "-DDD4HEP_USE_HEPMC3={0}".format(spec.satisfies('+hepmc3')),
             "-DBUILD_TESTING={0}".format(self.run_tests),


### PR DESCRIPTION
This adds a variant for dd4hep to build the LCIO input and output modules for the simulation parts.