### PR TITLE
Docs: remove duplication in Command Reference

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -21,7 +21,7 @@ import spack.report
 import spack.package
 
 description = "run spack's tests for an install"
-section = "administrator"
+section = "admin"
 level = "long"
 
 

--- a/lib/spack/spack/cmd/test_env.py
+++ b/lib/spack/spack/cmd/test_env.py
@@ -6,7 +6,7 @@ import spack.cmd.common.env_utility as env_utility
 
 description = "run a command in a spec's test environment, " \
               "or dump its environment to screen or file"
-section = "administration"
+section = "admin"
 level = "long"
 
 setup_parser = env_utility.setup_parser


### PR DESCRIPTION
The first 3 sections of the [Command Reference](https://spack.readthedocs.io/en/latest/command_index.html#command-reference) are duplicated. This PR fixes that.