### PR TITLE
mpich : add python build-only dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -162,7 +162,7 @@ spack package at this time.''',
     depends_on("m4", when="@3.3 +hwloc", type="build"),
     depends_on("autoconf@2.67:", when='@3.3 +hwloc', type="build")
 
-    # MPICH's Yaksa submodule reuqires python to configure
+    # MPICH's Yaksa submodule requires python to configure
     depends_on("python@3.0:", when="@3.3.99:", type="build")
 
     conflicts('device=ch4', when='@:3.2')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -163,7 +163,7 @@ spack package at this time.''',
     depends_on("autoconf@2.67:", when='@3.3 +hwloc', type="build")
 
     # MPICH's Yaksa submodule requires python to configure
-    depends_on("python@3.0:", when="@3.3.99:", type="build")
+    depends_on("python@3.0:", when="@develop", type="build")
 
     conflicts('device=ch4', when='@:3.2')
     conflicts('netmod=ofi', when='@:3.1.4')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -162,6 +162,9 @@ spack package at this time.''',
     depends_on("m4", when="@3.3 +hwloc", type="build"),
     depends_on("autoconf@2.67:", when='@3.3 +hwloc', type="build")
 
+    # MPICH's Yaksa submodule reuqires python to configure
+    depends_on("python@3.0:", when="@3.3.99:", type="build")
+
     conflicts('device=ch4', when='@:3.2')
     conflicts('netmod=ofi', when='@:3.1.4')
     conflicts('netmod=ucx', when='device=ch3')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -19,6 +19,8 @@ class Mpich(AutotoolsPackage):
     list_url = "http://www.mpich.org/static/downloads/"
     list_depth = 1
 
+    maintainers = ['raffenet', 'yfguo']
+
     executables = ['^mpichversion$']
 
     version('develop', submodules=True)


### PR DESCRIPTION
submodule [yaksa](https://github.com/pmodels/yaksa) requires python for the configure phase.

Without this the configure for submodule yaksa fails even though it doesn't list python as a dependency. The build error on develop is : 
```
==> Installing mpich
==> No binary for mpich found: installing from source
==> Warning: microarchitecture specific optimizations are not supported yet on mixed compiler toolchains [check clang@11.0.0 for further details]
==> mpich: Executing phase: 'autoreconf'
==> mpich: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/sajid/spack-stage/spack-stage-mpich-develop-s75yz3lw5ayvgreywlkpjoesliutyifl/spack-src/configure' '--prefix=/home/sajid/packages/spack/opt/spack/linux-rhel8-skylake_avx512/clang-11.0.0/mpich-develop-s75yz3lw5ayvgreywlkpjoesliutyifl' '--disable-silent-rules' '--enable-shared' '--with-hwloc-prefix=/home/sajid/packages/spack/opt/spack/linux-rhel8-skylake_avx512/clang-11.0.0/hwloc-2.2.0-k3pt3gktfyyhlxu5skjt3sbbupsbybil' '--with-pm=hydra' '--enable-romio' '--without-ibverbs' '--enable-wrapper-rpath=yes' '--with-slurm=no' '--with-pmi=simple' '--with-device=ch4:ucx' '--with-ucx=/home/sajid/packages/spack/opt/spack/linux-rhel8-skylake_avx512/clang-11.0.0/ucx-1.9.0-fi4fwqclo3dz4fb72gcay4l3ssouxrqv' '--enable-libxml2'

6 errors found in build log:
     799     configure.ac:6: installing './missing'
     800     Makefile.am: installing './depcomp'
     801     parallel-tests: installing './test-driver'
     802     autoreconf: Leaving directory `.'
     803     ------------------------------------------------------------------------
     804     running third-party initialization in modules/yaksa
  >> 805     generating backend pup functions for seq... /usr/bin/env: 'python': No such file or directory
     806     done
  >> 807     generating backend pup functions for cuda... /usr/bin/env: 'python': No such file or directory
     808     done
  >> 809     /usr/bin/env: 'python': No such file or directory
     810
     811     === generating configure files in main directory ===
     812     autoreconf: Entering directory `.'
     813     autoreconf: configure.ac: not using Gettext
     814     autoreconf: running: aclocal --force -I m4
     815     autoreconf: configure.ac: tracing

     ...

     828     configure.ac:81: installing 'm4/ar-lib'
     829     configure.ac:78: installing 'm4/compile'
     830     configure.ac:83: installing 'm4/config.guess'
     831     configure.ac:83: installing 'm4/config.sub'
     832     configure.ac:74: installing 'm4/install-sh'
     833     configure.ac:74: installing 'm4/missing'
  >> 834     automake: error: cannot open < src/backend/cuda/pup/Makefile.pup.mk: No such file or directory
     835     autoreconf: automake failed with exit status: 1
     836     === done ===
     837
     838     Generating a helper maint/Version... done
     839     ------------------------------------------------------------------------
     840     running third-party initialization in modules/izem

     ...

     1501    checking cuda_runtime_api.h usability... no
     1502    checking cuda_runtime_api.h presence... no
     1503    checking for cuda_runtime_api.h... no
     1504    checking for cudaStreamSynchronize in -lcudart... no
     1505    checking that generated files are newer than configure... done
     1506    configure: creating ./config.status
  >> 1507    config.status: error: cannot find input file: `Makefile.in'
  >> 1508    configure: error: YAKSA configure failed

See build log for details:
  /tmp/sajid/spack-stage/spack-stage-mpich-develop-s75yz3lw5ayvgreywlkpjoesliutyifl/spack-build-out.txt

[sajid@xrm-backup ~]$
```