### PR TITLE
ppopen-appl-fdm: change download site to github

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-fdm/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-fdm/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from spack import *
 
 
@@ -16,9 +15,9 @@ class PpopenApplFdm(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url      = "file://{0}/ppohFDM_0.3.1.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('0.3.1', sha256='5db7c28ef2df43c0ffa28e542d92320fe3c8cd7551aabe1de64647191ddf7d0b')
+    version('master', branch='APPL/FDM')
 
     # remove unused variable definition
     patch('unused.patch')


### PR DESCRIPTION
Down load site of 'ppopen-appl-fdm' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.