### PR TITLE
r-sf: fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -29,4 +29,4 @@ class RSf(RPackage):
     depends_on('gdal@2.0.1:')
     depends_on('geos@3.4.0:')
     depends_on('proj@4.8.0:5', when='@:0.7-3')
-    depends_on('proj@4.8.0:', when='@0.7-4:')
+    depends_on('proj@4.8.0:6.3.2', when='@0.7-4:')

--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -29,4 +29,4 @@ class RSf(RPackage):
     depends_on('gdal@2.0.1:')
     depends_on('geos@3.4.0:')
     depends_on('proj@4.8.0:5', when='@:0.7-3')
-    depends_on('proj@4.8.0:6.3.2', when='@0.7-4:')
+    depends_on('proj@4.8.0:6', when='@0.7-4:')


### PR DESCRIPTION
fix build error:
```
configure: pkg-config proj exists, will use it
checking proj_api.h usability... no
checking proj_api.h presence... no
checking for proj_api.h... no
configure: error: proj_api.h not found in standard or given locations.
ERROR: configuration failed for package 'sf'
* removing '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-sf-0.7-7-efvc3ydctgqief7maovseikhqjemiqbu/rlib/R/library/sf'
```

The `configure` file only recognize `proj@:6.99.99`, so we need change the version constraint.