### PR TITLE
Add cray mpich

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -1,0 +1,51 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class CrayMpich(Package):
+    """Cray's MPICH is a high performance and widely portable implementation of
+    the Message Passing Interface (MPI) standard."""
+
+    homepage = "https://docs.nersc.gov/development/compilers/wrappers/"
+    has_code = False    # Skip attempts to fetch source that is not available
+
+    maintainers = ['haampie']
+
+    version('7.7.15')
+    provides('mpi')
+
+    def setup_run_environment(self, env):
+        env.set('MPICC', spack_cc)
+        env.set('MPICXX', spack_cxx)
+        env.set('MPIF77', spack_fc)
+        env.set('MPIF90', spack_fc)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+        env.set('MPICH_CC', spack_cc)
+        env.set('MPICH_CXX', spack_cxx)
+        env.set('MPICH_F77', spack_f77)
+        env.set('MPICH_F90', spack_fc)
+        env.set('MPICH_FC', spack_fc)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        spec = self.spec
+        spec.mpicc = spack_cc
+        spec.mpicxx = spack_cxx
+        spec.mpifc = spack_fc
+        spec.mpif77 = spack_f77
+
+        spec.mpicxx_shared_libs = [
+            join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
+            join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
+        ]
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -17,6 +17,9 @@ class CrayMpich(Package):
 
     version('7.7.16')
     version('7.7.15')
+    version('7.7.14')
+    version('7.7.13')
+
     provides('mpi@3:')
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -15,6 +15,11 @@ class CrayMpich(Package):
 
     maintainers = ['haampie']
 
+    version('8.1.0')
+    version('8.0.16')
+    version('8.0.14')
+    version('8.0.11')
+    version('8.0.9')
     version('7.7.16')
     version('7.7.15')
     version('7.7.14')

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -15,6 +15,7 @@ class CrayMpich(Package):
 
     maintainers = ['haampie']
 
+    version('7.7.16')
     version('7.7.15')
     provides('mpi')
 

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -20,7 +20,7 @@ class CrayMpich(Package):
     version('7.7.14')
     version('7.7.13')
 
-    provides('mpi@3:')
+    provides('mpi@3')
 
     def setup_run_environment(self, env):
         env.set('MPICC', spack_cc)

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -17,7 +17,7 @@ class CrayMpich(Package):
 
     version('7.7.16')
     version('7.7.15')
-    provides('mpi')
+    provides('mpi@3:')
 
     def setup_run_environment(self, env):
         env.set('MPICC', spack_cc)

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -327,21 +327,12 @@ spack package at this time.''',
     def setup_dependent_package(self, module, dependent_spec):
         spec = self.spec
 
-        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
-        # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
-        external_modules = spec.external_modules
-        if external_modules and 'cray' in external_modules[0]:
-            spec.mpicc = spack_cc
-            spec.mpicxx = spack_cxx
-            spec.mpifc = spack_fc
-            spec.mpif77 = spack_f77
-        else:
-            spec.mpicc = join_path(self.prefix.bin, 'mpicc')
-            spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
+        spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+        spec.mpicxx = join_path(self.prefix.bin, 'mpic++')
 
-            if '+fortran' in spec:
-                spec.mpifc = join_path(self.prefix.bin, 'mpif90')
-                spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        if '+fortran' in spec:
+            spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+            spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
         spec.mpicxx_shared_libs = [
             join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -301,19 +301,10 @@ spack package at this time.''',
     def setup_run_environment(self, env):
         # Because MPI implementations provide compilers, they have to add to
         # their run environments the code to make the compilers available.
-        # For Cray MPIs, the regular compiler wrappers *are* the MPI wrappers.
-        # Cray MPIs always have cray in the module name, e.g. "cray-mpich"
-        external_modules = self.spec.external_modules
-        if external_modules and 'cray' in external_modules[0]:
-            env.set('MPICC', spack_cc)
-            env.set('MPICXX', spack_cxx)
-            env.set('MPIF77', spack_fc)
-            env.set('MPIF90', spack_fc)
-        else:
-            env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
-            env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
-            env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
-            env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+        env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
+        env.set('MPICXX', join_path(self.prefix.bin, 'mpic++'))
+        env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+        env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)


### PR DESCRIPTION
Although ABI-compatible, Cray's mpich might be slightly different from default mpich, so it makes sense to split up the package into `cray-mpich` and `mpich`.

In particular version numbers of cray-mpich differ from mpich, and having those Cray version numbers makes it easier to add constraints.

On my cluster I could only find a single version of cray-mpich, so the `version` list is a bit sparse now, hopefully people can add some versions they find on their systems.