### PR TITLE
update version to avoid compile error

### DIFF
--- a/var/spack/repos/builtin/packages/r-rgdal/package.py
+++ b/var/spack/repos/builtin/packages/r-rgdal/package.py
@@ -26,6 +26,7 @@ class RRgdal(RPackage):
     version('1.3-9',  sha256='3e44f88d09894be4c0abd8874d00b40a4a5f4542b75250d098ffbb3ba41e2654')
     version('1.2-16', sha256='017fefea4f9a6d4540d128c707197b7025b55e4aff98fc763065366b025b03c9')
 
+    depends_on('r@3.5.0:', when='@1.5:', type=('build', 'run'))
     depends_on('r@3.3.0:', type=('build', 'run'))
     depends_on('r-sp@1.1-0:', type=('build', 'run'))
     depends_on('gdal@1.11.4:')

--- a/var/spack/repos/builtin/packages/r-rgdal/package.py
+++ b/var/spack/repos/builtin/packages/r-rgdal/package.py
@@ -21,8 +21,9 @@ class RRgdal(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/rgdal_1.3-9.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/rgdal"
 
-    version('1.4-4', sha256='2532e76e0af27d145f799d70006a5dbecb2d3be698e3d0bbf580f4c41a34c5d7')
-    version('1.3-9', sha256='3e44f88d09894be4c0abd8874d00b40a4a5f4542b75250d098ffbb3ba41e2654')
+    version('1.5-18', sha256='53467c19bc93d8ea311458eaa281c8c456168ab75e84d76ef5cc6c00f53122df')
+    version('1.4-4',  sha256='2532e76e0af27d145f799d70006a5dbecb2d3be698e3d0bbf580f4c41a34c5d7')
+    version('1.3-9',  sha256='3e44f88d09894be4c0abd8874d00b40a4a5f4542b75250d098ffbb3ba41e2654')
     version('1.2-16', sha256='017fefea4f9a6d4540d128c707197b7025b55e4aff98fc763065366b025b03c9')
 
     depends_on('r@3.3.0:', type=('build', 'run'))


### PR DESCRIPTION
We need to use new version to avoid the building error at `r-rgdal`:
```
configure: CC: /home/spack-develop/lib/spack/env/gcc/gcc
configure: CXX: /home/spack-develop/lib/spack/env/gcc/g++
configure: C++11 support available
configure: rgdal: 1.4-4
checking for /usr/bin/svnversion... no
configure: svn revision: 833
checking for gdal-config... /home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/gdal-3.1.2-3vpkzyaeccdvmowvyz5phtjrjcyjqvap/bin/gdal-config
checking gdal-config usability... yes
configure: GDAL: 3.1.2
checking GDAL version >= 1.11.4... yes
checking GDAL version <= 2.5 or >= 3.0... yes
checking gdal: linking with --libs only... no
checking gdal: linking with --libs and --dep-libs... no
./configure: line 2004: ERROR:: command not found
./configure: line 2019: ERROR:: command not found
configure: Install failure: compilation and/or linkage problems.
configure: error: GDALAllRegister not found in libgdal.
ERROR: configuration failed for package 'rgdal'
* removing '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-rgdal-1.4-4-6ndkv5dvrdi5djsyavwi6m7vb5pqfezq/rlib/R/library/rgdal'
```