### PR TITLE
[julia]: CPU names are LLVM-style, must map across

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -164,6 +164,8 @@ class Julia(Package):
                 ]
             else:
                 target_str = str(spec.target).replace('_', '-')
+                if target_str == "zen2":
+                    target_str = "znver2"
                 options += [
                     'JULIA_CPU_TARGET={0}'.format(target_str)
                 ]


### PR DESCRIPTION
In this case, the `zen2` architecture is unknown; Spack must use the
LLVM-style `znver2` target instead.  I haven't done an exhaustive test, this was just the architecture of my dev machine.