### PR TITLE
py-gpytorch: add v1.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-gpytorch/package.py
@@ -10,12 +10,17 @@ class PyGpytorch(PythonPackage):
     process models with ease."""
 
     homepage = "https://gpytorch.ai/"
-    url      = "https://pypi.io/packages/source/g/gpytorch/gpytorch-1.1.1.tar.gz"
+    url      = "https://pypi.io/packages/source/g/gpytorch/gpytorch-1.2.1.tar.gz"
 
     maintainers = ['adamjstewart']
 
+    version('1.2.1', sha256='ddd746529863d5419872610af23b1a1b0e8a29742131c9d9d2b4f9cae3c90781')
+    version('1.2.0', sha256='fcb216e0c1f128a41c91065766508e91e487d6ffadf212a51677d8014aefca84')
     version('1.1.1', sha256='76bd455db2f17af5425f73acfaa6d61b8adb1f07ad4881c0fa22673f84fb571a')
 
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-torch@1.6:', when='@1.2:', type=('build', 'run'))
     depends_on('py-torch@1.5:', type=('build', 'run'))
+    depends_on('py-scikit-learn', when='@1.2:', type=('build', 'run'))
+    depends_on('py-scipy', when='@1.2:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.