### PR TITLE
Make url_fetch test independent of locale settings

### DIFF
--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -191,7 +191,7 @@ def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch, capfd):
         stage.fetch()
 
     status = capfd.readouterr()[1]
-    assert '##### 100.0%' in status
+    assert '##### 100' in status
 
 
 def test_url_extra_fetch(tmpdir, mock_archive):


### PR DESCRIPTION
This is just to avoid local failures when the locale settings is such to have a comma as a decimal separator. I think removing a few characters is robust enough, but let me know if a full regex is preferred.