### PR TITLE
Extend patch for XL to also support XL+cuda.

### DIFF
--- a/var/spack/repos/builtin/packages/random123/ibmxl.patch
+++ b/var/spack/repos/builtin/packages/random123/ibmxl.patch
@@ -9,3 +9,16 @@
  #include "xlcfeatures.h"
  #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
  #include "sunprofeatures.h"
+--- a/include/Random123/features/nvccfeatures.h
++++ b/include/Random123/features/nvccfeatures.h
+@@ -116,7 +116,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define R123_ULONG_LONG unsigned long long
+ #endif
+ 
+-#if defined(__GNUC__)
++#if defined(__xlC__) || defined(__ibmxl__)
++#include "xlcfeatures.h"
++#elif defined(__GNUC__)
+ #include "gccfeatures.h"
+ #elif defined(_MSC_FULL_VER)
+ #include "msvcfeatures.h"


### PR DESCRIPTION
We are attempting to use Random123 with IBM xl and cuda.  This patch fixes the include logic for this combo.

* This patch was also submitted to the package owner.  The ability to use nvcc with XL is very new, so this change seems reasonable to me (and it works!)