### PR TITLE
CMakePackage: Fix build directory

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -314,7 +314,7 @@ class CMakePackage(PackageBase):
 
         :return: directory where to build the package
         """
-        dirname = 'spack-build=%s' % self.spec.dag_hash(7)
+        dirname = 'spack-build-%s' % self.spec.dag_hash(7)
         return os.path.join(self.stage.path, dirname)
 
     def cmake_args(self):


### PR DESCRIPTION
Fix a typo that crept into the build directory for cmake packages.

Escaped review originally because I clicked the wrong button in github when fixing it.

@alalazo 