### PR TITLE
Trilinos: restrict SuperLU-dist version

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -352,6 +352,7 @@ class Trilinos(CMakePackage):
     depends_on('superlu-dist', when='+superlu-dist')
     depends_on('superlu-dist@:4.3', when='@11.14.1:12.6.1+superlu-dist')
     depends_on('superlu-dist@4.4:5.3', when='@12.6.2:12.12.1+superlu-dist')
+    depends_on('superlu-dist@5.4:6.2.0', when='@12.12.2:13.0+superlu-dist')
     depends_on('superlu-dist@develop', when='@develop+superlu-dist')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0+superlu-dist')
     depends_on('superlu+pic@4.3', when='+superlu')


### PR DESCRIPTION
SuperLU v6.3.0 changes the name of numerous structures, causing errors
in Amesos up through Trilinos 13.

```
packages/amesos/src/Amesos_Superludist.cpp:50:3: error: 'ScalePermstruct_t' does not name a type; did you mean 'dScalePermstruct_t'?
packages/amesos/src/Amesos_Superludist.cpp:51:3: error: 'LUstruct_t' does not name a type; did you mean 'dLUstruct_t'?
packages/amesos/src/Amesos_Superludist.cpp:52:3: error: 'SOLVEstruct_t' does not name a type; did you mean 'dSOLVEstruct_t'?
packages/amesos/src/Amesos_Superludist.cpp:166:47: error: 'class Amesos_Superlu_Pimpl' has no member named 'ScalePermstruct_'
packages/amesos/src/Amesos_Superludist.cpp:166:5: error: 'ScalePermstructFree' was not declared in this scope
packages/amesos/src/Amesos_Superludist.cpp:167:83: error: 'class Amesos_Superlu_Pimpl' has no member named 'LUstruct_'
packages/amesos/src/Amesos_Superludist.cpp:167:5: error: 'Destroy_LU' was not declared in this scope
packages/amesos/src/Amesos_Superludist.cpp:168:40: error: 'class Amesos_Superlu_Pimpl' has no member named 'LUstruct_'
packages/amesos/src/Amesos_Superludist.cpp:168:5: error: 'LUstructFree' was not declared in this scope
packages/amesos/src/Amesos_Superludist.cpp:170:76: error: 'class Amesos_Superlu_Pimpl' has no member named 'SOLVEstruct_'
packages/amesos/src/Amesos_Superludist.cpp:426:47: error: 'class Amesos_Superlu_Pimpl' has no member named 'ScalePermstruct_'
packages/amesos/src/Amesos_Superludist.cpp:426:5: error: 'ScalePermstructFree' was not declared in this scope
```