### PR TITLE
ocaml: support 4.11

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -15,6 +15,7 @@ class Ocaml(Package):
 
     maintainers = ['scemama']
 
+    version('4.11.0', sha256='b5bd04bf794a676389b167633f01f8275acdd853149b137f7575f2c2ddef1377')
     version('4.10.0', sha256='58d431dde66f5750ebe9b15d5a1c4872f80d283dec23448689b0d1a498b7e4c7')
     version('4.09.0', sha256='2b728f8a0e90da14f22fdc04660f2ab33819cdbb12bff0ceae3fdbb0133cf7a6')
     version('4.08.1', sha256='ee50118ee88472fd4b64311fa560f8f8ab66a1899f0117815c69a16070980f78')
@@ -50,11 +51,18 @@ class Ocaml(Package):
         # to use correct assembler. (See #17918)
         if self.spec.satisfies('%fj'):
             filter_file(
-                '${toolpref}clang -c -Wno-trigraphs',
-                spack_cc + ' -c',
+                'aspp="${toolpref}clang -c -Wno-trigraphs"',
+                'aspp="{0} -c"'.format(spack_cc),
                 'configure',
                 string=True
             )
+            if self.spec.satisfies('@4.11.0:'):
+                filter_file(
+                    'as="${toolpref}clang -c -Wno-trigraphs"',
+                    'as="${toolpref}as"',
+                    'configure',
+                    string=True
+                )
 
         configure(*(base_args))
 


### PR DESCRIPTION
1. add 4.11
Add `version()` 4.11

2. configure patch
Modify patch for `configure`  is updated to support both 4.10 and 4.11.
See also #17918.

`configure`@4.10
> case "$arch,$system" in #(
...
  amd64,*|arm,*|arm64,*|i386,*) : 
    default_as="${toolpref}as" // OK
    case $ocaml_cv_cc_vendor in #(
      clang-*) : // %fj comes here
        default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #( // Patch this line
      *) :
        default_aspp="${toolpref}gcc -c" ;;
    esac ;; #(

`configure`@4.11
> case "$arch,$system" in #(
...
  amd64,*|arm,*|arm64,*|i386,*|riscv,*) :
    case $ocaml_cv_cc_vendor in #(
      clang-*) :// %fj comes here
        default_as="${toolpref}clang -c -Wno-trigraphs" // Patch this line
        default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #( // Patch this line
      *) :
        default_as="${toolpref}as" 
        default_aspp="${toolpref}gcc -c" ;;
    esac ;; #(
