### PR TITLE
[range-v3] Set default to range-v3~doc

### DIFF
--- a/var/spack/repos/builtin/packages/range-v3/package.py
+++ b/var/spack/repos/builtin/packages/range-v3/package.py
@@ -48,7 +48,7 @@ class RangeV3(CMakePackage):
             description='Use the specified C++ standard when building.')
 
     variant('doc',
-            default=True,
+            default=False,
             description='Build and install documentation.')
 
     variant('examples',


### PR DESCRIPTION
This is a more sensible default, I think, as it avoids the doxygen dependency.