### PR TITLE
optipng: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/optipng/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/optipng/for_aarch64.patch
@@ -1,0 +1,11 @@
+--- spack-src/configure.bak	2017-12-27 20:57:00.000000000 +0900
++++ spack-src/configure	2020-09-28 17:04:51.030223443 +0900
+@@ -193,7 +193,7 @@
+ if test "$gccish" -ne 0
+ then
+     CC="${CC-$cc}"
+-    CFLAGS="${CFLAGS--O2 -Wall -Wextra}"
++    CFLAGS="${CFLAGS--O2 -Wall -Wextra -DPNG_ARM_NEON_OPT=0}"
+ else
+     CC="${CC-cc}"
+     CFLAGS="${CFLAGS--O}"

--- a/var/spack/repos/builtin/packages/optipng/package.py
+++ b/var/spack/repos/builtin/packages/optipng/package.py
@@ -18,4 +18,5 @@ class Optipng(AutotoolsPackage, SourceforgePackage):
     sourceforge_mirror_path = "optipng/optipng-0.7.7.tar.gz"
 
     version('0.7.7', sha256='4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452')
+    # See https://github.com/imagemin/optipng-bin/issues/97
     patch('for_aarch64.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/optipng/package.py
+++ b/var/spack/repos/builtin/packages/optipng/package.py
@@ -18,3 +18,4 @@ class Optipng(AutotoolsPackage, SourceforgePackage):
     sourceforge_mirror_path = "optipng/optipng-0.7.7.tar.gz"
 
     version('0.7.7', sha256='4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452')
+    patch('for_aarch64.patch', when='target=aarch64:')


### PR DESCRIPTION
I modified it with reference to the following issues.
https://github.com/imagemin/optipng-bin/issues/97

The configure file could not specify the environment variable CFLAGS as a parameter.
./configure: error: unknown option: CFLAGS=-DPNG_ARM_NEON_OPT=0

I modify the configure file with a patch file.