### PR TITLE
[pythia6] needs CFLAGS/FFLAGS=-fcommon when %gcc@10:

### DIFF
--- a/var/spack/repos/builtin/packages/pythia6/package.py
+++ b/var/spack/repos/builtin/packages/pythia6/package.py
@@ -144,6 +144,11 @@ class Pythia6(CMakePackage):
                     r'\1{0}'.format(self.spec.variants['nmxhep'].value),
                     'pyhepc.f')
 
+    def setup_build_environment(self, env):
+        if self.spec.satisfies('%gcc@10:'):
+            env.append_flags('CFLAGS', '-fcommon')
+            env.append_flags('FFLAGS', '-fcommon')
+
     def cmake_args(self):
         args = ['-DPYTHIA6_VERSION={0}'.format(self.version.dotted)]
         return args


### PR DESCRIPTION
Pythia6 uses fortran common blocks which are now [by default disallowed in gcc-10](https://gcc.gnu.org/gcc-10/porting_to.html). In this particular case, the common blocks are in e.g. pydata.f:
```fortran
COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
```
and collected in pythia6_common_address.c:
```c
int pydat1[200+2*200+200+2*200];
```
This fix adds `CFLAGS=-fcommon` and `FFLAGS=-fcommon` (both are needed) to the build environment for gcc-10 or later.

An alternative fix (adding `extern` in all relevant lines in `pythia6_common_address.c`) would have required a patch and some more testing, but I'm happy to implement that instead if requested. Since pythia6 is unmaintained, there won't be any future releases to invalidate the patch.

No maintainer to tag.