### PR TITLE
texlive: Fix install of @live version

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack import *
 import os
 import platform
+import tempfile
 
 
 class Texlive(AutotoolsPackage):
@@ -192,6 +194,11 @@ class Texlive(AutotoolsPackage):
 
     @when('@live')
     def install(self, spec, prefix):
+        # The binary install needs a profile file to be present
+        tmp_profile = tempfile.NamedTemporaryFile()
+        tmp_profile.write("selected_scheme {0}".format(
+            spec.variants['scheme']).encode())
+
         # Using texlive's mirror system leads to mysterious problems,
         # in lieu of being able to specify a repository as a variant, hardwire
         # a particular (slow, but central) one for now.
@@ -202,4 +209,6 @@ class Texlive(AutotoolsPackage):
         scheme = spec.variants['scheme'].value
         perl('./install-tl', '-scheme', scheme,
              '-repository', _repository,
-             '-portable', '-profile', '/dev/null')
+             '-portable', '-profile', tmp_profile.name)
+
+        tmp_profile.close()


### PR DESCRIPTION
The unattended install using the pre-compiled binaries (tl-install)
needs a .profile file or it goes in interactive mode blocking the
install process forever.

See: #19885 