### PR TITLE
Add new package: asciidoc-py3

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc-py3/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc-py3/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class AsciidocPy3(AutotoolsPackage):
+    """Python 3 port of Asciidoc Python.
+    AsciiDoc is a text document format for writing notes,
+    documentation, articles, books, ebooks, slideshows,
+    web pages, man pages and blogs. AsciiDoc files can
+    be translated to many formats including HTML, PDF,
+    EPUB, man page."""
+
+    homepage = "https://github.com/asciidoc/asciidoc-py3"
+    url      = "https://github.com/asciidoc/asciidoc-py3/releases/download/9.0.2/asciidoc-9.0.2.tar.gz"
+
+    version('9.0.2', sha256='185fd68e47034c4dd892e1d4ae64c81152bc049e9bdc7d1ad63f927d35810a3b')
+
+    depends_on('python@3.5:')

--- a/var/spack/repos/builtin/packages/asciidoc-py3/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc-py3/package.py
@@ -19,4 +19,4 @@ class AsciidocPy3(AutotoolsPackage):
 
     version('9.0.2', sha256='185fd68e47034c4dd892e1d4ae64c81152bc049e9bdc7d1ad63f927d35810a3b')
 
-    depends_on('python@3.5:')
+    depends_on('python@3.5:', type=('build', 'run'))


### PR DESCRIPTION
According to https://github.com/asciidoc/asciidoc/blob/master/README.asciidoc
> This repository (asciidoc-py2) is no longer supported as python 2 has entered end-of-life. Please see asciidoc-py3 for the current supported version.


We need to use `asciidoc-py3` instead of `asciidoc`