### PR TITLE
Add special version "commit-123foo" and construct git fetch strategy for it

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1270,6 +1270,17 @@ def _check_version_attributes(fetcher, pkg, version):
 
 def _extrapolate(pkg, version):
     """Create a fetcher from an extrapolated URL for this version."""
+
+    # handle special version 'commit-1234abc':
+    # build from commit '1234abc'
+    # convert to string to make sure to get the commit unchanged
+    _versionstrlist = str(version.dashed).split('-')
+    if _versionstrlist[0] == 'commit':
+        if len(_versionstrlist) == 2:
+            return GitFetchStrategy(git=pkg.git,
+                                    commit=_versionstrlist[1],
+                                    )
+
     try:
         return URLFetchStrategy(pkg.url_for_version(version),
                                 fetch_options=pkg.fetch_options)

--- a/lib/spack/spack/test/cmd/fetch.py
+++ b/lib/spack/spack/test/cmd/fetch.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+from spack.main import SpackCommand
+
+versions = SpackCommand('fetch')
+
+
+@pytest.mark.network
+@pytest.mark.usefixtures('mock_packages')
+def test_fetch_commit_extrapolation():
+    """Test the git commit extrapolation of a version."""
+
+    versions('--no-checksum', 'brillig@commit.e03d9f58a')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -40,7 +40,7 @@ __all__ = ['Version', 'VersionRange', 'VersionList', 'ver']
 VALID_VERSION = r'[A-Za-z0-9_.-]'
 
 # Infinity-like versions. The order in the list implies the comparison rules
-infinity_versions = ['develop', 'main', 'master', 'head', 'trunk']
+infinity_versions = ['develop', 'main', 'master', 'head', 'trunk', 'commit']
 
 
 def int_if_int(string):


### PR DESCRIPTION
As discussed on slack, a major shortcoming of building `package@master` is that there is no way of knowing what commit has been used for the build, and it has to be uninstalled in order to get an updated build if the branch has been changed. It's possible to add `version("foo", commit="12345bar")` to the recipe, but that is not really practical. This PR proposes a very simple solution to this problem, expanding the extrapolation to git commits, which is mainly geared towards nightly builds:

It introduces special versions of the form `commit-xxxxx` which do not have to be added to the package recipe and will build the package from git commit `xxxxx`. `commit` is added as an infinity version, so it will build with build options like master (this is in line with the most common use case of nightly builds, and comparing commits is a can of worms I don't want to open).

The commit is just forwarded to `git checkout`, so it is  possible to use a tag or a shortened commit, of course that won't compare as the same version as a longer hash of the same commit. I use a short macro-type function to query the github api for full hashes of the latest commit and add those as dependencies of a bundle package in order to get efficient nightly builds: https://github.com/key4hep/key4hep-spack/blob/master/packages/Ilcsoftpackage/package.py#L110