### PR TITLE
fix format issue with code-block section

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -515,7 +515,7 @@ module files, and to add the correct path to ``MODULEPATH``, you need to
 source the appropriate setup file. Assuming Spack is installed in
 ``$SPACK_ROOT``, run the appropriate command for your shell:
 
-. code-block:: console
+.. code-block:: console
 
    # For bash/zsh/sh
    $ . $SPACK_ROOT/share/spack/setup-env.sh


### PR DESCRIPTION
This is a simple fix i found when reading docs, the missing `.` in front caused format issues