### PR TITLE
Restore `spack checksum` verbosity

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -836,12 +836,12 @@ def get_checksums_for_versions(
     max_len = max(len(str(v)) for v in sorted_versions)
     num_ver = len(sorted_versions)
 
-    tty.debug('Found {0} version{1} of {2}:'.format(
-              num_ver, '' if num_ver == 1 else 's', name),
-              '',
-              *spack.cmd.elide_list(
-                  ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
-                   for v in sorted_versions]))
+    tty.msg('Found {0} version{1} of {2}:'.format(
+            num_ver, '' if num_ver == 1 else 's', name),
+            '',
+            *spack.cmd.elide_list(
+                ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
+                 for v in sorted_versions]))
     print()
 
     if batch:


### PR DESCRIPTION
This also affects `spack create`.

### Before

```console
$ spack checksum python

==> How many would you like to checksum? (default is 1, q to abort)
```

### After

```console
$ spack checksum python
==> Found 309 versions of python:
  
  3.10.0a1   https://www.python.org/ftp/python/3.10.0/Python-3.10.0a1.tgz
  3.9.0rc2   https://www.python.org/ftp/python/3.9.0/Python-3.9.0rc2.tgz
  3.9.0rc1   https://www.python.org/ftp/python/3.9.0/Python-3.9.0rc1.tgz
  3.9.0b5    https://www.python.org/ftp/python/3.9.0/Python-3.9.0b5.tgz
  3.9.0b4    https://www.python.org/ftp/python/3.9.0/Python-3.9.0b4.tgz
  3.9.0b3    https://www.python.org/ftp/python/3.9.0/Python-3.9.0b3.tgz
  3.9.0b2    https://www.python.org/ftp/python/3.9.0/Python-3.9.0b2.tgz
  3.9.0b1    https://www.python.org/ftp/python/3.9.0/Python-3.9.0b1.tgz
  3.9.0a6    https://www.python.org/ftp/python/3.9.0/Python-3.9.0a6.tgz
  ...
  2.0.1      https://www.python.org/ftp/python/2.0.1/Python-2.0.1.tgz

==> How many would you like to checksum? (default is 1, q to abort) 
```