### PR TITLE
[geant4] depends_on glu when +opengl

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -84,6 +84,7 @@ class Geant4(CMakePackage):
 
     # Visualization driver dependencies
     depends_on("gl", when='+opengl')
+    depends_on("glu", when='+opengl')
     depends_on("glx", when='+opengl+x11')
     depends_on("libx11", when='+x11')
     depends_on("libxmu", when='+x11')


### PR DESCRIPTION
geant4 depends on `glu`, not just `gl`, when using variant `+opengl`.

Relevant excerpt of `config/sys/Linux-g++.gmk` in geant4@10.6.2
```cmake
  ifndef OGLLIBS
    OGLLIBS   := -L$(OGLHOME)/lib$(ARCH) -lGLU -lGL
  endif
```

Maintainer tag: @drbenmorgan 

This fixes the following build error on centos7.
```
6 errors found in build log:
     44    GEANT4_USE_GDML: Building Geant4 with GDML support
     45    GEANT4_USE_G3TOG4: Building Geant3 ASCII call list reader library
     46    GEANT4_USE_QT: Build Geant4 with Qt support
     47    GEANT4_USE_PYTHON: Building bindings for Python 3.7
     48    
     49    -- Configuring done
  >> 50    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     51      Target "G4gl2ps" links to target "OpenGL::GLU" but the target was not
     52      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     53      an ALIAS target is missing?
     54    Call Stack (most recent call first):
     55      cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     56      source/visualization/externals/gl2ps/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
     57    
     58    
  >> 59    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     60      Target "G4OpenGL" links to target "OpenGL::GLU" but the target was not
     61      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     62      an ALIAS target is missing?
     63    Call Stack (most recent call first):
     64      cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     65      source/visualization/OpenGL/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
     66    
     67    
  >> 68    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     69      Target "G4OpenGL" links to target "OpenGL::GLU" but the target was not
     70      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     71      an ALIAS target is missing?
     72    Call Stack (most recent call first):
     73      cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     74      source/visualization/OpenGL/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
     75    
     76    
  >> 77    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     78      Target "G4gl2ps" links to target "OpenGL::GLU" but the target was not
     79      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     80      an ALIAS target is missing?
     81    Call Stack (most recent call first):
     82      cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     83      source/visualization/externals/gl2ps/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
     84    
     85    
  >> 86    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     87      Target "G4OpenGL" links to target "OpenGL::GLU" but the target was not
     88      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     89      an ALIAS target is missing?
     90    Call Stack (most recent call first):
     91      cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     92      source/visualization/OpenGL/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
     93    
     94    
  >> 95    CMake Error at cmake/Modules/G4DeveloperAPI_OLD.cmake:239 (add_library):
     96      Target "G4OpenGL" links to target "OpenGL::GLU" but the target was not
     97      found.  Perhaps a find_package() call is missing for an IMPORTED target, or
     98      an ALIAS target is missing?
     99    Call Stack (most recent call first):
     100     cmake/Modules/G4DeveloperAPI_OLD.cmake:427 (geant4_library_target)
     101     source/visualization/OpenGL/CMakeLists.txt:17 (GEANT4_GLOBAL_LIBRARY_TARGET)
```