### PR TITLE
environment installs: fix reporting.

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -255,7 +255,7 @@ environment variables:
             reporter.specs = specs
 
             tty.msg("Installing environment {0}".format(env.name))
-            with reporter:
+            with reporter('build'):
                 env.install_all(args, **kwargs)
 
             tty.debug("Regenerating environment views for {0}"


### PR DESCRIPTION
PR #15702 changed the invocation of the report context when installing
specs, do the same when building environments.

(should probably be backported to 0.16, too… is there a process for that?)