### PR TITLE
[whizard] Add compiler constraints and minimal ocaml version

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -55,8 +55,8 @@ class Whizard(AutotoolsPackage):
     variant('latex', default=False,
             description="data visualization with latex")
 
-    depends_on('ocaml', type='build', when="@3:")
-    depends_on('ocaml~force-safe-string', type='build', when="@:2.99.99")
+    depends_on('ocaml@4.02.3:', type='build', when="@3:")
+    depends_on('ocaml@4.02.3:~force-safe-string', type='build', when="@:2.99.99")
     depends_on('hepmc', when="hepmc=2")
     depends_on('hepmc3', when="hepmc=3")
     depends_on('lcio', when="+lcio")
@@ -68,6 +68,14 @@ class Whizard(AutotoolsPackage):
                when="+openloops")
     depends_on('texlive', when="+latex")
     depends_on('zlib')
+
+    conflicts('%gcc@:5.0.99',
+              msg='gfortran needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html')
+    conflicts('%gcc@6.5.0',
+              msg='Due to severe regressions, gfortran 6.5.0 can not be used. See https://whizard.hepforge.org/compilers.html')
+
+    conflicts('%intel@:17',
+              msg='The fortran compiler needs to support Fortran 2008. For more detailed information see https://whizard.hepforge.org/compilers.html')
 
     def setup_build_environment(self, env):
         # whizard uses the compiler during runtime,


### PR DESCRIPTION
Trying to put the constraints listed at https://whizard.hepforge.org/compilers.html into some sensible constraints that should catch the most obvious problems early.

@vvolkl could you have a look if this is OK, or if we should also add the smaller regressions for the intel compilers?