### PR TITLE
Revert hip improvements to package.py that broke it

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -56,7 +56,7 @@ class Hip(CMakePackage):
         env.set('HSA_PATH', self.spec['hsa-rocr-dev'].prefix)
         env.set('ROCMINFO_PATH', self.spec['rocminfo'].prefix)
         env.set('DEVICE_LIB_PATH',
-                self.spec['rocm-device-libs'].libs.directories[0])
+                self.spec['rocm-device-libs'].prefix.lib)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         self.setup_run_environment(env)


### PR DESCRIPTION
Revert this part:
    * hip: run environment: get lib dir using libs.directories[0], not prefix.lib
as it fails with Error: NoLibrariesError: Unable to recursively locate rocm-device-libs libraries.

Ping @eugeneswalker 