### PR TITLE
[openloops] fix variant for clingo concretizer

### DIFF
--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -68,10 +68,11 @@ class Openloops(Package):
                                      'library.php?repo=public for details',
             values=disjoint_sets(('all.coll',), ('lhc.coll',), ('lcg.coll',),
                                  all_processes).with_default('lhc.coll'))
-
     variant('num_jobs', description='Number of parallel jobs to run. '  +
                                     'Set to 1 if compiling a large number' +
-                                    'of processes (e.g. lcg.coll)', default=0)
+                                    'of processes (e.g. lcg.coll)', default=0,
+                                    values=('0', '1'), multi=False)
+
     depends_on('python', type=("build", "run"))
 
     phases = ['configure', 'build', 'build_processes', 'install']


### PR DESCRIPTION
@iarspider  Currently the new concretizer gets confused whether `num_jobs` is a single- or multi-valued variant and errors with:
```
==> Error: 'SingleValuedVariant' object has no attribute 'append'
```
this makes it explicitly a mulit-valued variant.

