### PR TITLE
superlu-mt: Add openmp flag to link command when using OpenMP

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-mt/package.py
+++ b/var/spack/repos/builtin/packages/superlu-mt/package.py
@@ -57,7 +57,8 @@ class SuperluMt(Package):
                 'TMGLIB     = libtmglib.a',
                 'MPLIB      = {0}'.format(self.compiler.openmp_flag),
                 'CFLAGS     = {0}'.format(self.compiler.openmp_flag),
-                'FFLAGS     = {0}'.format(self.compiler.openmp_flag)
+                'FFLAGS     = {0}'.format(self.compiler.openmp_flag),
+                'LOADOPTS   += {0}'.format(self.compiler.openmp_flag)
             ])
         elif '+pthread' in spec:
             # POSIX threads


### PR DESCRIPTION
Fix #19095

When given +openmp, add the correct compiler openmp flag to the link
stage.  This seems to be required for %intel compilers.
I do this for all compilers, not just %intel, because it does not seem
to harm anything and might be beneficial for others (and just seems
'correct').