### PR TITLE
mercury: turn off post limit by default to prevent potential deadlocks

### DIFF
--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -68,6 +68,7 @@ class Mercury(CMakePackage):
             '-DBUILD_SHARED_LIBS:BOOL=%s' % variant_bool('+shared'),
             '-DBUILD_TESTING:BOOL=%s' % str(self.run_tests),
             '-DMERCURY_ENABLE_PARALLEL_TESTING:BOOL=%s' % str(parallel_tests),
+            '-DMERCURY_ENABLE_POST_LIMIT:BOOL=OFF',
             '-DMERCURY_USE_BOOST_PP:BOOL=ON',
             '-DMERCURY_USE_CHECKSUMS:BOOL=ON',
             '-DMERCURY_USE_EAGER_BULK:BOOL=ON',


### PR DESCRIPTION
that issue has come up from several ECP middleware use cases. Setting that option to OFF on previous releases to prevent any issues.