### PR TITLE
autotools: refactor search paths for aclocal in its own method

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -261,13 +261,18 @@ class AutotoolsPackage(PackageBase):
             # This line is what is needed most of the time
             # --install, --verbose, --force
             autoreconf_args = ['-ivf']
-            for dep in spec.dependencies(deptype='build'):
-                if os.path.exists(dep.prefix.share.aclocal):
-                    autoreconf_args.extend([
-                        '-I', dep.prefix.share.aclocal
-                    ])
+            autoreconf_args += self.autoreconf_search_path_args
             autoreconf_args += self.autoreconf_extra_args
             m.autoreconf(*autoreconf_args)
+
+    @property
+    def autoreconf_search_path_args(self):
+        """Arguments to autoreconf to modify the search paths"""
+        search_path_args = []
+        for dep in self.spec.dependencies(deptype='build'):
+            if os.path.exists(dep.prefix.share.aclocal):
+                search_path_args.extend(['-I', dep.prefix.share.aclocal])
+        return search_path_args
 
     @run_after('autoreconf')
     def set_configure_or_die(self):

--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -2,9 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os.path
-
-
 class Audacious(AutotoolsPackage):
     """A lightweight and versatile audio player."""
 
@@ -28,11 +25,8 @@ class Audacious(AutotoolsPackage):
 
     def patch(self):
         search_path_args = ' '.join(self.autoreconf_search_path_args)
-        filter_file(
-            '-I m4',
-            '-I m4 {0}'.format(search_path_args),
-            os.path.join(self.stage.source_path, 'autogen.sh')
-        )
+        search_path_str = '-I m4 {0}'.format(search_path_args)
+        filter_file('-I m4', search_path_str, 'autogen.sh')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -2,8 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
+import os.path
 
 
 class Audacious(AutotoolsPackage):
@@ -26,6 +25,14 @@ class Audacious(AutotoolsPackage):
     depends_on('iconv',    type='link')
     depends_on('glib')
     depends_on('qt')
+
+    def patch(self):
+        search_path_args = ' '.join(self.autoreconf_search_path_args)
+        filter_file(
+            '-I m4',
+            '-I m4 {0}'.format(search_path_args),
+            os.path.join(self.stage.source_path, 'autogen.sh')
+        )
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')


### PR DESCRIPTION
closes #18582

This commit refactors the computation of the search path for aclocal in its own method, so that it's easier to reuse for packages that need to have a custom autoreconf phase. It's an alternative to #18582 that doesn't duplicate the way we pass this information to autotools. 

The difference between using ACLOCAL_PATH and the `-I` option is that the latter takes precedence over the former, so if we adopt this PR we'll still be using the "most authorative" way of extending the search path.