### PR TITLE
Scalapack: don't apply patches twice

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -102,10 +102,3 @@ class NetlibScalapack(ScalapackBase):
     version('2.0.0', sha256='e51fbd9c3ef3a0dbd81385b868e2355900148eea689bf915c5383d72daf73114')
     # versions before 2.0.0 are not using cmake and requires blacs as
     # a separated package
-
-    # See: https://github.com/Reference-ScaLAPACK/scalapack/issues/9
-    patch("cmake_fortran_mangle.patch", when='@2.0.2:2.0.99')
-    # See: https://github.com/Reference-ScaLAPACK/scalapack/pull/10
-    patch("mpi2-compatibility.patch", when='@2.0.2:2.0.99')
-    # See: https://github.com/Reference-ScaLAPACK/scalapack/pull/16
-    patch("int_overflow.patch", when='@2.0.0:2.1.0')


### PR DESCRIPTION
Fixes #19650 

#19457 introduced a common base class for Scalapack packages, but accidentally applied the same patches twice for `netlib-scalapack`. This PR fixes that.