### PR TITLE
Specify that cuda provides cublas

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -67,6 +67,17 @@ class Cuda(Package):
 
     homepage = "https://developer.nvidia.com/cuda-zone"
 
+    provides("cublas")
+    provides('cublas@11.2.1.74', when='@11.1.0')
+    provides('cublas@11.2.0.252', when='@11.0.2')
+    provides('cublas@10.2.2', when='@10.2.89')
+    provides('cublas@10.2.0', when='@10.1.243')
+    #provides('cublas@10.2.0', when='@10.0.130')  # Version not mentioned in release notes
+    #provides('cublas@9.2.174', when='@9.2.148')  # CUDA version 9.2.148 not specified in `_versions`
+    provides('cublas@9.1.181', when='@9.1.85')
+    provides('cublas@9.0.333', when='@9.0.176')
+    # No other release notes provide the version of cublas
+
     maintainers = ['ax3l', 'Rombur']
     executables = ['^nvcc$']
 


### PR DESCRIPTION
As mentioned on the [nvidia documentation page](https://developer.nvidia.com/cublas):

> Using cuBLAS, applications automatically benefit from regular performance improvements and new GPU architectures. The cuBLAS library is included in both the NVIDIA HPC SDK and the CUDA Toolkit.

Since CUDA provides cuBLAS, I think it might be worth explicitly adding this to the package file so it could be used as a virtual dependency.  The versions of cublas provided by cuda are taken from the 'Release Notes' section of the archived documentation here: https://docs.nvidia.com/cuda/archive/

To be honest I'm not sure if this PR is 'correct'. The documentation mentions virtual dependencies in the context of multiple packages providing the same dependency (e.g. MPI), but in this case it's one package providing multiple dependencies (since CUDA [contains a **lot** of individual components](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-major-component-versions)).

Actually this is a broader question: in situations like this, where the package you're defining is a toolkit comprising a lot of individual components, should you try to list all of the contained tools as providers?