### PR TITLE
Improve VisIt info message

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -15,9 +15,9 @@ class Visit(CMakePackage):
        LINUX-------------------------------------------------------------------
        spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0
        LINUX-W/O-OPENGL--------------------------------------------------------
-       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \ ^mesa+opengl
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\ ^mesa+opengl
        MACOS-------------------------------------------------------------------
-       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \ ^qt~framework
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\ ^qt~framework
 
     """
     ############################

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -15,9 +15,11 @@ class Visit(CMakePackage):
        LINUX-------------------------------------------------------------------
        spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0
        LINUX-W/O-OPENGL--------------------------------------------------------
-       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\ ^mesa+opengl
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\
+       ^mesa+opengl
        MACOS-------------------------------------------------------------------
-       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\ ^qt~framework
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \\
+       ^qt~framework
 
     """
     ############################

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -9,7 +9,16 @@ from spack import *
 class Visit(CMakePackage):
     """VisIt is an Open Source, interactive, scalable, visualization,
        animation and analysis tool. See comments in VisIt's package.py
-       for tips about building VisIt with spack.
+       for tips about building VisIt with spack. Building VisIt with
+       Spack is still experimental and many standard features are likely
+       disabled
+       LINUX-------------------------------------------------------------------
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0
+       LINUX-W/O-OPENGL--------------------------------------------------------
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \ ^mesa+opengl
+       MACOS-------------------------------------------------------------------
+       spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \ ^qt~framework
+
     """
     ############################
     # Suggestions for building:


### PR DESCRIPTION
I believe this may be a second attempt to ensure non-experts get some hints as to how to build correctly via `spack info visit` command *and* have it formatted reasonably well. The proposed changes result in `spack info visit` appearing as...

```
miller86% ./spack/bin/spack info visit
CMakePackage:   visit

Description:
    VisIt is an Open Source, interactive, scalable, visualization, animation
    and analysis tool. See comments in VisIt's package.py for tips about
    building VisIt with spack. Building VisIt with Spack is still
    experimental and many standard features are likely disabled
    LINUX-------------------------------------------------------------------
    spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0
    LINUX-W/O-OPENGL--------------------------------------------------------
    spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \
    ^mesa+opengl
    MACOS-------------------------------------------------------------------
    spack install visit ^python+shared ^glib@2.56.3 ^py-setuptools@44.1.0 \
    ^qt~framework
```

The options for formatting this text are extremely limited due to how the string is ultimately re-processed internally in Spack and so this is the only means I found to ensure somewhat reasonable formatting in the output. 