### PR TITLE
openblas@0.3.12 conflicts with gcc less than 8.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -112,6 +112,9 @@ class Openblas(MakefilePackage):
     patch('openblas_fujitsu_v0.3.11.patch', when='@0.3.11: %fj')
     patch('openblas_fujitsu2.patch', when='@0.3.10: %fj')
 
+    # See https://github.com/spack/spack/issues/19932
+    conflicts('%gcc@:8.2.99', when='@0.3.12')
+
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')
     conflicts('+consistent_fpcsr', when='threads=none',


### PR DESCRIPTION
GCC less than 8.3.0 cannot build OpenBLAS 0.3.12 due to this:
* https://github.com/xianyi/OpenBLAS/issues/2949

This PR makes this conflict explicit.

Resolves https://github.com/spack/spack/issues/19932

@siko1056 @scottwittenburg @t-karatsu 