### PR TITLE
openfoam: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -906,6 +906,7 @@ class OpenfoamArch(object):
             elif target == 'armv7l':
                 platform += 'ARM7'
             elif target == 'aarch64':
+                # overwritten as 'Arm64' in openfoam-org
                 platform += 'ARM64'
             elif target == 'ppc64':
                 platform += 'PPC64'

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -906,7 +906,7 @@ class OpenfoamArch(object):
             elif target == 'armv7l':
                 platform += 'ARM7'
             elif target == 'aarch64':
-                platform += 'Arm64'
+                platform += 'ARM64'
             elif target == 'ppc64':
                 platform += 'PPC64'
             elif target == 'ppc64le':


### PR DESCRIPTION
There was a difference with the assets I confirmed in the following PR.
https://github.com/spack/spack/pull/19778#event-3971525322
