### PR TITLE
concretizer: try to infer the real version of compilers if spec fails

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -959,3 +959,11 @@ class TestConcretize(object):
         # Check that non-default variant values are forced on the dependency
         d = s['dep-with-variants']
         assert '+foo+bar+baz' in d
+
+    @pytest.mark.regression('20055')
+    def test_custom_compiler_version(self):
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.xfail('Known failure of the original concretizer')
+
+        s = Spec('a %gcc@foo os=redhat6').concretized()
+        assert '%gcc@foo' in s

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -8,6 +8,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: gcc@4.5.0
     operating_system: {0.name}{0.version}
@@ -17,6 +18,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: clang@3.3
     operating_system: CNL
@@ -35,6 +37,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: clang@3.3
     operating_system: yosemite
@@ -44,6 +47,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -62,6 +66,7 @@ compilers:
     operating_system: SuSE11
     spec: gcc@4.5.0
     modules: 'None'
+    target: x86_64
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -71,6 +76,7 @@ compilers:
     operating_system: yosemite
     spec: gcc@4.5.0
     modules: 'None'
+    target: x86_64
 - compiler:
     paths:
       cc: /path/to/gcc
@@ -80,6 +86,7 @@ compilers:
     operating_system: elcapitan
     spec: gcc@4.5.0
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: clang@3.3
     operating_system: elcapitan
@@ -89,6 +96,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: gcc@4.7.2
     operating_system: redhat6
@@ -102,6 +110,7 @@ compilers:
       cxxflags: -O0 -g
       fflags: -O0 -g
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: gcc@4.4.0
     operating_system: redhat6
@@ -123,6 +132,7 @@ compilers:
       cflags: -O3
       cxxflags: -O3
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: clang@8.0.0
     operating_system: redhat7
@@ -135,6 +145,7 @@ compilers:
       cflags: -O3
       cxxflags: -O3
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: apple-clang@9.1.0
     operating_system: elcapitan
@@ -144,6 +155,7 @@ compilers:
       f77: None
       fc: None
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: gcc@foo
     operating_system: redhat6
@@ -153,6 +165,7 @@ compilers:
       f77: /path/to/gfortran
       fc: /path/to/gfortran
     modules: 'None'
+    target: x86_64
 - compiler:
     spec: gcc@4.4.0-special
     operating_system: redhat6
@@ -162,3 +175,4 @@ compilers:
       f77: /path/to/gfortran
       fc: /path/to/gfortran
     modules: 'None'
+    target: x86_64


### PR DESCRIPTION
fixes #20055

Compiler with custom versions like `gcc@foo` are not currently matched to the appropriate targets. This is because the version of spec doesn't match the real version of the compiler. This PR replicates the strategy used in the original concretizer to deal with that and tries to detect the real version of compilers if the version in the spec returns no results for targets.