### PR TITLE
Fix rdma-core package installation

### DIFF
--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -41,7 +41,13 @@ class PyDocutils(PythonPackage):
     depends_on('python@2.2.1:2.8',    when='@0.5.0:0.5.999', type=('build', 'run'))
     depends_on('python@2.1:2.8',      when='@:0.4',          type=('build', 'run'))
 
-    def install(self, spec, prefix):
-        super.install(spec, prefix)
-        os.symlink(os.path.join(prefix, "bin", "rst2man.py"),
-                   os.path.join(prefix, "bin", "rst2man"))
+    phases = ['build', 'install', 'post_install']
+
+    # NOTE: This creates symbolic links to be able to run docutils scripts without .py
+    # file extension similarly to various linux distributions to increase compatibility
+    # with other packages
+    def post_install(self, spec, prefix):
+        bin_path = os.path.join(prefix, "bin")
+        for file in os.listdir(bin_path):
+            if file.endswith(".py"):
+                os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class PyDocutils(PythonPackage):
@@ -39,3 +40,8 @@ class PyDocutils(PythonPackage):
     depends_on('python@2.2.1:3',      when='@0.6:0.9',       type=('build', 'run'))
     depends_on('python@2.2.1:2.8',    when='@0.5.0:0.5.999', type=('build', 'run'))
     depends_on('python@2.1:2.8',      when='@:0.4',          type=('build', 'run'))
+
+    def install(self, spec, prefix):
+        super.install(spec, prefix)
+        os.symlink(os.path.join(prefix, "bin", "rst2man.py"),
+                   os.path.join(prefix, "bin", "rst2man"))

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -41,13 +41,12 @@ class PyDocutils(PythonPackage):
     depends_on('python@2.2.1:2.8',    when='@0.5.0:0.5.999', type=('build', 'run'))
     depends_on('python@2.1:2.8',      when='@:0.4',          type=('build', 'run'))
 
-    phases = ['build', 'install', 'post_install']
-
     # NOTE: This creates symbolic links to be able to run docutils scripts without .py
     # file extension similarly to various linux distributions to increase compatibility
     # with other packages
-    def post_install(self, spec, prefix):
-        bin_path = os.path.join(prefix, "bin")
+    @run_after('install')
+    def post_install(self):
+        bin_path = self.prefix.bin
         for file in os.listdir(bin_path):
             if file.endswith(".py"):
                 os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))

--- a/var/spack/repos/builtin/packages/py-docutils/package.py
+++ b/var/spack/repos/builtin/packages/py-docutils/package.py
@@ -41,12 +41,13 @@ class PyDocutils(PythonPackage):
     depends_on('python@2.2.1:2.8',    when='@0.5.0:0.5.999', type=('build', 'run'))
     depends_on('python@2.1:2.8',      when='@:0.4',          type=('build', 'run'))
 
-    # NOTE: This creates symbolic links to be able to run docutils scripts without .py
-    # file extension similarly to various linux distributions to increase compatibility
-    # with other packages
+    # NOTE: This creates symbolic links to be able to run docutils scripts
+    # without .py file extension similarly to various linux distributions to
+    # increase compatibility with other packages
     @run_after('install')
     def post_install(self):
         bin_path = self.prefix.bin
         for file in os.listdir(bin_path):
             if file.endswith(".py"):
-                os.symlink(os.path.join(bin_path, file), os.path.join(bin_path, file[:-3]))
+                os.symlink(os.path.join(bin_path, file),
+                           os.path.join(bin_path, file[:-3]))

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class RdmaCore(CMakePackage):
@@ -18,7 +17,7 @@ class RdmaCore(CMakePackage):
     version('13', sha256='e5230fd7cda610753ad1252b40a28b1e9cf836423a10d8c2525b081527760d97')
 
     depends_on('pkgconfig', type='build')
-    depends_on('py-docutils', type=('build', 'run'))
+    depends_on('py-docutils', type='build')
     depends_on('libnl')
     conflicts('platform=darwin', msg='rdma-core requires FreeBSD or Linux')
     conflicts('%intel', msg='rdma-core cannot be built with intel (use gcc instead)')

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class RdmaCore(CMakePackage):
@@ -17,6 +18,7 @@ class RdmaCore(CMakePackage):
     version('13', sha256='e5230fd7cda610753ad1252b40a28b1e9cf836423a10d8c2525b081527760d97')
 
     depends_on('pkgconfig', type='build')
+    depends_on('py-docutils', type=('build', 'run'))
     depends_on('libnl')
     conflicts('platform=darwin', msg='rdma-core requires FreeBSD or Linux')
     conflicts('%intel', msg='rdma-core cannot be built with intel (use gcc instead)')


### PR DESCRIPTION
This PR fixes the installation of rdma-core which requires `rst2man` script of py-docutils.
See https://github.com/linux-rdma/rdma-core/commit/05568812f6cbe10546853b88e7a2036ff7655854 for details about the issue.
Related to https://github.com/spack/spack/pull/19604 and https://github.com/openucx/ucx/issues/5843 