### PR TITLE
graphviz: fix build with Apple Clang 12.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -19,6 +19,8 @@ class Graphviz(AutotoolsPackage):
     homepage = 'http://www.graphviz.org'
     git      = 'https://gitlab.com/graphviz/graphviz.git'
 
+    # This commit hash is tag='stable_release_2.44.1'
+    version('2.44.1', commit='771bc4dbff3e6f358fa75cdc7774a413ccacad51')
     # This commit hash is tag='stable_release_2.42.2'
     version('2.42.2', commit='da4c2ec6f24ca1b6d1752c6b5bc4389e55682147')
     # This commit hash is tag='stable_release_2.40.1'
@@ -74,6 +76,7 @@ class Graphviz(AutotoolsPackage):
     patch('https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/master/easybuild/easyconfigs/g/Graphviz/Graphviz-2.40.1_icc_vmalloc.patch',
           sha256='813e6529e79161a18b0f24a969b7de22f8417b2e942239e658b5402884541bc2',
           when='@:2.40%intel')
+    patch('ps2pdf.patch')
 
     if not MACOS_VERSION:
         conflicts('+quartz',

--- a/var/spack/repos/builtin/packages/graphviz/ps2pdf.patch
+++ b/var/spack/repos/builtin/packages/graphviz/ps2pdf.patch
@@ -1,0 +1,15 @@
+https://gitlab.com/graphviz/graphviz/-/issues/1826
+https://github.com/Homebrew/homebrew-core/pull/57132
+diff --git a/configure.ac b/configure.ac
+index cf42504..68db027 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -284,8 +284,7 @@ AC_CHECK_PROGS(SORT,gsort sort,false)
+
+ AC_CHECK_PROG(EGREP,egrep,egrep,false)
+ AC_CHECK_PROG(GROFF,groff,groff,false)
+-AC_CHECK_PROG(PS2PDF,ps2pdf,ps2pdf,false)
+-AC_CHECK_PROG(PS2PDF,pstopdf,pstopdf,false)
++AC_CHECK_PROGS(PS2PDF,ps2pdf pstopdf,false)
+
+ PKG_PROG_PKG_CONFIG


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Apple Clang 12.0.0.

Patch comes from Homebrew and is recommended by the Graphviz developers.