### PR TITLE
[gcc] depends_on diffutils (for all versions)

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -119,6 +119,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('isl@0.15:', when='@10:')
     depends_on('zlib', when='@6:')
     depends_on('zstd', when='@10:')
+    depends_on('diffutils', type='build')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
     depends_on('binutils~libiberty', when='+binutils', type=('build', 'link', 'run'))


### PR DESCRIPTION
Let me start by saying that I don't like adding dependencies to gcc any more than you do :-)

See discussion in issue #15510 where it appears that the absence of `cmp` (in diffutils) is causing the build to fail (numerous entries of `cmp: command not found`). Installing diffutils on the system (centos8 in my case) causes the build to succeed. One case where `cmp` is used is in [move-if-change](https://github.com/gcc-mirror/gcc/blob/master/move-if-change), which has include `cmp` in tags since 2.95.0 according to the git history. There are other places where `cmp` is used, though there are others too (e.g. [Makefile.in](https://github.com/gcc-mirror/gcc/blob/master/Makefile.in)).

Is it reasonable to expect `cmp` and `diff` to be available on the system? Maybe (they are pulled in by `apt-get install build-essentials` and `yum groupinstall "Development tools"`), but diffutils is not included in the [Spack prerequisites](https://spack.readthedocs.io/en/latest/getting_started.html#prerequisites). `patch` is in a separate package.

The [prerequisites for gcc](https://gcc.gnu.org/install/prerequisites.html) for gcc indicate that diffutils is only "useful when submitting patches" but it appears that diffutils should in fact be included as a prerequisite when building gcc.