### PR TITLE
py-(re)commonmark: dependency types

### DIFF
--- a/var/spack/repos/builtin/packages/py-commonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-commonmark/package.py
@@ -16,4 +16,5 @@ class PyCommonmark(PythonPackage):
 
     version('0.9.0', sha256='867fc5db078ede373ab811e16b6789e9d033b15ccd7296f370ca52d1ee792ce0')
 
+    depends_on('py-setuptools', type='build')
     depends_on('py-future', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-commonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-commonmark/package.py
@@ -16,4 +16,4 @@ class PyCommonmark(PythonPackage):
 
     version('0.9.0', sha256='867fc5db078ede373ab811e16b6789e9d033b15ccd7296f370ca52d1ee792ce0')
 
-    depends_on('py-future')
+    depends_on('py-future', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-recommonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-recommonmark/package.py
@@ -19,6 +19,6 @@ class PyRecommonmark(PythonPackage):
 
     version('0.6.0', sha256='29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb')
 
-    depends_on('py-commonmark@0.8.1:')
-    depends_on('py-docutils@0.11:')
-    depends_on('py-sphinx@1.3.1:')
+    depends_on('py-commonmark@0.8.1:', type=('build', 'run'))
+    depends_on('py-docutils@0.11:', type=('build', 'run'))
+    depends_on('py-sphinx@1.3.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-recommonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-recommonmark/package.py
@@ -19,6 +19,8 @@ class PyRecommonmark(PythonPackage):
 
     version('0.6.0', sha256='29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb')
 
+    depends_on('py-setuptools', type='build')
+    depends_on('py-future', type=('build', 'run'))
     depends_on('py-commonmark@0.8.1:', type=('build', 'run'))
     depends_on('py-docutils@0.11:', type=('build', 'run'))
     depends_on('py-sphinx@1.3.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-recommonmark/package.py
+++ b/var/spack/repos/builtin/packages/py-recommonmark/package.py
@@ -20,7 +20,6 @@ class PyRecommonmark(PythonPackage):
     version('0.6.0', sha256='29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-future', type=('build', 'run'))
     depends_on('py-commonmark@0.8.1:', type=('build', 'run'))
     depends_on('py-docutils@0.11:', type=('build', 'run'))
     depends_on('py-sphinx@1.3.1:', type=('build', 'run'))


### PR DESCRIPTION
fix the python dependency types for python packages.

Follow-up to #18714