### PR TITLE
New package: Intel OneAPI

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi/package.py
@@ -30,13 +30,13 @@ class IntelOneapi(Package):
         bash.add_default_env('HOME', prefix)
 
         bash('./l_HPCKit_b_%s_offline.sh' %
-                       spec.versions.lowest(),
-                       '-s', '-a', '-s', '--action', 'install',
-                       '--eula', 'accept',
-                       '--components',
-                       ('intel.oneapi.lin.dpcpp-cpp-compiler-pro'
-                        ':intel.oneapi.lin.ifort-compiler'),
-                        '--install-dir', prefix)
+             spec.versions.lowest(),
+             '-s', '-a', '-s', '--action', 'install',
+             '--eula', 'accept',
+             '--components',
+             ('intel.oneapi.lin.dpcpp-cpp-compiler-pro'
+              ':intel.oneapi.lin.ifort-compiler'),
+             '--install-dir', prefix)
 
         # preserve config and logs
         dst = os.path.join(self.prefix, '.spack')

--- a/var/spack/repos/builtin/packages/intel-oneapi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+class IntelOneapi(Package):
+    """
+    Includes the icx/ifx compiler executables.
+    """
+
+    homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
+
+    version('2021.1.9.2205', sha256='8926a3001e61edbb293cb607beb8eb3a3511330a4625c8f3b1b51603426f121a', url='https://registrationcenter-download.intel.com/akdlm/irc_nas/16949/l_HPCKit_b_2021.1.9.2205_offline.sh', expand=False)
+
+    phases = ['install']
+
+    def install(self, prefix):
+        bash = Executable('bash')
+
+        # Capture logs written in /tmp
+        tmpdir = tempfile.mkdtemp(prefix='spack-intel-')
+        bash.add_default_env('TMPDIR', tmpdir)
+
+        # Need to set HOME to avoid using ~/intel
+        bash.add_default_env('HOME', prefix)
+
+        bash('./l_HPCKit_b_%s_offline.sh' %
+                       spec.versions.lowest(),
+                       '-s', '-a', '-s', '--action', 'install',
+                       '--eula', 'accept',
+                       '--components',
+                       ('intel.oneapi.lin.dpcpp-cpp-compiler-pro'
+                        ':intel.oneapi.lin.ifort-compiler'),
+                        '--install-dir', prefix)
+
+        # preserve config and logs
+        dst = os.path.join(self.prefix, '.spack')
+        for f in glob.glob('%s/intel*log' % tmpdir):
+            install(f, dst)

--- a/var/spack/repos/builtin/packages/intel-oneapi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi/package.py
@@ -10,7 +10,8 @@ import glob
 
 class IntelOneapi(Package):
     """
-    Includes the icx/ifx compiler executables.
+    Includes the newer (icx/icpx/ifx/dpcpp) and older (icc/icpc/ifort)
+    compiler executables.
     """
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
@@ -43,8 +44,7 @@ class IntelOneapi(Package):
         for f in glob.glob('%s/intel*log' % tmpdir):
             install(f, dst)
 
-    # TODO: this package includes icc as well as icx. Question: is icc a link
-    # to icx?
-    # @property
-    # def cc(self):
-    #    pass
+    @property
+    def cc(self):
+        # TODO: this needs to select the proper path based on the host OS
+        return str(self.spec.prefix.compiler.latest.linux.bin.icx)

--- a/var/spack/repos/builtin/packages/intel-oneapi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi/package.py
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import tempfile
+import os
+import glob
+
+
 class IntelOneapi(Package):
     """
     Includes the icx/ifx compiler executables.
@@ -14,7 +19,7 @@ class IntelOneapi(Package):
 
     phases = ['install']
 
-    def install(self, prefix):
+    def install(self, spec, prefix):
         bash = Executable('bash')
 
         # Capture logs written in /tmp

--- a/var/spack/repos/builtin/packages/intel-oneapi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi/package.py
@@ -37,3 +37,9 @@ class IntelOneapi(Package):
         dst = os.path.join(self.prefix, '.spack')
         for f in glob.glob('%s/intel*log' % tmpdir):
             install(f, dst)
+
+    # TODO: this package includes icc as well as icx. Question: is icc a link
+    # to icx?
+    # @property
+    # def cc(self):
+    #    pass


### PR DESCRIPTION
This includes the `icx`/`ifx` executables. and is intended to 

This is similar to https://github.com/spack/spack/pull/19033 but differs in that this is a separate package rather than exposed as a new version of `intel`. This package does not appear to have the same requirements so it looked like it could be separated out.

At least one concern brought up by @rscohn2 was that both this and and Spack's `intel` package provide `icc` executables, so it may be confusing for users who want to install `icc`. I think this could be resolved by adding an `icc` virtual (provided by `intel` and `intel-oneapi`).

@rscohn I had a couple questions:

* Is `icc` distinct from `icx` (i.e. do they produce different compiled executables)?
* If the answer to the first question is "no", will `icx` be completely replacing `icc` at some point in the future?

TODOs

- [ ] I may need to tweak this to support bootstrapping of compiler installs (so that `spack install foo%intel-oneapi` will automatically install `intel-oneapi`

See also: https://github.com/spack/spack/pull/19330 (which adds the compiler definition)