### PR TITLE
Add "spack versions --new" flag to only show new versions

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -29,7 +29,7 @@ def setup_parser(subparser):
     output.add_argument('-r', '--remote', action='store_true',
                         help='only list remote versions of the package')
     output.add_argument('-n', '--new', action='store_true',
-                        help='only list remote versions newer than'
+                        help='only list remote versions newer than '
                         'the latest checksummed version')
     subparser.add_argument(
         '-c', '--concurrency', default=32, type=int,

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -24,7 +24,7 @@ def setup_parser(subparser):
     output.add_argument('-s', '--safe', action='store_true',
                         help='only list safe versions of the package')
     output.add_argument('--safe-only', action='store_true',
-                        help='[deprecated] only list safe versions'
+                        help='[deprecated] only list safe versions '
                         'of the package')
     output.add_argument('-r', '--remote', action='store_true',
                         help='only list remote versions of the package')

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -12,6 +12,7 @@ import llnl.util.tty as tty
 
 import spack.cmd.common.arguments as arguments
 import spack.repo
+from spack.version import VersionList, ver
 
 description = "list available versions of a package"
 section = "packaging"
@@ -19,8 +20,17 @@ level = "long"
 
 
 def setup_parser(subparser):
-    subparser.add_argument('-s', '--safe-only', action='store_true',
-                           help='only list safe versions of the package')
+    output = subparser.add_mutually_exclusive_group()
+    output.add_argument('-s', '--safe', action='store_true',
+                        help='only list safe versions of the package')
+    output.add_argument('--safe-only', action='store_true',
+                        help='[deprecated] only list safe versions'
+                        'of the package')
+    output.add_argument('-r', '--remote', action='store_true',
+                        help='only list remote versions of the package')
+    output.add_argument('-n', '--new', action='store_true',
+                        help='only list remote versions newer than'
+                        'the latest checksummed version')
     subparser.add_argument(
         '-c', '--concurrency', default=32, type=int,
         help='number of concurrent requests'
@@ -31,26 +41,38 @@ def setup_parser(subparser):
 def versions(parser, args):
     pkg = spack.repo.get(args.package)
 
-    if sys.stdout.isatty():
-        tty.msg('Safe versions (already checksummed):')
-
     safe_versions = pkg.versions
 
-    if not safe_versions:
-        if sys.stdout.isatty():
-            tty.warn('Found no versions for {0}'.format(pkg.name))
-            tty.debug('Manually add versions to the package.')
-    else:
-        colify(sorted(safe_versions, reverse=True), indent=2)
-
     if args.safe_only:
-        return
+        tty.warn('"--safe-only" is deprecated. Use "--safe" instead.')
+        args.safe = args.safe_only
 
-    if sys.stdout.isatty():
-        tty.msg('Remote versions (not yet checksummed):')
+    if not (args.remote or args.new):
+        if sys.stdout.isatty():
+            tty.msg('Safe versions (already checksummed):')
+
+        if not safe_versions:
+            if sys.stdout.isatty():
+                tty.warn('Found no versions for {0}'.format(pkg.name))
+                tty.debug('Manually add versions to the package.')
+        else:
+            colify(sorted(safe_versions, reverse=True), indent=2)
+
+        if args.safe:
+            return
 
     fetched_versions = pkg.fetch_remote_versions(args.concurrency)
-    remote_versions = set(fetched_versions).difference(safe_versions)
+
+    if args.new:
+        if sys.stdout.isatty():
+            tty.msg('New remote versions (not yet checksummed):')
+        highest_safe_version = VersionList(safe_versions).highest_numeric()
+        remote_versions  = set([ver(v) for v in set(fetched_versions)
+                                if v > highest_safe_version])
+    else:
+        if sys.stdout.isatty():
+            tty.msg('Remote versions (not yet checksummed):')
+        remote_versions = set(fetched_versions).difference(safe_versions)
 
     if not remote_versions:
         if sys.stdout.isatty():

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -13,7 +13,7 @@ versions = SpackCommand('versions')
 def test_safe_versions():
     """Only test the safe versions of a package."""
 
-    versions('--safe-only', 'zlib')
+    versions('--safe', 'zlib')
 
 
 @pytest.mark.network
@@ -21,6 +21,13 @@ def test_remote_versions():
     """Test a package for which remote versions should be available."""
 
     versions('zlib')
+
+
+@pytest.mark.network
+def test_remote_versions_only():
+    """Test a package for which remote versions should be available."""
+
+    versions('--remote', 'zlib')
 
 
 @pytest.mark.network

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -10,6 +10,14 @@ from spack.main import SpackCommand
 versions = SpackCommand('versions')
 
 
+def test_safe_only_versions():
+    """Only test the safe versions of a package.
+       (Using the deprecated command line argument)
+    """
+
+    versions('--safe-only', 'zlib')
+
+
 def test_safe_versions():
     """Only test the safe versions of a package."""
 

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -31,6 +31,14 @@ def test_remote_versions_only():
 
 
 @pytest.mark.network
+@pytest.mark.usefixtures('mock_packages')
+def test_new_versions_only():
+    """Test a package for which new versions should be available."""
+
+    versions('--new', 'brillig')
+
+
+@pytest.mark.network
 def test_no_versions():
     """Test a package for which no remote versions are available."""
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1649,7 +1649,7 @@ _spack_verify() {
 _spack_versions() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -s --safe-only -c --concurrency"
+        SPACK_COMPREPLY="-h --help -s --safe --safe-only -r --remote -n --new -c --concurrency"
     else
         _all_packages
     fi

--- a/var/spack/repos/builtin.mock/packages/brillig/package.py
+++ b/var/spack/repos/builtin.mock/packages/brillig/package.py
@@ -15,4 +15,3 @@ class Brillig(Package):
 
     version('2.0.0',  sha256='d4bb8f1737d5a7c0321e1675cceccb59dbcb66a94f3a9dd66a37f58bc6df7f15')
     version('1.0.0',  sha256='fcef53f45e82b881af9a6f0530b2732cdaf8c5c60e49b27671594ea658bfe315')
-

--- a/var/spack/repos/builtin.mock/packages/brillig/package.py
+++ b/var/spack/repos/builtin.mock/packages/brillig/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Brillig(Package):
+    """ Mock package to test the spack versions command."""
+
+    homepage = "https://www.example.com"
+    url      = "https://github.com/vvolkl/brillig/archive/v2.0.0.tar.gz"
+
+    version('2.0.0',  sha256='d4bb8f1737d5a7c0321e1675cceccb59dbcb66a94f3a9dd66a37f58bc6df7f15')
+    version('1.0.0',  sha256='fcef53f45e82b881af9a6f0530b2732cdaf8c5c60e49b27671594ea658bfe315')
+


### PR DESCRIPTION
Example (using a package from https://github.com/key4hep/key4hep-spack, just because its version history is a nice illustration):

```
~$ spack versions marlin
==> Safe versions (already checksummed):
  master  1.17
==> Remote versions (not yet checksummed):
  01-17-01  01-16  01-15-02  01-15-01  01-15  01-14  01-13  01-12  01-11  01-05
```
```
~$ spack versions --new marlin
==> Safe versions (already checksummed):
  master  1.17
==> Remote versions (not yet checksummed):
  01-17-01
```

The reasoning behind this is that a lot of packages have old versions that are outdated or not checksummed in the recipe for other reasons. As a maintainer, I'm mostly interested in checking for new versions - all the versions older than 01-17  in my example are basically noise. Together with `spack maintainers --by-user` this can then also be used to create automated checks, reminding me when new versions are available (not all of the packages I'm maintaining are on github, where I could configure notifications).