### PR TITLE
kokkos add "graviton" to spack_micro_arch_map

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -83,6 +83,7 @@ class Kokkos(CMakePackage, CudaPackage):
     conflicts("+hip", when="amd_gpu_arch=none")
 
     spack_micro_arch_map = {
+        "graviton": "",
         "aarch64": "",
         "arm": "",
         "ppc": "",

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -84,6 +84,7 @@ class Kokkos(CMakePackage, CudaPackage):
 
     spack_micro_arch_map = {
         "graviton": "",
+        "graviton2": "",
         "aarch64": "",
         "arm": "",
         "ppc": "",


### PR DESCRIPTION
```
==> Installing trilinos
==> No binary for trilinos found: installing from source
==> trilinos: Executing phase: 'cmake'
==> Error: KeyError: 'graviton'

/home/balay/spack/var/spack/repos/builtin/packages/trilinos/package.py:744, in cmake_args:
        741
        742        options.append(define(
        743            "Kokkos_ARCH_" +
  >>    744            Kokkos.spack_micro_arch_map[spec.target.name].upper(),
        745            True))
        746
        747        # ################# Miscellaneous Stuff ######################
```

cc: @jjwilke 