### PR TITLE
Smoke tests: Fix mpi flake8 issue from prior commit

### DIFF
--- a/var/spack/repos/builtin/packages/mpi/package.py
+++ b/var/spack/repos/builtin/packages/mpi/package.py
@@ -27,5 +27,5 @@ class Mpi(Package):
             if compiled:
                 self.run_test(mpirun,
                               options=['-np', '1', exe_name],
-                              expected=[r'Hello world! '
-                                        'From rank \s*0 of \s*1'])
+                              expected=[r'Hello world! From rank \s*0 of \s*1']
+                              )


### PR DESCRIPTION
Fixes the `mpi` package flake8 issues accidentally introduced in the fix of a previous flake8 issue.