### PR TITLE
libxcb, xcb-proto: Add 1.14 versions

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -13,8 +13,9 @@ class Libxcb(AutotoolsPackage):
     extensibility."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url      = "https://xcb.freedesktop.org/dist/libxcb-1.13.tar.gz"
+    url      = "https://xorg.freedesktop.org/archive/individual/lib/libxcb-1.14.tar.xz"
 
+    version('1.14',   sha256='a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34')
     version('1.13',   sha256='0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb')
     version('1.12',   sha256='092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06')
     version('1.11.1', sha256='660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd')
@@ -26,6 +27,7 @@ class Libxcb(AutotoolsPackage):
 
     # libxcb 1.X requires xcb-proto >= 1.X
     depends_on('xcb-proto', type='build')
+    depends_on('xcb-proto@1.14:', when='@1.14:1.14.999', type='build')
     depends_on('xcb-proto@1.13:', when='@1.13:1.13.999', type='build')
     depends_on('xcb-proto@1.12:', when='@1.12:1.12.999', type='build')
     depends_on('xcb-proto@1.11:', when='@1.11:1.11.999', type='build')
@@ -38,6 +40,14 @@ class Libxcb(AutotoolsPackage):
 
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+
+    def url_for_version(self, version):
+        if version >= Version('1.14'):
+            url = 'https://xorg.freedesktop.org/archive/individual/lib/libxcb-{0}.tar.xz'
+        else:
+            url = 'https://xcb.freedesktop.org/dist/libxcb-{0}.tar.gz'
+
+        return url.format(version)
 
     def configure_args(self):
         config_args = []

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -11,8 +11,10 @@ class XcbProto(AutotoolsPackage):
     generate the majority of its code and API."""
 
     homepage = "http://xcb.freedesktop.org/"
-    url      = "http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.gz"
+    url      = "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.14.1.tar.xz"
 
+    version('1.14.1', sha256='f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3')
+    version('1.14', sha256='186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605')
     version('1.13', sha256='0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7')
     version('1.12', sha256='cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59')
     version('1.11', sha256='d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906')
@@ -22,3 +24,11 @@ class XcbProto(AutotoolsPackage):
     # extends('python')
 
     patch('xcb-proto-1.12-schema-1.patch', when='@1.12')
+
+    def url_for_version(self, version):
+        if version >= Version('1.14'):
+            url = 'https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{0}.tar.xz'
+        else:
+            url = 'http://xcb.freedesktop.org/dist/xcb-proto-{0}.tar.gz'
+
+        return url.format(version)


### PR DESCRIPTION
At least xcb-proto 1.14.1 is only avaiable from the new URL, so change both to be future-proof.