### PR TITLE
Keep output machine readable using `spack find --format` in an env

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -234,11 +234,10 @@ def find(parser, args):
     # Display the result
     if args.json:
         cmd.display_specs_as_json(results, deps=args.deps)
-    elif args.format:
-        cmd.display_specs(results, args, decorator=decorator, all_headers=True)
     else:
-        if env:
-            display_env(env, args, decorator)
+        if not args.format:
+            if env:
+                display_env(env, args, decorator)
         if sys.stdout.isatty() and args.groups:
             tty.msg("%s" % plural(len(results), 'installed package'))
         cmd.display_specs(

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -234,6 +234,8 @@ def find(parser, args):
     # Display the result
     if args.json:
         cmd.display_specs_as_json(results, deps=args.deps)
+    elif args.format:
+        cmd.display_specs(results, args, decorator=decorator, all_headers=True)
     else:
         if env:
             display_env(env, args, decorator)

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -209,6 +209,7 @@ def test_find_format(database, config):
 
     output = find('--format', '{name}-{version}-{compiler.name}-{^mpi.name}',
                   'mpileaks')
+    assert "installed package" not in output
     assert set(output.strip().split('\n')) == set([
         "mpileaks-2.3-gcc-zmpi",
         "mpileaks-2.3-gcc-mpich",


### PR DESCRIPTION
Currently, full json output is the only machine readable option for `spack find` in an environment.

`spack find --format` is also designed to be machine readable, so we avoid printing portions that are not machine readable when using that option.