### PR TITLE
likwid: new release 5.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -16,11 +16,12 @@ class Likwid(Package):
     See https://github.com/RRZE-HPC/likwid/wiki/TutorialLikwidPerf#feature-limitations
     for information."""
 
-    homepage = "https://github.com/RRZE-HPC/likwid"
+    homepage = "https://hpc.fau.de/research/tools/likwid/"
     url      = "https://github.com/RRZE-HPC/likwid/archive/v5.0.0.tar.gz"
     git      = "https://github.com/RRZE-HPC/likwid.git"
     maintainers = ['TomTheBear']
 
+    version('5.1.0', sha256='5a180702a1656c6315b861a85031ab4cb090424aec42cbbb326b849e29f55571')
     version('5.0.2', sha256='0a1c8984e4b43ea8b99d09456ef05035eb934594af1669432117585c638a2da4')
     version('5.0.1', sha256='3757b0cb66e8af0116f9288c7f90543acbd8e2af8f72f77aef447ca2b3e76453')
     version('5.0.0', sha256='26623f5a1a5fec19d798f0114774a5293d1c93a148538b9591a13e50930fa41e')


### PR DESCRIPTION
Add new release 5.1.0 and change homepage to https://hpc.fau.de/research/tools/likwid/