### PR TITLE
Update packages.yaml format references in packages

### DIFF
--- a/var/spack/repos/builtin/packages/apple-libunwind/package.py
+++ b/var/spack/repos/builtin/packages/apple-libunwind/package.py
@@ -34,10 +34,10 @@ class AppleLibunwind(Package):
 
         packages:
           apple-libunwind:
-            paths:
-              apple-libunwind@35.3: /usr
             buildable: False
-
+            externals:
+            - spec: apple-libunwind@35.3
+              prefix: /usr
         """
         raise InstallError(msg)
 

--- a/var/spack/repos/builtin/packages/fca/package.py
+++ b/var/spack/repos/builtin/packages/fca/package.py
@@ -19,11 +19,12 @@ class Fca(Package):
     # FCA needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:
     #
-    # fca:
-    #   version: [2.5.2431]
-    #   paths:
-    #     fca@2.5.2431: /opt/mellanox/fca (path to your FCA installation)
-    #   buildable: False
+    # packages:
+    #   fca:
+    #     buildable: False
+    #     externals:
+    #     - spec: fca@2.5.2431
+    #       prefix: /opt/mellanox/fca (path to your FCA installation)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/hcoll/package.py
+++ b/var/spack/repos/builtin/packages/hcoll/package.py
@@ -19,11 +19,12 @@ class Hcoll(Package):
     # HCOLL needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:
     #
-    # hcoll:
-    #   version: [3.9.1927]
-    #   paths:
-    #     hcoll@3.9.1927: /opt/mellanox/hcoll (path to your HCOLL installation)
-    #   buildable: False
+    # packages:
+    #   hcoll:
+    #     buildable: False
+    #     externals:
+    #     - spec: hcoll@3.9.1927
+    #       prefix: /opt/mellanox/hcoll (path to your HCOLL installation)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/jdk/package.py
+++ b/var/spack/repos/builtin/packages/jdk/package.py
@@ -155,11 +155,13 @@ Spack will think it is a variant. Add JDK as an external package by running:
 and adding entries for each installation:
 
     packages:
-        jdk:
-            paths:
-                jdk@10.0.1_10:    /path/to/jdk/Home
-                jdk@1.7.0_45-b18: /path/to/jdk/Home
-            buildable: False""".format(self.homepage)
+      jdk:
+        buildable: False
+        externals:
+        - spec: jdk@10.0.1_10
+          prefix: /path/to/jdk/Home
+        - spec: jdk@1.7.0_45-b18
+          prefix: /path/to/jdk/Home""".format(self.homepage)
 
             tty.die(msg)
 

--- a/var/spack/repos/builtin/packages/lsf/package.py
+++ b/var/spack/repos/builtin/packages/lsf/package.py
@@ -17,11 +17,13 @@ class Lsf(Package):
 
     # LSF needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:
+    #
+    # packages:
     #   lsf:
-    #     version: [10.1]
-    #     paths:
-    #       lsf@10.1: /usr/local/lsf/10.1 (path to your LSF installation)
     #     buildable: False
+    #     externals:
+    #     - spec: lsf@10.1
+    #       prefix: /usr/local/lsf/10.1 (path to your LSF installation)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/lustre/package.py
+++ b/var/spack/repos/builtin/packages/lustre/package.py
@@ -27,11 +27,13 @@ class Lustre(Package):
     # Lustre is filesystem and needs to be installed on system.
     # To have it as external package in SPACK, follow below:
     # config file packages.yaml needs to be adjusted:
+    #
+    # packages:
     #   lustre:
-    #     version: [2.12]
-    #     paths:
-    #       lustre@2.12: /usr (Usual Lustre library path)
     #     buildable: False
+    #     externals:
+    #     - spec: lustre@2.12
+    #       prefix: /usr (Usual Lustre library path)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -76,9 +76,9 @@ class Mpt(Package):
 
         packages:
           mpt:
-            paths:
-              mpt@2.20: /opt/
             buildable: False
-
+            externals:
+            - spec: mpt@2.20
+              prefix: /opt
         """
         raise InstallError(msg)

--- a/var/spack/repos/builtin/packages/mxm/package.py
+++ b/var/spack/repos/builtin/packages/mxm/package.py
@@ -18,11 +18,13 @@ class Mxm(Package):
 
     # MXM needs to be added as an external package to SPACK. For this, the
     # config file packages.yaml needs to be adjusted:
+    #
+    # packages:
     #   mxm:
-    #     version: [3.6.3104]
-    #     paths:
-    #       mxm@3.6.3104: /opt/mellanox/mxm (path to your MXM installation)
     #     buildable: False
+    #     externals:
+    #     - spec: mxm@3.6.3104
+    #       prefix: /opt/mellanox/mxm (path to your MXM installation)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -57,9 +57,10 @@ class Opengl(Package):
 
         packages:
           opengl:
-            paths:
-              opengl@4.5.0: /opt/opengl
             buildable: False
+            externals:
+            - spec: opengl@4.5.0
+              prefix: /opt/opengl
 
         In that case, /opt/opengl/ should contain these two folders:
 
@@ -72,9 +73,10 @@ class Opengl(Package):
 
         packages:
           opengl:
-            paths:
-              opengl@4.1: /usr/X11R6
             buildable: False
+            externals:
+            - spec: opengl@4.1
+              prefix: /usr/X11R6
 
         In that case, /usr/X11R6 should contain
 

--- a/var/spack/repos/builtin/packages/openglu/package.py
+++ b/var/spack/repos/builtin/packages/openglu/package.py
@@ -31,9 +31,10 @@ class Openglu(Package):
 
         packages:
           openglu:
-            paths:
-              openglu@1.3: /opt/opengl
             buildable: False
+            externals:
+            - spec: openglu@1.3
+              prefix: /opt/opengl
 
         In that case, /opt/opengl/ should contain these two folders:
 
@@ -46,9 +47,10 @@ class Openglu(Package):
 
         packages:
           openglu:
-            paths:
-              openglu@1.3: /usr/X11R6
             buildable: False
+            externals:
+            - spec: openglu@1.3
+              prefix: /usr/X11R6
 
         In that case, /usr/X11R6 should contain
 


### PR DESCRIPTION
Follow-up to #17804 that updates references to the old `packages.yaml` format in some packages.