### PR TITLE
autotools: change user writable before copy config.*

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -6,6 +6,7 @@ import inspect
 import itertools
 import os
 import os.path
+import stat
 from subprocess import PIPE
 from subprocess import check_call
 from typing import List  # novm
@@ -174,6 +175,8 @@ class AutotoolsPackage(PackageBase):
         # Copy the good files over the bad ones
         for abs_path in to_be_patched:
             name = os.path.basename(abs_path)
+            m = os.stat(abs_path).st_mode & 0o777 | stat.S_IWUSR
+            os.chmod(abs_path, m)
             fs.copy(substitutes[name], abs_path)
 
     @run_before('configure')

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -175,9 +175,10 @@ class AutotoolsPackage(PackageBase):
         # Copy the good files over the bad ones
         for abs_path in to_be_patched:
             name = os.path.basename(abs_path)
-            m = os.stat(abs_path).st_mode & 0o777 | stat.S_IWUSR
-            os.chmod(abs_path, m)
+            mode = os.stat(abs_path).st_mode
+            os.chmod(abs_path, mode & 0o777 | stat.S_IWUSR)
             fs.copy(substitutes[name], abs_path)
+            os.chmod(abs_path, mode)
 
     @run_before('configure')
     def _set_autotools_environment_variables(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -176,7 +176,7 @@ class AutotoolsPackage(PackageBase):
         for abs_path in to_be_patched:
             name = os.path.basename(abs_path)
             mode = os.stat(abs_path).st_mode
-            os.chmod(abs_path, mode & 0o777 | stat.S_IWUSR)
+            os.chmod(abs_path, stat.S_IWUSR)
             fs.copy(substitutes[name], abs_path)
             os.chmod(abs_path, mode)
 


### PR DESCRIPTION
In #18347, we changed copy of config.guess and config.sub.
But when these files is not allow user write, the copy is failed.
This PR fix this by change user writable before copt the files.