### PR TITLE
commands: add `spack tutorial` command

### DIFF
--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -74,7 +74,11 @@ def tutorial(parser, args):
             "spack gpg trust %s" % tutorial_key)
     spack.util.gpg.trust(tutorial_key)
 
+    # Note that checkout MUST be last. It changes Spack under our feet.
+    # If you don't put this last, you'll get import errors for the code
+    # that follows (exacerbated by the various lazy singletons we use)
     tty.msg("Ensuring we're on the releases/v0.15 branch")
     git = which("git", required=True)
     with working_dir(spack.paths.prefix):
         git("checkout", tutorial_branch)
+    # NO CODE BEYOND HERE

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -32,8 +32,9 @@ tutorial_key    = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
 # configs to remove
 rm_configs = [
     "~/.spack/linux/compilers.yaml",
-    "~/.spack/repos.yaml",
+    "~/.spack/packages.yaml",
     "~/.spack/mirrors.yaml",
+    "~/.spack/repos.yaml",
 ]
 
 

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -34,7 +34,8 @@ rm_configs = [
     "~/.spack/linux/compilers.yaml",
     "~/.spack/packages.yaml",
     "~/.spack/mirrors.yaml",
-    "~/.spack/repos.yaml",
+    "~/.spack/modules.yaml",
+    "~/.spack/config.yaml",
 ]
 
 

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -50,17 +50,12 @@ def tutorial(parser, args):
                 "https://spack-tutorial.readthedocs.io.",
                 "")
         tty.warn("This will modify your Spack configuration by:",
-                 "  - checking out a particular branch of Spack",
                  "  - deleting some configuration in ~/.spack",
                  "  - adding a mirror and trusting its public key",
+                 "  - checking out a particular branch of Spack",
                  "")
         if not tty.get_yes_or_no("Are you sure you want to proceed?"):
             tty.die("Aborted")
-
-    tty.msg("Ensuring we're on the releases/v0.15 branch")
-    git = which("git", required=True)
-    with working_dir(spack.paths.prefix):
-        git("checkout", tutorial_branch)
 
     rm_cmds = ["rm -f %s" % f for f in rm_configs]
     tty.msg("Reverting compiler and repository configuration", *rm_cmds)
@@ -77,3 +72,8 @@ def tutorial(parser, args):
     tty.msg("Ensuring that we trust tutorial binaries",
             "spack gpg trust %s" % tutorial_key)
     spack.util.gpg.trust(tutorial_key)
