### PR TITLE
Allow gpu-burn to build with non-gcc compilers

### DIFF
--- a/var/spack/repos/builtin/packages/gpu-burn/Makefile.patch
+++ b/var/spack/repos/builtin/packages/gpu-burn/Makefile.patch
@@ -14,5 +14,5 @@
 -	g++ -O3 -Wno-unused-result -I${CUDAPATH}/include -c gpu_burn-drv.cpp
 -	g++ -o gpu_burn gpu_burn-drv.o -O3 -lcuda -L${CUDAPATH}/lib64 -L${CUDAPATH}/lib -Wl,-rpath=${CUDAPATH}/lib64 -Wl,-rpath=${CUDAPATH}/lib -lcublas -lcudart -o gpu_burn
 +	${NVCC} -arch=compute_30 -ptx compare.cu -o compare.ptx
-+	g++ -O3 -Wno-unused-result -c gpu_burn-drv.cpp
-+	g++ -o gpu_burn gpu_burn-drv.o -O3 -lcuda -lcublas -lcudart -o gpu_burn
++	$(CXX) -O3 -Wno-unused-result -c gpu_burn-drv.cpp
++	$(CXX) -o gpu_burn gpu_burn-drv.o -O3 -lcuda -lcublas -lcudart -o gpu_burn


### PR DESCRIPTION
This PR modifies the aptch to use $(CXX) rather than g++ to allow the
spack compiler to be used.