### PR TITLE
Update py-psycopg2 to work with python 3.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-psycopg2/package.py
+++ b/var/spack/repos/builtin/packages/py-psycopg2/package.py
@@ -12,7 +12,9 @@ class PyPsycopg2(PythonPackage):
     homepage = "http://initd.org/psycopg/"
     url = "http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-2.7.5.tar.gz"
 
+    version('2.8.6', sha256='fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543')
     version('2.7.5', sha256='eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e')
 
+    depends_on('python@:3.7', when='@2.7.5')
     depends_on('py-setuptools', type='build')
     depends_on('postgresql', type=('build', 'run'))


### PR DESCRIPTION
Updated the version of py-psycopg2 and added python version constraint
for previous version.