### PR TITLE
Add Allinea to cray-libsci

### DIFF
--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -13,6 +13,9 @@ class CrayLibsci(Package):
     homepage = "https://docs.nersc.gov/development/libraries/libsci/"
     has_code = False    # Skip attempts to fetch source that is not available
 
+    version("20.06.1")
+    version("19.06.1")
+    version("18.12.1")
     version("18.11.1.2")
     version("16.11.1")
     version("16.09.1")
@@ -32,6 +35,7 @@ class CrayLibsci(Package):
         'gcc': 'GNU',
         'cce': 'CRAY',
         'intel': 'INTEL',
+        'clang': 'ALLINEA'
     }
 
     @property


### PR DESCRIPTION
Allows `cray-libsci` to work on Cray with ARM (using clang as compiler).