### PR TITLE
GDAL: add v3.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -484,7 +484,7 @@ class Gdal(AutotoolsPackage):
         ])
 
         # TODO: add packages for these dependencies (only for 3.1 and older)
-        if spec.satisfes('@:3.1'):
+        if spec.satisfies('@:3.1'):
             # https://trac.osgeo.org/gdal/wiki/ArcSDE
             args.append('--with-sde=no')
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -15,7 +15,7 @@ class Gdal(AutotoolsPackage):
     """
 
     homepage   = "https://www.gdal.org/"
-    url        = "https://download.osgeo.org/gdal/3.1.4/gdal-3.1.4.tar.xz"
+    url        = "https://download.osgeo.org/gdal/3.2.0/gdal-3.2.0.tar.xz"
     list_url   = "https://download.osgeo.org/gdal/"
     list_depth = 1
 
@@ -26,6 +26,7 @@ class Gdal(AutotoolsPackage):
         'osgeo.gdal_array', 'osgeo.gdalconst'
     ]
 
+    version('3.2.0',  sha256='b051f852600ffdf07e337a7f15673da23f9201a9dbb482bd513756a3e5a196a6')
     version('3.1.4',  sha256='7b82486f71c71cec61f9b237116212ce18ef6b90f068cbbf9f7de4fc50b576a8')
     version('3.1.3',  sha256='161cf55371a143826f1d76ce566db1f0a666496eeb4371aed78b1642f219d51d')
     version('3.1.2',  sha256='767c8d0dfa20ba3283de05d23a1d1c03a7e805d0ce2936beaff0bb7d11450641')
@@ -473,8 +474,6 @@ class Gdal(AutotoolsPackage):
             '--with-dods-root=no',
             '--with-spatialite=no',
             '--with-idb=no',
-            # https://trac.osgeo.org/gdal/wiki/ArcSDE
-            '--with-sde=no',
             # https://trac.osgeo.org/gdal/wiki/Epsilon
             '--with-epsilon=no',
             '--with-webp=no',
@@ -484,9 +483,32 @@ class Gdal(AutotoolsPackage):
             '--with-rasdaman=no',
         ])
 
+        # TODO: add packages for these dependencies (only for 3.1 and older)
+        if spec.satisfes('@:3.1'):
+            # https://trac.osgeo.org/gdal/wiki/ArcSDE
+            args.append('--with-sde=no')
+
         # TODO: add packages for these dependencies (only for 2.3 and older)
         if spec.satisfies('@:2.3'):
             args.append('--with-php=no')
+
+        # TODO: add packages for these dependencies (only for 3.2 and newer)
+        if spec.satisfies('@3.2:'):
+            args.append('--with-heif=no')
+
+        # TODO: add packages for these dependencies (only for 3.1 and newer)
+        if spec.satisfies('@3.1:'):
+            args.extend([
+                '--with-exr=no',
+                '--with-rdb=no',
+            ])
+
+        # TODO: add packages for these dependencies (only for 3.0 and newer)
+        if spec.satisfies('@3.0:'):
+            args.extend([
+                '--with-tiledb=no',
+                '--with-mongocxxv3=no',
+            ])
 
         # TODO: add packages for these dependencies (only for 2.3 and newer)
         if spec.satisfies('@2.3:'):


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.15.7 with Apple Clang 12.0.0.

https://github.com/OSGeo/gdal/releases/tag/v3.2.0