### PR TITLE
Slate package: resolves missing header issue

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -24,13 +24,9 @@ class Slate(Package):
     variant('cuda',   default=True, description='Build with CUDA support.')
     variant('mpi',    default=True, description='Build with MPI support.')
     variant('openmp', default=True, description='Build with OpenMP support.')
-    variant('blas',   default='openblas', description='Select BLAS implementation', 
-            values=('openblas', 'essl', 'mkl'), multi=False)
 
     depends_on('scalapack')
-    depends_on('intel-mkl', when='blas=mkl')
-    depends_on('essl',      when='blas=essl')
-    depends_on('openblas',  when='blas=openblas')
+    depends_on('blas')
     depends_on('cuda@9:10', when='+cuda')
     depends_on('mpi',       when='+mpi')
 
@@ -46,10 +42,20 @@ class Slate(Package):
             comp_cxx = 'mpicxx'
             comp_for = 'mpif90'
 
+        if '^openblas' in spec:
+            blas = 'openblas'
+        elif '^intel-mkl' in spec:
+            blas = 'mkl'
+        elif '^essl' in spec:
+            blas = 'essl'
+        else:
+            raise InstallError('Supports only BLAS provider openblas, intel-mkl, or essl')
+
+
         make('all', 'install',
              'prefix=' + prefix,
              'mpi=' + f_mpi,
-             'blas=' + spec.variants['blas'].value,
+             'blas=' + blas,
              'cuda=' + f_cuda,
              'openmp=' + f_omp,
              'c_api=1',

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -49,8 +49,8 @@ class Slate(Package):
         elif '^essl' in spec:
             blas = 'essl'
         else:
-            raise InstallError('Supports only BLAS provider openblas, intel-mkl, or essl')
-
+            raise InstallError('Supports only BLAS provider '
+                               'openblas, intel-mkl, or essl')
 
         make('all', 'install',
              'prefix=' + prefix,

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -46,7 +46,7 @@ class Slate(Package):
             comp_cxx = 'mpicxx'
             comp_for = 'mpif90'
 
-        make('mpi=' + f_mpi, 'mkl=1', 'cuda=' + f_cuda, 'openmp=' + f_openmp,
+        make('mpi=' + f_mpi, 'blas=mkl', 'cuda=' + f_cuda, 'openmp=' + f_openmp,
              'CXX=' + comp_cxx, 'FC=' + comp_for)
         install_tree('lib', prefix.lib)
         install_tree('test', prefix.test)

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -27,6 +27,7 @@ class Slate(Package):
     variant('blas',   default='openblas', description='Select BLAS implementation', 
             values=('openblas', 'essl', 'mkl'), multi=False)
 
+    depends_on('bash', type='build')
     depends_on('scalapack')
     depends_on('intel-mkl', when='blas=mkl')
     depends_on('essl',      when='blas=essl')
@@ -47,6 +48,7 @@ class Slate(Package):
             comp_for = 'mpif90'
 
         make('all', 'install',
+             'SHELL=bash',
              'prefix=' + prefix,
              'mpi=' + f_mpi,
              'blas=' + spec.variants['blas'].value,

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -46,13 +46,6 @@ class Slate(Package):
             comp_cxx = 'mpicxx'
             comp_for = 'mpif90'
 
-        make('mpi=' + f_mpi, 'blas=mkl', 'cuda=' + f_cuda, 'openmp=' + f_openmp,
+        make('install', 'prefix=' + prefix, 
+             'mpi=' + f_mpi, 'blas=mkl', 'cuda=' + f_cuda, 'openmp=' + f_openmp,
              'CXX=' + comp_cxx, 'FC=' + comp_for)
-        install_tree('lib', prefix.lib)
-        install_tree('test', prefix.test)
-        mkdirp(prefix.include)
-        install('include/slate/slate.hh', prefix.include)
-        install('lapack_api/lapack_slate.hh',
-                prefix.include + "/slate_lapack_api.hh")
-        install('scalapack_api/scalapack_slate.hh',
-                prefix.include + "/slate_scalapack_api.hh")

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -45,14 +45,15 @@ class Slate(MakefilePackage):
                                'openblas, intel-mkl, or essl')
         config = [
             'SHELL=bash',
-            'prefix=' + prefix,
-            'mpi=' + ("1" if '+mpi' in spec else "0"),
-            'cuda=' + ("1" if '+cuda' in spec else "0"),
-            'openmp=' + ("1" if '+openmp' in spec else "0"),
-            'blas=' + blas
+            'prefix=%s' % prefix,
+            'mpi=%i'    % ('+mpi' in spec),
+            'cuda=%i'   % ('+cuda' in spec),
+            'openmp=%i' % ('+openmp' in spec),
+            'blas=%s'   % blas
         ]
         if '+mpi' in spec:
-            config.extend(['CXX=mpicxx', 'FC=mpif90'])
+            config.extend('CXX=' + spec['mpi'].mpicxx)
+            config.extend('FC=' + spec['mpi'].mpifc)
 
         with open('make.inc', 'w') as inc:
             for line in config:

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -52,8 +52,8 @@ class Slate(MakefilePackage):
             'blas=%s'   % blas
         ]
         if '+mpi' in spec:
-            config.extend('CXX=' + spec['mpi'].mpicxx)
-            config.extend('FC=' + spec['mpi'].mpifc)
+            config.append('CXX=' + spec['mpi'].mpicxx)
+            config.append('FC=' + spec['mpi'].mpifc)
 
         with open('make.inc', 'w') as inc:
             for line in config:

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -57,4 +57,3 @@ class Slate(MakefilePackage):
         with open('make.inc', 'w') as inc:
             for line in config:
                 inc.write('{0}\n'.format(line))
-

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -33,10 +33,7 @@ class Slate(MakefilePackage):
 
     conflicts('%gcc@:5')
 
-    @property
-    def make_args(self):
-        spec = self.spec
-
+    def edit(self, spec, prefix):
         if '^openblas' in spec:
             blas = 'openblas'
         elif '^intel-mkl' in spec:
@@ -46,20 +43,18 @@ class Slate(MakefilePackage):
         else:
             raise InstallError('Supports only BLAS provider '
                                'openblas, intel-mkl, or essl')
-        args = [
+        config = [
             'SHELL=bash',
-            'prefix=' + self.prefix,
+            'prefix=' + prefix,
             'mpi=' + ("1" if '+mpi' in spec else "0"),
             'cuda=' + ("1" if '+cuda' in spec else "0"),
             'openmp=' + ("1" if '+openmp' in spec else "0"),
             'blas=' + blas
         ]
         if '+mpi' in spec:
-            args.extend(['CXX=mpicxx', 'FC=mpif90'])
-        return args
+            config.extend(['CXX=mpicxx', 'FC=mpif90'])
 
-    def build(self, spec, prefix):
-        make(*self.make_args)
+        with open('make.inc', 'w') as inc:
+            for line in config:
+                inc.write('{0}\n'.format(line))
 
-    def install(self, spec, prefix):
-        make('install', *self.make_args)


### PR DESCRIPTION
This fixes https://github.com/spack/spack/issues/18978

It also:

- removes the deprecated variant 'mkl' and replaces it with 'blas'
- cleans up some formatting and unnecessary build environment setup
- adds a required dependency on scalapack