### PR TITLE
Ginkgo: add smoke tests.

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -93,3 +93,10 @@ class Ginkgo(CMakePackage, CudaPackage):
             args.append('-DHIPBLAS_PATH={0}'.
                         format(spec['hipblas'].prefix))
         return args
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def test_install(self):
+        """Perform smoke tests on the installed package."""
+        with working_dir(self.build_directory):
+            make("test_install")


### PR DESCRIPTION
This small PR runs Ginkgo's native smoke tests after installation, if requested.

If everything goes well, a small output is added to the build log. Otherwise, an error is thrown by `make test_install`.