### PR TITLE
Support tests in developer build.

### DIFF
--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -102,7 +102,6 @@ def dev_build(self, args):
     if args.no_checksum:
         spack.config.set('config:checksum', False, scope='command_line')
 
-    abstract_specs = spack.cmd.parse_specs(args.spec)
     tests = False
     if args.test == 'all':
         tests = True

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -107,7 +107,7 @@ def dev_build(self, args):
     if args.test == 'all':
         tests = True
     elif args.test == 'root':
-        tests = [spec.name for spec in abstract_specs]
+        tests = [package.name]
 
     package.do_install(
         make_jobs=args.jobs,

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -719,7 +719,7 @@ _spack_deprecate() {
 _spack_dev_build() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet --drop-in -b --before -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --keep-prefix --skip-patch -q --quiet --drop-in -b --before -u --until --clean --dirty --test"
     else
         _all_packages
     fi


### PR DESCRIPTION
When performing a developer build it should be possible to also run the tests, analogous to a regular install. This is useful when using Spack in a CI context where the build process also uses the Spack recipe.