### PR TITLE
Graphviz: don't build ghostscript when ~ghostscript

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -18,18 +18,12 @@ class Graphviz(AutotoolsPackage):
 
     homepage = 'http://www.graphviz.org'
     git      = 'https://gitlab.com/graphviz/graphviz.git'
+    url      = 'https://gitlab.com/graphviz/graphviz/-/archive/2.46.0/graphviz-2.46.0.tar.bz2'
 
-    # This commit hash is tag='stable_release_2.44.1'
-    version('2.44.1', commit='771bc4dbff3e6f358fa75cdc7774a413ccacad51')
-    # This commit hash is tag='stable_release_2.42.2'
-    version('2.42.2', commit='da4c2ec6f24ca1b6d1752c6b5bc4389e55682147')
-    # This commit hash is tag='stable_release_2.40.1'
-    version('2.40.1', commit='67cd2e5121379a38e0801cc05cce5033f8a2a609')
-
-    conflicts('%gcc@:5.9',
-              when='@2.40.1+qt ^qt@5:',
-              msg='graphviz-2.40.1 needs gcc-6 or greater to compile with QT5 '
-              'suppport')
+    version('2.46.0', sha256='1b11684fd5488940b45bf4624393140da6032abafae08f33dc3e986cffd55d71')
+    version('2.44.1', sha256='0f8f3fbeaddd474e0a270dc9bb0e247a1ae4284ae35125af4adceffae5c7ae9b')
+    version('2.42.4', sha256='a1ca0c4273d96bbf32fbfcbb784c8da2e38da13e7d2bbf9b24fe94ae45e79c4c')
+    version('2.38.0', sha256='c1b1e326b5d1f45b0ce91edd7acc68e80ff6be6b470008766e4d466aafc9801f')
 
     # Language bindings
     language_bindings = ['java']
@@ -81,7 +75,7 @@ class Graphviz(AutotoolsPackage):
     patch('https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/master/easybuild/easyconfigs/g/Graphviz/Graphviz-2.40.1_icc_vmalloc.patch',
           sha256='813e6529e79161a18b0f24a969b7de22f8417b2e942239e658b5402884541bc2',
           when='@:2.40%intel')
-    patch('ps2pdf.patch')
+    patch('ps2pdf.patch', when='@:2.45')
     patch('implicit.patch', level=0, when='@:2.44.0')
 
     if not MACOS_VERSION:
