### PR TITLE
add groff and ghostscript

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -117,6 +117,9 @@ class Graphviz(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('libtool', type='build')
+    # required to build docs
+    depends_on('groff', type='build')
+    depends_on('ghostscript', type='build')
 
     parallel = False
 


### PR DESCRIPTION
Without these packages, graphviz will set groff/ghostscript to
false which will cause the build to fail.