### PR TITLE
py-scipy: set F90 for all compilers

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -79,8 +79,7 @@ class PyScipy(PythonPackage):
 
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080
-        if self.spec.satisfies('%intel'):
-            env.set('F90', spack_fc)
+        env.set('F90', spack_fc)
 
         # https://github.com/scipy/scipy/issues/11611
         if self.spec.satisfies('@:1.4 %gcc@10:'):

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -78,6 +78,10 @@ class PyScipy(PythonPackage):
           sha256='5433f60831cb554101520a8f8871ac5a32c95f7a971ccd68b69049535b106780', when='@1.2:1.5.3')
 
     def setup_build_environment(self, env):
+        # https://github.com/scipy/scipy/issues/9080
+        if self.spec.satisfies('%intel'):
+            env.set('F90', spack_fc)
+
         # https://github.com/scipy/scipy/issues/11611
         if self.spec.satisfies('@:1.4 %gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')


### PR DESCRIPTION
This PR simply sets the F90 environment variable when compiling with Intel as suggested by [SciPy issue 9080](https://github.com/scipy/scipy/issues/9080).  Without this, the build script detects gfortran as the f90 compiler, resulting in runtime failures (e.g. missing symbols) when SciPy is subsequently used.