### PR TITLE
ppopen-appl-fdm-at: change download site to github

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-fdm-at/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-fdm-at/package.py
@@ -4,16 +4,15 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PpopenApplFdmAt(MakefilePackage):
     """ppOpen-APPL/FDM with Auto-Tuning"""
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url      = "file://{0}/ppohFDM_AT_1.0.0.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('1.0.0', sha256='f6052b73250a41b2b319b27efc4d753c6ec1f67cd109b53099c2b240f7acd65a')
+    version('master', branch='ATA/FDM')
 
     depends_on('mpi')
     # depends_on('ppopen-appl-fdm', type='build')


### PR DESCRIPTION
Down load site of 'ppopen-appl-fdm-at' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.