### PR TITLE
ncurses: fix libs method

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -141,9 +141,9 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def libs(self):
-        nc_libs = find_libraries(
-            ['libncurses', 'libncursesw'], root=self.prefix, recursive=True)
+        libraries = ['libncurses', 'libncursesw']
+
         if '+termlib' in self.spec:
-            nc_libs.extend(find_libraries(
-                ['libtinfo', 'libtinfow'], root=self.prefix, recursive=True))
-        return nc_libs
+            libraries += ['libtinfo', 'libtinfow']
+
+        return find_libraries(libraries, root=self.prefix, recursive=True)


### PR DESCRIPTION
### Before
```
>>> spec['ncurses'].libs.link_flags
'-lncurses'
```
### After
```
>>> spec['ncurses'].libs.link_flags
'-lncurses -lncursesw -ltinfo -ltinfow'
```
Not sure why the previous logic doesn't work, but the newer logic is simpler anyway.