### PR TITLE
SLATE package: New versions of slate, blaspp, and lapackpp with CMake build support

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -18,6 +18,7 @@ class Blaspp(CMakePackage, CudaPackage):
     maintainers = ['teonnik', 'Sely85', 'G-Ragghianti', 'mgates3']
 
     version('master', branch='master')
+    version('2020.10.02', sha256='36e45bb5a8793ba5d7bc7c34fc263f91f92b0946634682937041221a6bf1a150')
     version('2020.10.01', sha256='1a05dbc46caf797d59a7c189216b876fdb1b2ff3e2eb48f1e6ca4b2756c59153')
     version('2020.10.00', sha256='ce148cfe397428d507c72d7d9eba5e9d3f55ad4cd842e6e873c670183dcb7795')
     version('2020.09.00', sha256='ee5d29171bbed515734007dd121ce2e733e2f83920c4d5ede046e657f4a513ef')

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -21,7 +21,6 @@ class Blaspp(CMakePackage, CudaPackage):
     version('2020.10.02', sha256='36e45bb5a8793ba5d7bc7c34fc263f91f92b0946634682937041221a6bf1a150')
     version('2020.10.01', sha256='1a05dbc46caf797d59a7c189216b876fdb1b2ff3e2eb48f1e6ca4b2756c59153')
     version('2020.10.00', sha256='ce148cfe397428d507c72d7d9eba5e9d3f55ad4cd842e6e873c670183dcb7795')
-    version('2020.09.00', sha256='ee5d29171bbed515734007dd121ce2e733e2f83920c4d5ede046e657f4a513ef')
 
     variant('openmp', default=True, description='Use OpenMP internally.')
     variant('cuda',   default=True, description='Build with CUDA')

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -21,13 +21,12 @@ class Lapackpp(CMakePackage):
     version('2020.10.02', sha256='8dde9b95d75b494c4f8b893d68034e95b7a7541981359acb97b6c1c4a9c45cd9')
     version('2020.10.01', sha256='ecd659730b4c3cfb8d2595f9bbb6af65d96b79397db654f17fe045bdfea841c0')
     version('2020.10.00', sha256='5f6ab3bd3794711818a3a50198efd29571520bf455e13ffa8ba50fa8376d7d1a')
-    version('2020.09.00', sha256='b5d4defa8eb314f21b3788563da9d264e2b084f2eb6535f6c6798ba798a29ee5')
 
     variant('shared', default=True, description='Build shared library')
 
     # Needs to compile against a matching blaspp version
     depends_on('blaspp')
-    for ver in ['master', '2020.10.02', '2020.10.01', '2020.10.00', '2020.09.00']:
+    for ver in ['master', '2020.10.02', '2020.10.01', '2020.10.00']:
         depends_on('blaspp@' + ver, when='@' + ver)
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -18,6 +18,7 @@ class Lapackpp(CMakePackage):
     maintainers = ['teonnik', 'Sely85', 'G-Ragghianti', 'mgates3']
 
     version('master', branch='master')
+    version('2020.10.02', sha256='8dde9b95d75b494c4f8b893d68034e95b7a7541981359acb97b6c1c4a9c45cd9')
     version('2020.10.01', sha256='ecd659730b4c3cfb8d2595f9bbb6af65d96b79397db654f17fe045bdfea841c0')
     version('2020.10.00', sha256='5f6ab3bd3794711818a3a50198efd29571520bf455e13ffa8ba50fa8376d7d1a')
     version('2020.09.00', sha256='b5d4defa8eb314f21b3788563da9d264e2b084f2eb6535f6c6798ba798a29ee5')
@@ -26,7 +27,7 @@ class Lapackpp(CMakePackage):
 
     # Needs to compile against a matching blaspp version
     depends_on('blaspp')
-    for ver in ['master', '2020.10.01', '2020.10.00', '2020.09.00']:
+    for ver in ['master', '2020.10.02', '2020.10.01', '2020.10.00', '2020.09.00']:
         depends_on('blaspp@' + ver, when='@' + ver)
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -38,7 +38,7 @@ class Slate(CMakePackage):
     depends_on('lapackpp@master', when='@master')
     depends_on('scalapack')
 
