### PR TITLE
py-pycbc: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/py-pycbc/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/py-pycbc/for_aarch64.patch
@@ -1,0 +1,11 @@
+--- spack-src/setup.py.bak	2019-07-02 09:00:09.000000000 +0900
++++ spack-src/setup.py	2020-10-28 10:58:22.559034050 +0900
+@@ -207,7 +207,7 @@
+              'filter.matchedfilter',
+              'vetoes.chisq']
+ ext = []
+-cython_compile_args = ['-O3', '-w', '-msse4.2', '-ffast-math',
++cython_compile_args = ['-O3', '-w', '-ffast-math',
+                        '-ffinite-math-only']
+ cython_link_args = []
+ # Mac's clang compiler doesn't have openMP support by default. Therefore

--- a/var/spack/repos/builtin/packages/py-pycbc/package.py
+++ b/var/spack/repos/builtin/packages/py-pycbc/package.py
@@ -39,4 +39,4 @@ class PyPycbc(PythonPackage):
     depends_on('py-ligo-segments', type=('build', 'run'))
     depends_on('py-weave@0.16.0:', when='^python@:2', type=('build', 'run'))
 
-    patch('for_aarch64.patch', when='target=aarch64:')
+    patch('for_aarch64.patch', when='@:1.14.1 target=aarch64:')

--- a/var/spack/repos/builtin/packages/py-pycbc/package.py
+++ b/var/spack/repos/builtin/packages/py-pycbc/package.py
@@ -38,3 +38,5 @@ class PyPycbc(PythonPackage):
     depends_on('py-six@1.10.0:', type=('build', 'run'))
     depends_on('py-ligo-segments', type=('build', 'run'))
     depends_on('py-weave@0.16.0:', when='^python@:2', type=('build', 'run'))
+
+    patch('for_aarch64.patch', when='target=aarch64:')


### PR DESCRIPTION
I made a fix to be able to install on aarch64.