### PR TITLE
[acts] Add versions 1.2.1 and 2.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -35,6 +35,8 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version('master', branch='master')
+    version('2.00.0', commit='8708eae2b2ccdf57ab7b451cfbba413daa1fc43c')
+    version('1.02.1', commit='f6ebeb9a28297ba8c54fd08b700057dd4ff2a311')
     version('1.02.0', commit='e69b95acc9a264e63aded7d1714632066e090542')
     version('1.01.0', commit='836fddd02c3eff33825833ff97d6abda5b5c20a0')
     version('1.00.0', commit='ec9ce0bcdc837f568d42a12ddf3fc9c80db62f5d')


### PR DESCRIPTION
I did not find any build system related change in the changelog, so this should be a painless upgrade on the Spack side. But waiting for the test build anyway...