### PR TITLE
asdcplib: Added PATH of openssl installed by spack to configure_args.

### DIFF
--- a/var/spack/repos/builtin/packages/asdcplib/package.py
+++ b/var/spack/repos/builtin/packages/asdcplib/package.py
@@ -21,3 +21,12 @@ class Asdcplib(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
+    depends_on('openssl',  type=('build', 'link'))
+
+    def configure_args(self):
+
+        spec = self.spec
+
+        args = ['--with-openssl={0}'.format(spec['openssl'].prefix)]
+
+        return args


### PR DESCRIPTION
Due to openssl dependency and lack of PATH, the following errors occurred and the installation failed

```
 >> 210    AS_DCP_AES.cpp:42:10: fatal error: openssl/aes.h: No such file or directory
     211     #include <openssl/aes.h>
     212              ^~~~~~~~~~~~~~~
     213    compilation terminated.
```