### PR TITLE
Paraview 5.6.2's version of VTK (8.2.0) is incompatible with Python 3.8

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -77,7 +77,7 @@ class Paraview(CMakePackage, CudaPackage):
 
     # VTK < 8.2.1 can't handle Python 3.8
     # This affects Paraview 5.6.2 (VTK 8.2.0)
-    # https://gitlab.kitware.com/vtk/vtk/-/issues/17670 
+    # https://gitlab.kitware.com/vtk/vtk/-/issues/17670
     depends_on('python@3:3.7', when='@5.6.2 +python3', type=('build', 'run'))
 
     depends_on('py-numpy@:1.15.4', when='+python', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -75,6 +75,11 @@ class Paraview(CMakePackage, CudaPackage):
     depends_on('python@2.7:2.8', when='+python', type=('build', 'run'))
     depends_on('python@3:', when='+python3', type=('build', 'run'))
 
+    # VTK < 8.2.1 can't handle Python 3.8
+    # This affects Paraview 5.6.2 (VTK 8.2.0)
+    # https://gitlab.kitware.com/vtk/vtk/-/issues/17670 
+    depends_on('python@3:3.7', when='@5.6.2 +python3', type=('build', 'run'))
+
     depends_on('py-numpy@:1.15.4', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python3', type=('build', 'run'))
     depends_on('py-mpi4py', when='+python+mpi', type=('build', 'run'))


### PR DESCRIPTION
Paraview 5.6.2 with +python3 fails to build using the latest Python (3.8.5):

```bash
'Py_ssize_t' {aka 'long int'} in initialization
  230 | };
      | ^
make[2]: Leaving directory `/ram/tmp/quellyn/spack-stage/spack-stage-paraview-5.6.2-dholblehogxmeorng4nfi5isjxpek3wa/spack-build-dholble'
[ 12%] Built target vtkIOEnSightObjects
make[2]: *** [VTK/Wrapping/PythonCore/CMakeFiles/vtkWrappingPythonCore.dir/PyVTKMethodDescriptor.cxx.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

It appears that the VTK library version (8.2.0) in [Paraview 5.6.2 is incompatible with Python 3.8](https://gitlab.kitware.com/vtk/vtk/-/issues/17670)