### PR TITLE
Write  junit-report to reports directory to allow installation from read-only spack

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -190,7 +190,10 @@ def default_log_file(spec):
     """
     fmt = 'test-{x.name}-{x.version}-{hash}.xml'
     basename = fmt.format(x=spec, hash=spec.dag_hash())
-    dirname = fs.os.path.join(spack.paths.var_path, 'junit-report')
+    dirname = spack.config.get(
+        'config:misc_cache', spack.paths.var_path)
+    dirname = spack.util.path.canonicalize_path(dirname)
+    dirname = fs.os.path.join(dirname, 'junit-report')
     fs.mkdirp(dirname)
     return fs.os.path.join(dirname, basename)
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -190,10 +190,7 @@ def default_log_file(spec):
     """
     fmt = 'test-{x.name}-{x.version}-{hash}.xml'
     basename = fmt.format(x=spec, hash=spec.dag_hash())
-    dirname = spack.config.get(
-        'config:misc_cache', spack.paths.var_path)
-    dirname = spack.util.path.canonicalize_path(dirname)
-    dirname = fs.os.path.join(dirname, 'junit-report')
+    dirname = fs.os.path.join(spack.paths.reports_path, 'junit')
     fs.mkdirp(dirname)
     return fs.os.path.join(dirname, basename)
 

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -53,6 +53,8 @@ mock_packages_path = os.path.join(repos_path, "builtin.mock")
 user_config_path = os.path.expanduser('~/.spack')
 user_bootstrap_path = os.path.join(user_config_path, 'bootstrap')
 user_bootstrap_store = os.path.join(user_bootstrap_path, 'store')
+reports_path = os.path.join(user_config_path, "reports")
+
 
 opt_path        = os.path.join(prefix, "opt")
 etc_path        = os.path.join(prefix, "etc")


### PR DESCRIPTION
Together with https://github.com/spack/spack/pull/20137 this lets me use spack instances on read-only filesystems. It seemed like `misc_cache` was fine to use here, but I can also introduce a separate config entry.