### PR TITLE
[dd4hep] switch to ninja generator to avoid running out of memory …

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -35,7 +35,6 @@ class Dd4hep(CMakePackage):
 
     generator = 'Ninja'
 
-
     # Workarounds for various TBB issues in DD4hep v1.11
     # See https://github.com/AIDASoft/DD4hep/pull/613 .
     patch('tbb-workarounds.patch', when='@1.11.0')

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -33,6 +33,9 @@ class Dd4hep(CMakePackage):
     version('1.11.0', sha256='25643296f15f9d11ad4ad550b7c3b92e8974fc56f1ee8e4455501010789ae7b6')
     version('1.10.0', sha256='1d6b5d1c368dc8bcedd9c61b7c7e1a44bad427f8bd34932516aff47c88a31d95')
 
+    generator = 'Ninja'
+
+
     # Workarounds for various TBB issues in DD4hep v1.11
     # See https://github.com/AIDASoft/DD4hep/pull/613 .
     patch('tbb-workarounds.patch', when='@1.11.0')
@@ -46,6 +49,7 @@ class Dd4hep(CMakePackage):
     variant('debug', default=False, description="Enable debug build")
 
     depends_on('cmake @3.12:', type='build')
+    depends_on('ninja', type='build')
     depends_on('boost @1.49:')
     depends_on('root @6.08: +gdml +math +opengl +python +x')
     extends('python')


### PR DESCRIPTION
…while compiling ddparsers

More than half of the builds of DD4hep are failing for me because gcc runs out of memory when compiling DDParsers, and I have to restart them with `-j 1`. This is a known issue and the DD4hep developers have added some cmake configuration that basically fixes this problem, but only for the ninja generator: https://github.com/AIDASoft/DD4hep/blob/master/CMakeLists.txt#L65

So I'm switching the package recipe to use Ninja - as far as I can tell there are no downsides to this, except for the additional dependency. 