### PR TITLE
Fix for buildcache -o

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -465,7 +465,8 @@ def installtarball(args):
         tty.die("build cache file installation requires" +
                 " at least one package spec argument")
     pkgs = set(args.specs)
-    matches = match_downloaded_specs(pkgs, args.multiple, args.force, args.otherarch)
+    matches = match_downloaded_specs(pkgs, args.multiple, args.force,
+                                     args.otherarch)
 
     for match in matches:
         install_tarball(match, args)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -465,7 +465,7 @@ def installtarball(args):
         tty.die("build cache file installation requires" +
                 " at least one package spec argument")
     pkgs = set(args.specs)
-    matches = match_downloaded_specs(pkgs, args.multiple, args.otherarch)
+    matches = match_downloaded_specs(pkgs, args.multiple, args.force, args.otherarch)
 
     for match in matches:
         install_tarball(match, args)


### PR DESCRIPTION
```bash
spack buildcache install -o /abc123
```
Appears to fail to find hash in other arches when dealing with build caches.

The method has more positional arguments than the caller expects.

A simple oversight!
