### PR TITLE
Change how CUDA variants are handled for gpu-burn

### DIFF
--- a/var/spack/repos/builtin/packages/gpu-burn/package.py
+++ b/var/spack/repos/builtin/packages/gpu-burn/package.py
@@ -24,21 +24,22 @@ class GpuBurn(MakefilePackage, CudaPackage):
     variant('cuda', 'True', description='Use CUDA; must be true')
 
     conflicts('~cuda', msg='gpu-burn requires cuda')
+    conflicts('cuda_arch=none', msg='must select a CUDA architecture')
+
+    cuda_arch_values = CudaPackage.cuda_arch_values
+    variant(
+        'cuda_arch',
+        description='CUDA architecture',
+        default='none',
+        values=cuda_arch_values,
+        multi=False
+    )
 
     def edit(self, spec, prefix):
         # update cuda architecture if necessary
         if '+cuda' in self.spec:
             cuda_arch = self.spec.variants['cuda_arch'].value
-            archflag = ''
-
-            if cuda_arch != 'none':
-                if len(cuda_arch) > 1:
-                    raise InstallError(
-                        'gpu-burn only supports compilation for a single GPU'
-                        'type.'
-                    )
-                archflag = '-arch=compute_{0}'.format(cuda_arch[0])
-
+            archflag = '-arch=compute_{0}'.format(cuda_arch)
             filter_file('-arch=compute_30', archflag,
                         'Makefile', string=True)
 


### PR DESCRIPTION
- Override the cuda_arch variant setup, with multi=False to ensure one
  value is selected
- Use a conflicts statement rather than InstallError