### PR TITLE
Don't use prefix.lib in tcl/tk/glib/etc

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -155,7 +155,7 @@ class Atlas(Package):
                                  'test_cblas_dgemm.output')
 
         include_flags = ["-I%s" % self.spec.prefix.include]
-        link_flags = self.libs.ld_flags.split()
+        link_flags = self.spec['atlas'].libs.ld_flags.split()
 
         output = compile_c_and_execute(source_file, include_flags, link_flags)
         compare_output_file(output, blessed_file)

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -54,8 +54,8 @@ class EnvironmentModules(Package):
             "--without-tclx",
             "--with-tclx-ver=0.0",
             # It looks for tclConfig.sh
-            "--with-tcl=" + join_path(tcl.libs.directories[0], 'tclConfig.sh'),
-            "--with-tcl-ver={0}".format(*tcl.version.up_to(2)),
+            "--with-tcl=" + tcl.libs.directories[0],
+            "--with-tcl-ver={0}".format(tcl.version.up_to(2)),
             '--disable-versioning',
             '--datarootdir=' + prefix.share
         ]

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
-
 
 class EnvironmentModules(Package):
     """The Environment Modules package provides for the dynamic
@@ -51,21 +49,13 @@ class EnvironmentModules(Package):
     def install(self, spec, prefix):
         tcl = spec['tcl']
 
-        # Determine where we can find tclConfig.sh
-        for tcl_lib_dir in [tcl.prefix.lib, tcl.prefix.lib64]:
-            tcl_config_file = os.path.join(tcl_lib_dir, 'tclConfig.sh')
-            if os.path.exists(tcl_config_file):
-                break
-        else:
-            raise InstallError('Failed to locate tclConfig.sh')
-
         config_args = [
             "--prefix=" + prefix,
             "--without-tclx",
             "--with-tclx-ver=0.0",
             # It looks for tclConfig.sh
-            "--with-tcl=" + tcl_lib_dir,
-            "--with-tcl-ver={0}.{1}".format(*tcl.version.version[0:2]),
+            "--with-tcl=" + join_path(tcl.libs.directories[0], 'tclConfig.sh'),
+            "--with-tcl-ver={0}".format(*tcl.version.up_to(2)),
             '--disable-versioning',
             '--datarootdir=' + prefix.share
         ]

--- a/var/spack/repos/builtin/packages/expect/package.py
+++ b/var/spack/repos/builtin/packages/expect/package.py
@@ -24,6 +24,9 @@ class Expect(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
+    # https://github.com/spack/spack/issues/19767
+    conflicts('%apple-clang@12:')
+
     force_autoreconf = True
 
     patch('expect_detect_tcl_private_header_os_x_mountain_lion.patch', when='@5.45')

--- a/var/spack/repos/builtin/packages/expect/package.py
+++ b/var/spack/repos/builtin/packages/expect/package.py
@@ -37,8 +37,8 @@ class Expect(AutotoolsPackage):
             '--enable-threads',
             '--enable-shared',
             '--enable-64bit',
-            '--with-tcl={0}'.format(spec['tcl'].prefix.lib),
-            '--with-tclinclude={0}'.format(spec['tcl'].prefix.include),
+            '--with-tcl={0}'.format(spec['tcl'].libs.directories[0]),
+            '--with-tclinclude={0}'.format(spec['tcl'].headers.directories[0]),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -80,6 +80,10 @@ class Glib(Package):
         url = 'http://ftp.gnome.org/pub/gnome/sources/glib'
         return url + '/%s/glib-%s.tar.xz' % (version.up_to(2), version)
 
+    @property
+    def libs(self):
+        return find_libraries(['libglib*'], root=self.prefix, recursive=True)
+
     def meson_args(self):
         args = ['-Dgettext=external']
         if self.spec.satisfies('@2.63.5:'):
@@ -260,5 +264,6 @@ class Glib(Package):
             repl = 'Libs: -L{0} -Wl,-rpath={0} '.format(
                    spec['gettext'].libs.directories[0])
             myfile = join_path(
-                self.libs.directories[0], 'pkgconfig', 'glib-2.0.pc')
+                self.spec['glib'].libs.directories[0],
+                'pkgconfig', 'glib-2.0.pc')
             filter_file(pattern, repl, myfile, backup=False)

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -258,6 +258,7 @@ class Glib(Package):
         if spec.satisfies('@2:2.99'):
             pattern = 'Libs:'
             repl = 'Libs: -L{0} -Wl,-rpath={0} '.format(
-                   spec['gettext'].prefix.lib)
-            myfile = join_path(self.prefix.lib.pkgconfig, 'glib-2.0.pc')
+                   spec['gettext'].libs.directories[0])
+            myfile = join_path(
+                self.libs.directories[0], 'pkgconfig', 'glib-2.0.pc')
             filter_file(pattern, repl, myfile, backup=False)

--- a/var/spack/repos/builtin/packages/plplot/package.py
+++ b/var/spack/repos/builtin/packages/plplot/package.py
@@ -77,20 +77,22 @@ class Plplot(CMakePackage):
             # as is done for the tclsh executable
             args += [
                 '-DTCL_INCLUDE_PATH={0}/include'.format(
-                    self.spec['tcl'].prefix.include
+                    self.spec['tcl'].headers.directories[0]
                 ),
                 '-DTCL_LIBRARY={0}'.format(
                     LibraryList(find_libraries(
                         'libtcl*',
-                        self.spec['tcl'].prefix.lib,
+                        self.spec['tcl'].prefix,
                         shared=True,
+                        recursive=True,
                     )),
                 ),
                 '-DTCL_STUB_LIBRARY={0}'.format(
                     LibraryList(find_libraries(
                         'libtclstub*',
-                        self.spec['tcl'].prefix.lib,
+                        self.spec['tcl'].prefix,
                         shared=False,
+                        recursive=True,
                     )),
                 )
             ]

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -914,7 +914,8 @@ class Python(AutotoolsPackage):
         return join_path(self.site_packages_dir, "easy-install.pth")
 
     def setup_run_environment(self, env):
-        env.prepend_path('CPATH', os.pathsep.join(self.headers.directories))
+        env.prepend_path('CPATH', os.pathsep.join(
+            self.spec['python'].headers.directories))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set PYTHONPATH to include the site-packages directory for the

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -21,6 +21,7 @@ class R(AutotoolsPackage):
 
     extendable = True
 
+    version('4.0.3', sha256='09983a8a78d5fb6bc45d27b1c55f9ba5265f78fa54a55c13ae691f87c5bb9e0d')
     version('4.0.2', sha256='d3bceab364da0876625e4097808b42512395fdf41292f4915ab1fd257c1bbe75')
     version('4.0.1', sha256='95fe24a4d8d8f8f888460c8f5fe4311cec656e7a1722d233218bc03861bc6f32')
     version('4.0.0', sha256='06beb0291b569978484eb0dcb5d2339665ec745737bdfb4e873e7a5a75492940')
@@ -126,10 +127,8 @@ class R(AutotoolsPackage):
         spec   = self.spec
         prefix = self.prefix
 
-        tcl_config_path = join_path(spec['tcl'].prefix.lib, 'tclConfig.sh')
-        if not os.path.exists(tcl_config_path):
-            tcl_config_path = join_path(spec['tcl'].prefix,
-                                        'lib64', 'tclConfig.sh')
+        tcl_config_path = join_path(
+            spec['tcl'].libs.directories[0], 'tclConfig.sh')
 
         config_args = [
             '--libdir={0}'.format(join_path(prefix, 'rlib')),
@@ -142,10 +141,8 @@ class R(AutotoolsPackage):
                                                             'R', 'lib')),
         ]
         if '^tk' in spec:
-            tk_config_path = join_path(spec['tk'].prefix.lib, 'tkConfig.sh')
-            if not os.path.exists(tk_config_path):
-                tk_config_path = join_path(spec['tk'].prefix,
-                                           'lib64', 'tkConfig.sh')
+            tk_config_path = join_path(
+                spec['tk'].libs.directories[0], 'tkConfig.sh')
             config_args.append('--with-tk-config={0}'.format(tk_config_path))
 
         if '+external-lapack' in spec:

--- a/var/spack/repos/builtin/packages/tcl-itcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl-itcl/package.py
@@ -22,6 +22,7 @@ class TclItcl(AutotoolsPackage):
         args = [
             '--enable-shared',
             '--enable-threads',
-            '--with-tcl=' + self.spec['tcl'].tcl_lib_dir,
+            '--with-tcl=' + join_path(
+                'lib', 'tcl' + self.spec['tcl'].version.up_to(2)),
         ]
         return args

--- a/var/spack/repos/builtin/packages/tcl-itcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl-itcl/package.py
@@ -22,7 +22,6 @@ class TclItcl(AutotoolsPackage):
         args = [
             '--enable-shared',
             '--enable-threads',
-            '--with-tcl=' + join_path(
-                'lib', 'tcl' + self.spec['tcl'].version.up_to(2)),
+            '--with-tcl=' + self.spec['tcl'].libs.directories[0],
         ]
         return args

--- a/var/spack/repos/builtin/packages/tcl-tclxml/package.py
+++ b/var/spack/repos/builtin/packages/tcl-tclxml/package.py
@@ -30,10 +30,10 @@ class TclTclxml(AutotoolsPackage):
         return [
             '--exec-prefix={0}'.format(
                 self.prefix),
-            '--with-tcl={0}/lib'.format(
-                self.spec['tcl'].prefix),
-            '--with-xml2-config={0}/bin/xml2-config'.format(
-                self.spec['libxml2'].prefix),
-            '--with-xslt-config={0}/bin/xslt-config'.format(
-                self.spec['libxslt'].prefix),
+            '--with-tcl={0}'.format(
+                self.spec['tcl'].libs.directories[0]),
+            '--with-xml2-config={0}'.format(
+                self.spec['libxml2'].prefix.bin.join('xml2-config')),
+            '--with-xslt-config={0}'.format(
+                self.spec['libxslt'].prefix.bin.join('xslt-config')),
         ]

--- a/var/spack/repos/builtin/packages/tcl-tclxml/package.py
+++ b/var/spack/repos/builtin/packages/tcl-tclxml/package.py
@@ -26,6 +26,9 @@ class TclTclxml(AutotoolsPackage):
     depends_on('libxml2')
     depends_on('libxslt')
 
+    # Results in C99 build error
+    conflicts('%apple-clang@12:')
+
     def configure_args(self):
         return [
             '--exec-prefix={0}'.format(

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack.util.environment import is_system_path
-from spack import *
 
 
 class Tcl(AutotoolsPackage, SourceforgePackage):
@@ -56,7 +55,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
             # Replace stage dir -> installed src dir in tclConfig
             filter_file(
                 stage_src, installed_src,
-                join_path(self.spec.prefix, 'lib', 'tclConfig.sh'))
+                join_path(self.libs.directories[0], 'tclConfig.sh'))
 
         # Don't install binaries in src/ tree
         with working_dir(join_path(installed_src, self.configure_directory)):
@@ -85,45 +84,35 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         """
         return Executable(os.path.realpath(self.prefix.bin.tclsh))
 
