### PR TITLE
Dev/override cpu limit

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -450,7 +450,8 @@ def _set_variables_for_single_module(pkg, module):
         return
 
     jobs = spack.config.get('config:build_jobs', 16) if pkg.parallel else 1
-    jobs = min(jobs, multiprocessing.cpu_count())
+    if not spack.config.get('config:override_cpu_limit', False):
+        jobs = min(jobs, multiprocessing.cpu_count())
     assert jobs is not None, "no default set for config:build_jobs"
 
     m = module

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -102,7 +102,8 @@ class SetParallelJobs(argparse.Action):
                   '[expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, jobs))
 
-        jobs = min(jobs, multiprocessing.cpu_count())
+        if not spack.config.get('config:override_cpu_limit', False):
+            jobs = min(jobs, multiprocessing.cpu_count())
         spack.config.set('config:build_jobs', jobs, scope='command_line')
 
         setattr(namespace, 'jobs', jobs)


### PR DESCRIPTION
patch to add feature #18742

This adds a flag to allow the number of threads to exceed local cpus.  This is useful when using distcc and compiler caching.