### PR TITLE
[dire] dire is included in pythia8@8300: so dire depends_on adjusted

### DIFF
--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -24,7 +24,7 @@ class Dire(Package):
     depends_on('boost')
     depends_on('lhapdf')
     depends_on('hepmc')
-    depends_on('pythia8@8226:')
+    depends_on('pythia8@8226:8244')
 
     def install(self, spec, prefix):
         configure_args = ['--prefix={0}'.format(prefix)]


### PR DESCRIPTION
Dire now `depends_on('pythia8@8226:8244')` since after 8244 dire was incorporated into pythia8 (version 8.300).

To reviewers: An alternative could have been `conflicts('pythia8',when='pythia8@8300:',msg='pythia8.3 includes dire')` which would provide useful information, but depends_on is evaluated earlier in concretization. Preferences?

This fixes #19608.