### PR TITLE
A collection of tensorflow fixes and updates

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
@@ -14,15 +14,20 @@ class PyTensorboardPluginWit(Package):
        that requires minimal code."""
 
     homepage = "https://pypi.python.org/project/tensorboard-plugin-wit"
+    url      = "https://github.com/PAIR-code/what-if-tool/archive/v1.7.0.tar.gz"
     git      = "https://github.com/pair-code/what-if-tool.git"
 
     version('master', branch='master')
+    version('1.7.0', sha256='30dcab9065b02c3f1476f4fb92b27f6feb6c00cdb281699c44d8e69c86745247')
+
     depends_on('bazel@0.26.1:', type='build')
     depends_on('py-setuptools@36.2.0:', type='build')
     depends_on('python@2.7:2.8,3.2:', type=('build', 'run'))
     depends_on('py-wheel', type='build')
 
     extends('python')
+
+    patch('tboard_shellenv.patch')
 
     phases = ['setup', 'build', 'install']
 
@@ -38,13 +43,13 @@ class PyTensorboardPluginWit(Package):
                     'dest="{0}"'.format(builddir),
                     'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
         filter_file(r'pip install .*',
-                    ''.format(builddir),
+                    '',
                     'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
         filter_file(r'command \-v .*',
-                    ''.format(builddir),
+                    '',
                     'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
         filter_file(r'virtualenv venv',
-                    ''.format(builddir),
+                    '',
                     'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
@@ -17,6 +17,8 @@ class PyTensorboardPluginWit(Package):
     url      = "https://github.com/PAIR-code/what-if-tool/archive/v1.7.0.tar.gz"
     git      = "https://github.com/pair-code/what-if-tool.git"
 
+    maintainers = ['aweits']
+
     version('master', branch='master')
     version('1.7.0', sha256='30dcab9065b02c3f1476f4fb92b27f6feb6c00cdb281699c44d8e69c86745247')
 

--- a/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/tboard_shellenv.patch
+++ b/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/tboard_shellenv.patch
@@ -1,0 +1,31 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 48227b5d8439..5ce04e1097eb 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -97,6 +97,8 @@ http_archive(
+     name = "org_tensorflow_tensorboard",
+     sha256 = "528afecdcc551c31baa6c7c3f702439cb6a52b711a12f9773177d0a9221f0620",
+     strip_prefix = "tensorboard-22b1f7413a917249245ab63a33d1f03514039294",
++    patch_args = ["-p1"],
++    patches = ["defaultshellenv.patch"],
+     urls = [
+         "https://github.com/tensorflow/tensorboard/archive/22b1f7413a917249245ab63a33d1f03514039294.tar.gz",  # 2019-12-04
+     ],
+diff --git a/external/defaultshellenv.patch b/external/defaultshellenv.patch
+new file mode 100644
+index 000000000000..d22faf5662b6
+--- /dev/null
++++ b/external/defaultshellenv.patch
+@@ -0,0 +1,12 @@
++diff --git a/tensorboard/defs/web.bzl b/tensorboard/defs/web.bzl
++index dfca0bfd21b5..fb981493b25d 100644
++--- a/tensorboard/defs/web.bzl
+++++ b/tensorboard/defs/web.bzl
++@@ -180,6 +180,7 @@ def _tf_web_library(ctx):
++         tools=ctx.files._tsc,
++         inputs=ts_inputs,
++         outputs=ts_outputs,
+++       use_default_shell_env=True,
++         executable=ctx.executable._execrooter,
++         arguments=(
++             [er_config.path] +

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -12,6 +12,7 @@ class PyTensorboard(Package):
     homepage = "https://pypi.python.org/project/tensorboard"
     url      = "https://github.com/tensorflow/tensorboard/archive/2.2.0.tar.gz"
 
+    version('2.3.0', sha256='947a58702c2841eb4559637dbf8639633f79de9a0f422be9737f3563a1725440')
     version('2.2.0', sha256='d0dfbf0e4b3b5ebbc3fafa6d281d4b9aa5478eac6bac3330652ab6674278ab77')
 
     depends_on('python@2.7:2.8,3.2:', type=('build', 'run'))
@@ -21,7 +22,8 @@ class PyTensorboard(Package):
     depends_on('py-markdown@2.6.8:', type=('build', 'run'))
     depends_on('py-requests@2.21.0:2.999', type=('build', 'run'))
     depends_on('py-futures@3.1.1:', type=('build', 'run'), when='^python@:2')
-    depends_on('py-grpcio@1.23.3:', type=('build', 'run'))
+    depends_on('py-grpcio@1.24.3:', type=('build', 'run'), when='@2.3.0')
+    depends_on('py-grpcio@1.23.3:', type=('build', 'run'), when='@2.2.0')
     depends_on('py-google-auth@1.6.3:1.99.99', type=('build', 'run'))
     depends_on('py-numpy@1.12.0:', type=('build', 'run'))
     depends_on('py-protobuf@3.6.0:', type=('build', 'run'))
@@ -31,11 +33,22 @@ class PyTensorboard(Package):
     depends_on('py-wheel@0.26:', type='build', when='@0.6: ^python@3:')
     depends_on('py-google-auth-oauthlib@0.4.1:0.4.999', type=('build', 'run'))
     depends_on('py-tensorboard-plugin-wit@1.6.0:', type=('build', 'run'), when='@2.2.0:')
-    depends_on('py-tensorflow-estimator', type='run')
+    depends_on('py-tensorflow-estimator@2.2.0', type='run', when='@2.2.0')
+    depends_on('py-tensorflow-estimator@2.3.0', type='run', when='@2.3.0')
 
     extends('python')
 
+    patch('tboard_shellenv.patch')
+
     phases = ['configure', 'build', 'install']
+
+    def patch(self):
+        filter_file('build --define=angular_ivy_enabled=True',
+                    'build --define=angular_ivy_enabled=True\n'
+                    'build --distinct_host_configuration=false\n'
+                    'build --action_env=PYTHONPATH="{0}"\n'.format(
+                        env['PYTHONPATH']),
+                    '.bazelrc')
 
     def setup_build_environment(self, env):
         tmp_path = '/tmp/spack/tb'
@@ -48,6 +61,15 @@ class PyTensorboard(Package):
         filter_file(r'workdir=.*',
                     'workdir="{0}"'.format(builddir),
                     'tensorboard/pip_package/build_pip_package.sh')
+        filter_file(r'pip install .*',
+                    '',
+                    'tensorboard/pip_package/build_pip_package.sh')
+        filter_file(r'command \-v .*',
+                    '',
+                    'tensorboard/pip_package/build_pip_package.sh')
+        filter_file(r'virtualenv .*',
+                    '',
+                    'tensorboard/pip_package/build_pip_package.sh')
         filter_file('trap cleanup EXIT',
                     '',
                     'tensorboard/pip_package/build_pip_package.sh')
@@ -59,6 +81,8 @@ class PyTensorboard(Package):
               '--output_user_root=' + tmp_path,
               'build',
               '--verbose_failures',
+              '--spawn_strategy=local',
+              '--subcommands=pretty_print',
               '//tensorboard/pip_package')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -12,6 +12,8 @@ class PyTensorboard(Package):
     homepage = "https://pypi.python.org/project/tensorboard"
     url      = "https://github.com/tensorflow/tensorboard/archive/2.2.0.tar.gz"
 
+    maintainers = ['aweits']
+
     version('2.3.0', sha256='947a58702c2841eb4559637dbf8639633f79de9a0f422be9737f3563a1725440')
     version('2.2.0', sha256='d0dfbf0e4b3b5ebbc3fafa6d281d4b9aa5478eac6bac3330652ab6674278ab77')
 

--- a/var/spack/repos/builtin/packages/py-tensorboard/tboard_shellenv.patch
+++ b/var/spack/repos/builtin/packages/py-tensorboard/tboard_shellenv.patch
@@ -1,0 +1,12 @@
+diff --git a/tensorboard/defs/web.bzl b/tensorboard/defs/web.bzl
+index dfca0bfd21b5..fb981493b25d 100644
+--- a/tensorboard/defs/web.bzl
++++ b/tensorboard/defs/web.bzl
+@@ -180,6 +180,7 @@ def _tf_web_library(ctx):
+         tools=ctx.files._tsc,
+         inputs=ts_inputs,
+         outputs=ts_outputs,
++       use_default_shell_env=True,
+         executable=ctx.executable._execrooter,
+         arguments=(
+             [er_config.path] +

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -13,6 +13,7 @@ class PyTensorflowEstimator(Package):
     homepage = "https://github.com/tensorflow/estimator"
     url      = "https://github.com/tensorflow/estimator/archive/v2.2.0.tar.gz"
 
+    version('2.3.0', sha256='75403e7de7e8ec30ec0781ede56ed84cbe5e90daad64a9c242cd489c8fe63a17')
     version('2.2.0', sha256='2d68cb6e6442e7dcbfa2e092aa25bdcb0eda420536a829b85d732854a4c85d46')
     version('2.1', sha256='1d74c8181b981748976fa33ad97d3434c3cf2b7e29a0b00861365fe8329dbc4e')
     version('2.0.0', sha256='6f4bdf1ab219e1f1cba25d2af097dc820f56479f12a839853d97422fe4d8b465')
@@ -20,10 +21,16 @@ class PyTensorflowEstimator(Package):
 
     extends('python')
 
-    depends_on('py-tensorflow@2.2.0:',  when='@2.2.0')
+    depends_on('py-tensorflow@2.3.0:',  when='@2.3.0')
+    depends_on('py-tensorflow@2.2.0',  when='@2.2.0')
     depends_on('py-tensorflow@2.1.0:2.1.999',  when='@2.1')
     depends_on('py-tensorflow@2.0.0:2.0.999',  when='@2.0.0')
     depends_on('py-tensorflow@1.13.1', when='@1.13.0')
+
+    depends_on('py-absl-py@0.7.0:', type=('build', 'run'), when='@1.12.1,1.14:')
+    depends_on('py-numpy@1.16.0:1.18',  type=('build', 'run'), when='@1.13.2,1.15:')
+    depends_on('py-six@1.12.0:', type=('build', 'run'), when='@2.1:')
+    depends_on('py-keras-preprocessing@1.1.1:1.999', type=('build', 'run'), when='@2.3:')
 
     depends_on('bazel@0.19.0:', type='build')
     depends_on('py-funcsigs@1.0.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -13,6 +13,8 @@ class PyTensorflowEstimator(Package):
     homepage = "https://github.com/tensorflow/estimator"
     url      = "https://github.com/tensorflow/estimator/archive/v2.2.0.tar.gz"
 
+    maintainers = ['aweits']
+
     version('2.3.0', sha256='75403e7de7e8ec30ec0781ede56ed84cbe5e90daad64a9c242cd489c8fe63a17')
     version('2.2.0', sha256='2d68cb6e6442e7dcbfa2e092aa25bdcb0eda420536a829b85d732854a4c85d46')
     version('2.1', sha256='1d74c8181b981748976fa33ad97d3434c3cf2b7e29a0b00861365fe8329dbc4e')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -13,7 +13,7 @@ class PyTensorflow(Package, CudaPackage):
     homepage = "https://www.tensorflow.org"
     url      = "https://github.com/tensorflow/tensorflow/archive/v2.3.1.tar.gz"
 
-    maintainers = ['adamjstewart']
+    maintainers = ['adamjstewart', 'aweits']
     import_modules = ['tensorflow']
 
     version('2.3.1',  sha256='ee534dd31a811f7a759453567257d1e643f216d8d55a25c32d2fbfff8153a1ac')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -533,7 +533,7 @@ class PyTensorflow(Package, CudaPackage):
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)
 
     def patch(self):
-        if self.spec.satisfies('@2.3.0'):
+        if self.spec.satisfies('@2.3.0:2.3.1'):
             filter_file('deps = protodeps + well_known_proto_libs(),',
                         'deps = protodeps,',
                         'tensorflow/core/platform/default/build_config.bzl',


### PR DESCRIPTION
    * tensorflow 2.3.1 requires the workaround for external protobuf as well
    * Update tensorflow-estimator to 2.3.0
    * Update tensorboard to 2.3.0
    * Update tensorboard-plugin-wit to use actual releases
    * Patch that potentially fixes #16073
    * Add myself to maintainers on these

@adamjstewart 