### PR TITLE
Fix new concretizer issue for mesa18

### DIFF
--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -64,6 +64,8 @@ class Mesa18(AutotoolsPackage):
     variant('opengl', default=True, description="Enable full OpenGL support.")
     variant('opengles', default=False, description="Enable OpenGL ES support.")
 
+    conflicts('~opengl ~opengles')
+
     # Provides
     provides('gl@4.5',  when='+opengl')
     provides('glx@1.4', when='+glx')


### PR DESCRIPTION
The new concretizer likes to disable both opengl and opengles in mesa18; this results in a configure issue, and is not intercepted by the package. So this change will force either opengl or opengles to be turned on.
