### PR TITLE
py-opencensus-context: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-opencensus-context/package.py
+++ b/var/spack/repos/builtin/packages/py-opencensus-context/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyOpencensusContext(Package):
+    """OpenCensus Runtime Context."""
+
+    homepage = "https://github.com/census-instrumentation/opencensus-python/tree/master/context/opencensus-context"
+    url      = "https://pypi.io/packages/py2.py3/o/opencensus-context/opencensus_context-0.1.1-py2.py3-none-any.whl"
+
+    version('0.1.1', sha256='1a3fdf6bec537031efcc93d51b04f1edee5201f8c9a0c85681d63308b76f5702', expand=False)
+
+    extends('python')
+    depends_on('py-pip', type='build')
+    depends_on('py-contextvars', when='^python@3.6.0:3.6.999', type=('build', 'run'))
+
+    def install(self, spec, prefix):
+        pip = which('pip')
+        pip('install', self.stage.archive_file, '--prefix={0}'.format(prefix))


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.8.5 and Apple Clang 12.0.0.

Newer versions distribute tarballs we can build from. Unfortunately, the latest version of `py-opencensus` requires this exact version of `py-opencensus-context`, so until a new release comes out we're stuck with building from wheel.