### PR TITLE
libtheora: fix how package is configured

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/exit-prior-to-running-configure.patch
+++ b/var/spack/repos/builtin/packages/libtheora/exit-prior-to-running-configure.patch
@@ -1,0 +1,23 @@
+From 0060fd48c12a59a080974ca3754bf0eab9ab6d35 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Tue, 24 Nov 2020 15:14:41 -0700
+Subject: [PATCH] exit prior to running configure
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+
+diff --git a/autogen.sh b/autogen.sh
+index bbca69dc..4de1e783 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -112,6 +112,8 @@ if test -z "$*"; then
+         echo "to pass any to it, please specify them on the $0 command line."
+ fi
+ 
++exit 0
++
+ echo "Generating configuration files for $package, please wait...."
+ 
+ echo "  $ACLOCAL $ACLOCAL_FLAGS"
+-- 
+2.18.2
+

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -22,6 +22,8 @@ class Libtheora(AutotoolsPackage):
     depends_on('doxygen',  type='build')
     depends_on('libogg')
 
+    patch('exit-prior-to-running-configure.patch', when='@1.1.1')
+
     def autoreconf(self, spec, prefix):
         sh = which('sh')
         if self.spec.satisfies('target=aarch64:'):


### PR DESCRIPTION
Not sure how this was ever working before, but here's what I'm seeing trying to build paraview, which now has a dependency on libtheora:
```
==> libtheora: Executing phase: 'autoreconf'
==> libtheora: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/hpp/spack-stage/spack-stage-libtheora-1.1.1-4ujjd67rwaly4ca36pf2pfnex6p4bokx/spack-src/configure' '--prefix=/users/hpp/spack/opt/spack/cray-rhel8-aarch64/gcc-8.3.1/libtheora-1.1.1-4ujjd67rwaly4ca36pf2pfnex6p4bokx'

1 error found in build log:
     225    checking for a BSD-compatible install... /usr/bin/install -c
     226    checking whether build environment is sane... yes
     227    checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
     228    checking for gawk... gawk
     229    checking whether make sets $(MAKE)... yes
     230    checking whether make supports nested variables... yes
  >> 231    configure: error: source directory already configured; run "make distclean" there first
```
The problem is the autogen.sh script in the package also runs configure.  So when spack goes ahead and tries to run a configure stage, things don't work.

This commit reworks the build process to avoid this unneeded configure step

Signed-off-by: Howard Pritchard <howardp@lanl.gov>