### PR TITLE
Add LIKWID 5.0.2 and new depends_on rule

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -41,7 +41,7 @@ class Likwid(Package):
 
     depends_on('lua', when='@:4')
     depends_on('lua@5.2:', when='@5:5.0.1')
-    depends_on('lua:', when='@5.0.2')
+    depends_on('lua', when='@5.0.2:')
 
     # TODO: check
     # depends_on('gnuplot', type='run')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -21,6 +21,7 @@ class Likwid(Package):
     git      = "https://github.com/RRZE-HPC/likwid.git"
     maintainers = ['TomTheBear']
 
+    version('5.0.2', sha256='0a1c8984e4b43ea8b99d09456ef05035eb934594af1669432117585c638a2da4')
     version('5.0.1', sha256='3757b0cb66e8af0116f9288c7f90543acbd8e2af8f72f77aef447ca2b3e76453')
     version('5.0.0', sha256='26623f5a1a5fec19d798f0114774a5293d1c93a148538b9591a13e50930fa41e')
     version('4.3.4', sha256='5c0d1c66b25dac8292a02232f06454067f031a238f010c62f40ef913c6609a83')
@@ -39,7 +40,8 @@ class Likwid(Package):
     # functionality and functions are prefixed with "likwid_".
 
     depends_on('lua', when='@:4')
-    depends_on('lua@5.2:', when='@5:')
+    depends_on('lua@5.2:', when='@5:5.0.1')
+    depends_on('lua:', when='@5.0.2')
 
     # TODO: check
     # depends_on('gnuplot', type='run')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -32,7 +32,7 @@ class Likwid(Package):
 
     patch('https://github.com/RRZE-HPC/likwid/commit/e0332ace8fe8ca7dcd4b4477a25e37944f173a5c.patch', sha256='c3b8f939a46b425665577ce764d4fba080a23cab5999c53db71655fd54d7e0b1', when='@5.0.1')
     patch('https://github.com/RRZE-HPC/likwid/commit/d2d0ef333b5e0997d7c80fc6ac1a473b5e47d084.patch', sha256='636cbf40669261fdb36379d67253be2b731cfa7b6d610d232767d72fbdf08bc0', when='@4.3.4')
-
+    patch('https://github.com/RRZE-HPC/likwid/files/5341379/likwid-lua5.1.patch.txt', sha256='bc56253c1e3436b5ba7bf4c5533d0391206900c8663c008f771a16376975e416', when='@5.0.2^lua@5.1')
     variant('fortran', default=True, description='with fortran interface')
 
     # NOTE: There is no way to use an externally provided hwloc with Likwid.


### PR DESCRIPTION
This PR added the new bugfix release 5.0.2 to the recipe. Moreover, it was reported that Lua 5.1 was not supported for 5.0.0 and 5.0.1. This was fixed in 5.0.2 thus a new depends_on rule. 