### PR TITLE
qt: patch missing includes for 5.14

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -121,6 +121,7 @@ class Qt(Package):
     patch('qt5-12-configure.patch', when='@5.12')
     # https://bugreports.qt.io/browse/QTBUG-93402
     patch('qt5-15-gcc-10.patch', when='@5.12.7:5.15 %gcc@8:')
+    patch('qt514.patch', when='@5.14')
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
 
     # Build-only dependencies

--- a/var/spack/repos/builtin/packages/qt/qt514.patch
+++ b/var/spack/repos/builtin/packages/qt/qt514.patch
@@ -1,0 +1,9 @@
+diff -ruN qt-everywhere-src-5.14.2.orig/qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp qt-everywhere-src-5.14.2/qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp
+--- qt-everywhere-src-5.14.2.orig/qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp	2020-03-03 13:10:30.000000000 +0000
++++ qt-everywhere-src-5.14.2/qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp	2020-11-16 19:57:56.792619032 +0000
+@@ -38,4 +38,5 @@
+ **
+ ****************************************************************************/
+ 
++#include <math.h>
+ #include "qjp2handler_p.h"


### PR DESCRIPTION
Not sure if this happens with other distributions. In ArchLinux, Qt does not compile cleanly. Applying the changes in the included patch fixes it. 