### PR TITLE
ppopen-appl-amr-fdm:change download site to github.

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-amr-fdm/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-amr-fdm/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PpopenApplAmrFdm(MakefilePackage):
@@ -15,9 +14,9 @@ class PpopenApplAmrFdm(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url      = "file://{0}/ppohAMRFDM_0.3.0.tar.gz".format(os.getcwd())
+    git      = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('0.3.0', sha256='e82217e4c949dd079a56024d3d1c1761dc8efd5ad0d26a3af83564c3db7327bb')
+    version('master', branch='APPL/FDM_AMR')
 
     depends_on('mpi')
 
@@ -25,10 +24,12 @@ class PpopenApplAmrFdm(MakefilePackage):
     build_targets = ['default', 'advAMR3D']
 
     def edit(self, spec, prefix):
+        mkdirp('bin')
+        mkdirp('lib')
+        mkdirp('include')
         fflags = [
             '-O3',
             '-I.',
-            '-I{0}/include'.format(os.getcwd())
         ]
         makefile_in = FileFilter('Makefile.in')
         makefile_in.filter('^PREFIX +=.*', 'PREFIX = {0}'.format(prefix))


### PR DESCRIPTION
Down load site of ppopen-appl-amr-fdm is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.