### PR TITLE
audacious: add link type build to glib.

### DIFF
--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -24,7 +24,7 @@ class Audacious(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('gettext')
     depends_on('iconv',    type='link')
-    depends_on('glib',     type='link')
+    depends_on('glib')
     depends_on('qt')
 
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
In  #18584, I change glib linktype to link only.
But audacious is used glib command gdbus-codegen.
This PR add glib build dependency.