### PR TITLE
plplot:fix:　add: depends_on('libsm', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/plplot/package.py
+++ b/var/spack/repos/builtin/packages/plplot/package.py
@@ -38,6 +38,7 @@ class Plplot(CMakePackage):
     depends_on('qt', when='+qt')
     depends_on('tcl', when='+tcl')
     depends_on('wxwidgets', when='+wx')
+    depends_on('libsm', type='link')
 
     depends_on('freetype')
     depends_on('gtkplus')


### PR DESCRIPTION
I can't install plplot.
There are no dependencies of libsm in the recipe.

```
  >> 1058    //usr/lib64/libSM.so.6: undefined reference to `uuid_unparse_lower
             @@UUID_1.0'
  >> 1059    //usr/lib64/libSM.so.6: undefined reference to `uuid_generate@@UUID
             _1.0'
  >> 1060    collect2: error: ld returned 1 exit status

```