### PR TITLE
Update py-sympy version

### DIFF
--- a/var/spack/repos/builtin/packages/py-sympy/package.py
+++ b/var/spack/repos/builtin/packages/py-sympy/package.py
@@ -18,5 +18,6 @@ class PySympy(PythonPackage):
     version('1.0', sha256='3eacd210d839e4db911d216a9258a3ac6f936992f66db211e22767983297ffae')
     version('0.7.6', sha256='dfa3927e9befdfa7da7a18783ccbc2fe489ce4c46aa335a879e49e48fc03d7a7')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4,3.5', when='@:1.4', type=('build', 'run'))
+    depends_on('python@3.6:', when='@1.6:', type=('build', 'run'))
     depends_on('py-mpmath@0.19:', when='@1.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sympy/package.py
+++ b/var/spack/repos/builtin/packages/py-sympy/package.py
@@ -11,6 +11,7 @@ class PySympy(PythonPackage):
     homepage = "https://pypi.python.org/pypi/sympy"
     url      = "https://pypi.io/packages/source/s/sympy/sympy-0.7.6.tar.gz"
 
+    version('1.6.2', sha256='1cfadcc80506e4b793f5b088558ca1fcbeaec24cd6fc86f1fdccaa3ee1d48708')
     version('1.4', sha256='71a11e5686ae7ab6cb8feb5bd2651ef4482f8fd43a7c27e645a165e4353b23e1')
     version('1.3', sha256='e1319b556207a3758a0efebae14e5e52c648fc1db8975953b05fff12b6871b54')
     version('1.1.1', sha256='ac5b57691bc43919dcc21167660a57cc51797c28a4301a6144eff07b751216a4')


### PR DESCRIPTION
Hi everyone,

I wanted to update the current version of the python package `py-sympy` (to use `multigamma`, for example).

And I found its information in:
https://github.com/sympy/sympy/releases

I am testing this in my local machine (with a full `spack` installation - and python 3.8.6) and it seems to work well.

It might be useful to update also the *url* to the `.tar.gz` files for the recent versions (which seems to be different now).
What do you think?

Thanks,
Diana