### PR TITLE
libksba: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/libksba/package.py
+++ b/var/spack/repos/builtin/packages/libksba/package.py
@@ -18,6 +18,8 @@ class Libksba(AutotoolsPackage):
 
     depends_on('libgpg-error@1.8:')
 
+    conflicts('%apple-clang@12:', when='@:1.3')
+
     def configure_args(self):
         return [
             '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix

--- a/var/spack/repos/builtin/packages/libksba/package.py
+++ b/var/spack/repos/builtin/packages/libksba/package.py
@@ -13,6 +13,7 @@ class Libksba(AutotoolsPackage):
     homepage = "https://gnupg.org/software/libksba/index.html"
     url = "https://gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2"
 
+    version('1.4.0', sha256='bfe6a8e91ff0f54d8a329514db406667000cb207238eded49b599761bfca41b6')
     version('1.3.5', sha256='41444fd7a6ff73a79ad9728f985e71c9ba8cd3e5e53358e70d5f066d35c1a340')
 
     depends_on('libgpg-error@1.8:')


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Apple Clang 12.0.0.

Fixes a build error with Apple Clang 12.0.0.