### PR TITLE
buildcache list: add listed specs to database as not installed

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -506,6 +506,12 @@ def install_tarball(spec, args):
 def listspecs(args):
     """list binary packages available from mirrors"""
     specs = bindist.get_specs()
+
+    for spec in specs:
+        in_db = spack.store.db.query(spec, installed=any)
+        if not in_db:
+            spack.store.db.add(spec, spack.store.layout)
+
     if not args.allarch:
         arch = spack.architecture.default_arch().to_spec()
         specs = [s for s in specs if s.satisfies(arch)]
@@ -519,6 +525,7 @@ def listspecs(args):
         if not builds and not args.allarch:
             tty.msg("You can query all available architectures with:",
                     "spack buildcache list --allarch")
+
     display_specs(specs, args, all_headers=True)
 
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -507,10 +507,11 @@ def listspecs(args):
     """list binary packages available from mirrors"""
     specs = bindist.get_specs()
 
-    for spec in specs:
-        in_db = spack.store.db.query(spec, installed=any)
-        if not in_db:
-            spack.store.db.add(spec, spack.store.layout)
+    with spack.store.db.write_transaction():
+        for spec in specs:
+            in_db = spack.store.db.query(spec, installed=any)
+            if not in_db:
+                spack.store.db.add(spec, spack.store.layout)
 
     if not args.allarch:
         arch = spack.architecture.default_arch().to_spec()

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1073,21 +1073,20 @@ class Database(object):
                 }
                 self._add(dep, directory_layout, **extra_args)
 
-        if key not in self._data:
-            installed = bool(spec.external)
-            path = None
-            if not spec.external and directory_layout:
-                path = directory_layout.path_for_spec(spec)
-                try:
-                    directory_layout.check_installed(spec)
-                    installed = True
-                except DirectoryLayoutError as e:
-                    tty.warn(
-                        'Dependency missing: may be deprecated or corrupted:',
-                        path, str(e))
-            elif spec.external_path:
-                path = spec.external_path
+        installed = bool(spec.external)
+        path = None
+        if not spec.external and directory_layout:
+            path = directory_layout.path_for_spec(spec)
+            try:
+                installed = bool(directory_layout.check_installed(spec))
+            except DirectoryLayoutError as e:
+                tty.warn(
+                    'Dependency missing: may be deprecated or corrupted:',
+                    path, str(e))
+        elif spec.external_path:
+            path = spec.external_path
 
+        if key not in self._data:
             # Create a new install record with no deps initially.
             new_spec = spec.copy(deps=False)
             extra_args = {
@@ -1115,7 +1114,7 @@ class Database(object):
 
         else:
             # If it is already there, mark it as installed.
-            self._data[key].installed = True
+            self._data[key].installed = installed
 
         self._data[key].explicit = explicit
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -57,7 +57,7 @@ def test_buildcache_preview_just_runs(database):
 
 @pytest.mark.db
 @pytest.mark.regression('13757')
-def test_buildcache_list_duplicates(mock_get_specs, capsys):
+def test_buildcache_list_duplicates(mock_get_specs, mutable_database, capsys):
     with capsys.disabled():
         output = buildcache('list', 'mpileaks', '@2.3')
 
@@ -66,7 +66,8 @@ def test_buildcache_list_duplicates(mock_get_specs, capsys):
 
 @pytest.mark.db
 @pytest.mark.regression('17827')
-def test_buildcache_list_allarch(database, mock_get_specs_multiarch, capsys):
+def test_buildcache_list_allarch(
+        mutable_database, mock_get_specs_multiarch, capsys):
     with capsys.disabled():
         output = buildcache('list', '--allarch')
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -77,9 +77,11 @@ def test_buildcache_list_allarch(database, mock_get_specs_multiarch, capsys):
 
     assert output.count('mpileaks') == 2
 
+
 @pytest.mark.db
 @pytest.mark.regression('reference listed binaries by hash')
-def test_buildcache_reference_by_hash(mutable_database, mock_get_specs, capsys):
+def test_buildcache_reference_by_hash(
+        mutable_database, mock_get_specs, capsys):
     expected = mutable_database.query(installed=True)
     uninstall('-a', '-y')
 


### PR DESCRIPTION
This allows the following worflow

```
spack buildcache list -l  # note hash for desired package is abcdefg
spack install --cache-only /abcdefg
```

Included work: Database.add: allow packages to be added without being marked installed