### PR TITLE
CUDA 11.1.0

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -103,7 +103,7 @@ class CudaPackage(PackageBase):
     conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
     conflicts('%pgi@:17,20:',
               when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
-    conflicts('%pgi@:17,20.2:',
+    conflicts('%pgi@:17,21:',
               when='+cuda ^cuda@11.0.2:11.1.0' + arch_platform)
     conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
     conflicts('%clang@:3.7,4:',

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -26,7 +26,7 @@ class CudaPackage(PackageBase):
         '50', '52', '53',
         '60', '61', '62',
         '70', '72', '75',
-        '80',
+        '80', '86'
     ]
 
     # FIXME: keep cuda and cuda_arch separate to make usage easier until
@@ -77,6 +77,7 @@ class CudaPackage(PackageBase):
     depends_on('cuda@10.0:',    when='cuda_arch=75')
 
     depends_on('cuda@11.0:',    when='cuda_arch=80')
+    depends_on('cuda@11.1:',    when='cuda_arch=86')
 
     # There are at least three cases to be aware of for compiler conflicts
     # 1. Linux x86_64

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -95,6 +95,7 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89' + arch_platform)
     conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
     conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27' + arch_platform)
     conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5' + arch_platform)
     conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8' + arch_platform)
@@ -102,7 +103,8 @@ class CudaPackage(PackageBase):
     conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
     conflicts('%pgi@:17,20:',
               when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
-    conflicts('%pgi@:17,20.2:', when='+cuda ^cuda@11.0.2' + arch_platform)
+    conflicts('%pgi@:17,20.2:',
+              when='+cuda ^cuda@11.0.2:11.1.0' + arch_platform)
     conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
     conflicts('%clang@:3.7,4:',
               when='+cuda ^cuda@8.0:9.0' + arch_platform)
@@ -114,7 +116,9 @@ class CudaPackage(PackageBase):
     conflicts('%clang@:3.7,8.1:',
               when='+cuda ^cuda@10.1.105:10.1.243' + arch_platform)
     conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89' + arch_platform)
-    conflicts('%clang@:5,10:', when='+cuda ^cuda@11.0.2' + arch_platform)
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
 
     # x86_64 vs. ppc64le differ according to NVidia docs
     # Linux ppc64le compiler conflicts from Table from the docs below:
@@ -132,6 +136,7 @@ class CudaPackage(PackageBase):
     # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
     conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
     conflicts('%pgi', when='+cuda ^cuda@:8' + arch_platform)
     conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185' + arch_platform)
     conflicts('%pgi@:17', when='+cuda ^cuda@:10' + arch_platform)
@@ -141,7 +146,9 @@ class CudaPackage(PackageBase):
     conflicts('%clang@7:', when='+cuda ^cuda@10.0.130' + arch_platform)
     conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105' + arch_platform)
     conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%clang@:5,10.0:', when='+cuda ^cuda@11.0.2' + arch_platform)
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
 
     # Intel is mostly relevant for x86_64 Linux, even though it also
     # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
@@ -156,12 +163,12 @@ class CudaPackage(PackageBase):
     conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
     conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
     conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
-    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.0.2')
+    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
 
     # XL is mostly relevant for ppc64le Linux
     conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
     conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
-    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.0.2')
+    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
 
     # Mac OS X
     # platform = ' platform=darwin'

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -23,6 +23,10 @@ import llnl.util.tty as tty
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.1.0': {
+        'Linux-aarch64': ('878cbd36c5897468ef28f02da50b2f546af0434a8a89d1c724a4d2013d6aa993', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_sbsa.run'),
+        'Linux-x86_64': ('858cbab091fde94556a249b9580fadff55a46eafbcb4d4a741d2dcd358ab94a5', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run'),
+        'Linux-ppc64le': ('a561e6f7f659bc4100e4713523b0b8aad6b36aa77fac847f6423e7780c750064', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_ppc64le.run')},
     '11.0.2': {
         'Linux-aarch64': ('23851e30f7c47a1baad92891abde0adbc783de5962c7480b9725198ceacda4a0', 'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_sbsa.run'),
         'Linux-x86_64': ('48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1', 'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'),


### PR DESCRIPTION
Add the latest CUDA release (11.1.0) and update its compiler conflicts.

https://gist.github.com/ax3l/9489132

cc @svenevs 

- [x] rebase after #19035 was merged.