### PR TITLE
bowtie : Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie/fix_narrowing_err_1.3.0.patch
+++ b/var/spack/repos/builtin/packages/bowtie/fix_narrowing_err_1.3.0.patch
@@ -1,11 +1,11 @@
---- a/alphabet.cpp	2020-07-28 15:02:56.137635525 -0400
-+++ b/alphabet.cpp	2020-07-28 15:05:32.385589360 -0400
+--- spack-src/alphabet.cpp.bak	2020-07-23 11:52:57.000000000 +0900
++++ spack-src/alphabet.cpp	2020-09-16 17:05:52.093190703 +0900
 @@ -274,7 +274,7 @@
  const char *iupacs = "!ACMGRSVTWYHKDBN!acmgrsvtwyhkdbn";
  
  signed char mask2iupac[16] = {
 -	-1,
-+	static_cast<char>(-1),
++	static_cast<signed char>(-1),
  	'A', // 0001
  	'C', // 0010
  	'M', // 0011

--- a/var/spack/repos/builtin/packages/bowtie/package.py
+++ b/var/spack/repos/builtin/packages/bowtie/package.py
@@ -48,10 +48,10 @@ class Bowtie(MakefilePackage):
 
     # correspond to 'aarch64' architecture
     # reference: https://github.com/BenLangmead/bowtie/pull/13
-    patch('for_aarch64.patch', when='target=aarch64:')
+    patch('for_aarch64.patch', when='@1.2:1.2.999 target=aarch64:')
 
     # measures for narrowing error
-    patch('fix_narrowing_err.patch', when='@:1.2.3')
+    patch('fix_narrowing_err.patch', when='@1.2.1:1.2.3')
     patch('fix_narrowing_err_1.3.0.patch', when='@1.3.0:')
 
     def edit(self, spec, prefix):


### PR DESCRIPTION
Version 1.3.0 could not be built on aarch64.
I reviewed the application conditions for for_aarch64.patch and fix_narrowing_err.patch and fixed fix_narrowing_err_1.3.0.patch.
I checked the build from version 1.2 to 1.3.0 and confirmed that there was no problem.
