### PR TITLE
suite-sparse: gmp, mpfr: only needed when=@5.8.0:

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -35,8 +35,8 @@ class SuiteSparse(Package):
     variant('cuda', default=False, description='Build with CUDA')
     variant('openmp', default=False, description='Build with OpenMP')
 
-    depends_on('mpfr', type=('build', 'link'))
-    depends_on('gmp', type=('build', 'link'))
+    depends_on('mpfr', type=('build', 'link'), when='@5.8.0:')
+    depends_on('gmp', type=('build', 'link'), when='@5.8.0:')
     depends_on('blas')
     depends_on('lapack')
     depends_on('m4', type='build', when='@5.0.0:')


### PR DESCRIPTION
Follow up to https://github.com/spack/spack/pull/19883.

`mpfr` and `gmp` are only needed for `suite-sparse@5.8.0:`

@balay @adamjstewart 