### PR TITLE
prepend shortened shebang only to executables

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -126,6 +126,11 @@ def filter_shebangs_in_directory(directory, filenames=None):
         if not os.path.isfile(path):
             continue
 
+        # only handle executable files
+        st = os.stat(path)
+        if not st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+            continue
+
         # only handle links that resolve within THIS package's prefix.
         if os.path.islink(path):
             real_path = os.path.realpath(path)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -11,6 +11,8 @@ import shutil
 import pytest
 from jsonschema import ValidationError, validate
 
+import llnl.util.tty as tty
+
 import spack
 import spack.ci as ci
 import spack.cmd.buildcache as buildcache
@@ -681,6 +683,7 @@ def test_ci_rebuild(tmpdir, mutable_mock_env_path,
                     install_mockery, mock_packages, monkeypatch,
                     mock_gnupghome, mock_fetch, project_dir_env,
                     mock_binary_index):
+    tty.set_debug(1)
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('working_dir')
 
@@ -793,7 +796,8 @@ spack:
         set_env_var('CI_JOB_URL', ci_job_url)
         set_env_var('CI_PIPELINE_URL', ci_pipeline_url)
 
-        ci_cmd('rebuild', fail_on_error=False)
+        out = ci_cmd('rebuild', fail_on_error=False)
+        raise Exception(out)
 
         expected_repro_files = [
             'install.sh',

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -62,10 +62,18 @@ class ScriptDirectory(object):
         with open(self.short_shebang, 'w') as f:
             f.write(short_line)
             f.write(last_line)
+        self.make_executable(self.short_shebang)
 
         # Script with long shebang
         self.long_shebang = os.path.join(self.tempdir, 'long')
         with open(self.long_shebang, 'w') as f:
+            f.write(long_line)
+            f.write(last_line)
+        self.make_executable(self.long_shebang)
+
+        # Non-executable script with long shebang
+        self.nonexec_long_shebang = os.path.join(self.tempdir, 'nonexec_long')
+        with open(self.nonexec_long_shebang, 'w') as f:
             f.write(long_line)
             f.write(last_line)
 
@@ -74,6 +82,7 @@ class ScriptDirectory(object):
         with open(self.lua_shebang, 'w') as f:
             f.write(lua_line)
             f.write(last_line)
+        self.make_executable(self.lua_shebang)
 
         # Lua script with long shebang
         self.lua_textbang = os.path.join(self.tempdir, 'lua_in_text')
@@ -81,12 +90,14 @@ class ScriptDirectory(object):
             f.write(short_line)
             f.write(lua_in_text)
             f.write(last_line)
+        self.make_executable(self.lua_textbang)
 
         # Node script with long shebang
         self.node_shebang = os.path.join(self.tempdir, 'node')
         with open(self.node_shebang, 'w') as f:
             f.write(node_line)
             f.write(last_line)
+        self.make_executable(self.node_shebang)
 
         # Node script with long shebang
         self.node_textbang = os.path.join(self.tempdir, 'node_in_text')
@@ -94,12 +105,14 @@ class ScriptDirectory(object):
             f.write(short_line)
             f.write(node_in_text)
             f.write(last_line)
+        self.make_executable(self.node_textbang)
 
         # php script with long shebang
         self.php_shebang = os.path.join(self.tempdir, 'php')
         with open(self.php_shebang, 'w') as f:
             f.write(php_line)
             f.write(last_line)
+        self.make_executable(self.php_shebang)
 
         # php script with long shebang
         self.php_textbang = os.path.join(self.tempdir, 'php_in_text')
@@ -107,6 +120,7 @@ class ScriptDirectory(object):
             f.write(short_line)
             f.write(php_in_text)
             f.write(last_line)
+        self.make_executable(self.php_textbang)
 
         # Script already using sbang.
         self.has_sbang = os.path.join(self.tempdir, 'shebang')
@@ -114,14 +128,26 @@ class ScriptDirectory(object):
             f.write(sbang_line)
             f.write(long_line)
             f.write(last_line)
+        self.make_executable(self.has_sbang)
 
         # Fake binary file.
         self.binary = os.path.join(self.tempdir, 'binary')
         tar = which('tar', required=True)
         tar('czf', self.binary, self.has_sbang)
+        self.make_executable(self.binary)
 
     def destroy(self):
         shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def make_executable(self, path):
+        # make a file executable
+        st = os.stat(path)
+        executable_mode = st.st_mode \
+            | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        os.chmod(path, executable_mode)
+
+        st = os.stat(path)
+        assert oct(executable_mode) == oct(st.st_mode & executable_mode)
 
 
 @pytest.fixture
@@ -134,6 +160,7 @@ def script_dir(sbang_line):
 def test_shebang_handling(script_dir, sbang_line):
     assert sbang.shebang_too_long(script_dir.lua_shebang)
     assert sbang.shebang_too_long(script_dir.long_shebang)
+    assert sbang.shebang_too_long(script_dir.nonexec_long_shebang)
 
     assert not sbang.shebang_too_long(script_dir.short_shebang)
     assert not sbang.shebang_too_long(script_dir.has_sbang)
@@ -150,6 +177,11 @@ def test_shebang_handling(script_dir, sbang_line):
     # Make sure this got patched.
     with open(script_dir.long_shebang, 'r') as f:
         assert f.readline() == sbang_line
+        assert f.readline() == long_line
+        assert f.readline() == last_line
+
+    # Make sure this is untouched
+    with open(script_dir.nonexec_long_shebang, 'r') as f:
         assert f.readline() == long_line
         assert f.readline() == last_line
 

--- a/var/spack/repos/builtin.mock/packages/old-sbang/package.py
+++ b/var/spack/repos/builtin.mock/packages/old-sbang/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
 import spack.paths
 import spack.store
 from spack import *
@@ -28,8 +30,11 @@ class OldSbang(Package):
 
 {1}
 '''.format(spack.store.unpadded_root, prefix.bin)
-        with open('%s/sbang-style-1.sh' % self.prefix.bin, 'w') as f:
+        style_1 = '%s/sbang-style-1.sh' % self.prefix.bin
+        style_2 = '%s/sbang-style-2.sh' % self.prefix.bin
+        with open(style_1, 'w') as f:
             f.write(sbang_style_1)
-
-        with open('%s/sbang-style-2.sh' % self.prefix.bin, 'w') as f:
+        with open(style_2, 'w') as f:
             f.write(sbang_style_2)
+        os.chmod(style_1, 0o775)
+        os.chmod(style_2, 0o775)

--- a/var/spack/repos/builtin.mock/packages/old-sbang/package.py
+++ b/var/spack/repos/builtin.mock/packages/old-sbang/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-
 import spack.paths
 import spack.store
 from spack import *
@@ -30,11 +28,8 @@ class OldSbang(Package):
 
 {1}
 '''.format(spack.store.unpadded_root, prefix.bin)
-        style_1 = '%s/sbang-style-1.sh' % self.prefix.bin
-        style_2 = '%s/sbang-style-2.sh' % self.prefix.bin
-        with open(style_1, 'w') as f:
+        with open('%s/sbang-style-1.sh' % self.prefix.bin, 'w') as f:
             f.write(sbang_style_1)
-        with open(style_2, 'w') as f:
+
+        with open('%s/sbang-style-2.sh' % self.prefix.bin, 'w') as f:
             f.write(sbang_style_2)
-        os.chmod(style_1, 0o775)
-        os.chmod(style_2, 0o775)


### PR DESCRIPTION
The OS should only interpret shebangs, if a file is executable. So there
should not be a need to modify files where no execute bit is set.
This avoids a problem that I ran into while trying to package our visualization
software COVISE (https://github.com/hlrs-vis/covise), which includes example
data in Tecplot format: the sbang post-install hook is applied to every
installed file that starts with the two characters #!, but this fails on the
binary Tecplot files, as they happen to start with #!TDV. Decoding them with
UTF-8 fails and an exception is thrown during post_install.