### PR TITLE
bug fix: Report curl is missing if command not found

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -42,7 +42,7 @@ import spack.util.web as web_util
 from llnl.util.filesystem import (
     working_dir, mkdirp, temp_rename, temp_cwd, get_single_file)
 from spack.util.compression import decompressor_for, extension
-from spack.util.executable import which
+from spack.util.executable import which, CommandNotFoundError
 from spack.util.string import comma_and, quote
 from spack.version import Version, ver
 
@@ -267,7 +267,10 @@ class URLFetchStrategy(FetchStrategy):
     @property
     def curl(self):
         if not self._curl:
-            self._curl = which('curl', required=True)
+            try:
+                self._curl = which('curl', required=True)
+            except CommandNotFoundError as exc:
+                tty.error(str(exc))
         return self._curl
 
     def source_id(self):

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -237,9 +237,10 @@ def test_missing_curl(tmpdir, monkeypatch):
         err_msg = err_fmt.format(args[0])
         raise spack.util.executable.CommandNotFoundError(err_msg)
 
-    # Patching which_string (versus which) so patch actually works with the
-    # fetch strategy's curl property such that the property is None.
-    monkeypatch.setattr(spack.util.executable, 'which_string', _which)
+    # Patching the 'which' symbol imported by fetch_strategy works
+    # since it is too late in import processing to patch the defining
+    # (spack.util.executable) module's symbol.
+    monkeypatch.setattr(fs, 'which', _which)
 
     testpath = str(tmpdir)
     url = 'http://github.com/spack/spack'


### PR DESCRIPTION
Fixes #19673 

Reducing Spack install verbosity resulted in the loss of the error message if `curl` is not installed.

This PR outputs the error message generated by `Executable`.  It also handles the issue in a way -- basically allowing the command to be `None` -- that terminates immediately (instead of raising an exception that would then result in going through each fetcher).

Output before this change:
```
$ spack install zlib
==> Installing zlib
==> No binary for zlib found: installing from source
==> Error: FetchError: All fetchers failed

$HOME/spack/lib/spack/spack/package.py:1270, in do_fetch:
       1267                                 self.spec.format('{name}{@version}'), ck_msg)
       1268
       1269        self.stage.create()
  >>   1270        err_msg = None if not self.manual_download else self.download_instr
       1271        self.stage.fetch(mirror_only, err_msg=err_msg)
       1272        self._fetch_time = time.time() - start_time
```

Output after this change:

```
$ spack install zlib
==> Installing zlib
==> No binary for zlib found: installing from source
==> Error: spack requires 'curl'. Make sure it is in your path.
==> Error: TypeError: 'NoneType' object is not callable

$HOME/spack/lib/spack/spack/package.py:1270, in do_fetch:
       1267                                 self.spec.format('{name}{@version}'), ck_msg)
       1268
       1269        self.stage.create()
  >>   1270        err_msg = None if not self.manual_download else self.download_instr
       1271        self.stage.fetch(mirror_only, err_msg=err_msg)
       1272        self._fetch_time = time.time() - start_time
       1273
```