### PR TITLE
util-linux: fix bash completion install errors.

### DIFF
--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -25,7 +25,7 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('lvm2', type=('build', 'link'))
     depends_on('popt', type=('build', 'link'))
     depends_on('json-c', type=('build', 'link'))
-    depends_on('util-linux', type=('build', 'link'))
+    depends_on('util-linux~libuuid', type=('build', 'link'))
     depends_on('gettext', type=('build', 'link'))
 
     depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/cryptsetup/package.py
+++ b/var/spack/repos/builtin/packages/cryptsetup/package.py
@@ -25,7 +25,7 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('lvm2', type=('build', 'link'))
     depends_on('popt', type=('build', 'link'))
     depends_on('json-c', type=('build', 'link'))
-    depends_on('util-linux~libuuid', type=('build', 'link'))
+    depends_on('util-linux', type=('build', 'link'))
     depends_on('gettext', type=('build', 'link'))
 
     depends_on('pkgconfig', type='build')
@@ -35,6 +35,7 @@ class Cryptsetup(AutotoolsPackage):
     depends_on('m4',       type='build')
 
     depends_on('automake@:1.16.1', when='@2.2.1', type='build')
+    depends_on('openssl')
 
     # Upstream includes support for discovering the location of the libintl
     # library but is missing the bit in the Makefile.ac that includes it in
@@ -49,7 +50,8 @@ class Cryptsetup(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            'systemd_tmpfilesdir={0}/tmpfiles.d'.format(self.prefix)
+            'systemd_tmpfilesdir={0}/tmpfiles.d'.format(self.prefix),
+            '--with-crypto_backend=openssl',
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -43,8 +43,9 @@ class UtilLinux(AutotoolsPackage):
             '--without-systemd',
         ]
         if "+bash" in self.spec:
-            config_args.extend(['--enable-bash-completion',
-                                '--bash-completion-dir=',+self.spec['bash'].prefix])
+            config_args.extend(
+                ['--enable-bash-completion',
+                 '--bash-completion-dir=' + self.spec['bash'].prefix])
         else:
             config_args.append('--disable-bash-completion')
         config_args.extend(self.enable_or_disable('libuuid'))

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -48,8 +48,8 @@ class UtilLinux(AutotoolsPackage):
             config_args.extend(
                 ['--enable-bash-completion',
                  '--with-bashcompletiondir=' + os.path.join(
-                     self.spec['bash'].prefix,"share","bash-completion","completions"
-                     )])
+                     self.spec['bash'].prefix,
+                     "share", "bash-completion", "completions")])
         else:
             config_args.append('--disable-bash-completion')
         config_args.extend(self.enable_or_disable('libuuid'))

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -31,7 +31,7 @@ class UtilLinux(AutotoolsPackage):
     variant('libuuid', default=True, description='Build libuuid')
     variant('bash', default=False, description='Install bash completion scripts')
 
-    depends_on('bash', when="+bash")
+    depends_on('bash', when="+bash", type='run')
     depends_on('libuuid', when="+libuuid")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -32,7 +32,6 @@ class UtilLinux(AutotoolsPackage):
     variant('bash', default=False, description='Install bash completion scripts')
 
     depends_on('bash', when="+bash", type='run')
-    depends_on('libuuid', when="+libuuid")
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class UtilLinux(AutotoolsPackage):
@@ -46,7 +47,9 @@ class UtilLinux(AutotoolsPackage):
         if "+bash" in self.spec:
             config_args.extend(
                 ['--enable-bash-completion',
-                 '--bash-completion-dir=' + self.spec['bash'].prefix])
+                 '--with-bashcompletiondir=' + os.path.join(
+                     self.spec['bash'].prefix,"share","bash-completion","completions"
+                     )])
         else:
             config_args.append('--disable-bash-completion')
         config_args.extend(self.enable_or_disable('libuuid'))

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -31,6 +31,7 @@ class UtilLinux(AutotoolsPackage):
     variant('bash', default=False, description='Install bash completion scripts')
 
     depends_on('bash', when="+bash")
+    depends_on('libuuid', when="+libuuid")
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -28,6 +28,9 @@ class UtilLinux(AutotoolsPackage):
     # Make it possible to disable util-linux's libuuid so that you may
     # reliably depend_on(`libuuid`).
     variant('libuuid', default=True, description='Build libuuid')
+    variant('bash', default=False, description='Install bash completion scripts')
+
+    depends_on('bash', when="+bash")
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
@@ -37,7 +40,13 @@ class UtilLinux(AutotoolsPackage):
         config_args = [
             '--disable-use-tty-group',
             '--disable-makeinstall-chown',
-            '--without-systemd'
+            '--without-systemd',
         ]
+        if "+bash" in self.spec:
+            config_args.extend(['--enable-bash-completion',
+                                '--bash-completion-dir=',+self.spec['bash'].prefix])
+        else:
+            config_args.append('--disable-bash-completion')
         config_args.extend(self.enable_or_disable('libuuid'))
+
         return config_args


### PR DESCRIPTION
Fixes #18695
Fixes #18697 

In general someone needs to go over this package with a fine-tooth comb, as it looks like it has many dependencies. I also think the libuuid stuff could/should be handled through spack.