### PR TITLE
pexsi: Add -fopenmp flag to fortran flags if dependencies use OpenMP

### DIFF
--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -62,14 +62,15 @@ class Pexsi(MakefilePackage):
             ('@STDCXX_LIB', ' '.join(self.compiler.stdcxx_libs))
         ]
 
+        fldflags = ''
         if '@0.9.2' in self.spec:
-            substitutions.append(
-                ('@FLDFLAGS', '-Wl,--allow-multiple-definition')
-            )
-        else:
-            substitutions.append(
-                ('@FLDFLAGS', '')
-            )
+            fldflags += ' -Wl,--allow-multiple-definition'
+
+        if ('^superlu +openmp' in self.spec
+                or '^openblas threads=openmp' in self.spec):
+            fldflags += ' -fopenmp'
+
+        substitutions.append(('@FLDFLAGS', fldflags.lstrip()))
 
         template = join_path(
             os.path.dirname(inspect.getmodule(self).__file__),

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -68,7 +68,7 @@ class Pexsi(MakefilePackage):
 
         if ('^superlu +openmp' in self.spec
                 or '^openblas threads=openmp' in self.spec):
-            fldflags += ' -fopenmp'
+            fldflags += ' ' + self.compiler.openmp_flag
 
         substitutions.append(('@FLDFLAGS', fldflags.lstrip()))
 


### PR DESCRIPTION
Closes #18578

This patch causes OpenMP flags to be added to fortran compilation flags if superlu-dist or openblas dependencies use openmp.