### PR TITLE
concretizer: don't optimize emitting version_satisfies()

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1394,10 +1394,6 @@ class SpackSolverSetup(object):
             if exact_match:
                 allowed_versions = exact_match
 
-            # don't bother restricting anything if all versions are allowed
-            if len(allowed_versions) == len(self.possible_versions[pkg_name]):
-                continue
-
             predicates = [fn.version(pkg_name, v) for v in allowed_versions]
 
             # version_satisfies(pkg, constraint) is true if and only if a

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -501,6 +501,11 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
+    def test_conflict_in_all_directives_true(self):
+        s = Spec('when-directives-true')
+        with pytest.raises(spack.error.SpackError):
+            s.concretize()
+
     @pytest.mark.parametrize('spec_str', [
         'conflict@10.0%clang+foo'
     ])


### PR DESCRIPTION
The mock package when-directives-true should fail to concretize on a conflict, however it does not under the new concretizer:
the output asp was missing any version_satisfies() rules.


before:
```shell
[aweits@localhost spack]$ spack -m solve when-directives-true
==> Best of 0 answers.
==> Optimization: [0, 0, 1, 0, -2, 0]
when-directives-true@1.0%gcc@9.3.0 patches=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234 arch=linux-centos8-skylake_avx512
    ^b@1.0%gcc@9.3.0 arch=linux-centos8-skylake_avx512
    ^extendee@1.0%gcc@9.3.0 arch=linux-centos8-skylake_avx512
```

after:
```
[aweits@localhost spack]$ spack -m solve when-directives-true
==> The following constraints are unsatisfiable:
  :- node("when-directives-true"),version_satisfies("when-directives-true","1.0"),not external("when-directives-true").
  root("when-directives-true")
==> Error: Unsatisfiable spec.
```

Added a test to concretize everything in the mock repo.