### PR TITLE
make opengl and spectrum-mpi set has_code = False

### DIFF
--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -7,7 +7,7 @@ import re
 import sys
 
 
-class Opengl(Package):
+class Opengl(BundlePackage):
     """Placeholder for external OpenGL libraries from hardware vendors"""
 
     homepage = "https://www.opengl.org/"

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -7,8 +7,10 @@ import re
 import sys
 
 
-class Opengl(BundlePackage):
+class Opengl(Package):
     """Placeholder for external OpenGL libraries from hardware vendors"""
+
+    has_code = False
 
     homepage = "https://www.opengl.org/"
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -6,7 +6,7 @@ import os
 import re
 
 
-class SpectrumMpi(Package):
+class SpectrumMpi(BundlePackage):
     """IBM MPI implementation from Spectrum MPI."""
 
     homepage = "http://www-03.ibm.com/systems/spectrum-computing/products/mpi"

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -6,8 +6,10 @@ import os
 import re
 
 
-class SpectrumMpi(BundlePackage):
+class SpectrumMpi(Package):
     """IBM MPI implementation from Spectrum MPI."""
+
+    has_code = False
 
     homepage = "http://www-03.ibm.com/systems/spectrum-computing/products/mpi"
 


### PR DESCRIPTION
Fixes multiple issues with opengl and spectrum-mpi packages, which are written to be external-only.