### PR TITLE
Add a mechanism for Spack to bootstrap clingo

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -14,8 +14,8 @@ import spack.tengine
 
 
 def clingo():
-    """Bootstrap clingo for the current interpreter, if necessary, and
-    returns the path to be added to PYTHONPATH.
+    """Bootstrap clingo for the current interpreter, if not done before,
+    modify sys.path and return the imported Python module.
     """
     # Base directory where to bootstrap software for this interpreter
     root_dir = spack.paths.bootstrap_path
@@ -29,7 +29,7 @@ def clingo():
     # Check if clingo with Python support is already present
     clingo_libs = fs.find_libraries(['libclingo'], view_dir, recursive=True)
     if clingo_libs:
-        return _extract_extension_dir_from(clingo_libs)
+        return _import_clingo_module(clingo_libs)
 
     # We need to build clingo, so ensure prerequisites are met first.
     msg = "CLINGO BOOTSTRAP: libclingo.so not found [view={0}]"
@@ -53,10 +53,15 @@ def clingo():
             env.write()
 
     clingo_libs = fs.find_libraries(['libclingo'], view_dir, recursive=True)
-    if clingo_libs:
-        python_extension_dir = _extract_extension_dir_from(clingo_libs)
+    return _import_clingo_module(clingo_libs)
 
-    return python_extension_dir
+
+def _import_clingo_module(clingo_libs):
+    python_extension_dir = _extract_extension_dir_from(clingo_libs)
+    # Add the path to sys.path and import clingo
+    sys.path.append(python_extension_dir)
+    import clingo
+    return clingo
 
 
 def _extract_extension_dir_from(clingo_libs):

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -1,0 +1,107 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Bootstrap software needed by Spack"""
+import os.path
+import sys
+
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+import spack.environment
+import spack.paths
+import spack.tengine
+
+
+def clingo():
+    """Bootstrap clingo for the current interpreter, if necessary, and
+    returns the path to be added to PYTHONPATH.
+    """
+    # Base directory where to bootstrap software for this interpreter
+    root_dir = spack.paths.bootstrap_path
+
+    # Clingo will be installed with a Spack environment, so compute
+    # base directory for the manifest file and associated view
+    manifest_dir = os.path.join(root_dir, 'clingo')
+    manifest_file = os.path.join(manifest_dir, 'spack.yaml')
+    view_dir = os.path.join(root_dir, 'view')
+
+    # Check if clingo with Python support is already present
+    clingo_libs = fs.find_libraries(['libclingo'], view_dir, recursive=True)
+    if clingo_libs:
+        return _extract_extension_dir_from(clingo_libs)
+
+    # We need to build clingo, so ensure prerequisites are met first.
+    msg = "CLINGO BOOTSTRAP: libclingo.so not found [view={0}]"
+    tty.debug(msg.format(view_dir))
+    _ensure_clingo_prereq()
+
+    # Warn user that bootstrapping takes time and try to obtain
+    # explicit permission
+    if not _obtain_user_permission_to_proceed():
+        tty.die("Operation aborted.")
+
+    # Write a spack.yaml manifest with the software we need to bootstrap
+    _write_clingo_spack_yaml(manifest_file, root_dir)
+
+    with spack.environment.Environment(
+            manifest_dir, init_file=manifest_file
+    ) as env:
+        with env.write_transaction():
+            env.concretize()
+            env.install_all()
+            env.write()
+
+    clingo_libs = fs.find_libraries(['libclingo'], view_dir, recursive=True)
+    if clingo_libs:
+        python_extension_dir = _extract_extension_dir_from(clingo_libs)
+
+    return python_extension_dir
+
+
+def _extract_extension_dir_from(clingo_libs):
+    msg = "Clingo libraries spread over multiple directories"
+    assert len(clingo_libs.directories) == 1, msg
+    python_extension_dir = fs.find(clingo_libs.directories[0], 'site-packages')
+    msg = "Clingo built without python support"
+    assert len(python_extension_dir) == 1, msg
+    python_extension_dir = python_extension_dir[0]
+    msg = "CLINGO BOOTSTRAP: extensions dir found [dir={0}]"
+    tty.debug(msg.format(python_extension_dir))
+    return python_extension_dir
+
+
+def _ensure_clingo_prereq():
+    # TODO: Check prerequisites are met, raise if not
+    # TODO: 1. Compiler with support for C++14 (clingo)
+    pass
+
+
+def _write_clingo_spack_yaml(manifest_file, root_dir):
+    manifest_dir = os.path.dirname(manifest_file)
+    tenv = spack.tengine.make_environment()
+    template = tenv.get_template('bootstrap/clingo.yaml')
+
+    # Install clingo as an extension of the current interpreter
+    interpreter_spec = 'python@{0}.{1}.{2}'.format(
+        sys.version_info[0], sys.version_info[1], sys.version_info[2]
+    )
+    # Assume the interpreter is in a bin directory within the prefix
+    interpreter_prefix = os.path.dirname(os.path.dirname(sys.executable))
+    context = {
+        'interpreter_spec': interpreter_spec,
+        'interpreter_prefix': interpreter_prefix,
+        'root': root_dir
+    }
+    text = template.render(**context)
+
+    # Write the manifest file
+    fs.mkdirp(manifest_dir)
+    with open(manifest_file, 'w') as f:
+        f.write(text)
+
+
+def _obtain_user_permission_to_proceed():
+    msg = ("Do you want Spack to bootstrap clingo? [The process will take"
+           " several minutes]")
+    return tty.get_yes_or_no(msg, default=True)

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -2,18 +2,20 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 """Defines paths that are part of Spack's directory structure.
 
 Do not import other ``spack`` modules here. This module is used
 throughout Spack and should bring in a minimal number of external
 dependencies.
 """
