### PR TITLE
Fix append_flag for module files

### DIFF
--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -70,9 +70,7 @@ depends_on("{{ module }}")
 {% for command_name, cmd in environment_modifications %}
 {% if command_name == 'PrependPath' %}
 prepend_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
-{% elif command_name == 'AppendPath' %}
-append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
-{% elif command_name == 'AppendFlagsEnv' %}
+{% elif command_name == 'AppendPath' or command_name == 'AppendFlagsEnv' %}
 append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'RemovePath' %}
 remove_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -72,6 +72,8 @@ depends_on("{{ module }}")
 prepend_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'AppendPath' %}
 append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
+{% elif command_name == 'AppendFlagsEnv' %}
+append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'RemovePath' %}
 remove_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'SetEnv' %}

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -70,7 +70,7 @@ depends_on("{{ module }}")
 {% for command_name, cmd in environment_modifications %}
 {% if command_name == 'PrependPath' %}
 prepend_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
-{% elif command_name == 'AppendPath' or command_name == 'AppendFlagsEnv' %}
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
 append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
 {% elif command_name == 'RemovePath' %}
 remove_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -63,8 +63,6 @@ unsetenv {{ cmd.name }}
 {# We are using the usual separator #}
 {% if command_name == 'PrependPath' %}
 prepend-path {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
-append-path {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'RemovePath' %}
 remove-path {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'SetEnv' %}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -46,7 +46,6 @@ conflict {{ name }}
 
 {% block environment %}
 {% for command_name, cmd in environment_modifications %}
-{% if cmd.separator != ':' %}
 {# A non-standard separator is required #}
 {% if command_name == 'PrependPath' %}
 prepend-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -50,7 +50,7 @@ conflict {{ name }}
 {# A non-standard separator is required #}
 {% if command_name == 'PrependPath' %}
 prepend-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'AppendPath' %}
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
 append-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'RemovePath' %}
 remove-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
@@ -63,7 +63,7 @@ unsetenv {{ cmd.name }}
 {# We are using the usual separator #}
 {% if command_name == 'PrependPath' %}
 prepend-path {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'AppendPath' %}
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
 append-path {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'RemovePath' %}
 remove-path {{ cmd.name }} "{{ cmd.value }}"

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -54,20 +54,9 @@ append-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'RemovePath' %}
 remove-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'SetEnv' %}
-setenv --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'UnsetEnv' %}
-unsetenv {{ cmd.name }}
-{% else %}
-{# We are using the usual separator #}
-{% if command_name == 'PrependPath' %}
-prepend-path {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'RemovePath' %}
-remove-path {{ cmd.name }} "{{ cmd.value }}"
-{% elif command_name == 'SetEnv' %}
 setenv {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'UnsetEnv' %}
 unsetenv {{ cmd.name }}
-{% endif %}
 {#  #}
 {% endif %}
 {% endfor %}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -57,7 +57,6 @@ remove-path --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 setenv --delim "{{ cmd.separator }}" {{ cmd.name }} "{{ cmd.value }}"
 {% elif command_name == 'UnsetEnv' %}
 unsetenv {{ cmd.name }}
-{% endif %}
 {% else %}
 {# We are using the usual separator #}
 {% if command_name == 'PrependPath' %}


### PR DESCRIPTION
Resolves [#10299](https://github.com/spack/spack/issues/10299)

`run_env.append_flags('LDFLAGS', '-lflang')` was not making any changes in the module file when being called in `setup_environment(self, spack_env, run_env)`. Other commands work, such as `run_env.set('LDFLAGS', '-lflang')` but not append_flag