### PR TITLE
CMake fix: narrow versions that the PGI patch is applied to

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -168,7 +168,7 @@ class Cmake(Package):
     # Remove -A from the C++ flags we use when CXX_EXTENSIONS is OFF
     # Should be fixed in 3.19.
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
-    patch('pgi-cxx-ansi.patch', when='@3.1:3.18.99')
+    patch('pgi-cxx-ansi.patch', when='@3.15:3.18.99')
 
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 


### PR DESCRIPTION
Fix issue reported by @opadron in https://github.com/spack/spack/pull/19452#issuecomment-714892360.

The patch to remove the `-A` option from the PGI compiler command line does not cleanly apply to CMake 3.9 - 3.14 (inclusive) since there were other changes to the affected file starting in 3.15.

Before this fix:
```
$ spack install cmake@3.14.7
...
==> Installing cmake
==> No binary for cmake found: installing from source
==> Fetching https://github.com/Kitware/CMake/releases/download/v3.14.7/cmake-3.14.7.tar.gz
######################################################################### 100.0%######################################################################### 100.0%
1 out of 1 hunk FAILED -- saving rejects to file Modules/Compiler/PGI-CXX.cmake.rej
==> Patch /home/smcmillan/git/smcmillan/spack/var/spack/repos/builtin/packages/cmake/pgi-cxx-ansi.patch failed.
==> Error: ProcessError: Command exited with status 1:
    '/usr/bin/patch' '-s' '-p' '1' '-i' '/home/smcmillan/git/smcmillan/spack/var/spack/repos/builtin/packages/cmake/pgi-cxx-ansi.patch' '-d' '.'
```

With this fix:
```
$ spack install cmake@3.14.7
...
==> Installing cmake
==> No binary for cmake found: installing from source
==> Using cached archive: /home/smcmillan/git/smcmillan/spack/var/spack/cache/_source-cache/archive/92/9221993e0af3e6d10124d840ff24f5b2f3b884416fca04d3312cb0388dec1385.tar.gz
==> cmake: Executing phase: 'bootstrap'
==> cmake: Executing phase: 'build'
==> cmake: Executing phase: 'install'
[+] /home/smcmillan/git/smcmillan/spack/opt/spack/linux-centos8-haswell/gcc-8.3.1/cmake-3.14.7-aijhohpcj3rr3hvjojvdqi4qwuqecc56
```