### PR TITLE
WRF: Add version 3.9.1.1 and improve recipe robustness

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -5,8 +5,53 @@
 
 from spack import *
 
+from sys import stdout
 import glob
-import tempfile
+from os import O_NONBLOCK, rename
+from os.path import basename, join as path_join
+from fcntl import fcntl, F_GETFL, F_SETFL
+from subprocess import Popen, PIPE
+import time
+from llnl.util import tty
+import re
+
+re_optline = re.compile(r'\s+[0-9]+\..*\((serial|smpar|dmpar|dm\+sm)\)\s+')
+re_paroptname = re.compile(r'\((serial|smpar|dmpar|dm\+sm)\)')
+re_paroptnum = re.compile(r'\s+([0-9]+)\.\s+\(')
+re_nestline = re.compile(r'\(([0-9]+=[^)0-9]+)+\)')
+re_nestoptnum = re.compile(r'([0-9]+)=')
+re_nestoptname = re.compile(r'=([^,)]+)')
+
+
+def setNonBlocking(fd):
+    """
+    Set the given file descriptor to non-blocking
+    """
+    flags = fcntl(fd, F_GETFL) | O_NONBLOCK
+    fcntl(fd, F_SETFL, flags)
+
+
+def collect_platform_options(stdoutpipe):
+    # Attempt to parse to collect options
+    optiondict = {}
+    for line in stdoutpipe.splitlines():
+        if re_optline.match(line):
+            numbers = re_paroptnum.findall(line)
+            entries = re_paroptname.findall(line)
+            paropts = dict(zip(entries, numbers))
+            platline = re_optline.sub("", line).strip()
+            optiondict[platline] = paropts
+
+    return optiondict
+
+
+def collect_nesting_options(stdoutpipe):
+    nestoptline = re_nestline.search(stdoutpipe)[0]
+    nestoptnum = re_nestoptnum.findall(nestoptline)
+    nestoptname = re_nestoptname.findall(nestoptline)
+    nestoptname = [x.replace(" ", "_") for x in nestoptname]
+
+    return dict(zip(nestoptname, nestoptnum))
 
 
 class Wrf(Package):
