### PR TITLE
ppopen-appl-fem: change download site to github

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-fem/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-fem/package.py
@@ -16,9 +16,9 @@ class PpopenApplFem(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url = "file://{0}/ppohFEM_1.0.1.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('1.0.1', sha256='eea8837fa3eda284759b7ebf27c27cea8cbf9cf65cf37c62941700e1321aeb07')
+    version('master', branch='APPL/FEM')
 
     depends_on('mpi')
     depends_on('metis')
@@ -51,6 +51,7 @@ class PpopenApplFem(MakefilePackage):
         )
         makefile_in.filter('mpicc', spec['mpi'].mpicc)
         makefile_in.filter('mpif90', spec['mpi'].mpifc)
+        mkdirp(join_path('ppohFEM', 'bin'))
 
     def install(self, spec, prefix):
         for d in ['ppohFEM', 'app_flow', 'app_heat', 'app_struct']:


### PR DESCRIPTION
Down load site of 'ppopen-appl-fem' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.