### PR TITLE
Fix scalapack build error

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -73,11 +73,22 @@ class ScalapackBase(CMakePackage):
             '-DBLAS_LIBRARIES=%s' % (blas.joined(';'))
         ])
 
+        c_flags = []
         if '+pic' in spec:
-            options.extend([
-                "-DCMAKE_C_FLAGS=%s" % self.compiler.cc_pic_flag,
+            c_flags.append(self.compiler.cc_pic_flag)
+            options.append(
                 "-DCMAKE_Fortran_FLAGS=%s" % self.compiler.fc_pic_flag
-            ])
+            )
+
+        # Work around errors of the form:
+        #   error: implicit declaration of function 'BI_smvcopy' is
+        #   invalid in C99 [-Werror,-Wimplicit-function-declaration]
+        if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
+            c_flags.append('-Wno-error=implicit-function-declaration')
+
+        options.append(
+            self.define('CMAKE_C_FLAGS', ' '.join(c_flags))
+        )
 
         return options
 


### PR DESCRIPTION
On MacOS Catalina 10.15.7 building Scalapack 2.0.2 and 2.1.0 is not possible due to this warning
```
/<PATH>/spack-stage-netlib-scalapack-2.1.0-mnjgrebekoi6272ut6i3zyldgorynvcp/spack-src/BLACS/SRC/sgsum2d_.c:154:7: error: implicit declaration of function 'BI_smvcopy' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      BI_smvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
      ^
/<PATH>/spack-stage-netlib-scalapack-2.1.0-mnjgrebekoi6272ut6i3zyldgorynvcp/spack-src/BLACS/SRC/dgsum2d_.c:154:7: error: implicit declaration of function 'BI_dmvcopy' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      BI_dmvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
```
being promoted to an error. Although this should probably be fixed upstream, it does look like the warning has been around [for some time](https://clang.debian.net/logs/2013-01-28/blacs-mpi_1.1-31_unstable_clang.log) and so I'm guessing that its not a critical error. It builds fine for me, but I have not yet tested it.

Relates to https://github.com/dealii/dealii/issues/11138