### PR TITLE
py-vermin: add latest version 1.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -8,11 +8,12 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url      = "https://github.com/netromdk/vermin/archive/v1.0.1.tar.gz"
+    url      = "https://github.com/netromdk/vermin/archive/v1.0.2.tar.gz"
 
     maintainers = ['netromdk']
     import_modules = ['vermin']
 
+    version('1.0.2', sha256='e999d5f5455e1116b366cd1dcc6fecd254c7ae3606549a61bc044216f9bb5b55')
     version('1.0.1', sha256='c06183ba653b9d5f6687a6686da8565fb127fab035f9127a5acb172b7c445079')
     version('1.0.0', sha256='e598e9afcbe3fa6f3f3aa894da81ccb3954ec9c0783865ecead891ac6aa57207')
     version('0.10.5', sha256='00601356e8e10688c52248ce0acc55d5b45417b462d5aa6887a6b073f0d33e0b')


### PR DESCRIPTION
I've released [version 1.0.2](https://github.com/netromdk/vermin/releases/tag/v1.0.2) which, among other things, fixes a bug on Windows.
@adamjstewart @alalazo 