### PR TITLE
abi-dumper: Add phases

### DIFF
--- a/var/spack/repos/builtin/packages/abi-dumper/package.py
+++ b/var/spack/repos/builtin/packages/abi-dumper/package.py
@@ -23,5 +23,7 @@ class AbiDumper(MakefilePackage):
     depends_on('universal-ctags')
     depends_on('vtable-dumper@1.1:')
 
+    phases = ['install']
+
     def install(self, spec, prefix):
         make('prefix={0}'.format(prefix), 'install')


### PR DESCRIPTION
I fixed an issue that occurred during installation.
perl Makefile.pl -install -prefix "/usr" 
ERROR: you should be root
INSTALL PREFIX: /usr

I checked on x86_64 and aarch64.