### PR TITLE
py-opencensus: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-opencensus/package.py
+++ b/var/spack/repos/builtin/packages/py-opencensus/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyOpencensus(PythonPackage):
+    """A stats collection and distributed tracing framework."""
+
+    homepage = "https://github.com/census-instrumentation/opencensus-python"
+    url      = "https://pypi.io/packages/source/o/opencensus/opencensus-0.7.10.tar.gz"
+
+    version('0.7.10', sha256='2921e3e570cfadfd123cd8e3636a405031367fddff74c55d3fe627a4cf8b981c')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-opencensus-context@0.1.1', type=('build', 'run'))
+    depends_on('py-google-api-core@1.0:1.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.6 with Python 3.8.5 and Apple Clang 12.0.0.