### PR TITLE
py-catkin-pkg: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-catkin-pkg/package.py
+++ b/var/spack/repos/builtin/packages/py-catkin-pkg/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyCatkinPkg(PythonPackage):
+    """Library for retrieving information about catkin packages."""
+
+    homepage = "https://wiki.ros.org/catkin_pkg"
+    url      = "https://pypi.io/packages/source/c/catkin-pkg/catkin_pkg-0.4.23.tar.gz"
+
+    version('0.4.23', sha256='28ee181cca827c0aabf9397351f58a97e1475ca5ac7c106a5916e3ee191cd3d0')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-docutils', type=('build', 'run'))
+    depends_on('py-python-dateutil', type=('build', 'run'))
+    depends_on('py-pyparsing', type=('build', 'run'))
+    depends_on('py-argparse', when='^python@:2.6', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-catkin-pkg/package.py
+++ b/var/spack/repos/builtin/packages/py-catkin-pkg/package.py
@@ -12,7 +12,7 @@ class PyCatkinPkg(PythonPackage):
 
     version('0.4.23', sha256='28ee181cca827c0aabf9397351f58a97e1475ca5ac7c106a5916e3ee191cd3d0')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-docutils', type=('build', 'run'))
     depends_on('py-python-dateutil', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on Ubuntu 18.04 with Python 3.8.6 and GCC 7.5.0.