### PR TITLE
fix typo wrt target=graviton

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -11,7 +11,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.1.2 (commit 6e1b6502bb0a743d44a5eed7cfbbb84b4b817c43)
+* Version: 0.1.2 (commit 2846749dc5b12ae2b30ff1d3f0270a4a5954710d)
 
 argparse
 --------

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -1490,7 +1490,7 @@
               },
               {
                   "versions": "6:",
-                  "flags" : "-march==armv8-a+crc+crypto -mtune=cortex-a72"
+                  "flags" : "-march=armv8-a+crc+crypto -mtune=cortex-a72"
               }
           ],
           "clang" : [


### PR DESCRIPTION
This fixes spack build on aarch64 box

Ref:  https://github.com/spack/spack/issues/19653