### PR TITLE
WIP: add oneapi compilers

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -633,7 +633,7 @@ class IntelPackage(PackageBase):
         vars_file_info_for = {
             # key (usu. spack package name) -> [rel_path, component_suite_dir]
             # Extension note: handle additions by Spack name or ad-hoc keys.
-            '@oneapi':               ['env/vars',                   'compiler/latest'],
+            '@oneapi':               ['env/vars',     'compiler/latest'],
             '@early_compiler':       ['bin/compilervars',           None],
             'intel-parallel-studio': ['bin/psxevars', 'parallel_studio_xe'],
             'intel':                 ['bin/compilervars',           None],
@@ -1147,7 +1147,7 @@ class IntelPackage(PackageBase):
 
     def _oneapi_install(self, spec):
         return spec.versions.lowest() >= Version('2021')
-        
+
     def configure(self, spec, prefix):
         '''Generates the silent.cfg file to pass to installer.sh.
 
@@ -1239,10 +1239,13 @@ class IntelPackage(PackageBase):
 
         # perform
         if self._oneapi_install(spec):
-            install_script('./l_HPCKit_b_%s_offline.sh' % spec.versions.lowest(),
+            install_script('./l_HPCKit_b_%s_offline.sh' %
+                           spec.versions.lowest(),
                            '-s', '-a', '-s', '--action', 'install',
                            '--eula', 'accept',
-                           '--components', 'intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler',
+                           '--components',
+                           ('intel.oneapi.lin.dpcpp-cpp-compiler-pro'
+                            ':intel.oneapi.lin.ifort-compiler'),
                            '--install-dir', prefix)
         else:
             install_script('--silent', 'silent.cfg')

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -14,6 +14,7 @@ class Intel(IntelPackage):
 
     # Same as in ../intel-parallel-studio/package.py, Composer Edition,
     # but the version numbering in Spack differs.
+    version('2021.1.9.2205',       sha256='8926a3001e61edbb293cb607beb8eb3a3511330a4625c8f3b1b51603426f121a', url='https://registrationcenter-download.intel.com/akdlm/irc_nas/16949/l_HPCKit_b_2021.1.9.2205_offline.sh', expand=False)
     version('20.0.2',              sha256='42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd', url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz')
     version('20.0.1',              sha256='26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e', url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz')
     version('20.0.0',              sha256='9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae', url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz')


### PR DESCRIPTION
Add support for installing icc/icpc/ifort from oneapi installer
Differences versus PSXE:
* no license file needed
* directory structure and environment variable setup has changed
* installer does not need a config file, you can pass the required arguments on the command line

I am new to spack, so not sure if I did things the best way. Feel free to use this as a guide on what has to change and redo if you prefer.