### PR TITLE
ppopen-appl-bem: change download site to github.

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-bem/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-bem/package.py
@@ -21,9 +21,9 @@ class PpopenApplBem(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url = "file://{0}/ppohBEM_0.5.0.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('0.5.0', sha256='bf5e32902c97674c99353ee35de9c89206659e82b9c3d1f6edc9beffbb7c9d5f')
+    version('master', branch='APPL/BEM')
 
     depends_on('mpi')
 


### PR DESCRIPTION
Down load site of 'ppopen-appl-bem' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.