### PR TITLE
virtualgl: Change virtual jpeg dependency to libjpeg-turbo dep

### DIFF
--- a/var/spack/repos/builtin/packages/virtualgl/package.py
+++ b/var/spack/repos/builtin/packages/virtualgl/package.py
@@ -18,5 +18,6 @@ class Virtualgl(CMakePackage):
 
     version('2.5.2', sha256='4f43387678b289a24139c5b7c3699740ca555a9f10011c979e51aa4df2b93238')
 
-    depends_on("jpeg")
+    # This package will only work with libjpeg-turbo, not other jpeg providers
+    depends_on("libjpeg-turbo")
     depends_on("glu")


### PR DESCRIPTION
Closes #19784

virtualgl CMake system is looking for a specific libjpeg-turbo include
file, not present in libjpeg (currently the only other jpeg provider)