### PR TITLE
Added CUDAHOSTCXX variable needed to compile with cuda and mpi.

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -394,6 +394,11 @@ class Dealii(CMakePackage, CudaPackage):
                 self.define('MPI_CXX_COMPILER', spec['mpi'].mpicxx),
                 self.define('MPI_Fortran_COMPILER', spec['mpi'].mpifc)
             ])
+            if '+cuda' in spec:
+                options.extend([
+                    self.define('DEAL_II_MPI_WITH_CUDA_SUPPORT', True),
+                    self.define('CUDA_HOST_COMPILER', spec['mpi'].mpicxx)
+                ])
 
         # Python bindings
         if spec.satisfies('@8.5.0:'):
@@ -527,7 +532,7 @@ class Dealii(CMakePackage, CudaPackage):
     def setup_run_environment(self, env):
         env.set('DEAL_II_DIR', self.prefix)
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         spec = self.spec
-        if '+mpi' in spec:
-            spack_env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)
+        if '+cuda' in spec and '+mpi' in spec:
+            env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -529,4 +529,5 @@ class Dealii(CMakePackage, CudaPackage):
 
     def setup_environment(self, spack_env, run_env):
         spec = self.spec
-        spack_env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)
+        if '+mpi' in spec:
+            spack_env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -526,3 +526,7 @@ class Dealii(CMakePackage, CudaPackage):
 
     def setup_run_environment(self, env):
         env.set('DEAL_II_DIR', self.prefix)
+
+    def setup_environment(self, spack_env, run_env):
+        spec = self.spec
+        spack_env.set('CUDAHOSTCXX', spec['mpi'].mpicxx)


### PR DESCRIPTION
Spack seems to set the CUDAHOSTCXX environment variable in the build environment, which cmake picks up and passes to nvcc as -ccbin=(...)  Mine was g++-6.

When compiling with mpi, cuda files cannot include <mpi.h> unless the host compiler points to the mpi wrapper.  Without this environment variable specifically set, no amount of cmake options could switch over the -ccbin from g++-6.

Shouldn't spack automatically set CUDAHOSTCXX to the right thing when using mpi?  Maybe I missed some documentation on this.