### PR TITLE
speexdsp: fix link dependency on FFT library

### DIFF
--- a/var/spack/repos/builtin/packages/speexdsp/package.py
+++ b/var/spack/repos/builtin/packages/speexdsp/package.py
@@ -23,6 +23,12 @@ class Speexdsp(AutotoolsPackage):
 
     patch('mkl.patch')
 
+    def patch(self):
+        filter_file('libspeexdsp_la_LIBADD = $(LIBM)',
+                    'libspeexdsp_la_LIBADD = $(LIBM) $(FFT_LIBS)',
+                    'libspeexdsp/Makefile.am',
+                    string=True)
+
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--verbose', '--force')
 


### PR DESCRIPTION
without this, the library does not have a dependency
on the fft lib it was built with.