-import os
-from llnl.util.filesystem import ancestor
+import hashlib
+import os.path
+import sys
+
+import llnl.util.filesystem as fs
 
 #: This file lives in $prefix/lib/spack/spack/__file__
-prefix = ancestor(__file__, 4)
+prefix = fs.ancestor(__file__, 4)
 
 #: synonym for prefix
 spack_root = prefix
@@ -61,3 +63,9 @@ gpg_keys_path      = os.path.join(var_path, "gpg")
 mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
 mock_gpg_keys_path = os.path.join(var_path, "gpg.mock", "keys")
 gpg_path           = os.path.join(opt_path, "spack", "gpg")
+
+#: Path where to store bootstrapped software
+bootstrap_path = os.path.join(
+    user_config_path, "bootstrap",
+    hashlib.md5(os.path.abspath(sys.executable).encode('utf-8')).hexdigest()
+)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -23,9 +23,7 @@ try:
     import clingo
 except ImportError:
     import spack.bootstrap
-    extension_dir = spack.bootstrap.clingo()
-    sys.path.append(extension_dir)
-    import clingo
+    clingo = spack.bootstrap.clingo()
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -22,7 +22,10 @@ import archspec.cpu
 try:
     import clingo
 except ImportError:
-    clingo = None
+    import spack.bootstrap
+    extension_dir = spack.bootstrap.clingo()
+    sys.path.append(extension_dir)
+    import clingo
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -76,6 +76,13 @@ def no_path_access(monkeypatch):
     monkeypatch.setattr(os, 'access', _can_access)
 
 
+@pytest.fixture(scope='session', autouse=True)
+def pytest_configure():
+    # TODO: Disable bootstrapping for tests in a cleaner way
+    import spack.bootstrap
+    spack.bootstrap.clingo = lambda: None
+
+
 #
 # Disable any activate Spack environment BEFORE all tests
 #

--- a/share/spack/templates/bootstrap/clingo.yaml
+++ b/share/spack/templates/bootstrap/clingo.yaml
@@ -1,0 +1,15 @@
+spack:
+  specs:
+  - clingo@spack+python
+  config:
+    concretizer: original
+    install_tree:
+      root: {{ root }}/store
+  packages:
+    python:
+      externals:
+      - spec: {{ interpreter_spec }}
+        prefix: {{ interpreter_prefix }}
+  modules:
+    enable:: []
+  view: {{ root }}/view


### PR DESCRIPTION
This PR adds the ability to bootstrap clingo for any interpreter that is used to run Spack:
```console
[mculpo02@login02 spack]$ spack solve zlib
==> Do you want Spack to bootstrap clingo? [The process will take several minutes] [Y/n] 
==> Warning: Missing a source id for python@2.7.5
==> Installing libiconv-1.16-zczi37byglq3f5vweadydldeqadhr52u
==> Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
==> No binary for libiconv-1.16-zczi37byglq3f5vweadydldeqadhr52u found: installing from source
==> Using cached archive: /m100/home/userexternal/mculpo02/github/spack/var/spack/cache/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
==> libiconv: Executing phase: 'autoreconf'
==> libiconv: Executing phase: 'configure'
[ ... ]
```
At the moment the process is interactive, to avoid starting a ~15 mins. build without the user being aware of it, but ideally it should be automated (if made fast enough) or be interactive only for command line use of Spack. A Spack environment is used to bootstrap the software and install it at a fixed location. 

Improvements that can be made on top of this:

- [ ] Look for dependencies that are already in the system (e.g. cmake) and use them as "externals"
- [ ] Remove interactive confirmation from user, at least for non cli use of Spack
- [ ] Check prerequisites for building `clingo` (e.g. compiler with support for C++14)

Submitting as draft to get some early feedback.

@becker33 @tgamblin @cosmicexplorer 