### PR TITLE
backport to build old boost

### DIFF
--- a/var/spack/repos/builtin/packages/boost/boost_154.patch
+++ b/var/spack/repos/builtin/packages/boost/boost_154.patch
@@ -1,0 +1,31 @@
+--- a/tools/build/src/build/ac.jam
++++ b/tools/build/src/build/ac.jam
+@@ -76,14 +76,6 @@ rule construct-library ( name : property-set : provided-path ? )
+ rule find-library ( properties : names + : provided-path ? )
+ {
+     local result ;
+-    if ! $(.main.cpp)
+-    {
+-        local a = [ class.new action : ac.generate-main :
+-                    [ property-set.empty ] ] ;
+-        .main.cpp = [ virtual-target.register
+-            [ class.new file-target main.cpp exact
+-                : CPP : $(.project) : $(a) ] ] ;
+-    }
+     if [ $(properties).get <link> ] = shared
+     {
+         link-opts = <link>shared <link>static ;
+@@ -100,8 +92,12 @@ rule find-library ( properties : names + : provided-path ? )
+         {
+             local name = $(names-iter[1]) ;
+             local lib = [ construct-library $(name) : $(properties) : $(provided-path) ] ;
++            local a = [ class.new action : ac.generate-main :
++                [ property-set.empty ] ] ;
++            local main.cpp = [ virtual-target.register
++                [ class.new file-target main-$(name).cpp exact : CPP : $(.project) : $(a) ] ] ;
+             local test = [ generators.construct $(.project) $(name) : EXE
+-                : [ $(properties).add $(lib[1]) ] : $(.main.cpp) $(lib[2-])
++                : [ $(properties).add $(lib[1]) ] : $(main.cpp) $(lib[2-])
+                 : true ] ;
+             local jam-targets ;
+             for t in $(test[2-])

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -248,6 +248,10 @@ class Boost(Package):
           sha256='246508e052c44b6f4e8c2542a71c06cacaa72cd1447ab8d2a542b987bc35ace9',
           when='@1.73.0')
 
+    # Support bzip2 and gzip in other directory
+    # See https://github.com/boostorg/build/pull/154
+    patch('boost_154.patch', when='@:1.63.99')
+
     def url_for_version(self, version):
         if version >= Version('1.63.0'):
             url = "https://dl.bintray.com/boostorg/release/{0}/source/boost_{1}.tar.bz2"


### PR DESCRIPTION
I'm trying to build `alps`, so I need old version of `boost`.
see http://boost.2283326.n4.nabble.com/boost-1-63-fails-to-build-with-zlib-and-bzip2-in-different-directories-td4690868.html
In spack, glib and zip2 installed in other directories and same error occurred.

So I imported his patch ( https://github.com/boostorg/build/pull/154 ) to old `boost` before the merge.