-    @property
-    def tcl_lib_dir(self):
-        """The Tcl version-specific library directory where all extensions are
-        installed."""
-        return 'lib'
-
-    @property
-    def tcl_builtin_lib_dir(self):
-        """The Tcl version-specific library directory where all builtin
-        extensions are installed."""
-        return join_path(self.tcl_lib_dir,
-                         'tcl{0}'.format(self.version.up_to(2)))
-
     def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
-        env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
+        env.set('TCL_LIBRARY', self.libs.directories[0])
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCLLIBPATH to include the tcl-shipped directory for
         extensions and any other tcl extension it depends on.
         For further info see: https://wiki.tcl.tk/1787"""
 
-        env.set('TCL_LIBRARY', join_path(self.prefix, self.tcl_lib_dir))
+        env.set('TCL_LIBRARY', self.libs.directories[0])
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases
         # where a system provided tcl is run against the standard libraries
         # of a Spack built tcl. See issue #7128 that relates to python but
         # it boils down to the same situation we have here.
-        path = os.path.dirname(self.command.path)
-        if not is_system_path(path):
-            env.prepend_path('PATH', path)
+        if not is_system_path(self.prefix.bin):
+            env.prepend_path('PATH', self.prefix.bin)
 
-        tcl_paths = [join_path(self.prefix, self.tcl_builtin_lib_dir)]
+        tcl_paths = [join_path(self.libs.directories[0], 'tcl{0}'.format(
+            self.version.up_to(2)))]
 
         for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
             if d.package.extends(self.spec):
