### PR TITLE
OLCF Ascent GitLab CI trigger: pass relevant variables

### DIFF
--- a/share/spack/gitlab/ascent_pipeline.yml
+++ b/share/spack/gitlab/ascent_pipeline.yml
@@ -1,6 +1,9 @@
 merge_pipeline:
   only:
   - develop
+  variables:
+    SPACK_REPO: ${CI_PROJECT_URL}
+    SPACK_REF: ${CI_COMMIT_SHA}
   trigger:
     project: ecpcitest/e4s
     strategy: depend


### PR DESCRIPTION
This PR passes `SPACK_REF` and `SPACK_REPO` to the triggered pipeline.

@shahzebsiddiqui @scottwittenburg 