### PR TITLE
py-rosdep: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-rosdep/package.py
+++ b/var/spack/repos/builtin/packages/py-rosdep/package.py
@@ -12,7 +12,7 @@ class PyRosdep(PythonPackage):
 
     version('0.20.0', sha256='1de76e41ef17c7289a11d9de594f6c08e8422f26ad09bc855b4f1f4da5e9bfe7')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-catkin-pkg@0.4.0:', type=('build', 'run'))
     depends_on('py-rospkg@1.2.7:', type=('build', 'run'))
     depends_on('py-rosdistro@0.7.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-rosdep/package.py
+++ b/var/spack/repos/builtin/packages/py-rosdep/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyRosdep(PythonPackage):
+    """rosdep package manager abstraction tool for ROS."""
+
+    homepage = "https://wiki.ros.org/rosdep"
+    url      = "https://pypi.io/packages/source/r/rosdep/rosdep-0.20.0.tar.gz"
+
+    version('0.20.0', sha256='1de76e41ef17c7289a11d9de594f6c08e8422f26ad09bc855b4f1f4da5e9bfe7')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-catkin-pkg@0.4.0:', type=('build', 'run'))
+    depends_on('py-rospkg@1.2.7:', type=('build', 'run'))
+    depends_on('py-rosdistro@0.7.5:', type=('build', 'run'))
+    depends_on('py-pyyaml@3.1:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on Ubuntu 18.04 with Python 3.8.6 and GCC 7.5.0.