### PR TITLE
FAODEL: fix CMake failures on NERSC Cori in faodel@1.1906.1

### DIFF
--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -56,6 +56,7 @@ class Faodel(CMakePackage):
     # FAODEL Github issue #5
     patch('faodel_sbl.patch', when='@1.1811.1 logging=sbl')
     patch('lambda-capture-f0267fc.patch', when='@1.1906.1')
+    patch('ugni-target-redef-b67e856.patch', when='@1.1906.1')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/faodel/ugni-target-redef-b67e856.patch
+++ b/var/spack/repos/builtin/packages/faodel/ugni-target-redef-b67e856.patch
@@ -1,0 +1,36 @@
+From b67e856309c15f6e2bf5c4187b458f9e08fb1168 Mon Sep 17 00:00:00 2001
+From: Todd Kordenbrock <thkorde@sandia.gov>
+Date: Wed, 30 Sep 2020 12:22:23 -0500
+Subject: [PATCH] BUILD: When creating Cray DRC targets, check if the target
+ already exists.
+
+---
+ cmake/FaodelTPLs.cmake | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/cmake/FaodelTPLs.cmake b/cmake/FaodelTPLs.cmake
+index 5f621ec..e3eb10b 100644
+--- a/cmake/FaodelTPLs.cmake
++++ b/cmake/FaodelTPLs.cmake
+@@ -306,11 +306,13 @@ elseif( Faodel_NETWORK_LIBRARY STREQUAL "nnti" )
+     foreach(drclib ${DRC_PC_LIBRARIES})
+       find_library(${drclib}_LIBRARY NAMES ${drclib} HINTS ${DRC_PC_LIBRARY_DIRS})
+       if (${drclib}_LIBRARY)
+-	add_library( ${drclib} IMPORTED UNKNOWN )
+-	set_property( TARGET ${drclib} PROPERTY IMPORTED_LOCATION ${${drclib}_LIBRARY} )
+-	set_property( TARGET ${drclib} PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DRC_PC_INCLUDE_DIRS}" )
+-	LIST( APPEND DRC_TARGETS ${drclib} )
+-	LIST( APPEND DRC_LIBRARIES ${${drclib}_LIBRARY})
++        if( NOT TARGET ${drclib} )
++          add_library( ${drclib} IMPORTED UNKNOWN )
++          set_property( TARGET ${drclib} PROPERTY IMPORTED_LOCATION ${${drclib}_LIBRARY} )
++          set_property( TARGET ${drclib} PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DRC_PC_INCLUDE_DIRS}" )
++          LIST( APPEND DRC_TARGETS ${drclib} )
++          LIST( APPEND DRC_LIBRARIES ${${drclib}_LIBRARY})
++        endif ( NOT TARGET ${drclib} )
+       endif (${drclib}_LIBRARY)
+     endforeach(drclib)
+     LIST(APPEND DRC_INCLUDE_DIRS ${DRC_PC_INCLUDE_DIRS})
+-- 
+2.20.1
+


### PR DESCRIPTION
@eugeneswalker reported in #17892 that Faodel failed to build on NERSC Cori.  This has been resolved in https://github.com/faodel/faodel/issues/7.  This PR adds a patch file that is a backport of that fix to the Faodel 1.1906.1 release.
