### PR TITLE
py-google: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-google/package.py
+++ b/var/spack/repos/builtin/packages/py-google/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyGoogle(PythonPackage):
+    """Python bindings to the Google search engine."""
+
+    homepage = "http://breakingcode.wordpress.com/"
+    url      = "https://pypi.io/packages/source/g/google/google-3.0.0.tar.gz"
+
+    version('3.0.0', sha256='143530122ee5130509ad5e989f0512f7cb218b2d4eddbafbad40fd10e8d8ccbe')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-beautifulsoup4', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.8.5 and Apple Clang 12.0.0.