-    cpp_17_msg='Requires C++17 compiler support'
+    cpp_17_msg = 'Requires C++17 compiler support'
     conflicts('%gcc@:5', msg=cpp_17_msg)
     conflicts('%xl', msg=cpp_17_msg)
     conflicts('%xl_r', msg=cpp_17_msg)

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Slate(MakefilePackage):
+class Slate(CMakePackage):
     """The Software for Linear Algebra Targeting Exascale (SLATE) project is
     to provide fundamental dense linear algebra capabilities to the US
     Department of Energy and to the high-performance computing (HPC) community
@@ -17,44 +17,40 @@ class Slate(MakefilePackage):
 
     homepage = "https://icl.utk.edu/slate/"
     git      = "https://bitbucket.org/icl/slate"
+    url      = 'https://bitbucket.org/icl/slate/downloads/slate-2020.10.00.tar.gz'
     maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('develop', submodules=True)
+    version('master', branch='master')
+    version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 
     variant('cuda',   default=True, description='Build with CUDA support.')
     variant('mpi',    default=True, description='Build with MPI support.')
     variant('openmp', default=True, description='Build with OpenMP support.')
+    variant('shared', default=True, description='Build shared library')
 
-    depends_on('bash', type='build')
-    depends_on('scalapack')
+    depends_on('cuda', when='+cuda')
+    depends_on('mpi', when='+mpi')
     depends_on('blas')
-    depends_on('cuda@9:10', when='+cuda')
-    depends_on('mpi',       when='+mpi')
+    depends_on('blaspp ~cuda', when='~cuda')
+    depends_on('blaspp +cuda', when='+cuda')
+    depends_on('lapackpp')
+    depends_on('lapackpp@2020.10.02:', when='@2020.10.00')
+    depends_on('lapackpp@master', when='@master')
+    depends_on('scalapack')
 
-    conflicts('%gcc@:5')
+    cpp_17_msg='Requires C++17 compiler support'
+    conflicts('%gcc@:5', msg=cpp_17_msg)
+    conflicts('%xl', msg=cpp_17_msg)
+    conflicts('%xl_r', msg=cpp_17_msg)
+    conflicts('%intel@19:', msg='Does not currently build with icpc >= 2019')
 
-    def edit(self, spec, prefix):
-        if '^openblas' in spec:
-            blas = 'openblas'
-        elif '^intel-mkl' in spec:
-            blas = 'mkl'
-        elif '^essl' in spec:
-            blas = 'essl'
-        else:
-            raise InstallError('Supports only BLAS provider '
-                               'openblas, intel-mkl, or essl')
-        config = [
-            'SHELL=bash',
-            'prefix=%s' % prefix,
-            'mpi=%i'    % ('+mpi' in spec),
-            'cuda=%i'   % ('+cuda' in spec),
-            'openmp=%i' % ('+openmp' in spec),
-            'blas=%s'   % blas
+    def cmake_args(self):
+        spec = self.spec
+        return [
+            '-Dbuild_tests=%s'       % self.run_tests,
+            '-Duse_openmp=%s'        % ('+openmp' in spec),
+            '-DBUILD_SHARED_LIBS=%s' % ('+shared' in spec),
+            '-Duse_cuda=%s'          % ('+cuda' in spec),
+            '-Duse_mpi=%s'           % ('+mpi' in spec),
+            '-DSCALAPACK_LIBRARIES=%s'    % spec['scalapack'].libs.joined(';')
         ]
-        if '+mpi' in spec:
-            config.append('CXX=' + spec['mpi'].mpicxx)
-            config.append('FC=' + spec['mpi'].mpifc)
-
-        with open('make.inc', 'w') as inc:
-            for line in config:
-                inc.write('{0}\n'.format(line))


### PR DESCRIPTION
The SLATE package has been upgraded to support the new CMake build system, and corresponding version updates of the dependencies blaspp and lapackpp have been included.