### PR TITLE
Dealing with "Cannot locate ScaLAPACK/BLACS libraries" error with macOS in intel.py

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -806,7 +806,7 @@ class IntelPackage(PackageBase):
         # we must supply a personality matching the MPI implementation that
         # is active for the root package that asked for ScaLapack.
         spec_root = self.spec.root
-        if sys.platform == 'darwin': #and '^mpich' in spec_root:
+        if sys.platform == 'darwin':
             # The only supported choice for MKL 2018 on Mac.
             blacs_lib = 'libmkl_blacs_mpich'
         elif '^openmpi' in spec_root:

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -806,7 +806,7 @@ class IntelPackage(PackageBase):
         # we must supply a personality matching the MPI implementation that
         # is active for the root package that asked for ScaLapack.
         spec_root = self.spec.root
-        if sys.platform == 'darwin' and '^mpich' in spec_root:
+        if sys.platform == 'darwin': #and '^mpich' in spec_root:
             # The only supported choice for MKL 2018 on Mac.
             blacs_lib = 'libmkl_blacs_mpich'
         elif '^openmpi' in spec_root:


### PR DESCRIPTION
To fix #19937. 
Actually I'm not sure if this fix is appropriate... It may cause some problem. But it can fix my problem. 
