### PR TITLE
refine setuptools version to avoid spec conflict

### DIFF
--- a/var/spack/repos/builtin/packages/ambari/package.py
+++ b/var/spack/repos/builtin/packages/ambari/package.py
@@ -20,6 +20,6 @@ class Ambari(PythonPackage):
     version('2.7.1', sha256='ea4eb28f377ce9d0b9b7648f2020dda4be974c6d9a22ebaafbf1bc97890e4e42')
 
     depends_on('python@:2.7.999', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@:44.99.99', type='build')
     depends_on('py-mock', type='test')
     depends_on('py-coilmq', type=('build', 'run'))


### PR DESCRIPTION
`ambari` stage fail as:
```
[root@Estuary-CentOS8 ~]# spack stage ambari
==> Error: An unsatisfiable version constraint has been detected for spec:

    python@2.7.18%gcc@8.2.1+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib arch=linux-centos8-aarch64
        ^bzip2
            ^diffutils
                ^iconv
        ^expat
        ^gdbm
            ^readline
                ^ncurses
                    ^pkgconf@1.7.3%gcc@8.2.1 arch=linux-centos8-aarch64
        ^gettext+libxml2
            ^libxml2
                ^xz
                ^zlib@1.1.3:
        ^libffi
        ^libuuid
        ^openssl
            ^perl@5.14.0:
                ^berkeley-db
        ^sqlite@3.0.8:


while trying to concretize the partial spec:

    py-setuptools@50.1.0%gcc@8.2.1 arch=linux-centos8-aarch64
```

according to 
```
    depends_on('python@3.5:', type=('build', 'run'), when='@45.0.0:')
    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
```
in `py-setuptools`

We can use `setuptools@:44.99.99`