### PR TITLE
Generalization of 'include:' as config section

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -18,6 +18,7 @@ case you want to skip directly to specific docs:
 * :ref:`modules.yaml <modules>`
 * :ref:`packages.yaml <build-settings>`
 * :ref:`repos.yaml <repositories>`
+* :ref:`include.yaml <included-scopes>`
 
 -----------
 YAML Format
@@ -118,6 +119,27 @@ If multiple scopes are provided:
 
 #. Each must be preceded with the ``--config-scope`` or ``-C`` flag.
 #. They must be ordered from lowest to highest precedence.
+
+.. _included-scopes:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Included configuration scopes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``include`` config section can pull in custom configuration scopes:
+
+.. code-block:: yaml
+   :caption: ~/myscopes/somescope/include.yaml
+
+   include:
+   - /absolute/path/to/custom/scope/
+   - relative/path/to/packages.yaml
+   - ~/tmp/config.yaml
+
+Those paths support :ref:`config-file-variables`. They can either be absolute,
+or relative to the config scope including them. And they are listed from highest
+to lowest precedence, but all have lower precedence than the scope including
+them.
 
 """""""""""""""""""""""""""""""""""""""""""
 Example: scopes for release and development

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -422,13 +422,8 @@ a ``packages.yaml`` file) could contain:
 This configuration sets the default compiler for all packages to
 ``intel``.
 
-"""""""""""""""""""""""
-Included configurations
-"""""""""""""""""""""""
-
-Spack environments allow an ``include`` heading in their yaml
-schema. This heading pulls in external configuration files and applies
-them to the Environment.
+The ``include`` config section, covered in :ref:`included-scopes`, pulls in
+external configuration files and applies them to the Environment.
 
 .. code-block:: yaml
 
@@ -437,12 +432,10 @@ them to the Environment.
      - relative/path/to/config.yaml
      - /absolute/path/to/packages.yaml
 
