### PR TITLE
itstool :Installation is not possible due to lack of itstool dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/itstool/package.py
+++ b/var/spack/repos/builtin/packages/itstool/package.py
@@ -18,3 +18,5 @@ class Itstool(AutotoolsPackage):
     version('2.0.1', sha256='ec6b1b32403cbe338b6ac63c61ab1ecd361f539a6e41ef50eae56a4f577234d1')
     version('2.0.0', sha256='14708111b11b4a70e240e3b404d7a58941e61dbb5caf7e18833294d654c09169')
     version('1.2.0', sha256='46fed63fb89c72dbfc03097b4477084ff05ad6f171212d8f1f1546ea543978aa')
+
+    depends_on('libxml2+python', type=('build', 'run'))


### PR DESCRIPTION
 The installation fails with the following error.

```
   15    checking for python module libxml2... not found
  >> 16    configure: error: Python module libxml2 is needed to run this packag
```