### PR TITLE
bzip2: fix libs() search paths

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -39,9 +39,10 @@ class Bzip2(Package, SourcewarePackage):
     @property
     def libs(self):
         shared = '+shared' in self.spec
-        return find_libraries(
-            'libbz2', root=self.prefix, shared=shared, recursive=True
-        )
+        return find_libraries('libbz2', root=self.prefix.lib64, shared=shared,
+                              recursive=False) + \
+            find_libraries('libbz2', root=self.prefix.lib, shared=shared,
+                           recursive=False)
 
     def patch(self):
         # bzip2 comes with two separate Makefiles for static and dynamic builds


### PR DESCRIPTION
Previously, if bzip2 was installed as an external package whose prefix
is `/`, then the bzip2 would find all sorts of undesirable copies of
bzip installed by flatpak, anaconda, and others.  This makes the search
directories much more conservative to avoid that change.

See also: https://spackpm.slack.com/archives/C5W7NKZJT/p1604598268233500

@becker33 I didn't see a PR for this, so I went ahead and created one.  Thanks for helping me debug and fix this one.