### PR TITLE
papi: Restrict +sde to @6.0.0:

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -48,6 +48,7 @@ class Papi(AutotoolsPackage):
     depends_on('lm-sensors', when='+lmsensors')
 
     conflicts('%gcc@8:', when='@5.3.0', msg='Requires GCC version less than 8.0')
+    conflicts('+sde', when='@:5.9.99999', msg='Software defined events (SDE) added in 6.0.0')
 
     # This is the only way to match exactly version 6.0.0 without also
     # including version 6.0.0.1 due to spack version matching logic


### PR DESCRIPTION
Software defined events (SDE) appear to have been introduced only in @6.0.0 (see e.g. http://icl.utk.edu/papi/software/view.html?id=275)

Closes #19289