### PR TITLE
OpenBLAS: More Precise GCC Conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -113,8 +113,7 @@ class Openblas(MakefilePackage):
     patch('openblas_fujitsu2.patch', when='@0.3.10: %fj')
 
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
-    conflicts('%gcc@7.0.0:7.3.99', when='@0.3.11:')
-    conflicts('%gcc@8.0.0:8.2.99', when='@0.3.11:')
+    conflicts('%gcc@7.0.0:7.3.99,8.0.0:8.2.99', when='@0.3.11:')
 
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -112,8 +112,9 @@ class Openblas(MakefilePackage):
     patch('openblas_fujitsu_v0.3.11.patch', when='@0.3.11: %fj')
     patch('openblas_fujitsu2.patch', when='@0.3.10: %fj')
 
-    # See https://github.com/spack/spack/issues/19932
-    conflicts('%gcc@:8.2.99', when='@0.3.11:')
+    # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
+    conflicts('%gcc@7.0.0:7.3.99', when='@0.3.11:')
+    conflicts('%gcc@8.0.0:8.2.99', when='@0.3.11:')
 
     # See https://github.com/spack/spack/issues/3036
     conflicts('%intel@16', when='@0.2.15:0.2.19')


### PR DESCRIPTION
Add more precise GCC conflicts so e.g. GCC 6 and GCC 7.5 don't fail.

Tests: https://github.com/spack/spack/issues/19932#issuecomment-733452619

Re.: #19932
Follow-up to #19975

Fix: #20100

CC @eugeneswalker @siko1056 