### PR TITLE
ppopen-appl-bem-at:  change download site to github

### DIFF
--- a/var/spack/repos/builtin/packages/ppopen-appl-bem-at/package.py
+++ b/var/spack/repos/builtin/packages/ppopen-appl-bem-at/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class PpopenApplBemAt(MakefilePackage):
@@ -15,14 +14,14 @@ class PpopenApplBemAt(MakefilePackage):
     """
 
     homepage = "http://ppopenhpc.cc.u-tokyo.ac.jp/ppopenhpc/"
-    url = "file://{0}/ppohBEM_AT_0.1.0.tar.gz".format(os.getcwd())
+    git = "https://github.com/Post-Peta-Crest/ppOpenHPC.git"
 
-    version('0.1.0', sha256='215034fea7d9f64e6361d8e605e04c7f5d302c87ce048dcd6d146b14d22c17f9')
+    version('master', branch='ATA/BEM')
     # In OAT_bem-bb-fw-dense-0.1.0.f90 the 2 variables are defined.
     # But ame variables are already defined in include file DAT.h.
     # This patch is deleted the variables definitions
     # in OAT_bem-bb-fw-dense-0.1.0.f90.
-    patch('duplicate_defs.patch', when="@0.1.0")
+    patch('duplicate_defs.patch', when="@master")
 
     depends_on('mpi')
     depends_on('ppopen-appl-bem', type='run')


### PR DESCRIPTION
Down load site of 'ppopen-appl-bem-at' is changed from home page to github.
On github, the release file and version tag is not found.
This PR is changed download url and version.