### PR TITLE
bzip2: do not do recursive search for libraries

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -40,7 +40,9 @@ class Bzip2(Package, SourcewarePackage):
     def libs(self):
         shared = '+shared' in self.spec
         return find_libraries(
-            'libbz2', root=self.prefix, shared=shared, recursive=True
+            'libbz2', root=self.prefix.lib, shared=shared, recursive=False
+        ) + find_libraries(
+            'libbz2', root=self.prefix.lib64, shared=shared, recursive=False
         )
 
     def patch(self):


### PR DESCRIPTION
User on slack reported Spack was detecting all bz2 libraries on the entire system when using an external located in `/`. This PR changes bzip2's `libs` method to prevent that.