### PR TITLE
[xerces-c] add netaccessor variant, new version

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -66,7 +66,7 @@ class Geant4(CMakePackage):
                    when='@10.3.3: cxxstd=' + std)
 
         # Spack only supports Xerces-c 3 and above, so no version req
-        depends_on('xerces-c cxxstd=' + std, when='cxxstd=' + std)
+        depends_on('xerces-c netaccessor=curl cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom specific versions for each Geant4 version
         depends_on('vecgeom@1.1.5 cxxstd=' + std,

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -34,7 +34,7 @@ class XercesC(AutotoolsPackage):
 
     variant('netaccessor',
             default='curl',
-            # todo: add additional values (platform-specific) 
+            # todo: add additional values (platform-specific)
             # 'socket', 'cfurl', 'winsock'
             values=('curl', 'none'),
             multi=False,
@@ -78,7 +78,7 @@ class XercesC(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         args = []
-        
+
         if 'netaccessor=curl' in spec:
             args.append('--enable-netaccessor-curl')
         else:

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -17,6 +17,7 @@ class XercesC(AutotoolsPackage):
     homepage = "https://xerces.apache.org/xerces-c"
     url      = "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.2.1.tar.bz2"
 
+    version('3.2.3', sha256='45c2329e684405f2b8854ecbddfb8d5b055cdf0fe4d35736cc352c504989bbb6')
     version('3.2.2', sha256='1f2a4d1dbd0086ce0f52b718ac0fa4af3dc1ce7a7ff73a581a05fbe78a82bce0')
     version('3.2.1', sha256='a36b6e162913ec218cfb84772d2535d43c3365355a601d45d4b8ce11f0ece0da')
     version('3.1.4', sha256='9408f12c1628ecf80730bedbe8b2caad810edd01bb4c66f77b60c873e8cc6891')
@@ -30,6 +31,14 @@ class XercesC(AutotoolsPackage):
             values=('default', '98', '11', '14', '17'),
             multi=False,
             description='Use the specified C++ standard when building')
+
+    variant('netaccessor',
+            default='curl',
+            # todo: add additional values (platform-specific) 
+            # 'socket', 'cfurl', 'winsock'
+            values=('curl', 'none'),
+            multi=False,
+            description='Net Accessor (used to access network resources')
 
     # It's best to be explicit about the transcoder or else xerces may
     # choose another value.
@@ -47,6 +56,7 @@ class XercesC(AutotoolsPackage):
 
     depends_on('iconv', type='link', when='transcoder=gnuiconv')
     depends_on('icu4c',    type='link', when='transcoder=icu')
+    depends_on('curl', when='netaccessor=curl')
 
     # Pass flags to configure.  This is necessary for CXXFLAGS or else
     # the xerces default will override the spack wrapper.
@@ -67,7 +77,12 @@ class XercesC(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = ['--disable-network']
+        args = []
+        
+        if 'netaccessor=curl' in spec:
+            args.append('--enable-netaccessor-curl')
+        else:
+            args.append('--disable-network')
 
         if 'transcoder=gnuiconv' in spec:
             args.append('--enable-transcoder-gnuiconv')


### PR DESCRIPTION
Need this build option because geant4 requires it to validate xml schemas via url. There are a few alternative options for the netaccessor (see https://xerces.apache.org/xerces-c/build-3.html) which I cannot test as they are specific to platforms I don't use, so I leave it as a todo. 