### PR TITLE
sbang: Fix perl/ruby binary detection

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -78,13 +78,17 @@ EOF
 #
 # will be true for '#!/usr/bin/perl' and '#!/usr/bin/env perl'
 interpreter_is() {
-    if [ "${interpreter##*/}" = "$1" ]; then
-        return 0
-    elif [ "$interpreter" = "/usr/bin/env" ] && [ "$arg1" = "$1" ]; then
-        return 0
-    else
-        return 1
+    case "${interpreter##*/}" in
+        "$1"*) return 0 ;;
+    esac
+
+    if [ "$interpreter" = "/usr/bin/env" ]; then
+        case "$arg1" in
+            "$1"*) return 0 ;;
+        esac
     fi
+
+    return 1
 }
 
 if interpreter_is "sbang"; then


### PR DESCRIPTION
PR #14538 added support for detecting perlX.Y.Z binaries as installed by the development versions of perl. This adds back support by doing a prefix pattern match instead.

This can be reproduced pretty easily by trying to install `automake ^perl@5.31.7`.

@tgamblin