### PR TITLE
Update Datatransferkit

### DIFF
--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -11,12 +11,13 @@ class Datatransferkit(CMakePackage):
     parallel solution transfer services for multiphysics simulations"""
 
     homepage = "https://datatransferkit.readthedoc.io"
-    url      = "https://github.com/ORNL-CEES/DataTransferKit/archive/3.1-rc1.tar.gz"
+    url      = "https://github.com/ORNL-CEES/DataTransferKit/archive/3.1-rc2.tar.gz"
     git      = "https://github.com/ORNL-CEES/DataTransferKit.git"
 
     maintainers = ['Rombur']
 
     version('master', branch='master', submodules=True)
+    version('3.1-rc2', branch='3.1-rc2', submodules=True)
 
     variant('openmp', default=False, description='enable OpenMP backend')
     variant('serial', default=True, description='enable Serial backend (default)')
@@ -24,8 +25,10 @@ class Datatransferkit(CMakePackage):
             description='enable the build of shared lib')
 
     depends_on('cmake', type='build')
-    depends_on('trilinos@develop+intrepid2+shards~dtk', when='+serial')
-    depends_on('trilinos@develop+intrepid2+shards+openmp~dtk', when='+openmp')
+    depends_on('trilinos+intrepid2+shards~dtk', when='+serial')
+    depends_on('trilinos+intrepid2+shards+openmp~dtk', when='+openmp')
+    depends_on('trilinos+stratimikos+belos', when='@master')
+    depends_on('trilinos@13:13.99', when='@3.1-rc2')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Mirroring the changes proposed for the xsdk-0.6.0 release, see https://github.com/xsdk-project/spack-xsdk/blob/xsdk-0.6.0/var/spack/repos/builtin/packages/datatransferkit/package.py.