### PR TITLE
Update cuDNN packages to check Power installation

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -257,9 +257,12 @@ class Cudnn(Package):
         install_tree('.', prefix)
 
         if 'target=ppc64le: platform=linux' in spec:
-            target_lib = os.path.join(prefix, 'targets', 'ppc64le-linux', 'lib')
+            target_lib = os.path.join(prefix, 'targets', 
+                                      'ppc64le-linux', 'lib')
             if os.path.isdir(target_lib) and not os.path.isdir(prefix.lib):
                 symlink(target_lib, prefix.lib)
-            target_include = os.path.join(prefix, 'targets', 'ppc64le-linux', 'include')
-            if os.path.isdir(target_include) and not os.path.isdir(prefix.include):
+            target_include = os.path.join(prefix, 'targets', 
+                                          'ppc64le-linux', 'include')
+            if os.path.isdir(target_include) \
+               and not os.path.isdir(prefix.include):
                 symlink(target_include, prefix.include)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -257,8 +257,9 @@ class Cudnn(Package):
         install_tree('.', prefix)
 
         if 'target=ppc64le: platform=linux' in spec:
-            symlink(os.path.join(prefix, 'targets', 'ppc64le-linux', 'lib'),
-                    prefix.lib)
-            symlink(
-                os.path.join(prefix, 'targets', 'ppc64le-linux', 'include'),
-                prefix.include)
+            target_lib = os.path.join(prefix, 'targets', 'ppc64le-linux', 'lib')
+            if os.path.isdir(target_lib) and not os.path.isdir(prefix.lib):
+                symlink(target_lib, prefix.lib)
+            target_include = os.path.join(prefix, 'targets', 'ppc64le-linux', 'include')
+            if os.path.isdir(target_include) and not os.path.isdir(prefix.include):
+                symlink(target_include, prefix.include)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -257,11 +257,11 @@ class Cudnn(Package):
         install_tree('.', prefix)
 
         if 'target=ppc64le: platform=linux' in spec:
-            target_lib = os.path.join(prefix, 'targets', 
+            target_lib = os.path.join(prefix, 'targets',
                                       'ppc64le-linux', 'lib')
             if os.path.isdir(target_lib) and not os.path.isdir(prefix.lib):
                 symlink(target_lib, prefix.lib)
-            target_include = os.path.join(prefix, 'targets', 
+            target_include = os.path.join(prefix, 'targets',
                                           'ppc64le-linux', 'include')
             if os.path.isdir(target_include) \
                and not os.path.isdir(prefix.include):


### PR DESCRIPTION
Updated cuDNN package to check to make sure that target directory exists before linking it.