### PR TITLE
Calm "spack flake8"

### DIFF
--- a/var/spack/repos/builtin/packages/audacious/package.py
+++ b/var/spack/repos/builtin/packages/audacious/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class Audacious(AutotoolsPackage):
     """A lightweight and versatile audio player."""
 

--- a/var/spack/repos/builtin/packages/entt/package.py
+++ b/var/spack/repos/builtin/packages/entt/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class Entt(CMakePackage):
     """EnTT is a header-only, tiny and easy to use library for game
     programming and much more written in modern C++, mainly known for its

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class Libuv(AutotoolsPackage):
     """Multi-platform library with a focus on asynchronous IO"""
     homepage = "http://libuv.org"

--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class Nsimd(CMakePackage):
     """NSIMD is a vectorization library that abstracts SIMD programming.
     It was designed to exploit the maximum power of processors

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class PyArchspec(PythonPackage):
     """A library for detecting, labeling and reasoning about
     microarchitectures.

--- a/var/spack/repos/builtin/packages/py-click/package.py
+++ b/var/spack/repos/builtin/packages/py-click/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
 class PyClick(PythonPackage):
     """A simple wrapper around optparse for powerful command line utilities."""
 

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
 class PyPillowBase(PythonPackage):
     """Base class for Pillow and its fork Pillow-SIMD."""
 


### PR DESCRIPTION
There should be two blank lines in front of a class definition.

Error message:
[E302] expected 2 blank lines, found 0