### PR TITLE
llvm-amdgpu: fix the build for version 3.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/fix-ncurses-3.9.0.patch
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/fix-ncurses-3.9.0.patch
@@ -1,0 +1,25 @@
+Adapt the fix-system-zlib-ncurses.patch for version 3.9.0.
+
+--- llvm-project-rocm-3.9.0/llvm/cmake/config-ix.cmake.orig	2020-11-20 21:41:10.498772540 -0600
++++ llvm-project-rocm-3.9.0/llvm/cmake/config-ix.cmake	2020-11-20 22:27:57.242391054 -0600
+@@ -126,15 +126,11 @@
+   endif()
+   if(LLVM_ENABLE_TERMINFO)
+     set(HAVE_TERMINFO 0)
+-    foreach(library terminfo tinfo curses ncurses ncursesw)
+-      string(TOUPPER ${library} library_suffix)
+-      check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+-      if(HAVE_TERMINFO_${library_suffix})
+-        set(HAVE_TERMINFO 1)
+-        set(TERMINFO_LIBS "${library}")
+-        break()
+-      endif()
+-    endforeach()
++    find_library(FIND_TERMINFO NAMES terminfo tinfo curses ncurses ncursesw)
++    if(FIND_TERMINFO)
++      set(HAVE_TERMINFO 1)
++      set(TERMINFO_LIBS "${FIND_TERMINFO}")
++    endif()
+   else()
+     set(HAVE_TERMINFO 0)
+   endif()

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -23,7 +23,8 @@ class LlvmAmdgpu(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.4.3:',  type='build', when='@:3.8.99')
+    depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
     depends_on('python', type='build')
     depends_on('z3', type='link')
     depends_on('zlib', type='link')
@@ -31,6 +32,7 @@ class LlvmAmdgpu(CMakePackage):
 
     # Will likely only be fixed in LLVM 12 upstream
     patch('fix-system-zlib-ncurses.patch', when='@3.5.0:3.8.0')
+    patch('fix-ncurses-3.9.0.patch', when='@3.9.0:')
 
     root_cmakelists_dir = 'llvm'
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -34,6 +34,8 @@ class LlvmAmdgpu(CMakePackage):
     patch('fix-system-zlib-ncurses.patch', when='@3.5.0:3.8.0')
     patch('fix-ncurses-3.9.0.patch', when='@3.9.0:')
 
+    conflicts('^cmake@3.19.0')
+
     root_cmakelists_dir = 'llvm'
 
     install_targets = ['clang-tidy', 'install']


### PR DESCRIPTION
Adapt the fix-system-zlib-ncurses.patch for version 3.9.0.  Without
the patch, llvm-amdgpu builds, but then rocm-device-libs fails with
"cannot find -ltinfo."

Tighten the version requirements for cmake according to the
llvm/CMakeLists.txt file.

----------

ping @srekolam @arjun-raj-kuppala @haampie

The build for rocm-device-libs @3.9.0 was failing with:

```
>> 62    /usr/bin/ld: cannot find -ltinfo
>> 63    collect2: error: ld returned 1 exit status
```

This patch fixes the build for 3.9.0.  I assume that was the point of
the original patch for <= 3.8.0.

Adding an explicit dependency on ncurses to rocm-device-libs would
also fix the build, but I think this is the better solution.