### PR TITLE
asciidoc-py3 add docbook dependency and fix a enviroment variable problem for docbook-{xml,xsl}

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc-py3/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc-py3/package.py
@@ -23,3 +23,5 @@ class AsciidocPy3(AutotoolsPackage):
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('libxml2',     type=('build', 'run'))
     depends_on('libxslt',     type=('build', 'run'))
+    depends_on('docbook-xml', type=('build', 'run'))
+    depends_on('docbook-xsl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -20,6 +20,14 @@ class DocbookXml(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
+    @property
+    def catalog(self):
+        return os.path.join(self.prefix, 'catalog.xml')
+
     def setup_run_environment(self, env):
-        catalog = os.path.join(self.prefix, 'catalog.xml')
+        catalog = self.catalog
         env.set('XML_CATALOG_FILES', catalog, separator=' ')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        catalog = self.catalog
+        env.set("XML_CATALOG_FILES", catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -28,8 +28,8 @@ class DocbookXsl(Package):
 
     def setup_run_environment(self, env):
         catalog = self.catalog
-        env.set('XML_CATALOG_FILES', catalog, separator=' ')
+        env.prepend_path('XML_CATALOG_FILES', catalog, separator=' ')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         catalog = self.catalog
-        env.prepend_path("XML_CATALOG_FILES", catalog)
+        env.prepend_path("XML_CATALOG_FILES", catalog, separator=' ')


### PR DESCRIPTION
additional to https://github.com/spack/spack/pull/19491 I add `docbook-{xml,xsl}` as dependency, which also the old python2 package `asciidoc` has. 

This fixes a build problem of `ocl-icd` as these catalogs are needed to build the manpage.  Also `XML_CATALOG_FILES` needs to be exported in the build environment for `ocl-icd` as else way it won't be found, hence I added this to  `docbook-xml` and fix `docbook-xsl`, so it do not get overwrote or prepended with the wrong separator.