### PR TITLE
Fix bug for command find with option d, which print specs in wrong group

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -435,7 +435,7 @@ def display_specs(specs, args=None, **kwargs):
     out = ''
     if groups:
         for specs in iter_groups(specs, indent, all_headers):
-            out += format_list(specs)
+            output.write(format_list(specs))
     else:
         out = format_list(sorted(specs))
 


### PR DESCRIPTION
When we issue the command `spack find` with the option `-d`, it will print the specs in the wrong group like this:
```
yzz@DESKTOP-4EOODD5:~/spack$ spack find gcc
==> 2 installed packages
-- linux-ubuntu20.04-skylake / gcc@9.3.0 ------------------------
gcc@10.1.0

-- linux-ubuntu20.04-skylake / gcc@10.1.0 -----------------------
gcc@9.3.0
yzz@DESKTOP-4EOODD5:~/spack$ spack find -d gcc
==> 2 installed packages
-- linux-ubuntu20.04-skylake / gcc@9.3.0 ------------------------

-- linux-ubuntu20.04-skylake / gcc@10.1.0 -----------------------
gcc@10.1.0
    gmp@6.1.2
    isl@0.21
    mpc@1.1.0
        mpfr@4.0.2
    zlib@1.2.11
    zstd@1.4.5

gcc@9.3.0
    binutils@2.35.1
        gettext@0.21
            bzip2@1.0.8
            libiconv@1.16
            libxml2@2.9.10
                xz@5.2.5
                zlib@1.2.11
            ncurses@6.2
            tar@1.32
    gmp@6.1.2
    isl@0.20
    mpc@1.1.0
        mpfr@3.1.6
```

This is now fixed.

Fixes #21374