### PR TITLE
py-torchvision: gather correct cuda_arch setting from py-torch 

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -36,8 +36,6 @@ class PyTorchvision(PythonPackage):
     variant('backend', default='pil', description='Image backend',
             values=('pil', 'accimage', 'png', 'jpeg'), multi=False)
 
-    variant('cuda', default=False, description='Enable CUDA support')
-
     # https://github.com/pytorch/vision#installation
     depends_on('python@3.6:', when='@0.7:', type=('build', 'run'))
     depends_on('python@3.5:', when='@0.6.0:0.6.999', type=('build', 'run'))
@@ -62,9 +60,6 @@ class PyTorchvision(PythonPackage):
     depends_on('py-torch@1.2.0', when='@0.4.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.1.0', when='@0.3.0', type=('build', 'link', 'run'))
     depends_on('py-torch@:1.0.1', when='@0.2.2', type=('build', 'link', 'run'))
-
-    depends_on('py-torch+cuda', when="+cuda")
-    depends_on('py-torch~cuda', when="~cuda")
 
     # https://github.com/pytorch/vision/issues/1712
     depends_on('pil@4.1.1:6', when='@:0.4 backend=pil', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -36,6 +36,8 @@ class PyTorchvision(PythonPackage):
     variant('backend', default='pil', description='Image backend',
             values=('pil', 'accimage', 'png', 'jpeg'), multi=False)
 
+    variant('cuda', default=False, description='Enable CUDA support')
+
     # https://github.com/pytorch/vision#installation
     depends_on('python@3.6:', when='@0.7:', type=('build', 'run'))
     depends_on('python@3.5:', when='@0.6.0:0.6.999', type=('build', 'run'))
@@ -60,6 +62,9 @@ class PyTorchvision(PythonPackage):
     depends_on('py-torch@1.2.0', when='@0.4.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.1.0', when='@0.3.0', type=('build', 'link', 'run'))
     depends_on('py-torch@:1.0.1', when='@0.2.2', type=('build', 'link', 'run'))
+
+    depends_on('py-torch+cuda', when="+cuda")
+    depends_on('py-torch~cuda', when="~cuda")
 
     # https://github.com/pytorch/vision/issues/1712
     depends_on('pil@4.1.1:6', when='@:0.4 backend=pil', type=('build', 'run'))
@@ -98,5 +103,10 @@ class PyTorchvision(PythonPackage):
         if '+cuda' in self.spec['py-torch']:
             env.set('FORCE_CUDA', 1)
             env.set('CUDA_HOME', self.spec['cuda'].prefix)
+            pytorch_cuda_arch = ';'.join(
+                '{0:.1f}'.format(float(i) / 10.0) for i in
+                self.spec['py-torch'].variants['cuda_arch'].value
+            )
+            env.set('TORCH_CUDA_ARCH_LIST', pytorch_cuda_arch)
         else:
             env.set('FORCE_CUDA', 0)


### PR DESCRIPTION
The current py-torchvision recipe does not specify the CUDA arch so the build falls back to autodetection which may or may not match the users needs (buildhost, fat binaries etc.).

This PR brings py-torchvision into line with the other py-torch plugins like py-torch-cluster and gets the cuda_arch variant setting from the py-torch version it builds against.

(Alternative is make it a full CudaPackage, but some logic would still be required to ensure cuda_arch is matched with the underlying py-torch.