### PR TITLE
mfem: apply patches from #19452 when mfem@4.1:

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -697,6 +697,9 @@ class Mfem(Package):
         if install_em:
             install_tree('data', join_path(prefix_share, 'data'))
 
+    # The files referenced in this patch method do not exist in stable
+    # versions earlier than 4.1.
+    @when('@4.1:')
     def patch(self):
         # Remove the byte order mark since it messes with some compilers
         filter_file(u'\uFEFF', '', 'fem/gslib.hpp')


### PR DESCRIPTION
As part of pull request #19452, a patch method was added to the mfem
package to delete byte order marks from 3 mfem source files. These
files first appeared in a stable release of mfem as of version
4.1. Consequently, attempts to install mfem 3.4 or mfem 4.0 fail
because no files exist at the path arguments of the filter_file
commands used to execute this operation. Decorating the patch method
so it runs only on mfem versions 4.1 and later resolves the errors
that were thrown due to files not found.

This commit adds that decorator.