### PR TITLE
Restrict Python version for Strelka to Python 2.

### DIFF
--- a/var/spack/repos/builtin/packages/strelka/package.py
+++ b/var/spack/repos/builtin/packages/strelka/package.py
@@ -15,7 +15,7 @@ class Strelka(CMakePackage):
 
     version('2.8.2', sha256='27415f7c14f92e0a6b80416283a0707daed121b8a3854196872981d132f1496b')
 
-    depends_on('python@2.4:')
+    depends_on('python@2.4:2.7')
     depends_on('zlib')
     depends_on('bzip2')
     depends_on('cmake@2.8.5:')


### PR DESCRIPTION
Fix #19465