### PR TITLE
moab updates

### DIFF
--- a/var/spack/repos/builtin/packages/moab/package.py
+++ b/var/spack/repos/builtin/packages/moab/package.py
@@ -20,10 +20,13 @@ class Moab(AutotoolsPackage):
     git = "https://bitbucket.org/fathomteam/moab.git"
     url = "http://ftp.mcs.anl.gov/pub/fathom/moab-5.0.0.tar.gz"
 
+    maintainers = ['vijaysm', 'iulian787']
+
     version('develop', branch='develop')
     version('master', branch='master')
-    # Version 5.0.2 disappeared from FTP server. Instead set temporary version
-    # of MoAB to 5.0.2 set to current head of the master branch.
+    version('5.2.1', sha256='60d31762be3f0e5c89416c764e844ec88dac294169b59a5ead3c316b50f85c29')
+    version('5.2.0', sha256='805ed3546deff39e076be4d1f68aba1cf0dda8c34ce43e1fc179d1aff57c5d5d')
+    version('5.1.0', sha256='0371fc25d2594589e95700739f01614f097b6157fb6023ed8995e582726ca658')
     version('5.0.2', commit='01d05b1805236ef44da36f67eb2701095f2e33c7')
     version('5.0.1', commit='6cc12bd4ae3fa7c9ad81c595e4d38fa84f0884be')
     version('5.0.0', sha256='df5d5eb8c0d0dbb046de2e60aa611f276cbf007c9226c44a24ed19c570244e64')


### PR DESCRIPTION
also add maintainers, vijay and iulian
for older compilers like gcc 7.5.0, blas dependency is not resolved
correctly, because current openblas (0.3.12) cannot be built with
gcc 7.5.0 (default on ubuntu 18.04)
temporary solution is to specify something like
moab ^ openblas@0.3.10 , besides other constraints in build
or
use different compilers, for which blas dependency is resolved better
(intel for example)
or
build a newer version of gcc @:8.3