### PR TITLE
cp2k: fix lmax variant to use tuple

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -70,7 +70,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     variant('lmax',
             description='Maximum supported angular momentum (HFX and others)',
             default='5',
-            values=tuple(HFX_LMAX_RANGE),
+            values=tuple(map(str, HFX_LMAX_RANGE)),
             multi=False)
 
     depends_on('python', type='build')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -70,7 +70,7 @@ class Cp2k(MakefilePackage, CudaPackage):
     variant('lmax',
             description='Maximum supported angular momentum (HFX and others)',
             default='5',
-            values=map(str, HFX_LMAX_RANGE),
+            values=tuple(HFX_LMAX_RANGE),
             multi=False)
 
     depends_on('python', type='build')


### PR DESCRIPTION
discovered during testing #19501

@dev-zero