### PR TITLE
openfoam-org/openfoam: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -892,7 +892,7 @@ class OpenfoamArch(object):
             elif target == 'armv7l':
                 platform += 'ARM7'
             elif target == 'aarch64':
-                platform += 'Arm64'
+                platform += 'ARM64'
             elif target == 'ppc64':
                 platform += 'PPC64'
             elif target == 'ppc64le':


### PR DESCRIPTION
My following fix was incorrect.
https://github.com/spack/spack/pull/19622
Revert the openfoam fix and redo the openfoam-org fix.