### PR TITLE
gcc: Fix zstd patch version range

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -270,7 +270,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch('sys_ustat-4.9.patch', when='@4.9')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95005
-    patch('zstd.patch', when='@10.0:10.2')
+    patch('zstd.patch', when='@10')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
PR #19482 updated gcc to only apply the zstd patch until @10.2 but the releases/gcc-10 branch actually does not contain the patch yet, that is, gcc@10.3 will most likely have the same problem. Apply the patch for all 10.x releases instead.