### PR TITLE
clhep: new version 2.4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -18,6 +18,7 @@ class Clhep(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+    version('2.4.4.0', sha256='5df78c11733a091da9ae5a24ce31161d44034dd45f20455587db85f1ca1ba539')
     version('2.4.1.3', sha256='27c257934929f4cb1643aa60aeaad6519025d8f0a1c199bc3137ad7368245913')
     version('2.4.1.2', sha256='ff96e7282254164380460bc8cf2dff2b58944084eadcd872b5661eb5a33fa4b8')
     version('2.4.1.0', sha256='d14736eb5c3d21f86ce831dc1afcf03d423825b35c84deb6f8fd16773528c54d')


### PR DESCRIPTION
A very simple version bump to the CLHEP package. The intermediate 2.4.2.0 and 2.4.3.0 tags are not imported as these just represent individual MRs being merged, whilst 2.4.4.0 has everything since the last 2.4.1.3 tag spack has.