### PR TITLE
poplpler: fix patch for 0.90.1.

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -62,7 +62,8 @@ class Poppler(CMakePackage):
     # Splash is unconditionally disabled. Unfortunately there's
     # a small section of code in the QT5 wrappers that expects it
     # to be present.
-    patch('poppler_page_splash.patch', when='@0.64.0: ^qt@5.0:')
+    patch('poppler_page_splash.patch', when='@0.64.0:0.90.0 ^qt@5.0:')
+    patch('poppler_page_splash.0.90.1.patch', when='@0.90.1: ^qt@5.0:')
 
     # Only needed to run `make test`
     resource(

--- a/var/spack/repos/builtin/packages/poppler/poppler_page_splash.0.90.1.patch
+++ b/var/spack/repos/builtin/packages/poppler/poppler_page_splash.0.90.1.patch
@@ -1,0 +1,20 @@
+diff --git a/qt5/src/poppler-page.cc b/qt5/src/poppler-page.cc
+index c4d00a6..e72c26b 100644
+--- a/qt5/src/poppler-page.cc
++++ b/qt5/src/poppler-page.cc
+@@ -103,6 +103,8 @@ public:
+   QVariant payload;
+ };
+ 
++#if defined(HAVE_SPLASH)
++
+ class Qt5SplashOutputDev : public SplashOutputDev, public OutputDevCallbackHelper
+ {
+ public:
+@@ -163,5 +156,6 @@ private:
+   bool ignorePaperColor;
+ };
++#endif
+ 
+ class QImageDumpingArthurOutputDev : public ArthurOutputDev, public OutputDevCallbackHelper
+ {


### PR DESCRIPTION
poppler's source code is reformat by clang-format beforw 0.90.1.
So the patch of qt5 is faild.
Thie PR add patch for popler version 0.90.1.
