### PR TITLE
allow install of build-deps from cache via --include-build-deps switch

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -43,6 +43,7 @@ def update_kwargs_from_args(args, kwargs):
         'dirty': args.dirty,
         'use_cache': args.use_cache,
         'cache_only': args.cache_only,
+        'include_build_deps': args.include_build_deps,
         'explicit': True,  # Always true for install command
         'stop_at': args.until,
         'unsigned': args.unsigned,
@@ -104,6 +105,10 @@ the dependencies"""
     cache_group.add_argument(
         '--cache-only', action='store_true', dest='cache_only', default=False,
         help="only install package from binary mirrors")
+
+    subparser.add_argument(
+        '--include-build-deps', action='store_true', dest='include_build_deps',
+        default=False, help="include build deps when installing from cache")
 
     subparser.add_argument(
         '--no-check-signature', action='store_true',

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -108,7 +108,8 @@ the dependencies"""
 
     subparser.add_argument(
         '--include-build-deps', action='store_true', dest='include_build_deps',
-        default=False, help="include build deps when installing from cache")
+        default=False, help="""include build deps when installing from cache,
+which is useful for CI pipeline troubleshooting""")
 
     subparser.add_argument(
         '--no-check-signature', action='store_true',

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1367,7 +1367,6 @@ class PackageInstaller(object):
 
             pkg, pkg_id, spec = task.pkg, task.pkg_id, task.pkg.spec
             tty.verbose('Processing {0}: task={1}'.format(pkg_id, task))
-
             # Ensure that the current spec has NO uninstalled dependencies,
             # which is assumed to be reflected directly in its priority.
             #
@@ -1967,7 +1966,8 @@ class BuildRequest(object):
             (tuple) required dependency type(s) for the package
         """
         deptypes = ['link', 'run']
-        if not self.install_args.get('cache_only'):
+        include_build_deps = self.install_args.get('include_build_deps')
+        if not self.install_args.get('cache_only') or include_build_deps:
             deptypes.append('build')
         if self.run_tests(pkg):
             deptypes.append('test')

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1020,7 +1020,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi


### PR DESCRIPTION
This is a proposal that would fix https://github.com/spack/spack/issues/19953 .

This PR adds a switch to `spack install`, <b>`--include-build-deps`</b>, to enable installation of build deps from build cache when used in conjunction with `--cache-only`.

```
$> spack install --help
...
  --include-build-deps  include build deps when installing from cache
...
```

This would facilitate manual troubleshooting of pipeline issues where we need to install all dependencies of a package from cache, and then build the package from source using those dependencies.

```
$> spack install --cache-only --include-build-deps --only dependencies ...
```



@scottwittenburg @becker33 @scheibelp 