### PR TITLE
sollve: build on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/sollve/disable_unused_lock.patch
+++ b/var/spack/repos/builtin/packages/sollve/disable_unused_lock.patch
@@ -1,0 +1,27 @@
+commit 525b70302cea9b5850be9ee8d33b7660455082f2
+Author: Shintaro Iwasaki <siwasaki@anl.gov>
+Date:   Wed Apr 15 03:46:44 2020 +0000
+
+    [BOLT] disable futex and adaptive locks if unused
+    
+    On some architectures, including POWER 9, futex locks and/or adaptive locks are
+    not enabled by default, but BOLT assumed they are available, causing
+    compile-time errors on such a platform.  This patch fixes it.
+
+diff --git a/runtime/src/kmp_lock.cpp b/runtime/src/kmp_lock.cpp
+index 5dcc4ee..5cda629 100644
+--- a/runtime/src/kmp_lock.cpp
++++ b/runtime/src/kmp_lock.cpp
+@@ -219,8 +219,12 @@ KMP_DEFINE_LOCKS(tas)
+ KMP_DEFINE_LOCKS(ticket)
+ KMP_DEFINE_LOCKS(queuing)
+ KMP_DEFINE_LOCKS(drdpa)
++#if KMP_USE_FUTEX
+ KMP_DEFINE_LOCKS(futex)
++#endif
++#if KMP_USE_ADAPTIVE_LOCKS
+ KMP_DEFINE_LOCKS(adaptive)
++#endif
+ typedef kmp_abt_mutex_lock_t kmp_hle_lock_t;
+ KMP_DEFINE_LOCKS(hle)
+ typedef kmp_abt_mutex_lock_t kmp_rtm_lock_t;

--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -7,9 +7,10 @@ from spack import *
 
 
 class Sollve(CMakePackage):
-    """The SOLLVE Project aims at scaling OpenMP by leveraging LLVM for exascale
-       performance and portability of applications.  This package provides a
-       collection of Clang/LLVM compilers and an OpenMP runtime library.
+    """The SOLLVE Project aims at scaling OpenMP by leveraging LLVM for
+       exascale performance and portability of applications.  This package
+       provides a collection of Clang/LLVM compilers and an OpenMP runtime
+       library.
     """
 
     homepage = 'https://www.bnl.gov/compsci/projects/SOLLVE/'
@@ -136,6 +137,8 @@ class Sollve(CMakePackage):
 
     conflicts('%gcc@:5.0.999')
     conflicts('+omp_tsan')
+
+    patch('disable_unused_lock.patch', when='@1.0a2', working_dir='projects/openmp')
 
     @run_before('cmake')
     def check_darwin_lldb_codesign_requirement(self):


### PR DESCRIPTION
Currently `spack install sollve`  is failed on aarch64 because `kmp_adaptive_lock_t` is not defined.
This PR add patch for this probrem.
