### PR TITLE
metis: Ignore pragma omp warnings/errors with %intel

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -55,6 +55,11 @@ class Metis(Package):
     patch('install_gklib_defs_rename.patch', when='@5:')
     patch('gklib_nomisleadingindentation_warning.patch', when='@5: %gcc@6:')
 
+    def setup_build_environment(self, env):
+        # Ignore warnings/errors re unrecognized omp pragmas on %intel
+        if '%intel@14:' in self.spec:
+            env.append_flags('CFLAGS', '-diag-disable 3180')
+
     @when('@5:')
     def patch(self):
         source_path = self.stage.source_path


### PR DESCRIPTION
Should fix issue #14785

It looks like intel compilers generate warnings for omp pragmas when
openmp flag is not given, which due to other flags set get promoted to
errors.

This adds a flag to ignore the pragma omp warnings (icc diagnostic
number 3180 on %intel@14:).  See e.g.
https://community.intel.com/t5/Intel-C-Compiler/ICC-should-not-generate-warning-about-quot-pragma-omp-quot-when/td-p/810081?profile.language=pt