@@ -125,6 +119,11 @@ class Graphviz(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('libtool', type='build')
+
+    conflicts('%gcc@:5.9',
+              when='@2.40.1+qt ^qt@5:',
+              msg='graphviz-2.40.1 needs gcc-6 or greater to compile with QT5 '
+              'suppport')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -62,9 +62,6 @@ class Graphviz(AutotoolsPackage):
     variant('x', default=False,
             description='Use the X Window System')
 
-    #patch('https://gitlab.com/graphviz/graphviz/-/commit/3b2a27f4a04b6c816ef294fff5e94058dfc7a893.diff',
-    #      sha256='f6baa102238847f8cf8def7e4a6dcd575f0b0c9e3f32a2b8f894e3b7911e9e38',
-    #      when='@2.44.1~doc')
     patch('http://www.linuxfromscratch.org/patches/blfs/9.0/graphviz-2.40.1-qt5-1.patch',
           sha256='bd532df325df811713e311d17aaeac3f5d6075ea4fd0eae8d989391e6afba930',
           when='@:2.40+qt^qt@5:')
@@ -111,15 +108,17 @@ class Graphviz(AutotoolsPackage):
     depends_on('qt', when='+qt')
     depends_on('libx11', when="+x")
 
-    # Build dependencies
-    depends_on('pkgconfig', type='build')
-    # The following are needed when building from git
+    # Build dependencies (graphviz binaries don't include configurefile)
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('libtool', type='build')
+    depends_on('pkgconfig', type='build')
 
+    conflicts('~doc',
+              when='@:2.45',
+              msg='graphviz always builds documentation below version 2.46')
     conflicts('%gcc@:5.9',
               when='@2.40.1+qt ^qt@5:',
               msg='graphviz-2.40.1 needs gcc-6 or greater to compile with QT5 '
@@ -172,5 +171,9 @@ class Graphviz(AutotoolsPackage):
 
         args.append('--{0}-gtk'.format(
             "with" if "+gtkplus" in spec else "without"))
+
+        if spec.version >= Version('2.46'):
+            args.append('--{0}-man-pdfs'.format(
+                'enable' if '+doc' in spec else 'disable'))
 
         return args

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -108,7 +108,7 @@ class Graphviz(AutotoolsPackage):
     depends_on('qt', when='+qt')
     depends_on('libx11', when="+x")
 
-    # Build dependencies (graphviz binaries don't include configurefile)
+    # Build dependencies (graphviz binaries don't include configure file)
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -68,9 +68,9 @@ class Graphviz(AutotoolsPackage):
     variant('x', default=False,
             description='Use the X Window System')
 
-    patch('https://gitlab.com/graphviz/graphviz/-/commit/3b2a27f4a04b6c816ef294fff5e94058dfc7a893.diff',
-          sha256='f6baa102238847f8cf8def7e4a6dcd575f0b0c9e3f32a2b8f894e3b7911e9e38',
-          when='@2.44.1~doc')
+    #patch('https://gitlab.com/graphviz/graphviz/-/commit/3b2a27f4a04b6c816ef294fff5e94058dfc7a893.diff',
+    #      sha256='f6baa102238847f8cf8def7e4a6dcd575f0b0c9e3f32a2b8f894e3b7911e9e38',
+    #      when='@2.44.1~doc')
     patch('http://www.linuxfromscratch.org/patches/blfs/9.0/graphviz-2.40.1-qt5-1.patch',
           sha256='bd532df325df811713e311d17aaeac3f5d6075ea4fd0eae8d989391e6afba930',
           when='@:2.40+qt^qt@5:')

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -120,7 +120,6 @@ class Graphviz(AutotoolsPackage):
     depends_on('libtool', type='build')
     # required to build docs
     depends_on('groff', type='build')
-    depends_on('ghostscript', type='build')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -45,6 +45,8 @@ class Graphviz(AutotoolsPackage):
                 'bindings'.format(lang))
 
     # Feature variants
+    variant('doc', default=False,
+            description='Build and install graphviz documentation')
     variant('expat', default=False,
             description='Build with Expat support (enables HTML-like labels)')
     variant('gts', default=False,
@@ -66,6 +68,9 @@ class Graphviz(AutotoolsPackage):
     variant('x', default=False,
             description='Use the X Window System')
 
+    patch('https://gitlab.com/graphviz/graphviz/-/commit/3b2a27f4a04b6c816ef294fff5e94058dfc7a893.diff',
+          sha256='f6baa102238847f8cf8def7e4a6dcd575f0b0c9e3f32a2b8f894e3b7911e9e38',
+          when='@2.44.1~doc')
     patch('http://www.linuxfromscratch.org/patches/blfs/9.0/graphviz-2.40.1-qt5-1.patch',
           sha256='bd532df325df811713e311d17aaeac3f5d6075ea4fd0eae8d989391e6afba930',
           when='@:2.40+qt^qt@5:')
@@ -92,6 +97,9 @@ class Graphviz(AutotoolsPackage):
         depends_on('swig', when=('+' + lang))
 
     # Feature dependencies
+    depends_on('zlib')
+    depends_on('groff', type='build', when='+doc')
+    depends_on('ghostscript', type='build', when='+doc')
     depends_on('expat', when='+expat')
     depends_on('libgd', when='+libgd')
     depends_on('fontconfig', when='+libgd')
@@ -106,7 +114,6 @@ class Graphviz(AutotoolsPackage):
     depends_on('libpng', when='+pangocairo')
     depends_on('pango', when='+pangocairo')
     depends_on('poppler+glib', when='+poppler')
-    depends_on('zlib')
     depends_on('qt', when='+qt')
     depends_on('libx11', when="+x")
 
@@ -118,8 +125,6 @@ class Graphviz(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('libtool', type='build')
-    # required to build docs
-    depends_on('groff', type='build')
 
     parallel = False
 


### PR DESCRIPTION
#18803 forced ghostscript to be built even when graphviz was specified with `~ghostscript`. This caused a huge number of packages to be required when not really needed. I've removed the `ghostscript` requirement and it builds fine. The second part of that PR was to add `groff` as a build requirement, and it does indeed appear that the `graphviz` configure script looks for `groff`, though I can't verify that it breaks without it. I've therefore left in the `groff` requirement, but since it's a commonly distributed binary and build-only dependency, I've added `spack find external` support for `groff`.

I suggest @joequant add a `conflicts('~ghostscript', when='....')` for whatever system/circumstance failed to build without a spack-installed ghostscript.