### PR TITLE
Use commit instead of branch as version for dtk 3.1-rc2

### DIFF
--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -17,7 +17,7 @@ class Datatransferkit(CMakePackage):
     maintainers = ['Rombur']
 
     version('master', branch='master', submodules=True)
-    version('3.1-rc2', branch='3.1-rc2', submodules=True)
+    version('3.1-rc2', commit='1abc1a43b33dffc7a16d7497b4185d09d865e36a', submodules=True)
 
     variant('openmp', default=False, description='enable OpenMP backend')
     variant('serial', default=True, description='enable Serial backend (default)')


### PR DESCRIPTION
The release is in fact a tagged commit not corresponding to a separate branch, see https://github.com/ORNL-CEES/DataTransferKit/tags.