### PR TITLE
bugfix: don't recompute full_hash or build_hash

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1011,6 +1011,14 @@ class Spec(object):
         self.external_modules = Spec._format_module_list(external_modules)
         self._full_hash = full_hash
 
+        # Older spack versions did not compute full_hash or build_hash,
+        # and we may not have the necessary information to recompute them
+        # if we read in old specs. Old concrete specs are marked "final"
+        # when read in to indicate that we shouldn't recompute full_hash
+        # or build_hash. New specs are not final; we can lazily compute
+        # their hashes.
+        self._hashes_final = False
+
         # This attribute is used to store custom information for
         # external specs. None signal that it was not set yet.
         self.extra_attributes = None
@@ -1649,24 +1657,34 @@ class Spec(object):
         spec is concrete, the full hash is added as well.  If 'build' is in
         the hash_type, the build hash is also added. """
         node = self.to_node_dict(hash)
+        node[self.name]['hash'] = self.dag_hash()
 
+        # full_hash and build_hash are lazily computed -- but if we write
+        # a spec out, we want them to be included. This is effectively
+        # the last chance we get to compute them accurately.
         if self.concrete:
-            # if the spec is concrete, all hashes have already been
-            # computed, DAG hash is required, so always add it
-            node[self.name]['hash'] = self.dag_hash()
+            # build and full hashes can be written out if:
+            # 1. they're precomputed (i.e. we read them from somewhere
+            #    and they were already on the spec
+            # 2. we can still compute them lazily (i.e. we just made them and
+            #    have the full dependency graph on-hand)
+            #
+            # we want to avoid recomputing either hash for specs we read
+            # in from the DB or elsewhere, as we may not have the info
+            # (like patches, package versions, etc.) that we need to
+            # compute them. Unknown hashes are better than wrong hashes.
+            write_full_hash = (
+                self._hashes_final and self._full_hash or   # cached and final
+                not self._hashes_final)                     # lazily compute
+            write_build_hash = 'build' in hash.deptype and (
+                self._hashes_final and self._build_hash or  # cached and final
+                not self._hashes_final)                     # lazily compute
 
-            # full_hash and build_hash may not have been computed by
-            # older spack versions, so they may not be on a concrete spec
-            # read in from somewhere. We want to avoid computing
-            # full_hash or build_hash on old specs, as we likely don't
-            # have the information needed to do it right (packages,
-            # patches, etc. have likely changed). So we do not attempt to
-            # recompute full_hash or build_hash for old specs, and we
-            # only write these if they're present.
-            if self._full_hash:
-                node[self.name]['full_hash'] = self._full_hash
-            if self._build_hash and 'build' in hash.deptype:
-                node[self.name]['build_hash'] = self._build_hash
+            if write_full_hash:
+                node[self.name]['full_hash'] = self.full_hash()
+            if write_build_hash:
+                node[self.name]['build_hash'] = self.build_hash()
+
         return node
 
     def to_record_dict(self):
@@ -1755,6 +1773,11 @@ class Spec(object):
 
         # specs read in are concrete unless marked abstract
         spec._concrete = node.get('concrete', True)
+
+        # this spec may have been built with older packages than we have
+        # on-hand, and we may not have the build dependencies, so mark it
+        # so we don't recompute full_hash and build_hash.
+        spec._hashes_final = spec._concrete
 
         if 'patches' in node:
             patches = node['patches']
@@ -2345,12 +2368,6 @@ class Spec(object):
 
         # Mark everything in the spec as concrete, as well.
         self._mark_concrete()
-
-        # compute all hashes at concretization time, so that we're
-        # guaranteed that if one is there, they're all there.
-        self.dag_hash()
-        self.full_hash()
-        self.build_hash()
 
         # If any spec in the DAG is deprecated, throw an error
         deprecated = []
@@ -3195,6 +3212,7 @@ class Spec(object):
             self._dup_deps(other, deptypes, caches)
 
         self._concrete = other._concrete
+        self._hashes_final = other._hashes_final
 
         if caches:
             self._hash = other._hash


### PR DESCRIPTION
Fixes #19649.

There was an error introduced in #19209 where `full_hash()` and `build_hash()` are called on older specs that we've read in from the DB.

Since we evaluate hashes lazily, `node_dict_with_hashes()` has no way of knowing whether the spec just never had a `full_hash` or a `build_hash` or whether they need to be lazily computed. When we just had `dag_hash`, this wasn't an issue since it was always computed when concrete specs were stored -- it would always be there for specs read in from files.

To get around this ambiguity and to fix the issue, this makes two changes:

- [x] Always compute `dag_hash`, `build_hash`, and `full_hash` after concretization, so we know if one is present, then all should be, if they are avaialble.

- [x] Only store `full_hash` and `build_hash` if they are present. If not, don't bother recomputing.

This *may* make concretization slightly slower. If it does we could look at some other way to store whether full_hash and build_hash can be computed (e.g. we coudl store a `bool` on the `Spec` at concretize time), or we could look at other options like using JSON for these hashes to speed them up.  I think this solution is simpler for now.