### PR TITLE
Don't run string.join on string

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -282,7 +282,8 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
                 tty.debug(
                     'The following executables in {0} were decidedly not '
                     'part of the package {1}: {2}'
-                    .format(prefix, pkg.name, ', '.join(exes_in_prefix))
+                    .format(prefix, pkg.name, ', '.join(
+                        _convert_to_iterable(exes_in_prefix)))
                 )
 
             for spec in specs:
@@ -295,7 +296,8 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
                     continue
 
                 if spec in resolved_specs:
-                    prior_prefix = ', '.join(resolved_specs[spec])
+                    prior_prefix = ', '.join(
+                        _convert_to_iterable(resolved_specs[spec]))
 
                     tty.debug(
                         "Executables in {0} and {1} are both associated"


### PR DESCRIPTION
Cosmetic fix for spack debug output: was, e.g. `Executables in /bin and /,u,s,r,/,b,i,n are both associated with the same spec xz@5.2.2`, will be `Executables in /bin and /usr/bin are both associated with the same spec xz@5.2.2`.