### PR TITLE
py-nvidia-ml-py3: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-nvidia-ml-py3/package.py
+++ b/var/spack/repos/builtin/packages/py-nvidia-ml-py3/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyNvidiaMlPy3(PythonPackage):
+    """Python Bindings for the NVIDIA Management Library."""
+
+    homepage = "http://www.nvidia.com/"
+    url      = "https://pypi.io/packages/source/n/nvidia-ml-py3/nvidia-ml-py3-7.352.0.tar.gz"
+
+    version('7.352.0', sha256='390f02919ee9d73fe63a98c73101061a6b37fa694a793abf56673320f1f51277')


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.8.5 and Apple Clang 12.0.0.