### PR TITLE
fix tumbleweed naming

### DIFF
--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -51,6 +51,11 @@ class LinuxDistro(OperatingSystem):
 
         if 'ubuntu' in distname:
             version = '.'.join(version[0:2])
+        # openSUSE Tumbleweed is a rolling release which can change
+        # more than once in a week, so set version to tumbleweed
+        elif 'opensuse-tumbleweed' in distname:
+            distname = 'opensuse'
+            version = 'tumbleweed'
         else:
             version = version[0]
 

--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import platform as py_platform
 import re
+from subprocess import check_output
 
 from spack.version import Version
-
-from subprocess import check_output
 
 from ._operating_system import OperatingSystem
 
@@ -58,9 +57,9 @@ class LinuxDistro(OperatingSystem):
         elif 'opensuse-tumbleweed' in distname or 'opensusetumbleweed' in distname:
             distname = 'opensuse'
             output = check_output(["ldd", "--version"]).decode()
-            libcvers = re.findall(r'ldd \(GNU libc\) (.*)',output)
+            libcvers = re.findall(r'ldd \(GNU libc\) (.*)', output)
             if len(libcvers) == 1:
-                version = 'tumbleweed'+libcvers[0]
+                version = 'tumbleweed' + libcvers[0]
             else:
                 version = 'tumbleweed' + version[0]
 

--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -7,6 +7,8 @@ import re
 
 from spack.version import Version
 
+from subprocess import check_output
+
 from ._operating_system import OperatingSystem
 
 
@@ -52,10 +54,16 @@ class LinuxDistro(OperatingSystem):
         if 'ubuntu' in distname:
             version = '.'.join(version[0:2])
         # openSUSE Tumbleweed is a rolling release which can change
-        # more than once in a week, so set version to tumbleweed
-        elif 'opensuse-tumbleweed' in distname:
+        # more than once in a week, so set version to tumbleweed$GLIBVERS
+        elif 'opensuse-tumbleweed' in distname or 'opensusetumbleweed' in distname:
             distname = 'opensuse'
-            version = 'tumbleweed'
+            output = check_output(["ldd", "--version"]).decode()
+            libcvers = re.findall(r'ldd \(GNU libc\) (.*)',output)
+            if len(libcvers) == 1:
+                version = 'tumbleweed'+libcvers[0]
+            else:
+                version = 'tumbleweed' + version[0]
+
         else:
             version = version[0]
 


### PR DESCRIPTION
fixes #28911

 openSUSE Tumbleweed is a rolling release which can change more than once in a week, so set version to tumbleweed
