### PR TITLE
added magma variant to heffte develop

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -43,16 +43,11 @@ class Heffte(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DBUILD_SHARED_LIBS={0:1s}'.format(
-                'ON' if '+shared' in self.spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('Heffte_ENABLE_CUDA', 'cuda'),
+            self.define_from_variant('Heffte_ENABLE_FFTW', 'fftw'),
+            self.define_from_variant('Heffte_ENABLE_MKL', 'mkl'),
+            self.define_from_variant('Heffte_ENABLE_MAGMA', 'magma'),
             '-DBUILD_GPU={0:1s}'.format(
                 'ON' if ('+cuda' in self.spec and
-                         '+fftw' in self.spec) else 'OFF'),
-            '-DHeffte_ENABLE_CUDA={0:1s}'.format(
-                'ON' if '+cuda' in self.spec else 'OFF'),
-            '-DHeffte_ENABLE_FFTW={0:1s}'.format(
-                'ON' if '+fftw' in self.spec else 'OFF'),
-            '-DHeffte_ENABLE_MKL={0:1s}'.format(
-                'ON' if '+mkl' in self.spec else 'OFF'),
-            '-DHeffte_ENABLE_MAGMA={0:1s}'.format(
-                'ON' if '+magma' in self.spec else 'OFF'), ]
+                         '+fftw' in self.spec) else 'OFF'), ]

--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -26,16 +26,20 @@ class Heffte(CMakePackage):
     variant('fftw', default=False, description='Builds with support for FFTW backend')
     variant('mkl',  default=False, description='Builds with support for MKL backend')
     variant('cuda', default=False, description='Builds with support for GPUs via CUDA')
+    variant('magma', default=False, description='Use helper methods from the UTK MAGMA library')
 
     conflicts('~fftw', when='~mkl~cuda')  # requires at least one backend
-    conflicts('+fftw', when='+mkl')  # old API supports at most one CPU backend
+    conflicts('+fftw', when='+mkl@:1.0')  # old API supports at most one CPU backend
     conflicts('openmpi~cuda', when='+cuda')  # +cuda requires CUDA enabled OpenMPI
+    conflicts('~cuda', when='+magma')  # magma requires CUDA or HIP
+    conflicts('+magma', when="@:1.0")  # magma support was added post v1.0
 
     depends_on('mpi', type=('build', 'run'))
 
     depends_on('fftw@3.3.8:', when="+fftw", type=('build', 'run'))
     depends_on('intel@16.0:', when="+mkl", type=('build', 'run'))
     depends_on('cuda@8.0:', when="+cuda", type=('build', 'run'))
+    depends_on('magma@2.5.3:', when="+cuda+magma", type=('build', 'run'))
 
     def cmake_args(self):
         return [
@@ -49,4 +53,6 @@ class Heffte(CMakePackage):
             '-DHeffte_ENABLE_FFTW={0:1s}'.format(
                 'ON' if '+fftw' in self.spec else 'OFF'),
             '-DHeffte_ENABLE_MKL={0:1s}'.format(
-                'ON' if '+mkl' in self.spec else 'OFF'), ]
+                'ON' if '+mkl' in self.spec else 'OFF'),
+            '-DHeffte_ENABLE_MAGMA={0:1s}'.format(
+                'ON' if '+magma' in self.spec else 'OFF'), ]


### PR DESCRIPTION
* next xSDK release will feature heFFTe 1.1 with UTK MAGMA support
* added `+magma` variant to the heffte package so we can begin testing