### PR TITLE
popt: Add missing libiconv dependency

### DIFF
--- a/var/spack/repos/builtin/packages/popt/package.py
+++ b/var/spack/repos/builtin/packages/popt/package.py
@@ -13,3 +13,5 @@ class Popt(AutotoolsPackage):
     url      = "https://launchpad.net/popt/head/1.16/+download/popt-1.16.tar.gz"
 
     version('1.16', sha256='e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8')
+
+    depends_on('libiconv')


### PR DESCRIPTION
Without this dependency, the build fails due to undefined references:
```
./.libs/libpopt.so: undefined reference to `libiconv'
./.libs/libpopt.so: undefined reference to `libiconv_open'
./.libs/libpopt.so: undefined reference to `libiconv_close'
collect2: error: ld returned 1 exit status
```