### PR TITLE
concretizer: prioritize matching compilers over newer versions

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -537,9 +537,6 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
     1@8,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), not root(Package)
 }.
-#minimize{
-    Weight@8,Package : version_weight(Package, Weight)
-}.
 
 % Try to maximize the number of compiler matches in the DAG,
 % while minimizing the number of nodes. This is done because
@@ -548,10 +545,15 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 #minimize{ 1@7,Package : node(Package) }.
 #maximize{ Weight@7,Package : compiler_version_match(Package, Weight) }.
 
+% Choose more recent versions for nodes
+#minimize{
+    Weight@6,Package : version_weight(Package, Weight)
+}.
+
 % Try to use preferred compilers
-#minimize{ Weight@6,Package : compiler_weight(Package, Weight) }.
+#minimize{ Weight@5,Package : compiler_weight(Package, Weight) }.
 
 % Maximize the number of matches for targets in the DAG, try
 % to select the preferred target.
-#maximize{ Weight@5,Package : node_target_match(Package, Weight) }.
-#minimize{ Weight@4,Package : node_target_weight(Package, Weight) }.
+#maximize{ Weight@4,Package : node_target_match(Package, Weight) }.
+#minimize{ Weight@3,Package : node_target_weight(Package, Weight) }.

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -103,6 +103,15 @@ compilers:
       fflags: -O0 -g
     modules: 'None'
 - compiler:
+    spec: gcc@4.4.0
+    operating_system: redhat6
+    paths:
+      cc: /path/to/gcc440
+      cxx: /path/to/g++440
+      f77: /path/to/gfortran440
+      fc: /path/to/gfortran440
+    modules: 'None'
+- compiler:
     spec: clang@3.5
     operating_system: redhat6
     paths:

--- a/var/spack/repos/builtin.mock/packages/openblas/package.py
+++ b/var/spack/repos/builtin.mock/packages/openblas/package.py
@@ -12,5 +12,10 @@ class Openblas(Package):
     url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
 
     version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9')
+    version('0.2.14', 'b1190f3d3471685f17cfd1ec1d252ac9')
+    version('0.2.13', 'b1190f3d3471685f17cfd1ec1d252ac9')
+
+    # See #20019 for this conflict
+    conflicts('%gcc@:4.4.99', when='@0.2.14:')
 
     provides('blas')


### PR DESCRIPTION
fixes #20019

Before this modification having a newer version of a node came at higher priority in the optimization than having matching
compilers. This could result in unexpected configurations for packages with conflict directives on compilers of the type:
```python
conflicts('%gcc@X.Y:', when='@:A.B')
```
where changing the compiler for just that node is preferred to lower the node version to less than `A.B`. Now the priority has been switched so the solver will try to lower the version of the nodes in question before changing their compiler.

**Before this PR**

```console
$ spack solve netlib-scalapack %gcc@:7 ^openblas
==> Best of 0 answers.
==> Optimization: [0, 0, -4, 30, -1, 1, -45, 1, 57, -19, 0]
netlib-scalapack@2.1.0%gcc@7.5.0~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-broadwell
    ^cmake@3.18.4%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt patches=bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu18.04-broadwell
    ^openblas@0.3.12%gcc@10.1.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-broadwell
    ^openmpi@4.0.5%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-broadwell
        ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev~libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-broadwell
            ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                    ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-broadwell
                        ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
        ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-broadwell
            ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-broadwell
                    ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                    ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                        ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                            ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-broadwell
            ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
        ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-broadwell
```

**After this PR**

```console
$ spack solve netlib-scalapack %gcc@:7 ^openblas
==> Best of 0 answers.
==> Optimization: [0, 0, -4, 30, -1, 1, -46, 0, 3, 60, -19, 0]
netlib-scalapack@2.1.0%gcc@7.5.0~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-broadwell
    ^cmake@3.18.4%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt patches=bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu18.04-broadwell
    ^openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-broadwell
    ^openmpi@4.0.5%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-broadwell
        ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev~libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-broadwell
            ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                    ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-broadwell
                        ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
        ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-broadwell
            ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-broadwell
                    ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                    ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                        ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
                            ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-broadwell
            ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-broadwell
        ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-broadwell
```