### PR TITLE
Dyninst: add elfutils versioning

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -37,7 +37,7 @@ bin/spack -h
 bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-spack -p --lines 20 spec mpileaks%gcc ^dyninst@10.2.1 ^elfutils@0.170
+spack -p --lines 20 spec mpileaks%gcc ^dyninst@10.0.0 ^elfutils@0.170
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -47,7 +47,10 @@ class Dyninst(CMakePackage):
 
     # Dyninst uses elfutils starting with 9.3.0, and used libelf
     # before that.
-    depends_on('elfutils', type='link', when='@9.3.0:')
+    # NB: Parallel DWARF parsing in Dyninst 10.2.0 requires a thread-
+    #     safe libdw
+    depends_on('elfutils@0.178:', type='link', when='@10.2.0:')
+    depends_on('elfutils', type='link', when='@9.3.0:10.1.99')
     depends_on('libelf', type='link', when='@:9.2.99')
 
     # Dyninst uses libdw from elfutils starting with 10.0, and used


### PR DESCRIPTION
Parallel DWARF parsing introduced in Dyninst 10.2.0 requires elfutils >=0.178 in order to have a thread-safe libdw