### PR TITLE
iwyu: Add llvm +all_targets variant for non-x86_64.

### DIFF
--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -23,10 +23,20 @@ class Iwyu(CMakePackage):
 
     patch('iwyu-013-cmake.patch', when='@0.13:0.14')
 
-    depends_on('llvm+clang@10.0:10.999 +all_targets', when='@0.14')
-    depends_on('llvm+clang@9.0:9.999 +all_targets', when='@0.13')
-    depends_on('llvm+clang@8.0:8.999 +all_targets', when='@0.12')
-    depends_on('llvm+clang@7.0:7.999 +all_targets', when='@0.11')
+    depends_on('llvm+clang@10.0:10.999', when='@0.14')
+    depends_on('llvm+clang@9.0:9.999', when='@0.13')
+    depends_on('llvm+clang@8.0:8.999', when='@0.12')
+    depends_on('llvm+clang@7.0:7.999', when='@0.11')
+
+    # Non-X86 CPU use all_targets variants because iwyu use X86AsmParser
+    depends_on('llvm+all_targets', when='target=aarch64:')
+    depends_on('llvm+all_targets', when='target=arm:')
+    depends_on('llvm+all_targets', when='target=ppc:')
+    depends_on('llvm+all_targets', when='target=ppcle:')
+    depends_on('llvm+all_targets', when='target=ppc64:')
+    depends_on('llvm+all_targets', when='target=ppc64le:')
+    depends_on('llvm+all_targets', when='target=sparc:')
+    depends_on('llvm+all_targets', when='target=sparc64:')
 
     @when('@0.14:')
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -23,10 +23,10 @@ class Iwyu(CMakePackage):
 
     patch('iwyu-013-cmake.patch', when='@0.13:0.14')
 
-    depends_on('llvm+clang@10.0:10.999', when='@0.14')
-    depends_on('llvm+clang@9.0:9.999', when='@0.13')
-    depends_on('llvm+clang@8.0:8.999', when='@0.12')
-    depends_on('llvm+clang@7.0:7.999', when='@0.11')
+    depends_on('llvm+clang@10.0:10.999 +all_targets', when='@0.14')
+    depends_on('llvm+clang@9.0:9.999 +all_targets', when='@0.13')
+    depends_on('llvm+clang@8.0:8.999 +all_targets', when='@0.12')
+    depends_on('llvm+clang@7.0:7.999 +all_targets', when='@0.11')
 
     @when('@0.14:')
     def cmake_args(self):


### PR DESCRIPTION
iwyu use X86AsmParser in llvm.
But this is not found to build llvm on non-x86 host.
This PR add +all_target variant to llvm.