### PR TITLE
Arch swapping features for specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1151,8 +1151,8 @@ class Spec(object):
         for dep in self.traverse(root=True):
             dep._swap_architecture(**kwargs)
         if concrete:
-            # re-cache dag_hash
-            _ = self.dag_hash()
+            for hash_type in [ht.dag_hash, ht.build_hash, ht.full_hash]:
+                setattr(self, hash_type.attr, None)
             self._mark_concrete()
 
     def _swap_architecture(self, **kwargs):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -122,6 +122,8 @@ def test_arch_apply(config, mock_packages):
     be_spec._apply_architecture(os='be', target='be')
 
     platform = spack.architecture.platform()
+    assert be_spec.concrete
+    assert be_spec.dag_hash() != fe_spec.dag_hash()  # no overeager caching
     for be, fe in zip(be_spec.traverse(), fe_spec.traverse()):
         assert be != fe
         assert be.architecture.os == str(platform.operating_system('be'))

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -103,6 +103,31 @@ def test_user_back_end_input(config):
     assert backend_target == backend_spec.architecture.target
 
 
+def test_arch_swap(config):
+    """Test swapping architectures"""
+    fe_spec = Spec('mpileaks os=fe target=fe')
+    be_spec = fe_spec.copy()
+    be_spec._swap_architecture(os='be')
+
+    assert be_spec != fe_spec
+    platform = spack.architecture.platform()
+    assert be_spec.architecture.os == str(platform.operating_system('be'))
+    assert be_spec.architecture.target == py_platform.machine()
+
+
+def test_arch_apply(config, mock_packages):
+    """Test swapping architectures"""
+    fe_spec = Spec('mpileaks os=fe target=fe').concretized()
+    be_spec = fe_spec.copy()
+    be_spec._apply_architecture(os='be', target='be')
+
+    platform = spack.architecture.platform()
+    for be, fe in zip(be_spec.traverse(), fe_spec.traverse()):
+        assert be != fe
+        assert be.architecture.os == str(platform.operating_system('be'))
+        assert be.architecture.target == str(platform.target('be'))
+
+
 def test_user_defaults(config):
     platform = spack.architecture.platform()
     default_os = str(platform.operating_system("default_os"))

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -107,11 +107,12 @@ def test_arch_swap(config):
     """Test swapping architectures"""
     fe_spec = Spec('mpileaks os=fe target=fe')
     be_spec = fe_spec.copy()
-    be_spec._swap_architecture(os='be')
+    be_spec._swap_architecture()
 
     assert be_spec != fe_spec
     platform = spack.architecture.platform()
-    assert be_spec.architecture.os == str(platform.operating_system('be'))
+    assert be_spec.architecture.os == str(platform.operating_system(
+        'default_os'))
     assert be_spec.architecture.target == py_platform.machine()
 
 


### PR DESCRIPTION
This is preliminary work for bootstrapping for the new concretizer. The goal is to eventually vendor a concrete spec that can be applied to different architectures and download appropriate binaries for bootstrapping.

@tgamblin @alalazo @cosmicexplorer