### PR TITLE
cpio: Fix issue compiling with newer intel compilers (#18854)

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -23,7 +23,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
 
         if name == 'cflags':
-            if '%intel' in spec:
+            if '%intel@:19.999' in spec:
                 flags.append('-no-gcc')
 
             elif '%clang' in spec or '%fj' in spec:

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -23,7 +23,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
 
         if name == 'cflags':
-            if '%intel@:19.999' in spec:
+            if '%intel@:18.999' in spec:
                 flags.append('-no-gcc')
 
             elif '%clang' in spec or '%fj' in spec:


### PR DESCRIPTION
Do not add --no-gcc for recent intel compilers (e.g. 20.x)