### PR TITLE
LBANN update HWLOC versions

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -38,7 +38,7 @@ class Aluminum(CMakePackage, CudaPackage):
     depends_on('cmake@3.16.0:', type='build')
     depends_on('mpi')
     depends_on('nccl', when='+nccl')
-    depends_on('hwloc@2.0:')
+    depends_on('hwloc@1.11:')
 
     generator = 'Ninja'
     depends_on('ninja', type='build')

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -35,7 +35,7 @@ class Aluminum(CMakePackage, CudaPackage):
     variant('cuda_rma', default=False, description='Builds with support for CUDA intra-node '
             ' Put/Get and IPC RMA functionality')
 
-    depends_on('cmake@3.16.0:', type='build')
+    depends_on('cmake@3.17.0:', type='build')
     depends_on('mpi')
     depends_on('nccl', when='+nccl')
     depends_on('hwloc@1.11:')

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -105,7 +105,7 @@ class Dihydrogen(CMakePackage, CudaPackage):
 
     generator = 'Ninja'
     depends_on('ninja', type='build')
-    depends_on('cmake@3.16.0:', type='build')
+    depends_on('cmake@3.17.0:', type='build')
 
     depends_on('py-breathe', type='build', when='+docs')
     depends_on('doxygen', type='build', when='+docs')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -63,7 +63,7 @@ class Hydrogen(CMakePackage, CudaPackage):
             description='Use OpenMP taskloops instead of parallel for loops.')
     variant('half', default=True,
             description='Builds with support for FP16 precision data types')
-    depends_on('cmake@3.16.0:', type='build')
+    depends_on('cmake@3.17.0:', type='build')
     depends_on('mpi')
     depends_on('hwloc@1.11:')
 

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -65,7 +65,7 @@ class Hydrogen(CMakePackage, CudaPackage):
             description='Builds with support for FP16 precision data types')
     depends_on('cmake@3.16.0:', type='build')
     depends_on('mpi')
-    depends_on('hwloc@2.0:')
+    depends_on('hwloc@1.11:')
 
     # Note that #1712 forces us to enumerate the different blas variants
     depends_on('openblas', when='blas=openblas ~openmp_blas ~int64_blas')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -100,7 +100,7 @@ class Lbann(CMakePackage, CudaPackage):
     depends_on('cudnn@8.0.2:', when='@:0.90,0.101: +cuda')
     depends_on('cub', when='@0.94:0.98.2 +cuda')
     depends_on('mpi')
-    depends_on('hwloc@2.0:')
+    depends_on('hwloc@1.11:')
 
     depends_on('half', when='+half')
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -60,7 +60,7 @@ class Lbann(CMakePackage, CudaPackage):
 
     conflicts('@:0.90,0.99:', when='~conduit')
 
-    depends_on('cmake@3.16.0:', type='build')
+    depends_on('cmake@3.17.0:', type='build')
 
     # Specify the correct versions of Hydrogen
     depends_on('hydrogen@:1.3.4', when='@0.95:0.100')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -100,7 +100,8 @@ class Lbann(CMakePackage, CudaPackage):
     depends_on('cudnn@8.0.2:', when='@:0.90,0.101: +cuda')
     depends_on('cub', when='@0.94:0.98.2 +cuda')
     depends_on('mpi')
-    depends_on('hwloc@1.11:')
+    depends_on('hwloc@1.11:', when='@:0.90,0.102:')
+    depends_on('hwloc@1.11:1.11.99', when='@0.95:0.101.99')
 
     depends_on('half', when='+half')
 


### PR DESCRIPTION
Updates in LBANN an Aluminum code now allow working with versions HWLOC 1.11.x and 2.x and up.