### PR TITLE
macOS CI: replace jupyter with jupyterlab

### DIFF
--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -46,8 +46,7 @@ jobs:
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
-        spack config add packages:opengl:paths:opengl@4.1:/usr/X11R6
-        spack install -v --fail-fast py-jupyter %apple-clang
+        spack install -v --fail-fast py-jupyterlab %apple-clang
 
   install_scipy_clang:
     name: scipy, mpl, pd


### PR DESCRIPTION
Our macOS CI has been failing for months now. Repeated attempts have been made to get Qt to pick up OpenGL but nothing has worked. For now, I propose we replace `py-jupyter` with `py-jupyterlab` (or `py-notebook`) to get the tests working again. This also significantly cuts down on the 6+ hr build times.

@ax3l 

Closes #18370 
Closes #18684