### PR TITLE
spack debug report: print concretizer

### DIFF
--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -15,6 +15,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack.architecture as architecture
+import spack.config
 import spack.paths
 from spack.main import get_version
 from spack.util.executable import which
@@ -89,6 +90,7 @@ def report(args):
     print('* **Python:**', platform.python_version())
     print('* **Platform:**', architecture.Arch(
         architecture.platform(), 'frontend', 'frontend'))
+    print('* **Concretizer:**', spack.config.get('config:concretizer'))
 
 
 def debug(parser, args):

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -11,6 +11,7 @@ import os
 import os.path
 
 import spack.architecture as architecture
+import spack.config
 from spack.main import SpackCommand, get_version
 from spack.util.executable import which
 
@@ -53,3 +54,4 @@ def test_report():
     assert get_version() in out
     assert platform.python_version() in out
     assert str(arch) in out
+    assert spack.config.get('config:concretizer') in out


### PR DESCRIPTION
Example output:

* **Spack:** 0.15.4-2107-eb7e9c5a1a
* **Python:** 3.8.6
* **Platform:** darwin-catalina-ivybridge
* **Concretizer:** original

I think this will be extremely useful information for bug reports.