### PR TITLE
Make DEAL_II_MPI_WITH_CUDA_SUPPORT conditional on mpi package option.

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -396,7 +396,8 @@ class Dealii(CMakePackage, CudaPackage):
             ])
             if '+cuda' in spec:
                 options.extend([
-                    self.define('DEAL_II_MPI_WITH_CUDA_SUPPORT', True),
+                    self.define('DEAL_II_MPI_WITH_CUDA_SUPPORT',
+                                spec['mpi'].satisfies('+cuda')),
                     self.define('CUDA_HOST_COMPILER', spec['mpi'].mpicxx)
                 ])
 


### PR DESCRIPTION
This addresses the last-minute discussion on DEAL_II_MPI_WITH_CUDA_SUPPORT by enabling only if mpi has the +cuda option.  According to the discussion there, at present this would work for a properly annotated openmpi, but isn't set in a standard way for the other mpi-s.