### PR TITLE
Remove more variables from build environment

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -149,11 +149,16 @@ def clean_environment():
     # can affect how some packages find libraries.  We want to make
     # sure that builds never pull in unintended external dependencies.
     env.unset('LD_LIBRARY_PATH')
-    env.unset('LIBRARY_PATH')
-    env.unset('CPATH')
     env.unset('LD_RUN_PATH')
     env.unset('DYLD_LIBRARY_PATH')
     env.unset('DYLD_FALLBACK_LIBRARY_PATH')
+
+    # These vars affect how the compiler finds libraries and include dirs.
+    env.unset('LIBRARY_PATH')
+    env.unset('CPATH')
+    env.unset('C_INCLUDE_PATH')
+    env.unset('CPLUS_INCLUDE_PATH')
+    env.unset('OBJC_INCLUDE_PATH')
 
     # On Cray "cluster" systems, unset CRAY_LD_LIBRARY_PATH to avoid
     # interference with Spack dependencies.


### PR DESCRIPTION
GCC looks for included files based on several env vars.
Remove `C_INCLUDE_PATH`, `CPLUS_INCLUDE_PATH`, and `OBJC_INCLUDE_PATH` from the build environment to ensure it's clean and prevent accidental clobbering.

I had encountered difficulties in building certain packages (notably `py-pandas`) after having loaded spack modules; I was building with GCC, but some of the loaded modules had been built with Intel and had loaded its internal include path in `C_INCLUDE_PATH`, which clobbered GCC's internal `<float.h>` and suppressed the definition of `DBL_MIN_EXP` and `DBL_MAX_EXP` (Intel's `float.h` only defines these macros when the compiler is actually Intel).