### PR TITLE
tests: increase tolerance of termios tests

### DIFF
--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -432,11 +432,15 @@ def test_foreground_background_output(
     # output should contain mostly "on" lines, but may contain an "off"
     # or two. This is because the controller toggles echo by sending "v" on
     # stdin to the minion, but this is not synchronized with our locks.
-    # It's good enough for a test, though.  We allow at most 2 "off"'s in
+    # It's good enough for a test, though.  We allow at most 4 "off"'s in
     # the output to account for the race.
+    #
+    # Originally we only allowed 2, but GitHub's macOS runners seem to be
+    # very slow, and frequently we get 3 "off"'s. Increased limit to 4 to
+    # account for this. Real errors should still be caught with this limit.
     assert (
         ['forced output', 'on'] == uniq(output) or
-        output.count("off") <= 2  # if controller_fd is a bit slow
+        output.count("off") <= 4  # if controller_fd is a bit slow
     )
 
     # log should be off for a while, then on, then off


### PR DESCRIPTION
Synchronization on GitHub macOS runners seems to be very slow, and frequently the foreground/background tests fail due to the race this causes. This increases the tolerance for slowness a bit more, to allow up to 4 spurious output lines in the tests.

This should hopefully result in no more false negatives on these tests for macOS on GitHub.

I looked through the tests results and only saw failures with 3 `"off"` results (just above the current limit of 2).  If this were really not working, we should see quite a few more.