### PR TITLE
ppopen-at: change download site to github.

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-at/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-at/package.py
@@ -5,22 +5,22 @@
 
 
 from spack import *
-import os
 
 
 class PpopenAt(MakefilePackage):
     """ppOpen-AT is a part of the ppOpenHPC"""
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url = "file://{0}/ppohAT_1.0.0.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('1.0.0', sha256='2b5664839762c941e0b2dd7c15416e2dcfd5d909558cf7e4347a79ce535f3887')
+    version('master', branch='AT')
 
     def edit(self, spec, prefix):
         makefile_in = FileFilter('Makefile.in')
         makefile_in.filter('gcc', spack_cxx)
         makefile_in.filter('~/ppohAT_1.0.0', prefix)
         makefile_in.filter('mkdir', 'mkdir -p')
+        mkdirp('bin')
 
     def install(self, spec, prefix):
         make('install')


### PR DESCRIPTION
Down load site of ppOpen-AT is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.