### PR TITLE
macOS: Big Sur reports as either 10.16 or 11.0

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -54,6 +54,7 @@ class MacOs(OperatingSystem):
             '10.13': 'highsierra',
             '10.14': 'mojave',
             '10.15': 'catalina',
+            '10.16': 'bigsur',
             '11.0':  'bigsur',
         }
 


### PR DESCRIPTION
macOS Big Sur is both 10.16 and 11.0: https://eclecticlight.co/2020/07/21/big-sur-is-both-10-16-and-11-0-its-official/