### PR TITLE
openfoam: remove mplibUSER provisioning

### DIFF
--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -17,9 +17,7 @@
 ##############################################################################
 #
 # Notes
-# - mpi handling: WM_MPLIB=USER and provide wmake rules for special purpose
-#   'USER and 'USERMPI' mpi implementations.
-#   The choice of 'USER' vs 'USERMPI' may change in the future.
+# - mpi handling: WM_MPLIB=USERMPI and generate mplibUSERMPI wmake rules.
 #
 # Changes
 # 2017-03-28 Mark Olesen <mark.olesen@esi-group.com>
@@ -99,7 +97,7 @@ class FoamExtend(Package):
     # Some user config settings
     config = {
         'label-size': False,    # <- No int32/int64 support
-        'mplib': 'USERMPI',     # USER | USERMPI
+        'mplib': 'USERMPI',     # USERMPI
     }
 
     # The openfoam architecture, compiler information etc

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+#
+# Original Author: Mark Olesen <mark.olesen@esi-group.com>
+#
 # Legal Notice
 # ------------
 # OPENFOAM is a trademark owned by OpenCFD Ltd
@@ -20,13 +23,12 @@
 # - The openfoam-org package is a modified version of the openfoam package.
 #   If changes are needed here, consider if they should also be applied there.
 #
+# - mpi handling: WM_MPLIB=SYSTEMMPI and populate prefs.{csh,sh} with values
+#   from spack.
+#
 # - Building with boost/cgal is not included, since some of the logic is not
 #   entirely clear and thus untested.
 # - Resolution of flex, zlib needs more attention (within OpenFOAM)
-#
-# - mpi handling: WM_MPLIB=SYSTEMMPI and use spack to populate prefs.sh for it.
-#   Provide wmake rules for special purpose 'USER' and 'USERMPI'
-#   mpi implementations, in case these are required.
 #
 # Known issues
 # - Combining +zoltan with +int64 has not been tested, but probably won't work.
@@ -129,7 +131,7 @@ class OpenfoamOrg(Package):
     @property
     def config(self):
         settings = {
-            # Use system mpi for spack
+            # Use SYSTEMMPI since openfoam-org doesn't have USERMPI
             'mplib': 'SYSTEMMPI',
 
             # Add links into bin/, lib/ (eg, for other applications)

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -20,9 +20,8 @@
 ##############################################################################
 #
 # Notes
-# - mpi handling: WM_MPLIB=USERMPI and use spack to populate an appropriate
-#   configuration and generate wmake rules for 'USER' and 'USERMPI'
-#   mpi implementations.
+# - mpi handling: WM_MPLIB=USERMPI and use spack to generate mplibUSERMPI
+#   wmake rules.
 #
 # - Resolution of flex, zlib needs more attention (within OpenFOAM)
 # - +paraview:
@@ -359,7 +358,7 @@ class Openfoam(Package):
 
     # Some user config settings
     # default: 'compile-option': '-spack',
-    # default: 'mplib': 'USERMPI',     # Use user mpi for spack
+    # default: 'mplib': 'USERMPI',  # User-defined mpi for spack
     config = {
         # Add links into bin/, lib/ (eg, for other applications)
         'link':  False
@@ -978,7 +977,7 @@ class OpenfoamArch(object):
         return True
 
     def create_rules(self, projdir, foam_pkg):
-        """ Create {c,c++}-spack and mplib{USER,USERMPI}
+        """ Create {c,c++}-spack and mplib{USERMPI}
         rules in the specified project directory.
         The compiler rules are based on the respective {c,c++}Opt rules
         but with additional rpath information for the OpenFOAM libraries.
@@ -1019,12 +1018,13 @@ class OpenfoamArch(object):
                             outfile.write('\n')
 
             # MPI rules
-            for mplib in ['mplibUSER', 'mplibUSERMPI']:
+            for mplib in ['mplibUSERMPI']:
                 with open(mplib, 'w') as out:
-                    out.write("""# Use mpi from spack ({name})\n
+                    out.write("""# MPI from spack ({name})\n
 PFLAGS  = {FLAGS}
 PINC    = {PINC}
 PLIBS   = {PLIBS}
+#-------
 """.format(**user_mpi))
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- has never been used by the spack package or by the upstream package