### PR TITLE
py-cvxopt: refine dependency @1.1.9 and update version to @1.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-cvxopt/package.py
+++ b/var/spack/repos/builtin/packages/py-cvxopt/package.py
@@ -15,6 +15,7 @@ class PyCvxopt(PythonPackage):
 
     import_modules = ['cvxopt']
 
+    version('1.2.5', sha256='94ec8c36bd6628a11de9014346692daeeef99b3b7bae28cef30c7490bbcb2d72')
     version('1.1.9', sha256='8f157e7397158812cabd340b68546f1baa55a486ed0aad8bc26877593dc2983d')
 
     variant('gsl',   default=False, description='Use GSL random number generators for constructing random matrices')
@@ -25,6 +26,7 @@ class PyCvxopt(PythonPackage):
 
     # Required dependencies
     depends_on('python@2.7:')
+    depends_on('python@2.7:3.7.999', when='@:1.1.9')
     depends_on('py-setuptools', type='build')
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/py-cvxopt/package.py
+++ b/var/spack/repos/builtin/packages/py-cvxopt/package.py
@@ -25,8 +25,8 @@ class PyCvxopt(PythonPackage):
     variant('dsdp',  default=False, description='Enable support for the semidefinite programming solver DSDP')
 
     # Required dependencies
-    depends_on('python@2.7:')
-    depends_on('python@2.7:3.7.999', when='@:1.1.9')
+    depends_on('python@2.7:', type=('build', 'link', 'run'))
+    depends_on('python@2.7:3.7.999', type=('build', 'link', 'run'), when='@:1.1.9')
     depends_on('py-setuptools', type='build')
     depends_on('blas')
     depends_on('lapack')


### PR DESCRIPTION
some build error report when install `py-cvxopt`:
```
==> py-cvxopt: Executing phase: 'build'
==> [2020-09-25-12:10:19.070288] '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/python-3.8.5-rvp2d3s6nyt65vfrkkbikqp5pt4wfknj/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'
Traceback (most recent call last):
  File "setup.py", line 59, in <module>
    lnx_dist = platform.linux_distribution()
AttributeError: module 'platform' has no attribute 'linux_distribution'
```

we can fix this error by using `python@:3.7.999` or using the latest version `1.2.5`