-                tcl_paths.append(join_path(d.prefix, self.tcl_lib_dir))
+                # Tcl libraries may be installed in lib or lib64, see #19546
+                for lib in ['lib', 'lib64']:
+                    tcl_paths.append(join_path(
+                        d.prefix, lib, 'tcl{0}'.format(self.version.up_to(2))))
 
         # WARNING: paths in $TCLLIBPATH must be *space* separated,
         # its value is meant to be a Tcl list, *not* an env list
@@ -141,6 +130,9 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         # For run time environment set only the path for
         # dependent_spec and prepend it to TCLLIBPATH
         if dependent_spec.package.extends(self.spec):
-            dependent_tcllibpath = join_path(dependent_spec.prefix,
-                                             self.tcl_lib_dir)
-            env.prepend_path('TCLLIBPATH', dependent_tcllibpath, separator=' ')
+            # Tcl libraries may be installed in lib or lib64, see #19546
+            for lib in ['lib', 'lib64']:
+                tcllibpath = join_path(
+                    self.prefix, lib, 'tcl{0}'.format(self.version.up_to(2)))
+                if os.path.exists(tcllibpath):
+                    env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -55,7 +55,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
             # Replace stage dir -> installed src dir in tclConfig
             filter_file(
                 stage_src, installed_src,
-                join_path(self.libs.directories[0], 'tclConfig.sh'))
+                join_path(self.spec['tcl'].libs.directories[0],
+                          'tclConfig.sh'))
 
         # Don't install binaries in src/ tree
         with working_dir(join_path(installed_src, self.configure_directory)):
