### PR TITLE
autotools.py: Removed some options from libtool only for Fujitsu.

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -217,7 +217,7 @@ class AutotoolsPackage(PackageBase):
             objfile = ['fjcrt0.o', 'fjlang08.o', 'fjomp.o',
                        'crti.o', 'crtbeginS.o', 'crtendS.o']
             for o in objfile:
-               fs.filter_file(rehead + o, '', libtool_path)
+                fs.filter_file(rehead + o, '', libtool_path)
 
     @property
     def configure_directory(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -212,7 +212,12 @@ class AutotoolsPackage(PackageBase):
                            .format(self.compiler.cc_pic_flag),
                            libtool_path)
         if self.spec.satisfies('%fj'):
-            fs.filter_file(r'/\S*/fjhpctag.o', '', libtool_path)
+            fs.filter_file('-nostdlib', '', libtool_path)
+            rehead = r'/\S*/'
+            objfile = ['fjcrt0.o', 'fjlang08.o', 'fjomp.o',
+                       'crti.o', 'crtbeginS.o', 'crtendS.o']
+            for o in objfile:
+               fs.filter_file(rehead + o, '', libtool_path)
 
     @property
     def configure_directory(self):


### PR DESCRIPTION
Fixed to remove options and objects that are problematic when using the Fujitsu compiler from the generated `libtool`.