### PR TITLE
krb5: Support static lib creation. Added variant +static

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/mit-krb5-1.17-static-libs.patch
+++ b/var/spack/repos/builtin/packages/krb5/mit-krb5-1.17-static-libs.patch
@@ -1,0 +1,15 @@
+--- src/lib/crypto/builtin/aes/Makefile.in.orig	2019-06-27 14:51:51.305688932 +0200
++++ src/lib/crypto/builtin/aes/Makefile.in	2019-06-27 14:52:46.428203235 +0200
+@@ -34,10 +34,10 @@
+ 
+ all-unix: all-libobjs # aes-gen
+ 
+-iaesx64@SHOBJEXT@: $(srcdir)/iaesx64.s
++iaesx64.$(OBJEXT) iaesx64@SHOBJEXT@: $(srcdir)/iaesx64.s
+ 	$(YASM) $(AESNI_FLAGS) -o $@ $(srcdir)/iaesx64.s
+ 
+-iaesx86@SHOBJEXT@: $(srcdir)/iaesx86.s
++iaesx86.$(OBJEXT) iaesx86@SHOBJEXT@: $(srcdir)/iaesx86.s
+ 	$(YASM) $(AESNI_FLAGS) -o $@ $(srcdir)/iaesx86.s
+ 
+ includes: depend

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -27,7 +27,7 @@ class Krb5(AutotoolsPackage):
     depends_on('openssl')
 
     variant(
-        'shared', default=True, 
+        'shared', default=True,
         description='install shared libraries if True, static if false'
     )
     patch('mit-krb5-1.17-static-libs.patch', level=0)

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -26,6 +26,9 @@ class Krb5(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('openssl')
 
+    variant('static', default=False )
+    patch('mit-krb5-1.17-static-libs.patch', level=0)
+
     configure_directory = 'src'
     build_directory = 'src'
 
@@ -51,4 +54,12 @@ class Krb5(AutotoolsPackage):
             string=True)
 
     def configure_args(self):
-        return ['--without-system-verto']
+        args = ['--without-system-verto']
+
+        if '+static' in self.spec:
+            args.append('--enable-static')
+            args.append('--disable-shared')
+        else:
+            args.append('--disable-static')
+
+        return args

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -26,7 +26,10 @@ class Krb5(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('openssl')
 
-    variant('static', default=False)
+    variant(
+        'shared', default=True, 
+        description='install shared libraries if True, static if false'
+    )
     patch('mit-krb5-1.17-static-libs.patch', level=0)
 
     configure_directory = 'src'

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -59,7 +59,7 @@ class Krb5(AutotoolsPackage):
     def configure_args(self):
         args = ['--without-system-verto']
 
-        if '+static' in self.spec:
+        if '~shared' in self.spec:
             args.append('--enable-static')
             args.append('--disable-shared')
         else:

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -26,7 +26,7 @@ class Krb5(AutotoolsPackage):
     depends_on('bison', type='build')
     depends_on('openssl')
 
-    variant('static', default=False )
+    variant('static', default=False)
     patch('mit-krb5-1.17-static-libs.patch', level=0)
 
     configure_directory = 'src'


### PR DESCRIPTION
The upstream version does not allow creating both versions at the same time

--enable-shared --enable-static will lead in an error

mit-krb5-1.17-static-libs.patch fixes an assembler error
when compiling the static version