### PR TITLE
Smoke tests: Added __init__.py to address test collection on the tty.py test

### DIFF
--- a/lib/spack/spack/test/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/test/llnl/util/tty/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
This PR adds an `__init__.py` file to the `tty` subdirectory since doing so may be the solution to the `tty.py` test failure showing up in #15702 .