### PR TITLE
add trilinos 13.0.1 [and update superlu-dist dependency]

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -36,6 +36,7 @@ class Trilinos(CMakePackage, CudaPackage):
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
     version('develop', branch='develop')
     version('master', branch='master')
+    version('13.0.1', commit='1ae207392fd36ad5bd24334c8b025c829765161f')  # yet to be tagged
     version('13.0.0', commit='9fec35276d846a667bc668ff4cbdfd8be0dfea08')  # tag trilinos-release-13-0-0
     version('12.18.1', commit='55a75997332636a28afc9db1aee4ae46fe8d93e7')  # tag trilinos-release-12-8-1
     version('12.14.1', sha256='52a4406cca2241f5eea8e166c2950471dd9478ad6741cbb2a7fc8225814616f0')
@@ -374,7 +375,8 @@ class Trilinos(CMakePackage, CudaPackage):
     depends_on('superlu-dist', when='+superlu-dist')
     depends_on('superlu-dist@:4.3', when='@11.14.1:12.6.1+superlu-dist')
     depends_on('superlu-dist@4.4:5.3', when='@12.6.2:12.12.1+superlu-dist')
-    depends_on('superlu-dist@5.4:6.2.0', when='@12.12.2:13.0+superlu-dist')
+    depends_on('superlu-dist@5.4:6.2.0', when='@12.12.2:13.0.0+superlu-dist')
+    depends_on('superlu-dist@6.3.0:', when='@13.0.1:+superlu-dist')
     depends_on('superlu-dist@develop', when='@develop+superlu-dist')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0+superlu-dist')
     depends_on('superlu+pic@4.3', when='+superlu')


### PR DESCRIPTION
cc: @jwillenbring 

Marked this as WIP to get feedback.

In case 13.0.1 gets tagged in the near future [before xsdk-0.6.0 PR] - we can update this PR.