### PR TITLE
WRF: Fixes compile time errors

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -289,7 +289,7 @@ class Wrf(Package):
         csh = Executable(csh_bin)
 
         # num of compile jobs capped at 20 in wrf
-        num_jobs = str(min(int(make_jobs, 10)))
+        num_jobs = str(min(int(make_jobs), 10))
 
         # Now run the compile script and track the output to check for
         # failure/success We need to do this because upstream use `make -i -k`
@@ -300,6 +300,8 @@ class Wrf(Package):
             "-j",
             num_jobs,
             self.spec.variants["compile_type"].value,
+            output=str,
+            error=str
         )
 
         if "Executables successfully built" in result_buf:


### PR DESCRIPTION
Fixes a couple of bugs introduced in  #19882 
- result_buf was not receiving the build output, so the run_compile_script function always returned false.

Note: this was checked for V4.2. 
V3.9.1.1 may also require a followup. 
@ptooley please take a look :) 
