### PR TITLE
include share/pkgconfig in user environments

### DIFF
--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -35,6 +35,7 @@ def prefix_inspections(platform):
         'include': ['CPATH'],
         'lib/pkgconfig': ['PKG_CONFIG_PATH'],
         'lib64/pkgconfig': ['PKG_CONFIG_PATH'],
+        'share/pkgconfig': ['PKG_CONFIG_PATH'],
         '': ['CMAKE_PREFIX_PATH']
     }
 


### PR DESCRIPTION
According to the documentation for spack and pkg-config,
$view/share/pkgconfig should also be a valid place to look
for package config files.  This commit ensures that when
spack activate env $dir is called, the environment has this
directory in PKG_CONFIG_PATH.