### PR TITLE
py-numpy: Add Fujitsu Fortran compiler to compiler type.

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
@@ -1,0 +1,56 @@
+diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
+--- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
++++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
+@@ -0,0 +1,38 @@
++from numpy.distutils.fcompiler import FCompiler
++
++compilers = ['FJFCompiler']
++
++class FJFCompiler(FCompiler):
++    compiler_type = 'fj'
++    description = 'Fujitsu Fortran Compiler'
++
++    possible_executables = ['frt']
++    version_pattern = r'frt \(FRT\) (?P<version>[a-z\d.]+)'
++    # $ frt --version
++    # frt (FRT) x.x.x yyyymmdd
++
++    executables = {
++        'version_cmd'  : ["<F77>", "--version"],
++        'compiler_f77' : ["frt", "-Fixed"],
++        'compiler_fix' : ["frt", "-Fixed"],
++        'compiler_f90' : ["frt"],
++        'linker_so'    : ["frt", "-shared"],
++        'archiver'     : ["ar", "-cr"],
++        'ranlib'       : ["ranlib"]
++        }
++    pic_flags = ['-KPIC']
++    module_dir_switch = '-M'
++    module_include_switch = '-I'
++
++    def get_flags_opt(self):
++        return ['-O3']
++    def get_flags_debug(self):
++        return ['-g']
++    def runtime_library_dir_option(self, dir):
++        return f'-Wl,-rpath={dir}'
++
++if __name__ == '__main__':
++    from distutils import log
++    from numpy.distutils import customized_fcompiler
++    log.set_verbosity(2)
++    print(customized_fcompiler('fj').get_version())
+diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/numpy/distutils/fcompiler/__init__.py
+--- numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:51:35.693490207 +0900
++++ numpy-1.19.4/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:56:30.434878812 +0900
+@@ -745,8 +745,8 @@
+     ('win32', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95',
+                'intelvem', 'intelem', 'flang')),
+     ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
+-    ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
+-                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
++    ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
++                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
+     ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
+     ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
+     ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
@@ -1,6 +1,6 @@
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
+--- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 17:55:57.608802456 +0900
 @@ -0,0 +1,38 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
@@ -40,13 +40,13 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
 +    print(customized_fcompiler('fj').get_version())
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/numpy/distutils/fcompiler/__init__.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:51:35.693490207 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:48:49.316744476 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
+--- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:55:31.638677631 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:56:29.978957954 +0900
 @@ -746,7 +746,7 @@
                 'intelvem', 'intelem', 'flang')),
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
-     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
+     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
 -                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
 +                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
@@ -1,6 +1,6 @@
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
+--- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:30:06.698641953 +0900
 @@ -0,0 +1,38 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
@@ -33,20 +33,20 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +    def get_flags_debug(self):
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
-+        return f'-Wl,-rpath={dir}'
++        return '-Wl,-rpath=%s' %dir
 +
 +if __name__ == '__main__':
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
 +    print(customized_fcompiler('fj').get_version())
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/numpy/distutils/fcompiler/__init__.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:51:35.693490207 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:48:49.316744476 +0900
-@@ -746,7 +746,7 @@
+diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
+--- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:25:26.087294181 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:26:19.987553070 +0900
+@@ -750,7 +750,7 @@
                 'intelvem', 'intelem', 'flang')),
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
-     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
+     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
 -                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
 +                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
@@ -1,6 +1,6 @@
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
+--- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:42:47.672297372 +0900
 @@ -0,0 +1,38 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
@@ -33,22 +33,22 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +    def get_flags_debug(self):
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
-+        return f'-Wl,-rpath={dir}'
++        return '-Wl,-rpath=%s' %dir
 +
 +if __name__ == '__main__':
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
 +    print(customized_fcompiler('fj').get_version())
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/numpy/distutils/fcompiler/__init__.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:51:35.693490207 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:48:49.316744476 +0900
-@@ -746,7 +746,7 @@
-                'intelvem', 'intelem', 'flang')),
+diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
+--- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:43:18.112443626 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:44:54.062904636 +0900
+@@ -709,7 +709,7 @@
+                'intelvem', 'intelem')),
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
-     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
--                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
-+                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
+     ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
+-                'intele', 'intelem', 'gnu', 'g95', 'pathf95')),
++                'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'fj')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
      ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
      ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -105,7 +105,10 @@ class PyNumpy(PythonPackage):
     patch('blas-lapack-order.patch', when='@1.15:1.16')
 
     # Add Fujitsu Fortran compiler
-    patch('add_fj_compiler.patch', when='%fj')
+    patch('add_fj_compiler.patch', when='@1.19.3:%fj')
+    patch('add_fj_compiler2.patch', when='@1.19.0:1.19.2%fj')
+    patch('add_fj_compiler3.patch', when='@1.14.0:1.18.5%fj')
+    patch('add_fj_compiler4.patch', when='@:1.13.3%fj')
 
     # GCC 4.8 is the minimum version that works
     conflicts('%gcc@:4.7', msg='GCC 4.8+ required')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -104,6 +104,9 @@ class PyNumpy(PythonPackage):
     # https://github.com/numpy/numpy/pull/13132
     patch('blas-lapack-order.patch', when='@1.15:1.16')
 
+    # Add Fujitsu Fortran compiler
+    patch('add_fj_compiler.patch', when='%fj')
+
     # GCC 4.8 is the minimum version that works
     conflicts('%gcc@:4.7', msg='GCC 4.8+ required')
 

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -84,6 +84,8 @@ class PyScipy(PythonPackage):
 
     def build_args(self, spec, prefix):
         args = []
+        if spec.satisfies('%fj'):
+            args.extend(['config_fc', '--fcompiler=fj'])
 
         # Build in parallel
         # Known problems with Python 3.5+


### PR DESCRIPTION
When building `py-scipy` with Fujitsu compiler, gcc's commands were recognized as f90/fix compiler.
```
Fortran f77 compiler: /pathtospack/spack/lib/spack/env/fj/frt -Wall -g -ffixed-form -fno-second-underscore -fPIC
Fortran f90 compiler: /usr/bin/gfortran -Wall -g -fno-second-underscore -fPIC
Fortran fix compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -Wall -g -fno-second-underscore -fPIC
```
So, I added Fujitsu fortran compiler to compiler types of `py-numpy`.
(I'm considering proposing this fix to upstream as well)
And I specified Fujitsu to fortran compiler types when building `py-scipy` with Fujitsu compiler.