### PR TITLE
uqtk: Add version and fixes for Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/uqtk/not_link_gfortran.patch
+++ b/var/spack/repos/builtin/packages/uqtk/not_link_gfortran.patch
@@ -1,0 +1,563 @@
+diff -ur spack-src.org/cpp/app/gen_mi/CMakeLists.txt spack-src/cpp/app/gen_mi/CMakeLists.txt
+--- spack-src.org/cpp/app/gen_mi/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/gen_mi/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -29,7 +29,7 @@
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (gen_mi gfortran stdc++)
++    target_link_libraries (gen_mi stdc++)
+   else()
+     target_link_libraries (gen_mi ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/generate_quad/CMakeLists.txt spack-src/cpp/app/generate_quad/CMakeLists.txt
+--- spack-src.org/cpp/app/generate_quad/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/generate_quad/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -29,7 +29,7 @@
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (generate_quad gfortran stdc++)
++    target_link_libraries (generate_quad stdc++)
+   else()
+     target_link_libraries (generate_quad ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/gkpSparse/CMakeLists.txt spack-src/cpp/app/gkpSparse/CMakeLists.txt
+--- spack-src.org/cpp/app/gkpSparse/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/gkpSparse/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -30,7 +30,7 @@
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (gkpSparse gfortran stdc++)
++    target_link_libraries (gkpSparse stdc++)
+   else()
+     target_link_libraries (gkpSparse ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/gp_regr/CMakeLists.txt spack-src/cpp/app/gp_regr/CMakeLists.txt
+--- spack-src.org/cpp/app/gp_regr/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/gp_regr/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -41,7 +41,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (gp_regr gfortran stdc++)
++    target_link_libraries (gp_regr stdc++)
+   else()
+     target_link_libraries (gp_regr ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/lr_eval/CMakeLists.txt spack-src/cpp/app/lr_eval/CMakeLists.txt
+--- spack-src.org/cpp/app/lr_eval/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/lr_eval/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -42,7 +42,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (lr_eval gfortran stdc++)
++    target_link_libraries (lr_eval stdc++)
+   else()
+     target_link_libraries (lr_eval ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/lr_regr/CMakeLists.txt spack-src/cpp/app/lr_regr/CMakeLists.txt
+--- spack-src.org/cpp/app/lr_regr/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/lr_regr/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -42,7 +42,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (lr_regr gfortran stdc++)
++    target_link_libraries (lr_regr stdc++)
+   else()
+     target_link_libraries (lr_regr ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/model_inf/CMakeLists.txt spack-src/cpp/app/model_inf/CMakeLists.txt
+--- spack-src.org/cpp/app/model_inf/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/model_inf/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -40,7 +40,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (model_inf gfortran stdc++)
++    target_link_libraries (model_inf stdc++)
+   else()
+     target_link_libraries (model_inf ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pce_eval/CMakeLists.txt spack-src/cpp/app/pce_eval/CMakeLists.txt
+--- spack-src.org/cpp/app/pce_eval/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pce_eval/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -37,7 +37,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_eval gfortran stdc++)
++    target_link_libraries (pce_eval stdc++)
+   else()
+     target_link_libraries (pce_eval ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pce_quad/CMakeLists.txt spack-src/cpp/app/pce_quad/CMakeLists.txt
+--- spack-src.org/cpp/app/pce_quad/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pce_quad/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -38,7 +38,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_quad gfortran stdc++)
++    target_link_libraries (pce_quad stdc++)
+   else()
+     target_link_libraries (pce_quad ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pce_resp/CMakeLists.txt spack-src/cpp/app/pce_resp/CMakeLists.txt
+--- spack-src.org/cpp/app/pce_resp/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pce_resp/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -37,7 +37,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_resp gfortran stdc++)
++    target_link_libraries (pce_resp stdc++)
+   else()
+     target_link_libraries (pce_resp ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pce_rv/CMakeLists.txt spack-src/cpp/app/pce_rv/CMakeLists.txt
+--- spack-src.org/cpp/app/pce_rv/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pce_rv/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -36,7 +36,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_rv gfortran stdc++)
++    target_link_libraries (pce_rv stdc++)
+   else()
+     target_link_libraries (pce_rv ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pce_sens/CMakeLists.txt spack-src/cpp/app/pce_sens/CMakeLists.txt
+--- spack-src.org/cpp/app/pce_sens/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pce_sens/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -37,7 +37,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_sens gfortran stdc++)
++    target_link_libraries (pce_sens stdc++)
+   else()
+     target_link_libraries (pce_sens ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/pdf_cl/CMakeLists.txt spack-src/cpp/app/pdf_cl/CMakeLists.txt
+--- spack-src.org/cpp/app/pdf_cl/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/pdf_cl/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -34,7 +34,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pdf_cl gfortran stdc++)
++    target_link_libraries (pdf_cl stdc++)
+   else()
+     target_link_libraries (pdf_cl ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/regression/CMakeLists.txt spack-src/cpp/app/regression/CMakeLists.txt
+--- spack-src.org/cpp/app/regression/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/regression/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -42,7 +42,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (regression gfortran stdc++)
++    target_link_libraries (regression stdc++)
+   else()
+     target_link_libraries (regression ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/app/sens/CMakeLists.txt spack-src/cpp/app/sens/CMakeLists.txt
+--- spack-src.org/cpp/app/sens/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/app/sens/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -52,8 +52,8 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (sens gfortran stdc++)
+-    target_link_libraries (trdSpls gfortran stdc++)
++    target_link_libraries (sens stdc++)
++    target_link_libraries (trdSpls stdc++)
+   else()
+     target_link_libraries (sens ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+     target_link_libraries (trdSpls ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+diff -ur spack-src.org/cpp/tests/Array1DMiscTest/CMakeLists.txt spack-src/cpp/tests/Array1DMiscTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/Array1DMiscTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/Array1DMiscTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -29,7 +29,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (Array1DMiscTest gfortran stdc++)
++    target_link_libraries (Array1DMiscTest stdc++)
+   else()
+     target_link_libraries (Array1DMiscTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/Array2DMiscTest/CMakeLists.txt spack-src/cpp/tests/Array2DMiscTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/Array2DMiscTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/Array2DMiscTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -29,7 +29,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (Array2DMiscTest gfortran stdc++)
++    target_link_libraries (Array2DMiscTest stdc++)
+   else()
+     target_link_libraries (Array2DMiscTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/ArrayDelColumn/CMakeLists.txt spack-src/cpp/tests/ArrayDelColumn/CMakeLists.txt
+--- spack-src.org/cpp/tests/ArrayDelColumn/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/ArrayDelColumn/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -28,7 +28,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (ArrayDelColumn gfortran stdc++)
++    target_link_libraries (ArrayDelColumn stdc++)
+   else()
+     target_link_libraries (ArrayDelColumn ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/ArrayReadAndWrite/CMakeLists.txt spack-src/cpp/tests/ArrayReadAndWrite/CMakeLists.txt
+--- spack-src.org/cpp/tests/ArrayReadAndWrite/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/ArrayReadAndWrite/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -28,7 +28,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (ArrayReadAndWrite gfortran expat stdc++)
++    target_link_libraries (ArrayReadAndWrite expat stdc++)
+   else()
+     target_link_libraries (ArrayReadAndWrite ${ClangLibPath}/libgfortran.dylib expat ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/ArraySortTest/CMakeLists.txt spack-src/cpp/tests/ArraySortTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/ArraySortTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/ArraySortTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -30,7 +30,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (ArraySortTest gfortran stdc++)
++    target_link_libraries (ArraySortTest stdc++)
+   else()
+     target_link_libraries (ArraySortTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/BCS1dTest/CMakeLists.txt spack-src/cpp/tests/BCS1dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/BCS1dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/BCS1dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (BCS1dTest gfortran stdc++)
++    target_link_libraries (BCS1dTest stdc++)
+   else()
+     target_link_libraries (BCS1dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/BCS2dTest/CMakeLists.txt spack-src/cpp/tests/BCS2dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/BCS2dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/BCS2dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -37,7 +37,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (BCS2dTest gfortran stdc++)
++    target_link_libraries (BCS2dTest stdc++)
+   else()
+     target_link_libraries (BCS2dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/CorrTest/CMakeLists.txt spack-src/cpp/tests/CorrTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/CorrTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/CorrTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -48,7 +48,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (CorrTest gfortran stdc++)
++    target_link_libraries (CorrTest stdc++)
+   else()
+     target_link_libraries (CorrTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/Deriv1dTest/CMakeLists.txt spack-src/cpp/tests/Deriv1dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/Deriv1dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/Deriv1dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -32,7 +32,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (Deriv1dTest gfortran stdc++)
++    target_link_libraries (Deriv1dTest stdc++)
+   else()
+     target_link_libraries (Deriv1dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/GradHessianTest/CMakeLists.txt spack-src/cpp/tests/GradHessianTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/GradHessianTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/GradHessianTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (GradHessianTest gfortran stdc++)
++    target_link_libraries (GradHessianTest stdc++)
+   else()
+     target_link_libraries (GradHessianTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/GradientPCETest/CMakeLists.txt spack-src/cpp/tests/GradientPCETest/CMakeLists.txt
+--- spack-src.org/cpp/tests/GradientPCETest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/GradientPCETest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (GradientPCETest gfortran stdc++)
++    target_link_libraries (GradientPCETest stdc++)
+   else()
+     target_link_libraries (GradientPCETest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/Hessian2dTest/CMakeLists.txt spack-src/cpp/tests/Hessian2dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/Hessian2dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/Hessian2dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (Hessian2dTest gfortran stdc++)
++    target_link_libraries (Hessian2dTest stdc++)
+   else()
+     target_link_libraries (Hessian2dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/LowRankRegrTest/CMakeLists.txt spack-src/cpp/tests/LowRankRegrTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/LowRankRegrTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/LowRankRegrTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -25,7 +25,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (LowRankRegrTest gfortran stdc++)
++    target_link_libraries (LowRankRegrTest stdc++)
+   else()
+     target_link_libraries (LowRankRegrTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/MCMC2dTest/CMakeLists.txt spack-src/cpp/tests/MCMC2dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/MCMC2dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/MCMC2dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (MCMC2dTest gfortran stdc++)
++    target_link_libraries (MCMC2dTest stdc++)
+   else()
+     target_link_libraries (MCMC2dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/MCMCNestedTest/CMakeLists.txt spack-src/cpp/tests/MCMCNestedTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/MCMCNestedTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/MCMCNestedTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (MCMCNestedTest gfortran stdc++)
++    target_link_libraries (MCMCNestedTest stdc++)
+   else()
+     target_link_libraries (MCMCNestedTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/MCMCRandomTest/CMakeLists.txt spack-src/cpp/tests/MCMCRandomTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/MCMCRandomTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/MCMCRandomTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (MCMCRandomTest gfortran stdc++)
++    target_link_libraries (MCMCRandomTest stdc++)
+   else()
+     target_link_libraries (MCMCRandomTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/MultiIndexTest/CMakeLists.txt spack-src/cpp/tests/MultiIndexTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/MultiIndexTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/MultiIndexTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -34,7 +34,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (MultiIndexTest gfortran stdc++)
++    target_link_libraries (MultiIndexTest stdc++)
+   else()
+     target_link_libraries (MultiIndexTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/PCE1dTest/CMakeLists.txt spack-src/cpp/tests/PCE1dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/PCE1dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/PCE1dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -32,7 +32,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (PCE1dTest gfortran stdc++)
++    target_link_libraries (PCE1dTest stdc++)
+   else()
+     target_link_libraries (PCE1dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/PCEImplTest/CMakeLists.txt spack-src/cpp/tests/PCEImplTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/PCEImplTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/PCEImplTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -32,7 +32,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (PCEImplTest gfortran stdc++)
++    target_link_libraries (PCEImplTest stdc++)
+   else()
+     target_link_libraries (PCEImplTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/PCELogTest/CMakeLists.txt spack-src/cpp/tests/PCELogTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/PCELogTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/PCELogTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -32,7 +32,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (PCELogTest gfortran stdc++)
++    target_link_libraries (PCELogTest stdc++)
+   else()
+     target_link_libraries (PCELogTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/QuadLUTest/CMakeLists.txt spack-src/cpp/tests/QuadLUTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/QuadLUTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/QuadLUTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -36,7 +36,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (QuadLUTest gfortran stdc++)
++    target_link_libraries (QuadLUTest stdc++)
+   else()
+     target_link_libraries (QuadLUTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/SecondDeriv1dTest/CMakeLists.txt spack-src/cpp/tests/SecondDeriv1dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/SecondDeriv1dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/SecondDeriv1dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -31,7 +31,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (SecondDeriv1dTest gfortran stdc++)
++    target_link_libraries (SecondDeriv1dTest stdc++)
+   else()
+     target_link_libraries (SecondDeriv1dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/cpp/tests/TMCMC2dTest/CMakeLists.txt spack-src/cpp/tests/TMCMC2dTest/CMakeLists.txt
+--- spack-src.org/cpp/tests/TMCMC2dTest/CMakeLists.txt	2020-10-13 16:38:53.000000000 +0900
++++ spack-src/cpp/tests/TMCMC2dTest/CMakeLists.txt	2020-10-13 16:38:56.000000000 +0900
+@@ -47,7 +47,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (TMCMC2dTest gfortran stdc++)
++    target_link_libraries (TMCMC2dTest stdc++)
+   else()
+     target_link_libraries (TMCMC2dTest ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/examples/kle_ex1/CMakeLists.txt spack-src/examples/kle_ex1/CMakeLists.txt
+--- spack-src.org/examples/kle_ex1/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/kle_ex1/CMakeLists.txt	2020-10-13 17:15:16.000000000 +0900
+@@ -73,9 +73,9 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (kl_1D.x  gfortran stdc++)
+-    target_link_libraries (kl_2D.x  gfortran stdc++)
+-    target_link_libraries (kl_2Du.x gfortran stdc++)
++    target_link_libraries (kl_1D.x  stdc++)
++    target_link_libraries (kl_2D.x  stdc++)
++    target_link_libraries (kl_2Du.x stdc++)
+   else()
+     target_link_libraries (kl_1D.x  ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+     target_link_libraries (kl_2D.x  ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+diff -ur spack-src.org/examples/line_infer/CMakeLists.txt spack-src/examples/line_infer/CMakeLists.txt
+--- spack-src.org/examples/line_infer/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/line_infer/CMakeLists.txt	2020-10-13 17:16:41.000000000 +0900
+@@ -56,7 +56,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (line_infer.x gfortran stdc++)
++    target_link_libraries (line_infer.x stdc++)
+   else()
+     target_link_libraries (line_infer.x ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/examples/muq/CMakeLists.txt spack-src/examples/muq/CMakeLists.txt
+--- spack-src.org/examples/muq/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/muq/CMakeLists.txt	2020-10-13 17:18:04.000000000 +0900
+@@ -61,7 +61,7 @@
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-maybe-uninitialized -Wno-sign-compare")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-unused-variable -Wno-unused-local-typedefs")
+ if ("${GnuLibPath}" STREQUAL "")
+-  target_link_libraries (muqPCE2uqtk.x gfortran stdc++)
++  target_link_libraries (muqPCE2uqtk.x stdc++)
+ else()
+   target_link_libraries (muqPCE2uqtk.x  ${GnuLibPath}/libgfortran.a ${GnuLibPath}/libquadmath.a stdc++)
+ endif()
+diff -ur spack-src.org/examples/ops/CMakeLists.txt spack-src/examples/ops/CMakeLists.txt
+--- spack-src.org/examples/ops/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/ops/CMakeLists.txt	2020-10-13 17:44:31.000000000 +0900
+@@ -58,7 +58,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (Ops.x gfortran stdc++)
++    target_link_libraries (Ops.x stdc++)
+   else()
+     target_link_libraries (Ops.x ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+@@ -99,7 +99,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (LogComp.x gfortran stdc++)
++    target_link_libraries (LogComp.x stdc++)
+   else()
+     target_link_libraries (LogComp.x ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+diff -ur spack-src.org/examples/pce_bcs/CMakeLists.txt spack-src/examples/pce_bcs/CMakeLists.txt
+--- spack-src.org/examples/pce_bcs/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/pce_bcs/CMakeLists.txt	2020-10-13 17:16:04.000000000 +0900
+@@ -59,7 +59,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (pce_bcs.x gfortran stdc++)
++    target_link_libraries (pce_bcs.x stdc++)
+   else()
+     target_link_libraries (pce_bcs.x ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+   endif()
+Only in spack-src/examples: spack-cc-uqtk-re5kp6x.in.log
+Only in spack-src/examples: spack-cc-uqtk-re5kp6x.out.log
+diff -ur spack-src.org/examples/surf_rxn/CMakeLists.txt spack-src/examples/surf_rxn/CMakeLists.txt
+--- spack-src.org/examples/surf_rxn/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/surf_rxn/CMakeLists.txt	2020-10-13 17:17:04.000000000 +0900
+@@ -99,10 +99,10 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (SurfRxnNISP.x    gfortran stdc++)
+-    target_link_libraries (SurfRxnNISP_MC.x gfortran stdc++)
+-    target_link_libraries (SurfRxnISP.x     gfortran stdc++)
+-    target_link_libraries (SurfRxnDet.x     gfortran stdc++)
++    target_link_libraries (SurfRxnNISP.x    stdc++)
++    target_link_libraries (SurfRxnNISP_MC.x stdc++)
++    target_link_libraries (SurfRxnISP.x     stdc++)
++    target_link_libraries (SurfRxnDet.x     stdc++)
+   else()
+     target_link_libraries (SurfRxnNISP.x    ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+     target_link_libraries (SurfRxnNISP_MC.x ${ClangLibPath}/libgfortran.dylib ${ClangLibPath}/libquadmath.dylib ${ClangLibPath}/libstdc++.dylib)
+diff -ur spack-src.org/examples/tmcmc_bimodal/CMakeLists.txt spack-src/examples/tmcmc_bimodal/CMakeLists.txt
+--- spack-src.org/examples/tmcmc_bimodal/CMakeLists.txt	2020-10-13 16:38:55.000000000 +0900
++++ spack-src/examples/tmcmc_bimodal/CMakeLists.txt	2020-10-13 17:14:38.000000000 +0900
+@@ -41,7 +41,7 @@
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   # using Clang
+   if ("${ClangLibPath}" STREQUAL "")
+-    target_link_libraries (tmcmc_bimodal.x gfortran stdc++)
++    target_link_libraries (tmcmc_bimodal.x stdc++)
+   else()
+     target_link_libraries (tmcmc_bimodal.x ${ClangLibPath}/libgfortran.dylib  ${ClangLibPath}/libstdc++.dylib)
+   endif()

--- a/var/spack/repos/builtin/packages/uqtk/package.py
+++ b/var/spack/repos/builtin/packages/uqtk/package.py
@@ -16,5 +16,29 @@ class Uqtk(CMakePackage):
 
     version('master', branch='master')
     version('3.0.4', sha256='0a72856438134bb571fd328d1d30ce3d0d7aead32eda9b7fb6e436a27d546d2e')
+    version('3.1.0', sha256='56ecd3d13bdd908d568e9560dc52cc0f66d7bdcdbe64ab2dd0147a7cf1734f97')
 
     depends_on('expat')
+    depends_on('sundials', when='@3.1.0:')
+    depends_on('blas', when='@3.1.0:')
+    depends_on('lapack', when='@3.1.0:')
+
+    # Modify the process of directly specifying blas/lapack
+    # as the library name.
+    patch('remove_unique_libname.patch', when='@3.1.0:')
+
+    # Do not link the gfortran library when using the Fujitsu compiler.
+    patch('not_link_gfortran.patch', when='@3.1.0:%fj')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        # Make sure we use Spack's blas/lapack:
+        lapack_libs = spec['lapack'].libs.joined(';')
+        blas_libs = spec['blas'].libs.joined(';')
+
+        return [
+            '-DCMAKE_SUNDIALS_DIR={0}'.format(spec['sundials'].prefix),
+            '-DLAPACK_LIBRARIES={0}'.format(lapack_libs),
+            '-DBLAS_LIBRARIES={0}'.format(blas_libs)
+        ]

--- a/var/spack/repos/builtin/packages/uqtk/package.py
+++ b/var/spack/repos/builtin/packages/uqtk/package.py
@@ -15,8 +15,8 @@ class Uqtk(CMakePackage):
     git      = "https://github.com/sandialabs/UQTk.git"
 
     version('master', branch='master')
-    version('3.0.4', sha256='0a72856438134bb571fd328d1d30ce3d0d7aead32eda9b7fb6e436a27d546d2e')
     version('3.1.0', sha256='56ecd3d13bdd908d568e9560dc52cc0f66d7bdcdbe64ab2dd0147a7cf1734f97')
+    version('3.0.4', sha256='0a72856438134bb571fd328d1d30ce3d0d7aead32eda9b7fb6e436a27d546d2e')
 
     depends_on('expat')
     depends_on('sundials', when='@3.1.0:')

--- a/var/spack/repos/builtin/packages/uqtk/package.py
+++ b/var/spack/repos/builtin/packages/uqtk/package.py
@@ -30,6 +30,7 @@ class Uqtk(CMakePackage):
     # Do not link the gfortran library when using the Fujitsu compiler.
     patch('not_link_gfortran.patch', when='@3.1.0:%fj')
 
+    @when('@3.1.0:')
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/uqtk/remove_unique_libname.patch
+++ b/var/spack/repos/builtin/packages/uqtk/remove_unique_libname.patch
@@ -1,0 +1,962 @@
+diff -ur UQTk-3.1.0.org/cpp/app/generate_quad/CMakeLists.txt UQTk-3.1.0/cpp/app/generate_quad/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/generate_quad/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/generate_quad/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -6,8 +6,8 @@
+ target_link_libraries (generate_quad uqtkarray)
+ 
+ target_link_libraries (generate_quad depdsfmt )
+-target_link_libraries (generate_quad m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (generate_quad m blas ${BLAS_LIBRARIES})
++target_link_libraries (generate_quad m ${LAPACK_LIBRARIES})
++target_link_libraries (generate_quad m ${BLAS_LIBRARIES})
+ target_link_libraries (generate_quad depfigtree )
+ target_link_libraries (generate_quad depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/gen_mi/CMakeLists.txt UQTk-3.1.0/cpp/app/gen_mi/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/gen_mi/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/gen_mi/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -6,8 +6,8 @@
+ target_link_libraries (gen_mi uqtktools)
+ 
+ target_link_libraries (gen_mi depdsfmt )
+-target_link_libraries(gen_mi m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(gen_mi m blas ${BLAS_LIBRARIES})
++target_link_libraries(gen_mi m ${LAPACK_LIBRARIES})
++target_link_libraries(gen_mi m ${BLAS_LIBRARIES})
+ target_link_libraries (gen_mi depfigtree )
+ target_link_libraries (gen_mi depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/gkpSparse/CMakeLists.txt UQTk-3.1.0/cpp/app/gkpSparse/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/gkpSparse/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/gkpSparse/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -7,8 +7,8 @@
+ target_link_libraries (gkpSparse uqtkarray)
+ 
+ target_link_libraries (gkpSparse depdsfmt )
+-target_link_libraries (gkpSparse m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (gkpSparse m blas ${BLAS_LIBRARIES})
++target_link_libraries (gkpSparse m ${LAPACK_LIBRARIES})
++target_link_libraries (gkpSparse m ${BLAS_LIBRARIES})
+ target_link_libraries (gkpSparse depfigtree )
+ target_link_libraries (gkpSparse depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/gp_regr/CMakeLists.txt UQTk-3.1.0/cpp/app/gp_regr/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/gp_regr/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/gp_regr/CMakeLists.txt	2020-10-05 17:27:48.636634342 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (gp_regr sundials_sunlinsoldense)
+ target_link_libraries (gp_regr sundials_sunmatrixdense)
+ target_link_libraries (gp_regr depslatec)
+-target_link_libraries (gp_regr lapack)
+-target_link_libraries (gp_regr blas)
++target_link_libraries (gp_regr ${LAPACK_LIBRARIES})
++target_link_libraries (gp_regr ${BLAS_LIBRARIES})
+ target_link_libraries (gp_regr depfigtree )
+ target_link_libraries (gp_regr depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/lr_eval/CMakeLists.txt UQTk-3.1.0/cpp/app/lr_eval/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/lr_eval/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/lr_eval/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -17,8 +17,8 @@
+ target_link_libraries (lr_eval sundials_sunlinsoldense)
+ target_link_libraries (lr_eval sundials_sunmatrixdense)
+ target_link_libraries (lr_eval depslatec)
+-target_link_libraries(lr_eval m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(lr_eval m blas ${BLAS_LIBRARIES})
++target_link_libraries(lr_eval m ${LAPACK_LIBRARIES})
++target_link_libraries(lr_eval m ${BLAS_LIBRARIES})
+ target_link_libraries (lr_eval depfigtree )
+ target_link_libraries (lr_eval depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/lr_regr/CMakeLists.txt UQTk-3.1.0/cpp/app/lr_regr/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/lr_regr/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/lr_regr/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -17,8 +17,8 @@
+ target_link_libraries (lr_regr sundials_sunlinsoldense)
+ target_link_libraries (lr_regr sundials_sunmatrixdense)
+ target_link_libraries (lr_regr depslatec)
+-target_link_libraries (lr_regr m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (lr_regr m blas ${BLAS_LIBRARIES})
++target_link_libraries (lr_regr m ${LAPACK_LIBRARIES})
++target_link_libraries (lr_regr m ${BLAS_LIBRARIES})
+ target_link_libraries (lr_regr depfigtree )
+ target_link_libraries (lr_regr depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/model_inf/CMakeLists.txt UQTk-3.1.0/cpp/app/model_inf/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/model_inf/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/model_inf/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (model_inf sundials_sunlinsoldense)
+ target_link_libraries (model_inf sundials_sunmatrixdense)
+ target_link_libraries (model_inf depslatec)
+-target_link_libraries (model_inf m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (model_inf m blas ${BLAS_LIBRARIES})
++target_link_libraries (model_inf m ${LAPACK_LIBRARIES})
++target_link_libraries (model_inf m ${BLAS_LIBRARIES})
+ target_link_libraries (model_inf depfigtree )
+ target_link_libraries (model_inf depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pce_eval/CMakeLists.txt UQTk-3.1.0/cpp/app/pce_eval/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pce_eval/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pce_eval/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,8 +13,8 @@
+ target_link_libraries (pce_eval sundials_sunlinsoldense)
+ target_link_libraries (pce_eval sundials_sunmatrixdense)
+ target_link_libraries (pce_eval depslatec)
+-target_link_libraries (pce_eval m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_eval m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_eval m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_eval m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_eval depfigtree )
+ target_link_libraries (pce_eval depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pce_quad/CMakeLists.txt UQTk-3.1.0/cpp/app/pce_quad/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pce_quad/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pce_quad/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -15,8 +15,8 @@
+ target_link_libraries (pce_quad sundials_sunlinsoldense)
+ target_link_libraries (pce_quad sundials_sunmatrixdense)
+ target_link_libraries (pce_quad depslatec)
+-target_link_libraries (pce_quad m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_quad m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_quad m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_quad m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_quad depfigtree )
+ target_link_libraries (pce_quad depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pce_resp/CMakeLists.txt UQTk-3.1.0/cpp/app/pce_resp/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pce_resp/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pce_resp/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,8 +13,8 @@
+ target_link_libraries (pce_resp sundials_sunlinsoldense)
+ target_link_libraries (pce_resp sundials_sunmatrixdense)
+ target_link_libraries (pce_resp depslatec)
+-target_link_libraries (pce_resp m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_resp m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_resp m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_resp m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_resp depfigtree )
+ target_link_libraries (pce_resp depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pce_rv/CMakeLists.txt UQTk-3.1.0/cpp/app/pce_rv/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pce_rv/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pce_rv/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,8 +13,8 @@
+ target_link_libraries (pce_rv sundials_sunlinsoldense)
+ target_link_libraries (pce_rv sundials_sunmatrixdense)
+ target_link_libraries (pce_rv depslatec)
+-target_link_libraries (pce_rv m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_rv m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_rv m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_rv m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_rv depfigtree )
+ target_link_libraries (pce_rv depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pce_sens/CMakeLists.txt UQTk-3.1.0/cpp/app/pce_sens/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pce_sens/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pce_sens/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,8 +13,8 @@
+ target_link_libraries (pce_sens sundials_sunlinsoldense)
+ target_link_libraries (pce_sens sundials_sunmatrixdense)
+ target_link_libraries (pce_sens depslatec)
+-target_link_libraries (pce_sens m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_sens m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_sens m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_sens m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_sens depfigtree )
+ target_link_libraries (pce_sens depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/pdf_cl/CMakeLists.txt UQTk-3.1.0/cpp/app/pdf_cl/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/pdf_cl/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/pdf_cl/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -11,8 +11,8 @@
+ target_link_libraries (pdf_cl sundials_sunlinsoldense)
+ target_link_libraries (pdf_cl sundials_sunmatrixdense)
+ target_link_libraries (pdf_cl depslatec)
+-target_link_libraries (pdf_cl m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pdf_cl m blas ${BLAS_LIBRARIES})
++target_link_libraries (pdf_cl m ${LAPACK_LIBRARIES})
++target_link_libraries (pdf_cl m ${BLAS_LIBRARIES})
+ target_link_libraries (pdf_cl depfigtree )
+ target_link_libraries (pdf_cl depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/regression/CMakeLists.txt UQTk-3.1.0/cpp/app/regression/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/regression/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/regression/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (regression sundials_sunlinsoldense)
+ target_link_libraries (regression sundials_sunmatrixdense)
+ target_link_libraries (regression depslatec)
+-target_link_libraries (regression m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (regression m blas ${BLAS_LIBRARIES})
++target_link_libraries (regression m ${LAPACK_LIBRARIES})
++target_link_libraries (regression m ${BLAS_LIBRARIES})
+ target_link_libraries (regression depfigtree )
+ target_link_libraries (regression depann   )
+ 
+diff -ur UQTk-3.1.0.org/cpp/app/sens/CMakeLists.txt UQTk-3.1.0/cpp/app/sens/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/app/sens/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/app/sens/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (trdSpls sundials_sunlinsoldense)
+ target_link_libraries (trdSpls sundials_sunmatrixdense)
+ target_link_libraries (trdSpls depslatec)
+-target_link_libraries (trdSpls m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (trdSpls m blas ${BLAS_LIBRARIES})
++target_link_libraries (trdSpls m ${LAPACK_LIBRARIES})
++target_link_libraries (trdSpls m ${BLAS_LIBRARIES})
+ target_link_libraries (trdSpls depfigtree )
+ target_link_libraries (trdSpls depann   )
+ 
+@@ -27,8 +27,8 @@
+ target_link_libraries (sens depdsfmt )
+ #find_package(BLAS)
+ #find_package(LAPACK)
+-target_link_libraries (sens m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (sens m blas ${BLAS_LIBRARIES})
++target_link_libraries (sens m ${LAPACK_LIBRARIES})
++target_link_libraries (sens m ${BLAS_LIBRARIES})
+ 
+ # Link fortran libraries
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+diff -ur UQTk-3.1.0.org/cpp/lib/array/CMakeLists.txt UQTk-3.1.0/cpp/lib/array/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/array/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/array/CMakeLists.txt	2020-10-05 17:28:35.616860867 +0900
+@@ -13,7 +13,7 @@
+ include_directories (../include)
+ 
+ #find and include blas and lapack
+-target_link_libraries(uqtkarray blas lapack)
++target_link_libraries(uqtkarray ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ 
+ # Install the library
+ INSTALL(TARGETS uqtkarray DESTINATION lib)
+diff -ur UQTk-3.1.0.org/cpp/lib/bcs/CMakeLists.txt UQTk-3.1.0/cpp/lib/bcs/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/bcs/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/bcs/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,7 +13,7 @@
+ 
+ include_directories (../../../dep/slatec)
+ 
+-target_link_libraries(uqtkbcs m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtkbcs m ${LAPACK_LIBRARIES})
+ 
+ include_directories (../../../dep/dsfmt)
+ include_directories (../../../dep/figtree)
+diff -ur UQTk-3.1.0.org/cpp/lib/gproc/CMakeLists.txt UQTk-3.1.0/cpp/lib/gproc/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/gproc/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/lib/gproc/CMakeLists.txt	2020-10-05 17:29:16.917060005 +0900
+@@ -13,7 +13,7 @@
+ include_directories (../pce    )
+ include_directories (../bcs    )
+ 
+-target_link_libraries(uqtkgproc blas lapack)
++target_link_libraries(uqtkgproc ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/lbfgs)
+ include_directories (../../../dep/dsfmt)
+ include_directories (../../../dep/figtree)
+diff -ur UQTk-3.1.0.org/cpp/lib/infer/CMakeLists.txt UQTk-3.1.0/cpp/lib/infer/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/infer/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/infer/CMakeLists.txt	2020-10-05 17:30:02.617280359 +0900
+@@ -16,7 +16,7 @@
+ include_directories (../mcmc   )
+ 
+ include_directories (../../../dep/slatec)
+-target_link_libraries(uqtkinfer  lapack)
++target_link_libraries(uqtkinfer ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/dsfmt )
+ include_directories (../../../dep/figtree )
+ include_directories (../../../dep/lbfgs )
+diff -ur UQTk-3.1.0.org/cpp/lib/kle/CMakeLists.txt UQTk-3.1.0/cpp/lib/kle/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/kle/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/kle/CMakeLists.txt	2020-10-05 17:30:53.547525931 +0900
+@@ -10,7 +10,7 @@
+ include_directories (../tools  )
+ 
+ #find and include lapack
+-target_link_libraries(uqtkkle m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtkkle m ${LAPACK_LIBRARIES})
+ 
+ # Install the library
+ INSTALL(TARGETS uqtkkle DESTINATION lib)
+diff -ur UQTk-3.1.0.org/cpp/lib/lowrank/CMakeLists.txt UQTk-3.1.0/cpp/lib/lowrank/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/lowrank/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/lib/lowrank/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -14,8 +14,8 @@
+ include_directories (../bcs    )
+ 
+ 
+-target_link_libraries(uqtklowrank m blas ${BLAS_LIBRARIES})
+-target_link_libraries(uqtklowrank m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtklowrank m ${BLAS_LIBRARIES})
++target_link_libraries(uqtklowrank m ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/lbfgs)
+ include_directories (../../../dep/dsfmt)
+ include_directories (../../../dep/figtree)
+diff -ur UQTk-3.1.0.org/cpp/lib/lreg/CMakeLists.txt UQTk-3.1.0/cpp/lib/lreg/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/lreg/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/lreg/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,8 +13,8 @@
+ include_directories (../pce    )
+ include_directories (../bcs    )
+ 
+-target_link_libraries(uqtklreg m blas ${BLAS_LIBRARIES})
+-target_link_libraries(uqtklreg m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtklreg m ${BLAS_LIBRARIES})
++target_link_libraries(uqtklreg m ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/lbfgs)
+ include_directories (../../../dep/dsfmt)
+ include_directories (../../../dep/figtree)
+diff -ur UQTk-3.1.0.org/cpp/lib/mcmc/CMakeLists.txt UQTk-3.1.0/cpp/lib/mcmc/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/mcmc/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/mcmc/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,7 +13,7 @@
+ include_directories (../tmcmc  )
+ 
+ include_directories (../../../dep/slatec)
+-target_link_libraries(uqtkmcmc m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtkmcmc m ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/dsfmt )
+ include_directories (../../../dep/figtree)
+ include_directories (../../../dep/lbfgs )
+diff -ur UQTk-3.1.0.org/cpp/lib/pce/CMakeLists.txt UQTk-3.1.0/cpp/lib/pce/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/pce/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/lib/pce/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -13,7 +13,7 @@
+ include_directories (../quad   )
+ 
+ # TPL
+-target_link_libraries(uqtkpce m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtkpce m ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/slatec)
+ include_directories (../../../dep/dsfmt )
+ include_directories (${CMAKE_SUNDIALS_DIR}/include)
+diff -ur UQTk-3.1.0.org/cpp/lib/tools/CMakeLists.txt UQTk-3.1.0/cpp/lib/tools/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/lib/tools/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/cpp/lib/tools/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -25,7 +25,7 @@
+ include_directories (../quad)
+ 
+ include_directories (../../../dep/dsfmt )
+-target_link_libraries(uqtktools m lapack ${LAPACK_LIBRARIES})
++target_link_libraries(uqtktools m ${LAPACK_LIBRARIES})
+ include_directories (../../../dep/slatec )
+ include_directories (../../../dep/figtree)
+ include_directories (${CMAKE_SUNDIALS_DIR}/include)
+diff -ur UQTk-3.1.0.org/cpp/tests/Array1DMiscTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/Array1DMiscTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/Array1DMiscTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/Array1DMiscTest/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (Array1DMiscTest sundials_sunlinsoldense)
+ target_link_libraries (Array1DMiscTest sundials_sunmatrixdense)
+ target_link_libraries (Array1DMiscTest depslatec)
+-target_link_libraries (Array1DMiscTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (Array1DMiscTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (Array1DMiscTest m ${LAPACK_LIBRARIES})
++target_link_libraries (Array1DMiscTest m ${BLAS_LIBRARIES})
+ target_link_libraries (Array1DMiscTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/Array2DMiscTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/Array2DMiscTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/Array2DMiscTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/Array2DMiscTest/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (Array2DMiscTest sundials_sunlinsoldense)
+ target_link_libraries (Array2DMiscTest sundials_sunmatrixdense)
+ target_link_libraries (Array2DMiscTest depslatec)
+-target_link_libraries(Array2DMiscTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(Array2DMiscTest m blas ${BLAS_LIBRARIES})
++target_link_libraries(Array2DMiscTest m ${LAPACK_LIBRARIES})
++target_link_libraries(Array2DMiscTest m ${BLAS_LIBRARIES})
+ target_link_libraries (Array2DMiscTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/ArrayDelColumn/CMakeLists.txt UQTk-3.1.0/cpp/tests/ArrayDelColumn/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/ArrayDelColumn/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/ArrayDelColumn/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (ArrayDelColumn sundials_sunlinsoldense)
+ target_link_libraries (ArrayDelColumn sundials_sunmatrixdense)
+ target_link_libraries (ArrayDelColumn depslatec)
+-target_link_libraries(ArrayDelColumn m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(ArrayDelColumn m blas ${BLAS_LIBRARIES})
++target_link_libraries(ArrayDelColumn m ${LAPACK_LIBRARIES})
++target_link_libraries(ArrayDelColumn m ${BLAS_LIBRARIES})
+ target_link_libraries (ArrayDelColumn deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/ArrayReadAndWrite/CMakeLists.txt UQTk-3.1.0/cpp/tests/ArrayReadAndWrite/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/ArrayReadAndWrite/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/ArrayReadAndWrite/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (ArrayReadAndWrite sundials_sunlinsoldense)
+ target_link_libraries (ArrayReadAndWrite sundials_sunmatrixdense)
+ target_link_libraries (ArrayReadAndWrite depslatec)
+-target_link_libraries(ArrayReadAndWrite m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(ArrayReadAndWrite m blas ${BLAS_LIBRARIES})
++target_link_libraries(ArrayReadAndWrite m ${LAPACK_LIBRARIES})
++target_link_libraries(ArrayReadAndWrite m ${BLAS_LIBRARIES})
+ target_link_libraries (ArrayReadAndWrite deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/ArraySortTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/ArraySortTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/ArraySortTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/ArraySortTest/CMakeLists.txt	2020-10-05 16:34:42.011268806 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (ArraySortTest sundials_sunlinsoldense)
+ target_link_libraries (ArraySortTest sundials_sunmatrixdense)
+ target_link_libraries (ArraySortTest depslatec)
+-target_link_libraries(ArraySortTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(ArraySortTest m blas ${BLAS_LIBRARIES})
++target_link_libraries(ArraySortTest m ${LAPACK_LIBRARIES})
++target_link_libraries(ArraySortTest m ${BLAS_LIBRARIES})
+ target_link_libraries (ArraySortTest deplbfgs  )
+ target_link_libraries (ArraySortTest depfigtree )
+ target_link_libraries (ArraySortTest  depann   )
+diff -ur UQTk-3.1.0.org/cpp/tests/BCS1dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/BCS1dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/BCS1dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/BCS1dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (BCS1dTest sundials_sunlinsoldense)
+ target_link_libraries (BCS1dTest sundials_sunmatrixdense)
+ target_link_libraries (BCS1dTest depslatec)
+-target_link_libraries(BCS1dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries(BCS1dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries(BCS1dTest m ${LAPACK_LIBRARIES})
++target_link_libraries(BCS1dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (BCS1dTest deplbfgs  )
+ target_link_libraries (BCS1dTest depfigtree  )
+ target_link_libraries (BCS1dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/BCS2dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/BCS2dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/BCS2dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/BCS2dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (BCS2dTest sundials_sunlinsoldense)
+ target_link_libraries (BCS2dTest sundials_sunmatrixdense)
+ target_link_libraries (BCS2dTest depslatec)
+-target_link_libraries (BCS2dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (BCS2dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (BCS2dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (BCS2dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (BCS2dTest deplbfgs  )
+ target_link_libraries (BCS2dTest depfigtree  )
+ target_link_libraries (BCS2dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/CorrTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/CorrTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/CorrTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/CorrTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -26,8 +26,8 @@
+ target_link_libraries (CorrTest sundials_sunlinsoldense)
+ target_link_libraries (CorrTest sundials_sunmatrixdense)
+ target_link_libraries (CorrTest depslatec)
+-target_link_libraries (CorrTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (CorrTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (CorrTest m ${LAPACK_LIBRARIES})
++target_link_libraries (CorrTest m ${BLAS_LIBRARIES})
+ target_link_libraries (CorrTest deplbfgs  )
+ target_link_libraries (CorrTest depfigtree  )
+ target_link_libraries (CorrTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/Deriv1dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/Deriv1dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/Deriv1dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/Deriv1dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (Deriv1dTest sundials_sunlinsoldense)
+ target_link_libraries (Deriv1dTest sundials_sunmatrixdense)
+ target_link_libraries (Deriv1dTest depslatec)
+-target_link_libraries (Deriv1dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (Deriv1dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (Deriv1dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (Deriv1dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (Deriv1dTest deplbfgs  )
+ target_link_libraries (Deriv1dTest depfigtree  )
+ target_link_libraries (Deriv1dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/GradHessianTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/GradHessianTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/GradHessianTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/GradHessianTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (GradHessianTest sundials_sunlinsoldense)
+ target_link_libraries (GradHessianTest sundials_sunmatrixdense)
+ target_link_libraries (GradHessianTest depslatec)
+-target_link_libraries (GradHessianTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (GradHessianTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (GradHessianTest m ${LAPACK_LIBRARIES})
++target_link_libraries (GradHessianTest m ${BLAS_LIBRARIES})
+ target_link_libraries (GradHessianTest deplbfgs  )
+ target_link_libraries (GradHessianTest depfigtree  )
+ target_link_libraries (GradHessianTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/GradientPCETest/CMakeLists.txt UQTk-3.1.0/cpp/tests/GradientPCETest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/GradientPCETest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/GradientPCETest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (GradientPCETest sundials_sunlinsoldense)
+ target_link_libraries (GradientPCETest sundials_sunmatrixdense)
+ target_link_libraries (GradientPCETest depslatec)
+-target_link_libraries (GradientPCETest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (GradientPCETest m blas ${BLAS_LIBRARIES})
++target_link_libraries (GradientPCETest m ${LAPACK_LIBRARIES})
++target_link_libraries (GradientPCETest m ${BLAS_LIBRARIES})
+ target_link_libraries (GradientPCETest deplbfgs  )
+ target_link_libraries (GradientPCETest depfigtree  )
+ target_link_libraries (GradientPCETest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/Hessian2dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/Hessian2dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/Hessian2dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/Hessian2dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (Hessian2dTest sundials_sunlinsoldense)
+ target_link_libraries (Hessian2dTest sundials_sunmatrixdense)
+ target_link_libraries (Hessian2dTest depslatec)
+-target_link_libraries (Hessian2dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (Hessian2dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (Hessian2dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (Hessian2dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (Hessian2dTest deplbfgs  )
+ target_link_libraries (Hessian2dTest depfigtree  )
+ target_link_libraries (Hessian2dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/LowRankRegrTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/LowRankRegrTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/LowRankRegrTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/LowRankRegrTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -5,8 +5,8 @@
+ target_link_libraries (LowRankRegrTest uqtk )
+ 
+ target_link_libraries (LowRankRegrTest depdsfmt )
+-target_link_libraries (LowRankRegrTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (LowRankRegrTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (LowRankRegrTest m ${LAPACK_LIBRARIES})
++target_link_libraries (LowRankRegrTest m ${BLAS_LIBRARIES})
+ target_link_libraries (LowRankRegrTest depfigtree  )
+ target_link_libraries (LowRankRegrTest depann  )
+ 
+diff -ur UQTk-3.1.0.org/cpp/tests/MCMC2dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/MCMC2dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/MCMC2dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/MCMC2dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -12,8 +12,8 @@
+ target_link_libraries (MCMC2dTest sundials_sunlinsoldense)
+ target_link_libraries (MCMC2dTest sundials_sunmatrixdense)
+ target_link_libraries (MCMC2dTest depslatec)
+-target_link_libraries (MCMC2dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (MCMC2dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (MCMC2dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (MCMC2dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (MCMC2dTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/MCMCNestedTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/MCMCNestedTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/MCMCNestedTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/MCMCNestedTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -12,8 +12,8 @@
+ target_link_libraries (MCMCNestedTest sundials_sunlinsoldense)
+ target_link_libraries (MCMCNestedTest sundials_sunmatrixdense)
+ target_link_libraries (MCMCNestedTest depslatec)
+-target_link_libraries (MCMCNestedTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (MCMCNestedTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (MCMCNestedTest m ${LAPACK_LIBRARIES})
++target_link_libraries (MCMCNestedTest m ${BLAS_LIBRARIES})
+ target_link_libraries (MCMCNestedTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/MCMCRandomTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/MCMCRandomTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/MCMCRandomTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/MCMCRandomTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -12,8 +12,8 @@
+ target_link_libraries (MCMCRandomTest sundials_sunlinsoldense)
+ target_link_libraries (MCMCRandomTest sundials_sunmatrixdense)
+ target_link_libraries (MCMCRandomTest depslatec)
+-target_link_libraries (MCMCRandomTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (MCMCRandomTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (MCMCRandomTest m ${LAPACK_LIBRARIES})
++target_link_libraries (MCMCRandomTest m ${BLAS_LIBRARIES})
+ target_link_libraries (MCMCRandomTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/cpp/tests/MultiIndexTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/MultiIndexTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/MultiIndexTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/MultiIndexTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (MultiIndexTest sundials_sunlinsoldense)
+ target_link_libraries (MultiIndexTest sundials_sunmatrixdense)
+ target_link_libraries (MultiIndexTest depslatec  )
+-target_link_libraries (MultiIndexTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (MultiIndexTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (MultiIndexTest m ${LAPACK_LIBRARIES})
++target_link_libraries (MultiIndexTest m ${BLAS_LIBRARIES})
+ target_link_libraries (MultiIndexTest deplbfgs   )
+ target_link_libraries (MultiIndexTest depfigtree )
+ target_link_libraries (MultiIndexTest depann     )
+diff -ur UQTk-3.1.0.org/cpp/tests/PCE1dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/PCE1dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/PCE1dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/PCE1dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (PCE1dTest sundials_sunlinsoldense)
+ target_link_libraries (PCE1dTest sundials_sunmatrixdense)
+ target_link_libraries (PCE1dTest depslatec)
+-target_link_libraries (PCE1dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (PCE1dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (PCE1dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (PCE1dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (PCE1dTest deplbfgs  )
+ target_link_libraries (PCE1dTest depfigtree  )
+ target_link_libraries (PCE1dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/PCEImplTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/PCEImplTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/PCEImplTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/PCEImplTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (PCEImplTest sundials_sunlinsoldense)
+ target_link_libraries (PCEImplTest sundials_sunmatrixdense)
+ target_link_libraries (PCEImplTest depslatec)
+-target_link_libraries (PCEImplTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (PCEImplTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (PCEImplTest m ${LAPACK_LIBRARIES})
++target_link_libraries (PCEImplTest m ${BLAS_LIBRARIES})
+ target_link_libraries (PCEImplTest deplbfgs  )
+ target_link_libraries (PCEImplTest depfigtree  )
+ target_link_libraries (PCEImplTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/PCELogTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/PCELogTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/PCELogTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/PCELogTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (PCELogTest sundials_sunlinsoldense)
+ target_link_libraries (PCELogTest sundials_sunmatrixdense)
+ target_link_libraries (PCELogTest depslatec)
+-target_link_libraries (PCELogTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (PCELogTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (PCELogTest m ${LAPACK_LIBRARIES})
++target_link_libraries (PCELogTest m ${BLAS_LIBRARIES})
+ target_link_libraries (PCELogTest deplbfgs  )
+ target_link_libraries (PCELogTest depfigtree  )
+ target_link_libraries (PCELogTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/QuadLUTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/QuadLUTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/QuadLUTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/QuadLUTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -16,8 +16,8 @@
+ target_link_libraries (QuadLUTest sundials_sunlinsoldense)
+ target_link_libraries (QuadLUTest sundials_sunmatrixdense)
+ target_link_libraries (QuadLUTest depslatec)
+-target_link_libraries (QuadLUTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (QuadLUTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (QuadLUTest m ${LAPACK_LIBRARIES})
++target_link_libraries (QuadLUTest m ${BLAS_LIBRARIES})
+ target_link_libraries (QuadLUTest deplbfgs )
+ target_link_libraries (QuadLUTest depfigtree )
+ target_link_libraries (QuadLUTest depann   )
+diff -ur UQTk-3.1.0.org/cpp/tests/SecondDeriv1dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/SecondDeriv1dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/SecondDeriv1dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/SecondDeriv1dTest/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -10,8 +10,8 @@
+ target_link_libraries (SecondDeriv1dTest sundials_sunlinsoldense)
+ target_link_libraries (SecondDeriv1dTest sundials_sunmatrixdense)
+ target_link_libraries (SecondDeriv1dTest depslatec)
+-target_link_libraries (SecondDeriv1dTest m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (SecondDeriv1dTest m blas ${BLAS_LIBRARIES})
++target_link_libraries (SecondDeriv1dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (SecondDeriv1dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (SecondDeriv1dTest deplbfgs  )
+ target_link_libraries (SecondDeriv1dTest depfigtree  )
+ target_link_libraries (SecondDeriv1dTest depann  )
+diff -ur UQTk-3.1.0.org/cpp/tests/TMCMC2dTest/CMakeLists.txt UQTk-3.1.0/cpp/tests/TMCMC2dTest/CMakeLists.txt
+--- UQTk-3.1.0.org/cpp/tests/TMCMC2dTest/CMakeLists.txt	2020-10-05 16:13:58.865293397 +0900
++++ UQTk-3.1.0/cpp/tests/TMCMC2dTest/CMakeLists.txt	2020-10-05 17:32:09.417892030 +0900
+@@ -28,8 +28,8 @@
+ target_link_libraries (TMCMC2dTest sundials_sunlinsoldense)
+ target_link_libraries (TMCMC2dTest sundials_sunmatrixdense)
+ target_link_libraries (TMCMC2dTest depslatec)
+-target_link_libraries (TMCMC2dTest m lapack)
+-target_link_libraries (TMCMC2dTest m  blas)
++target_link_libraries (TMCMC2dTest m ${LAPACK_LIBRARIES})
++target_link_libraries (TMCMC2dTest m ${BLAS_LIBRARIES})
+ target_link_libraries (TMCMC2dTest deplbfgs  )
+ 
+ # Link fortran libraries
+diff -ur UQTk-3.1.0.org/examples/kle_ex1/CMakeLists.txt UQTk-3.1.0/examples/kle_ex1/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/kle_ex1/CMakeLists.txt	2020-10-05 16:13:58.885293494 +0900
++++ UQTk-3.1.0/examples/kle_ex1/CMakeLists.txt	2020-10-05 17:33:36.298311846 +0900
+@@ -30,22 +30,22 @@
+ add_executable (kl_1D.x kl_1D.cpp kl_utils.cpp)
+ target_link_libraries (kl_1D.x uqtktools uqtkarray uqtkkle)
+ target_link_libraries (kl_1D.x depdsfmt depslatec depann depfigtree)
+-target_link_libraries (kl_1D.x lapack)
+-target_link_libraries (kl_1D.x blas)
++target_link_libraries (kl_1D.x ${LAPACK_LIBRARIES})
++target_link_libraries (kl_1D.x ${BLAS_LIBRARIES})
+ 
+ # kl_2D.x
+ add_executable (kl_2D.x kl_2D.cpp kl_utils.cpp)
+ target_link_libraries (kl_2D.x uqtktools uqtkarray uqtkkle)
+ target_link_libraries (kl_2D.x depdsfmt depslatec depann depfigtree)
+-target_link_libraries (kl_2D.x lapack)
+-target_link_libraries (kl_2D.x blas)
++target_link_libraries (kl_2D.x ${LAPACK_LIBRARIES})
++target_link_libraries (kl_2D.x ${BLAS_LIBRARIES})
+ 
+ # kl_2Du.x
+ add_executable (kl_2Du.x kl_2Du.cpp kl_utils.cpp)
+ target_link_libraries (kl_2Du.x uqtktools uqtkarray uqtkkle)
+ target_link_libraries (kl_2Du.x depdsfmt depslatec depann depfigtree)
+-target_link_libraries (kl_2Du.x lapack)
+-target_link_libraries (kl_2Du.x blas)
++target_link_libraries (kl_2Du.x ${LAPACK_LIBRARIES})
++target_link_libraries (kl_2Du.x ${BLAS_LIBRARIES})
+ 
+ # Link fortran libraries
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+diff -ur UQTk-3.1.0.org/examples/line_infer/CMakeLists.txt UQTk-3.1.0/examples/line_infer/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/line_infer/CMakeLists.txt	2020-10-05 16:13:58.885293494 +0900
++++ UQTk-3.1.0/examples/line_infer/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -29,8 +29,8 @@
+ target_link_libraries (line_infer.x sundials_sunlinsoldense)
+ target_link_libraries (line_infer.x sundials_sunmatrixdense)
+ target_link_libraries (line_infer.x depslatec)
+-target_link_libraries (line_infer.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (line_infer.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (line_infer.x m ${LAPACK_LIBRARIES})
++target_link_libraries (line_infer.x m ${BLAS_LIBRARIES})
+ target_link_libraries (line_infer.x depfigtree  )
+ target_link_libraries (line_infer.x depann   )
+ 
+diff -ur UQTk-3.1.0.org/examples/muq/CMakeLists.txt UQTk-3.1.0/examples/muq/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/muq/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/examples/muq/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -30,8 +30,8 @@
+ target_link_libraries (muqPCE2uqtk.x sundials_sunlinsoldense)
+ target_link_libraries (muqPCE2uqtk.x sundials_sunmatrixdense)
+ target_link_libraries (muqPCE2uqtk.x depslatec )
+-target_link_libraries (muqPCE2uqtk.x m blas ${BLAS_LIBRARIES})
+-target_link_libraries (muqPCE2uqtk.x m lapack ${LAPACK_LIBRARIES})
++target_link_libraries (muqPCE2uqtk.x m ${BLAS_LIBRARIES})
++target_link_libraries (muqPCE2uqtk.x m ${LAPACK_LIBRARIES})
+ target_link_libraries (muqPCE2uqtk.x depfigtree )
+ target_link_libraries (muqPCE2uqtk.x depann   )
+ target_link_libraries (muqPCE2uqtk.x expat )
+diff -ur UQTk-3.1.0.org/examples/ops/CMakeLists.txt UQTk-3.1.0/examples/ops/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/ops/CMakeLists.txt	2020-10-05 16:13:58.885293494 +0900
++++ UQTk-3.1.0/examples/ops/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -35,8 +35,8 @@
+ target_link_libraries (Ops.x sundials_sunlinsoldense)
+ target_link_libraries (Ops.x sundials_sunmatrixdense)
+ target_link_libraries (Ops.x depslatec)
+-target_link_libraries (Ops.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (Ops.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (Ops.x m ${LAPACK_LIBRARIES})
++target_link_libraries (Ops.x m ${BLAS_LIBRARIES})
+ target_link_libraries (Ops.x depfigtree )
+ target_link_libraries (Ops.x depann   )
+ 
+@@ -76,8 +76,8 @@
+ target_link_libraries (LogComp.x sundials_sunlinsoldense)
+ target_link_libraries (LogComp.x sundials_sunmatrixdense)
+ target_link_libraries (LogComp.x depslatec)
+-target_link_libraries (LogComp.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (LogComp.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (LogComp.x m ${LAPACK_LIBRARIES})
++target_link_libraries (LogComp.x m ${BLAS_LIBRARIES})
+ target_link_libraries (LogComp.x depfigtree )
+ target_link_libraries (LogComp.x depann   )
+ 
+diff -ur UQTk-3.1.0.org/examples/pce_bcs/CMakeLists.txt UQTk-3.1.0/examples/pce_bcs/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/pce_bcs/CMakeLists.txt	2020-10-05 16:13:58.885293494 +0900
++++ UQTk-3.1.0/examples/pce_bcs/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -32,8 +32,8 @@
+ target_link_libraries (pce_bcs.x sundials_sunlinsoldense)
+ target_link_libraries (pce_bcs.x sundials_sunmatrixdense)
+ target_link_libraries (pce_bcs.x depslatec)
+-target_link_libraries (pce_bcs.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (pce_bcs.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (pce_bcs.x m ${LAPACK_LIBRARIES})
++target_link_libraries (pce_bcs.x m ${BLAS_LIBRARIES})
+ target_link_libraries (pce_bcs.x depfigtree )
+ target_link_libraries (pce_bcs.x depann   )
+ 
+diff -ur UQTk-3.1.0.org/examples/surf_rxn/CMakeLists.txt UQTk-3.1.0/examples/surf_rxn/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/surf_rxn/CMakeLists.txt	2020-10-05 16:13:58.875293445 +0900
++++ UQTk-3.1.0/examples/surf_rxn/CMakeLists.txt	2020-10-05 16:34:42.021268854 +0900
+@@ -48,26 +48,26 @@
+ target_link_libraries (SurfRxnNISP.x  uqtkpce uqtkmcmc uqtkquad uqtktools uqtkarray uqtkxmlutils)
+ target_link_libraries (SurfRxnNISP.x sundials_cvode sundials_nvecserial sundials_sunlinsoldense sundials_sunmatrixdense)
+ target_link_libraries (SurfRxnNISP.x  depdsfmt deplbfgs depslatec depfigtree depann)
+-target_link_libraries (SurfRxnNISP.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (SurfRxnNISP.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (SurfRxnNISP.x m ${LAPACK_LIBRARIES})
++target_link_libraries (SurfRxnNISP.x m ${BLAS_LIBRARIES})
+ 
+ target_link_libraries (SurfRxnNISP_MC.x uqtkpce uqtkmcmc uqtkquad uqtktools uqtkarray uqtkxmlutils)
+ target_link_libraries (SurfRxnNISP_MC.x sundials_cvode sundials_nvecserial sundials_sunlinsoldense sundials_sunmatrixdense)
+ target_link_libraries (SurfRxnNISP_MC.x depdsfmt deplbfgs depslatec depfigtree depann)
+-target_link_libraries (SurfRxnNISP_MC.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (SurfRxnNISP_MC.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (SurfRxnNISP_MC.x m ${LAPACK_LIBRARIES})
++target_link_libraries (SurfRxnNISP_MC.x m ${BLAS_LIBRARIES})
+ 
+ target_link_libraries (SurfRxnISP.x  uqtkpce uqtkmcmc uqtkquad uqtktools uqtkarray uqtkxmlutils)
+ target_link_libraries (SurfRxnISP.x sundials_cvode sundials_nvecserial sundials_sunlinsoldense sundials_sunmatrixdense)
+ target_link_libraries (SurfRxnISP.x  depdsfmt deplbfgs depslatec depfigtree depann)
+-target_link_libraries (SurfRxnISP.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (SurfRxnISP.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (SurfRxnISP.x m ${LAPACK_LIBRARIES})
++target_link_libraries (SurfRxnISP.x m ${BLAS_LIBRARIES})
+ 
+ target_link_libraries (SurfRxnDet.x  uqtkpce uqtkmcmc uqtkquad uqtktools uqtkarray uqtkxmlutils)
+ target_link_libraries (SurfRxnDet.x sundials_cvode sundials_nvecserial sundials_sunlinsoldense sundials_sunmatrixdense)
+ target_link_libraries (SurfRxnDet.x  depdsfmt deplbfgs depslatec depfigtree depann)
+-target_link_libraries (SurfRxnDet.x m lapack ${LAPACK_LIBRARIES})
+-target_link_libraries (SurfRxnDet.x m blas ${BLAS_LIBRARIES})
++target_link_libraries (SurfRxnDet.x m ${LAPACK_LIBRARIES})
++target_link_libraries (SurfRxnDet.x m ${BLAS_LIBRARIES})
+ 
+ # Link fortran libraries
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+diff -ur UQTk-3.1.0.org/examples/tmcmc_bimodal/CMakeLists.txt UQTk-3.1.0/examples/tmcmc_bimodal/CMakeLists.txt
+--- UQTk-3.1.0.org/examples/tmcmc_bimodal/CMakeLists.txt	2020-10-05 16:13:58.885293494 +0900
++++ UQTk-3.1.0/examples/tmcmc_bimodal/CMakeLists.txt	2020-10-05 17:34:33.508588292 +0900
+@@ -21,8 +21,8 @@
+ target_link_libraries (tmcmc_bimodal.x sundials_sunlinsoldense)
+ target_link_libraries (tmcmc_bimodal.x sundials_sunmatrixdense)
+ target_link_libraries (tmcmc_bimodal.x depslatec)
+-target_link_libraries (tmcmc_bimodal.x m lapack)
+-target_link_libraries (tmcmc_bimodal.x m blas)
++target_link_libraries (tmcmc_bimodal.x m ${LAPACK_LIBRARIES})
++target_link_libraries (tmcmc_bimodal.x m ${BLAS_LIBRARIES})
+ target_link_libraries (tmcmc_bimodal.x deplbfgs  )
+ 
+ 
+diff -ur UQTk-3.1.0.org/PyUQTk/bcs/CMakeLists.txt UQTk-3.1.0/PyUQTk/bcs/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/bcs/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/bcs/CMakeLists.txt	2020-10-05 17:09:06.581219170 +0900
+@@ -57,11 +57,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+ 	SWIG_LINK_LIBRARIES(bcs uqtkpce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(bcs blas lapack)
++	SWIG_LINK_LIBRARIES(bcs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+ 	# using Intel
+ 	SWIG_LINK_LIBRARIES(bcs uqtkpce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(bcs blas lapack)
++	SWIG_LINK_LIBRARIES(bcs ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ endif()
+ 
+ if(BUILD_SUNDIALS)
+diff -ur UQTk-3.1.0.org/PyUQTk/kle/CMakeLists.txt UQTk-3.1.0/PyUQTk/kle/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/kle/CMakeLists.txt	2020-10-05 16:13:58.755292865 +0900
++++ UQTk-3.1.0/PyUQTk/kle/CMakeLists.txt	2020-10-05 17:35:16.348795301 +0900
+@@ -45,13 +45,13 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   SWIG_LINK_LIBRARIES(kle uqtktools uqtkquad uqtkarray  depdsfmt  gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES (kle m blas ${BLAS_LIBRARIES})
+-	SWIG_LINK_LIBRARIES (kle m lapack ${LAPACK_LIBRARIES})
++	SWIG_LINK_LIBRARIES (kle m ${BLAS_LIBRARIES})
++	SWIG_LINK_LIBRARIES (kle m ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+   # using Intel
+   SWIG_LINK_LIBRARIES(kle uqtktools uqtkquad uqtkarray  depdsfmt  ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES (kle m blas ${BLAS_LIBRARIES})
+-	SWIG_LINK_LIBRARIES (kle m lapack ${LAPACK_LIBRARIES})
++	SWIG_LINK_LIBRARIES (kle m ${BLAS_LIBRARIES})
++	SWIG_LINK_LIBRARIES (kle m ${LAPACK_LIBRARIES})
+ endif()
+ 
+ INSTALL(TARGETS _kle DESTINATION PyUQTk/)
+diff -ur UQTk-3.1.0.org/PyUQTk/mcmc/CMakeLists.txt UQTk-3.1.0/PyUQTk/mcmc/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/mcmc/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/mcmc/CMakeLists.txt	2020-10-05 17:09:06.581219170 +0900
+@@ -60,11 +60,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+ 	SWIG_LINK_LIBRARIES(mcmc deplbfgs uqtkbcs uqtkpce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree gfortran ${PYTHON_LIBRARIES})
+-  SWIG_LINK_LIBRARIES(mcmc blas lapack)
++  SWIG_LINK_LIBRARIES(mcmc ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+ 	# using Intel
+ 	SWIG_LINK_LIBRARIES(mcmc deplbfgs uqtkbcs uqtkpce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree ifcore ifport ${PYTHON_LIBRARIES})
+-  SWIG_LINK_LIBRARIES(mcmc blas lapack)
++  SWIG_LINK_LIBRARIES(mcmc ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ endif()
+ 
+ if(BUILD_SUNDIALS)
+diff -ur UQTk-3.1.0.org/PyUQTk/pce/CMakeLists.txt UQTk-3.1.0/PyUQTk/pce/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/pce/CMakeLists.txt	2020-10-05 16:13:58.755292865 +0900
++++ UQTk-3.1.0/PyUQTk/pce/CMakeLists.txt	2020-10-05 17:35:30.878865512 +0900
+@@ -63,13 +63,13 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+ 	SWIG_LINK_LIBRARIES(pce uqtkquad uqtkarray uqtktools depslatec depdsfmt depfigtree depann gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(pce m blas ${BLAS_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(pce m lapack ${LAPACK_LIBRARIES})
++	SWIG_LINK_LIBRARIES(pce m ${BLAS_LIBRARIES})
++	SWIG_LINK_LIBRARIES(pce m ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+ 	# using Intel
+   SWIG_LINK_LIBRARIES(pce uqtktools uqtkquad uqtkarray depslatec depdsfmt depann depfigtree depcvode ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(pce m blas ${BLAS_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(pce m lapack ${LAPACK_LIBRARIES})
++	SWIG_LINK_LIBRARIES(pce m ${BLAS_LIBRARIES})
++	SWIG_LINK_LIBRARIES(pce m ${LAPACK_LIBRARIES})
+ endif()
+ 
+ if(BUILD_SUNDIALS)
+diff -ur UQTk-3.1.0.org/PyUQTk/quad/CMakeLists.txt UQTk-3.1.0/PyUQTk/quad/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/quad/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/quad/CMakeLists.txt	2020-10-05 17:09:06.581219170 +0900
+@@ -46,11 +46,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   SWIG_LINK_LIBRARIES(quad uqtkarray uqtktools depdsfmt depfigtree depann gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(quad blas lapack)
++	SWIG_LINK_LIBRARIES(quad ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+   # using Intel
+   SWIG_LINK_LIBRARIES(quad uqtkarray uqtktools depdsfmt depfigtree depann ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(quad blas lapack)
++	SWIG_LINK_LIBRARIES(quad ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ endif()
+ 
+ 
+diff -ur UQTk-3.1.0.org/PyUQTk/tmcmc/CMakeLists.txt UQTk-3.1.0/PyUQTk/tmcmc/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/tmcmc/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/tmcmc/CMakeLists.txt	2020-10-05 17:12:13.472119676 +0900
+@@ -25,11 +25,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   SWIG_LINK_LIBRARIES(tmcmc depslatec depdsfmt gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(tmcmc m lapack blas)
++	SWIG_LINK_LIBRARIES(tmcmc m ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+   # using Intel
+   SWIG_LINK_LIBRARIES(tmcmc depslatec depdsfmt ifcore ifport ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(tmcmc m lapack blas)
++	SWIG_LINK_LIBRARIES(tmcmc m ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+ endif()
+ 
+ INSTALL(TARGETS _tmcmc DESTINATION PyUQTk/)
+diff -ur UQTk-3.1.0.org/PyUQTk/tools/CMakeLists.txt UQTk-3.1.0/PyUQTk/tools/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/tools/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/tools/CMakeLists.txt	2020-10-05 17:09:06.581219170 +0900
+@@ -45,11 +45,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   SWIG_LINK_LIBRARIES(tools uqtkarray depdsfmt depfigtree depann gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(tools blas lapack)
++	SWIG_LINK_LIBRARIES(tools ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+   # using Intel
+   SWIG_LINK_LIBRARIES(tools uqtkarray depdsfmt depfigtree depann ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(tools blas lapack)
++	SWIG_LINK_LIBRARIES(tools ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ endif()
+ 
+ 
+diff -ur UQTk-3.1.0.org/PyUQTk/uqtkarray/CMakeLists.txt UQTk-3.1.0/PyUQTk/uqtkarray/CMakeLists.txt
+--- UQTk-3.1.0.org/PyUQTk/uqtkarray/CMakeLists.txt	2020-10-05 16:13:58.765292913 +0900
++++ UQTk-3.1.0/PyUQTk/uqtkarray/CMakeLists.txt	2020-10-05 17:09:06.581219170 +0900
+@@ -36,11 +36,11 @@
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   SWIG_LINK_LIBRARIES(uqtkarray gfortran ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(uqtkarray blas lapack)
++	SWIG_LINK_LIBRARIES(uqtkarray ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+   # using Intel
+   SWIG_LINK_LIBRARIES(uqtkarray ifcore ${PYTHON_LIBRARIES})
+-	SWIG_LINK_LIBRARIES(uqtkarray blas lapack)
++	SWIG_LINK_LIBRARIES(uqtkarray ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+ endif()
+ 
+ 


### PR DESCRIPTION
`Uqtk` always uses internal blas/lapack library until version 3.0.4, so I added version 3.1.0: it also assumes that it takes in external library. And I fixed some processes to use on Spack.
- Modify the process of directly specifying blas/lapack as the library name.
- (For Fujitsu compiler) Do not link the gfortran library when using the Fujitsu compiler.