### PR TITLE
py-pyqt4: Require older version of PySIP

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyqt4/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt4/package.py
@@ -33,7 +33,7 @@ class PyPyqt4(SIPPackage):
 
     # Supposedly can also be built with Qt 5 compatibility layer
     depends_on('qt@:4')
-    depends_on('py-sip module=PyQt4.sip')
+    depends_on('py-sip@:4.19.18 module=PyQt4.sip')
 
     # https://www.riverbankcomputing.com/static/Docs/PyQt4/installation.html
     def configure_file(self):


### PR DESCRIPTION
Fixes #19322, thanks to @Sinan81.