### PR TITLE
plplot:fix:　add depends_on('libsm', type=('build', 'link'))

### DIFF
--- a/var/spack/repos/builtin/packages/plplot/package.py
+++ b/var/spack/repos/builtin/packages/plplot/package.py
@@ -44,7 +44,7 @@ class Plplot(CMakePackage):
     depends_on('libx11')
     depends_on('qhull')
     depends_on('swig')
-    depends_on('libsm', type=('build', 'link'))
+    depends_on('libsm', type='link')
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/plplot/package.py
+++ b/var/spack/repos/builtin/packages/plplot/package.py
@@ -44,7 +44,7 @@ class Plplot(CMakePackage):
     depends_on('libx11')
     depends_on('qhull')
     depends_on('swig')
-    depends_on('libsm', type=('build', 'link'))    
+    depends_on('libsm', type=('build', 'link'))
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/plplot/package.py
+++ b/var/spack/repos/builtin/packages/plplot/package.py
@@ -44,6 +44,7 @@ class Plplot(CMakePackage):
     depends_on('libx11')
     depends_on('qhull')
     depends_on('swig')
+    depends_on('libsm', type=('build', 'link'))    
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION

I can't install plplot.
There are no dependencies of libsm in the recipe.

```
  >> 1058    //usr/lib64/libSM.so.6: undefined reference to `uuid_unparse_lower
             @@UUID_1.0'
  >> 1059    //usr/lib64/libSM.so.6: undefined reference to `uuid_generate@@UUID
             _1.0'
  >> 1060    collect2: error: ld returned 1 exit status
```
