### PR TITLE
add package py-lmodule version 0.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-lmodule/package.py
+++ b/var/spack/repos/builtin/packages/py-lmodule/package.py
@@ -7,9 +7,9 @@ from spack import *
 
 
 class PyLmodule(PythonPackage):
-    """Lmodule is a Python API for Lmod module system. It's primary purpose is 
-    to help automate module testing. Lmodule uses Lmod spider tool to query 
-    all modules in-order to automate module testing. Lmodule can be used with 
+    """Lmodule is a Python API for Lmod module system. It's primary purpose is
+    to help automate module testing. Lmodule uses Lmod spider tool to query
+    all modules in-order to automate module testing. Lmodule can be used with
     environment-modules to interact with module using the Module class."""
 
     homepage = "https://lmodule.readthedocs.io/en/latest/"
@@ -23,4 +23,3 @@ class PyLmodule(PythonPackage):
     depends_on('python@3.6.0:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('lmod@7.0:', type='run')
-

--- a/var/spack/repos/builtin/packages/py-lmodule/package.py
+++ b/var/spack/repos/builtin/packages/py-lmodule/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-lmodule
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-lmodule
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class PyLmodule(PythonPackage):
+    """Lmodule is a Python API for Lmod module system. It's primary purpose is to help
+    automate module testing. Lmodule uses Lmod spider tool to query all modules inorder
+    to automate module testing. Lmodule can be used with environment-modules to interact
+    with module command with limited support for module interface."""
+
+    homepage = "https://lmodule.readthedocs.io/en/latest/"
+    url      = "https://pypi.io/packages/source/l/lmodule/lmodule-0.1.0.tar.gz"
+    git      = "https://github.com/buildtesters/lmodule"
+
+    maintainers = ['shahzebsiddiqui']
+
+    version('0.1.0', sha256='cac8f3dad2df27b10e051b2c56ccbde1fcdd7044af594d13fd2e4144d3d46a29')
+
+    depends_on('python@3.6.0:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+

--- a/var/spack/repos/builtin/packages/py-lmodule/package.py
+++ b/var/spack/repos/builtin/packages/py-lmodule/package.py
@@ -3,31 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-lmodule
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-lmodule
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 
 class PyLmodule(PythonPackage):
-    """Lmodule is a Python API for Lmod module system. It's primary purpose is to help
-    automate module testing. Lmodule uses Lmod spider tool to query all modules inorder
-    to automate module testing. Lmodule can be used with environment-modules to interact
-    with module command with limited support for module interface."""
+    """Lmodule is a Python API for Lmod module system. It's primary purpose is 
+    to help automate module testing. Lmodule uses Lmod spider tool to query 
+    all modules in-order to automate module testing. Lmodule can be used with 
+    environment-modules to interact with module using the Module class."""
 
     homepage = "https://lmodule.readthedocs.io/en/latest/"
     url      = "https://pypi.io/packages/source/l/lmodule/lmodule-0.1.0.tar.gz"
@@ -39,4 +22,5 @@ class PyLmodule(PythonPackage):
 
     depends_on('python@3.6.0:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('lmod@7.0:', type='run')
 


### PR DESCRIPTION
I have installed py-lmodule in my spack environment 

```
siddiq90@cori05:/global/u1/s/siddiq90/spack/var/spack/environments/lmodule> spack find
==> In environment lmodule
==> Root specs
py-lmodule 

==> 17 installed packages
-- cray-cnl7-haswell / gcc@9.3.0 --------------------------------
bzip2@1.0.8  gdbm@1.18.1   libbsd@0.10.0  libuuid@1.0.3  openssl@1.1.1g  py-lmodule@0.1.0      python@3.8.5  sqlite@3.31.1  zlib@1.2.11
expat@2.2.9  gettext@0.21  libffi@3.3     ncurses@6.2    pkgconf@1.7.3   py-setuptools@50.1.0  readline@8.0  xz@5.2.5
```

Here is a simple test using the API to ensure package was installed properly
```
siddiq90@cori05:/global/u1/s/siddiq90/spack/var/spack/environments/lmodule> spack load py-lmodule
siddiq90@cori05:/global/u1/s/siddiq90/spack/var/spack/environments/lmodule> which python
/global/u1/s/siddiq90/spack/opt/spack/cray-cnl7-haswell/gcc-9.3.0/python-3.8.5-4742qkh2vmi6ksgwtnc6jyyuyvs5do2l/bin/python
siddiq90@cori05:/global/u1/s/siddiq90/spack/var/spack/environments/lmodule> python
Python 3.8.5 (default, Sep 21 2020, 14:08:29) 
[GCC 9.3.0 20200312 (Cray Inc.)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from lmod.module import Module
>>> cmd = Module("gcc",debug=True)
>>> cmd.test_modules()
[DEBUG] Executing module command: module purge && module load gcc  
[DEBUG] Return Code: 0
0
```