### PR TITLE
bump up version for rocm 3.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/rdc/package.py
+++ b/var/spack/repos/builtin/packages/rdc/package.py
@@ -15,13 +15,22 @@ class Rdc(CMakePackage):
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    def url_for_version(self, version):
+        if version == Version('3.9.0'):
+            return "https://github.com/RadeonOpenCompute/rdc/archive/rdc_so_ver-0.3.tar.gz"
+
+        url = "https://github.com/RadeonOpenCompute/rdc/archive/rocm-{0}.tar.gz"
+        return url.format(version)
+
+    version('3.9.0', sha256='bc6339e7f41850a4a049d085a880cfafd3fd8e1610fb94c572d79753d01aa298')
     version('3.8.0', sha256='d0d0a0e68a848b7a8fa2d88c1d0352ce68e1e142debf32c31d941904f03c4b2f')
 
     depends_on('cmake@3.15:', type='build')
     depends_on('grpc@1.28.1+shared', type='build')
     depends_on('protobuf', type=('build', 'link'))
-    depends_on('rocm-smi-lib@3.8.0', type=('build', 'link'))
     depends_on('libcap', type=('build', 'link'))
+    for ver in ['3.8.0', '3.9.0']:
+        depends_on('rocm-smi-lib@' + ver, type=('build', 'link'), when='@' + ver)
 
     def patch(self):
         filter_file(


### PR DESCRIPTION
updates to rdc package recipe for rocm-3.9.0.