### PR TITLE
llvm: fix +lldb build with external ncurses on openSUSE

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/lldb_external_ncurses-10.patch
+++ b/var/spack/repos/builtin/packages/llvm/lldb_external_ncurses-10.patch
@@ -1,0 +1,31 @@
+diff --git a/lldb/include/lldb/Host/Config.h.cmake b/lldb/include/lldb/Host/Config.h.cmake
+--- a/lldb/include/lldb/Host/Config.h.cmake
++++ b/lldb/include/lldb/Host/Config.h.cmake
+@@ -38,6 +38,8 @@
+ 
+ #cmakedefine01 LLDB_ENABLE_CURSES
+ 
++#cmakedefine01 CURSES_HAVE_NCURSES_CURSES_H
++
+ #cmakedefine01 LLDB_ENABLE_LIBEDIT
+ 
+ #cmakedefine01 LLDB_ENABLE_LIBXML2
+diff --git a/lldb/source/Core/IOHandlerCursesGUI.cpp b/lldb/source/Core/IOHandlerCursesGUI.cpp
+--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
++++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
+@@ -10,9 +10,14 @@
+ #include "lldb/Host/Config.h"
+ 
+ #if LLDB_ENABLE_CURSES
++#if CURSES_HAVE_NCURSES_CURSES_H
++#include <ncurses/curses.h>
++#include <ncurses/panel.h>
++#else
+ #include <curses.h>
+ #include <panel.h>
+ #endif
++#endif
+ 
+ #if defined(__APPLE__)
+ #include <deque>
+

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -208,6 +208,10 @@ class Llvm(CMakePackage, CudaPackage):
     # https://bugs.llvm.org/show_bug.cgi?id=39696
     patch("thread-p9.patch", when="@develop+libcxx")
 
+    # https://github.com/spack/spack/issues/19625,
+    # merged in llvm-11.0.0_rc2
+    patch("lldb_external_ncurses-10.patch", when="@10.0.0:10.99+lldb")
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #


### PR DESCRIPTION
fixes #19625