### PR TITLE
bash: add ssh flag

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -61,20 +61,16 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         spec = self.spec
 
-        args = [
+        return [
+            # https://github.com/Homebrew/legacy-homebrew/pull/23234
+            # https://trac.macports.org/ticket/40603
+            'CFLAGS=-DSSH_SOURCE_BASHRC',
+            'LIBS=' + spec['ncurses'].libs.link_flags,
             '--with-curses',
             '--enable-readline',
             '--with-installed-readline',
             '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix),
-            'LIBS=' + spec['ncurses'].libs.link_flags,
         ]
-
-        # https://github.com/Homebrew/legacy-homebrew/pull/23234
-        # https://trac.macports.org/ticket/40603
-        if 'platform=darwin' in spec:
-            args.append('CFLAGS=-DSSH_SOURCE_BASHRC')
-
-        return args
 
     def check(self):
         make('tests')

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -61,13 +61,20 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         spec = self.spec
 
-        return [
-            'LIBS=' + spec['ncurses'].libs.link_flags,
+        args = [
             '--with-curses',
             '--enable-readline',
             '--with-installed-readline',
             '--with-libiconv-prefix={0}'.format(spec['iconv'].prefix),
+            'LIBS=' + spec['ncurses'].libs.link_flags,
         ]
+
+        # https://github.com/Homebrew/legacy-homebrew/pull/23234
+        # https://trac.macports.org/ticket/40603
+        if 'platform=darwin' in spec:
+            args.append('CFLAGS=-DSSH_SOURCE_BASHRC')
+
+        return args
 
     def check(self):
         make('tests')


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Apple Clang 12.0.0.

It's not entirely clear to me why this is needed, but both Homebrew and Macports add it, so why not...