### PR TITLE
py-ipykernel: fix install

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -40,3 +40,9 @@ class PyIpykernel(PythonPackage):
     depends_on('py-pytest-cov', type='test')
     # depends_on('py-flaky', type='test')
     depends_on('py-nose', type='test')
+
+    phases = ['build', 'install', 'install_data']
+
+    def install_data(self):
+        """ install the Jupyter kernel spec """
+        self.spec['python'].command('-m ipykernel', ['install'])


### PR DESCRIPTION
There is a post-install routine in `ipykernel` that needs to be called for proper registration with jupyter.

Fix #19416

Ref.: https://ipython.readthedocs.io/en/stable/install/kernel_install.html#kernels-for-python-2-and-3

```
The last command installs a kernel spec file for the current python installation.
Kernel spec files are JSON files, which can be viewed and changed with a normal text editor.
```