### PR TITLE
Add relocatable code flag to trilinos for CUDA builds

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -751,7 +751,9 @@ class Trilinos(CMakePackage, CudaPackage):
             options.extend([
                 define('Kokkos_ENABLE_CUDA', True),
                 define('Kokkos_ENABLE_CUDA_UVM', True),
-                define('Kokkos_ENABLE_CUDA_LAMBDA', True)])
+                define('Kokkos_ENABLE_CUDA_LAMBDA', True),
+                define('Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE', True)])
+
             for iArchCC in spec.variants['cuda_arch'].value:
                 options.append(define(
                     "Kokkos_ARCH_" +

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -77,7 +77,7 @@ class Trilinos(CMakePackage, CudaPackage):
             description='Compile with Fortran support')
     variant('wrapper', default=False,
             description="Use nvcc-wrapper for CUDA build")
-    variant('cuda_rdc', default=True,
+    variant('cuda_rdc', default=False,
             description='turn on RDC for CUDA build')
     variant('cxxstd', default='11', values=['11', '14', '17'], multi=False)
     variant('hwloc', default=False,

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -77,6 +77,8 @@ class Trilinos(CMakePackage, CudaPackage):
             description='Compile with Fortran support')
     variant('wrapper', default=False,
             description="Use nvcc-wrapper for CUDA build")
+    variant('cuda_rdc', default=True,
+            description='turn on RDC for CUDA build')
     variant('cxxstd', default='11', values=['11', '14', '17'], multi=False)
     variant('hwloc', default=False,
             description='Enable hwloc')
@@ -328,6 +330,7 @@ class Trilinos(CMakePackage, CudaPackage):
     conflicts('+adios2', when='@:12.14.1')
     conflicts('+adios2', when='@xsdk-0.2.0')
     conflicts('+pnetcdf', when='~netcdf')
+    conflicts('+cuda_rdc', when='~cuda')
     conflicts('+wrapper', when='~cuda')
     conflicts('+wrapper', when='%clang')
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
@@ -751,9 +754,11 @@ class Trilinos(CMakePackage, CudaPackage):
             options.extend([
                 define('Kokkos_ENABLE_CUDA', True),
                 define('Kokkos_ENABLE_CUDA_UVM', True),
-                define('Kokkos_ENABLE_CUDA_LAMBDA', True),
-                define('Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE', True)])
-
+                define('Kokkos_ENABLE_CUDA_LAMBDA', True)])
+            if '+cuda_rdc' in spec:
+                options.append(define(
+                    'Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE',
+                    True))
             for iArchCC in spec.variants['cuda_arch'].value:
                 options.append(define(
                     "Kokkos_ARCH_" +


### PR DESCRIPTION
I've been testing out the cuda option that was added into trilinos via #19119 but I keep getting `ptxas fatal: Unresolved extern function` errors when trying to use it as a dependency.

This resolve that error.