### PR TITLE
llvm: add variant: llvm_dylib (LLVM_BUILD_LLVM_DYLIB:Bool)

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -108,6 +108,12 @@ class Llvm(CMakePackage, CudaPackage):
         "less memory to build, less stable",
     )
     variant(
+        "llvm_dylib",
+        default=False,
+        description="Build LLVM shared library, containing all "
+        "components in a single shared library",
+    )
+    variant(
         "all_targets",
         default=False,
         description="Build all supported targets, default targets "
@@ -161,6 +167,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("gmp", when="@:3.6.999 +polly")
     depends_on("isl", when="@:3.6.999 +polly")
 
+    conflicts("+llvm_dylib", when="+shared_libs")
     conflicts("+lldb", when="~clang")
     conflicts("+libcxx", when="~clang")
     conflicts("+internal_unwind", when="~clang")
@@ -430,6 +437,8 @@ class Llvm(CMakePackage, CudaPackage):
 
         if "+shared_libs" in spec:
             cmake_args.append("-DBUILD_SHARED_LIBS:Bool=ON")
+        if "+llvm_dylib" in spec:
+            cmake_args.append("-DLLVM_BUILD_LLVM_DYLIB:Bool=ON")
         if "+omp_debug" in spec:
             cmake_args.append("-DLIBOMPTARGET_ENABLE_DEBUG:Bool=ON")
 


### PR DESCRIPTION
Add `llvm` variant:
* `+llvm_dylib` adds `-DLLVM_BUILD_LLVM_DYLIB:Bool=ON` to the cmake args