### PR TITLE
workaround to ILCSoft/LCIO#114 parallel builds

### DIFF
--- a/var/spack/repos/builtin/packages/lcio/package.py
+++ b/var/spack/repos/builtin/packages/lcio/package.py
@@ -40,6 +40,8 @@ class Lcio(CMakePackage):
     depends_on('delphes', when="+examples")
     depends_on('readline', when="+examples")
 
+    patch('sio-dependencies.patch')
+
     def cmake_args(self):
         args = [
             self.define('CMAKE_CXX_STANDARD',

--- a/var/spack/repos/builtin/packages/lcio/sio-dependencies.patch
+++ b/var/spack/repos/builtin/packages/lcio/sio-dependencies.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d6d02ba..6c557691 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -276,7 +276,9 @@ OPTION( BUILD_LCIO_EXAMPLES "Set to ON to build LCIO examples" ON )
+ # lcio library
+ ADD_SUBDIRECTORY( ./src/cpp lcio )
+ 
+-
++IF( NOT SIO_FOUND )
++  ADD_DEPENDENCIES( lcio sio )
++ENDIF()
+ 
+ # fortran examples
+ OPTION( BUILD_F77_TESTJOBS "Set to ON to build LCIO F77 testjobs" OFF )


### PR DESCRIPTION
This is a workaround for a missing dependency for Lcio
that shows up in massive builds