+
+    tty.msg("Ensuring we're on the releases/v0.15 branch")
+    git = which("git", required=True)
+    with working_dir(spack.paths.prefix):
+        git("checkout", tutorial_branch)

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -65,7 +65,7 @@ def tutorial(parser, args):
             shutil.rmtree(path, ignore_errors=True)
 
     tty.msg("Ensuring that the tutorial binary mirror is configured:",
-            "spack mirrror add tutorial %s" % tutorial_mirror)
+            "spack mirror add tutorial %s" % tutorial_mirror)
     mirror_config = syaml_dict()
     mirror_config["tutorial"] = tutorial_mirror
     spack.config.set('mirrors', mirror_config, scope="user")

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from __future__ import print_function
+
+import os.path
+import shutil
+
+import llnl.util.tty as tty
+from llnl.util.filesystem import working_dir
+
+import spack.cmd.common.arguments as arguments
+import spack.config
+import spack.paths
+import spack.util.gpg
+from spack.util.executable import which
+from spack.util.spack_yaml import syaml_dict
+
+
+description = "set up spack for our tutorial (WARNING: modifies config!)"
+section = "config"
+level = "long"
+
+
+# tutorial configuration parameters
+tutorial_branch = "releases/v0.15"
+tutorial_mirror = "s3://spack-tutorial-container/mirror/"
+tutorial_key    = os.path.join(spack.paths.share_path, "keys", "tutorial.pub")
+
+# configs to remove
+rm_configs = [
+    "~/.spack/linux/compilers.yaml",
+    "~/.spack/repos.yaml",
+    "~/.spack/mirrors.yaml",
+]
+
+
+def setup_parser(subparser):
+    arguments.add_common_arguments(subparser, ['yes_to_all'])
+
+
+def tutorial(parser, args):
+    if not spack.cmd.spack_is_git_repo():
+        tty.die("This command requires a git installation of Spack!")
+
+    if not args.yes_to_all:
+        tty.msg("This command will set up Spack for the tutorial at "
+                "https://spack-tutorial.readthedocs.io.",
+                "")
+        tty.warn("This will modify your Spack configuration by:",
+                 "  - checking out a particular branch of Spack",
+                 "  - deleting some configuration in ~/.spack",
+                 "  - adding a mirror and trusting its public key",
+                 "")
+        if not tty.get_yes_or_no("Are you sure you want to proceed?"):
+            tty.die("Aborted")
+
+    tty.msg("Ensuring we're on the releases/v0.15 branch")
+    git = which("git", required=True)
+    with working_dir(spack.paths.prefix):
+        git("checkout", tutorial_branch)
+
+    rm_cmds = ["rm -f %s" % f for f in rm_configs]
+    tty.msg("Reverting compiler and repository configuration", *rm_cmds)
+    for path in rm_configs:
+        if os.path.exists(path):
+            shutil.rmtree(path, ignore_errors=True)
+
+    tty.msg("Ensuring that the tutorial binary mirror is configured:",
+            "spack mirrror add tutorial %s" % tutorial_mirror)
+    mirror_config = syaml_dict()
+    mirror_config["tutorial"] = tutorial_mirror
+    spack.config.set('mirrors', mirror_config, scope="user")
+
+    tty.msg("Ensuring that we trust tutorial binaries",
+            "spack gpg trust %s" % tutorial_key)
+    spack.util.gpg.trust(tutorial_key)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -320,7 +320,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test undevelop uninstall unload url verify versions view"
+        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup spec stage test tutorial undevelop uninstall unload url verify versions view"
     fi
 }
 
@@ -1489,6 +1489,10 @@ _spack_test() {
     else
         _tests
     fi
+}
+
+_spack_tutorial() {
+    SPACK_COMPREPLY="-h --help -y --yes-to-all"
 }
 
 _spack_undevelop() {


### PR DESCRIPTION
Added a command to set up Spack for our tutorial at https://spack-tutorial.readthedocs.io.

The command does some common operations we need first-time users to do.

Specifically:

- checks out a particular branch of Spack
- deletes spurious configuration in `~/.spack` that might be
  left over from prior parts of the tutorial
- adds a mirror and trusts its public key

Example usage:

```console
$ spack tutorial
==> This command will set up Spack for the tutorial at https://spack-tutorial.readthedocs.io.
  
==> Warning: This will modify your Spack configuration by:
    - deleting some configuration in ~/.spack
    - adding a mirror and trusting its public key
    - checking out a particular branch of Spack
  
==> Are you sure you want to proceed? [y/n] y
==> Reverting compiler and repository configuration
  rm -f ~/.spack/linux/compilers.yaml
  rm -f ~/.spack/packages.yaml
  rm -f ~/.spack/mirrors.yaml
  rm -f ~/.spack/repos.yaml
==> Ensuring that the tutorial binary mirror is configured:
  spack mirrror add tutorial s3://spack-tutorial-container/mirror/
==> Ensuring that we trust tutorial binaries
  spack gpg trust /home/spack7/spack/share/spack/keys/tutorial.pub
gpgconf: socketdir is '/run/user/1007/gnupg'
gpg: key 95F8681195E239D8: "Spack Build Pipeline (Demo Key) <key@spack.demo>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
==> Ensuring we're on the releases/v0.15 branch
Switched to branch 'releases/v0.15'
Your branch is up to date with 'origin/releases/v0.15'.
```
