### PR TITLE
qt: patch missing includes when +opengl %gcc@10:

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -116,6 +116,8 @@ class Qt(Package):
     patch('qt5-12-intel-overflow.patch', when='@5.12:5.14.0 %intel')
     # https://bugreports.qt.io/browse/QTBUG-78937
     patch('qt5-12-configure.patch', when='@5.12')
+    # https://bugreports.qt.io/browse/QTBUG-93402
+    patch('qt5-15-gcc-10.patch', when='@5.9:5.15 %gcc@10:')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -117,7 +117,8 @@ class Qt(Package):
     # https://bugreports.qt.io/browse/QTBUG-78937
     patch('qt5-12-configure.patch', when='@5.12')
     # https://bugreports.qt.io/browse/QTBUG-93402
-    patch('qt5-15-gcc-10.patch', when='@5.9:5.15 %gcc@10:')
+    patch('qt5-15-gcc-10.patch', when='@5.12.7:5.15 %gcc@10:')
+    conflicts('%gcc@10:', when='@5.9:5.12.6')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -118,7 +118,7 @@ class Qt(Package):
     patch('qt5-12-configure.patch', when='@5.12')
     # https://bugreports.qt.io/browse/QTBUG-93402
     patch('qt5-15-gcc-10.patch', when='@5.12.7:5.15 %gcc@10:')
-    conflicts('%gcc@10:', when='@5.9:5.12.6')
+    conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')

--- a/var/spack/repos/builtin/packages/qt/qt5-15-gcc-10.patch
+++ b/var/spack/repos/builtin/packages/qt/qt5-15-gcc-10.patch
@@ -1,0 +1,39 @@
+diff --git a/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp b/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
+index 02ec7fe..6c1284e 100644
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
+@@ -1,6 +1,7 @@
+ #include <mbgl/util/util.hpp>
+ 
+ #include <array>
++#include <stdint.h>
+ #include <type_traits>
+ #include <utility>
+ 
+diff --git a/qtlocation/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp b/qtlocation/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+index d475c38..6947f0b 100644
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+@@ -4,6 +4,7 @@
+ #include <unicode/ubidi.h>
+ #include <unicode/ushape.h>
+ 
++#include <stdexcept>
+ #include <memory>
+ 
+ namespace mbgl {
+diff --git a/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/renderer/sources/render_vector_source.cpp b/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/renderer/sources/render_vector_source.cpp
+index 4de4f01..afb639d 100644
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/renderer/sources/render_vector_source.cpp
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/renderer/sources/render_vector_source.cpp
+@@ -2,6 +2,7 @@
+ #include <mbgl/renderer/render_tile.hpp>
+ #include <mbgl/renderer/paint_parameters.hpp>
+ #include <mbgl/tile/vector_tile.hpp>
++#include <mbgl/tile/tile_loader_impl.hpp>
+ 
+ #include <mbgl/algorithm/generate_clip_ids.hpp>
+ #include <mbgl/algorithm/generate_clip_ids_impl.hpp>
+-- 
+2.26.0
+


### PR DESCRIPTION
With gcc-10, `qt@5.14.2+opengl` fails with
```console
  >> 55479    src/mbgl/util/convert.cpp:6:56: error: 'int32_t' was not declared in this scope
     55480        6 | template std::array<float, 2> convert(const std::array<int32_t, 2>&);
     55481          |                                                        ^~~~~~~
  >> 55482    src/mbgl/util/convert.cpp:6:66: error: template argument 1 is invalid
     55483        6 | template std::array<float, 2> convert(const std::array<int32_t, 2>&);
     55484          |                                                                  ^
  >> 55485    src/mbgl/util/convert.cpp:6:31: error: template-id 'convert<>' for 'std::array<float, 2> mbgl::util::convert(const int&)' does not match any template declaration
     55486        6 | template std::array<float, 2> convert(const std::array<int32_t, 2>&);
     55487          |                               ^~~~~~~
     55488    In file included from src/mbgl/util/convert.cpp:1:
     55489    include/mbgl/util/convert.hpp:12:37: note: candidate is: 'template<class To, class From, long unsigned int Size, class> constexpr std::array<To, Size> mbgl::util::convert(const std::array<_Tp, _Nm>&)'
     55490       12 | MBGL_CONSTEXPR std::array<To, Size> convert(const std::array<From, Size>&from) {
     55491          |  
```
The offending file, `convert.cpp`, is in `qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert/` and the error is caused by a missing `#include "stdint.h"`.

This has been reported [upstream](https://bugreports.qt.io/browse/QTBUG-84106) and resolved in qt@5.16. That bug report includes the patch included here to allows a specific qtlocation 3rd party plugin (which is only used when `+opengl`) to compile with gcc-10.

I tested that this patch applies cleanly against qt@5.12.7 through the most recent version, qt@5.14.2 at this time. The patch is set to apply for qt@5.12.7:5.15 since 5.16 has the fix upstream. Before qt@5.12.7 other patches fail to apply (`qt5-12-configure.patch` fails against qt@5.12.5), and spack never gets to trying to apply this new patch. mapbox-gl-native was added in qt@5.9, so before then the patch should not apply. The conflict excludes potentially problematic compiles instead of addressing the hypothetical of someone running gcc-10 but wanting a specific older version of qt.

I tested that qt@5.12.7 and qt@5.14.2 both build fine with gcc@10.2.0 with this patch, but didn't explicitly build any versions in between (qt is a fairly big compile...).

Maintainer tag: @sethrj 