### PR TITLE
changes to support hip build of camp

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -21,6 +21,10 @@ class Camp(CMakePackage, CudaPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
 
+    variant('hip', default=False, description='Enable HIP support')
+    depends_on('llvm-amdgpu', when='+hip')
+    depends_on('hip', when='+hip')
+
     def cmake_args(self):
         spec = self.spec
 
@@ -38,6 +42,20 @@ class Camp(CMakePackage, CudaPackage):
                 options.append('-DCMAKE_CUDA_FLAGS:STRING={0}'.format(flag))
         else:
             options.append('-DENABLE_CUDA=OFF')
+
+        # Please note that there is currently a bug in how spack detects hip.
+        # There is a workaound involving some manual changes to the hip
+        # package file and to the packages.yaml file.
+        # Please contact a developer for details.
+        if '+hip' in spec:
+            # Possibly add '-DHIP_CLANG_PATH={0}'
+            #  .format(self.spec['llvm-amdgpu'].prefix.bin
+            # in the future if there are issues.
+            options.extend([
+                '-DENABLE_HIP=ON',
+                '-DHIP_ROOT_DIR={0}'. format(spec['hip'].prefix)])
+        else:
+            options.append('-DENABLE_HIP=OFF')
 
         options.append('-DENABLE_TESTS=ON')
 

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -61,14 +61,7 @@ class Camp(CMakePackage, CudaPackage):
         else:
             options.append('-DENABLE_CUDA=OFF')
 
-        # Please note that there is currently a bug in how spack detects hip.
-        # There is a workaound involving some manual changes to the hip
-        # package file and to the packages.yaml file.
-        # Please contact a developer for details.
         if '+hip' in spec:
-            # Possibly add '-DHIP_CLANG_PATH={0}'
-            #  .format(self.spec['llvm-amdgpu'].prefix.bin
-            # in the future if there are issues.
             arch = self.spec.variants['amdgpu_target'].value
             options.extend([
                 '-DENABLE_HIP=ON',

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -54,7 +54,7 @@ class Camp(CMakePackage, CudaPackage):
             # in the future if there are issues.
             options.extend([
                 '-DENABLE_HIP=ON',
-                '-DHIP_ROOT_DIR={0}'. format(spec['hip'].prefix)])
+                '-DHIP_ROOT_DIR={0}'.format(spec['hip'].prefix)])
         else:
             options.append('-DENABLE_HIP=OFF')
 

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -56,7 +56,9 @@ class Hip(CMakePackage):
         # required in the packages.yaml file. Please contact a developer
         # for details.
         mydict = {}
-        fallback_path = os.path.abspath('/opt/rocm')
+        # typically, self.spec.prefix is /opt/rocm/hip, so fallback_path
+        # will be /opt/rocm after dirname is called.
+        fallback_path = os.path.dirname(self.spec.prefix)
         found_fallback_path = os.path.isdir(fallback_path)
 
         if 'llvm-amdgpu' in self.spec:

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -49,6 +49,10 @@ class Hip(CMakePackage):
     patch('0002-Fix-detection-of-HIP_CLANG_ROOT.patch', when='@3.5.0:')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        # Please note that there is currently a bug in how spack detects hip.
+        # There is a workaound involving some manual changes to the following
+        # lines to hard-code paths. Manual edits will also be needed to the
+        # packages.yaml file. Please contact a developer for details.
         env.set('ROCM_PATH', '')
         env.set('HIP_COMPILER', 'clang')
         env.set('HIP_PLATFORM', 'hcc')

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -57,7 +57,8 @@ class Hip(CMakePackage):
         # assumption does not hold.
         if self.spec.external:
             # typically, self.spec.prefix is /opt/rocm/hip, so fallback_path
-            # will be /opt/rocm.
+            # will be /opt/rocm. The rocminfo executable is usually
+            # found at /opt/rocm/bin/rocminfo.
             fallback_prefix = Prefix(os.path.dirname(self.spec.prefix))
             if not os.path.isdir(fallback_prefix):
                 msg = "Could not determine prefix for other rocm components\n"
@@ -69,7 +70,7 @@ class Hip(CMakePackage):
             return {
                 'llvm-amdgpu': fallback_prefix.llvm,
                 'hsa-rocr-dev': fallback_prefix.hsa,
-                'rocminfo': fallback_prefix.share.info,
+                'rocminfo': fallback_prefix.bin,
                 'rocm-device-libs': fallback_prefix,
             }
         else:

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -67,11 +67,11 @@ class Hip(CMakePackage):
                 raise RuntimeError(msg)
 
             return {
-                'llvm-amdgpu': fallback_prefix.llvm
-                'hsa-rocr-dev': fallback_prefix.hsa
+                'llvm-amdgpu': fallback_prefix.llvm,
+                'hsa-rocr-dev': fallback_prefix.hsa,
                 'rocminfo': fallback_prefix.share.info,
-                'rocm-device-libs': fallback_prefix
-                }
+                'rocm-device-libs': fallback_prefix,
+            }
         else:
             return dict((name, self.spec[name].prefix)
                         for name in ('llvm-amdgpu', 'hsa-rocr-dev', 'rocminfo',


### PR DESCRIPTION
There are issues with how hip detects spack that need to be resolved. Please see the confluence page https://lc.llnl.gov/confluence/pages/viewpage.action?pageId=669526837 for a warkaround. Thanks to Robert Blake, Greg Becker, and others for their help during the debugging process and for helping to make the Wiki to document the issue for future users.

Please wait until Monday at least to merge so that David Beckinsale, Todd Gamblin, and others have a chance to take a look at the confluence page above and give their input on the (non-ideal) workaround for packages depending on hip.