### PR TITLE
seacas: Force use of non-mpi-enabled hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -79,6 +79,7 @@ class Seacas(CMakePackage):
 
     depends_on('netcdf-c@4.6.2:+mpi+parallel-netcdf', when='+mpi')
     depends_on('netcdf-c@4.6.2:~mpi', when='~mpi')
+    depends_on('hdf5+hl~mpi', when='~mpi')
     depends_on('cgns@develop+mpi+scoping', when='+cgns +mpi')
     depends_on('cgns@develop~mpi+scoping', when='+cgns ~mpi')
     depends_on('adios2@develop~mpi', when='+adios2 ~mpi')


### PR DESCRIPTION
Due to recent changes in the `netcdf-c` package, it is now necessary to explicitly request a non-mpi-enabled hdf5 build if building a non-mpi-enabled seacas.

Discussion in #18682