### PR TITLE
openblas: Fix to build v0.3.11 or later with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas_fujitsu_v0.3.11.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas_fujitsu_v0.3.11.patch
@@ -1,0 +1,14 @@
+--- spack-src/f_check.org	2020-11-11 10:48:18.827643938 +0900
++++ spack-src/f_check	2020-11-11 10:51:46.448618264 +0900
+@@ -69,7 +69,10 @@
+ 	    $bu       = "_";
+ 	}
+ 
+-	if ($data =~ /GNU/ || $data =~ /GCC/ ) {
++        if ($data =~ /Fujitsu/) {
++            $vendor = FUJITSU;
++            $openmp = "-Kopenmp";
++        } elsif ($data =~ /GNU/ || $data =~ /GCC/ ) {
+ 
+ 	    $data =~ /(\d+)\.(\d+).(\d+)/;
+ 	    $major = $1;

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -108,8 +108,9 @@ class Openblas(MakefilePackage):
           when='@0.3.8:0.3.10 %apple-clang@12.0.0:')
 
     # Add conditions to f_check to determine the Fujitsu compiler
-    patch('openblas_fujitsu.patch', when='%fj')
-    patch('openblas_fujitsu2.patch', when='@0.3.10 %fj')
+    patch('openblas_fujitsu.patch', when='@:0.3.10 %fj')
+    patch('openblas_fujitsu_v0.3.11.patch', when='@0.3.11: %fj')
+    patch('openblas_fujitsu2.patch', when='@0.3.10: %fj')
 
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')


### PR DESCRIPTION
Add patch for building v0.3.11 or later with Fujitsu compiler.