### PR TITLE
m4: Fix issue compiling with new intel compilers (#18894)

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -60,7 +60,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         if spec.satisfies('%fj') and not spec.satisfies('platform=darwin'):
             args.append('LDFLAGS=-rtlib=compiler-rt')
 
-        if spec.satisfies('%intel'):
+        if spec.satisfies('%intel@:18.999'):
             args.append('CFLAGS=-no-gcc')
 
         if '+sigsegv' in spec:
@@ -72,7 +72,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         # http://lists.gnu.org/archive/html/bug-m4/2016-09/msg00002.html
         arch = spec.architecture
         if (arch.platform == 'darwin' and arch.os == 'sierra' and
-            '%gcc' in spec):
+                '%gcc' in spec):
             args.append('ac_cv_type_struct_sched_param=yes')
 
         return args


### PR DESCRIPTION
Original version added --no-gcc to CFLAGS when compiling with intel
compilers.  This does not appear to be needed and indeed causes problems
(see #18894) with newer intel compilers; I have modified so it is not
added for intel@19: (I confirmed it is needed/works for intel@20, based
on comments in #18854 looks like holds for intel@19 as well).

(Also fix old formatting issue flake8 was complaining about)

Fixes #18894