### PR TITLE
make py-pillow the default for pil

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -38,7 +38,7 @@ packages:
       mpi: [openmpi, mpich]
       mysql-client: [mysql, mariadb-c-client]
       opencl: [pocl]
-      pil: [py-pillow-simd]
+      pil: [py-pillow]
       pkgconfig: [pkgconf, pkg-config]
       rpc: [libtirpc]
       scalapack: [netlib-scalapack]


### PR DESCRIPTION
py-pillow-simd is not portable to non-Intel architectures.

Fixes #19250 

cc @adamjstewart 