### PR TITLE
suite-sparse: add deps: mpfr, gmp

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -35,6 +35,8 @@ class SuiteSparse(Package):
     variant('cuda', default=False, description='Build with CUDA')
     variant('openmp', default=False, description='Build with OpenMP')
 
+    depends_on('mpfr', type=('build', 'link'))
+    depends_on('gmp', type=('build', 'link'))
     depends_on('blas')
     depends_on('lapack')
     depends_on('m4', type='build', when='@5.0.0:')


### PR DESCRIPTION
`suite-sparse` needs `mpfr` and `gmp`

fixes https://github.com/spack/spack/issues/19880

@adamjstewart @siko1056 @mathsen @t-karatsu @jppelteret 