### PR TITLE
oneDNN: add v1.7

### DIFF
--- a/var/spack/repos/builtin/packages/onednn/package.py
+++ b/var/spack/repos/builtin/packages/onednn/package.py
@@ -12,10 +12,11 @@ class Onednn(CMakePackage):
     Formerly known as Intel MKL-DNN and DNNL."""
 
     homepage = "https://01.org/onednn"
-    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.6.5.tar.gz"
+    url      = "https://github.com/oneapi-src/oneDNN/archive/v1.7.tar.gz"
 
     maintainers = ['adamjstewart']
 
+    version('1.7',    sha256='2dbd53578b36bd84bbc3e411d1a4cacc0eed832892818c5fa16b72cbf1dab015')
     version('1.6.5',  sha256='6258d961fe1757b70d10cf34f0925079401ffae264f056b15024270b11d5c1eb')
     version('1.6.4',  sha256='5369f7b2f0b52b40890da50c0632c3a5d1082d98325d0f2bff125d19d0dcaa1d')
     version('1.6.3',  sha256='471c877671f672e4119e5f49143890c5ce2efff80a52a5eaf7ef3730eb3e1738')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.

https://github.com/oneapi-src/oneDNN/releases/tag/v1.7