### PR TITLE
ffb: Fixed a recipe error when using the Intel compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/ffb/package.py
+++ b/var/spack/repos/builtin/packages/ffb/package.py
@@ -156,7 +156,7 @@ class Ffb(MakefilePackage):
             cxx_fortran_flags.append('--linkfortran')
             m = FileFilter(editfile)
             m.filter('-lifcore -limf', ' '.join(cxx_fortran_flags))
-        elif spec.satisfies('%intel'):    
+        elif spec.satisfies('%intel'):
             pass
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/ffb/package.py
+++ b/var/spack/repos/builtin/packages/ffb/package.py
@@ -156,6 +156,8 @@ class Ffb(MakefilePackage):
             cxx_fortran_flags.append('--linkfortran')
             m = FileFilter(editfile)
             m.filter('-lifcore -limf', ' '.join(cxx_fortran_flags))
+        elif spec.satisfies('%intel'):    
+            pass
 
     def build(self, spec, prefix):
         for m in [join_path('make',  'Makeall'),

--- a/var/spack/repos/builtin/packages/ffb/package.py
+++ b/var/spack/repos/builtin/packages/ffb/package.py
@@ -150,12 +150,12 @@ class Ffb(MakefilePackage):
         cxx_fortran_flags = []
         if spec.satisfies('%gcc'):
             cxx_fortran_flags.append('-lgfortran')
-        elif spec.satisfies('%intel'):
-            cxx_fortran_flags.expand(['-lifcore', '-limf'])
+            m = FileFilter(editfile)
+            m.filter('-lifcore -limf', ' '.join(cxx_fortran_flags))
         elif spec.satisfies('%fj'):
             cxx_fortran_flags.append('--linkfortran')
-        m = FileFilter(editfile)
-        m.filter('-lifcore -limf', ' '.join(cxx_fortran_flags))
+            m = FileFilter(editfile)
+            m.filter('-lifcore -limf', ' '.join(cxx_fortran_flags))
 
     def build(self, spec, prefix):
         for m in [join_path('make',  'Makeall'),


### PR DESCRIPTION
Fixed a recipe error when using the Intel compiler.
```
==> Installing ffb
==> No binary for ffb found: installing from source
==> Using cached archive: /data/test-1/spack/var/spack/cache/_source-cache/archive/1a/1ad008c909152b6c27668bafbad820da3e6ec3309c7e858ddb785f0a3d6e43ae.tar.gz
==> ffb: Executing phase: 'edit'
==> Error: AttributeError: 'list' object has no attribute 'expand'


/data/test-1/spack/var/spack/repos/builtin/packages/ffb/package.py:154, in edit:
        151        if spec.satisfies('%gcc'):
        152            cxx_fortran_flags.append('-lgfortran')
        153        elif spec.satisfies('%intel'):
  >>    154            cxx_fortran_flags.expand(['-lifcore', '-limf'])
        155        elif spec.satisfies('%fj'):
        156            cxx_fortran_flags.append('--linkfortran')
        157        m = FileFilter(editfile)
```