### PR TITLE
globalarrays: added v5.8 and earlier, simplified recipe

### DIFF
--- a/var/spack/repos/builtin/packages/globalarrays/package.py
+++ b/var/spack/repos/builtin/packages/globalarrays/package.py
@@ -2,20 +2,24 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
+import os.path
 
 
 class Globalarrays(AutotoolsPackage):
     """Global Arrays (GA) is a Partitioned Global Address Space (PGAS)
-    programming model. It provides primitives for one-sided communication
-    (Get, Put, Accumulate) and Atomic Operations (read increment).
-    It supports blocking and non-blocking primtives, and supports location
-    consistency."""
+    programming model.
+
+    It provides primitives for one-sided communication (Get, Put, Accumulate)
+    and Atomic Operations (read increment). It supports blocking and
+    non-blocking primtives, and supports location consistency.
+    """
 
     homepage = "http://hpc.pnl.gov/globalarrays/"
     url = "https://github.com/GlobalArrays/ga/releases/download/v5.7/ga-5.7.tar.gz"
 
+    version('5.8',   sha256='64df7d1ea4053d24d84ca361e67a6f51c7b17ed7d626cb18a9fbc759f4a078ac')
+    version('5.7.2', sha256='8cd0fcfd85bc7f9c168c831616f66f1e8b9b2ca31dc7dd93cc55b27cc7fe7069')
+    version('5.7.1', sha256='aa4c6038d792cabf1766e264320da58a555da81a3a36be32b7c4d3e71c08ffa9')
     version('5.7',   sha256='3ed1ab47adfda7bceb7beca12fc05a2e1631732f0e55bbaf9036dad4e3da4774')
     version('5.6.5', sha256='17a7111dfe67d44cf0888c7b79abd48bf4968874f26b3f16cce9fd04e2c72bb9')
     version('5.6.4', sha256='3daf742053502755c0b581041a56f8f7086af05980c7146d194b0fd6526ee14f')
@@ -24,39 +28,38 @@ class Globalarrays(AutotoolsPackage):
     version('5.6.1', sha256='b324deed49f930f55203e1d18294ce07dd02680b9ac0728ebc54f94a12557ebc')
     version('5.6',   sha256='a228dfbae9a6cfaae34694d7e56f589ac758e959b58f4bc49e6ef44058096767')
 
-    variant('int64', default=False, description='Compile with 64 bit indices support')
-    variant('blas', default=False, description='Enable BLAS')
-    variant('lapack', default=False, description='Enable LAPACK')
     variant('scalapack', default=False, description='Enable SCALAPACK')
     variant('armci', values=('mpi-ts', 'mpi-pr', 'mpi3', 'openib', 'ofi'),
             default='mpi-ts', description='ARMCI runtime')
 
     depends_on('mpi')
-    depends_on('blas', when='+blas')
-    depends_on('lapack', when='+lapack')
+    depends_on('blas')
+    depends_on('lapack')
+
     depends_on('scalapack', when='+scalapack')
 
-    conflicts('+lapack', when='~blas')
-    conflicts('+scalapack', when='~blas')
-    conflicts('+scalapack', when='~lapack')
+    # See release https://github.com/GlobalArrays/ga/releases/tag/v5.7.1
+    conflicts('%gcc@10:', when='@5.7')
+    conflicts('%gcc@10:', when='@:5.6.5')
+
+    @property
+    def build_directory(self):
+        return os.path.join(str(self.stage.source_path), '..', 'spack-build')
 
     def configure_args(self):
-        args = ['--with-mpi']
+        blas_flags = self.spec['blas'].libs.ld_flags
+        lapack_libs = self.spec['lapack'].libs.ld_flags
 
-        if '+blas' in self.spec:
-            if '+int64' in self.spec:
-                args.append('--with-blas8')
-            else:
-                args.append('--with-blas')
-
-        if '+lapack' in self.spec:
-            args.append('--with-lapack')
+        args = [
+            '--enable-shared',
+            '--with-mpi',
+            '--with-blas={0}'.format(blas_flags),
+            '--with-lapack={0}'.format(lapack_libs),
+        ]
 
         if '+scalapack' in self.spec:
-            if '+int64' in self.spec:
-                args.append('--with-scalapack8')
-            else:
-                args.append('--with-scalapack')
+            scalapack_libs = self.spec['scalapack'].libs.ld_flags
+            args.append('--with-scalapack={0}'.format(scalapack_libs))
 
         args.append('--with-' + self.spec.variants['armci'].value)
 


### PR DESCRIPTION
fixes #19966

Modifications to the recipe:
 - [x] Global arrays supports GCC 10 since version 5.7.1, therefore a conflict has been added to avoid old releases to error at build-time.
- [x] Removed the `blas` and `lapack` variant since BLAS and LAPACK are always a dependency and, if not specified during configure, a version of these APIs vendored with Global Arrays is built.
- [x] Fixed a few options in configuration to locate BLAS, LAPACK and SCALAPACK correctly.
- [x] Build shared libraries too.