### PR TITLE
pythia8: Add version 8303

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -17,9 +17,10 @@ class Pythia8(AutotoolsPackage):
 
     maintainers = ['ChristianTackeGSI']
 
+    version('8303', sha256='cd7c2b102670dae74aa37053657b4f068396988ef7da58fd3c318c84dc37913e')
     version('8302', sha256='7372e4cc6f48a074e6b7bc426b040f218ec4a64b0a55e89da6af56933b5f5085')
     version('8301', sha256='51382768eb9aafb97870dca1909516422297b64ef6a6b94659259b3e4afa7f06')
-    version('8244', sha256='e34880f999daf19cdd893a187123927ba77d1bf851e30f6ea9ec89591f4c92ca', preferred=True)
+    version('8244', sha256='e34880f999daf19cdd893a187123927ba77d1bf851e30f6ea9ec89591f4c92ca')
     version('8240', sha256='d27495d8ca7707d846f8c026ab695123c7c78c7860f04e2c002e483080418d8d')
     version('8235', sha256='e82f0d6165a8250a92e6aa62fb53201044d8d853add2fdad6d3719b28f7e8e9d')
     version('8230', sha256='332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d')


### PR DESCRIPTION
@kresan, @michaelkuhn, and @vvolkl

8303 has been released and looking at http://home.thep.lu.se/~torbjorn/Pythia.html
> With 8.302 the code should be sufficiently well tested to offer a fully functional upgrade from the 8.2 series, and starting with 8.303 new physics features are being introduced that should make 8.3 the natural choice. 

So it seems, we can remove the `preferred=True` from version 8244. Would you agree? If so, I would augment this PR accordingly.