### PR TITLE
mesa: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -177,6 +177,10 @@ class Mesa(MesonPackage):
 
         return args
 
+    def setup_build_environment(self, env):
+        if self.spec.target.family == 'aarch64':
+            env.append_flags('LDFLAGS', '-ltinfo')
+
     @property
     def libs(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -24,7 +24,7 @@ class Mesa(MesonPackage):
     depends_on('cmake', type='build')
     # Starting with 0.54.0, meson will not try the cmake method when a
     # shared link is requested, so it will use version 0.53.2.
-    depends_on('meson@0.53.2', type='build')
+    depends_on('meson@0.52:0.53.2', type='build')
 
     depends_on('pkgconfig', type='build')
     depends_on('binutils', when=(sys.platform != 'darwin'), type='build')

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -21,7 +21,10 @@ class Mesa(MesonPackage):
     version('master', tag='master')
     version('20.2.1', sha256='d1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a')
 
-    depends_on('meson@0.52:', type='build')
+    depends_on('cmake', type='build')
+    # Starting with 0.54.0, meson will not try the cmake method when a
+    # shared link is requested, so it will use version 0.53.2.
+    depends_on('meson@0.53.2', type='build')
 
     depends_on('pkgconfig', type='build')
     depends_on('binutils', when=(sys.platform != 'darwin'), type='build')
@@ -176,10 +179,6 @@ class Mesa(MesonPackage):
         args.append('-Ddri-drivers=' + ','.join(args_dri_drivers))
 
         return args
-
-    def setup_build_environment(self, env):
-        if self.spec.target.family == 'aarch64':
-            env.append_flags('LDFLAGS', '-ltinfo')
 
     @property
     def libs(self):


### PR DESCRIPTION
When I built on aarch64 I had an undefined reference to the following function.
　 `setupterm',  `tigetnum', `set_curterm',  `del_curterm'

I thought about the correction by referring to at-spi2-core which has the same Pakage type.
I have confirmed that at least 32 OSSs cannot be built because mesa cannot build.

I hope to resolve this issue early.