### PR TITLE
Add maximum Python version for Snakemake

### DIFF
--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -14,7 +14,7 @@ class Snakemake(PythonPackage):
 
     version('3.11.2', sha256='f7a3b586bc2195f2dce4a4817b7ec828b6d2a0cff74a04e0f7566dcd923f9761')
 
-    depends_on('python@3.3:')
+    depends_on('python@3.3:3.6.999')
     depends_on('py-requests', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-wrapt', type=('build', 'run'))


### PR DESCRIPTION
Running with Python 3.7 returns a SyntaxError close to `async=True`.