### PR TITLE
veloc: add v1.4, unconstrain dependency on boost

### DIFF
--- a/var/spack/repos/builtin/packages/veloc/package.py
+++ b/var/spack/repos/builtin/packages/veloc/package.py
@@ -17,7 +17,8 @@ class Veloc(CMakePackage):
     tags = ['ecp']
 
     version('master', branch='master')
-    version('1.1',    sha256='2bbdacf3e0ce4e7c9e360874d8d85b405525bdc7bd992bdb1f1ba49218072160', preferred=True)
+    version('1.4',    sha256='d5d12aedb9e97f079c4428aaa486bfa4e31fe1db547e103c52e76c8ec906d0a8')
+    version('1.1',    sha256='2bbdacf3e0ce4e7c9e360874d8d85b405525bdc7bd992bdb1f1ba49218072160')
     version('1.0',    sha256='d594b73d6549a61fce8e67b8984a17cebc3e766fc520ed1636ae3683cdde77cb')
     version('1.0rc1', sha256='81686ca0994a22475911d38d21c7c74b64ffef4ca872fd01f76d155c5124b0bc')
 

--- a/var/spack/repos/builtin/packages/veloc/package.py
+++ b/var/spack/repos/builtin/packages/veloc/package.py
@@ -22,11 +22,7 @@ class Veloc(CMakePackage):
     version('1.0',    sha256='d594b73d6549a61fce8e67b8984a17cebc3e766fc520ed1636ae3683cdde77cb')
     version('1.0rc1', sha256='81686ca0994a22475911d38d21c7c74b64ffef4ca872fd01f76d155c5124b0bc')
 
-    depends_on('boost~atomic~chrono~clanglibcpp~date_time~debug~exception'
-               '~filesystem~graph~icu~iostreams~locale~log~math~mpi'
-               '~multithreaded~numpy~program_options~python~random~regex'
-               '~serialization~shared~signals~singlethreaded~system'
-               '~taggedlayout~test~thread~timer~versionedlayout~wave')
+    depends_on('boost')
     depends_on('libpthread-stubs')
     depends_on('mpi')
     depends_on('er')


### PR DESCRIPTION
* Add `veloc@1.4`
* Unconstrain dependency on `boost`