### PR TITLE
python: improved external detection for obscure variants

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -143,8 +143,8 @@ class Python(AutotoolsPackage):
     variant('tix',      default=False, description='Build Tix module')
 
     depends_on('pkgconfig@0.9.0:', type='build')
-#    depends_on('gettext +libxml2', when='+libxml2')
-#    depends_on('gettext ~libxml2', when='~libxml2')
+    depends_on('gettext +libxml2', when='+libxml2')
+    depends_on('gettext ~libxml2', when='~libxml2')
 
     # Optional dependencies
     # See detect_modules() in setup.py for details

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -317,8 +317,7 @@ class Python(AutotoolsPackage):
             '-c', '%s; print(sysconfig.get_config_var("LIBPL"))' % sysconf_imp,
             output=str, error=str).strip()
         # Search for shared libraries in the prefix and set shared variant
-        matches = fs.find_libraries(
-            'libpython*', prefix=libdir, shared=True, recursive=True)
+        matches = fs.find_libraries('libpython*', prefix=libdir, shared=True)
         variants += '+shared' if len(matches) > 0 else '~shared'
 
         # check for debug

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -345,9 +345,8 @@ class Python(AutotoolsPackage):
                                 output=str, error=str)
             variants += '~ucs4' if maxunicode == 0xFFFF else '+ucs4'
 
-        # +pythoncommand does not apply to python@2
-        if version >= Version('3') and 'python' in [os.path.basename(exe)
-                                                     for exe in exes]:
+        # Will always be true for python2, but relevant for python3
+        if 'python' in [os.path.basename(exe) for exe in exes]:
             variants += '+pythoncmd'
         else:
             variants += '~pythoncmd'


### PR DESCRIPTION
@adamjstewart @alalazo @tgamblin @cosmicexplorer

Depending on our eventual strategy to bootstrap clingo, we may need to be able to detect a fully concrete spec for python without using the concretizer. This is a step in that direction.

As the comment says, the `libxml2` variant for python should go away as we add cycle-detection into the new concretizer and deprecate the old.