### PR TITLE
phist: two new versions and disable ccache because we don't have a de…

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -26,6 +26,8 @@ class Phist(CMakePackage):
 
     version('develop', branch='devel')
     version('master', branch='master')
+    version('1.9.3', sha256='3ab7157e9f535a4c8537846cb11b516271ef13f82d0f8ebb7f96626fb9ab86cf')
+    version('1.9.2', sha256='289678fa7172708f5d32d6bd924c8fdfe72b413bba5bbb8ce6373c85c5ec5ae5')
     version('1.9.1', sha256='6e6411115ec48afe605b4f2179e9bc45d60f15459428f474f3f32b80d2830f1f')
     version('1.9.0', sha256='990d3308fc0083ed0f9f565d00c649ee70c3df74d44cbe5f19dfe05263d06559')
     version('1.8.0', sha256='ee42946bce187e126452053b5f5c200b57b6e40ee3f5bcf0751f3ced585adeb0')
@@ -140,7 +142,8 @@ class Phist(CMakePackage):
                         find_system_libraries(['libm'])).joined(';')
         lapacke_include_dir = spec['lapack:c'].headers.directories[0]
 
-        args = ['-DPHIST_KERNEL_LIB=%s' % kernel_lib,
+        args = ['-DPHIST_USE_CCACHE=OFF',
+                '-DPHIST_KERNEL_LIB=%s' % kernel_lib,
                 '-DPHIST_OUTLEV=%s' % outlev,
                 '-DTPL_LAPACKE_LIBRARIES=%s' % lapacke_libs,
                 '-DTPL_LAPACKE_INCLUDE_DIRS=%s' % lapacke_include_dir,


### PR DESCRIPTION
…pendency on ccache.

Otherwise, phist would look for ccache via cmake, which is not the spack way to do it.