### PR TITLE
Bash: fix build with Xcode 12

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -48,6 +48,8 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
         patch('https://ftpmirror.gnu.org/bash/bash-{0}-patches/bash{1}-{2}'.format(ver, ver.joined, num),
               level=0, when='@{0}'.format(ver), sha256=checksum)
 
+    patch('xcode12-strsignal-conf.patch', when='@:5.0 %apple-clang@12:')
+
     executables = ['^bash$']
 
     @classmethod
@@ -60,7 +62,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
 
         return [
-            'LIBS=-lncursesw',
+            'LIBS=' + spec['ncurses'].libs.link_flags,
             '--with-curses',
             '--enable-readline',
             '--with-installed-readline',

--- a/var/spack/repos/builtin/packages/bash/xcode12-strsignal-conf.patch
+++ b/var/spack/repos/builtin/packages/bash/xcode12-strsignal-conf.patch
@@ -1,0 +1,18 @@
+--- a/configure	2019-01-02 08:43:31.000000000 -0600
++++ b/configure	2020-09-21 10:40:42.000000000 -0500
+@@ -14568,6 +14568,7 @@
+ /* end confdefs.h.  */
+ #include <sys/types.h>
+ #include <signal.h>
++#include <string.h>
+ int
+ main ()
+ {
+@@ -14999,6 +15000,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ 
+ main()
+ {


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.15.6 with Apple Clang 12.0.0.

Fixes a build error with Xcode 12. This patch is already incorporated in the release candidate for Bash 5.1.