### PR TITLE
autotools.py: Add the object to remove from libtool.

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -227,7 +227,7 @@ class AutotoolsPackage(PackageBase):
         if self.spec.satisfies('%fj'):
             fs.filter_file('-nostdlib', '', libtool_path)
             rehead = r'/\S*/'
-            objfile = ['fjcrt0.o', 'fjlang08.o', 'fjomp.o',
+            objfile = ['fjhpctag.o', 'fjcrt0.o', 'fjlang08.o', 'fjomp.o',
                        'crti.o', 'crtbeginS.o', 'crtendS.o']
             for o in objfile:
                 fs.filter_file(rehead + o, '', libtool_path)


### PR DESCRIPTION
https://github.com/spack/spack/pull/19217
I excluded `fjhpctag.o` from the deletion targets in this PR, but it was wrong, so I will add it to the deletion targets again.