### PR TITLE
env view failures: print underlying error message

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -680,7 +680,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
 
     try:
         yield tmp_dir
-    except (Exception, KeyboardInterrupt, SystemExit):
+    except (Exception, KeyboardInterrupt, SystemExit) as e:
         # Delete what was there, before copying back the original content
         if os.path.exists(directory_name):
             shutil.rmtree(directory_name)
@@ -691,6 +691,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
         tty.debug('DIRECTORY RECOVERED [{0}]'.format(directory_name))
 
         msg = 'the transactional move of "{0}" failed.'
+        msg += '\n    ' + str(e)
         raise RuntimeError(msg.format(directory_name))
     else:
         # Otherwise delete the temporary directory

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1041,6 +1041,17 @@ def test_env_updates_view_install(
     check_mpileaks_and_deps_in_view(view_dir)
 
 
+def test_env_view_fails(
+        tmpdir, mock_packages, mock_stage, mock_fetch, install_mockery):
+    view_dir = tmpdir.mkdir('view')
+    env('create', '--with-view=%s' % view_dir, 'test')
+    with ev.read('test'):
+        add('libelf')
+        add('libelf cflags=-g')
+        with pytest.raises(RuntimeError, match='merge blocked by file'):
+            install('--fake')
+
+
 def test_env_without_view_install(
         tmpdir, mock_stage, mock_fetch, install_mockery):
     # Test enabling a view after installing specs


### PR DESCRIPTION
#17608 fixed a class of bugs related to environment view generation, but it also obfuscated the error message created when an environment view fails.

This PR ensures the underlying error message is propagated, and includes a regression test.