-Environments can include files with either relative or absolute
-paths. Inline configurations take precedence over included
-configurations, so you don't have to change shared configuration files
-to make small changes to an individual Environment. Included configs
-listed later will have higher precedence, as the included configs are
-applied in order.
+Inline configurations take precedence over included configurations, so you don't
+have to change shared configuration files to make small changes to an individual
+Environment. Included configs listed later will have higher precedence, as the
+included configs are applied in order.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Manually Editing the Specs List

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -66,13 +66,6 @@ schema = {
                 spack.schema.merged.properties,
                 # extra environment schema properties
                 {
-                    'include': {
-                        'type': 'array',
-                        'default': [],
-                        'items': {
-                            'type': 'string'
-                        },
-                    },
                     'develop': {
                         'type': 'object',
                         'default': {},

--- a/lib/spack/spack/schema/include.py
+++ b/lib/spack/spack/schema/include.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for include.yaml configuration file.
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/include.py
+   :lines: 13-
+"""
+
+
+#: Properties for inclusion in other schemas
+properties = {
+    'include': {
+        'type': 'array',
+        'default': [],
+        'items': {'type': 'string'},
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Spack include other configuration scopes',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}

--- a/lib/spack/spack/schema/merged.py
+++ b/lib/spack/spack/schema/merged.py
@@ -20,6 +20,7 @@ import spack.schema.modules
 import spack.schema.packages
 import spack.schema.repos
 import spack.schema.upstreams
+import spack.schema.include
 
 
 #: Properties for inclusion in other schemas
@@ -33,7 +34,8 @@ properties = union_dicts(
     spack.schema.modules.properties,
     spack.schema.packages.properties,
     spack.schema.repos.properties,
-    spack.schema.upstreams.properties
+    spack.schema.upstreams.properties,
+    spack.schema.include.properties
 )
 
 

--- a/lib/spack/spack/test/config_include.py
+++ b/lib/spack/spack/test/config_include.py
@@ -1,0 +1,191 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+import os
+import os.path
+
+from six import StringIO
+
+from llnl.util.filesystem import mkdirp
+
+import spack.config
+import spack.environment
+from spack.cmd.env import _env_create
+
+
+# everything here uses the mock_env_path
+pytestmark = pytest.mark.usefixtures(
+    'mutable_mock_env_path', 'config')
+
+
+@pytest.fixture()
+def write_custom_scope(tmpdir):
+    """Returns a function that writes a custom scope."""
+    def _write(scope_name, **sections):
+        scopedir = os.path.join(str(tmpdir), scope_name)
+        mkdirp(scopedir)
+        for section, content in sections.items():
+            with open(os.path.join(scopedir, section + '.yaml'), 'w') as f:
+                f.write(content)
+        return scopedir
+    return _write
+
+
+def in_config_scopes(needle):
+    """Returns true if needle is found in current config scopes names"""
+    return any(needle in n for n in spack.config.config.scopes.keys())
+
+
+def test_config_include_section(write_custom_scope):
+    """Test include.yaml config including another config scope"""
+    scopea = write_custom_scope(
+        'scopea', include="""\
+include:
+  - ../scopeb
+""")
+    write_custom_scope(
+        'scopeb', packages="""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+
+    # Sanity check
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' not in packages
+
+    configscope = spack.config.ConfigScope('scopea', scopea)
+    spack.config.config.push_scope(configscope)
+
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' in packages
+
+    spack.config.config.remove_scope(configscope.name)
+
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' not in packages
+
+
+def test_config_include_variable(write_custom_scope):
+    """Test env variable in included path"""
+    scopea = write_custom_scope(
+        'scopea', include="""\
+include:
+  - ${TEST_ENV_VAR}/scopeb
+""")
+    scopeb = write_custom_scope(
+        'scopeb', packages="""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+    os.environ['TEST_ENV_VAR'] = str(os.path.dirname(scopeb))
+
+    # Sanity check
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' not in packages
+
+    configscope = spack.config.ConfigScope('scopea', scopea)
+    spack.config.config.push_scope(configscope)
+
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' in packages
+
+    spack.config.config.remove_scope(configscope.name)
+
+    os.environ.pop('TEST_ENV_VAR')
+
+
+def test_config_include_in_env_configscope(write_custom_scope):
+    """Test a spack-env including a config scope"""
+    included = write_custom_scope(
+        'included-config', packages="""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+
+    test_config = """\
+env:
+  include:
+  - %s
+  specs:
+  - mpileaks
+""" % str(included)
+    _env_create('test', StringIO(test_config))
+    e = spack.environment.read('test')
+
+    # Sanity check
+    assert not in_config_scopes('included-config')
+
+    with e:
+        assert in_config_scopes('included-config')
+
+    assert not in_config_scopes('included-config')
+
+
+def test_config_include_in_env_singlefile(write_custom_scope):
+    """Test a spack-env including a "single file" config"""
+    test_config = """\
+env:
+  include:
+  - ./included-config.yaml
+  specs:
+  - mpileaks
+"""
+    _env_create('test', StringIO(test_config))
+    e = spack.environment.read('test')
+
+    with open(os.path.join(e.path, 'included-config.yaml'), 'w') as f:
+        f.write("""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+
+    # Sanity check
+    assert not in_config_scopes('included-config')
+
+    with e:
+        assert in_config_scopes('included-config')
+
+    assert not in_config_scopes('included-config')
+
+
+def test_config_include_multiple_levels(write_custom_scope):
+    """Test multiple levels of includes"""
+    scopes = []
+    for i in range(3):
+        scope = write_custom_scope(
+            'testscope-%d' % i, include="""\
+include:
+  - ../testscope-%d
+""" % (i + 1))
+        scopes.append(scope)
+    i += 1
+    write_custom_scope(
+        'testscope-%d' % i, packages="""\
+packages:
+  mpileaks:
+    version: [2.2]
+""")
+
+    # Sanity check
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' not in packages
+
+    configscope = spack.config.ConfigScope('testscope-0', scopes[0])
+    spack.config.config.push_scope(configscope)
+
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' in packages
+
+    spack.config.config.remove_scope(configscope.name)
+
+    # All "testscope-%d" must have been removed
+    assert not in_config_scopes('testscope-')
+
+    packages = spack.config.config.get_config('packages')
+    assert 'mpileaks' not in packages


### PR DESCRIPTION
This is a generalization of the spack-env's `include:` feature into a new `include` config section.

So config scopes can have their own `include.yaml` to include custom configuration scopes. And spack-env's `spack:include:` still works as before, but is now seen as a simple config section (like `packages:`) instead of being spack-env-specific.

The current implementation is very similar to the one that were written for spack-envs: when registering a new config scope in the `spack.config.config.scopes` list, the `include` config section is read and scopes are pushed recursively (at lower precedence than the incluer). The `remove_scope` implementation is a bit trickier, but works.

Currently, this PR is a "first working version", I thought of a few more TODOs, **I could do them in this PR, or step-by-step in later PRs ?**:
- [ ] Catch infinite include recursion
- [ ] Test including the same custom scope in different "root" scopes (check for scope.name conflicts)
- [ ] Handle manual calls to `config.remove_scope` of "non-root" included scope (forbid, or warn ?)

---

As for the **why I did this**: we want to automate the selection between different configurations (beyond just the arch), but keep sharing the same instance/files were we can. We started to look at `spack -C` but it didn't work for us. We then went to spack-env's `include:` with unix-env variables set by a custom setup-env.sh. But the day-to-day package development with a spack-env activated is often frustrating...

So, looking around for better solution in the source code, I found that this solution of generalizing the `include` feature was actually not too difficult to implement (so I didn't go through creating an Issue to discuss about it first, but I am open to it if need be). This solution would enable us to automate some configuration selection for day-to-day devs with a near-vanilla "standard" spack experience (without activating a spack-env), and keeping spack-env for deployments and specific software stacks configurations.
