### PR TITLE
openscenegraph: really remove dependency on Qt for >= 3.5.4

### DIFF
--- a/var/spack/repos/builtin/packages/openscenegraph/package.py
+++ b/var/spack/repos/builtin/packages/openscenegraph/package.py
@@ -27,7 +27,7 @@ class Openscenegraph(CMakePackage):
     depends_on('cmake@2.8.7:', type='build')
     depends_on('gl')
     depends_on('qt+opengl', when='@:3.5.4')  # Qt windowing system was moved into separate osgQt project
-    depends_on('qt@4:', when='@3.2:')
+    depends_on('qt@4:', when='@3.2:3.5.4')
     depends_on('qt@:4', when='@:3.1')
     depends_on('libxinerama')
     depends_on('libxrandr')


### PR DESCRIPTION
last time I missed that the dependency on qt@4: has to restricted by version, too