### PR TITLE
p7zip: fix build on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/p7zip/package.py
+++ b/var/spack/repos/builtin/packages/p7zip/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 
 class P7zip(MakefilePackage):
     """A Unix port of the 7z file archiver"""
@@ -16,6 +14,13 @@ class P7zip(MakefilePackage):
 
     # all3 includes 7z, 7za, and 7zr
     build_targets = ['all3']
+
+    def edit(self, spec, prefix):
+        if 'platform=darwin' in self.spec:
+            if '%gcc' in self.spec:
+                copy('makefile.macosx_gcc_64bits', 'makefile.machine')
+            elif '%apple-clang' in self.spec or '%clang' in self.spec:
+                copy('makefile.macosx_llvm_64bits', 'makefile.machine')
 
     @property
     def install_targets(self):


### PR DESCRIPTION
Successfully installs and passes all tests (and opens a .7z file!) on macOS 10.15.7 with Apple Clang 12.0.0.

There are many other arch-/compiler-specific makefiles but I don't have access to any machines to test them. The default `makefile.machine` is for generic linux.