### PR TITLE
bazel: add latest version

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -18,6 +18,12 @@ class Bazel(Package):
 
     maintainers = ['adamjstewart']
 
+    version('3.5.0',  sha256='334429059cf82e222ca8a9d9dbbd26f8e1eb308613463c2b8655dd4201b127ec')
+    version('3.4.1',  sha256='27af1f11c8f23436915925b25cf6e1fb07fccf2d2a193a307c93437c60f63ba8')
+    version('3.4.0',  sha256='7583abf8905ba9dd5394294e815e8873635ac4e5067e63392e8a33b397e450d8')
+    version('3.3.1',  sha256='e0f1f43c65c4e0a38522b37e81f6129d8a1f7cd3d8884847be306544a7492747')
+    version('3.3.0',  sha256='05a03960de09d5775839c5766ad8a0a30f261feaba5fa53ce3e49168d1eee826')
+    version('3.2.0',  sha256='44ec129436f6de45f2230e14100104919443a1364c2491f5601666b358738bfa')
     version('3.1.0',  sha256='d7f40d0cac95a06cea6cb5b7f7769085257caebc3ee84269dd9298da760d5615')
     version('3.0.0',  sha256='530f5132e0a50da7ebb0ed08d9b6f1ddfd0d7d9b5d0beb2df5d687a4c8daf6b3')
     version('2.2.0',  sha256='9379878a834d105a47a87d3d7b981852dd9f64bc16620eacd564b48533e169a7')
@@ -97,7 +103,7 @@ class Bazel(Package):
 
     depends_on('java', type=('build', 'run'))
     depends_on('python', type=('build', 'run'))
-    depends_on('zip', type=('build', 'run'))
+    depends_on('zip', when='platform=linux', type=('build', 'run'))
 
     # Pass Spack environment variables to the build
     patch('bazelruleclassprovider-0.25.patch', when='@0.25:')


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Apple Clang 12.0.0.

I noticed a couple of build problems on macOS. First of all, I'm not able to build `zip`. I'm not actually sure if this dependency is required or if it's only needed to unzip the zip file that gets downloaded. It looks like @melven added this in #15402. According to the [Ubuntu installation instructions](https://docs.bazel.build/versions/master/install-ubuntu.html), zip is required, but the [macOS installation instructions](https://docs.bazel.build/versions/master/install-os-x.html) make no mention of `zip`, so maybe it's not required (or assumed to be present on the OS)? What should we do here? I suppose I could add `zip` as an external package and still get `bazel` to build. But if it's only needed to extract the zip file, it shouldn't be a dependency.

The other issue I encountered is when I have a Spack-built bash in the `PATH`. This causes the `bazel` build to immediately fail with:
```
==> bazel: Executing phase: 'bootstrap'
==> [2020-09-25-23:09:00.253263] '/Users/Adam/.spack/.spack-env/view/bin/bash' './compile.sh'
shell-init: error retrieving current directory: getcwd: cannot access parent directories: Bad file descriptor
chdir: error retrieving current directory: getcwd: cannot access parent directories: Bad file descriptor
```
I have no idea how to fix our bash package, but things work with the system `/bin/bash`.