### PR TITLE
Fix trilinos error (when building packages that depend in it? dtk, petsc..)

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -419,7 +419,7 @@ class Trilinos(CMakePackage, CudaPackage):
             env.set('CUDA_LAUNCH_BLOCKING', '1')
 
     def setup_dependent_package(self, module, dependent_spec):
-        if '+wrapper' in spec:
+        if '+wrapper' in self.spec:
             self.spec.kokkos_cxx = self.spec["kokkos-nvcc-wrapper"].kokkos_cxx
         else:
             self.spec.kokkos_cxx = spack_cxx


### PR DESCRIPTION
```
==> Installing datatransferkit
==> No binary for datatransferkit found: installing from source
==> Warning: gcc@7.4.0 cannot build optimized binaries for "cascadelake". Using best target possible: "skylake_avx512"
==> Warning: Missing a source id for trilinos@13.0.1
==> Warning: Missing a source id for xsdk@0.6.0
==> Error: NameError: name 'spec' is not defined

/data/balay/spack-xsdk/var/spack/repos/builtin/packages/trilinos/package.py:423, in setup_dependent_package:
        422    def setup_dependent_package(self, module, dependent_spec):
  >>    423        if '+wrapper' in spec:
        424            self.spec.kokkos_cxx = self.spec["kokkos-nvcc-wrapper"].kokkos_cxx
        425        else:
        426            self.spec.kokkos_cxx = spack_cxx


==> Installing petsc
==> No binary for petsc found: installing from source
==> Warning: Skipping build of xsdk since datatransferkit failed
==> Error: NameError: name 'spec' is not defined

/data/balay/spack-xsdk/var/spack/repos/builtin/packages/trilinos/package.py:423, in setup_dependent_package:
        422    def setup_dependent_package(self, module, dependent_spec):
  >>    423        if '+wrapper' in spec:
        424            self.spec.kokkos_cxx = self.spec["kokkos-nvcc-wrapper"].kokkos_cxx
        425        else:
        426            self.spec.kokkos_cxx = spack_cxx
```

Issue from #19119