### PR TITLE
5 gcc master zstd patch fix

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -270,7 +270,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch('sys_ustat-4.9.patch', when='@4.9')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95005
-    patch('zstd.patch', when='@10:10.2')
+    patch('zstd.patch', when='@10.0:10.2')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -270,7 +270,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch('sys_ustat-4.9.patch', when='@4.9')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95005
-    patch('zstd.patch', when='@10:')
+    patch('zstd.patch', when='@10:10.2')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
To fix the patch on gcc@master we have to set the versions that the zstd patch is applied since current latest code of gcc has the patch already applied.

Fixes #19478 