### PR TITLE
sbml: The value of DWITH_PYTHON:BOOL is wrong

### DIFF
--- a/var/spack/repos/builtin/packages/sbml/package.py
+++ b/var/spack/repos/builtin/packages/sbml/package.py
@@ -95,7 +95,7 @@ class Sbml(CMakePackage):
                 "-DWITH_PYTHON_INCLUDE:PATH=%s" % spec['python'].prefix,
             ])
         else:
-            args.append('-DWITH_PYTHON:BOOL=ON')
+            args.append('-DWITH_PYTHON:BOOL=OFF')
 
         args.append(self.define_from_variant('WITH_CSHARP', 'mono'))
 


### PR DESCRIPTION
      The value of DWITH_PYTHON:BOOL is wrong when the python is not used.

```
        if '+python' in spec:
            args.extend([
                "-DWITH_PYTHON:BOOL=ON",
                "-DWITH_PYTHON_INCLUDE:PATH=%s" % spec['python'].prefix,
            ])
        else:
            args.append('-DWITH_PYTHON:BOOL=ON')

```

