### PR TITLE
ghostscript: fix: add: depends_on('krb5', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -23,6 +23,7 @@ class Ghostscript(AutotoolsPackage):
     version('9.18', sha256='5fc93079749a250be5404c465943850e3ed5ffbc0d5c07e10c7c5ee8afbbdb1b')
 
     depends_on('pkgconfig', type='build')
+    depends_on('krb5', type='link')
 
     depends_on('freetype@2.4.2:')
     depends_on('jpeg')


### PR DESCRIPTION
I can't install ghostscript.
There are no dependencies of krb5 in the recipe.

```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

6 errors found in build log:
     1990    DEVICE_DEVS4= DEVICE_DEVS5= DEVICE_DEVS6= DEVICE_DEVS7= DEVICE_DEVS8= \
     1991    DEVICE_DEVS9= DEVICE_DEVS10= DEVICE_DEVS11= DEVICE_DEVS12= \
     1992    DEVICE_DEVS13= DEVICE_DEVS14= DEVICE_DEVS15= DEVICE_DEVS16= \
     1993    DEVICE_DEVS17= DEVICE_DEVS18= DEVICE_DEVS19= DEVICE_DEVS20= \
     1994    DEVICE_DEVS_EXTRA= \
     1995    /bin/sh <./obj/ldt.tr
  >> 1996    /usr/lib/gcc/aarch64-redhat-linux/8/../../../../lib64/libk5crypto.so: undefined reference to `EVP
             _KDF_derive@@OPENSSL_1_1_1b'
  >> 1997    /usr/lib/gcc/aarch64-redhat-linux/8/../../../../lib64/libk5crypto.so: undefined reference to `EVP
             _KDF_ctrl@@OPENSSL_1_1_1b'
  >> 1998    /usr/lib/gcc/aarch64-redhat-linux/8/../../../../lib64/libk5crypto.so: undefined reference to `EVP
             _KDF_CTX_free@@OPENSSL_1_1_1b'
  >> 1999    /usr/lib/gcc/aarch64-redhat-linux/8/../../../../lib64/libk5crypto.so: undefined reference to `EVP
             _KDF_CTX_new_id@@OPENSSL_1_1_1b'
  >> 2000    collect2: error: ld returned 1 exit status
  >> 2001    make: *** [base/unixlink.mak:172: bin/gs] Error 1
```