@@ -87,14 +88,14 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
     def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
-        env.set('TCL_LIBRARY', self.libs.directories[0])
+        env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCLLIBPATH to include the tcl-shipped directory for
         extensions and any other tcl extension it depends on.
         For further info see: https://wiki.tcl.tk/1787"""
 
-        env.set('TCL_LIBRARY', self.libs.directories[0])
+        env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases
@@ -104,8 +105,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         if not is_system_path(self.prefix.bin):
             env.prepend_path('PATH', self.prefix.bin)
 
-        tcl_paths = [join_path(self.libs.directories[0], 'tcl{0}'.format(
-            self.version.up_to(2)))]
+        tcl_paths = [join_path(self.spec['tcl'].libs.directories[0],
+                               'tcl{0}'.format(self.version.up_to(2)))]
 
         for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
             if d.package.extends(self.spec):

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -20,13 +20,14 @@ class Tix(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = ['--with-tcl={0}'.format(spec['tcl'].prefix.lib),
-                       '--with-tk={0}'.format(spec['tk'].prefix.lib),
-                       '--exec-prefix={0}'.format(spec.prefix)]
-        return config_args
+        args = [
+            '--with-tcl={0}'.format(spec['tcl'].libs.directories[0]),
+            '--with-tk={0}'.format(spec['tk'].libs.directories[0]),
+            '--exec-prefix={0}'.format(self.prefix),
+        ]
+        return args
 
-    def install(self, spec, prefix):
-        make('install')
-        with working_dir(self.prefix.lib):
-            symlink('Tix{0}/libTix{0}.{1}'.format(self.version, dso_suffix),
-                    'libtix.{0}'.format(dso_suffix))
+    @property
+    def libs(self):
+        return find_libraries(['libTix{0}'.format(self.version)],
+                              root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -53,7 +53,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
             # Replace stage dir -> installed src dir in tkConfig
             filter_file(
                 stage_src, installed_src,
-                join_path(self.spec.prefix, 'lib', 'tkConfig.sh'))
+                join_path(self.libs.directories[0], 'tkConfig.sh'))
 
     @property
     def libs(self):
@@ -63,19 +63,17 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
-        env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
-            self.spec.version.up_to(2))))
+        env.set('TK_LIBRARY', self.libs.directories[0])
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('TK_LIBRARY', join_path(self.prefix.lib, 'tk{0}'.format(
-            self.spec.version.up_to(2))))
+        env.set('TK_LIBRARY', self.libs.directories[0])
 
     def configure_args(self):
         spec = self.spec
         config_args = [
-            '--with-tcl={0}'.format(spec['tcl'].prefix.lib),
-            '--x-includes={0}'.format(spec['libx11'].prefix.include),
-            '--x-libraries={0}'.format(spec['libx11'].prefix.lib)
+            '--with-tcl={0}'.format(spec['tcl'].libs.directories[0]),
+            '--x-includes={0}'.format(spec['libx11'].headers.directories[0]),
+            '--x-libraries={0}'.format(spec['libx11'].libs.directories[0])
         ]
         config_args += self.enable_or_disable('xft')
         config_args += self.enable_or_disable('xss')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -17,10 +17,11 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     homepage = "http://www.tcl.tk"
     sourceforge_mirror_path = "tcl/tk8.6.5-src.tar.gz"
 
