### PR TITLE
saga-gis: add  "depends_on('libsm',    type='link')"

### DIFF
--- a/var/spack/repos/builtin/packages/saga-gis/package.py
+++ b/var/spack/repos/builtin/packages/saga-gis/package.py
@@ -56,6 +56,7 @@ class SagaGis(AutotoolsPackage, SourceforgePackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('libsm',    type='link')
 
     depends_on('libharu')
     depends_on('wxwidgets')


### PR DESCRIPTION
I can't install I can't install saga-gis.
There are no dependencies of libsm in the recipe.

```
  >> 906    //usr/lib64/libSM.so.6: undefined reference to `uuid_generate@@UUID_
            1.0'
  >> 907    //usr/lib64/libSM.so.6: undefined reference to `uuid_unparse_lower@@
            UUID_1.0'
  >> 908    collect2: error: ld returned 1 exit status

```