### PR TITLE
AOCC-2.3.0 is now added to spack

### DIFF
--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -465,6 +465,28 @@ def test_aocc_flags():
     supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("version_argument", "--version", "aocc@2.2.0")
 
+    supported_flag_test("debug_flags",
+                        ['-gcodeview', '-gdwarf-2', '-gdwarf-3',
+                         '-gdwarf-4', '-gdwarf-5', '-gline-tables-only',
+                         '-gmodules', '-gz', '-g'],
+                        'aocc@2.3.0')
+    supported_flag_test("opt_flags",
+                        ['-O0', '-O1', '-O2', '-O3', '-Ofast',
+                         '-Os', '-Oz', '-Og',
+                         '-O', '-O4'],
+                        'aocc@2.3.0')
+    supported_flag_test("openmp_flag", "-fopenmp", "aocc@2.3.0")
+    supported_flag_test("cxx11_flag", "-std=c++11", "aocc@2.3.0")
+    supported_flag_test("cxx14_flag", "-std=c++14", "aocc@2.3.0")
+    supported_flag_test("cxx17_flag", "-std=c++17", "aocc@2.3.0")
+    supported_flag_test("c99_flag", "-std=c99", "aocc@2.3.0")
+    supported_flag_test("c11_flag", "-std=c11", "aocc@2.3.0")
+    supported_flag_test("cc_pic_flag", "-fPIC", "aocc@2.3.0")
+    supported_flag_test("cxx_pic_flag", "-fPIC", "aocc@2.3.0")
+    supported_flag_test("f77_pic_flag", "-fPIC", "aocc@2.3.0")
+    supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.3.0")
+    supported_flag_test("version_argument", "--version", "aocc@2.3.0")
+
 
 def test_fj_flags():
     supported_flag_test("openmp_flag", "-Kopenmp", "fj@4.0.0")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -465,28 +465,6 @@ def test_aocc_flags():
     supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("version_argument", "--version", "aocc@2.2.0")
 
-    supported_flag_test("debug_flags",
-                        ['-gcodeview', '-gdwarf-2', '-gdwarf-3',
-                         '-gdwarf-4', '-gdwarf-5', '-gline-tables-only',
-                         '-gmodules', '-gz', '-g'],
-                        'aocc@2.3.0')
-    supported_flag_test("opt_flags",
-                        ['-O0', '-O1', '-O2', '-O3', '-Ofast',
-                         '-Os', '-Oz', '-Og',
-                         '-O', '-O4'],
-                        'aocc@2.3.0')
-    supported_flag_test("openmp_flag", "-fopenmp", "aocc@2.3.0")
-    supported_flag_test("cxx11_flag", "-std=c++11", "aocc@2.3.0")
-    supported_flag_test("cxx14_flag", "-std=c++14", "aocc@2.3.0")
-    supported_flag_test("cxx17_flag", "-std=c++17", "aocc@2.3.0")
-    supported_flag_test("c99_flag", "-std=c99", "aocc@2.3.0")
-    supported_flag_test("c11_flag", "-std=c11", "aocc@2.3.0")
-    supported_flag_test("cc_pic_flag", "-fPIC", "aocc@2.3.0")
-    supported_flag_test("cxx_pic_flag", "-fPIC", "aocc@2.3.0")
-    supported_flag_test("f77_pic_flag", "-fPIC", "aocc@2.3.0")
-    supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.3.0")
-    supported_flag_test("version_argument", "--version", "aocc@2.3.0")
-
 
 def test_fj_flags():
     supported_flag_test("openmp_flag", "-Kopenmp", "fj@4.0.0")

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -331,6 +331,11 @@ def test_cray_frontend_compiler_detection(
 
 @pytest.mark.parametrize('version_str,expected_version', [
     # This applies to C,C++ and FORTRAN compiler
+    ('AMD clang version 11.0.0 (CLANG: AOCC_2.3.0-Build#85 2020_11_10)'
+     '(based on LLVM Mirror.Version.11.0.0)\n'
+     'Target: x86_64-unknown-linux-gnu\n'
+     'Thread model: posix\n', '2.3.0'
+     ),
     ('AMD clang version 10.0.0 (CLANG: AOCC_2.2.0-Build#93 2020_06_25)'
      '(based on LLVM Mirror.Version.10.0.0)\n'
      'Target: x86_64-unknown-linux-gnu\n'

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -29,6 +29,11 @@ class Aocc(Package):
     '''
     family = 'compiler'
     homepage = "https://developer.amd.com/amd-aocc/"
+
+    maintainers = ['amd-toolchain-support']
+
+    version(ver="2.3.0", sha256='9f8a1544a5268a7fb8cd21ac4bdb3f8d1571949d1de5ca48e2d3309928fc3d15',
+            url='http://developer.amd.com/wordpress/media/files/aocc-compiler-2.3.0.tar')
     version(ver="2.2.0", sha256='500940ce36c19297dfba3aa56dcef33b6145867a1f34890945172ac2be83b286',
             url='http://developer.amd.com/wordpress/media/files/aocc-compiler-2.2.0.tar')
 


### PR DESCRIPTION
Newly released AOCC-2.3.0 is now added to spack 