### PR TITLE
py-hiredis: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-hiredis/package.py
+++ b/var/spack/repos/builtin/packages/py-hiredis/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyHiredis(PythonPackage):
+    """Python extension that wraps protocol parsing code in hiredis.
+    It primarily speeds up parsing of multi bulk replies."""
+
+    homepage = "https://github.com/redis/hiredis-py"
+    url      = "https://pypi.io/packages/source/h/hiredis/hiredis-1.1.0.tar.gz"
+
+    version('1.1.0', sha256='996021ef33e0f50b97ff2d6b5f422a0fe5577de21a8873b58a779a5ddd1c3132')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.8.5 and Apple Clang 12.0.0.