### PR TITLE
Add opencl-headers and use ocl-icd as OpenCL provider

### DIFF
--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -28,3 +28,16 @@ OpenCL ICD loaders."""
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('ruby',     type='build')
+
+    def flag_handler(self, name, flags):
+        if name == 'cflags' and self.spec.satisfies('@:2.2.12'):
+            # https://github.com/OCL-dev/ocl-icd/issues/8
+            # should be fixed in version grater than 2.2.12
+            flags.append('-O2')
+            # gcc-10 change the default from -fcommon to fno-common
+            # This will be fixed in versions greater than 2.2.12:
+            # https://github.com/OCL-dev/ocl-icd/commit/4667bddd365bcc1dc66c483835971f0083b44b1d
+            if self.spec.satisfies('%gcc@10:'):
+                flags.append('-fcommon')
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -24,11 +24,16 @@ OpenCL ICD loaders."""
     version('2.2.4',  sha256='92853137ffff393cc74f829357fdd80ac46a82b46c970e80195db86164cca316')
     version('2.2.3',  sha256='46b8355d90f8cc240555e4e077f223c47b950abeadf3e1af52d6e68d2efc2ff3')
 
+    variant("headers", default=False, description="Install also OpenCL headers to use this as OpenCL provider")
+
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('ruby',     type='build')
+    depends_on('opencl-headers', when='+headers')
+
+    provides('opencl@:2.2', when='+headers')
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -32,6 +32,8 @@ OpenCL ICD loaders."""
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('ruby',     type='build')
+    depends_on('asciidoc-py3', type='build')
+    depends_on('xmlto',    type='build')
     depends_on('opencl-headers', when='+headers')
 
     provides('opencl@:2.2', when='+headers')

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -34,10 +34,9 @@ OpenCL ICD loaders."""
     depends_on('ruby',     type='build')
     depends_on('asciidoc-py3', type='build')
     depends_on('xmlto',    type='build')
-    depends_on('opencl-headers@3.0:', when='+headers')
+    depends_on('opencl-headers@2.2:', when='+headers')
 
-    provides('opencl@:3.0', when='@2.2.13:+headers')
-    provides('opencl@:2.2', when='@2.2.12+headers')
+    provides('opencl@:2.2', when='@2.2.12:+headers')
     provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -13,6 +13,7 @@ OpenCL ICD loaders."""
     homepage = "https://github.com/OCL-dev/ocl-icd"
     url      = "https://github.com/OCL-dev/ocl-icd/archive/v2.2.12.tar.gz"
 
+    version('2.2.13', sha256='f85d59f3e8327f15637b91e4ae8df0829e94daeff68c647b2927b8376b1f8d92')
     version('2.2.12', sha256='17500e5788304eef5b52dbe784cec197bdae64e05eecf38317840d2d05484272')
     version('2.2.11', sha256='c1865ef7701b8201ebc6930ed3ac757c7e5cb30f3aa4c1e742a6bc022f4f2292')
     version('2.2.10', sha256='d0459fa1421e8d86aaf0a4df092185ea63bc4e1a7682d3af261ae5d3fae063c7')
@@ -38,10 +39,10 @@ OpenCL ICD loaders."""
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):
             # https://github.com/OCL-dev/ocl-icd/issues/8
-            # should be fixed in version grater than 2.2.12
+            # this is fixed in version grater than 2.2.12
             flags.append('-O2')
             # gcc-10 change the default from -fcommon to fno-common