-    version('8.6.8', sha256='49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33')
-    version('8.6.6', sha256='d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d')
-    version('8.6.5', sha256='fbbd93541b4cd467841208643b4014c4543a54c3597586727f0ab128220d7946')
-    version('8.6.3', sha256='ba15d56ac27d8c0a7b1a983915a47e0f635199b9473cf6e10fbce1fc73fd8333')
+    version('8.6.10', sha256='63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386')
+    version('8.6.8',  sha256='49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33')
+    version('8.6.6',  sha256='d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d')
+    version('8.6.5',  sha256='fbbd93541b4cd467841208643b4014c4543a54c3597586727f0ab128220d7946')
+    version('8.6.3',  sha256='ba15d56ac27d8c0a7b1a983915a47e0f635199b9473cf6e10fbce1fc73fd8333')
     version('8.5.19', sha256='407af1de167477d598bd6166d84459a3bdccc2fb349360706154e646a9620ffa')
 
     variant('xft', default=True,

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -54,7 +54,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
             # Replace stage dir -> installed src dir in tkConfig
             filter_file(
                 stage_src, installed_src,
-                join_path(self.libs.directories[0], 'tkConfig.sh'))
+                join_path(self.spec['tk'].libs.directories[0], 'tkConfig.sh'))
 
     @property
     def libs(self):
@@ -64,10 +64,10 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     def setup_run_environment(self, env):
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
-        env.set('TK_LIBRARY', self.libs.directories[0])
+        env.set('TK_LIBRARY', self.spec['tk'].libs.directories[0])
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('TK_LIBRARY', self.libs.directories[0])
+        env.set('TK_LIBRARY', self.spec['tk'].libs.directories[0])
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/wordnet/package.py
+++ b/var/spack/repos/builtin/packages/wordnet/package.py
@@ -21,8 +21,8 @@ class Wordnet(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        args.append('--with-tk=%s' % self.spec['tk'].prefix.lib)
-        args.append('--with-tcl=%s' % self.spec['tcl'].prefix.lib)
+        args.append('--with-tk=%s' % self.spec['tk'].libs.directories[0])
+        args.append('--with-tcl=%s' % self.spec['tcl'].libs.directories[0])
         if self.spec.satisfies('^tcl@8.6:'):
             args.append('CPPFLAGS=-DUSE_INTERP_RESULT')
 


### PR DESCRIPTION
Fixes #19546 

Packages I would like to have tested before merging:

- [x] tcl (%apple-clang and %gcc)
- [x] tk (%apple-clang and %gcc)
- [x] tix (%gcc but not %apple-clang)
- [x] tcl-itcl
- [x] tcl-tcllib
- [x] tcl-tclxml (%gcc but not %apple-clang)
- [x] environment-modules
- [x] lmod
- [x] python+tkinter
- [ ] r+X (build failure, even on develop: #19788)
- [x] ruby
- [x] expect (%gcc but not %apple-clang: #19767)
- [x] glib

@andymwood can you help test this on your system?