### PR TITLE
r-rgeos: fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/r-rgeos/package.py
+++ b/var/spack/repos/builtin/packages/r-rgeos/package.py
@@ -22,4 +22,4 @@ class RRgeos(RPackage):
 
     depends_on('r@3.3.0:', type=('build', 'run'))
     depends_on('r-sp@1.1-0:', type=('build', 'run'))
-    depends_on('geos@3.2.0:')
+    depends_on('geos@3.2.0:3.8.0')


### PR DESCRIPTION
fix r-rgeos build error:
```
ERROR: configuration failed for package 'rgeos'
* removing '/home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/r-rgeos-0.5-1-w2hkx2nrzgmkj3am5zj2nnyxldairrdx/rlib/R/library/rgeos'
==> Error: ProcessError: Command exited with status 1:
    '/home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/r-4.0.2-iy4kyyrm3grzicmjeheeaxy2dvivao6b/bin/R' 'CMD' 'INSTALL' '--library=/home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/r-rgeos-0.5-1-w2hkx2nrzgmkj3am5zj2nnyxldairrdx/rlib/R/library' '/tmp/root/spack-stage/spack-stage-r-rgeos-0.5-1-w2hkx2nrzgmkj3am5zj2nnyxldairrdx/spack-src'

1 error found in build log:
     115    configure: svn revision: 614
     116    checking for geos-config... /home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/geos-3
            .8.1-6576b5fdtvgdfktbl56lhp4ugv3ktlax/bin/geos-config
     117    checking geos-config usability... yes
     118    configure: GEOS version: 3.8.1
     119    checking geos version at least 3.2.0... yes
     120    checking geos version not more than 3.8.0... no
  >> 121    configure: error: GEOS version number too high
     122    ERROR: configuration failed for package 'rgeos'
     123    * removing '/home/xiaojun/spack/opt/spack/linux-centos8-aarch64/gcc-8.2.1/r-rgeos-0.5-1-w2hkx2nr
            zgmkj3am5zj2nnyxldairrdx/rlib/R/library/rgeos'
```