### PR TITLE
CI: disable vermin check

### DIFF
--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -45,8 +45,8 @@ class DeprecatedHash(object):
                           " supported in future Spack releases."
                           .format(self.hash_alg))
         if self.disable_security_check:
-            return hashlib.new(
-                self.hash_alg, usedforsecurity=False)  # novermin
+            return hashlib.new(  # novermin
+                self.hash_alg, usedforsecurity=False)
         else:
             return hashlib.new(self.hash_alg)
 

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -45,7 +45,7 @@ class DeprecatedHash(object):
                           " supported in future Spack releases."
                           .format(self.hash_alg))
         if self.disable_security_check:
-            return hashlib.new(self.hash_alg, usedforsecurity=False)
+            return hashlib.new(self.hash_alg, usedforsecurity=False)  # novermin
         else:
             return hashlib.new(self.hash_alg)
 

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -45,7 +45,8 @@ class DeprecatedHash(object):
                           " supported in future Spack releases."
                           .format(self.hash_alg))
         if self.disable_security_check:
-            return hashlib.new(self.hash_alg, usedforsecurity=False)  # novermin
+            return hashlib.new(
+                self.hash_alg, usedforsecurity=False)  # novermin
         else:
             return hashlib.new(self.hash_alg)
 


### PR DESCRIPTION
Spack has a fallback for hash checking that uses hashlib logic that may not be supported in earlier versions of Python 3.x. The comments in the Spack code acknowledge that this is best effort and may fail, but recent `vermin` checks (running as part of our CI) reject this. This disables `vermin` checks for that fallback.

It's possible that this fallback code is no longer needed since https://github.com/spack/spack/commit/62927654dd26db7a6a45c8bb307bf1cf6ba3470d was merged, although I'd like not to hold up all PRs while figuring that out.

See also: https://bugs.python.org/issue9216