### PR TITLE
gcc: Restrict permitted cuda versions

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -123,7 +123,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils', type=('build', 'link', 'run'))
     depends_on('zip', type='build', when='languages=java')
-    depends_on('cuda', when='+nvptx')
+    depends_on('cuda@:10', when='+nvptx')
 
     # The server is sometimes a bit slow to respond
     timeout = {'timeout': 60}


### PR DESCRIPTION
gcc seems to use sm_30, which has been dropped in cuda@11.