### PR TITLE
xsdk@0.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -16,6 +16,7 @@ class Alquimia(CMakePackage):
     maintainers = ['smolins', 'balay']
 
     version('develop')
+    version('xsdk-0.6.0', commit='9a0aedd3a927d4d5e837f8fd18b74ad5a78c3821')
     version('xsdk-0.5.0', commit='8397c3b00a09534c5473ff3ab21f0e32bb159380')
     version('xsdk-0.4.0', commit='2edad6733106142d014bb6e6a73c2b21d5e3cf2d')
     version('xsdk-0.3.0', tag='xsdk-0.3.0')
@@ -26,6 +27,7 @@ class Alquimia(CMakePackage):
 
     depends_on('mpi')
     depends_on('hdf5')
+    depends_on('pflotran@xsdk-0.6.0', when='@xsdk-0.6.0')
     depends_on('pflotran@xsdk-0.5.0', when='@xsdk-0.5.0')
     depends_on('pflotran@xsdk-0.4.0', when='@xsdk-0.4.0')
     depends_on('pflotran@xsdk-0.3.0', when='@xsdk-0.3.0')

--- a/var/spack/repos/builtin/packages/petsc/disable-DEPRECATED_ENUM.diff
+++ b/var/spack/repos/builtin/packages/petsc/disable-DEPRECATED_ENUM.diff
@@ -1,0 +1,43 @@
+diff --git a/include/petscksp.h b/include/petscksp.h
+index 11806c115f..ba49dfaf6c 100644
+--- a/include/petscksp.h
++++ b/include/petscksp.h
+@@ -464,7 +464,7 @@ PETSC_EXTERN PetscErrorCode KSPSetSupportedNorm(KSP ksp,KSPNormType,PCSide,Petsc
+ PETSC_EXTERN PetscErrorCode KSPSetCheckNormIteration(KSP,PetscInt);
+ PETSC_EXTERN PetscErrorCode KSPSetLagNorm(KSP,PetscBool);
+ 
+-#define KSP_DIVERGED_PCSETUP_FAILED_DEPRECATED KSP_DIVERGED_PCSETUP_FAILED PETSC_DEPRECATED_ENUM("Use KSP_DIVERGED_PC_FAILED (since version 3.11)")
++#define KSP_DIVERGED_PCSETUP_FAILED_DEPRECATED KSP_DIVERGED_PCSETUP_FAILED
+ /*E
+     KSPConvergedReason - reason a Krylov method was said to have converged or diverged
+ 
+diff --git a/include/petscsnes.h b/include/petscsnes.h
+index 27c6169209..d0e1ef8f77 100644
+--- a/include/petscsnes.h
++++ b/include/petscsnes.h
+@@ -186,7 +186,7 @@ PETSC_EXTERN PetscErrorCode SNESSetJacobianDomainError(SNES);
+ PETSC_EXTERN PetscErrorCode SNESSetCheckJacobianDomainError(SNES,PetscBool);
+ PETSC_EXTERN PetscErrorCode SNESGetCheckJacobianDomainError(SNES,PetscBool*);
+ 
+-#define SNES_CONVERGED_TR_DELTA_DEPRECATED SNES_CONVERGED_TR_DELTA PETSC_DEPRECATED_ENUM("Use SNES_DIVERGED_TR_DELTA (since version 3.12)")
++#define SNES_CONVERGED_TR_DELTA_DEPRECATED SNES_CONVERGED_TR_DELTA
+ /*E
+     SNESConvergedReason - reason a SNES method was said to
+          have converged or diverged
+diff --git a/include/petscviewer.h b/include/petscviewer.h
+index 2db3276b07..75e0a5a659 100644
+--- a/include/petscviewer.h
++++ b/include/petscviewer.h
+@@ -108,9 +108,9 @@ PETSC_EXTERN PetscErrorCode PetscViewerWritable(PetscViewer,PetscBool*);
+ PETSC_EXTERN PetscErrorCode PetscViewerCheckReadable(PetscViewer);
+ PETSC_EXTERN PetscErrorCode PetscViewerCheckWritable(PetscViewer);
+ 
+-#define PETSC_VIEWER_ASCII_VTK_ATTR        PETSC_VIEWER_ASCII_VTK        PETSC_DEPRECATED_ENUM("Legacy VTK deprecated; use PetscViewerVTKOpen() with XML (.vtr .vts .vtu) format (since 3.14)")
+-#define PETSC_VIEWER_ASCII_VTK_CELL_ATTR   PETSC_VIEWER_ASCII_VTK_CELL   PETSC_DEPRECATED_ENUM("Legacy VTK deprecated; use PetscViewerVTKOpen() with XML (.vtr .vts .vtu) format (since 3.14)")
+-#define PETSC_VIEWER_ASCII_VTK_COORDS_ATTR PETSC_VIEWER_ASCII_VTK_COORDS PETSC_DEPRECATED_ENUM("Legacy VTK deprecated; use PetscViewerVTKOpen() with XML (.vtr .vts .vtu) format (since 3.14)")
++#define PETSC_VIEWER_ASCII_VTK_ATTR        PETSC_VIEWER_ASCII_VTK
++#define PETSC_VIEWER_ASCII_VTK_CELL_ATTR   PETSC_VIEWER_ASCII_VTK_CELL
++#define PETSC_VIEWER_ASCII_VTK_COORDS_ATTR PETSC_VIEWER_ASCII_VTK_COORDS
+ /*E
+     PetscViewerFormat - Way a viewer presents the object
+ 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -160,10 +160,9 @@ class Petsc(Package):
     # the patch is an adaptation of the original commit to 3.7.5
     patch('macos-clang-8.1.0.diff', when='@3.7.5%apple-clang@8.1.0:')
     patch('pkg-config-3.7.6-3.8.4.diff', when='@3.7.6:3.8.4')
-
     patch('xcode_stub_out_of_sync.patch', when='@:3.10.4')
-
     patch('xlf_fix-dup-petscfecreate.patch', when='@3.11.0')
+    patch('disable-DEPRECATED_ENUM.diff', when='@3.14.1 +cuda')
 
     depends_on('diffutils', type='build')
 

--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -18,6 +18,7 @@ class Pflotran(AutotoolsPackage):
     maintainers = ['ghammond86', 'balay']
 
     version('develop')
+    version('xsdk-0.6.0', commit='46e14355c1827c057f2e1b3e3ae934119ab023b2')
     version('xsdk-0.5.0', commit='98a959c591b72f73373febf5f9735d2c523b4c20')
     version('xsdk-0.4.0', commit='c851cbc94fc56a32cfdb0678f3c24b9936a5584e')
     version('xsdk-0.3.0', branch='release/xsdk-0.3.0')
@@ -26,6 +27,7 @@ class Pflotran(AutotoolsPackage):
     depends_on('mpi')
     depends_on('hdf5@1.8.12:+mpi+fortran+hl')
     depends_on('petsc@develop:+hdf5+metis', when='@develop')
+    depends_on('petsc@3.14:+hdf5+metis', when='@xsdk-0.6.0')
     depends_on('petsc@3.12:+hdf5+metis', when='@xsdk-0.5.0')
     depends_on('petsc@3.10:+hdf5+metis', when='@xsdk-0.4.0')
     depends_on('petsc@xsdk-0.2.0+hdf5+metis', when='@xsdk-0.2.0')

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -19,6 +19,7 @@ class Xsdk(BundlePackage):
     maintainers = ['balay', 'luszczek']
 
     version('develop')
+    version('0.6.0')
     version('0.5.0')
     version('0.4.0')
     version('0.3.0')
@@ -27,6 +28,7 @@ class Xsdk(BundlePackage):
     variant('debug', default=False, description='Compile in debug mode')
     variant('cuda', default=False, description='Enable CUDA dependent packages')
     variant('trilinos', default=True, description='Enable trilinos package build')
+    variant('datatransferkit', default=True, description='Enable datatransferkit package build')
     variant('omega-h', default=True, description='Enable omega-h package build')
     variant('strumpack', default=True, description='Enable strumpack package build')
     variant('dealii', default=True, description='Enable dealii package build')
@@ -36,26 +38,33 @@ class Xsdk(BundlePackage):
     variant('precice', default=(sys.platform != 'darwin'),
             description='Enable precice package build')
     variant('butterflypack', default=True, description='Enable butterflypack package build')
+    variant('heffte', default=True, description='Enable heffte package build')
+    variant('slate', default=True, description='Enable slate package build')
 
     depends_on('hypre@develop+superlu-dist+shared', when='@develop')
+    depends_on('hypre@2.20.0+superlu-dist+shared', when='@0.6.0')
     depends_on('hypre@2.18.2+superlu-dist+shared', when='@0.5.0')
     depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
     depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
     depends_on('hypre@xsdk-0.2.0~internal-superlu', when='@xsdk-0.2.0')
 
-    depends_on('mfem@develop+mpi+superlu-dist+petsc~sundials+examples+miniapps', when='@develop')
+    depends_on('mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@develop')
+    depends_on('mfem@4.2.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.6.0')
     depends_on('mfem@4.0.1-xsdk+mpi~superlu-dist+petsc+sundials+examples+miniapps', when='@0.5.0')
     depends_on('mfem@3.4.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.4.0')
     depends_on('mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
 
     depends_on('superlu-dist@develop', when='@develop')
+    depends_on('superlu-dist@6.4.0', when='@0.6.0')
     depends_on('superlu-dist@6.1.1', when='@0.5.0')
     depends_on('superlu-dist@6.1.0', when='@0.4.0')
     depends_on('superlu-dist@5.2.2', when='@0.3.0')
     depends_on('superlu-dist@xsdk-0.2.0', when='@xsdk-0.2.0')
 
-    depends_on('trilinos@develop+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
+    depends_on('trilinos@develop+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards gotype=int',
                when='@develop +trilinos')
+    depends_on('trilinos@13.0.1+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus~dtk+intrepid2+shards gotype=int',
+               when='@0.6.0 +trilinos')
     depends_on('trilinos@12.18.1+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
                when='@0.5.0 +trilinos')
     depends_on('trilinos@12.14.1+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
@@ -65,11 +74,15 @@ class Xsdk(BundlePackage):
     depends_on('trilinos@xsdk-0.2.0+hypre+superlu-dist+metis+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan2~amesos2~exodus',
                when='@xsdk-0.2.0 +trilinos')
 
+    depends_on('datatransferkit@3.1-rc2', when='@0.6.0 +trilinos +datatransferkit')
+
     depends_on('petsc +trilinos', when='+trilinos')
-    depends_on('petsc ~trilinos', when='~trilinos')
+    depends_on('petsc +cuda', when='+cuda @0.6.0:')
     depends_on('petsc +batch', when='platform=cray @0.5.0:')
     depends_on('petsc@develop+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@develop')
+    depends_on('petsc@3.14.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+               when='@0.6.0')
     depends_on('petsc@3.12.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@0.5.0')
     depends_on('petsc@3.10.3+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
@@ -79,67 +92,83 @@ class Xsdk(BundlePackage):
     depends_on('petsc@xsdk-0.2.0+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@xsdk-0.2.0')
 
-    depends_on('dealii +trilinos', when='+trilinos +dealii')
+    depends_on('dealii +trilinos~adol-c', when='+trilinos +dealii')
     depends_on('dealii ~trilinos', when='~trilinos +dealii')
     depends_on('dealii@develop~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@develop +dealii')
+    depends_on('dealii@9.2.0~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@0.6.0 +dealii')
     depends_on('dealii@9.1.1~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@0.5.0 +dealii')
     depends_on('dealii@9.0.1~assimp~python~doc~gmsh+petsc~slepc+mpi~int64+hdf5~netcdf+metis~ginkgo~symengine', when='@0.4.0 +dealii')
 
     depends_on('pflotran@develop', when='@develop')
+    depends_on('pflotran@xsdk-0.6.0', when='@0.6.0')
     depends_on('pflotran@xsdk-0.5.0', when='@0.5.0')
     depends_on('pflotran@xsdk-0.4.0', when='@0.4.0')
     depends_on('pflotran@xsdk-0.3.0', when='@0.3.0')
     depends_on('pflotran@xsdk-0.2.0', when='@xsdk-0.2.0')
 
     depends_on('alquimia@develop', when='@develop')
+    depends_on('alquimia@xsdk-0.6.0', when='@0.6.0')
     depends_on('alquimia@xsdk-0.5.0', when='@0.5.0')
     depends_on('alquimia@xsdk-0.4.0', when='@0.4.0')
     depends_on('alquimia@xsdk-0.3.0', when='@0.3.0')
     depends_on('alquimia@xsdk-0.2.0', when='@xsdk-0.2.0')
 
-    depends_on('sundials+superlu-dist', when='@0.5.0: %gcc@6.1:')
-    depends_on('sundials@develop~int64+hypre+petsc', when='@develop')
-    depends_on('sundials@5.0.0~int64+hypre+petsc', when='@0.5.0')
+    depends_on('sundials +cuda', when='+cuda @0.6.0:')
+    depends_on('sundials +trilinos', when='+trilinos @0.6.0:')
+    depends_on('sundials@develop~int64+hypre+petsc+superlu-dist', when='@develop')
+    depends_on('sundials@5.5.0~int64+hypre+petsc+superlu-dist', when='@0.6.0')
+    depends_on('sundials@5.0.0~int64+hypre+petsc+superlu-dist', when='@0.5.0')
     depends_on('sundials@3.2.1~int64+hypre', when='@0.4.0')
     depends_on('sundials@3.1.0~int64+hypre', when='@0.3.0')
 
-    depends_on('plasma@19.8.1:', when='@develop %gcc@6.0:')
+    depends_on('plasma@20.9.20:', when='@develop %gcc@6.0:')
+    depends_on('plasma@20.9.20:', when='@0.6.0 %gcc@6.0:')
     depends_on('plasma@19.8.1:', when='@0.5.0 %gcc@6.0:')
     depends_on('plasma@18.11.1:', when='@0.4.0 %gcc@6.0:')
 
-    depends_on('magma@2.5.1', when='@develop +cuda')
+    depends_on('magma@2.5.4', when='@develop +cuda')
+    depends_on('magma@2.5.4', when='@0.6.0 +cuda')
     depends_on('magma@2.5.1', when='@0.5.0 +cuda')
     depends_on('magma@2.4.0', when='@0.4.0 +cuda')
     depends_on('magma@2.2.0', when='@0.3.0 +cuda')
 
     depends_on('amrex@develop', when='@develop %intel')
     depends_on('amrex@develop', when='@develop %gcc')
+    depends_on('amrex@20.10', when='@0.6.0 %intel')
+    depends_on('amrex@20.10', when='@0.6.0 %gcc')
     depends_on('amrex@19.08', when='@0.5.0 %intel')
     depends_on('amrex@19.08', when='@0.5.0 %gcc')
     depends_on('amrex@18.10.1', when='@0.4.0 %intel')
     depends_on('amrex@18.10.1', when='@0.4.0 %gcc')
 
     depends_on('slepc@develop', when='@develop')
+    depends_on('slepc@3.14.0', when='@0.6.0')
     depends_on('slepc@3.12.0', when='@0.5.0')
     depends_on('slepc@3.10.1', when='@0.4.0')
 
     depends_on('omega-h +trilinos', when='+trilinos +omega-h')
     depends_on('omega-h ~trilinos', when='~trilinos +omega-h')
     depends_on('omega-h@develop', when='@develop +omega-h')
+    depends_on('omega-h@9.32.5', when='@0.6.0 +omega-h')
     depends_on('omega-h@9.29.0', when='@0.5.0 +omega-h')
     depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
 
+    depends_on('strumpack ~cuda', when='~cuda @0.6.0:')
     depends_on('strumpack@master', when='@develop +strumpack')
+    depends_on('strumpack@5.0.0', when='@0.6.0 +strumpack')
     depends_on('strumpack@3.3.0', when='@0.5.0 +strumpack')
     depends_on('strumpack@3.1.1', when='@0.4.0 +strumpack')
 
     depends_on('pumi@develop', when='@develop')
+    depends_on('pumi@2.2.5', when='@0.6.0')
     depends_on('pumi@2.2.1', when='@0.5.0')
     depends_on('pumi@2.2.0', when='@0.4.0')
 
     tasmanian_openmp = '~openmp' if sys.platform == 'darwin' else '+openmp'
     depends_on('tasmanian@develop+xsdkflags+blas' + tasmanian_openmp, when='@develop')
     depends_on('tasmanian@develop+xsdkflags+blas+cuda+magma' + tasmanian_openmp, when='@develop +cuda')
+    depends_on('tasmanian@7.3+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.6.0')
+    depends_on('tasmanian@7.3+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.6.0 +cuda')
     depends_on('tasmanian@7.0+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.5.0')
     depends_on('tasmanian@7.0+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.5.0 +cuda')
     depends_on('tasmanian@6.0+xsdkflags+blas~openmp', when='@0.4.0')
@@ -153,25 +182,39 @@ class Xsdk(BundlePackage):
 
     depends_on('phist kernel_lib=tpetra', when='+trilinos +phist')
     depends_on('phist kernel_lib=petsc', when='~trilinos +phist')
-    depends_on('phist@develop ~fortran ~scamac ~openmp ~host', when='@develop +phist')
-    depends_on('phist@1.8.0 ~fortran ~scamac ~openmp ~host', when='@0.5.0 +phist')
-    depends_on('phist@1.7.5 ~fortran ~scamac ~openmp ~host', when='@0.4.0 +phist')
+    depends_on('phist@develop ~fortran ~scamac ~host', when='@develop +phist')
+    depends_on('phist@1.9.3 ~fortran ~scamac ~openmp ~host ~int64', when='@0.6.0 +phist')
+    depends_on('phist@1.8.0 ~fortran ~scamac ~openmp ~host ~int64', when='@0.5.0 +phist')
+    depends_on('phist@1.7.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.4.0 +phist')
 
     depends_on('ginkgo@develop ~openmp', when='@develop +ginkgo')
     depends_on('ginkgo@develop ~openmp+cuda', when='@develop +ginkgo +cuda')
+    depends_on('ginkgo@1.3.0 ~openmp', when='@0.6.0 +ginkgo')
+    depends_on('ginkgo@1.3.0 ~openmp+cuda', when='@0.6.0 +cuda +ginkgo')
     depends_on('ginkgo@1.1.0 ~openmp', when='@0.5.0 +ginkgo')
     depends_on('ginkgo@1.1.0 ~openmp+cuda', when='@0.5.0 +cuda +ginkgo')
 
     depends_on('py-libensemble@develop+petsc4py', type='run', when='@develop +libensemble')
+    depends_on('py-libensemble@0.7.1+petsc4py', type='run', when='@0.6.0 +libensemble')
     depends_on('py-libensemble@0.5.2+petsc4py', type='run', when='@0.5.0 +libensemble')
     depends_on('py-petsc4py@3.12.0', type='run', when='@0.5.0 +libensemble')
 
     depends_on('precice ~petsc', when='platform=cray +precice')
     depends_on('precice@develop', when='@develop +precice')
+    depends_on('precice@2.1.1', when='@0.6.0 +precice')
     depends_on('precice@1.6.1', when='@0.5.0 +precice')
 
     depends_on('butterflypack@master', when='@develop +butterflypack')
+    depends_on('butterflypack@1.2.1', when='@0.6.0 +butterflypack')
     depends_on('butterflypack@1.1.0', when='@0.5.0 +butterflypack')
+
+    depends_on('heffte +fftw+cuda+magma', when='+cuda +heffte')
+    depends_on('openmpi +cuda', when='+cuda +heffte')
+    depends_on('heffte@develop+fftw', when='@develop +heffte')
+    depends_on('heffte@2.0.0+fftw', when='@0.6.0 +heffte')
+
+    depends_on('slate@2020.10.00 ~cuda', when='~cuda +slate %gcc@6.0:')
+    depends_on('slate@2020.10.00 +cuda', when='+cuda +slate %gcc@6.0:')
 
     # xSDKTrilinos depends on the version of Trilinos built with
     # +tpetra which is turned off for faster xSDK


### PR DESCRIPTION
```
Update:
 hypre@2.20.0
 mfem@4.2.0
 superlu-dist@6.4.0
 trilinos@13.0.1
 datatransferkit@3.1-rc2
 petsc@3.14.1
 dealii@9.2.0
 pflotran@xsdk-0.6.0
 alquimia@xsdk-0.6.0
 sundials@5.5.0
 plasma@20.9.20
 magma@2.5.4
 amrex@20.10
 slepc@3.14.0
 omega-h@9.32.5
 strumpack@5.0.0
 pumi@2.2.5
 tasmanian@7.3
 phist@1.9.3
 ginkgo@1.3.0
 py-libensemble@0.7.1
 precice@2.1.1
 butterflypack@1.2.1

New:
 heffte@2.0.0
 slate@2020.10.00

Variants:
 datatransferkit
 heffte
 slate

petsc: enable +cuda
sundials: enable +cuda +trilinos
strumpack: enable +cuda

```
cc: @ulrikeyang