### PR TITLE
ppopen-appl-dem-util:change download site to github.

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-dem-util/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-dem-util/package.py
@@ -27,7 +27,7 @@ class PpopenApplDemUtil(MakefilePackage):
     def edit(self, spec, prefix):
         mkdirp('bin')
         mkdirp('lib')
-        mkdirp('include')        
+        mkdirp('include')
         makefile_in = FileFilter('Makefile.in')
         makefile_in.filter('PREFIX += .*', 'PREFIX = {0}'.format(prefix))
         makefile_in.filter('F90 += .*', 'F90 = {0}'.format(spack_fc))

--- a/var/spack/repos/builtin/packages/ppopen-appl-dem-util/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-dem-util/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PpopenApplDemUtil(MakefilePackage):
@@ -19,13 +18,16 @@ class PpopenApplDemUtil(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url      = "file://{0}/ppohDEM_util_1.0.0.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('1.0.0', sha256='e0aa9a61be3b9858a2885c9feff9b0fcd1d7039408f6bd82a73a79dfe86b0488')
+    version('master', branch='APPL/DEM')
 
     depends_on('mpi')
 
     def edit(self, spec, prefix):
+        mkdirp('bin')
+        mkdirp('lib')
+        mkdirp('include')        
         makefile_in = FileFilter('Makefile.in')
         makefile_in.filter('PREFIX += .*', 'PREFIX = {0}'.format(prefix))
         makefile_in.filter('F90 += .*', 'F90 = {0}'.format(spack_fc))


### PR DESCRIPTION
Down load site of 'ppopen-appl-dem-util' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.