### PR TITLE
Compatibility with Python 3 when sorting specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3343,7 +3343,7 @@ class Spec(object):
     def _cmp_node(self):
         """Comparison key for just *this node* and not its deps."""
         return (self.name,
-                self.namespace,
+                self.namespace or '',
                 tuple(self.versions),
                 self.variants,
                 self.architecture,

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1003,3 +1003,10 @@ def test_is_extension_after_round_trip_to_dict(config, spec_str):
     # Using 'y' since the round-trip make us lose build dependencies
     for d in y.traverse():
         assert x[d.name].package.is_extension == y[d.name].package.is_extension
+
+
+def test_spec_sort_namespace():
+    # Check that it is possible to compare two specs, one of which has a
+    # namespace and another one does not.
+    s = [Spec('builtin.mpich'), Spec('mpich')]
+    assert s[::-1] == sorted(s)


### PR DESCRIPTION
There are cases when we compare two specs, one of which has a namespace and another one does not (i.e. the corresponding property is set to `None`). As a result, we get a variation of the following error when running Spack with Python 3:
```console
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```
Note that Python 2 does not have a problem comparing None to a string.

I am not sure whether this is the right way to fix the problem. However, it can be reproduced by running
```console
$ spack spec cdo
```
with the following `packages.yaml`:
```yaml
packages:
  all:
    providers:
      szip: [libaec]
  eccodes:
    variants: +aec
  hdf5:
    variants: +szip
```