### PR TITLE
kokkos-legacy: fix host_arch/gpu_arch variants

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-legacy/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-legacy/package.py
@@ -86,7 +86,7 @@ class KokkosLegacy(Package):
     variant(
         'host_arch',
         default='none',
-        values=host_values,
+        values=host_values + ('none',),
         description='Set the host architecture to use'
     )
 
@@ -94,7 +94,7 @@ class KokkosLegacy(Package):
     variant(
         'gpu_arch',
         default='none',
-        values=gpu_values,
+        values=gpu_values + ('none',),
         description='Set the GPU architecture to use'
     )
 


### PR DESCRIPTION
'default' specifies a value that is not present in 'values'.

discovered during testing #19501