### PR TITLE
libepoxy: remove meson dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libepoxy/package.py
+++ b/var/spack/repos/builtin/packages/libepoxy/package.py
@@ -16,7 +16,6 @@ class Libepoxy(AutotoolsPackage):
     version('1.4.3', sha256='0b808a06c9685a62fca34b680abb8bc7fb2fda074478e329b063c1f872b826f6')
 
     depends_on('pkgconfig', type='build')
-    depends_on('meson')
     depends_on('gl')
     depends_on('libx11', when='+glx')
 


### PR DESCRIPTION
libepoxy switched from Autotools to Meson in its latest release. The version in our Spack package does not use Meson, it uses Autotools.

Successfully installs on macOS 10.15.7 with Apple Clang 12.0.0.