### PR TITLE
drop unnecessary tk dependency of py-git-review

### DIFF
--- a/var/spack/repos/builtin/packages/py-git-review/package.py
+++ b/var/spack/repos/builtin/packages/py-git-review/package.py
@@ -22,7 +22,6 @@ class PyGitReview(PythonPackage):
     depends_on('py-pbr',           type=('build', 'run'))
     depends_on('py-requests@1.1:', type=('build', 'run'))
     depends_on('git',              type=('run'))
-    depends_on('tk',               type=('run'))
 
     def setup_run_environment(self, env):
         env.set('PBR_VERSION', str(self.spec.version))


### PR DESCRIPTION
* seems to have been introduced errorously by users using gitk-based
  workflows. This should be handled by the git package
* fixes build problems on OSX bigsur see also #19905