### PR TITLE
CudaPackage: clang -x cuda

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -38,6 +38,16 @@ class CudaPackage(PackageBase):
             description='CUDA architecture',
             values=spack.variant.any_combination_of(*cuda_arch_values))
 
+    variant('cudacxx', default='nvcc',
+            values=('nvcc', 'clang'),
+            multi=False,
+            description='Device compiler for the CUDA backend')
+
+    # note: for NVCC, we can set -allow-unsupported-compiler in 10.2+
+    variant('cuda_check_cxx', default=True,
+            description='Check via Spack conflicts if the host and device '
+                        'compiler are a supported combination')
+
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-examples
     # https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code
     @staticmethod
@@ -88,38 +98,62 @@ class CudaPackage(PackageBase):
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
+    _cuda_nvcc = '+cuda +cuda_check_cxx cudacxx=nvcc'
+    _nvcc_msg = 'this version of CUDA nvcc does not officially support ' + \
+                'the selected host compiler'
     arch_platform = ' target=x86_64: platform=linux'
-    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5' + arch_platform)
-    conflicts('%gcc@6:', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27' + arch_platform)
-    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5' + arch_platform)
-    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8' + arch_platform)
-    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1' + arch_platform)
-    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
-    conflicts('%pgi@:17,20:',
-              when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
-    conflicts('%pgi@:17,21:',
-              when='+cuda ^cuda@11.0.2:11.1.0' + arch_platform)
-    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
-    conflicts('%clang@:3.7,4:',
-              when='+cuda ^cuda@8.0:9.0' + arch_platform)
-    conflicts('%clang@:3.7,4.1:',
-              when='+cuda ^cuda@9.1' + arch_platform)
-    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2' + arch_platform)
-    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105' + arch_platform)
-    conflicts('%clang@:3.7,8.1:',
-              when='+cuda ^cuda@10.1.105:10.1.243' + arch_platform)
-    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+    conflicts('%gcc@5:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:7.5' + arch_platform)
+    conflicts('%gcc@6:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:8' + arch_platform)
+    conflicts('%gcc@7:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.1' + arch_platform)
+    conflicts('%gcc@8:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.0.130' + arch_platform)
+    conflicts('%gcc@9:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.2.89' + arch_platform)
+    conflicts('%gcc@:4', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@11.0.2:' + arch_platform)
+    conflicts('%gcc@10:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.0.2' + arch_platform)
+    conflicts('%gcc@11:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0' + arch_platform)
+    conflicts('%pgi@:14.8', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:7.0.27' + arch_platform)
+    conflicts('%pgi@:15.3,15.5:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@7.5' + arch_platform)
+    conflicts('%pgi@:16.2,16.0:16.3', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@8' + arch_platform)
+    conflicts('%pgi@:15,18:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@9.0:9.1' + arch_platform)
+    conflicts('%pgi@:16,19:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@9.2.88:10' + arch_platform)
+    conflicts('%pgi@:17,20:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.1.105:10.2.89' + arch_platform)
+    conflicts('%pgi@:17,21:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@11.0.2:11.1.0' + arch_platform)
+    conflicts('%clang@:3.4', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:7.5' + arch_platform)
+    conflicts('%clang@:3.7,4:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@8.0:9.0' + arch_platform)
+    conflicts('%clang@:3.7,4.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@9.1' + arch_platform)
+    conflicts('%clang@:3.7,5.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@9.2' + arch_platform)
+    conflicts('%clang@:3.7,6.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.0.130' + arch_platform)
+    conflicts('%clang@:3.7,7.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.1.105' + arch_platform)
+    conflicts('%clang@:3.7,8.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.1.105:10.1.243' + arch_platform)
+    conflicts('%clang@:3.2,9:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.2.89' + arch_platform)
+    conflicts('%clang@:5', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@11.0.2:' + arch_platform)
+    conflicts('%clang@10:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.0.2' + arch_platform)
+    conflicts('%clang@11:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0' + arch_platform)
 
     # x86_64 vs. ppc64le differ according to NVidia docs
     # Linux ppc64le compiler conflicts from Table from the docs below:
@@ -131,45 +165,109 @@ class CudaPackage(PackageBase):
 
     arch_platform = ' target=ppc64le: platform=linux'
     # information prior to CUDA 9 difficult to find
-    conflicts('%gcc@6:', when='+cuda ^cuda@:9' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243' + arch_platform)
+    conflicts('%gcc@6:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9' + arch_platform)
+    conflicts('%gcc@8:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.0.130' + arch_platform)
+    conflicts('%gcc@9:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.1.243' + arch_platform)
     # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185' + arch_platform)
-    conflicts('%pgi@:17', when='+cuda ^cuda@:10' + arch_platform)
-    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176' + arch_platform)
-    conflicts('%clang@5:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%clang@6:', when='+cuda ^cuda@:9.2' + arch_platform)
-    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105' + arch_platform)
-    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+    conflicts('%gcc@:4', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@11.0.2:' + arch_platform)
+    conflicts('%gcc@10:', msg=_nvcc_msg,
+              when=_cuda_nvcc + ' ^cuda@:11.0.2' + arch_platform)
+    conflicts('%gcc@11:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0' + arch_platform)
+    conflicts('%pgi', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:8' + arch_platform)
+    conflicts('%pgi@:16', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.1.185' + arch_platform)
+    conflicts('%pgi@:17', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10' + arch_platform)
+    conflicts('%clang@4:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.0.176' + arch_platform)
+    conflicts('%clang@5:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.1' + arch_platform)
+    conflicts('%clang@6:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.2' + arch_platform)
+    conflicts('%clang@7:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@10.0.130' + arch_platform)
+    conflicts('%clang@7.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.1.105' + arch_platform)
+    conflicts('%clang@8.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.2.89' + arch_platform)
+    conflicts('%clang@:5', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@11.0.2:' + arch_platform)
+    conflicts('%clang@10:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.0.2' + arch_platform)
+    conflicts('%clang@11:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0' + arch_platform)
 
     # Intel is mostly relevant for x86_64 Linux, even though it also
     # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
-    conflicts('%intel@:11.0', when='+cuda ^cuda@:3.1')
-    conflicts('%intel@:12.0', when='+cuda ^cuda@5.5:')
-    conflicts('%intel@:13.0', when='+cuda ^cuda@6.0:')
-    conflicts('%intel@:13.2', when='+cuda ^cuda@6.5:')
-    conflicts('%intel@:14.9', when='+cuda ^cuda@7:')
+    conflicts('%intel@:11.0', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:3.1')
+    conflicts('%intel@:12.0', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@5.5:')
+    conflicts('%intel@:13.0', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@6.0:')
+    conflicts('%intel@:13.2', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@6.5:')
+    conflicts('%intel@:14.9', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@7:')
     # Intel 15.x is compatible with CUDA 7 thru current CUDA
-    conflicts('%intel@16.0:', when='+cuda ^cuda@:8.0.43')
-    conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
-    conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
-    conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
-    conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
-    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
+    conflicts('%intel@16.0:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:8.0.43')
+    conflicts('%intel@17.0:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:8.0.60')
+    conflicts('%intel@18.0:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.9')
+    conflicts('%intel@19.0:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.0')
+    conflicts('%intel@19.1:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:10.1')
+    conflicts('%intel@19.2:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0')
 
     # XL is mostly relevant for ppc64le Linux
-    conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
-    conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
-    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
+    conflicts('%xl@:12,14:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:9.1')
+    conflicts('%xl@:12,14:15,17:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@9.2')
+    conflicts('%xl@:12,17:', msg=_nvcc_msg,
+              when=_cuda_nvcc + '^cuda@:11.1.0')
+
+    # clang -x cuda
+    #   only works paired with clang
+    _clangcuda_check = '+cuda +cuda_check_cxx cudacxx=clang'
+    _cudacxx_clang_mix_msg = 'cudacxx=clang must be paired with %clang'
+    conflicts('%xl', msg=_cudacxx_clang_mix_msg, when=_clangcuda_check)
+    conflicts('%gcc', msg=_cudacxx_clang_mix_msg, when=_clangcuda_check)
+    conflicts('%pgi', msg=_cudacxx_clang_mix_msg, when=_clangcuda_check)
+    conflicts('%intel', msg=_cudacxx_clang_mix_msg, when=_clangcuda_check)
+    conflicts('%xl', msg=_cudacxx_clang_mix_msg, when=_clangcuda_check)
+
+    # and clang -x cuda has its own supported CUDA releases
+    #   https://gist.github.com/ax3l/9489132#clang--x-cuda
+    _clangcuda_check = '+cuda +cuda_check_cxx cudacxx=clang'
+    _cudacxx_clang_ver_msg = 'Combination of clang +x cuda and CUDA ' + \
+                             'version are not officially supported'
+    conflicts('%clang', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@:6.99')
+    conflicts('%clang@:3.8', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check)
+    conflicts('%clang@:5.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@9.0:')
+    conflicts('%clang@:6.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@9.1:')
+    conflicts('%clang@:7.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@10.0:')
+    conflicts('%clang@:8.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@10.1:')
+    conflicts('%clang@:10.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@10.2:')
+    conflicts('%clang@:11.0', msg=_cudacxx_clang_ver_msg,
+              when=_clangcuda_check + '^cuda@11.1:')
 
     # Mac OS X
     # platform = ' platform=darwin'
@@ -180,7 +278,8 @@ class CudaPackage(PackageBase):
     # `clang-apple@x.y.z as a possible fix.
     # Compiler conflicts will be eventual taken from here:
     # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#abstract
-    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2:')
+    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2:',
+              msg='macOS support has been dropped in CUDA 11.0 and newer')
 
     # Make sure cuda_arch can not be used without +cuda
     for value in cuda_arch_values:


### PR DESCRIPTION
Support a new `cudacxx` variant with default to `nvcc` and optional `clang` as an alternative CUDA device compiler.
Clang as device compiler only pairs with clang as host compiler.

Conflicts for each device compiler are different.
Don't despair, we got you covered: https://gist.github.com/ax3l/9489132#clang--x-cuda

Add an additional variant to skip all host-device compiler support checks: `+cuda_check_cxx`/`~cuda_check_cxx`

Note: downstream packages need to implement their own logic (CMake flags, etc.) for a set variant `cudacxx=clang` (for now). In the future this could be unified, when relying on CMake 3.18+.
Note: the `%clang` used needs to have been built with cuda support. (E.g. the clang shipped on Ubuntu/Debian does that.) Not sure if we should to a quick usability check or if that is the job of each individual project (e.g. in CMake scripts).

cc @svenevs @alalazo @DavidPoliakoff @scothalverson @JulienLoiseau @adamjstewart @jjwilke

- [x] rebase after #19036
- [x] check if some packages already have a `cudacxx` variant
- [ ] add the Clang-specific SM support check as well or just roll with the general conflicts from the CUDA toolkit?
- [ ] test test test :), e.g. Kokkos folks in #18001 and [PIConGPU](https://github.com/ComputationalRadiationPhysics/spack-repo/blob/348e1443150d7134937746b33de3531db31dc340/packages/picongpu/package.py) / Alpaka and RAJA and WarpX / AMReX