### PR TITLE
Pipelines: Compare target family instead of architecture

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -195,6 +195,7 @@ spack:
   definitions:
     - bootstrap:
       - gcc@3.0
+      - gcc@2.0
   specs:
     - dyninst%gcc@3.0
   mirrors:


### PR DESCRIPTION
In compiler bootstrapping pipelines, we add an artificial dependency
between jobs for packages to be built with a bootstrapped compiler
and the job building the compiler.  To find the right bootstrapped
compiler for each spec, we compared not only the compiler spec to
that required by the package spec, but also the architectures of
the compiler and package spec.

But this prevented us from finding the bootstrapped compiler for a
spec in cases where the architecture of the compiler wasn't exactly
the same as the spec.  For example, a gcc@4.8.5 might have given
haswell as the architecture, while the spec had broadwell.  By
comparing the families instead of the architecture itself, we know
that we can build the zlib for broadwell with the gcc for haswell.

Compiler bootstrapping is still going to have issues until #17563 can be rebased and merged, but this is fixes a problem orthogonal to the issues addressed in that PR.  And since that PR doesn't touch the same files, it should be fine to merge this ahead of it.