### PR TITLE
axel: fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/axel/package.py
+++ b/var/spack/repos/builtin/packages/axel/package.py
@@ -21,3 +21,7 @@ class Axel(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('gettext')
     depends_on('openssl')
+
+    def autoreconf(self, spec, prefix):
+        bash = which('bash')
+        bash('./autogen.sh')


### PR DESCRIPTION
fix build error:
```
make[2]: Leaving directory '/home/spack-stage/root/spack-stage-axel-2.16.1-hup77jub3t4xkyykc4nq5wcbcb56ttpd/spack-src/src'
Making all in po
make[2]: Entering directory '/home/spack-stage/root/spack-stage-axel-2.16.1-hup77jub3t4xkyykc4nq5wcbcb56ttpd/spack-src/po'
make axel.pot-update
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.18 but the autoconf macros are from gettext version 0.20
make[2]: *** [Makefile:155: check-macro-version] Error 1
make[2]: *** Waiting for unfinished jobs....
make[3]: Entering directory '/home/spack-stage/root/spack-stage-axel-2.16.1-hup77jub3t4xkyykc4nq5wcbcb56ttpd/spack-src/po'
sed -e '/^#/d' remove-potcdate.sin > t-remove-potcdate.sed
mv t-remove-potcdate.sed remove-potcdate.sed
```

We need use `autogen.sh` to get the latest `gettext`