### PR TITLE
add test to ensure that all packages can be pickled

### DIFF
--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -18,6 +18,9 @@ import spack.util.executable as executable
 # do sanity checks only on packagess modified by a PR
 import spack.cmd.flake8 as flake8
 import spack.util.crypto as crypto
+import pickle
+
+import llnl.util.tty as tty
 
 
 def check_repo():
@@ -30,6 +33,24 @@ def check_repo():
 def test_get_all_packages():
     """Get all packages once and make sure that works."""
     check_repo()
+
+
+def test_packages_are_pickleable():
+    failed_to_pickle = list()
+    for name in spack.repo.all_package_names():
+        pkg = spack.repo.get(name)
+        try:
+            pickle.dumps(pkg)
+        except:
+            failed_to_pickle.append(name)
+
+    if failed_to_pickle:
+        tty.msg('The following packages failed to pickle: ' +
+                ', '.join(failed_to_pickle))
+
+        for name in failed_to_pickle:
+            pkg = spack.repo.get(name)
+            pickle.dumps(pkg)
 
 
 def test_get_all_mock_packages():

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -41,7 +41,10 @@ def test_packages_are_pickleable():
         pkg = spack.repo.get(name)
         try:
             pickle.dumps(pkg)
-        except:
+        except Exception:
+            # If there are any failures, keep track of all packages that aren't
+            # pickle-able and re-run the pickling later on to recreate the
+            # error
             failed_to_pickle.append(name)
 
     if failed_to_pickle:


### PR DESCRIPTION
As of https://github.com/spack/spack/pull/18205 (merged today November 12), all packages must be pickle-able to be installed by Spack.

This adds a test to check that each package can be pickled. If any package fails to pickle, the test keeps going and collects the names of all failed packages; it then takes the first one that failed and attempts to re-pickle it, generating the full stacktrace for the failed pickle attempt.