-            # This will be fixed in versions greater than 2.2.12:
+            # This is fixed in versions greater than 2.2.12:
             # https://github.com/OCL-dev/ocl-icd/commit/4667bddd365bcc1dc66c483835971f0083b44b1d
             if self.spec.satisfies('%gcc@10:'):
                 flags.append('-fcommon')

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -34,9 +34,12 @@ OpenCL ICD loaders."""
     depends_on('ruby',     type='build')
     depends_on('asciidoc-py3', type='build')
     depends_on('xmlto',    type='build')
-    depends_on('opencl-headers', when='+headers')
+    depends_on('opencl-headers@3.0:', when='+headers')
 
-    provides('opencl@:2.2', when='+headers')
+    provides('opencl@:3.0', when='@2.2.13:+headers')
+    provides('opencl@:2.2', when='@2.2.12+headers')
+    provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
+    provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):

--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+import sys
+
+
+class OpenclCHeaders(Package):
+    """OpenCL (Open Computing Language) C header files"""
+
+    homepage = "https://www.khronos.org/registry/OpenCL/"
+    url      = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.06.16.tar.gz"
+
+    version('2020.06.16', sha256='2f5a60e5ac4b127650618c58a7e3b35a84dbf23c1a0ac72eb5e7baf221600e06')
+    version('2020.03.13', sha256='664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476')
+
+    def install(self, spec, prefix):
+        install_tree('CL', prefix.include.CL)
+        if sys.platform == 'darwin':
+            ln = which('ln')
+            ln('-s', prefix.include.CL, prefix.include.OpenCL)

--- a/var/spack/repos/builtin/packages/opencl-clhpp/package.py
+++ b/var/spack/repos/builtin/packages/opencl-clhpp/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+import sys
+
+
+class OpenclClhpp(CMakePackage):
+    """C++ headers for OpenCL development"""
+
+    homepage = "https://www.khronos.org/registry/OpenCL/"
+    url      = "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/v2.0.12.tar.gz"
+
+    version('2.0.12', sha256='20b28709ce74d3602f1a946d78a2024c1f6b0ef51358b9686612669897a58719')
+    version('2.0.11', sha256='ffc2ca08cf4ae90ee55f14ea3735ccc388f454f4422b69498b2e9b93a1d45181')
+    version('2.0.10', sha256='fa27456295c3fa534ce824eb0314190a8b3ebd3ba4d93a0b1270fc65bf378f2b')
+    version('2.0.9',  sha256='ba8ac4977650d833804f208a1b0c198006c65c5eac7c83b25dc32cea6199f58c')
+
+    root_cmakelists_dir = 'include'
+
+    @run_after('install')
+    def post_install(self):
+        if sys.platform == 'darwin':
+            ln = which('ln')
+            ln('-s', prefix.include.CL, prefix.include.OpenCL)

--- a/var/spack/repos/builtin/packages/opencl-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-headers/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class OpenclHeaders(BundlePackage):
+    """Bundled OpenCL (Open Computing Language) header files"""
+
+    homepage = "https://www.khronos.org/registry/OpenCL/"
+
+    version('2.2')
+
+    depends_on('opencl-c-headers')
+    depends_on('opencl-clhpp')

--- a/var/spack/repos/builtin/packages/opencl-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-headers/package.py
@@ -13,6 +13,12 @@ class OpenclHeaders(BundlePackage):
     homepage = "https://www.khronos.org/registry/OpenCL/"
 
     version('3.0')
+    version('2.2')
+    version('2.1')
+    version('2.0')
 
-    depends_on('opencl-c-headers@2020.06.16:')
-    depends_on('opencl-clhpp@2.0.12:')
+    depends_on('opencl-c-headers@2020.06.16:', when='@3.0')
+    depends_on('opencl-c-headers@2020.03.13:', when='@:2.2')
+    depends_on('opencl-clhpp@2.0.12:', when='@3.0')
+    depends_on('opencl-clhpp@2.0.11:', when='@2.1:2.2')
+    depends_on('opencl-clhpp@2.0.9:', when='@2.0')

--- a/var/spack/repos/builtin/packages/opencl-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-headers/package.py
@@ -12,7 +12,7 @@ class OpenclHeaders(BundlePackage):
 
     homepage = "https://www.khronos.org/registry/OpenCL/"
 
-    version('2.2')
+    version('3.0')
 
-    depends_on('opencl-c-headers')
-    depends_on('opencl-clhpp')
+    depends_on('opencl-c-headers@2020.06.16:')
+    depends_on('opencl-clhpp@2.0.12:')

--- a/var/spack/repos/builtin/packages/opencl-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-headers/package.py
@@ -12,13 +12,10 @@ class OpenclHeaders(BundlePackage):
 
     homepage = "https://www.khronos.org/registry/OpenCL/"
 
-    version('3.0')
     version('2.2')
     version('2.1')
     version('2.0')
 
-    depends_on('opencl-c-headers@2020.06.16:', when='@3.0')
-    depends_on('opencl-c-headers@2020.03.13:', when='@:2.2')
-    depends_on('opencl-clhpp@2.0.12:', when='@3.0')
-    depends_on('opencl-clhpp@2.0.11:', when='@2.1:2.2')
+    depends_on('opencl-c-headers@2020.03.13:')
+    depends_on('opencl-clhpp@2.0.11:', when='@2.1:')
     depends_on('opencl-clhpp@2.0.9:', when='@2.0')


### PR DESCRIPTION
This PR adds a bundled package `opencl-headers`, which bundles the official OpenCL C headers and the  OpenCL C++ headers from the Khronos Group ( they are added as two separated packages: `opencl-c-headers` and `opencl-clhpp` ).

Also it adds a new variant `headers` to `ocl-icd`, so one could use this as OpenCL provider, as this is enough to build and execute OpenCL programs and usually one uses the OpenCL implementation of the GPU driver in the end.

Furthermore I fix a few build problems of `ocl-icd` and add a new release, which fixes these build problems also. Also I add `ruby` as dependency, as it is needed, and `asciidoc-py3` and `xmlto` for generating the man page.

The new release (2.2.13) from `ocl-icd` already provides OpenCL 3.0, but for the headers there was not an official release since the final version of the specifications were release, hence `ocl-icd+headers` now provides OpenCL 2.2. I am not aware of any program which will uses OpenCL 3.0, so we can wait until they make releases of the header files I think. Surprising to me there is already a driver, which supports it, i.e the Intel OpenCL driver since the [latest release](https://github.com/intel/compute-runtime/releases/tag/20.41.18123)
