### PR TITLE
mfem: Fix support for SUNDIALS and PETSc features

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -682,7 +682,10 @@ class Mfem(Package):
         """Return the SUNDIALS components needed by MFEM."""
         sun_comps = 'arkode,cvodes,nvecserial,kinsol'
         if '+mpi' in self.spec:
-            sun_comps += ',nvecparhyp,nvecparallel,nvecmpiplusx'
+            if self.spec.satisfies('@4.2:'):
+                sun_comps += ',nvecparallel,nvecmpiplusx'
+            else:
+                sun_comps += ',nvecparhyp,nvecparallel'
         return sun_comps
 
     @property

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -475,9 +475,7 @@ class Mfem(Package):
 
         if '+petsc' in spec:
             options += [
-                'PETSC_OPT=%s' % spec['petsc'].headers.cpp_flags,
-                'PETSC_LIB=%s' %
-                ld_flags_from_library_list(spec['petsc'].libs)]
+                'PETSC_DIR=%s' % spec['petsc'].prefix]
 
         if '+pumi' in spec:
             pumi_libs = ['pumi', 'crv', 'ma', 'mds', 'apf', 'pcu', 'gmi',
@@ -676,9 +674,9 @@ class Mfem(Package):
     @property
     def sundials_components(self):
         """Return the SUNDIALS components needed by MFEM."""
-        sun_comps = 'arkode,cvode,nvecserial,kinsol'
+        sun_comps = 'arkode,cvodes,nvecserial,kinsol'
         if '+mpi' in self.spec:
-            sun_comps += ',nvecparhyp,nvecparallel'
+            sun_comps += ',nvecparhyp,nvecparallel,nvecmpiplusx'
         return sun_comps
 
     @property

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -474,8 +474,14 @@ class Mfem(Package):
                 ld_flags_from_library_list(spec[sun_spec].libs)]
 
         if '+petsc' in spec:
-            options += [
-                'PETSC_DIR=%s' % spec['petsc'].prefix]
+            if '+shared' in spec:
+                options += [
+                    'PETSC_OPT=%s' % spec['petsc'].headers.cpp_flags,
+                    'PETSC_LIB=%s' %
+                    ld_flags_from_library_list(spec['petsc'].libs)]
+            else:
+                options += [
+                    'PETSC_DIR=%s' % spec['petsc'].prefix]
 
         if '+pumi' in spec:
             pumi_libs = ['pumi', 'crv', 'ma', 'mds', 'apf', 'pcu', 'gmi',


### PR DESCRIPTION
PETSc_DIR is specified so the Makefile logic can detect the proper link flags, see https://github.com/mfem/mfem/issues/1755

CVODES (not CVODE) is the required SUNDIALS component, and `nvecmpiplusx` is now required as of https://github.com/mfem/mfem/commit/e70cf4c5d6dab24f64c3a41affe4e974c6c9820b