### PR TITLE
extends: add type kwarg

### DIFF
--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -120,8 +120,6 @@ so ``PerlPackage`` contains:
 
    extends('perl')
 
-   depends_on('perl', type=('build', 'run'))
-
 
 If your package requires a specific version of Perl, you should
 specify this.

--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -138,7 +138,6 @@ every R package needs this, the ``RPackage`` base class contains:
 .. code-block:: python
 
    extends('r')
-   depends_on('r', type=('build', 'run'))
 
 
 Take a close look at the homepage for ``caret``. If you look at the

--- a/lib/spack/docs/build_systems/rubypackage.rst
+++ b/lib/spack/docs/build_systems/rubypackage.rst
@@ -113,7 +113,6 @@ the base class contains:
 .. code-block:: python
 
    extends('ruby')
-   depends_on('ruby', type=('build', 'run'))
 
 
 The ``*.gemspec`` file may contain something like:

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -5,7 +5,7 @@
 
 import inspect
 
-from spack.directives import depends_on, extends
+from spack.directives import extends
 from spack.package import PackageBase, run_after
 
 

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -27,7 +27,6 @@ class OctavePackage(PackageBase):
     build_system_class = 'OctavePackage'
 
     extends('octave')
-    depends_on('octave', type=('build', 'run'))
 
     def setup_build_environment(self, env):
         # octave does not like those environment variables to be set:

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -45,8 +45,6 @@ class PerlPackage(PackageBase):
 
     extends('perl')
 
-    depends_on('perl', type=('build', 'run'))
-
     def configure_args(self):
         """Produces a list containing the arguments that must be passed to
         :py:meth:`~.PerlPackage.configure`. Arguments should not include

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -7,7 +7,7 @@
 import inspect
 import os
 
-from spack.directives import depends_on, extends
+from spack.directives import extends
 from spack.package import PackageBase, run_after
 from spack.util.executable import Executable
 from llnl.util.filesystem import filter_file

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -96,8 +96,6 @@ class PythonPackage(PackageBase):
 
     extends('python')
 
-    depends_on('python', type=('build', 'run'))
-
     py_namespace = None
 
     def setup_file(self):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -6,7 +6,7 @@ import inspect
 import os
 import shutil
 
-from spack.directives import depends_on, extends
+from spack.directives import extends
 from spack.package import PackageBase, run_after
 
 from llnl.util.filesystem import (working_dir, get_filetype, filter_file,

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -6,7 +6,7 @@
 
 import inspect
 
-from spack.directives import depends_on, extends
+from spack.directives import extends
 from spack.package import PackageBase, run_after
 
 

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -31,8 +31,6 @@ class RPackage(PackageBase):
 
     extends('r')
 
-    depends_on('r', type=('build', 'run'))
-
     def configure_args(self):
         """Arguments to pass to install via ``--configure-args``."""
         return []

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -27,8 +27,6 @@ class RubyPackage(PackageBase):
 
     extends('ruby')
 
-    depends_on('ruby', type=('build', 'run'))
-
     def build(self, spec, prefix):
         """Build a Ruby gem."""
 

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -6,7 +6,7 @@
 import glob
 import inspect
 
-from spack.directives import depends_on, extends
+from spack.directives import extends
 from spack.package import PackageBase, run_after
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -392,7 +392,7 @@ def depends_on(spec, when=None, type=default_deptype, patches=None):
 
 
 @directive(('extendees', 'dependencies'))
-def extends(spec, **kwargs):
+def extends(spec, type=('build', 'run'), **kwargs):
     """Same as depends_on, but allows symlinking into dependency's
     prefix tree.
 
@@ -413,7 +413,7 @@ def extends(spec, **kwargs):
         if not when_spec:
             return
 
-        _depends_on(pkg, spec, when=when)
+        _depends_on(pkg, spec, when=when, type=type)
         pkg.extendees[spec] = (spack.spec.Spec(spec), kwargs)
     return _execute_extends
 

--- a/var/spack/repos/builtin/packages/the-platinum-searcher/package.py
+++ b/var/spack/repos/builtin/packages/the-platinum-searcher/package.py
@@ -14,7 +14,7 @@ class ThePlatinumSearcher(Package):
 
     version('head')
 
-    extends("go", deptypes='build')
+    extends("go", type='build')
 
     def install(self, spec, prefix):
         env['GOPATH'] = self.stage.source_path + ':' + env['GOPATH']


### PR DESCRIPTION
In packages, `extends` implies `depends_on`, but until now there was no way to control what deptype to use. Since `depends_on` defaults to `type=('build', 'link')`, all extensions were marked as this deptype. It was possible to add `type=('build', 'run')`, but Spack would simply merge this and the deptype would become `type=('build', 'link', 'run')`.

This PR adds a `type` kwarg to the `extends` directive, which is then passed to the `depends_on` call. The deptype for this defaults to `type=('build', 'run')`, as is the case for (almost?) every extension currently in Spack.

This behavior is so intuitive that the following packages already use it, even though it didn't work until now:

* heffte
* tasmanian
* the-platinum-searcher

### Before

```console
$ spack spec -t py-setuptools
...
[blr ]      ^python@3.8.6%apple-clang@12.0.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=darwin-catalina-x86_64
```

### After

```console
$ spack spec -t py-setuptools
...
[b r ]      ^python@3.8.6%apple-clang@12.0.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=darwin-catalina-x86_64
```

**Note**: this will likely break some packages that link to the Python libs/headers but don't explicitly declare a link dependency. I would love to have better PR testing to make sure that this change doesn't break anything, but I'm also fine with dealing with issues as they are reported.