### PR TITLE
update version to avoid compile error

### DIFF
--- a/var/spack/repos/builtin/packages/r-genefilter/package.py
+++ b/var/spack/repos/builtin/packages/r-genefilter/package.py
@@ -13,6 +13,7 @@ class RGenefilter(RPackage):
     homepage = "https://bioconductor.org/packages/genefilter"
     git      = "https://git.bioconductor.org/packages/genefilter.git"
 
+    version('3.11.0', commit='a071480ffc48393a4385a94c96a752285064989f')
     version('1.66.0', commit='1c4c471ccca873bf92dcf0b50f611eaa64c4f0cf')
     version('1.64.0', commit='82e91b7751bae997b9c898c219ea201fd02a8512')
     version('1.62.0', commit='eb119894f015c759f93f458af7733bdb770a22ad')


### PR DESCRIPTION
update version to avoid this issue:
```
/home/spack-develop/lib/spack/env/gcc/g++ -std=gnu++11 -shared -L/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-4.0.2-kyflwfdhj63kvb67y5z7fqbxsb6sxcfe/rlib/R/lib -L/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-4.0.2-kyflwfdhj63kvb67y5z7fqbxsb6sxcfe/rlib/R/lib -Wl,-rpath,/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-4.0.2-kyflwfdhj63kvb67y5z7fqbxsb6sxcfe/rlib/R/lib -o genefilter.so half_range_mode.o init.o nd.o pAUC.o rowPAUCs.o rowttests.o ttest.o -lgfortran -lm -L/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-4.0.2-kyflwfdhj63kvb67y5z7fqbxsb6sxcfe/rlib/R/lib -lR
installing to /home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-genefilter-1.66.0-yrlczxbuim4tcivg2marptqkjgpxuafu/rlib/R/library/00LOCK-spack-src/00new/genefilter/libs
** R
** data
*** moving datasets to lazyload DB
** inst
** byte-compile and prepare package for lazy loading
Error: objects 'rowSums', 'colSums', 'rowMeans', 'colMeans' are not exported by 'namespace:S4Vectors'
Execution halted
ERROR: lazy loading failed for package 'genefilter'
* removing '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-genefilter-1.66.0-yrlczxbuim4tcivg2marptqkjgpxuafu/rlib/R/library/genefilter'
```