### PR TITLE
qt: Silence build and force `xmlpatterns` library on for Qt4

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -333,10 +333,13 @@ class Qt(Package):
                     conf('g++-unix'))
 
         if self.spec.satisfies('@4'):
-            # Necessary to build with GCC 6 and other modern compilers
-            # http://stackoverflow.com/questions/10354371/
+            # The gnu98 flag is necessary to build with GCC 6 and other modern
+            # compilers (see http://stackoverflow.com/questions/10354371/);
+            # be permissive because of the abundance of older code, and hide
+            # all warnings because there are so many of them with newer
+            # compilers
             with open(conf('gcc-base'), 'a') as f:
-                f.write("QMAKE_CXXFLAGS += -std=gnu++98\n")
+                f.write("QMAKE_CXXFLAGS += -std=gnu++98 -fpermissive -w\n")
 
     @when('@4: %intel')
     def patch(self):
@@ -523,6 +526,7 @@ class Qt(Package):
             '-{0}webkit'.format('' if '+webkit' in spec else 'no-'),
             '-{0}phonon'.format('' if '+phonon' in spec else 'no-'),
             '-arch', str(spec.target.family),
+            '-xmlpatterns',
         ])
 
         # Disable phonon backend until gstreamer is setup as dependency


### PR DESCRIPTION
For some mysterious reason Qt4 stopped building the xmlpatterns
component, needed by some downstream packages. With this patch, the
component successfully builds with
```
qt@4.8.7~dbus~debug~examples~framework~gtk~opengl~phonon+shared~sql~ssl~tools~webkit freetype=none arch=linux-rhel7-haswell %gcc@10.2.0
```