### PR TITLE
Fix fetch of spec.yaml files from buildcache

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -270,8 +270,7 @@ class BinaryDistributionCacheManager(object):
         # Fetch the hash first so we can check if we actually need to fetch
         # the index itself.
         try:
-            _, _, fs = web_util.read_from_url(
-                hash_fetch_url, 'text/plain')
+            _, _, fs = web_util.read_from_url(hash_fetch_url)
             fetched_hash = codecs.getreader('utf-8')(fs).read()
         except (URLError, web_util.SpackWebError) as url_err:
             tty.debug('Unable to read index hash {0}'.format(
@@ -287,8 +286,7 @@ class BinaryDistributionCacheManager(object):
 
         # Fetch index itself
         try:
-            _, _, fs = web_util.read_from_url(
-                index_fetch_url, 'application/json')
+            _, _, fs = web_util.read_from_url(index_fetch_url)
             index_object_str = codecs.getreader('utf-8')(fs).read()
         except (URLError, web_util.SpackWebError) as url_err:
             tty.debug('Unable to read index {0}'.format(index_fetch_url),
@@ -1157,8 +1155,7 @@ def try_direct_fetch(spec, force=False, full_hash_match=False):
             mirror.fetch_url, _build_cache_relative_path, specfile_name)
 
         try:
-            _, _, fs = web_util.read_from_url(
-                buildcache_fetch_url, 'text/plain')
+            _, _, fs = web_util.read_from_url(buildcache_fetch_url)
             fetched_spec_yaml = codecs.getreader('utf-8')(fs).read()
         except (URLError, web_util.SpackWebError, HTTPError) as url_err:
             tty.debug('Did not find {0} on {1}'.format(


### PR DESCRIPTION
Since those files currently exist in buildcaches (in S3 buckets) with
potentially different content types, we should be less restrictive in
what content types we accept when attempting to fetch them.  This PR
removes the content type constraint so any file with the matching
name will be found.