### PR TITLE
mysql: Add sasl as dependency for versions <5.7.999

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -117,6 +117,7 @@ class Mysql(CMakePackage):
     depends_on('perl', type=['build', 'test'], when='@:7.99.99')
     depends_on('bison@2.1:', type='build')
     depends_on('m4', type='build', when='@develop platform=solaris')
+    depends_on('cyrus-sasl', when='@:5.7.999')
 
     patch('fix-no-server-5.5.patch', level=1, when='@5.5.0:5.5.999')
 


### PR DESCRIPTION
This patch is intended to address failing builds due to missing libsasl2 when compiling mysql@5.7.27 %gcc@4.8.5