### PR TITLE
spack edit: open read-only packages

### DIFF
--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -40,7 +40,7 @@ def edit_package(name, repo_path, namespace):
     if os.path.exists(path):
         if not os.path.isfile(path):
             tty.die("Something is wrong. '{0}' is not a file!".format(path))
-        if not os.access(path, os.R_OK | os.W_OK):
+        if not os.access(path, os.R_OK):
             tty.die("Insufficient permissions on '%s'!" % path)
     else:
         tty.die("No package for '{0}' was found.".format(spec.name),


### PR DESCRIPTION
We use an upstream repository that is read-only for our users. Currently, the `spack edit` command requires write access to the package, but is nevertheless useful to view the content of `package.py`.
```console
$ spack edit qt
==> Error: Insufficient permissions on '/cvmfs/eic.opensciencegrid.org/packages/spack/rollout/var/spack/repos/builtin/packages/qt/package.py'!
```
This enhancement requires that `package.py` be readable, regardless of whether it is writable.