### PR TITLE
comgr is linked to by libamdhip64, so it should be a link dep

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -29,7 +29,7 @@ class Hip(CMakePackage):
         depends_on('hip-rocclr@' + ver,  type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)


### PR DESCRIPTION
Ping @arjun-raj-kuppala, in my case `rocfft-kernel-generator` errored during the build of rocfft@3.8.0. In case you wanna debug these kinds of things too, try using `spack install libtree`, can be useful:

![Screenshot from 2020-09-28 13-20-11](https://user-images.githubusercontent.com/194764/94426097-5ac7eb80-018d-11eb-985b-8ecfabc1f793.png)
