### PR TITLE
py-recommonmark: fix docutils version

### DIFF
--- a/var/spack/repos/builtin/packages/py-recommonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-recommonmark/package.py
@@ -15,7 +15,7 @@ class PyRecommonmark(PythonPackage):
     http://recommonmark.readthedocs.org"""
 
     homepage = "https://github.com/readthedocs/recommonmark"
-    url      = "https://files.pythonhosted.org/packages/f5/71/046160d730f664662d65b3f8b399b519ad378ffa4369ff3b6060cf1318d7/recommonmark-0.6.0.tar.gz"
+    url      = "https://pypi.io/packages/source/r/recommonmark/recommonmark-0.6.0.tar.gz"
 
     version('0.6.0', sha256='29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb')
 

--- a/var/spack/repos/builtin/packages/py-recommonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-recommonmark/package.py
@@ -20,5 +20,5 @@ class PyRecommonmark(PythonPackage):
     version('0.6.0', sha256='29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb')
 
     depends_on('py-commonmark@0.8.1:')
-    depends_on('py-docutils@011:')
+    depends_on('py-docutils@0.11:')
     depends_on('py-sphinx@1.3.1:')


### PR DESCRIPTION
Fix a version constraint that leads to build errors.