### PR TITLE
Fix InvalidVariantValueCombinationError with depends_on('pkg some_variant=none')

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -347,7 +347,11 @@ class AbstractVariant(object):
 
         old_value = self.value
 
-        values = list(sorted(set(self.value + other.value)))
+        if len(other.value) == 1 and other.value[0] == 'none':
+            values = ("none",)
+        else:
+            values = list(sorted(set(self.value + other.value)))
+
         # If we constraint wildcard by another value, just take value
         if '*' in values and len(values) > 1:
             values.remove('*')


### PR DESCRIPTION
Fixes #19951.

I'm not familiar with spack's internals, so just opening this PR because it's easier to explain the issue like this than spelling it out in #19951.