### PR TITLE
New Package:  py-hepunits and py-particle

### DIFF
--- a/var/spack/repos/builtin/packages/py-hepunits/package.py
+++ b/var/spack/repos/builtin/packages/py-hepunits/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyHepunits(PythonPackage):
+    """Units and constants in the HEP system of units."""
+
+    git = "https://github.com/scikit-hep/hepunits.git"
+    url = "https://pypi.io/packages/source/h/hepunits/hepunits-1.2.1.tar.gz"
+    homepage = "https://github.com/scikit-hep/hepunits"
+
+    maintainers = ['vvolkl']
+
+    version('master', branch='master')
+    version('1.2.1', sha256='b05b0dda32bf797806d506d7508d4eb23b78f34d67bbba9348a2b4a9712666fa')
+
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build')
+    depends_on('py-toml', type='build')

--- a/var/spack/repos/builtin/packages/py-particle/package.py
+++ b/var/spack/repos/builtin/packages/py-particle/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyParticle(PythonPackage):
+    """Particle provides a pythonic interface to the Particle Data Group (PDG)
+    particle data tables and particle identification codes, with extended
+    particle information and extra goodies."""
+
+    git = "https://github.com/scikit-hep/particle.git"
+    url = "https://pypi.io/packages/source/p/particle/particle-0.11.0.tar.gz"
+    homepage = "https://github.com/scikit-hep/particle"
+
+    maintainers = ['vvolkl']
+
+    version('master', branch='master')
+    version('0.11.0', sha256='e90dc36c8b7d7431bd14ee5a28486d28b6c0708555845d1d7bdf59a165405f12')
+
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    depends_on('py-attrs@19.2.0:', type=('build', 'run'))
+    depends_on('py-hepunits@1.2.0:', type=('build', 'run'))
+    depends_on('py-importlib-resources@1.0:', when='^python@:3.6', type=('build', 'run'))
+
+    depends_on('py-enum34@1.1:', when='^python@:3.3', type=('build', 'run'))
+    depends_on("py-typing@3.7:", when='^python@:3.4', type=('build', 'run'))


### PR DESCRIPTION
I'm using the github tags instead of the source tarballs because I hit a "version could not be detected" error due to scm (see below) -- other python package recipes using scm in spack seem to be doing fine. @adamjstewart do you maybe know how best to solve this?

```
==> py-hepunits: Executing phase: 'build'
==> [2020-09-28-20:19:06.837306] '/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/python-3.7.8-i2m3ookul64ub5to5vhrdvxl3tbl5ttx/bin/python3.7' '-s' 'setup.py' '--no-user-cfg' 'build'
Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    setup()
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-50.1.0-brlja4gbe7o3phk7yijrr52kyngewzcw/lib/python3.7/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/python-3.7.8-i2m3ookul64ub5to5vhrdvxl3tbl5ttx/lib/python3.7/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-50.1.0-brlja4gbe7o3phk7yijrr52kyngewzcw/lib/python3.7/site-packages/setuptools/dist.py", line 424, in __init__
    k: v for k, v in attrs.items()
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/python-3.7.8-i2m3ookul64ub5to5vhrdvxl3tbl5ttx/lib/python3.7/distutils/dist.py", line 292, in __init__
    self.finalize_options()
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-50.1.0-brlja4gbe7o3phk7yijrr52kyngewzcw/lib/python3.7/site-packages/setuptools/dist.py", line 695, in finalize_options
    ep(self)
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-scm-4.1.2-t2c2yolgdl3nlsi6uxt5jwsdhgkfmcsu/lib/python3.7/site-packages/setuptools_scm/integration.py", line 48, in infer_version
    dist.metadata.version = _get_version(config)
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-scm-4.1.2-t2c2yolgdl3nlsi6uxt5jwsdhgkfmcsu/lib/python3.7/site-packages/setuptools_scm/__init__.py", line 148, in _get_version
    parsed_version = _do_parse(config)
  File "/cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/py-setuptools-scm-4.1.2-t2c2yolgdl3nlsi6uxt5jwsdhgkfmcsu/lib/python3.7/site-packages/setuptools_scm/__init__.py", line 118, in _do_parse
    "use git+https://github.com/user/proj.git#egg=proj" % config.absolute_root
LookupError: setuptools-scm was unable to detect version for '/tmp/vavolkl/spack-stage/spack-stage-py-hepunits-1.2.1-qdqkgrokyhrtqn275jx7q3l5glsm6hmm/spack-src'.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
```  