### PR TITLE
clingo+python extends python

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -35,6 +35,7 @@ class Clingo(CMakePackage):
     depends_on('bison@2.5:', type="build")
 
     depends_on('python', type=("build", "link", "run"), when="+python")
+    extends('python', when='+python')
 
     def patch(self):
         # Doxygen is optional but can't be disabled with a -D, so patch


### PR DESCRIPTION
Fixes but using clingo python interface after `spack load clingo`.