### PR TITLE
WIP Add permissions command

### DIFF
--- a/lib/spack/spack/cmd/permissions.py
+++ b/lib/spack/spack/cmd/permissions.py
@@ -37,14 +37,15 @@ def setup_parser(subparser):
 def perm_check(args):
     """Check that permissions match those specified by packages.yaml."""
     # First check permissions for the database directory and its contents
-    spp.check_permissions(spack.store.db._db_dir, None, contents=True)
+    spp.check_permissions(spack.store.db._db_dir, None, contents=True,
+                          header=True)
 
     # Now check permissions for installed packages
     env = ev.get_env(args, 'permissions')
     hashes = env.all_hashes() if env else None
     specs = spack.store.db.query(hashes=hashes)
     for spec in specs:
-        spp.check_permissions(spec.prefix, spec, contents=True)
+        spp.check_permissions(spec.prefix, spec, contents=True, header=False)
 
 
 def perm_repair(args):

--- a/lib/spack/spack/cmd/permissions.py
+++ b/lib/spack/spack/cmd/permissions.py
@@ -3,7 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.store
+
 import spack.cmd.common.arguments as arguments
+import spack.environment as ev
+import spack.package_permissions as spp
 
 description = "manage spack permissions"
 section = "build"
@@ -32,15 +36,25 @@ def setup_parser(subparser):
 
 def perm_check(args):
     """Check that permissions match those specified by packages.yaml."""
-    # TODO: Add the database and metadata directories
-    # TODO: Process installed packages
-    raise NotImplementedError('The command is not yet implemented')
+    # First check permissions for the database directory and its contents
+    spp.check_permissions(spack.store.db._db_dir, None, contents=True)
+
+    # Now check permissions for installed packages
+    env = ev.get_env(args, 'permissions')
+    hashes = env.all_hashes() if env else None
+    specs = spack.store.db.query(hashes=hashes)
+    for spec in specs:
+        spp.check_permissions(spec.prefix, spec, contents=True)
 
 
 def perm_repair(args):
     """Repair any permissions that do not match packages.yaml specs."""
     # TODO: Add the database and metadata directories
-    # TODO: Process installed packages
+
+    env = ev.get_env(args, 'permissions')
+    hashes = env.all_hashes() if env else None
+    specs = spack.store.db.query(hashes=hashes)
+    spack.cmd.display_specs(specs, long=True)
     raise NotImplementedError('The command is not yet implemented')
 
 

--- a/lib/spack/spack/cmd/permissions.py
+++ b/lib/spack/spack/cmd/permissions.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.cmd.common.arguments as arguments
+
+description = "manage spack permissions"
+section = "build"
+level = "long"
+
+
+def first_line(docstring):
+    """Return the first line of the docstring."""
+    return docstring.split('\n')[0]
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(metavar='COMMAND',
+                                  dest='permissions_command')
+
+    # Check
+    check_parser = sp.add_parser('check', description=perm_check.__doc__,
+                                 help=first_line(perm_check.__doc__))
+    arguments.add_common_arguments(check_parser, ['installed_specs'])
+
+    # Repair
+    repair_parser = sp.add_parser('repair', description=perm_repair.__doc__,
+                                  help=first_line(perm_repair.__doc__))
+    arguments.add_common_arguments(repair_parser, ['installed_specs'])
+
+
+def perm_check(args):
+    """Check that permissions match those specified by packages.yaml."""
+    # TODO: Add the database and metadata directories
+    # TODO: Process installed packages
+    raise NotImplementedError('The command is not yet implemented')
+
+
+def perm_repair(args):
+    """Repair any permissions that do not match packages.yaml specs."""
+    # TODO: Add the database and metadata directories
+    # TODO: Process installed packages
+    raise NotImplementedError('The command is not yet implemented')
+
+
+def permissions(parser, args):
+    globals()['perm_{0}'.format(args.permissions_command)](args)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -37,6 +37,7 @@ except ImportError:
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
+import spack.package_permissions as spp
 import spack.repo
 import spack.spec
 import spack.store
@@ -348,6 +349,10 @@ class Database(object):
 
         if not os.path.exists(self._failure_dir) and not is_upstream:
             fs.mkdirp(self._failure_dir)
+
+        # Ensure the database and failure subdirectories have the proper
+        # permissions according to packages.yaml.
+        spp.update_permissions(self._db_dir, None, contents=True)
 
         self.is_upstream = is_upstream
         self.last_seen_verifier = ''

