### PR TITLE
run unit tests on 3.8 only for Mac OS vs. both 3.8 and 3.9

### DIFF
--- a/.github/workflows/macos_unit_tests.yaml
+++ b/.github/workflows/macos_unit_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Mac OS unit tests are "expensive" for the CI in the sense that limited runners are available. Since 3.8 is more commonly available on Mac OS, focus on that and omit testing with 3.9.