### PR TITLE
py-pykwalify: fix conflict directive (missing '^')

### DIFF
--- a/var/spack/repos/builtin/packages/py-pykwalify/package.py
+++ b/var/spack/repos/builtin/packages/py-pykwalify/package.py
@@ -23,6 +23,6 @@ class PyPykwalify(PythonPackage):
     depends_on('py-python-dateutil@2.4.2:', type=('build', 'run'))
     depends_on('py-pyyaml@3.11:', type=('build', 'run'), when='@1.6.1')
 
-    conflicts('py-ruamel@0.16.0:', when='@1.6.1')
-    conflicts('python@2.8.0:3.2.99', when='@1.6.1')
-    conflicts('python@2.8.0:3.4.99', when='@1.7.0:')
+    conflicts('^py-ruamel@0.16.0:', when='@1.6.1')
+    conflicts('^python@2.8.0:3.2.99', when='@1.6.1')
+    conflicts('^python@2.8.0:3.4.99', when='@1.7.0:')


### PR DESCRIPTION
discovered during testing #19501

there's other work that needs to be done here, but getting this out of the way.