### PR TITLE
perl: make 5.32.0 the preferred version

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -33,15 +33,14 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # see http://www.cpan.org/src/README.html for
     # explanation of version numbering scheme
 
-    # Maintenance releases (even numbers, recommended)
-    version('5.32.0', sha256='efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4')
-
     # Development releases (odd numbers)
+    version('5.33.3', sha256='4f4ba0aceb932e6cf7c05674d05e51ef759d1c97f0685dee65a8f3d190f737cd')
     version('5.31.7', sha256='d05c4e72128f95ef6ffad42728ecbbd0d9437290bf0f88268b51af011f26b57d')
     version('5.31.4', sha256='418a7e6fe6485cc713a86d1227ef112f0bb3f80322e3b715ffe42851d97804a5')
 
     # Maintenance releases (even numbers, recommended)
-    version('5.30.3', sha256='32e04c8bb7b1aecb2742a7f7ac0eabac100f38247352a73ad7fa104e39e7406f', preferred=True)
+    version('5.32.0', sha256='efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4', preferred=True)
+    version('5.30.3', sha256='32e04c8bb7b1aecb2742a7f7ac0eabac100f38247352a73ad7fa104e39e7406f')
     version('5.30.2', sha256='66db7df8a91979eb576fac91743644da878244cf8ee152f02cd6f5cd7a731689')
     version('5.30.1', sha256='bf3d25571ff1ee94186177c2cdef87867fd6a14aa5a84f0b1fb7bf798f42f964')
     version('5.30.0', sha256='851213c754d98ccff042caa40ba7a796b2cee88c5325f121be5cbb61bbf975f2')
@@ -190,7 +189,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if '+threads' in spec:
             config_args.append('-Dusethreads')
 
-        if spec.satisfies('@5.31'):
+        # Development versions have an odd second component
+        if spec.version[1] % 2 == 1:
             config_args.append('-Dusedevel')
 
         return config_args


### PR DESCRIPTION
Version 5.32.0 has been out for quite a while and Linux distributions are shipping it. I have also done a rebuild of some common packages with the new version. Let's make it the preferred version.