### PR TITLE
hip: setup run environments

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -32,7 +32,7 @@ class Hip(CMakePackage):
         depends_on('comgr@' + ver, type=('build', 'link', 'run'), when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type=('build', 'link', 'run'), when='@' + ver)
-        depends_on('rocminfo@' + ver, type='build', when='@' + ver)
+        depends_on('rocminfo@' + ver, type=('build','run'), when='@' + ver)
 
     # Notice: most likely this will only be a hard dependency on 3.7.0
     depends_on('numactl', when='@3.7.0:')

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -55,7 +55,8 @@ class Hip(CMakePackage):
         env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
         env.set('HSA_PATH', self.spec['hsa-rocr-dev'].prefix)
         env.set('ROCMINFO_PATH', self.spec['rocminfo'].prefix)
-        env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+        env.set('DEVICE_LIB_PATH',
+                self.spec['rocm-device-libs'].libs.directories[0])
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         self.setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -32,7 +32,7 @@ class Hip(CMakePackage):
         depends_on('comgr@' + ver, type=('build', 'link', 'run'), when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type=('build', 'link', 'run'), when='@' + ver)
-        depends_on('rocminfo@' + ver, type=('build','run'), when='@' + ver)
+        depends_on('rocminfo@' + ver, type=('build', 'run'), when='@' + ver)
 
     # Notice: most likely this will only be a hard dependency on 3.7.0
     depends_on('numactl', when='@3.7.0:')
@@ -47,6 +47,18 @@ class Hip(CMakePackage):
 
     # See https://github.com/ROCm-Developer-Tools/HIP/pull/2141
     patch('0002-Fix-detection-of-HIP_CLANG_ROOT.patch', when='@3.5.0:')
+
+    def setup_run_environment(self, env):
+        env.set('ROCM_PATH', '')
+        env.set('HIP_COMPILER', 'clang')
+        env.set('HIP_PLATFORM', 'hcc')
+        env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        env.set('HSA_PATH', self.spec['hsa-rocr-dev'].prefix)
+        env.set('ROCMINFO_PATH', self.spec['rocminfo'].prefix)
+        env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
 
     def get_rocm_prefix_info(self):
         # External packages in Spack do not currently contain dependency


### PR DESCRIPTION
* make `rocminfo` a run dependency (needed to set env vars used by `hipcc`)
* sets environment variables needed by `hipcc` in run environment

without these changes:

```
root@c5b69e3ae101:/# spack load hip
root@c5b69e3ae101:/# hipcc --version
Can't exec "/opt/rocm/llvm/bin/clang++": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 141.
Use of uninitialized value $HIP_CLANG_VERSION in pattern match (m//) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 142.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 145.
Can't exec "/opt/rocm/llvm/bin/clang++": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 141.
Use of uninitialized value $HIP_CLANG_VERSION in pattern match (m//) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 142.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 145.
Can't exec "/opt/rocm/llvm/bin/clang++": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 141.
Use of uninitialized value $HIP_CLANG_VERSION in pattern match (m//) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 142.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 145.
Can't exec "/opt/rocm/llvm/bin/clang++": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 141.
Use of uninitialized value $HIP_CLANG_VERSION in pattern match (m//) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 142.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipconfig line 145.
Can't exec "/opt/rocm/llvm/bin/clang": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 203.
Use of uninitialized value $HIP_CLANG_VERSION in pattern match (m//) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 204.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 208.
Use of uninitialized value $HIP_CLANG_INCLUDE_PATH in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 233.
Use of uninitialized value $HIP_CLANG_INCLUDE_PATH in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 234.
Can't exec "/opt/rocm/bin/rocm_agent_enumerator": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 725.
Use of uninitialized value $targetsStr in substitution (s///) at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 726.
Use of uninitialized value $targetsStr in split at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 732.
Use of uninitialized value $HIP_CLANG_VERSION in concatenation (.) or string at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 849.
HIP version: 3.8.20436-
Can't exec "/opt/rocm/llvm/bin/clang": No such file or directory at /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hip-3.8.0-7nko7g6nqh5v6fydefxhdc7de4kkakqt/bin/hipcc line 898.
failed to execute: No such file or directory
```

with these changes:
```
root@c5b69e3ae101:/# spack load hip
root@c5b69e3ae101:/# hipcc --version
HIP version: 3.8.20436-
clang version 11.0.0
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/llvm-amdgpu-3.8.0-4tggbkqapj7luocehu26tva7sqxydgsu/bin
```


@haampie @srekolam @arjun-raj-kuppala @becker33 @dtaller 