### PR TITLE
Smoke tests: Fix test subcommand help/description

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -30,7 +30,7 @@ def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='test_command')
 
     # Run
-    run_parser = sp.add_parser('run', help=test_run.__doc__)
+    run_parser = sp.add_parser('run', description=test_run.__doc__)
 
     alias_help_msg = "Provide an alias for this test-suite"
     alias_help_msg += " for subsequent access."
@@ -81,31 +81,31 @@ def setup_parser(subparser):
     arguments.add_common_arguments(run_parser, ['installed_specs'])
 
     # List
-    list_parser = sp.add_parser('list', help=test_list.__doc__)
+    list_parser = sp.add_parser('list', description=test_list.__doc__)
     list_parser.add_argument(
         'filter', nargs=argparse.REMAINDER,
         help='optional case-insensitive glob patterns to filter results.')
 
     # Find
-    find_parser = sp.add_parser('find', help=test_find.__doc__)
+    find_parser = sp.add_parser('find', description=test_find.__doc__)
     find_parser.add_argument(
         'filter', nargs=argparse.REMAINDER,
         help='optional case-insensitive glob patterns to filter results.')
 
     # Status
-    status_parser = sp.add_parser('status', help=test_status.__doc__)
+    status_parser = sp.add_parser('status', description=test_status.__doc__)
     status_parser.add_argument(
         'names', nargs=argparse.REMAINDER,
         help="Test suites for which to print status")
 
     # Results
-    results_parser = sp.add_parser('results', help=test_results.__doc__)
+    results_parser = sp.add_parser('results', description=test_results.__doc__)
     results_parser.add_argument(
         'names', nargs=argparse.REMAINDER,
         help="Test suites for which to print results")
 
     # Remove
-    remove_parser = sp.add_parser('remove', help=test_remove.__doc__)
+    remove_parser = sp.add_parser('remove', description=test_remove.__doc__)
     arguments.add_common_arguments(remove_parser, ['yes_to_all'])
     remove_parser.add_argument(
         'names', nargs=argparse.REMAINDER,


### PR DESCRIPTION
Prior to this PR, the descriptions for `spack test` subcommands were not being displayed.  The reason they were missing is because they were being provided in the `help`, not `description` argument.

For example, `spack test list --help` output was:
```
usage: spack test list [-h] ...

positional arguments:
  filter      optional case-insensitive glob patterns to filter results.

optional arguments:
  -h, --help  show this help message and exit
```

and is now:
```
usage: spack test list [-h] ...

List all installed packages with available tests.

positional arguments:
  filter      optional case-insensitive glob patterns to filter results.

optional arguments:
  -h, --help  show this help message and exit
```