### PR TITLE
ADIOS2: ~dataman default

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -51,7 +51,7 @@ class Adios2(CMakePackage):
     # transport engines
     variant('sst', default=True,
             description='Enable the SST staging engine')
-    variant('dataman', default=True,
+    variant('dataman', default=False,
             description='Enable the DataMan engine for WAN transports')
     variant('dataspaces', default=False,
             description='Enable support for DATASPACES')


### PR DESCRIPTION
Disable dataman by default. It pulls heavy dependencies that are often not needed for HPC (ZMQ) and it currently does not link with popular compilers.

Refs.:
- #18598
- https://github.com/ornladios/ADIOS2/issues/2494
- https://github.com/ornladios/ADIOS2/issues/2457

CC: @chuckatkins @williamfgc