### PR TITLE
PyTorch: future needed at run-time for Python 2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -127,7 +127,7 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
-    depends_on('py-future', when='@1.1: ^python@:2', type='build')
+    depends_on('py-future', when='@1.1: ^python@:2', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-typing', when='@0.4: ^python@:3.4', type=('build', 'run'))
     depends_on('py-pybind11', when='@0.4:', type=('build', 'link', 'run'))


### PR DESCRIPTION
Without this I see the following error:
```
>>> import torch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/Adam/Documents/UIUC/Homework/CS598MAV/cs598mav_fa20/.spack-env/view/lib/python2.7/site-packages/torch/__init__.py", line 17, in <module>
    from ._six import string_classes as _string_classes
  File "/Users/Adam/Documents/UIUC/Homework/CS598MAV/cs598mav_fa20/.spack-env/view/lib/python2.7/site-packages/torch/_six.py", line 23, in <module>
    import builtins
ImportError: No module named builtins
```