--- a/lib/spack/spack/package_permissions.py
+++ b/lib/spack/spack/package_permissions.py
@@ -1,0 +1,243 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import grp
+import os
+import stat
+
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+
+import spack.config as cfg
+
+
+# The format for specifying the key to specific spec permissions in
+# packages.yaml files.
+permissions_key = 'packages:{0}:permissions:{1}'
+
+
+def _add_gid_bit(perms):
+    """Adds the GID bit for directories if group permissions are on.
+
+    Args
+        perms (int): the appropriate directory stat permissions or mode
+    """
+    if perms & stat.S_IRWXG and cfg.get('config:allow_sgid', True):
+        perms |= stat.S_ISGID
+    return perms
+
+
+def _check_perms(path, perms, group, check_exists=False):
+    """Checks permissions for the specified path against those given.
+
+    Args:
+        path (str): path whose permissions are to be checked
+        perms (int): the appropriate stat permissions or mode
+        group (str): the appropriate group name or empty string if the group
+            option does not apply
+        check_exists (bool): ``True`` if the path existence should be checked;
+            otherwise, skip the existence check
+    """
+    if check_exists and not os.path.exists(path):
+        tty.warn('Cannot check permissions on missing path {0}'
+                 .format(path))
+        return
+
+    tty.debug('{0}: checking permissions against configuration'.format(path))
+
+    status = os.stat(path)
+
+    err_fmt = '{0}: {1} is {2}, not {3}'
+
+    # Check the path's group.
+    if group:
+        name, _, _, _ = grp.getgrgid(status.st_gid)
+        if group != name:
+            tty.error(err_fmt.format(path, 'group', name, group))
+
+    # Check the path's permissions.
+    mode = status.st_mode
+    if mode != perms:
+        tty.error(err_fmt.format(path, 'permissions', mode, perms))
+
+
+def _process_permissions(path, spec, update, contents):
+    """
+    Permissions for the path and, optionally contents for directories, are
+    either updated or checked against those specified in the configuration
+    (i.e., the packages.yaml file).
+
+    Permissions are determined based on the (packages.yaml) configuration
+    that applies to the spec.
+
+    Args:
+        path (str): path whose permissions are being
+        spec (Spec or None): spec instance or None if want all permissions
+        update (bool): ``True`` to set permissions, ``False`` to check them
+        contents (bool): ``True`` to process the contents of the
+            and files and ``False`` to apply the permissions only to the
+            specified directory
+    """
+    if not os.path.exists(path):
+        tty.warn('Cannot process permissions for missing path {0}'
+                 .format(path))
+        return
+
+    func = _set_perms if update else _check_perms
+
+    group = get_package_group(spec)
+    perms = get_package_permissions(spec)
+    dir_perms = _add_gid_bit(perms)
+
+    is_dir = os.path.isdir(path)
+    path_perms = dir_perms if is_dir else perms
+
+    func(path, path_perms, group)
+
+    # We're done if the path is a file OR we don't need to process
+    # permissions for the directory's contents.
+    if not (is_dir and contents):
+        return
+
+    for root, dirs, _ in os.walk(path):
+        for d in dirs:
+            dir_name = os.path.join(root, d)
+            func(dir_name, dir_perms, group)
+        for f in dirs:
+            dir_name = os.path.join(root, d)
+            func(dir_name, perms, group)
+
+
+def _set_perms(path, perms, group, check_exists=False):
+    """Set permissions for the specified path to the given permissions.
+
+    Args:
+        path (str): path whose permissions are to be set
+        perms (int): the appropriate stat permissions or mode
+        group (str): the appropriate group name or empty string if the group
+            option does not apply
+        check_exists (bool): ``True`` if the path existence should be checked;
+            otherwise, skip the existence check
+    """
+    if check_exists and not os.path.exists(path):
+        tty.warn('Cannot set permissions on missing path {0}'
+                 .format(path))
+        return
+
+    # Set the path's group.
+    if group:
+        fs.chgrp(path, group)
+
+    # Set the path's permissions.
+    #
+    # This has to be done *after* any group change because doing so removes
+    # the SGID bit on directories.
+    mode = os.stat(path).st_mode
+    if mode != perms:
+        os.chmod(path, perms)
+
+
+def check_permissions(path, spec, contents=True):
+    """Checks permissions against those expected by the configuration."""
+    _process_permissions(path, spec, False, contents)
+
+
+def update_permissions(path, spec, contents=True):
+    """Checks permissions against those expected by the configuration."""
+    _process_permissions(path, spec, True, contents)
+
+
+def get_package_dir_permissions(spec):
+    """Return the permissions configured for the spec or for ``all`` if no spec
+
+    Include the GID bit if group permissions are on. This makes the group
+    attribute sticky for the directory. Package-specific settings take
+    precedent over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        perms (int): the appropriate stat permissions or mode
+    """
+    return _add_gid_bit(get_package_permissions(spec))
+
+
+def get_package_permissions(spec):
+    """Return the permissions configured for the spec or for ``all`` if no spec
+
+    Package-specific settings take precedence over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        perms (int): the appropriate stat permissions or mode
+    """
+    names = ['all'] if spec is None else [spec.name, 'all']
+
+    # Get read permissions level
+    for name in names:
+        try:
+            readable = cfg.get(permissions_key.format(name, 'read'), '')
+            if readable:
+                break
+        except AttributeError:
+            readable = 'world'
+
+    # Get write permissions level
+    for name in names:
+        try:
+            writable = cfg.get(permissions_key.format(name, 'write'), '')
+            if writable:
+                break
+        except AttributeError:
+            writable = 'user'
+
+    perms = stat.S_IRWXU
+    if readable in ('world', 'group'):  # world includes group
+        perms |= stat.S_IRGRP | stat.S_IXGRP
+    if readable == 'world':
+        perms |= stat.S_IROTH | stat.S_IXOTH
+
+    if writable in ('world', 'group'):
+        if readable == 'user':
+            raise cfg.ConfigError('Writable permissions may not be more' +
+                                  ' permissive than readable permissions.\n' +
+                                  '      Violating package is {0}'
+                                  .format(spec.name))
+        perms |= stat.S_IWGRP
+    if writable == 'world':
+        if readable != 'world':
+            raise cfg.ConfigError('Writable permissions may not be more' +
+                                  ' permissive than readable permissions.\n' +
+                                  '      Violating package is {0}'
+                                  .format(spec.name))
+        perms |= stat.S_IWOTH
+
+    return perms
+
+
+def get_package_group(spec):
+    """Return the unix group associated with the spec or for ``all`` if no spec
+
+    Package-specific settings take precedence over settings for ``all``.
+
+    Args:
+        spec (Spec or None): spec instance or None if want all permissions
+
+    Returns:
+        group (str): the appropriate group name
+    """
+    names = ['all'] if spec is None else [spec.name, 'all']
+
+    for name in names:
+        try:
+            group = cfg.get(permissions_key.format(name, 'group'), '')
+            if group:
+                break
+        except AttributeError:
+            group = ''
+    return group

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -15,7 +15,7 @@ import spack.binary_distribution
 import spack.compilers
 import spack.directory_layout as dl
 import spack.installer as inst
