### PR TITLE
[root] fix package definition

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -435,7 +435,7 @@ class Root(CMakePackage):
                                   True))
 
         if '+x+opengl' in self.spec:
-            ftgl_prefix = self.spec('ftgl').prefix
+            ftgl_prefix = self.spec['ftgl'].prefix
             options.append(define('FTGL_ROOT_DIR', ftgl_prefix))
             options.append(define('FTGL_INCLUDE_DIR', ftgl_prefix.include))
         if '+python' in self.spec:


### PR DESCRIPTION
Need braces not parenthesis here, otherwise we run into a `TypeError`:

```
==> Error: TypeError: 'Spec' object is not callable

/home/tmadlener/work/spack/var/spack/repos/builtin/packages/root/package.py:438, in cmake_args:
        435                                  True))
        436
        437        if '+x+opengl' in self.spec:
  >>    438            ftgl_prefix = self.spec('ftgl').prefix
        439            options.append(define('FTGL_ROOT_DIR', ftgl_prefix))
        440            options.append(define('FTGL_INCLUDE_DIR', ftgl_prefix.include))
        441        if '+python' in self.spec:

See build log for details:
  /tmp/tmadlener/spack-stage/spack-stage-root-6.20.04-4pbhpedobzxtcfkonhms55gq2vq6neso/spack-build-out.txt
```
