### PR TITLE
fix python scripts relying on external python in env

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -418,7 +418,7 @@ class PythonPackage(PackageBase):
     def add_files_to_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin
         python_prefix = self.extendee_spec.prefix
-        python_is_external = self.spec['python'].external
+        python_is_external = self.extendee_spec.external
         global_view = same_path(python_prefix, view.get_projection_for_spec(
             self.spec
         ))

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -430,7 +430,7 @@ class PythonPackage(PackageBase):
             elif not os.path.islink(src):
                 shutil.copy2(src, dst)
                 is_script = 'script' in get_filetype(src)
-                if is_script and python_is_external:
+                if is_script and not python_is_external:
                     filter_file(
                         python_prefix, os.path.abspath(
                             view.get_projection_for_spec(self.spec)), dst

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -418,6 +418,7 @@ class PythonPackage(PackageBase):
     def add_files_to_view(self, view, merge_map):
         bin_dir = self.spec.prefix.bin
         python_prefix = self.extendee_spec.prefix
+        python_is_external = self.spec['python'].external
         global_view = same_path(python_prefix, view.get_projection_for_spec(
             self.spec
         ))
@@ -428,7 +429,8 @@ class PythonPackage(PackageBase):
                 view.link(src, dst)
             elif not os.path.islink(src):
                 shutil.copy2(src, dst)
-                if 'script' in get_filetype(src) and not self.spec['python'].external:
+                is_script = 'script' in get_filetype(scr)
+                if is_script and python_is_external:
                     filter_file(
                         python_prefix, os.path.abspath(
                             view.get_projection_for_spec(self.spec)), dst

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -428,7 +428,7 @@ class PythonPackage(PackageBase):
                 view.link(src, dst)
             elif not os.path.islink(src):
                 shutil.copy2(src, dst)
-                if 'script' in get_filetype(src):
+                if 'script' in get_filetype(src) and not self.spec['python'].external:
                     filter_file(
                         python_prefix, os.path.abspath(
                             view.get_projection_for_spec(self.spec)), dst

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -429,7 +429,7 @@ class PythonPackage(PackageBase):
                 view.link(src, dst)
             elif not os.path.islink(src):
                 shutil.copy2(src, dst)
-                is_script = 'script' in get_filetype(scr)
+                is_script = 'script' in get_filetype(src)
                 if is_script and python_is_external:
                     filter_file(
                         python_prefix, os.path.abspath(


### PR DESCRIPTION
@AndrewGaspar I think this solves a problem you have.

Currently, when in an environment view, the python scripts are updated to point to the python in the view. This is done even when the python is external (and therefore not merged into the view).

The fix is simple: only do that relocation when the python is actually linked into the view (i.e. when it is not external).