@@ -15,132 +60,309 @@ class Wrf(Package):
     for both atmospheric research and operational forecasting applications.
     """
 
-    homepage = "https://www.mmm.ucar.edu/weather-research-and-forecasting-model"
-    url      = "https://github.com/wrf-model/WRF/archive/v4.2.tar.gz"
-    maintainers = ['MichaelLaufer']
+    homepage = (
+        "https://www.mmm.ucar.edu/weather-research-and-forecasting-model"
+    )
+    url = "https://github.com/wrf-model/WRF/archive/v4.2.tar.gz"
+    maintainers = ["ptooley"]
+    parallel = False
 
-    version('4.2', sha256='c39a1464fd5c439134bbd39be632f7ce1afd9a82ad726737e37228c6a3d74706')
-    version('4.0', sha256='a5b072492746f96a926badda7e6b44cb0af26695afdd6c029a94de5e1e5eec73')
+    version(
+        "4.2",
+        sha256="c39a1464fd5c439134bbd39be632f7ce1afd9a82ad726737e37228c6a3d74706",
+    )
+    version(
+        "4.0",
+        sha256="9718f26ee48e6c348d8e28b8bc5e8ff20eafee151334b3959a11b7320999cf65",
+    )
+    version(
+        "3.9.1.1",
+        sha256="a04f5c425bedd262413ec88192a0f0896572cc38549de85ca120863c43df047a",
+        url="https://github.com/wrf-model/WRF/archive/V3.9.1.1.tar.gz",
+    )
 
-    variant('build_type', default='dmpar',
-            values=('serial', 'smpar', 'dmpar', 'dmsm'))
+    variant(
+        "build_type",
+        default="dmpar",
+        values=("serial", "smpar", "dmpar", "dm+sm"),
+    )
 
-    variant('nesting', default='basic',
-            values=('basic', 'preset', 'vortex'))
+    variant(
+        "nesting",
+        default="basic",
+        values=("no_nesting", "basic", "preset_moves", "vortex_following"),
+    )
 
-    variant('compile_type', default='em_real',
-            values=('em_real', 'em_quarter_ss', 'em_b_wave', 'em_les',
-                    'em_heldsuarez', 'em_tropical_cyclone', 'em_hill2d_x',
-                    'em_squall2d_x', 'em_squall2d_y', 'em_grav2d_x',
-                    'em_seabreeze2d_x', 'em_scm_xy'))
+    variant(
+        "compile_type",
+        default="em_real",
+        values=(
+            "em_real",
+            "em_quarter_ss",
+            "em_b_wave",
+            "em_les",
+            "em_heldsuarez",
+            "em_tropical_cyclone",
+            "em_hill2d_x",
+            "em_squall2d_x",
+            "em_squall2d_y",
+            "em_grav2d_x",
+            "em_seabreeze2d_x",
+            "em_scm_xy",
+        ),
+    )
 
-    variant('pnetcdf', default=True,
-            description='Parallel IO support through Pnetcdf libray')
+    variant(
+        "pnetcdf",
+        default=True,
+        description="Parallel IO support through Pnetcdf libray",
+    )
+
+    patch("patches/3.9/netcdf_backport.patch", when="@3.9.1.1")
+    patch("patches/3.9/tirpc_detect.patch", when="@3.9.1.1")
+    patch("patches/3.9/add_aarch64.patch", when="@3.9.1.1")
 
     # These patches deal with netcdf & netcdf-fortran being two diff things
     # Patches are based on:
     # https://github.com/easybuilders/easybuild-easyconfigs/blob/master/easybuild/easyconfigs/w/WRF/WRF-3.5_netCDF-Fortran_separate_path.patch
-    patch('patches/4.0/arch.Config.pl.patch', when='@4.0')
-    patch('patches/4.0/arch.configure.defaults.patch', when='@4.0')
-    patch('patches/4.0/arch.conf_tokens.patch', when='@4.0')
-    patch('patches/4.0/arch.postamble.patch', when='@4.0')
-    patch('patches/4.0/configure.patch', when='@4.0')
-    patch('patches/4.0/external.io_netcdf.makefile.patch', when='@4.0')
-    patch('patches/4.0/Makefile.patch', when='@4.0')
+    patch("patches/4.0/arch.Config.pl.patch", when="@4.0")
+    patch("patches/4.0/arch.configure.defaults.patch", when="@4.0")
+    patch("patches/4.0/arch.conf_tokens.patch", when="@4.0")
+    patch("patches/4.0/arch.postamble.patch", when="@4.0")
+    patch("patches/4.0/configure.patch", when="@4.0")
+    patch("patches/4.0/external.io_netcdf.makefile.patch", when="@4.0")
+    patch("patches/4.0/Makefile.patch", when="@4.0")
+    patch("patches/4.0/tirpc_detect.patch", when="@4.0")
+    patch("patches/4.0/add_aarch64.patch", when="@4.0")
 
-    patch('patches/4.2/arch.Config.pl.patch', when='@4.2')
-    patch('patches/4.2/arch.configure.defaults.patch', when='@4.2')
-    patch('patches/4.2/arch.conf_tokens.patch', when='@4.2')
-    patch('patches/4.2/arch.postamble.patch', when='@4.2')
-    patch('patches/4.2/configure.patch', when='@4.2')
-    patch('patches/4.2/external.io_netcdf.makefile.patch', when='@4.2')
-    patch('patches/4.2/var.gen_be.Makefile.patch', when='@4.2')
-    patch('patches/4.2/Makefile.patch', when='@4.2')
+    patch("patches/4.2/arch.Config.pl.patch", when="@4.2")
+    patch("patches/4.2/arch.configure.defaults.patch", when="@4.2")
+    patch("patches/4.2/arch.conf_tokens.patch", when="@4.2")
+    patch("patches/4.2/arch.postamble.patch", when="@4.2")
+    patch("patches/4.2/configure.patch", when="@4.2")
+    patch("patches/4.2/external.io_netcdf.makefile.patch", when="@4.2")
+    patch("patches/4.2/var.gen_be.Makefile.patch", when="@4.2")
+    patch("patches/4.2/Makefile.patch", when="@4.2")
+    patch("patches/4.2/tirpc_detect.patch", when="@4.2")
+    patch("patches/4.2/add_aarch64.patch", when="@4.2")
 
-    depends_on('mpi')
+    depends_on("pkg-config", type=("build"))
+    depends_on("libtirpc")
+
+    depends_on("mpi")
     # According to:
     # http://www2.mmm.ucar.edu/wrf/users/docs/user_guide_v4/v4.0/users_guide_chap2.html#_Required_Compilers_and_1
     # Section: "Required/Optional Libraries to Download"
-    depends_on('parallel-netcdf', when='+pnetcdf')
-    depends_on('netcdf-c')
-    depends_on('netcdf-fortran')
-    depends_on('jasper')
-    depends_on('libpng')
-    depends_on('zlib')
-    depends_on('perl')
+    depends_on("parallel-netcdf", when="+pnetcdf")
+    depends_on("netcdf-c")
+    depends_on("netcdf-fortran")
+    depends_on("jasper")
+    depends_on("libpng")
+    depends_on("zlib")
+    depends_on("perl")
     # not sure if +fortran is required, but seems like a good idea
-    depends_on('hdf5+fortran+hl+mpi')
+    depends_on("hdf5+fortran+hl+mpi")
     # build script use csh
-    depends_on('tcsh', type=('build'))
+    depends_on("tcsh", type=("build"))
     # time is not installed on all systems b/c bash provides it
     # this fixes that for csh install scripts
-    depends_on('time', type=('build'))
-    depends_on('m4', type='build')
-    depends_on('libtool', type='build')
-    phases = ['configure', 'build', 'install']
+    depends_on("time", type=("build"))
+    depends_on("m4", type="build")
+    depends_on("libtool", type="build")
+    phases = ["configure", "build", "install"]
 
     def setup_build_environment(self, env):
-        env.set('NETCDF', self.spec['netcdf-c'].prefix)
-        if '+pnetcdf' in self.spec:
-            env.set('PNETCDF', self.spec['parallel-netcdf'].prefix)
+        env.set("NETCDF", self.spec["netcdf-c"].prefix)
+        if "+pnetcdf" in self.spec:
+            env.set("PNETCDF", self.spec["parallel-netcdf"].prefix)
         # This gets used via the applied patch files
-        env.set('NETCDFF', self.spec['netcdf-fortran'].prefix)
-        env.set('PHDF5', self.spec['hdf5'].prefix)
-        env.set('JASPERINC', self.spec['jasper'].prefix.include)
-        env.set('JASPERLIB', self.spec['jasper'].prefix.lib)
+        env.set("NETCDFF", self.spec["netcdf-fortran"].prefix)
+        env.set("PHDF5", self.spec["hdf5"].prefix)
+        env.set("JASPERINC", self.spec["jasper"].prefix.include)
+        env.set("JASPERLIB", self.spec["jasper"].prefix.lib)
 
-        if self.spec.satisfies('%gcc@10:'):
-            args = '-w -O2 -fallow-argument-mismatch -fallow-invalid-boz'
-            env.set('FCFLAGS', args)
-            env.set('FFLAGS', args)
+        if self.spec.satisfies("%gcc@10:"):
+            args = "-w -O2 -fallow-argument-mismatch -fallow-invalid-boz"
+            env.set("FCFLAGS", args)
+            env.set("FFLAGS", args)
 
     def patch(self):
         # Let's not assume csh is intalled in bin
-        files = glob.glob('*.csh')
+        files = glob.glob("*.csh")
 
-        filter_file('^#!/bin/csh -f', '#!/usr/bin/env csh', *files)
-        filter_file('^#!/bin/csh', '#!/usr/bin/env csh', *files)
+        filter_file("^#!/bin/csh -f", "#!/usr/bin/env csh", *files)
+        filter_file("^#!/bin/csh", "#!/usr/bin/env csh", *files)
+
+    def answer_configure_question(self, outputbuf):
+
+        # Platform options question:
+        if "Please select from among the following" in outputbuf:
+            options = collect_platform_options(outputbuf)
+            comp_pair = "%s/%s" % (
+                basename(self.compiler.fc),
+                basename(self.compiler.cc),
+            )
+            compiler_matches = {
+                x: y for x, y in options.items() if comp_pair in x.lower()
+            }
+            if len(compiler_matches) > 1:
+                tty.warn("Found multiple potential build options")
+            try:
+                compiler_key = min(compiler_matches.keys(), key=len)
+                tty.warn("Selected build option %s." % compiler_key)
+                return (
+                    "%s\n"
+                    % compiler_matches[compiler_key][
+                        self.spec.variants["build_type"].value
+                    ]
+                )
+            except KeyError:
+                InstallError(
+                    "build_type %s unsupported for %s compilers"
+                    % (self.spec.variants["build_type"].value, comp_pair)
+                )
+
+        if "Compile for nesting?" in outputbuf:
+            options = collect_nesting_options(outputbuf)
+            try:
+                return "%s\n" % options[self.spec.variants["nesting"].value]
+            except KeyError:
+                InstallError("Failed to parse correct nesting option")
+
+    def do_configure_fixup(self):
+        # Fix mpi compiler wrapper aliases
+        if (
+            self.spec.satisfies("@3.9.1.1")
+            and self.spec.compiler.name == "gcc"
+        ):
+            rename(
+                "./arch/configure_new.defaults",
+                "./arch/configure_new.defaults.bak",
+            )
+            with open("./arch/configure_new.defaults.bak", "rt") as ifh, open(
+                "./arch/configure_new.defaults", "wt"
+            ) as ofh:
+                for line in ifh:
+                    if line.startswith("DM_"):
+                        line = line.replace("mpif90 -f90=$(SFC)", "mpif90")
+                        line = line.replace("mpicc -cc=$(SCC)", "mpicc")
+                    ofh.write(line)
 
     def configure(self, spec, prefix):
-        build_opts = {"gcc":   {"serial": '32',
-                                "smpar":  '33',
-                                "dmpar":  '34',
-                                "dmsm":   '35'},
-                      "intel": {"serial": '13',
-                                "smpar":  '14',
-                                "dmpar":  '15',
-                                "dmsm":   '16'},
-                      "pgi":   {"serial": '52',
-                                "smpar":  '53',
-                                "dmpar":  '54',
-                                "dmsm":   '55'},
-                      }
 
-        nesting_opts = {"basic":  "1",
-                        "preset": "2",
-                        "vortex": "3"}
+        # Remove broken default options...
+        self.do_configure_fixup()
 
-        try:
-            compiler_opts = build_opts[self.spec.compiler.name]
-        except KeyError:
-            raise InstallError("Compiler not recognized nor supported.")
+        if self.spec.compiler.name not in ["intel", "gcc"]:
+            raise InstallError(
+                "Compiler %s not currently supported for WRF build."
+                % self.spec.compiler.name
+            )
 
-        # Spack already makes sure that the variant value is part of the set.
-        build_type = compiler_opts[spec.variants['build_type'].value]
+        p = Popen("./configure", stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        setNonBlocking(p.stdout)
+        setNonBlocking(p.stderr)
 
-        nesting_value = nesting_opts[spec.variants['nesting'].value]
+        # Because of WRFs custom configure scripts that require interactive
+        # input we need to parse and respond to questions.  The details can
+        # vary somewhat with the exact version, so try to detect and fail
+        # gracefully on unexpected questions.
+        stallcounter = 0
+        outputbuf = ""
+        while True:
+            line = p.stderr.readline().decode()
+            if not line:
+                line = p.stdout.readline().decode()
+            if not line:
+                if p.poll() is not None:
+                    returncode = p.returncode
+                    break
+                if stallcounter > 300:
+                    raise InstallError(
+                        "Output stalled for 30s, presumably an "
+                        "undetected question."
+                    )
+                time.sleep(0.1)  # Try to do a bit of rate limiting
+                stallcounter += 1
+                continue
+            stdout.write(line)
+            stallcounter = 0
+            outputbuf += line
+            if (
+                "Enter selection" in outputbuf
+                or "Compile for nesting" in outputbuf
+            ):
+                answer = self.answer_configure_question(outputbuf)
+                p.stdin.write(answer.encode())
+                p.stdin.flush()
+                outputbuf = ""
 
-        with tempfile.TemporaryFile(mode='w') as fp:
-            fp.write(build_type + '\n' + nesting_value + '\n')
-            fp.seek(0)
-            Executable('./configure')(input=fp)
+        if returncode != 0:
+            raise InstallError("Configure failed - unknown error")
+
+    def run_compile_script(self):
+        csh_bin = path_join(self.spec["tcsh"].prefix, "bin/csh")
+
+        compilation = Popen(
+            [
+                csh_bin,
+                "./compile",
+                "-j",
+                "10",
+                self.spec.variants["compile_type"].value,
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        setNonBlocking(compilation.stdout)
+        setNonBlocking(compilation.stderr)
+        tty.warn("Running compile")
+
+        stallcounter = 0
+        result_buf = ""
+        while True:
+            line = compilation.stderr.readline().decode()
+            if not line:
+                line = compilation.stdout.readline().decode()
+            if not line:
+                if compilation.poll() is not None:
+                    returncode = compilation.returncode
+                    break
+                if stallcounter > 3000:
+                    raise InstallError(
+                        "Output stalled for 300s, presuming an "
+                        "undetected question."
+                    )
+                time.sleep(0.1)  # Try to do a bit of rate limiting
+                stallcounter += 1
+                continue
+
+            stallcounter = 0
+            stdout.write(line)
+            result_buf += line
+
+        if "Executables successfully built" in result_buf and returncode == 0:
+            return True
+
+        return False
 
     def build(self, spec, prefix):
-        csh = which('csh')
+
         # num of compile jobs capped at 20 in wrf
-        csh('./compile', '-j', str(min(int(make_jobs), 20)),
-            spec.variants['compile_type'].value)
+        result = self.run_compile_script()
+
+        if not result:
+            tty.warn(
+                "Compilation failed first time (WRF idiosyncrasies?) "
+                "trying again"
+            )
+            result = self.run_compile_script()
+
+        if not result:
+            raise InstallError(
+                "Compile failed. Check the output log for details."
+            )
 
     def install(self, spec, prefix):
         # Save all install files as many are needed for WPS and WRF runs
-        install_tree('.', prefix)
+        install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -215,10 +215,7 @@ class Wrf(Package):
 
     def do_configure_fixup(self):
         # Fix mpi compiler wrapper aliases
-        if (
-            self.spec.satisfies("@3.9.1.1")
-            and self.spec.compiler.name == "gcc"
-        ):
+        if self.spec.satisfies("@3.9.1.1 %gcc"):
             rename(
                 "./arch/configure_new.defaults",
                 "./arch/configure_new.defaults.bak",
@@ -228,8 +225,12 @@ class Wrf(Package):
             ) as ofh:
                 for line in ifh:
                     if line.startswith("DM_"):
-                        line = line.replace("mpif90 -f90=$(SFC)", "mpif90")
-                        line = line.replace("mpicc -cc=$(SCC)", "mpicc")
+                        line = line.replace(
+                            "mpif90 -f90=$(SFC)", self.spec['mpi'].mpif90
+                        )
+                        line = line.replace(
+                            "mpicc -cc=$(SCC)", self.spec['mpi'].mpicc
+                        )
                     ofh.write(line)
 
     def configure(self, spec, prefix):
@@ -289,7 +290,7 @@ class Wrf(Package):
         csh = Executable(csh_bin)
 
         # num of compile jobs capped at 20 in wrf
-        num_jobs = str(make_jobs if make_jobs < 20 else 20)
+        num_jobs = str(min(int(make_jobs, 10)))
 
         # Now run the compile script and track the output to check for
         # failure/success We need to do this because upstream use `make -i -k`

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -220,18 +220,17 @@ class Wrf(Package):
                 "./arch/configure_new.defaults",
                 "./arch/configure_new.defaults.bak",
             )
-            with open("./arch/configure_new.defaults.bak", "rt") as ifh, open(
-                "./arch/configure_new.defaults", "wt"
-            ) as ofh:
-                for line in ifh:
-                    if line.startswith("DM_"):
-                        line = line.replace(
-                            "mpif90 -f90=$(SFC)", self.spec['mpi'].mpif90
-                        )
-                        line = line.replace(
-                            "mpicc -cc=$(SCC)", self.spec['mpi'].mpicc
-                        )
-                    ofh.write(line)
+            with open("./arch/configure_new.defaults.bak", "rt") as ifh:
+                with open("./arch/configure_new.defaults", "wt") as ofh:
+                    for line in ifh:
+                        if line.startswith("DM_"):
+                            line = line.replace(
+                                "mpif90 -f90=$(SFC)", self.spec['mpi'].mpif90
+                            )
+                            line = line.replace(
+                                "mpicc -cc=$(SCC)", self.spec['mpi'].mpicc
+                            )
+                        ofh.write(line)
 
     def configure(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -186,9 +186,9 @@ class Wrf(Package):
                 basename(self.compiler.fc),
                 basename(self.compiler.cc),
             )
-            compiler_matches = {
-                x: y for x, y in options.items() if comp_pair in x.lower()
-            }
+            compiler_matches = dict(
+                (x, y) for x, y in options.items() if comp_pair in x.lower()
+            )
             if len(compiler_matches) > 1:
                 tty.warn("Found multiple potential build options")
             try:

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/add_aarch64.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/add_aarch64.patch
@@ -1,0 +1,124 @@
+From bee649e663c8117943077793061d3608314b51db Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Fri, 16 Oct 2020 13:20:24 +0100
+Subject: [PATCH] add aarch64 gcc support
+
+---
+ arch/configure_new.defaults | 101 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 101 insertions(+)
+
+diff --git a/arch/configure_new.defaults b/arch/configure_new.defaults
+index 4f76bc21..be98ac25 100644
+--- a/arch/configure_new.defaults
++++ b/arch/configure_new.defaults
+@@ -1917,6 +1917,107 @@ RANLIB          =      ranlib
+ RLFLAGS		=	
+ CC_TOOLS        =      $(SCC) 
+ 
++###########################################################
++#ARCH    CYGWIN_NT i686 x86_64 Cygwin, gfortran compiler with gcc  #serial smpar dmpar dm+sm
++#
++DESCRIPTION     =       GNU ($SFC/$SCC)
++DMPARALLEL      =       # 1
++OMPCPP          =       # -D_OPENMP
++OMP             =       # -fopenmp
++OMPCC           =       # -fopenmp
++SFC             =       gfortran
++SCC             =       gcc
++CCOMP           =       gcc
++DM_FC           =       mpif90
++DM_CC           =       mpicc
++FC              =       CONFIGURE_FC
++CC              =       CONFIGURE_CC
++LD              =       $(FC)
++RWORDSIZE       =       CONFIGURE_RWORDSIZE
++PROMOTION       =       #-fdefault-real-8
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
++CFLAGS_LOCAL    =       -w -O3 -c
++LDFLAGS_LOCAL   =       
++CPLUSPLUSLIB    =       
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
++FCREDUCEDOPT	=       $(FCOPTIM)
++FCNOOPT		=       -O0
++FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
++FORMAT_FIXED    =       -ffixed-form
++FORMAT_FREE     =       -ffree-form -ffree-line-length-none
++FCSUFFIX        =       
++BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FFLAGS)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =     
++TRADFLAG        =      -traditional
++CPP             =      /lib/cpp -P
++AR              =      ar
++ARFLAGS         =      ru
++M4              =      m4 -G
++RANLIB          =      ranlib
++RLFLAGS		=	
++CC_TOOLS        =      $(SCC)
++
++LIB_EXTERNAL    = \
++                     $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
++		     -L CONFIGURE_NETCDF_PATH -lnetcdff -lnetcdf -lnetcdf -ltirpc -lhdf5_hl -lhdf5 -lm -lz \
++		     CONFIGURE_GRIB2_LIB
++ESMF_IO_LIB     =    $(WRF_SRC_ROOT_DIR)/external/esmf_time_f90/libesmf_time.a
++LIB_BUNDLED     = \
++                     $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
++                     $(ESMF_IO_LIB) \
++                     CONFIGURE_COMMS_LIB \
++                     $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
++                     $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
++
++###########################################################
++#ARCH    Linux aarch64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
++#
++DESCRIPTION     =       Arm GNU ($SFC/$SCC): Aarch64
++DMPARALLEL      =       # 1
++OMPCPP          =       # -D_OPENMP
++OMP             =       # -fopenmp
++OMPCC           =       # -fopenmp
++SFC             =       gfortran
++SCC             =       gcc
++CCOMP           =       gcc
++DM_FC           =       mpif90 
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       CONFIGURE_FC
++CC              =       CONFIGURE_CC
++LD              =       $(FC)
++RWORDSIZE       =       CONFIGURE_RWORDSIZE
++PROMOTION       =       #-fdefault-real-8
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
++CFLAGS_LOCAL    =       -w -O3 -c -march=native -mtune=native
++DFLAGS_LOCAL   =       
++CPLUSPLUSLIB    =       
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=native -mtune=native
++FCREDUCEDOPT	=       $(FCOPTIM)
++FCNOOPT		=       -O0
++FCDEBUG         =       -g # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
++FORMAT_FIXED    =       -ffixed-form
++FORMAT_FREE     =       -ffree-form -ffree-line-length-none
++FCSUFFIX        =       
++BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =     
++TRADFLAG        =      CONFIGURE_TRADFLAG
++CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
++AR              =      ar
++ARFLAGS         =      ru
++M4              =      m4 -G
++RANLIB          =      ranlib
++RLFLAGS		=	
++CC_TOOLS        =      $(SCC) 
++
+ #insert new stanza here
+ 
+ ###########################################################
+-- 
+2.28.0
+

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/netcdf_backport.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/netcdf_backport.patch
@@ -1,0 +1,578 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2017-08-28 21:29:47.000000000 +0100
++++ b/Makefile	2020-10-15 14:20:18.745280481 +0100
+@@ -868,14 +868,14 @@
+ 	@ echo '--------------------------------------'
+ 	( cd frame ; $(MAKE) $(J) framework; \
+           cd ../external/io_netcdf ; \
+-          $(MAKE) NETCDFPATH="$(NETCDFPATH)" \
+-               FC="$(FC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
++          $(MAKE) NETCDFPATH="$(NETCDFPATH)" FNETCDFFPATH="$(NETCDFFPATH)" \
++               C="$(FC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
+                CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" TRADFLAG="$(TRADFLAG)" ESMF_IO_LIB_EXT="$(ESMF_IO_LIB_EXT)" \
+ 	       LIB_LOCAL="$(LIB_LOCAL)" \
+                ESMF_MOD_DEPENDENCE="$(ESMF_MOD_DEPENDENCE)" AR="INTERNAL_BUILD_ERROR_SHOULD_NOT_NEED_AR" diffwrf; \
+           cd ../io_netcdf ; \
+-          $(MAKE) NETCDFPATH="$(NETCDFPATH)" \
+-               FC="$(SFC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
++          $(MAKE) NETCDFPATH="$(NETCDFPATH)" FNETCDFFPATH="$(NETCDFFPATH)"\
++               C="$(SFC) $(FCBASEOPTS) $(PROMOTION) $(FCDEBUG) $(OMP)" RANLIB="$(RANLIB)" \
+                CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" TRADFLAG="$(TRADFLAG)" ESMF_IO_LIB_EXT="$(ESMF_IO_LIB_EXT)" \
+ 	       LIB_LOCAL="$(LIB_LOCAL)" \
+                ESMF_MOD_DEPENDENCE="$(ESMF_MOD_DEPENDENCE)" AR="INTERNAL_BUILD_ERROR_SHOULD_NOT_NEED_AR"; \
+diff -Naur a/arch/Config_new.pl b/arch/Config_new.pl
+--- a/arch/Config_new.pl	2017-08-28 21:29:47.000000000 +0100
++++ b/arch/Config_new.pl	2020-10-15 14:34:48.371350270 +0100
+@@ -8,6 +8,7 @@
+ select((select(STDOUT), $|=1)[0]);
+ $sw_perl_path = perl ;
+ $sw_netcdf_path = "" ;
++$sw_netcdff_path = "" ;
+ $sw_pnetcdf_path = "" ;
+ $sw_hdf5_path=""; 
+ $sw_phdf5_path=""; 
+@@ -64,6 +65,10 @@
+   {
+     $sw_netcdf_path = substr( $ARGV[0], 8 ) ;
+   }
++  if (substr( $ARGV[0], 1, 8) eq "netcdff=" )
++  {
++    $sw_netcdff_path = substr( $ARGV[0], 9) ;
++  }
+   if ( substr( $ARGV[0], 1, 13 ) eq "dep_lib_path=" )
+   {
+     $sw_dep_lib_path = substr( $ARGV[0], 14 ) ;
+@@ -118,6 +123,7 @@
+   if ( substr( $ARGV[0], 1, 11 ) eq "USENETCDFF=" )
+   {
+     $sw_usenetcdff = substr( $ARGV[0], 12 ) ;
++    $sw_usenetcdff =~ s/!/ /g ;
+   }
+   if ( substr( $ARGV[0], 1, 10 ) eq "USENETCDF=" )
+   {
+@@ -445,6 +451,7 @@
+   {
+     $_ =~ s/CONFIGURE_PERL_PATH/$sw_perl_path/g ;
+     $_ =~ s/CONFIGURE_NETCDF_PATH/$sw_netcdf_path/g ;
++    $_ =~ s/CONFIGURE_NETCDFF_PATH/$sw_netcdff_path/g ;
+     $_ =~ s/CONFIGURE_PNETCDF_PATH/$sw_pnetcdf_path/g ;
+     $_ =~ s/CONFIGURE_HDF5_PATH/$sw_hdf5_path/g ;
+     $_ =~ s/CONFIGURE_PHDF5_PATH/$sw_phdf5_path/g ;
+diff -Naur a/arch/conf_tokens b/arch/conf_tokens
+--- a/arch/conf_tokens	2017-08-28 21:29:47.000000000 +0100
++++ b/arch/conf_tokens	2020-10-15 14:24:02.231298416 +0100
+@@ -5,6 +5,7 @@
+        CONFIGURE_DMPARALLEL
+ CONFIGURE_RWORDSIZE
+ CONFIGURE_NETCDF_FLAG
++CONFIGURE_NETCDFF_FLAG
+ CONFIGURE_GRIB2_FLAG
+ CONFIGURE_NETCDF_LIB_PATH
+ CONFIGURE_GRIB2_LIB
+@@ -13,4 +14,5 @@
+ CONFIGURE_WRFIO_NF 
+ CONFIGURE_WRFIO_GRIB2 
+ CONFIGURE_NETCDF_PATH
++CONFIGURE_NETCDFF_PATH
+ CONFIGURE_GRIB2_INC
+diff -Naur a/arch/configure_new.defaults b/arch/configure_new.defaults
+--- a/arch/configure_new.defaults	2017-08-28 21:29:47.000000000 +0100
++++ b/arch/configure_new.defaults	2020-10-15 14:25:07.821303680 +0100
+@@ -1598,6 +1598,7 @@
+ 
+ LIB_EXTERNAL    = \
+                      ../external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.lib \
++                     CONFIGURE_NETCDFF_PATH/lib/libnetcdff.lib
+                      ../external/wavelet/libWavelet.a ../external/wavelet/lib_wavelet.a
+ ESMF_IO_LIB     =    ../external/esmf_time_f90/libesmf_time.a
+ LIB_BUNDLED     = \
+diff -Naur a/arch/postamble_new b/arch/postamble_new
+--- a/arch/postamble_new	2017-08-28 21:29:47.000000000 +0100
++++ b/arch/postamble_new	2020-10-15 14:25:31.037305543 +0100
+@@ -45,6 +45,7 @@
+                       -I$(WRF_SRC_ROOT_DIR)/phys \
+                       -I$(WRF_SRC_ROOT_DIR)/chem -I$(WRF_SRC_ROOT_DIR)/inc \
+                       -I$(NETCDFPATH)/include \
++                      -I$(NETCDFFPATH)/include \
+                       CONFIGURE_RTTOV_INC
+ REGISTRY        =    Registry
+ CC_TOOLS_CFLAGS = CONFIGURE_NMM_CORE
+@@ -67,6 +68,7 @@
+ ENVCOMPDEFS     =    CONFIGURE_COMPILEFLAGS
+ CPPFLAGS        =    $(ARCHFLAGS) $(ENVCOMPDEFS) -I$(LIBINCLUDE) $(TRADFLAG) CONFIGURE_COMMS_INCLUDE
+ NETCDFPATH      =    CONFIGURE_NETCDF_PATH
++NETCDFFPATH     =    CONFIGURE_NETCDFF_PATH
+ HDF5PATH        =    CONFIGURE_HDF5_PATH
+ WRFPLUSPATH     =    CONFIGURE_WRFPLUS_PATH
+ RTTOVPATH       =    CONFIGURE_RTTOV_PATH
+@@ -98,7 +100,7 @@
+ 
+ wrfio_nf : 
+ 	( cd $(WRF_SRC_ROOT_DIR)/external/io_netcdf ; \
+-          make $(J) NETCDFPATH="$(NETCDFPATH)" RANLIB="$(RANLIB)" CPP="$(CPP)" \
++          make $(J) NETCDFPATH="$(NETCDFPATH)" NETCDFFPATH="$(NETCDFFPATH)" RANLIB="$(RANLIB)" CPP="$(CPP)" \
+           CC="$(SCC)" CFLAGS="$(CFLAGS)" \
+           FC="$(SFC) $(PROMOTION) $(OMP) $(FCFLAGS)" TRADFLAG="$(TRADFLAG)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" )
+ 
+diff -Naur a/configure b/configure
+--- a/configure	2017-08-28 21:29:47.000000000 +0100
++++ b/configure	2020-10-15 14:29:09.225323053 +0100
+@@ -305,6 +305,15 @@
+   else
+     USENETCDF=" "
+   fi
++  # for netCDF 4.2 and greater, the Fortran library is a separate install
++  if [ -z "$NETCDFF" ]; then
++    NETCDFF="$NETCDF"
++  fi
++  if [ -f "$NETCDFF/lib/libnetcdff.a" ] ; then
++    USENETCDFF="-L$NETCDFF/lib!-lnetcdff" # ! will be replaced with space
++  fi
++  export USENETCDF=$USENETCDF
++  export USENETCDFF=$USENETCDFF
+ else
+   echo "Will configure for use without NetCDF"
+ fi
+@@ -631,10 +640,11 @@
+    srch=`grep -i "^#ARCH.*$os" arch/configure_new.defaults | grep -i "$mach"`
+    if [ -n "$srch" ] ; then
+      $PERL arch/Config_new.pl -dmparallel=$COMMLIB -ompparallel=$OMP -perl=$PERL \
+-          -netcdf=$NETCDF -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
+-          -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF -USENETCDF=$USENETCDF \
+-          -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" -config_line="$config_line" \
+-          -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH -dep_lib_path="$DEP_LIB_PATH"
++          -netcdf=$NETCDF -netcdff=$NETCDFF -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os \
++               -mach=$mach -ldflags=$ldflags -compileflags=$compileflags -opt_level=$opt_level \
++               -USENETCDFF=$USENETCDFF -USENETCDF=$USENETCDF -time=$FORTRAN_COMPILER_TIMER \
++               -tfl="$TFL" -cfl="$CFL" -config_line="$config_line" -wrf_core=$wrf_core \
++               -gpfs=$GPFS_PATH -curl=$CURL_PATH -dep_lib_path="$DEP_LIB_PATH"
+      if test ! -f configure.wrf ; then
+        echo "configure.wrf not created! Exiting configure script..."
+        exit 1
+@@ -744,10 +754,10 @@
+ echo "If you wish to change the default options, edit the file:"
+ echo "     arch/configure_new.defaults"
+ 
+-if test -n "$NETCDF" ; then
+-  if [ ! -f $NETCDF/include/netcdf.inc ] ; then
++if test -n "$NETCDFF" ; then
++  if [ ! -f $NETCDFF/include/netcdf.inc ] ; then
+     echo
+-    echo "Error : Not found $NETCDF/include/netcdf.inc"
++    echo "Error : Not found $NETCDFF/include/netcdf.inc"
+     echo "        Please check this installation of NetCDF and re-run this configure script"
+     echo
+     if test -n "$NETCDF4" ; then
+@@ -756,7 +766,7 @@
+     fi
+     exit -1
+   fi
+-  grep nf_format_64bit $NETCDF/include/netcdf.inc > /dev/null
++  grep nf_format_64bit $NETCDFF/include/netcdf.inc > /dev/null
+   configure_aaaa=$? ; export configure_aaaa
+   if [ $configure_aaaa -a -z "$WRFIO_NCD_NO_LARGE_FILE_SUPPORT" ] ; then
+     echo "NetCDF users note:"
+@@ -1092,6 +1102,42 @@
+   echo " "
+   echo "*****************************************************************************"
+ fi
++
++# testing for location of rpc/types.h file, used in landuse
++if [ -f /usr/include/rpc/types.h ] ; then
++  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=1/' configure.wrf > configure.wrf.edit
++  mv configure.wrf.edit configure.wrf
++echo standard location of RPC
++elif [ -f /usr/include/tirpc/rpc/types.h ] ; then
++  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=2/' configure.wrf > configure.wrf.edit
++  mv configure.wrf.edit configure.wrf
++echo newer location of RPC
++else
++  echo "************************** W A R N I N G ************************************"
++  echo " "
++  echo "The moving nest option is not available due to missing rpc/types.h file."
++  echo "Copy landread.c.dist to landread.c in share directory to bypass compile error."
++  echo " "
++  echo "*****************************************************************************"
++fi
++
++# testing for location of rpc/types.h file, used in landuse
++if [ -f /usr/include/rpc/types.h ] ; then
++  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=1/' configure.wrf > configure.wrf.edit
++  mv configure.wrf.edit configure.wrf
++echo standard location of RPC
++elif [ -f /usr/include/tirpc/rpc/types.h ] ; then
++  sed -e '/^ARCH_LOCAL/s/$/ -DRPC_TYPES=2/' configure.wrf > configure.wrf.edit
++  mv configure.wrf.edit configure.wrf
++echo newer location of RPC
++else
++  echo "************************** W A R N I N G ************************************"
++  echo " "
++  echo "The moving nest option is not available due to missing rpc/types.h file."
++  echo "Copy landread.c.dist to landread.c in share directory to bypass compile error."
++  echo " "
++  echo "*****************************************************************************"
++fi
+ 
+ # testing for netcdf4 IO features
+ if [ -n "$NETCDF4" ] ; then
+diff -Naur a/external/io_netcdf/makefile b/external/io_netcdf/makefile
+--- a/external/io_netcdf/makefile	2017-08-28 21:29:47.000000000 +0100
++++ b/external/io_netcdf/makefile	2020-10-15 14:25:49.581307031 +0100
+@@ -3,9 +3,9 @@
+ OBJSL   = wrf_io.o field_routines.o module_wrfsi_static.o
+ OBJS    = $(OBJSL)
+ CODE    = ext_ncd_get_dom_ti.code ext_ncd_get_var_td.code ext_ncd_get_var_ti.code ext_ncd_put_dom_ti.code ext_ncd_put_var_td.code ext_ncd_put_var_ti.code transpose.code 
+-FFLAGS  =  $(FCFLAGS) -I$(NETCDFPATH)/include -I../ioapi_share
+-LIBS    = $(LIB_LOCAL) -L$(NETCDFPATH)/lib -lnetcdf
+-LIBFFS  = $(LIB_LOCAL) -L$(NETCDFPATH)/lib -lnetcdff -lnetcdf $(NETCDF4_DEP_LIB)
++FFLAGS  =  $(FCFLAGS) -I$(NETCDFFPATH)/include -I../ioapi_share
++LIBS    = $(LIB_LOCAL) -L$(NETCDFFPATH)/lib -lnetcdf
++LIBFFS  = $(LIB_LOCAL) -L$(NETCDFFPATH)/lib -lnetcdff -lnetcdf $(NETCDF4_DEP_LIB)
+ CPP1    = $(CPP) -P $(TRADFLAG)
+ M4      = m4 -Uinclude -Uindex -Ulen
+ AR      = ar
+@@ -24,7 +24,7 @@
+ 			$(RANLIB) $@
+ 
+ wrf_io.o:               wrf_io.F90 $(CODE)
+-			grep nf_format_64bit $(NETCDFPATH)/include/netcdf.inc ;\
++			grep nf_format_64bit $(NETCDFFPATH)/include/netcdf.inc ;\
+                         a=$$? ; export a ; \
+ 			if [ $$a -a "$$WRFIO_NCD_LARGE_FILE_SUPPORT" = "1" ] ; then \
+                           $(CPP1) -DWRFIO_NCD_LARGE_FILE_SUPPORT -I../ioapi_share wrf_io.F90 | $(M4) - > wrf_io.f ; \
+@@ -43,14 +43,14 @@
+ 	x=`echo "$(FC)" | awk '{print $$1}'` ; export x ; \
+ 	if [ $$x = "gfortran" ] ; then \
+            echo removing external declaration of iargc for gfortran ; \
+-	   $(CPP1) -I$(NETCDFPATH)/include -I../ioapi_share diffwrf.F90 | sed '/integer *, *external.*iargc/d' > diffwrf.f ;\
++	   $(CPP1) -I$(NETCDFFPATH)/include -I../ioapi_share diffwrf.F90 | sed '/integer *, *external.*iargc/d' > diffwrf.f ;\
+         else \
+-	   $(CPP1) -I$(NETCDFPATH)/include -I../ioapi_share diffwrf.F90 > diffwrf.f ; \
++	   $(CPP1) -I$(NETCDFFPATH)/include -I../ioapi_share diffwrf.F90 > diffwrf.f ; \
+         fi
+ 	$(FC) -c $(FFLAGS) diffwrf.f
+ 	@if [ \( -f ../../frame/wrf_debug.o \) -a \( -f ../../frame/module_wrf_error.o \) -a \( -f $(ESMF_MOD_DEPENDENCE) \) -a \( -f ../../frame/clog.o \) ] ; then \
+ 	  echo "diffwrf io_netcdf is being built now. " ; \
+-          if [ \( -f $(NETCDFPATH)/lib/libnetcdff.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
++          if [ \( -f $(NETCDFFPATH)/lib/libnetcdff.a -o -f $(NETCDFPATH)/lib/libnetcdff.so \) ] ; then \
+             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBFFS) ;\
+           else \
+             $(FC) $(FFLAGS) $(LDFLAGS) -o diffwrf diffwrf.o $(OBJSL) ../../frame/wrf_debug.o ../../frame/module_wrf_error.o ../../frame/clog.o $(ESMF_IO_LIB_EXT) $(LIBS) ;\
+diff -Naur a/tools/reg_parse.c b/tools/reg_parse.c
+--- a/tools/reg_parse.c	2017-08-28 21:29:47.000000000 +0100
++++ b/tools/reg_parse.c	2020-10-15 15:01:56.935480966 +0100
+@@ -1,6 +1,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <ctype.h>
+ #ifdef _WIN32
+ # define rindex(X,Y) strrchr(X,Y)
+ # define index(X,Y) strchr(X,Y)
+@@ -92,7 +93,7 @@
+ {
+   /* Decreased size for SOA from 8192 to 8000--double check if necessary, Manish Shrivastava 2010 */
+   char inln[8000], parseline[8000], parseline_save[8000] ;
+-  int found ; 
++  int found ;
+   char *p, *q ;
+   char *tokens[MAXTOKENS], *toktmp[MAXTOKENS], newdims[NAMELEN_LONG], newdims4d[NAMELEN_LONG],newname[NAMELEN_LONG] ;
+   int i, ii, len_of_tok ;
+@@ -131,7 +132,7 @@
+           fclose( include_fp ) ;
+         } else {
+           fprintf(stderr,"Registry warning: cannot open %s. Ignoring.\n", include_file_name ) ;
+-        } 
++        }
+       }
+     }
+     else if ( !strncmp( p , "ifdef", 5 ) ) {
+@@ -139,7 +140,7 @@
+       p += 5 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
+       strncpy(value, p, 31 ) ; value[31] = '\0' ;
+       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
+-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
++      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ;
+       ifdef_stack_ptr++ ;
+       ifdef_stack[ifdef_stack_ptr] = ( sym_get(value) != NULL && ifdef_stack[ifdef_stack_ptr-1] ) ;
+       if ( ifdef_stack_ptr >= 100 ) { fprintf(stderr,"Registry fatal: too many nested ifdefs\n") ; exit(1) ; }
+@@ -150,14 +151,14 @@
+       p += 6 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
+       strncpy(value, p, 31 ) ; value[31] = '\0' ;
+       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
+-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
++      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ;
+       ifdef_stack_ptr++ ;
+       ifdef_stack[ifdef_stack_ptr] = ( sym_get(value) == NULL && ifdef_stack[ifdef_stack_ptr-1] ) ;
+       if ( ifdef_stack_ptr >= 100 ) { fprintf(stderr,"Registry fatal: too many nested ifdefs\n") ; exit(1) ; }
+       continue ;
+     }
+     else if ( !strncmp( p , "endif", 5 ) ) {
+-      ifdef_stack_ptr-- ; 
++      ifdef_stack_ptr-- ;
+       if ( ifdef_stack_ptr < 0 ) { fprintf(stderr,"Registry fatal: unmatched endif\n") ; exit(1) ; }
+       continue ;
+     }
+@@ -166,7 +167,7 @@
+       p += 6 ; for ( ; ( *p == ' ' || *p == '	' ) && *p != '\0' ; p++ ) ;
+       strncpy(value, p, 31 ) ; value[31] = '\0' ;
+       if ( (p=index(value,'\n')) != NULL ) *p = '\0' ;
+-      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ; 
++      if ( (p=index(value,' ')) != NULL ) *p = '\0' ; if ( (p=index(value,'	')) != NULL ) *p = '\0' ;
+       sym_add( value ) ;
+       continue ;
+     }
+@@ -223,7 +224,7 @@
+         int inbrace = 0 ;
+         strcpy( newdims, "" ) ;
+         strcpy( newdims4d, "" ) ;
+-        is4d = 0 ; wantstend = 0 ; wantsbdy = 0 ; 
++        is4d = 0 ; wantstend = 0 ; wantsbdy = 0 ;
+         for ( i = 0 ; i < (len_of_tok = strlen(tokens[F_DIMS])) ; i++ )
+         {
+           x = tolower(tokens[F_DIMS][i]) ;
+@@ -252,7 +253,7 @@
+ /* next, output some additional entries for the boundary arrays for these guys */
+             if ( is4d == 1 ) {
+               for ( i = 0, found = 0 ; i < ntracers ; i++ ) {
+-	        if ( !strcmp( tokens[F_USE] , tracers[i] ) ) found = 1 ; 
++	        if ( !strcmp( tokens[F_USE] , tracers[i] ) ) found = 1 ;
+               }
+ 	      if ( found == 0 ) {
+ 	        sprintf(tracers[ntracers],tokens[F_USE]) ;
+@@ -304,7 +305,7 @@
+   /* Had to increase size for SOA from 4096 to 7000, Manish Shrivastava 2010 */
+   char inln[7000], parseline[7000] ;
+   char *p, *q ;
+-  char *tokens[MAXTOKENS], *toktmp[MAXTOKENS] ; 
++  char *tokens[MAXTOKENS], *toktmp[MAXTOKENS] ;
+   int i, ii, idim ;
+   int defining_state_field, defining_rconfig_field, defining_i1_field ;
+ 
+@@ -316,7 +317,7 @@
+ /* Had to increase size for SOA from 4096 to 7000, Manish Shrivastava 2010 */
+   while ( fgets ( inln , 7000 , infile ) != NULL )
+   {
+-    strcat( parseline , inln ) ; 
++    strcat( parseline , inln ) ;
+     /* allow \ to continue the end of a line */
+     if (( p = index( parseline,  '\\'  )) != NULL )
+     {
+@@ -330,10 +331,10 @@
+     make_lower( parseline ) ;
+     if (( p = index( parseline , '#' ))  != NULL  ) *p = '\0' ; /* discard comments (dont worry about quotes for now) */
+     if (( p = index( parseline , '\n' )) != NULL  ) *p = '\0' ; /* discard newlines */
+-    for ( i = 0 ; i < MAXTOKENS ; i++ ) tokens[i] = NULL ; 
++    for ( i = 0 ; i < MAXTOKENS ; i++ ) tokens[i] = NULL ;
+     i = 0 ;
+ 
+-    if ((tokens[i] = my_strtok(parseline)) != NULL ) i++ ; 
++    if ((tokens[i] = my_strtok(parseline)) != NULL ) i++ ;
+ 
+     while (( tokens[i] = my_strtok(NULL) ) != NULL && i < MAXTOKENS ) i++ ;
+     if ( i <= 0 ) continue ;
+@@ -362,7 +363,7 @@
+       tokens[TABLE] = "typedef" ;
+       for ( i = MAXTOKENS-1 ; i >= 2 ; i-- ) tokens[i] = tokens[i-1] ; /* shift the fields to the left */
+       tokens[FIELD_OF] = "domain" ;
+-                 if ( !strcmp( tokens[FIELD_TYPE], "double" ) ) tokens[FIELD_TYPE] = "doubleprecision" ; 
++                 if ( !strcmp( tokens[FIELD_TYPE], "double" ) ) tokens[FIELD_TYPE] = "doubleprecision" ;
+       defining_state_field = 1 ;
+     }
+     if      ( !strcmp( tokens[ TABLE ] , "rconfig" ) )
+@@ -383,7 +384,7 @@
+       tokens[TABLE] = "typedef" ;
+       tokens[FIELD_OF]       = "domain" ;
+       tokens[RCNF_TYPE]      = toktmp[RCNF_TYPE_PRE] ;
+-                 if ( !strcmp( tokens[RCNF_TYPE], "double" ) ) tokens[RCNF_TYPE] = "doubleprecision" ; 
++                 if ( !strcmp( tokens[RCNF_TYPE], "double" ) ) tokens[RCNF_TYPE] = "doubleprecision" ;
+       tokens[RCNF_SYM]       = toktmp[RCNF_SYM_PRE] ;
+       tokens[RCNF_IO]        = toktmp[RCNF_IO_PRE] ;
+       tokens[RCNF_DNAME]     = toktmp[RCNF_DNAME_PRE] ;
+@@ -397,13 +398,13 @@
+     }
+     if      ( !strcmp( tokens[ TABLE ] , "i1" ) )
+     {
+-      /* turn a state entry into a typedef to define a field in 
++      /* turn a state entry into a typedef to define a field in
+          the top-level built-in type domain */
+       tokens[TABLE] = "typedef" ;
+       /* shift the fields to the left */
+-      for ( i = MAXTOKENS-1 ; i >= 2 ; i-- ) tokens[i] = tokens[i-1] ; 
++      for ( i = MAXTOKENS-1 ; i >= 2 ; i-- ) tokens[i] = tokens[i-1] ;
+       tokens[FIELD_OF] = "domain" ;
+-                 if ( !strcmp( tokens[FIELD_TYPE], "double" ) ) tokens[FIELD_TYPE] = "doubleprecision" ; 
++                 if ( !strcmp( tokens[FIELD_TYPE], "double" ) ) tokens[FIELD_TYPE] = "doubleprecision" ;
+       defining_i1_field = 1 ;
+     }
+ 
+@@ -415,13 +416,13 @@
+       node_t * field_struct ;
+       node_t * type_struct ;
+ 
+-      if ( !defining_state_field && ! defining_i1_field && 
++      if ( !defining_state_field && ! defining_i1_field &&
+            !defining_rconfig_field && !strcmp(tokens[FIELD_OF],"domain") )
+        { fprintf(stderr,"Registry warning: 'domain' is a reserved registry type name. Cannot 'typedef domain'\n") ; }
+ 
+       type_struct = get_type_entry( tokens[ FIELD_OF ] ) ;
+-      if ( type_struct == NULL ) 
+-      {  
++      if ( type_struct == NULL )
++      {
+         type_struct = new_node( TYPE ) ;
+         strcpy( type_struct->name, tokens[FIELD_OF] ) ;
+         type_struct->type_type = DERIVED ;
+@@ -469,7 +470,7 @@
+       }
+ 
+       field_struct->restart  = 0 ; field_struct->boundary  = 0 ;
+-      for ( i = 0 ; i < MAX_STREAMS ; i++ ) { 
++      for ( i = 0 ; i < MAX_STREAMS ; i++ ) {
+         reset_mask( field_struct->io_mask, i ) ;
+       }
+ 
+@@ -494,14 +495,14 @@
+             mask = field_struct->io_mask ;
+             set_mask( mask , stream ) ;
+             strcpy(tmp1, &(tmp[++i])) ;
+-            for ( p = tmp1  ; *p ; i++, p++ ) { 
++            for ( p = tmp1  ; *p ; i++, p++ ) {
+               c = tolower(*p) ; if ( c >= 'a' && c <= 'z' ) { *p = '\0' ; i-- ; break ; }
+               reset_mask( mask , stream ) ;
+             }
+-            for ( p = tmp1  ; *p ; p++ ) { 
++            for ( p = tmp1  ; *p ; p++ ) {
+               x = *p ;
+-              if ( x >= '0' && x <= '9' ) { 
+-                set_mask( mask , stream + x - '0' ) ; 
++              if ( x >= '0' && x <= '9' ) {
++                set_mask( mask , stream + x - '0' ) ;
+               }
+ 	      else if ( x == '{' ) {
+                 strcpy(tmp2,p+1) ;
+@@ -529,7 +530,7 @@
+             int ii,iii ;
+             char * pp ;
+             char tmp[NAMELEN] ;
+-            strcpy(tmp,tokens[FIELD_IO]) ;   
++            strcpy(tmp,tokens[FIELD_IO]) ;
+ 
+             if (( pp = index(tmp,'}') ) != NULL ) {
+               *pp = '\0' ;
+@@ -553,9 +554,9 @@
+ 	  } else if ( x >= 'a' && x <= 'z' ) {
+ 	    if ( x == 'r' ) { field_struct->restart = 1 ; set_mask( field_struct->io_mask , RESTART_STREAM   ) ; }
+ 	    if ( x == 'b' ) { field_struct->boundary  = 1 ; set_mask( field_struct->io_mask , BOUNDARY_STREAM   ) ; }
+-	    if ( x == 'f' || x == 'd' || x == 'u' || x == 's' ) { 
++	    if ( x == 'f' || x == 'd' || x == 'u' || x == 's' ) {
+                                strcpy(aux_fields,"") ;
+-                               strcpy(fcn_name,"") ; 
++                               strcpy(fcn_name,"") ;
+ 	                       if ( tokens[FIELD_IO][i+1] == '(' )     /* catch a possible error */
+                                {
+ 				 fprintf(stderr,
+@@ -564,7 +565,7 @@
+ 				    "                  equal sign needed before left paren\n") ;
+ 			       }
+ 
+-	                       if ( tokens[FIELD_IO][i+1] == '=' ) 
++	                       if ( tokens[FIELD_IO][i+1] == '=' )
+ 			       {
+ 				 int ii, jj, state ;
+ 				 state = 0 ;
+@@ -629,7 +630,7 @@
+                                    fprintf(stderr,"ERROR: %s %c function invalid.  You must specify the function to call in f=, d=, u= or s= when using the NMM cores.  The ARW interp functions do not correctly handle the E grid.\n",tokens[FIELD_SYM],x);
+                                    exit(1);
+                                  } else {
+-                                   /*  warning should no longer be needed 
++                                   /*  warning should no longer be needed
+                                       fprintf(stderr,"WARNING: %c interpolation unspecified for %s.  Using %s.\n",
+                                            x,tokens[FIELD_SYM],fcn_name);
+                                    */
+@@ -652,23 +653,23 @@
+                                  exit(1);
+                                }
+ #endif
+-	                       if      ( x == 'f' )  { 
+-                                 field_struct->nest_mask |= FORCE_DOWN ; 
++	                       if      ( x == 'f' )  {
++                                 field_struct->nest_mask |= FORCE_DOWN ;
+                                  strcpy(field_struct->force_fcn_name, fcn_name ) ;
+                                  strcpy(field_struct->force_aux_fields, aux_fields ) ;
+                                }
+-                               else if ( x == 'd' )  { 
+-                                 field_struct->nest_mask |= INTERP_DOWN ; 
++                               else if ( x == 'd' )  {
++                                 field_struct->nest_mask |= INTERP_DOWN ;
+                                  strcpy(field_struct->interpd_fcn_name, fcn_name ) ;
+                                  strcpy(field_struct->interpd_aux_fields, aux_fields ) ;
+                                }
+-                               else if ( x == 's' )  { 
+-                                 field_struct->nest_mask |= SMOOTH_UP ; 
++                               else if ( x == 's' )  {
++                                 field_struct->nest_mask |= SMOOTH_UP ;
+                                  strcpy(field_struct->smoothu_fcn_name, fcn_name ) ;
+                                  strcpy(field_struct->smoothu_aux_fields, aux_fields ) ;
+                                }
+-                               else if ( x == 'u' )  { 
+-                                 field_struct->nest_mask |= INTERP_UP ; 
++                               else if ( x == 'u' )  {
++                                 field_struct->nest_mask |= INTERP_UP ;
+                                  strcpy(field_struct->interpu_fcn_name, fcn_name ) ;
+                                  strcpy(field_struct->interpu_aux_fields, aux_fields ) ;
+                                }
+@@ -726,12 +727,12 @@
+       }
+ /**/  else   /* if ( field_struct->scalar_array_member ) */
+       {
+-/* 
++/*
+    Here we are constructing a list of nodes to represent the list of 4D scalar arrays in the model
+ 
+    This list is rooted at the FourD pointer.
+    Each array is represented by its own node; each node has a pointer, members, to the list
+-   of fields that make it up.  
++   of fields that make it up.
+ 
+ */
+ 	node_t * q , * member  ;
+@@ -828,7 +829,7 @@
+ #if 1
+       for ( i = COMM_DEFINE, q=comm_struct->comm_define ; strcmp(tokens[i],"-") ; i++ )  {
+         for(p=tokens[i];*p;p++)if(*p!=' '&&*p!='\t'){*q++=*p;}
+-      } 
++      }
+ #else
+       strcpy( comm_struct->comm_define , tokens[COMM_DEFINE] ) ;
+ #endif
+@@ -843,7 +844,7 @@
+ #if 1
+       for ( i = COMM_DEFINE, q=comm_struct->comm_define ; strcmp(tokens[i],"-") ; i++ )  {
+         for(p=tokens[i];*p;p++)if(*p!=' '&&*p!='\t'){*q++=*p;}
+-      } 
++      }
+ #else
+       strcpy( comm_struct->comm_define , tokens[COMM_DEFINE] ) ;
+ #endif
+@@ -858,7 +859,7 @@
+ #if 1
+       for ( i = COMM_DEFINE, q=comm_struct->comm_define ; strcmp(tokens[i],"-") ; i++ )  {
+         for(p=tokens[i];*p;p++)if(*p!=' '&&*p!='\t'){*q++=*p;}
+-      } 
++      }
+ #else
+       strcpy( comm_struct->comm_define , tokens[COMM_DEFINE] ) ;
+ #endif
+@@ -995,9 +996,9 @@
+ {
+   if      (!strcmp( dimorient , "x" ))
+    { dim_entry->coord_axis = COORD_X ; }
+-  else if (!strcmp( dimorient , "y" )) 
++  else if (!strcmp( dimorient , "y" ))
+    { dim_entry->coord_axis = COORD_Y ; }
+-  else if (!strcmp( dimorient , "z" )) 
++  else if (!strcmp( dimorient , "z" ))
+    { dim_entry->coord_axis = COORD_Z ; }
+   else
+    { dim_entry->coord_axis = COORD_C ; }

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/tirpc_detect.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/tirpc_detect.patch
@@ -1,0 +1,129 @@
+From 4e70e6f7fe782bb00266bd84dfc4c901cb67b560 Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Thu, 15 Oct 2020 17:26:26 +0100
+Subject: [PATCH] fix tirpc detection
+
+---
+ arch/Config_new.pl | 14 ++++++++++++++
+ arch/postamble_new |  6 ++++--
+ configure          | 29 ++++++++++++++++++++++++-----
+ 3 files changed, 42 insertions(+), 7 deletions(-)
+
+diff --git a/arch/Config_new.pl b/arch/Config_new.pl
+index 945288df..e614f7ef 100644
+--- a/arch/Config_new.pl
++++ b/arch/Config_new.pl
+@@ -7,6 +7,9 @@
+ 
+ select((select(STDOUT), $|=1)[0]);
+ $sw_perl_path = perl ;
++$sw_tirpc_inc = "";
++$sw_tirpc_lib = "";
++$sw_tirpc_libdir = "";
+ $sw_netcdf_path = "" ;
+ $sw_netcdff_path = "" ;
+ $sw_pnetcdf_path = "" ;
+@@ -61,6 +64,15 @@ while ( substr( $ARGV[0], 0, 1 ) eq "-" )
+   {
+     $sw_perl_path = substr( $ARGV[0], 6 ) ;
+   }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_inc=" )
++  {
++    $sw_tirpc_inc = substr( $ARGV[0], 11 ) ;
++  }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_lib=" )
++  {
++    $sw_tirpc_libdir = substr( $ARGV[0], 11 ) ;
++    $sw_tirpc_lib = "-ltirpc" ;
++  }
+   if ( substr( $ARGV[0], 1, 7 ) eq "netcdf=" )
+   {
+     $sw_netcdf_path = substr( $ARGV[0], 8 ) ;
+@@ -450,6 +462,8 @@ while ( <CONFIGURE_DEFAULTS> )
+   if ( $latchon == 1 )
+   {
+     $_ =~ s/CONFIGURE_PERL_PATH/$sw_perl_path/g ;
++    $_ =~ s/CONFIGURE_TIRPC_INC/$sw_tirpc_inc/g ;
++    $_ =~ s/CONFIGURE_TIRPC_LIB/$sw_tirpc_libdir $sw_tirpc_lib/g ;
+     $_ =~ s/CONFIGURE_NETCDF_PATH/$sw_netcdf_path/g ;
+     $_ =~ s/CONFIGURE_NETCDFF_PATH/$sw_netcdff_path/g ;
+     $_ =~ s/CONFIGURE_PNETCDF_PATH/$sw_pnetcdf_path/g ;
+diff --git a/arch/postamble_new b/arch/postamble_new
+index 9c4ca327..9beb448d 100644
+--- a/arch/postamble_new
++++ b/arch/postamble_new
+@@ -29,7 +29,7 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
+                       -DMAX_HISTORY=$(MAX_HISTORY) \
+ 		      -DNMM_NEST=$(WRF_NMM_NEST)
+ CFLAGS          =    $(CFLAGS_LOCAL) CONFIGURE_DMPARALLEL CONFIGURE_STUBMPI \
+-                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE
++                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE $(TIRPCINC)
+ FCFLAGS         =    $(FCOPTIM) $(FCBASEOPTS)
+ ESMF_LIB_FLAGS  =    ESMFLIBFLAG
+ # ESMF 5 -- these are defined in esmf.mk, included above
+@@ -63,7 +63,7 @@ CC_TOOLS_CFLAGS = CONFIGURE_NMM_CORE
+ #NOWIN LIB_EXTERNAL    = \
+ #NOWIN                      CONFIGURE_NETCDF_LIB_PATH CONFIGURE_PNETCDF_LIB_PATH CONFIGURE_GRIB2_LIB CONFIGURE_ATMOCN_LIB CONFIGURE_HDF5_LIB_PATH
+ 
+-LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO)
++LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO) $(LIB_TIRPC)
+ LDFLAGS         =    $(OMP) $(FCFLAGS) $(LDFLAGS_LOCAL) CONFIGURE_LDFLAGS
+ ENVCOMPDEFS     =    CONFIGURE_COMPILEFLAGS
+ CPPFLAGS        =    $(ARCHFLAGS) $(ENVCOMPDEFS) -I$(LIBINCLUDE) $(TRADFLAG) CONFIGURE_COMMS_INCLUDE
+@@ -73,6 +73,8 @@ HDF5PATH        =    CONFIGURE_HDF5_PATH
+ WRFPLUSPATH     =    CONFIGURE_WRFPLUS_PATH
+ RTTOVPATH       =    CONFIGURE_RTTOV_PATH
+ PNETCDFPATH     =    CONFIGURE_PNETCDF_PATH
++TIRPCINC        =    CONFIGURE_TIRPC_INC
++LIB_TIRPC       =    CONFIGURE_TIRPC_LIB
+ 
+ bundled:  io_only CONFIGURE_ATMOCN
+ external: io_only CONFIGURE_COMMS_EXTERNAL $(ESMF_TARGET)
+diff --git a/configure b/configure
+index 26abcc4e..f9040a60 100755
+--- a/configure
++++ b/configure
+@@ -635,16 +635,35 @@ elif command -v time > /dev/null 2>&1; then
+   echo "Will use 'time' to report timing information"
+ fi
+ 
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_INCLUDE_DIR ]; then
++  TIRPC_INC=$(pkg-config --cflags-only-I libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_INC="-I${TIRPC_INCLUDE_DIR}"
++fi
++echo "TIRPC_INC=${TIRPC_INC}"
++
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_LIB_DIR ]; then
++  TIRPC_LIB=$(pkg-config --libs-only-L libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_LIB="-L${TIRPC_LIB_DIR}"
++fi
++echo "TIRPC_LIB=${TIRPC_LIB}"
++
+ # Found perl, so proceed with configuration
+ if test -n "$PERL" ; then
+    srch=`grep -i "^#ARCH.*$os" arch/configure_new.defaults | grep -i "$mach"`
+    if [ -n "$srch" ] ; then
+      $PERL arch/Config_new.pl -dmparallel=$COMMLIB -ompparallel=$OMP -perl=$PERL \
+-          -netcdf=$NETCDF -netcdff=$NETCDFF -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os \
+-               -mach=$mach -ldflags=$ldflags -compileflags=$compileflags -opt_level=$opt_level \
+-               -USENETCDFF=$USENETCDFF -USENETCDF=$USENETCDF -time=$FORTRAN_COMPILER_TIMER \
+-               -tfl="$TFL" -cfl="$CFL" -config_line="$config_line" -wrf_core=$wrf_core \
+-               -gpfs=$GPFS_PATH -curl=$CURL_PATH -dep_lib_path="$DEP_LIB_PATH"
++        -tirpc_inc=$TIRPC_INC -tirpc_lib=$TIRPC_LIB -netcdf=$NETCDF -netcdff=$NETCDFF \
++        -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
++        -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF \
++        -USENETCDF=$USENETCDF -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" \
++        -config_line="$config_line" -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH \
++        -dep_lib_path="$DEP_LIB_PATH"
+      if test ! -f configure.wrf ; then
+        echo "configure.wrf not created! Exiting configure script..."
+        exit 1
+-- 
+2.28.0
+

--- a/var/spack/repos/builtin/packages/wrf/patches/4.0/add_aarch64.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.0/add_aarch64.patch
@@ -1,0 +1,124 @@
+From 34c03dc455dc7b18d3d0c6489075d63c66fbb5be Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Fri, 16 Oct 2020 13:20:24 +0100
+Subject: [PATCH] add aarch64 gcc support
+
+---
+ arch/configure.defaults | 101 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 101 insertions(+)
+
+diff --git a/arch/configure.defaults b/arch/configure.defaults
+index 6ecf44ed..fb7694b8 100644
+--- a/arch/configure.defaults
++++ b/arch/configure.defaults
+@@ -1917,6 +1917,107 @@ RANLIB          =      ranlib
+ RLFLAGS		=	
+ CC_TOOLS        =      $(SCC) 
+ 
++###########################################################
++#ARCH    CYGWIN_NT i686 x86_64 Cygwin, gfortran compiler with gcc  #serial smpar dmpar dm+sm
++#
++DESCRIPTION     =       GNU ($SFC/$SCC)
++DMPARALLEL      =       # 1
++OMPCPP          =       # -D_OPENMP
++OMP             =       # -fopenmp
++OMPCC           =       # -fopenmp
++SFC             =       gfortran
++SCC             =       gcc
++CCOMP           =       gcc
++DM_FC           =       mpif90
++DM_CC           =       mpicc
++FC              =       CONFIGURE_FC
++CC              =       CONFIGURE_CC
++LD              =       $(FC)
++RWORDSIZE       =       CONFIGURE_RWORDSIZE
++PROMOTION       =       #-fdefault-real-8
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
++CFLAGS_LOCAL    =       -w -O3 -c
++LDFLAGS_LOCAL   =       
++CPLUSPLUSLIB    =       
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       -O2 -ftree-vectorize -funroll-loops
++FCREDUCEDOPT	=       $(FCOPTIM)
++FCNOOPT		=       -O0
++FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
++FORMAT_FIXED    =       -ffixed-form
++FORMAT_FREE     =       -ffree-form -ffree-line-length-none
++FCSUFFIX        =       
++BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FFLAGS)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =     
++TRADFLAG        =      -traditional
++CPP             =      /lib/cpp -P
++AR              =      ar
++ARFLAGS         =      ru
++M4              =      m4 -G
++RANLIB          =      ranlib
++RLFLAGS		=	
++CC_TOOLS        =      $(SCC)
++
++LIB_EXTERNAL    = \
++                     $(WRF_SRC_ROOT_DIR)/external/io_netcdf/libwrfio_nf.a CONFIGURE_NETCDF_PATH/lib/libnetcdf.dll.a \
++		     -L CONFIGURE_NETCDF_PATH -lnetcdff -lnetcdf -lnetcdf -ltirpc -lhdf5_hl -lhdf5 -lm -lz \
++		     CONFIGURE_GRIB2_LIB
++ESMF_IO_LIB     =    $(WRF_SRC_ROOT_DIR)/external/esmf_time_f90/libesmf_time.a
++LIB_BUNDLED     = \
++                     $(WRF_SRC_ROOT_DIR)/external/fftpack/fftpack5/libfftpack.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_grib1/libio_grib1.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_grib_share/libio_grib_share.a \
++                     $(WRF_SRC_ROOT_DIR)/external/io_int/libwrfio_int.a \
++                     $(ESMF_IO_LIB) \
++                     CONFIGURE_COMMS_LIB \
++                     $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
++                     $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
++
++###########################################################
++#ARCH    Linux aarch64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
++#
++DESCRIPTION     =       Arm GNU ($SFC/$SCC): Aarch64
++DMPARALLEL      =       # 1
++OMPCPP          =       # -D_OPENMP
++OMP             =       # -fopenmp
++OMPCC           =       # -fopenmp
++SFC             =       gfortran
++SCC             =       gcc
++CCOMP           =       gcc
++DM_FC           =       mpif90 
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       CONFIGURE_FC
++CC              =       CONFIGURE_CC
++LD              =       $(FC)
++RWORDSIZE       =       CONFIGURE_RWORDSIZE
++PROMOTION       =       #-fdefault-real-8
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
++CFLAGS_LOCAL    =       -w -O3 -c -march=native -mtune=native
++DFLAGS_LOCAL   =       
++CPLUSPLUSLIB    =       
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=native -mtune=native
++FCREDUCEDOPT	=       $(FCOPTIM)
++FCNOOPT		=       -O0
++FCDEBUG         =       -g # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
++FORMAT_FIXED    =       -ffixed-form
++FORMAT_FREE     =       -ffree-form -ffree-line-length-none
++FCSUFFIX        =       
++BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =     
++TRADFLAG        =      CONFIGURE_TRADFLAG
++CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
++AR              =      ar
++ARFLAGS         =      ru
++M4              =      m4 -G
++RANLIB          =      ranlib
++RLFLAGS		=	
++CC_TOOLS        =      $(SCC) 
++
+ #insert new stanza here
+ 
+ ###########################################################
+-- 
+2.28.0
+

--- a/var/spack/repos/builtin/packages/wrf/patches/4.0/tirpc_detect.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.0/tirpc_detect.patch
@@ -1,0 +1,128 @@
+From 43f8764c8e30918f967c14155bb0b25504ea77f8 Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Fri, 16 Oct 2020 12:39:59 +0100
+Subject: [PATCH] tirpc_detection_patch
+
+---
+ arch/Config.pl | 14 ++++++++++++++
+ arch/postamble |  6 ++++--
+ configure      | 28 ++++++++++++++++++++++++----
+ 3 files changed, 42 insertions(+), 6 deletions(-)
+
+diff --git a/arch/Config.pl b/arch/Config.pl
+index 6d332386..4bf2862d 100644
+--- a/arch/Config.pl
++++ b/arch/Config.pl
+@@ -7,6 +7,9 @@
+ 
+ select((select(STDOUT), $|=1)[0]);
+ $sw_perl_path = perl ;
++$sw_tirpc_inc = "";
++$sw_tirpc_lib = "";
++$sw_tirpc_libdir = "";
+ $sw_netcdf_path = "" ;
+ $sw_netcdff_path = "" ;
+ $sw_pnetcdf_path = "" ;
+@@ -60,6 +63,15 @@ while ( substr( $ARGV[0], 0, 1 ) eq "-" )
+   {
+     $sw_perl_path = substr( $ARGV[0], 6 ) ;
+   }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_inc=" )
++  {
++    $sw_tirpc_inc = substr( $ARGV[0], 11 ) ;
++  }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_lib=" )
++  {
++    $sw_tirpc_libdir = substr( $ARGV[0], 11 ) ;
++    $sw_tirpc_lib = "-ltirpc" ;
++  }
+   if ( substr( $ARGV[0], 1, 7 ) eq "netcdf=" )
+   {
+     $sw_netcdf_path = substr( $ARGV[0], 8 ) ;
+@@ -444,6 +456,8 @@ while ( <CONFIGURE_DEFAULTS> )
+   if ( $latchon == 1 )
+   {
+     $_ =~ s/CONFIGURE_PERL_PATH/$sw_perl_path/g ;
++    $_ =~ s/CONFIGURE_TIRPC_INC/$sw_tirpc_inc/g ;
++    $_ =~ s/CONFIGURE_TIRPC_LIB/$sw_tirpc_libdir $sw_tirpc_lib/g ;
+     $_ =~ s/CONFIGURE_NETCDF_PATH/$sw_netcdf_path/g ;
+     $_ =~ s/CONFIGURE_NETCDFF_PATH/$sw_netcdff_path/g ;
+     $_ =~ s/CONFIGURE_PNETCDF_PATH/$sw_pnetcdf_path/g ;
+diff --git a/arch/postamble b/arch/postamble
+index f00b55c0..07dfbbc6 100644
+--- a/arch/postamble
++++ b/arch/postamble
+@@ -31,7 +31,7 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
+                       -DMAX_HISTORY=$(MAX_HISTORY) \
+ 		      -DNMM_NEST=$(WRF_NMM_NEST)
+ CFLAGS          =    $(CFLAGS_LOCAL) CONFIGURE_DMPARALLEL CONFIGURE_STUBMPI \
+-                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE
++                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE $(TIRPCINC)
+ FCFLAGS         =    $(FCOPTIM) $(FCBASEOPTS)
+ ESMF_LIB_FLAGS  =    ESMFLIBFLAG
+ # ESMF 5 -- these are defined in esmf.mk, included above
+@@ -66,7 +66,7 @@ CC_TOOLS_CFLAGS = CONFIGURE_NMM_CORE
+ #NOWIN LIB_EXTERNAL    = \
+ #NOWIN                      CONFIGURE_NETCDF_LIB_PATH CONFIGURE_PNETCDF_LIB_PATH CONFIGURE_GRIB2_LIB CONFIGURE_ATMOCN_LIB CONFIGURE_HDF5_LIB_PATH
+ 
+-LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO)
++LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO) $(LIB_TIRPC)
+ LDFLAGS         =    $(OMP) $(FCFLAGS) $(LDFLAGS_LOCAL) CONFIGURE_LDFLAGS
+ ENVCOMPDEFS     =    CONFIGURE_COMPILEFLAGS
+ CPPFLAGS        =    $(ARCHFLAGS) $(ENVCOMPDEFS) -I$(LIBINCLUDE) $(TRADFLAG) CONFIGURE_COMMS_INCLUDE
+@@ -76,6 +76,8 @@ HDF5PATH        =    CONFIGURE_HDF5_PATH
+ WRFPLUSPATH     =    CONFIGURE_WRFPLUS_PATH
+ RTTOVPATH       =    CONFIGURE_RTTOV_PATH
+ PNETCDFPATH     =    CONFIGURE_PNETCDF_PATH
++TIRPCINC        =    CONFIGURE_TIRPC_INC
++LIB_TIRPC       =    CONFIGURE_TIRPC_LIB
+ 
+ bundled:  io_only CONFIGURE_ATMOCN
+ external: io_only CONFIGURE_COMMS_EXTERNAL $(ESMF_TARGET)
+diff --git a/configure b/configure
+index b26b0d67..c511f6f9 100755
+--- a/configure
++++ b/configure
+@@ -551,15 +551,35 @@ elif command -v time > /dev/null 2>&1; then
+   echo "Will use 'time' to report timing information"
+ fi
+ 
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_INCLUDE_DIR ]; then
++  TIRPC_INC=$(pkg-config --cflags-only-I libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_INC="-I${TIRPC_INCLUDE_DIR}"
++fi
++echo "TIRPC_INC=${TIRPC_INC}"
++
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_LIB_DIR ]; then
++  TIRPC_LIB=$(pkg-config --libs-only-L libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_LIB="-L${TIRPC_LIB_DIR}"
++fi
++echo "TIRPC_LIB=${TIRPC_LIB}"
++
+ # Found perl, so proceed with configuration
+ if test -n "$PERL" ; then
+    srch=`grep -i "^#ARCH.*$os" arch/configure.defaults | grep -i "$mach"`
+    if [ -n "$srch" ] ; then
+      $PERL arch/Config.pl -dmparallel=$COMMLIB -ompparallel=$OMP -perl=$PERL \
+-          -netcdf=$NETCDF -netcdff=$NETCDFF -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
+-          -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF -USENETCDF=$USENETCDF \
+-          -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" -config_line="$config_line" \
+-          -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH -dep_lib_path="$DEP_LIB_PATH"
++        -tirpc_inc=$TIRPC_INC -tirpc_lib=$TIRPC_LIB -netcdf=$NETCDF -netcdff=$NETCDFF \
++        -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
++        -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF \
++        -USENETCDF=$USENETCDF -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" \
++        -config_line="$config_line" -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH \
++        -dep_lib_path="$DEP_LIB_PATH"
+      if test ! -f configure.wrf ; then
+        echo "configure.wrf not created! Exiting configure script..."
+        exit 1
+-- 
+2.28.0
+

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/add_aarch64.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/add_aarch64.patch
@@ -1,0 +1,66 @@
+From 9eb0c715cfcefb3df204200d44f5e8526bd14e31 Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Fri, 16 Oct 2020 13:20:24 +0100
+Subject: [PATCH] add aarch64 gcc support
+
+---
+ arch/configure.defaults | 43 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+
+diff --git a/arch/configure.defaults b/arch/configure.defaults
+index 7767a81e..bfd2a802 100644
+--- a/arch/configure.defaults
++++ b/arch/configure.defaults
+@@ -1975,6 +1975,49 @@ LIB_BUNDLED     = \
+                      $(WRF_SRC_ROOT_DIR)/frame/module_internal_header_util.o \
+                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
+ 
++###########################################################
++#ARCH    Linux aarch64, gfortran compiler with gcc  #serial smpar dmpar dm+sm
++#
++DESCRIPTION     =       Arm GNU ($SFC/$SCC): Aarch64
++DMPARALLEL      =       # 1
++OMPCPP          =       # -D_OPENMP
++OMP             =       # -fopenmp
++OMPCC           =       # -fopenmp
++SFC             =       gfortran
++SCC             =       gcc
++CCOMP           =       gcc
++DM_FC           =       mpif90 
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       CONFIGURE_FC
++CC              =       CONFIGURE_CC
++LD              =       $(FC)
++RWORDSIZE       =       CONFIGURE_RWORDSIZE
++PROMOTION       =       #-fdefault-real-8
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR  -DWRF_USE_CLM
++CFLAGS_LOCAL    =       -w -O3 -c -march=native -mtune=native
++DFLAGS_LOCAL   =       
++CPLUSPLUSLIB    =       
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       -O3 -ftree-vectorize -funroll-loops -march=native -mtune=native
++FCREDUCEDOPT	=       $(FCOPTIM)
++FCNOOPT		=       -O0
++FCDEBUG         =       -g # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
++FORMAT_FIXED    =       -ffixed-form
++FORMAT_FREE     =       -ffree-form -ffree-line-length-none
++FCSUFFIX        =       
++BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =     
++TRADFLAG        =      CONFIGURE_TRADFLAG
++CPP             =      /lib/cpp CONFIGURE_CPPFLAGS
++AR              =      ar
++ARFLAGS         =      ru
++M4              =      m4 -G
++RANLIB          =      ranlib
++RLFLAGS		=	
++CC_TOOLS        =      $(SCC) 
++
+ #insert new stanza here
+ 
+ ###########################################################
+-- 
+2.28.0
+

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/tirpc_detect.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/tirpc_detect.patch
@@ -1,0 +1,129 @@
+From fcc33da2cc325f54c9ff7803854bae22fad32f65 Mon Sep 17 00:00:00 2001
+From: Phil Tooley <phil.tooley@nag.co.uk>
+Date: Fri, 16 Oct 2020 12:39:59 +0100
+Subject: [PATCH] tirpc detection
+
+---
+ arch/Config.pl | 14 ++++++++++++++
+ arch/postamble |  7 +++++--
+ configure      | 28 ++++++++++++++++++++++++----
+ 3 files changed, 43 insertions(+), 6 deletions(-)
+
+diff --git a/arch/Config.pl b/arch/Config.pl
+index 19cc6278..482846ac 100644
+--- a/arch/Config.pl
++++ b/arch/Config.pl
+@@ -7,6 +7,9 @@
+ 
+ select((select(STDOUT), $|=1)[0]);
+ $sw_perl_path = perl ;
++$sw_tirpc_inc = "";
++$sw_tirpc_lib = "";
++$sw_tirpc_libdir = "";
+ $sw_netcdf_path = "" ;
+ $sw_netcdff_path = "" ;
+ $sw_pnetcdf_path = "" ;
+@@ -60,6 +63,15 @@ while ( substr( $ARGV[0], 0, 1 ) eq "-" )
+   {
+     $sw_perl_path = substr( $ARGV[0], 6 ) ;
+   }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_inc=" )
++  {
++    $sw_tirpc_inc = substr( $ARGV[0], 11 ) ;
++  }
++  if ( substr( $ARGV[0], 1, 10 ) eq "tirpc_lib=" )
++  {
++    $sw_tirpc_libdir = substr( $ARGV[0], 11 ) ;
++    $sw_tirpc_lib = "-ltirpc" ;
++  }
+   if ( substr( $ARGV[0], 1, 7 ) eq "netcdf=" )
+   {
+     $sw_netcdf_path = substr( $ARGV[0], 8 ) ;
+@@ -448,6 +460,8 @@ while ( <CONFIGURE_DEFAULTS> )
+   if ( $latchon == 1 )
+   {
+     $_ =~ s/CONFIGURE_PERL_PATH/$sw_perl_path/g ;
++    $_ =~ s/CONFIGURE_TIRPC_INC/$sw_tirpc_inc/g ;
++    $_ =~ s/CONFIGURE_TIRPC_LIB/$sw_tirpc_libdir $sw_tirpc_lib/g ;
+     $_ =~ s/CONFIGURE_NETCDF_PATH/$sw_netcdf_path/g ;
+     $_ =~ s/CONFIGURE_NETCDFF_PATH/$sw_netcdff_path/g ;
+     $_ =~ s/CONFIGURE_PNETCDF_PATH/$sw_pnetcdf_path/g ;
+diff --git a/arch/postamble b/arch/postamble
+index 93e4ae35..36a39a33 100644
+--- a/arch/postamble
++++ b/arch/postamble
+@@ -36,7 +36,8 @@ ARCHFLAGS       =    $(COREDEFS) -DIWORDSIZE=$(IWORDSIZE) -DDWORDSIZE=$(DWORDSIZ
+ 		      -DNMM_NEST=$(WRF_NMM_NEST)
+ CFLAGS          =    $(CFLAGS_LOCAL) CONFIGURE_DMPARALLEL CONFIGURE_STUBMPI \
+                      CONFIGURE_TERRAIN_AND_LANDUSE \
+-                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE
++                      -DMAX_HISTORY=$(MAX_HISTORY) CONFIGURE_NMM_CORE $(TIRPCINC)
++
+ FCFLAGS         =    $(FCOPTIM) $(FCBASEOPTS)
+ ESMF_LIB_FLAGS  =    ESMFLIBFLAG
+ # ESMF 5 -- these are defined in esmf.mk, included above
+@@ -58,7 +59,7 @@ INCLUDE_MODULES =    $(MODULE_SRCH_FLAG) \
+ REGISTRY        =    Registry
+ CC_TOOLS_CFLAGS = CONFIGURE_NMM_CORE
+ 
+-LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO)
++LIB             =    $(LIB_BUNDLED) $(LIB_EXTERNAL) $(LIB_LOCAL) $(LIB_WRF_HYDRO) $(LIB_TIRPC)
+ LDFLAGS         =    $(OMP) $(FCFLAGS) $(LDFLAGS_LOCAL) CONFIGURE_LDFLAGS
+ ENVCOMPDEFS     =    CONFIGURE_COMPILEFLAGS
+ CPPFLAGS        =    $(ARCHFLAGS) $(ENVCOMPDEFS) -I$(LIBINCLUDE) $(TRADFLAG) CONFIGURE_COMMS_INCLUDE
+@@ -68,6 +69,8 @@ HDF5PATH        =    CONFIGURE_HDF5_PATH
+ WRFPLUSPATH     =    CONFIGURE_WRFPLUS_PATH
+ RTTOVPATH       =    CONFIGURE_RTTOV_PATH
+ PNETCDFPATH     =    CONFIGURE_PNETCDF_PATH
++TIRPCINC        =    CONFIGURE_TIRPC_INC
++LIB_TIRPC       =    CONFIGURE_TIRPC_LIB
+ 
+ bundled:  io_only CONFIGURE_ATMOCN
+ external: io_only CONFIGURE_COMMS_EXTERNAL $(ESMF_TARGET)
+diff --git a/configure b/configure
+index 16a9ef57..188b6f03 100755
+--- a/configure
++++ b/configure
+@@ -548,15 +548,35 @@ if test -n "$wrf_core" ; then
+    fi
+ fi
+ 
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_INCLUDE_DIR ]; then
++  TIRPC_INC=$(pkg-config --cflags-only-I libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_INC="-I${TIRPC_INCLUDE_DIR}"
++fi
++echo "TIRPC_INC=${TIRPC_INC}"
++
++# Try to get an include dir for libtirpc, an empty string is acceptable...
++if [ -z $TIRPC_LIB_DIR ]; then
++  TIRPC_LIB=$(pkg-config --libs-only-L libtirpc 2>/dev/null)
++else
++  echo Using passed TIRPC include path
++  TIRPC_LIB="-L${TIRPC_LIB_DIR}"
++fi
++echo "TIRPC_LIB=${TIRPC_LIB}"
++
+ # Found perl, so proceed with configuration
+ if test -n "$PERL" ; then
+    srch=`grep -i "^#ARCH.*$os" arch/configure.defaults | grep -i "$mach"`
+    if [ -n "$srch" ] ; then
+      $PERL arch/Config.pl -dmparallel=$COMMLIB -ompparallel=$OMP -perl=$PERL \
+-          -netcdf=$NETCDF -netcdff=$NETCDFF -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
+-          -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF -USENETCDF=$USENETCDF \
+-          -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" -config_line="$config_line" \
+-          -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH -dep_lib_path="$DEP_LIB_PATH"
++        -tirpc_inc=$TIRPC_INC -tirpc_lib=$TIRPC_LIB -netcdf=$NETCDF -netcdff=$NETCDFF \
++        -pnetcdf=$PNETCDF -hdf5=$HDF5 -phdf5=$PHDF5 -os=$os -mach=$mach -ldflags=$ldflags \
++        -compileflags=$compileflags -opt_level=$opt_level -USENETCDFF=$USENETCDFF \
++        -USENETCDF=$USENETCDF -time=$FORTRAN_COMPILER_TIMER -tfl="$TFL" -cfl="$CFL" \
++        -config_line="$config_line" -wrf_core=$wrf_core -gpfs=$GPFS_PATH -curl=$CURL_PATH \
++        -dep_lib_path="$DEP_LIB_PATH"
+      if test ! -f configure.wrf ; then
+        echo "configure.wrf not created! Exiting configure script..."
+        exit 1
+-- 
+2.28.0
+


### PR DESCRIPTION
PR to improve several aspects of WRF support in Spack:

The headline issue here is the fact that upstream use `make -i -k` and their custom make script always returns 0. This means that the standard approach of checking the return code won't detect a failed build.  Instead we need to actually check the output of the script to see if it succeeded.  My approach is the least-bad solution I could find.

Second big issue is that the configure script *enforces* interactivity and dynamically generates its option.  Previous recipe version had response values hardcoded for an assumed x86 platform.  This new version should be platform independent and has been tested on at least aarch64 and x86_64.

Additionally I have added support for v 3.9 which is a common HPC benchmarking workload, and fixed an issue with failure to compile against recent glibcs that don't ship sunrpc headers.

* Include version 3.9.1.1 as common benchmarking workload
* Fix compilation against recent glibc (use spack installed libtirpc)
* Detect and handle failed compilation (upstream use make -i)