### PR TITLE
10.1 release and various bug fixes for SST packages

### DIFF
--- a/var/spack/repos/builtin/packages/ramulator/ramulator_sha_7d2e723_libPatch.patch
+++ b/var/spack/repos/builtin/packages/ramulator/ramulator_sha_7d2e723_libPatch.patch
@@ -1,22 +1,25 @@
 diff --git a/Makefile b/Makefile
-index ea340c8..314113d 100644
+index ea340c8..bcc765d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -9,7 +9,7 @@ OBJS := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
+@@ -7,9 +7,7 @@ OBJS := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
+ 
+ # Ramulator currently supports g++ 5.1+ or clang++ 3.4+.  It will NOT work with
  #   g++ 4.x due to an internal compiler error when processing lambda functions.
- CXX := clang++
- # CXX := g++-5
+-CXX := clang++
+-# CXX := g++-5
 -CXXFLAGS := -O3 -std=c++11 -g -Wall
 +CXXFLAGS := -O3 -std=c++11 -g -Wall -fpic
  
  .PHONY: all clean depend
  
-@@ -38,6 +38,9 @@ ramulator: $(MAIN) $(OBJS) $(SRCDIR)/*.h | depend
+@@ -38,6 +36,10 @@ ramulator: $(MAIN) $(OBJS) $(SRCDIR)/*.h | depend
  libramulator.a: $(OBJS) $(OBJDIR)/Gem5Wrapper.o
  	libtool -static -o $@ $(OBJS) $(OBJDIR)/Gem5Wrapper.o
  
 +libramulator.so: $(OBJS) $(OBJDIR)/Gem5Wrapper.o
 +	$(CXX) -shared -o $@ $(OBJS) $(OBJDIR)/Gem5Wrapper.o
++
 +
  $(OBJS): | $(OBJDIR)
  

--- a/var/spack/repos/builtin/packages/sst-core/package.py
+++ b/var/spack/repos/builtin/packages/sst-core/package.py
@@ -18,9 +18,10 @@ class SstCore(AutotoolsPackage):
 
     maintainers = ['jjwilke']
 
+    version('10.1.0', sha256="e464213a81c7b3ccec994fdba2b56992b52fb9a6db089ef7c3445b54306d4b87")
     version('10.0.0', sha256="64cf93a46dfab011fba49244bf0e0efe25ef928c6fbde1d49003220d0eb7735a")
-    version('9.1.0', sha256="cfeda39bb2ce9f32032480427517df62e852c0b3713797255e3b838075f3614d")
-    version('develop',   branch='devel')
+    version('9.1.0',  sha256="cfeda39bb2ce9f32032480427517df62e852c0b3713797255e3b838075f3614d")
+    version('develop', branch='devel')
     version('master',  branch='master')
 
     variant("pdes_mpi", default=True,
@@ -44,6 +45,7 @@ class SstCore(AutotoolsPackage):
     depends_on('automake@1.11.1:', type='build', when='@master:')
     depends_on('libtool@1.2.4:', type='build', when='@master:')
     depends_on('m4', type='build', when='@master:')
+    depends_on('gettext')
 
     # force out-of-source builds
     build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/sst-elements/package.py
+++ b/var/spack/repos/builtin/packages/sst-elements/package.py
@@ -18,6 +18,7 @@ class SstElements(AutotoolsPackage):
 
     maintainers = ['jjwilke']
 
+    version('10.1.0', sha256="a790561449795dac48a84c525b8e0b09f05d0b0bff1a0da1aa2e903279a03c4a")
     version('10.0.0', sha256="ecf28ef97b27ea75be7e64cb0acb99d36773a888c1b32ba16034c62174b02693")
     version('9.1.0', sha256="e19b05aa6e59728995fc059840c79e476ba866b67887ccde7eaf52a18a1f52ca")
 
@@ -44,15 +45,15 @@ class SstElements(AutotoolsPackage):
     depends_on("sst-core@develop",  when="@develop")
     depends_on("sst-core@master", when="@master")
 
-    depends_on("intel-pin@2.14",   when="+pin")
-    depends_on("dramsim2@2.2",     when="+dramsim2")
+    depends_on("intel-pin",        when="+pin")
+    depends_on("dramsim2@2:",      when="+dramsim2")
     depends_on("hybridsim@2.0.1",  when="+hybridsim")
     depends_on("nvdimmsim@2.0.0",  when="+nvdimmsim")
     depends_on("goblin-hmc-sim",   when="+goblin")
     depends_on("ramulator@sst",    when="+ramulator")
     depends_on("hbm-dramsim2",     when="+hbm")
-    depends_on("dramsim2@2.2.2",   when="+hybridsim")
     depends_on("nvdimmsim@2.0.0",  when="+hybridsim")
+    depends_on("gettext")
 
     depends_on('autoconf@1.68:', type='build', when='@master:')
     depends_on('automake@1.11.1:', type='build', when='@master:')

--- a/var/spack/repos/builtin/packages/sst-macro/package.py
+++ b/var/spack/repos/builtin/packages/sst-macro/package.py
@@ -21,6 +21,7 @@ class SstMacro(AutotoolsPackage):
 
     maintainers = ['jjwilke']
 
+    version('10.1.0', sha256='e15d99ce58d282fdff849af6de267746a4c89f3b8c5ab6c1e1e7b53a01127e73')
     version('10.0.0', sha256='064b732256f3bec9b553e00bcbc9a1d82172ec194f2b69c8797f585200b12566')
     version('master',  branch='master')
     version('develop', branch='devel')
@@ -37,6 +38,9 @@ class SstMacro(AutotoolsPackage):
     depends_on('mpi', when='+pdes_mpi')
     depends_on('sst-core@develop',   when='@develop+core')
     depends_on('sst-core@master',  when='@master+core')
+    depends_on('sst-core@10.1.0', when='@10.1.0+core')
+    depends_on('sst-core@10.0.0', when='@10.0.0+core')
+    depends_on('gettext')
 
     variant('pdes_threads', default=True,
             description='Enable thread-parallel PDES simulation')


### PR DESCRIPTION
* Adds tarballs for 10.1 release
* Workaround for `-lintl` build problems with Python 3
* Patches ramulator compiler bug
* Fixes DramSim version dependency error