### PR TITLE
py-pillow-simd: add older version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow-simd/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow-simd/package.py
@@ -16,6 +16,7 @@ class PyPillowSimd(PyPillowBase):
     url      = "https://pypi.io/packages/source/P/Pillow-SIMD/Pillow-SIMD-7.0.0.post3.tar.gz"
 
     version('7.0.0.post3', sha256='c27907af0e7ede1ceed281719e722e7dbf3e1dbfe561373978654a6b64896cb7')
+    version('6.2.2.post1', sha256='d29b673ac80091797f1e8334458be307e4ac4ab871b0e495cfe56cb7b1d7704e')
 
-    for ver in ['7.0.0.post3']:
+    for ver in ['6.2.2.post1', '7.0.0.post3']:
         provides('pil@' + ver, when='@' + ver)


### PR DESCRIPTION
I needed an older version for Python 2 support ☹️ 

Successfully installs on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.