### PR TITLE
glew: Refactor as CMakePackage

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
-
-class Glew(Package):
+class Glew(CMakePackage):
     """The OpenGL Extension Wrangler Library."""
 
     homepage = "http://glew.sourceforge.net/"
@@ -15,22 +13,14 @@ class Glew(Package):
     version('2.1.0',  sha256='04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95')
     version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')
 
-    depends_on("cmake", type='build')
     depends_on("gl")
     depends_on('libsm')
     depends_on('libice')
 
-    def install(self, spec, prefix):
-        options = []
-        options.extend(std_cmake_args)
+    root_cmakelists_dir = "build/cmake"
 
-        with working_dir('build'):
-            cmake('./cmake/', *options)
-
-            # https://github.com/Homebrew/legacy-homebrew/issues/22025
-            # Note: This file is generated only after cmake is run
-            filter_file(r'Requires: glu',
-                        (''), '../glew.pc')
-
-            make()
-            make("install")
+    @run_after('cmake')
+    def patch_glew_pc(self):
+        # https://github.com/Homebrew/legacy-homebrew/issues/22025
+        # Note: This file is generated only after cmake is run
+        filter_file(r'Requires: glu', '', 'glew.pc')


### PR DESCRIPTION
In #18394 it was noted, that this package should be changed from a generic "Package" to a "CMakePackage". It makes a bunch of things easier.

And it uses all the common cmake code.

pinging @adamjstewart who asked about this conversion in https://github.com/spack/spack/pull/18394#issuecomment-683339463