### PR TITLE
concretizer: allow a bool as argument for test dependendencies

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -916,8 +916,13 @@ class SpackSolverSetup(object):
                 named_cond.name = named_cond.name or pkg.name
 
                 for t in sorted(dep.type):
-                    # Skip test dependencies if they're not requested
-                    if t == 'test' and (not tests or pkg.name not in tests):
+                    # Skip test dependencies if they're not requested at all
+                    if t == 'test' and not tests:
+                        continue
+
+                    # ... or if they are requested only for certain packages
+                    if t == 'test' and (not isinstance(tests, bool)
+                                        and pkg.name not in tests):
                         continue
 
                     if cond == spack.spec.Spec():

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2463,8 +2463,14 @@ class Spec(object):
         self._dup(concretized)
         self._mark_concrete()
 
-    #: choose your concretizer here.
     def concretize(self, tests=False):
+        """Concretize the current spec.
+
+        Args:
+            tests (bool or list): if False disregard 'test' dependencies,
+                if a list of names activate them for the packages in the list,
+                if True activate 'test' dependencies for all packages.
+        """
         if spack.config.get('config:concretizer') == "clingo":
             self._new_concretize(tests)
         else:
@@ -2482,12 +2488,19 @@ class Spec(object):
             s._normal = value
             s._concrete = value
 
-    def concretized(self):
-        """This is a non-destructive version of concretize().  First clones,
-           then returns a concrete version of this package without modifying
-           this package. """
+    def concretized(self, tests=False):
+        """This is a non-destructive version of concretize().
+
+        First clones, then returns a concrete version of this package
+        without modifying this package.
+
+        Args:
+            tests (bool or list): if False disregard 'test' dependencies,
+                if a list of names activate them for the packages in the list,
+                if True activate 'test' dependencies for all packages.
+        """
         clone = self.copy(caches=False)
-        clone.concretize()
+        clone.concretize(tests=tests)
         return clone
 
     def flat_dependencies(self, **kwargs):

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -31,6 +31,7 @@ class A(AutotoolsPackage):
     variant('bvv', default=True, description='The good old BV variant')
 
     depends_on('b', when='foobar=bar')
+    depends_on('test-dependency', type='test')
 
     parallel = False
 

--- a/var/spack/repos/builtin.mock/packages/test-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-dependency/package.py
@@ -2,16 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
-
-
-class B(Package):
-    """Simple package with no dependencies"""
-
+class TestDependency(Package):
+    """Represent a dependency that is pulled-in to allow testing other
+    packages.
+    """
     homepage = "http://www.example.com"
-    url      = "http://www.example.com/b-1.0.tar.gz"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-
-    depends_on('test-dependency', type='test')


### PR DESCRIPTION
refers #20079

Added docstrings to 'concretize' and 'concretized' to document the format for tests. Added tests for the activation of test dependencies.