### PR TITLE
Axom: update package

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -422,19 +422,24 @@ class Axom(CMakePackage, CudaPackage):
 
         # Only turn on clangformat support if devtools is on
         if "+devtools" in spec:
-            lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
-            # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
-            # /usr/bin/clang-format which would require actually running the executable to grab the version
-            apt_clangformatpath = "/usr/bin/clang-format-10"
-            if os.path.exists(lc_clangformatpath):
-                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
-            elif os.path.exists(apt_clangformatpath):
-                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
-            else:
+            cf_paths = []
+            lc_clangpath = "/usr/tce/packages/clang/clang-10.0.0"
+            cf_paths.append(pjoin(lc_clangpath, "bin/clang-format"))
+            cf_paths.append("/usr/bin/clang-format-10")
+            cf_paths.append("/usr/bin/clang-format")
+
+            cf_found = False
+            for path in cf_paths:
+                if os.path.exists(path):
+                    cf_found = True
+                    cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE",
+                                                path))
+
+            if not cf_found:
                 cfg.write("# Unable to find clang-format\n\n")
                 cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
         else:
-            cfg.write("# Devtools disabled\n\n")
+            cfg.write("# ClangFormat disabled due to disabled devtools\n")
             cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
 
         ##################################

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -53,11 +53,12 @@ class Axom(CMakePackage, CudaPackage):
 
     version('main', branch='main', submodules=True)
     version('develop', branch='develop', submodules=True)
-    version('0.3.3', tag='v0.3.3', submodules="True")
-    version('0.3.2', tag='v0.3.2', submodules="True")
-    version('0.3.1', tag='v0.3.1', submodules="True")
-    version('0.3.0', tag='v0.3.0', submodules="True")
-    version('0.2.9', tag='v0.2.9', submodules="True")
+    version('0.4.0', tag='v0.4.0', submodules=True)
+    version('0.3.3', tag='v0.3.3', submodules=True)
+    version('0.3.2', tag='v0.3.2', submodules=True)
+    version('0.3.1', tag='v0.3.1', submodules=True)
+    version('0.3.0', tag='v0.3.0', submodules=True)
+    version('0.2.9', tag='v0.2.9', submodules=True)
 
     phases = ["hostconfig", "cmake", "build", "install"]
     root_cmakelists_dir = 'src'
@@ -69,6 +70,8 @@ class Axom(CMakePackage, CudaPackage):
             description='Enable build of shared libraries')
     variant('debug',    default=False,
             description='Build debug instead of optimized version')
+
+    variant('cpp14',  default=True, description="Build with C++14 support")
 
     variant('fortran',  default=True, description="Build with Fortran support")
 
@@ -84,10 +87,8 @@ class Axom(CMakePackage, CudaPackage):
     variant("umpire",   default=True, description="Build with umpire")
 
     variant("raja",     default=True, description="Build with raja")
-    variant("cub",      default=True,
-            description="Build with RAJA's internal CUB support")
 
-    varmsg = "Build development tools (such as Sphinx, Uncrustify, etc...)"
+    varmsg = "Build development tools (such as Sphinx, Doxygen, etc...)"
     variant("devtools", default=False, description=varmsg)
 
     # -----------------------------------------------------------------------
@@ -104,7 +105,7 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("conduit~hdf5", when="~hdf5")
 
     # HDF5 needs to be the same as Conduit's
-    depends_on("hdf5@1.8.19:1.8.999~mpi~cxx~shared~fortran", when="+hdf5")
+    depends_on("hdf5@1.8.19:1.8.999~cxx~shared~fortran", when="+hdf5")
 
     depends_on("lua", when="+lua")
 
@@ -124,7 +125,8 @@ class Axom(CMakePackage, CudaPackage):
         depends_on('umpire cuda_arch={0}'.format(sm_),
                    when='+umpire cuda_arch={0}'.format(sm_))
 
-    depends_on("mfem~mpi~metis~zlib", when="+mfem")
+    depends_on("mfem", when="+mfem")
+    depends_on("mfem~mpi", when="+mfem~mpi")
 
     depends_on("python", when="+python")
 
@@ -135,7 +137,6 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("python", when="+devtools")
     depends_on("py-sphinx", when="+devtools")
     depends_on("py-shroud", when="+devtools")
-    depends_on("uncrustify@0.61", when="+devtools")
 
     def flag_handler(self, name, flags):
         if name in ('cflags', 'cxxflags', 'fflags'):
@@ -244,6 +245,9 @@ class Axom(CMakePackage, CudaPackage):
             if flags:
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
                                             description))
+
+        if "+cpp14" in spec:
+            cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14", ""))
 
         # TPL locations
         cfg.write("#------------------{0}\n".format("-" * 60))
@@ -370,7 +374,7 @@ class Axom(CMakePackage, CudaPackage):
         # Add common prefix to path replacement list
         if "+devtools" in spec:
             # Grab common devtools root and strip the trailing slash
-            path1 = os.path.realpath(spec["uncrustify"].prefix)
+            path1 = os.path.realpath(spec["cppcheck"].prefix)
             path2 = os.path.realpath(spec["doxygen"].prefix)
             devtools_root = os.path.commonprefix([path1, path2])[:-1]
             path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
@@ -410,19 +414,28 @@ class Axom(CMakePackage, CudaPackage):
             cfg.write(cmake_cache_entry("SHROUD_EXECUTABLE",
                                         pjoin(shroud_bin_dir, "shroud")))
 
-        if "uncrustify" in spec:
-            uncrustify_bin_dir = get_spec_path(spec, "uncrustify",
-                                               path_replacements,
-                                               use_bin=True)
-            cfg.write(cmake_cache_entry("UNCRUSTIFY_EXECUTABLE",
-                                        pjoin(uncrustify_bin_dir,
-                                              "uncrustify")))
-
         if "cppcheck" in spec:
             cppcheck_bin_dir = get_spec_path(spec, "cppcheck",
                                              path_replacements, use_bin=True)
             cfg.write(cmake_cache_entry("CPPCHECK_EXECUTABLE",
                                         pjoin(cppcheck_bin_dir, "cppcheck")))
+
+        # Only turn on clangformat support if devtools is on
+        if "+devtools" in spec:
+            lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
+            # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
+            # /usr/bin/clang-format which would require actually running the executable to grab the version
+            apt_clangformatpath = "/usr/bin/clang-format-10"
+            if os.path.exists(lc_clangformatpath):
+                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
+            elif os.path.exists(apt_clangformatpath):
+                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
+            else:
+                cfg.write("# Unable to find clang-format\n\n")
+                cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
+        else:
+            cfg.write("# Devtools disabled\n\n")
+            cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
 
         ##################################
         # Other machine specifics
@@ -495,11 +508,6 @@ class Axom(CMakePackage, CudaPackage):
                                              True))
 
                 cfg.write(cmake_cache_option("AXOM_ENABLE_ANNOTATIONS", True))
-
-                if "+cub" in spec:
-                    cfg.write(cmake_cache_option("AXOM_ENABLE_CUB", True))
-                else:
-                    cfg.write(cmake_cache_option("AXOM_ENABLE_CUB", False))
 
                 # CUDA_FLAGS
                 cudaflags  = "-restrict "


### PR DESCRIPTION
* Add 0.4.0 release
* Add `cpp14` variant
* Explicitly turn off clang-format unless `devtools` variant is turned on
* Loosen more locked down variants in general
* Remove `cub` variant