### PR TITLE
powertop: Add depend ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/powertop/package.py
+++ b/var/spack/repos/builtin/packages/powertop/package.py
@@ -16,6 +16,7 @@ class Powertop(AutotoolsPackage):
     version('2.9', sha256='aa7fb7d8e9a00f05e7d8a7a2866d85929741e0d03a5bf40cab22d2021c959250')
 
     depends_on('libnl')
+    depends_on('ncurses', type='link')
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', self.prefix.sbin)


### PR DESCRIPTION
When building on x86_64 and aarch64, I got the following error:
  >> 218    configure: error: ncurses is required but was not found

I added ncurses depend.