### PR TITLE
yaml-cpp: Improve shared library building

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -23,9 +23,7 @@ class YamlCpp(CMakePackage):
     version('0.3.0', sha256='ab8d0e07aa14f10224ed6682065569761f363ec44bc36fcdb2946f6d38fe5a89')
 
     variant('shared', default=True,
-            description='Enable build of shared libraries')
-    variant('static', default=False,
-            description='Build with static libraries')
+            description='Build shared instead of static libraries')
     variant('pic',   default=True,
             description='Build with position independent code')
     variant('tests', default=False,
@@ -60,18 +58,13 @@ class YamlCpp(CMakePackage):
         return (flags, None, None)
 
     def cmake_args(self):
-        spec = self.spec
         options = []
 
         options.extend([
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DBUILD_STATIC_LIBS=%s' % (
-                'ON' if '+static' in spec else 'OFF'),
-            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
-                'ON' if '+pic' in spec else 'OFF'),
-            '-DYAML_CPP_BUILD_TESTS:BOOL=%s' % (
-                'ON' if '+tests' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('YAML_BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
+            self.define_from_variant('YAML_CPP_BUILD_TESTS', 'tests'),
         ])
 
         return options


### PR DESCRIPTION
* No version of yaml-cpp in spack can build shared AND static libraries at the same time. So drop the "static" variant and let "shared" handle that alone.

  Or in other words: No version handles the BUILD_STATIC_LIBS flag.

* The flag for building shared libraries changed from BUILD_SHARED_LIBS to YAML_BUILD_SHARED_LIBS at some point. So just pass both flags.

* Use the newer define_from_variant.