### PR TITLE
env: add pre_cmd script option

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -626,6 +626,20 @@ class Environment(object):
         # If with_view is None, then defer to the view settings determined by
         # the manifest file
 
+        # Run pre command if the environment has one
+        self.run_pre_cmd()
+
+    def run_pre_cmd(self):
+        """Run the user-defined pre-environment script"""
+        script = config_dict(self.yaml).get('pre_cmd', None)
+        if script:
+            try:
+                exec(script, locals(), locals())
+            except BaseException as e:
+                msg = "Pre-cmd script for environment %s failed.\n" % self.name
+                msg += str(e)
+                tty.die(msg)
+
     def _re_read(self):
         """Reinitialize the environment object if it has been written (this
            may not be true if the environment was just created in this running

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -66,6 +66,9 @@ schema = {
                 spack.schema.merged.properties,
                 # extra environment schema properties
                 {
+                    'pre_cmd': {
+                        'type': 'string'
+                    },
                     'include': {
                         'type': 'array',
                         'default': [],


### PR DESCRIPTION
Allow environments to define a pre_cmd which runs before every individual command.

This is intended to allow developers to put conditions on their environments to warn users or raise errors.

For an environment that warns the user if they run it from a different environment (to help avoid "wrong environment loaded" bugs)
```
spack:
  pre_cmd: |
    import llnl.util.tty as tty
    import os
    if os.getcwd() != self.path:
        tty.warn("RUNNING ENV %s FROM ALTERNATIVE DIRECTORY" % self.name)
  specs: []
  ...
```

For an environment that raises an error if a given environment variable is not defined.
```
spack:
  pre_cmd: |
    import os
    assert 'CANARY' in os.environ, "CANARY not set in environment"
  specs:
  ...
```

This PR already includes tests, I will add documentation if reviewers find the general architecture acceptable.