### PR TITLE
spack: add nvidia compiler support

### DIFF
--- a/lib/spack/spack/compilers/nvidia.py
+++ b/lib/spack/spack/compilers/nvidia.py
@@ -1,0 +1,90 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.compiler
+from spack.compiler import Compiler, UnsupportedCompilerFlag
+from spack.version import ver
+
+import re
+
+
+class Nvidia(Compiler):
+    # Subclasses use possible names of C compiler
+    cc_names = ['nvc']
+
+    # Subclasses use possible names of C++ compiler
+    cxx_names = ['nvc++', 'nvCC']
+
+    # Subclasses use possible names of Fortran 77 compiler
+    f77_names = ['nvfortran']
+
+    # Subclasses use possible names of Fortran 90 compiler
+    fc_names = ['nvfortran']
+
+    # Named wrapper links within build_env_path
+    link_paths = {'cc': 'nvidia/nvc',
+                  'cxx': 'nvidia/nvc++',
+                  'f77': 'nvidia/nvfortran',
+                  'fc': 'nvidia/nvfortran'}
+
+    PrgEnv = 'PrgEnv-nvidia'
+    PrgEnv_compiler = 'nvidia'
+
+    version_argument = '--version'
+    version_regex = r'nv[^ ]* ([0-9.]+)-[0-9]+ (LLVM )?[^ ]+ target on '
+
+    @property
+    def verbose_flag(self):
+        return "-v"
+
+    @property
+    def debug_flags(self):
+        return ['-g', '-gopt']
+
+    @property
+    def opt_flags(self):
+        return ['-O', '-O0', '-O1', '-O2', '-O3', '-O4']
+
+    @property
+    def openmp_flag(self):
+        return "-mp"
+
+    @property
+    def cxx11_flag(self):
+        return "-std=c++11"
+
+    @property
+    def cxx14_flag(self):
+        return "-std=c++14"
+
+    @property
+    def cxx17_flag(self):
+        return "-std=c++17"
+
+    @property
+    def c99_flag(self):
+        return "-std=c99"
+
+    @property
+    def c11_flag(self):
+        return "-std=c11"
+
+    @property
+    def cc_pic_flag(self):
+        return "-fpic"
+
+    @property
+    def cxx_pic_flag(self):
+        return "-fpic"
+
+    @property
+    def f77_pic_flag(self):
+        return "-fpic"
+
+    @property
+    def fc_pic_flag(self):
+        return "-fpic"
+
+    required_libs = ['libnvc', 'libnvf']

--- a/lib/spack/spack/compilers/nvidia.py
+++ b/lib/spack/spack/compilers/nvidia.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.compiler import Compiler
 
 
 class Nvidia(Compiler):

--- a/lib/spack/spack/compilers/nvidia.py
+++ b/lib/spack/spack/compilers/nvidia.py
@@ -3,12 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.compiler
-from spack.compiler import Compiler, UnsupportedCompilerFlag
-from spack.version import ver
-
-import re
-
 
 class Nvidia(Compiler):
     # Subclasses use possible names of C compiler

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -533,6 +533,21 @@ def test_nag_flags():
                         'nag@1.0')
 
 
+def test_nvidia_flags():
+    supported_flag_test("openmp_flag", "-mp", "nvidia@20.7")
+    supported_flag_test("cxx11_flag", "-std=c++11", "nvidia@20.7")
+    supported_flag_test("cxx14_flag", "-std=c++14", "nvidia@20.7")
+    supported_flag_test("cxx17_flag", "-std=c++17", "nvidia@20.7")
+    supported_flag_test("c99_flag", "-std=c99", "nvidia@20.7")
+    supported_flag_test("c11_flag", "-std=c11", "nvidia@20.7")
+    supported_flag_test("cc_pic_flag",  "-fpic", "nvidia@20.7")
+    supported_flag_test("cxx_pic_flag", "-fpic", "nvidia@20.7")
+    supported_flag_test("f77_pic_flag", "-fpic", "nvidia@20.7")
+    supported_flag_test("fc_pic_flag",  "-fpic", "nvidia@20.7")
+    supported_flag_test("opt_flags", ['-O', '-O0', '-O1', '-O2', '-O3', '-O4'],
+                        'nvidia@20.7')
+
+
 def test_pgi_flags():
     supported_flag_test("openmp_flag", "-mp", "pgi@1.0")
     supported_flag_test("cxx11_flag", "-std=c++11", "pgi@1.0")

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -15,6 +15,7 @@ import spack.compilers.fj
 import spack.compilers.gcc
 import spack.compilers.intel
 import spack.compilers.nag
+import spack.compilers.nvidia
 import spack.compilers.pgi
 import spack.compilers.xl
 import spack.compilers.xl_r
@@ -154,6 +155,30 @@ def test_intel_version_detection(version_str, expected_version):
 ])
 def test_nag_version_detection(version_str, expected_version):
     version = spack.compilers.nag.Nag.extract_version_from_output(version_str)
+    assert version == expected_version
+
+
+@pytest.mark.parametrize('version_str,expected_version', [
+    # C compiler on x86-64
+    ('nvc 20.7-0 LLVM 64-bit target on x86-64 Linux -tp haswell\n'
+     'NVIDIA Compilers and Tools\n'
+     'Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.',
+     '20.7'),
+    # C++ compiler on x86-64
+    ('nvc++ 20.7-0 LLVM 64-bit target on x86-64 Linux -tp haswell\n'
+     'NVIDIA Compilers and Tools\n'
+     'Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.',
+     '20.7'),
+    # Fortran compiler on x86-64
+    ('nvfortran 20.7-0 LLVM 64-bit target on x86-64 Linux -tp haswell\n'
+     'NVIDIA Compilers and Tools\n'
+     'Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.',
+     '20.7')
+])
+def test_nvidia_version_detection(version_str, expected_version):
+    version = spack.compilers.nvidia.Nvidia.extract_version_from_output(
+        version_str
+    )
     assert version == expected_version
 
 


### PR DESCRIPTION
This adds preliminary support to detection of nvidia compilers provided by nvidia hpc sdk. Possible solution to #17930 