### PR TITLE
mpifileutils: Add patch for aarch64.

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/nosys_getdents.patch
+++ b/var/spack/repos/builtin/packages/mpifileutils/nosys_getdents.patch
@@ -1,0 +1,12 @@
+--- spack-src/src/common/mfu_flist_walk.c.old   2020-09-15 16:08:24.587662032 +0900
++++ spack-src/src/common/mfu_flist_walk.c       2020-09-15 16:31:49.825204748 +0900
+@@ -162,6 +162,9 @@
+     /* Read all directory entries */
+     while (1) {
+         /* execute system call to get block of directory entries */
++#ifndef SYS_getdents
++#define SYS_getdents SYS_getdents64
++#endif
+         int nread = syscall(SYS_getdents, fd, buf, (int) BUF_SIZE);
+         if (nread == -1) {
+             MFU_LOG(MFU_LOG_ERR, "syscall to getdents failed when reading `%s' (errno=%d %s)", dir, errno, strerror(errno));

--- a/var/spack/repos/builtin/packages/mpifileutils/nosys_getdents.patch
+++ b/var/spack/repos/builtin/packages/mpifileutils/nosys_getdents.patch
@@ -1,12 +1,25 @@
---- spack-src/src/common/mfu_flist_walk.c.old   2020-09-15 16:08:24.587662032 +0900
-+++ spack-src/src/common/mfu_flist_walk.c       2020-09-15 16:31:49.825204748 +0900
-@@ -162,6 +162,9 @@
+commit 66c5273035396c34998c32e9d7918bce9aeca58f
+Author: Toyohisa Kameyama <kameyama@riken.jp>
+Date:   Fri Sep 25 10:04:58 2020 +0900
+
+    mfu: support aarch64
+    
+    aarch64 kernel is not found SYS_getdents.
+    If SYS_getdents is not defined, use sys_getdents64.
+    
+    Signed-off-by: Toyohisa Kameyama <kameyama@riken.jp>
+
+diff --git a/src/common/mfu_flist_walk.c b/src/common/mfu_flist_walk.c
+index ed81c8d..08836c4 100644
+--- a/src/common/mfu_flist_walk.c
++++ b/src/common/mfu_flist_walk.c
+@@ -161,6 +161,9 @@ static void walk_getdents_process_dir(const char* dir, CIRCLE_handle* handle)
+         return;
+     }
+ 
++#if !defined(SYS_getdents) && defined(SYS_getdents64)
++#define SYS_getdents SYS_getdents64
++#endif
      /* Read all directory entries */
      while (1) {
          /* execute system call to get block of directory entries */
-+#ifndef SYS_getdents
-+#define SYS_getdents SYS_getdents64
-+#endif
-         int nread = syscall(SYS_getdents, fd, buf, (int) BUF_SIZE);
-         if (nread == -1) {
-             MFU_LOG(MFU_LOG_ERR, "syscall to getdents failed when reading `%s' (errno=%d %s)", dir, errno, strerror(errno));

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -26,6 +26,8 @@ class Mpifileutils(Package):
     version('0.9.1',  sha256='15a22450f86b15e7dc4730950b880fda3ef6f59ac82af0b268674d272aa61c69')
     version('0.9',    sha256='1b8250af01aae91c985ca5d61521bfaa4564e46efa15cee65cd0f82cf5a2bcfb')
 
+    patch('nosys_getdents.patch', when='target=aarch64:')
+
     conflicts('platform=darwin')
 
     depends_on('mpi')

--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -26,7 +26,7 @@ class Mpifileutils(Package):
     version('0.9.1',  sha256='15a22450f86b15e7dc4730950b880fda3ef6f59ac82af0b268674d272aa61c69')
     version('0.9',    sha256='1b8250af01aae91c985ca5d61521bfaa4564e46efa15cee65cd0f82cf5a2bcfb')
 
-    patch('nosys_getdents.patch', when='target=aarch64:')
+    patch('nosys_getdents.patch', when='@:0.10.1 target=aarch64:')
 
     conflicts('platform=darwin')
 


### PR DESCRIPTION
mpifileutils use SYS_getdents system call.
But aarch64 linux kernel is not found SYS_getdents.

This PR use SYS_getdents64 if SYS_getents is not used.