### PR TITLE
[fetch_strategy] add a header request fallback when checking for exis…

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -341,16 +341,12 @@ class URLFetchStrategy(FetchStrategy):
             raise FailedDownloadError(url)
 
     def _existing_url(self, url):
-        # first, try the range request, if that fails
-        # (which can happen with some server configurations)
-        # try header request
-        return (self._check_existing_url_by_range_request(url) or
-                self._check_existing_url_by_header_request(url))
-
-    def _check_existing_url_by_range_request(self, url):
         tty.debug('Checking existence of {0}'.format(url))
 
         if spack.config.get('config:url_fetch_method') == 'curl':
+            # first, try the range request, if that fails
+            # (which can happen with some server configurations)
+            # try header request
             curl = self.curl
             # Telling curl to fetch the first byte (-r 0-0) is supposed to be
             # portable.
@@ -358,7 +354,12 @@ class URLFetchStrategy(FetchStrategy):
             if not spack.config.get('config:verify_ssl'):
                 curl_args.append('-k')
             _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
-            return curl.returncode == 0
+            if not curl.returncode == 0:
+                # Try a header request to the url
+                curl_args = ['--stderr', '-', '-s', '-f', '-I', url]
+                _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
+                return curl.returncode == 0
+            return False
         else:
             # Telling urllib to check if url is accessible
             try:
@@ -368,16 +369,6 @@ class URLFetchStrategy(FetchStrategy):
                       {0}\n with error {1}".format(url, werr)
                 raise FailedDownloadError(url, msg)
             return (response.getcode() is None or response.getcode() == 200)
-
-    def _check_existing_url_by_header_request(self, url):
-        tty.debug('Checking existence of {0}'.format(url))
-        if spack.config.get('config:url_fetch_method') == 'curl':
-            curl = self.curl
-            # Try a header request to the url
-            curl_args = ['--stderr', '-', '-s', '-f', '-I', url]
-            _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
-            return curl.returncode == 0
-        return False
 
     def _fetch_from_url(self, url):
         if spack.config.get('config:url_fetch_method') == 'curl':

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -371,11 +371,14 @@ class URLFetchStrategy(FetchStrategy):
 
     def _check_existing_url_by_header_request(self, url):
         tty.debug('Checking existence of {0}'.format(url))
-        curl = self.curl
-        # Try a header request to the url
-        curl_args = ['--stderr', '-', '-s', '-f', '-I', url]
-        _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
-        return curl.returncode == 0
+        if spack.config.get('config:url_fetch_method') == 'curl':
+            curl = self.curl
+            # Try a header request to the url
+            curl_args = ['--stderr', '-', '-s', '-f', '-I', url]
+            _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
+            return curl.returncode == 0
+        else:
+            return False
 
     def _fetch_from_url(self, url):
         if spack.config.get('config:url_fetch_method') == 'curl':

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -377,8 +377,7 @@ class URLFetchStrategy(FetchStrategy):
             curl_args = ['--stderr', '-', '-s', '-f', '-I', url]
             _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
             return curl.returncode == 0
-        else:
-            return False
+        return False
 
     def _fetch_from_url(self, url):
         if spack.config.get('config:url_fetch_method') == 'curl':


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/20050 by trying a header request when the first range request fails, when checking for urls. Probably adds a little bit of overhead when checking for many  non-existing urls, but makes it more robust when dealing with strange server configurations.