-import spack.package_prefs as prefs
+import spack.package_permissions as spp
 import spack.repo
 import spack.spec
 import spack.store
@@ -797,7 +797,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     def _chgrp(path, group):
         tty.msg(mock_chgrp_msg.format(path, group))
 
-    monkeypatch.setattr(prefs, 'get_package_group', _get_group)
+    monkeypatch.setattr(spp, 'get_package_group', _get_group)
     monkeypatch.setattr(fs, 'chgrp', _chgrp)
 
     const_arg = installer_args(['trivial-install-test-package'], {})

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -56,7 +56,7 @@ def mock_module_filename(monkeypatch, tmpdir):
 @pytest.fixture()
 def mock_package_perms(monkeypatch):
     perms = stat.S_IRGRP | stat.S_IWGRP
-    monkeypatch.setattr(spack.package_prefs,
+    monkeypatch.setattr(spack.package_permissions,
                         'get_package_permissions',
                         lambda spec: perms)
 

--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -6,17 +6,17 @@
 import os
 import stat as st
 import llnl.util.filesystem as fs
-import spack.package_prefs as pp
+import spack.package_permissions as spp
 from spack.error import SpackError
 
 
 def set_permissions_by_spec(path, spec):
     # Get permissions for spec
     if os.path.isdir(path):
-        perms = pp.get_package_dir_permissions(spec)
+        perms = spp.get_package_dir_permissions(spec)
     else:
-        perms = pp.get_package_permissions(spec)
-    group = pp.get_package_group(spec)
+        perms = spp.get_package_permissions(spec)
+    group = spp.get_package_group(spec)
 
     set_permissions(path, perms, group)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -320,7 +320,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage setup solve spec stage test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module patch permissions pkg providers pydoc python reindex remove rm repo resource restage setup solve spec stage test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1269,6 +1269,33 @@ _spack_patch() {
         SPACK_COMPREPLY="-h --help -n --no-checksum"
     else
         _all_packages
+    fi
+}
+
+_spack_permissions() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY="check repair"
+    fi
+}
+
+_spack_permissions_check() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _installed_packages
+    fi
+}
+
+_spack_permissions_repair() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _installed_packages
     fi
 }
 


### PR DESCRIPTION
Fixes #16283
Replaces #16614

This PR provides Spack subcommands to check and repair permissions for the database, failure tracking, and installed packages such that they are consistent with configured settings (`packages.yaml`).

The new routines are also used to set permissions from configuration options during processing (e.g., installs).

TODO:

- [ ] Finish comparison with `spack verify` results
- [ ] Refactor for `permissions` and `verify` re-use
- [ ] Finish filling out command skeletons
- [ ] Add unit tests