### PR TITLE
py-rosinstall-generator: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-rosinstall-generator/package.py
+++ b/var/spack/repos/builtin/packages/py-rosinstall-generator/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyRosinstallGenerator(PythonPackage):
+    """A tool for generating rosinstall files."""
+
+    homepage = "https://wiki.ros.org/rosinstall_generator"
+    url      = "https://pypi.io/packages/source/r/rosinstall-generator/rosinstall_generator-0.1.22.tar.gz"
+
+    version('0.1.22', sha256='22d22599cd3f08a1f77fb2b1d9464cc8062ede50752a75564d459fcf5447b8c5')
+
+    depends_on('py-catkin-pkg@0.1.28:', type=('build', 'run'))
+    depends_on('py-rosdistro@0.7.3:', type=('build', 'run'))
+    depends_on('py-rospkg', type=('build', 'run'))
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on Ubuntu 18.04 with Python 3.8.6 and GCC 7.5.0.