### PR TITLE
clean up how spack builds clingo

### DIFF
--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -117,6 +117,8 @@ jobs:
           git fetch origin ${{ github.ref }}:test-branch
           git checkout test-branch
           share/spack/qa/run-unit-tests
+          # Test bootstrapping clingo from scratch!
+          share/spack/qa/run-clingo-py2-bootstrap
   clingo:
     # Test for the clingo based solver
     runs-on: ubuntu-latest

--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -117,7 +117,8 @@ jobs:
           git fetch origin ${{ github.ref }}:test-branch
           git checkout test-branch
           share/spack/qa/run-unit-tests
-          # Test bootstrapping clingo from scratch!
+
+          # TODO(#20123): Test bootstrapping clingo from scratch!
           share/spack/qa/run-clingo-py2-bootstrap
   clingo:
     # Test for the clingo based solver

--- a/bin/spack
+++ b/bin/spack
@@ -11,6 +11,10 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer python3, then python, then python2
+# TODO: this hacky interpreter selection process makes it impossible to stop python@3: from bleeding
+# through. This results in confusing errors, e.g. when clingo bootstraps successfully and then spack
+# continues to fail to find the appropriate interpreter. The Pex library API or PEX file
+# distribution format from https://github.com/pantsbuild/pex can fix this!
 for cmd in python3 python python2; do
    command -v > /dev/null $cmd && exec $cmd $0 "$@"
 done

--- a/bin/spack
+++ b/bin/spack
@@ -9,13 +9,14 @@
 # This file is bilingual. The following shell code finds our preferred python.
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
+
+# TODO(#20430): iterating through interpreter binaries via shell script makes it difficult to stop
+# python@3: from bleeding through. This results in confusing errors, e.g. when clingo bootstraps
+# successfully, but spack continues to fail to find the appropriate interpreter. PEX has well-tested
+# code which would do this part for us:
+# https://github.com/pantsbuild/pex/blob/4b899b73262f60e70556e9f24dc27c818a990356/pex/pex_bootstrapper.py#L260-L277
 """:"
 # prefer python3, then python, then python2
-# TODO: this hacky interpreter selection process makes it impossible to stop
-# python@3: from bleeding through. This results in confusing errors, e.g. when
-# clingo bootstraps successfully and then spack continues to fail to find the
-# appropriate interpreter. The Pex library API or PEX file distribution format
-# from https://github.com/pantsbuild/pex can fix this!
 for cmd in python3 python python2; do
    command -v > /dev/null $cmd && exec $cmd $0 "$@"
 done

--- a/bin/spack
+++ b/bin/spack
@@ -10,9 +10,10 @@
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
 
-# TODO(#20430): iterating through interpreter binaries via shell script makes it difficult to stop
-# python@3: from bleeding through. This results in confusing errors, e.g. when clingo bootstraps
-# successfully, but spack continues to fail to find the appropriate interpreter. PEX has well-tested
+# TODO(#20430): iterating through interpreter binaries via shell script makes
+# it difficult to stop python@3: from bleeding through. This results in
+# confusing errors, e.g. when clingo bootstraps successfully, but spack
+# continues to fail to find the appropriate interpreter. PEX has well-tested
 # code which would do this part for us:
 # https://github.com/pantsbuild/pex/blob/4b899b73262f60e70556e9f24dc27c818a990356/pex/pex_bootstrapper.py#L260-L277
 """:"

--- a/bin/spack
+++ b/bin/spack
@@ -11,10 +11,11 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer python3, then python, then python2
-# TODO: this hacky interpreter selection process makes it impossible to stop python@3: from bleeding
-# through. This results in confusing errors, e.g. when clingo bootstraps successfully and then spack
-# continues to fail to find the appropriate interpreter. The Pex library API or PEX file
-# distribution format from https://github.com/pantsbuild/pex can fix this!
+# TODO: this hacky interpreter selection process makes it impossible to stop
+# python@3: from bleeding through. This results in confusing errors, e.g. when
+# clingo bootstraps successfully and then spack continues to fail to find the
+# appropriate interpreter. The Pex library API or PEX file distribution format
+# from https://github.com/pantsbuild/pex can fix this!
 for cmd in python3 python python2; do
    command -v > /dev/null $cmd && exec $cmd $0 "$@"
 done

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -98,7 +98,7 @@ class CMakePackage(PackageBase):
     variant('ipo', default=False,
             description='CMake interprocedural optimization')
     # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
-    conflicts('+ipo', when='^cmake@:3.8',
+    conflicts('+ipo', when='^cmake@:3.8.99',
               msg='+ipo is not supported by CMake < 3.9')
 
     depends_on('cmake', type='build')

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -150,9 +150,9 @@ class PythonPackage(PackageBase):
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + args
         with working_dir(self.build_directory):
-            self.python('-s', setup, *trailing_args, *args, **kwargs)
+            self.python(*args, **kwargs)
 
     def _setup_command_available(self, command):
         """Determines whether or not a setup.py command exists.
@@ -172,8 +172,11 @@ class PythonPackage(PackageBase):
         python = inspect.getmodule(self).python
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
-        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + (
+            command,
+            '--help',
+        )
+        python(*args, **kwargs)
         return python.returncode == 0
 
     # The following phases and their descriptions come from:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -139,11 +139,42 @@ class PythonPackage(PackageBase):
     def python(self, *args, **kwargs):
         inspect.getmodule(self).python(*args, **kwargs)
 
+    def _is_py26(self):
+        return self.spec['python'].version.up_to(2).string == '2.6'
+
+    def trailing_setup_args(self):
+        if self._is_py26():
+            return []
+        return ['--no-user-cfg']
+
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
+        trailing_args = tuple(self.trailing_setup_args())
         with working_dir(self.build_directory):
-            self.python('-s', setup, '--no-user-cfg', *args, **kwargs)
+            self.python('-s', setup, *trailing_args, *args, **kwargs)
+
+    def _setup_command_available(self, command):
+        """Determines whether or not a setup.py command exists.
+
+        Args:
+            command (str): The command to look for
+
+        Returns:
+            bool: True if the command is found, else False
+        """
+        kwargs = {
+            'output': os.devnull,
+            'error':  os.devnull,
+            'fail_on_error': False
+        }
+
+        python = inspect.getmodule(self).python
+        setup = self.setup_file()
+
+        trailing_args = tuple(self.trailing_setup_args())
+        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        return python.returncode == 0
 
     # The following phases and their descriptions come from:
     #   $ python setup.py --help-commands

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -288,7 +288,8 @@ def get_uninstall_list(args, specs, env):
             msgs.append(
                 'use `spack uninstall --dependents` to remove dependents too')
         if spec_envs:
-            msgs.append('use `spack env remove` to remove from environments')
+            msgs.append(
+                'use `spack -e ENV remove` to remove from environment ENV')
         print()
         tty.die('There are still dependents.', *msgs)
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1309,6 +1309,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         checksum = spack.config.get('config:checksum')
         fetch = self.stage.managed_by_spack
         if checksum and fetch and self.version not in self.versions:
+            # TODO: allow user to select to input the checksum by hand!
             tty.warn("There is no checksum on file to fetch %s safely." %
                      self.spec.cformat('{name}{@version}'))
 

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+def setup_libtirpc_build_environment(spec, env):
+    if 'libtirpc' in spec:
+        libtirpc = spec['libtirpc']
+        env.prepend_path('CPATH', libtirpc.prefix.include.tirpc)
+        env.append_flags('LDFLAGS', '-ltirpc')

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 def setup_libtirpc_build_environment(spec, env):
-    """The `libtirpc` package places its headers differently than some of its consumers expect.
+    """The `libtirpc` package places its headers in a weird directory.
 
     The `libtirpc` package provides the virtual dependency `rpc`.
     """

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 def setup_libtirpc_build_environment(spec, env):
+    """The `libtirpc` package places its headers differently than some of its consumers expect.
+
+    The `libtirpc` package provides the virtual dependency `rpc`.
+    """
     if 'libtirpc' in spec:
         libtirpc = spec['libtirpc']
         env.prepend_path('CPATH', libtirpc.prefix.include.tirpc)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -102,6 +102,9 @@ def read_from_url(url, accept_content_type=None):
             else:
                 # User wants SSL verification, and it *can* be provided.
                 context = ssl.create_default_context()  # novm
+        elif __UNABLE_TO_VERIFY_SSL:
+            # User wants SSL verification, but it cannot be provided.
+            warn_no_ssl_cert_checking()
         else:
             # User has explicitly indicated that they do not want SSL
             # verification.

--- a/share/spack/qa/run-clingo-py2-bootstrap
+++ b/share/spack/qa/run-clingo-py2-bootstrap
@@ -67,6 +67,9 @@ spack install "${CLI_INSTALL_ARGS[@]}" 'python@2.7.18~dbm~pyexpat+shared'
 # unless we also enable +binutils.
 spack install "${CLI_INSTALL_ARGS[@]}" -j 6 'gcc@10.2.0+binutils'
 
+# Please use this mildly recent gcc now.
+spack load 'gcc@10.2.0+binutils'
+
 # Load the newer python to avoid having this build fail while looking for the
 # broken centos6 python library in /usr/lib64.
 spack load 'python@2.7.18~dbm~pyexpat+shared'
@@ -76,8 +79,6 @@ spack install "${CLI_INSTALL_ARGS[@]}" "python@$(cat python-full-version.txt)~db
 # Our python is now the same (version) again, but with a reasonable header and shared
 # library arrangement!
 spack load "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
-# Ensure spack has registered the built gcc as a compiler (this should error if not).
-spack compiler find
 # Build clingo.
 spack install "${CLI_INSTALL_ARGS[@]}" 'clingo@spack+python%gcc@10.2.0'
 

--- a/share/spack/qa/run-clingo-py2-bootstrap
+++ b/share/spack/qa/run-clingo-py2-bootstrap
@@ -25,6 +25,8 @@ ORIGINAL_PATH="$PATH"
 . "$(dirname $0)/setup.sh"
 check_dependencies $coverage git
 
+set -euxo pipefail
+
 # Move to root directory of Spack
 # Allows script to be run from anywhere
 cd "$SPACK_ROOT"
@@ -54,27 +56,30 @@ fi
 # accident, we actually need to install *yet another* python whose libpython doesn't clash with the
 # OS python, then work our way back to the python we want.
 
+# TODO: it would be really nice if these could be specified in a config file!
+CLI_INSTALL_ARGS=( --verbose --fail-fast -y -n )
+
 # '~dbm~pyexpat' is necessary to build python 2.7 in specifically this environment. To be clear,
 # in most other environments, using '+dbm+pyexpat' is necessary to build.
-spack install 'python@2.7.18~dbm~pyexpat+shared'
+spack install "${CLI_INSTALL_ARGS[@]}" 'python@2.7.18~dbm~pyexpat+shared'
 
 # Many other libraries will fail to build correctly when we load this new gcc
 # unless we also enable +binutils.
-spack install --verbose --fail-fast -y -n -j 6 'gcc@10.2.0+binutils'
+spack install "${CLI_INSTALL_ARGS[@]}" -j 6 'gcc@10.2.0+binutils'
 
 # Load the newer python to avoid having this build fail while looking for the
 # broken centos6 python library in /usr/lib64.
 spack load 'python@2.7.18~dbm~pyexpat+shared'
 # Install the same python again, this time ready to build modules against (with normal headers and
 # libpython).
-spack install "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
+spack install "${CLI_INSTALL_ARGS[@]}" "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
 # Our python is now the same (version) again, but with a reasonable header and shared
 # library arrangement!
 spack load "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
 # Ensure spack has registered the built gcc as a compiler (this should error if not).
 spack compiler find
 # Build clingo.
-spack install --verbose --fail-fast -y -n 'clingo@spack+python%gcc@10.2.0'
+spack install "${CLI_INSTALL_ARGS[@]}" 'clingo@spack+python%gcc@10.2.0'
 
 # For fun, make it run a solve on the same spec.
 spack solve 'clingo@spack+python'

--- a/share/spack/qa/run-clingo-py2-bootstrap
+++ b/share/spack/qa/run-clingo-py2-bootstrap
@@ -1,0 +1,70 @@
+#!/bin/bash -e
+#
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# Description:
+#     Bootstraps clingo, assuming the current machine has only python 2.6 and
+#     gcc <4.5.
+#
+# Usage:
+#     run-clingo-py2-bootstrap
+#
+
+ORIGINAL_PATH="$PATH"
+
+. "$(dirname $0)/setup.sh"
+check_dependencies $coverage git
+
+# Move to root directory of Spack
+# Allows script to be run from anywhere
+cd "$SPACK_ROOT"
+
+# Extract the major.minor.patch version in order to make spack install the
+# exact same python later.
+python --version 2>&1 \
+  | awk '{print $2}' \
+        > python-full-version.txt
+
+# Verify that we are running python 2.6.
+if ! python --version 2>&1 | grep -F 2.6; then
+  echo >&2 "python was not 2.6! was $(cat python-full-version.txt)"
+  exit 1
+fi
+
+# Game plan: install the same python, with a much less broken installation
+# (headers and libraries where clingo can find them). But first, we'll need to
+# install yet another python, then work our way back.
+
+# (~dbm~pyexpat is necessary to build python 2 in this environment.)
+spack install 'python@2.7.18~dbm~pyexpat+shared'
+
+# Many other libraries will fail to build correctly when we load this new gcc
+# unless we enable +binutils.
+spack install --verbose --fail-fast -y -n -j 6 'gcc@10.2.0+binutils'
+
+# Load the newer python to avoid having this build fail while looking for the
+# broken centos6 python library in /usr/lib64.
+# TODO: sandbox all builds with fakechroot to avoid this double bootstrapping!
+spack load 'python@2.7.18~dbm~pyexpat+shared'
+# Install the same python again, this time ready to build modules against.
+spack install "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
+# Our python is now the same again, but with a reasonable header and shared
+# library arrangement!
+spack load "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
+# Ensure spack has registered the built gcc as a compiler.
+spack compiler find
+# Build clingo.
+spack install --verbose --fail-fast -y -n 'clingo@spack+python%gcc@10.2.0'
+
+# For fun, make it run a solve on the same spec.
+spack solve 'clingo@spack+python'
+if spack spec 'clingo@spack+python'; then
+  echo 1>&2 UNEXPECTED FAILURE: spack spec should have failed
+  exit 1
+else
+  echo 1>&2 EXPECTED FAILURE: spack spec uses the v1 concretizer.
+fi

--- a/share/spack/qa/run-clingo-py2-bootstrap
+++ b/share/spack/qa/run-clingo-py2-bootstrap
@@ -14,6 +14,12 @@
 #     run-clingo-py2-bootstrap
 #
 
+# TODO(#20123): there are multiple alternatives to this script:
+#  - TODO(#20430): package spack as a PEX file to avoid mixing up spack-installed packages
+#                  and others!
+#  - TODO(#20260): sandbox all builds with fakechroot to avoid this double bootstrapping!
+# - Add your own! #20207 makes python configuration a lot smarter, and yet still fails CentOS 6.
+
 ORIGINAL_PATH="$PATH"
 
 . "$(dirname $0)/setup.sh"
@@ -36,26 +42,36 @@ if ! python --version 2>&1 | grep -F 2.6; then
 fi
 
 # Game plan: install the same python, with a much less broken installation
-# (headers and libraries where clingo can find them). But first, we'll need to
-# install yet another python, then work our way back.
+# (headers and libraries where clingo can find them).
 
-# (~dbm~pyexpat is necessary to build python 2 in this environment.)
+# TODO: thanks to a quirk of CentOS 6 (and maybe others), it *does* contain libpython in /usr/lib64.
+# However, all but one of the necessary python-dev header files are missing by default, and
+# even that libpython library is somehow corrupt, causing any attempt to install another python
+# interpreter of the same version to fail at install time.
+
+# Note that installing, and then requiring the user to use an interpreter with a different version,
+# may break a lot of 2.6-only code. So to avoid changing the python version for the user by
+# accident, we actually need to install *yet another* python whose libpython doesn't clash with the
+# OS python, then work our way back to the python we want.
+
+# '~dbm~pyexpat' is necessary to build python 2.7 in specifically this environment. To be clear,
+# in most other environments, using '+dbm+pyexpat' is necessary to build.
 spack install 'python@2.7.18~dbm~pyexpat+shared'
 
 # Many other libraries will fail to build correctly when we load this new gcc
-# unless we enable +binutils.
+# unless we also enable +binutils.
 spack install --verbose --fail-fast -y -n -j 6 'gcc@10.2.0+binutils'
 
 # Load the newer python to avoid having this build fail while looking for the
 # broken centos6 python library in /usr/lib64.
-# TODO: sandbox all builds with fakechroot to avoid this double bootstrapping!
 spack load 'python@2.7.18~dbm~pyexpat+shared'
-# Install the same python again, this time ready to build modules against.
+# Install the same python again, this time ready to build modules against (with normal headers and
+# libpython).
 spack install "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
-# Our python is now the same again, but with a reasonable header and shared
+# Our python is now the same (version) again, but with a reasonable header and shared
 # library arrangement!
 spack load "python@$(cat python-full-version.txt)~dbm~pyexpat+shared"
-# Ensure spack has registered the built gcc as a compiler.
+# Ensure spack has registered the built gcc as a compiler (this should error if not).
 spack compiler find
 # Build clingo.
 spack install --verbose --fail-fast -y -n 'clingo@spack+python%gcc@10.2.0'
@@ -63,8 +79,8 @@ spack install --verbose --fail-fast -y -n 'clingo@spack+python%gcc@10.2.0'
 # For fun, make it run a solve on the same spec.
 spack solve 'clingo@spack+python'
 if spack spec 'clingo@spack+python'; then
-  echo 1>&2 UNEXPECTED FAILURE: spack spec should have failed
+  echo 1>&2 'UNEXPECTED FAILURE: spack spec should have failed!'
   exit 1
 else
-  echo 1>&2 EXPECTED FAILURE: spack spec uses the v1 concretizer.
+  echo 1>&2 'EXPECTED FAILURE: spack spec uses the v1 concretizer!'
 fi

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -23,7 +23,7 @@
 ORIGINAL_PATH="$PATH"
 
 . "$(dirname $0)/setup.sh"
-check_dependencies $coverage git hg svn
+check_dependencies $coverage git hg svn svnadmin
 
 # Move to root directory of Spack
 # Allows script to be run from anywhere
@@ -37,7 +37,13 @@ bin/spack -h
 bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
-spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+if [[ "$(uname)" == 'Darwin' ]]; then
+  # There's a conflict with mpileaks on darwin. So that we can run unit tests
+  # on OSX, let's something else like hdf5!
+  spack -p --lines 20 spec hdf5%gcc ^elfutils@0.170
+else
+  spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
+fi
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -10,6 +10,18 @@
 #     Common setup code to be sourced by Spack's test scripts.
 #
 
+# Our spack/centos6 image doesn't have a `realpath`, and we can't put it in
+# another source file, because it's used to set `$SPACK_ROOT`.
+function command_exists {
+  hash "$@" 2>/dev/null
+}
+
+if ! command_exists realpath; then
+  function realpath {
+    readlink -f "$@"
+  }
+fi
+
 QA_DIR="$(dirname ${BASH_SOURCE[0]})"
 export SPACK_ROOT=$(realpath "$QA_DIR/../../..")
 
@@ -79,7 +91,7 @@ check_dependencies() {
                 kcov)
                     spack_package=kcov
                     ;;
-                svn)
+                svn|svnadmin)
                     spack_package=subversion
                     ;;
                 *)

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -94,6 +94,7 @@ check_dependencies() {
             if [[ $spack_package ]]; then
                 echo "To install with Spack, run:"
                 echo "    $ spack install $spack_package"
+                echo "    $ spack load $spack_package"
             fi
 
             if [[ $pip_package ]]; then

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-import re
-
 from spack import *
 
 
@@ -78,8 +75,10 @@ class Clingo(CMakePackage):
                 '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
                 '-DPYTHON_EXECUTABLE={0}'.format(python.command.path),
                 '-DPYTHON_LIBRARY={0}'.format(python.libs.libraries[0]),
-                '-DPYTHON_INCLUDE_DIR={0}'.format(python.headers.directories[0]),
-                '-DCLINGO_PYTHON_VERSION:LIST={0};EXACT'.format(python.version.up_to(3)),
+                '-DPYTHON_INCLUDE_DIR={0}'.format(
+                    python.headers.directories[0]),
+                '-DCLINGO_PYTHON_VERSION:LIST={0};EXACT'.format(
+                    python.version.up_to(3)),
             ]
         else:
             python_args = []

--- a/var/spack/repos/builtin/packages/clingo/revert-python-abi-usage.patch
+++ b/var/spack/repos/builtin/packages/clingo/revert-python-abi-usage.patch
@@ -1,0 +1,264 @@
+diff --git a/libclingo/clingo.h b/libclingo/clingo.h
+index 0091ed8..938067f 100644
+--- a/libclingo/clingo.h
++++ b/libclingo/clingo.h
+@@ -3661,23 +3661,6 @@ typedef struct clingo_options clingo_options_t;
+ //! @return whether the call was successful
+ typedef bool (*clingo_main_function_t) (clingo_control_t *control, char const *const * files, size_t size, void *data);
+ 
+-//! Callback to print a model in default format.
+-//!
+-//! @param[in] data user data for the callback
+-//!
+-//! @return whether the call was successful
+-typedef bool (*clingo_default_model_printer_t) (void *data);
+-
+-//! Callback to customize model printing.
+-//!
+-//! @param[in] model the model
+-//! @param[in] printer the default model printer
+-//! @param[in] printer_data user data for the printer
+-//! @param[in] data user data for the callback
+-//!
+-//! @return whether the call was successful
+-typedef bool (*clingo_model_printer_t) (clingo_model_t const *model, clingo_default_model_printer_t printer, void *printer_data, void *data);
+-
+ //! This struct contains a set of functions to customize the clingo application.
+ typedef struct clingo_application {
+     char const *(*program_name) (void *data);                        //!< callback to obtain program name
+@@ -3685,7 +3668,6 @@ typedef struct clingo_application {
+     unsigned (*message_limit) (void *data);                          //!< callback to obtain message limit
+     clingo_main_function_t main;                                     //!< callback to override clingo's main function
+     clingo_logger_t logger;                                          //!< callback to override default logger
+-    clingo_model_printer_t printer;                                  //!< callback to override default model printing
+     bool (*register_options)(clingo_options_t *options, void *data); //!< callback to register options
+     bool (*validate_options)(void *data);                            //!< callback validate options
+ } clingo_application_t;
+diff --git a/libclingo/clingo.hh b/libclingo/clingo.hh
+index 3ab9dbb..32bf362 100644
+--- a/libclingo/clingo.hh
++++ b/libclingo/clingo.hh
+@@ -2297,7 +2297,6 @@ struct Application {
+     virtual char const *version() const noexcept;
+     virtual void main(Control &ctl, StringSpan files) = 0;
+     virtual void log(WarningCode code, char const *message) noexcept;
+-    virtual void print_model(Model const &model, std::function<void()> default_printer) noexcept;
+     virtual void register_options(ClingoOptions &app);
+     virtual void validate_options();
+     virtual ~Application() = default;
+@@ -4547,9 +4546,7 @@ inline char const *Application::program_name() const noexcept {
+ inline char const *Application::version() const noexcept {
+     return CLINGO_VERSION;
+ }
+-inline void Application::print_model(Model const &, std::function<void()> default_printer) noexcept {
+-    default_printer();
+-}
++
+ inline void Application::log(WarningCode, char const *message) noexcept {
+     fprintf(stderr, "%s\n", message);
+     fflush(stderr);
+@@ -4595,16 +4592,6 @@ inline static void g_logger(clingo_warning_t code, char const *message, void *ad
+     return data.app.log(static_cast<WarningCode>(code), message);
+ }
+ 
+-inline static bool g_model_printer(clingo_model_t const *model, clingo_default_model_printer_t printer, void *printer_data, void *data) {
+-    ApplicationData &app_data = *static_cast<ApplicationData*>(data);
+-    CLINGO_TRY {
+-        app_data.app.print_model(Model(const_cast<clingo_model_t*>(model)), [&]() {
+-            Detail::handle_error(printer(printer_data));
+-        });
+-    }
+-    CLINGO_CATCH;
+-}
+-
+ inline static bool g_register_options(clingo_options_t *options, void *adata) {
+     ApplicationData &data = *static_cast<ApplicationData*>(adata);
+     CLINGO_TRY {
+@@ -5415,7 +5402,6 @@ inline int clingo_main(Application &application, StringSpan arguments) {
+         Detail::g_message_limit,
+         Detail::g_main,
+         Detail::g_logger,
+-        Detail::g_model_printer,
+         Detail::g_register_options,
+         Detail::g_validate_options
+     };
+diff --git a/libclingo/clingo/clingocontrol.hh b/libclingo/clingo/clingocontrol.hh
+index 10126e2..df94eaa 100644
+--- a/libclingo/clingo/clingocontrol.hh
++++ b/libclingo/clingo/clingocontrol.hh
+@@ -190,11 +190,6 @@ public:
+         static_cast<void>(message);
+         std::terminate();
+     }
+-    virtual bool has_printer() const { return false; }
+-    virtual void print_model(Model *model, std::function<void()> printer) {
+-        static_cast<void>(model);
+-        printer();
+-    }
+     virtual void register_options(ClingoApp &app) { static_cast<void>(app); }
+     virtual void validate_options() { }
+     virtual ~IClingoApp() = default;
+diff --git a/libclingo/src/clingo_app.cc b/libclingo/src/clingo_app.cc
+index 3e4d14c..9e9a629 100644
+--- a/libclingo/src/clingo_app.cc
++++ b/libclingo/src/clingo_app.cc
+@@ -161,80 +161,9 @@ Clasp::ProblemType ClingoApp::getProblemType() {
+     return Clasp::ClaspFacade::detectProblemType(getStream());
+ }
+ 
+-// TODO: the code below is annoying. There is too much copy and paste. The
+-// easiest way would be if the textoutput would already provide something to
+-// customize the output.
+-namespace {
+-
+-class CustomTextOutput : public Clasp::Cli::TextOutput {
+-public:
+-    CustomTextOutput(std::unique_ptr<ClingoControl> &ctl, IClingoApp &app, Clasp::uint32 verbosity, Format f, const char* catAtom = 0, char ifs = ' ')
+-    : TextOutput(verbosity, f, catAtom, ifs), ctl_(ctl), app_(app) { }
+-
+-protected:
+-    void printModel(const Clasp::OutputTable& out, const Clasp::Model& m, PrintLevel x) override {
+-        if (ctl_) {
+-            if (x == modelQ()) {
+-                comment(1, "%s: %" PRIu64"\n", !m.up ? "Answer" : "Update", m.num);
+-                ClingoModel cm(*ctl_, &m);
+-                std::lock_guard<decltype(ctl_->propLock_)> lock(ctl_->propLock_);
+-                app_.print_model(&cm, [&]() { printValues(out, m); });
+-            }
+-            if (x == optQ()) {
+-                printMeta(out, m);
+-            }
+-            fflush(stdout);
+-        }
+-        else { Clasp::Cli::TextOutput::printModel(out, m, x); }
+-    }
+-private:
+-    std::unique_ptr<ClingoControl> &ctl_;
+-    IClingoApp &app_;
+-};
+-
+-} // namespace
+-
+ ClingoApp::ClaspOutput* ClingoApp::createOutput(ProblemType f) {
+     if (mode_ == mode_gringo) return 0;
+-    using namespace Clasp;
+-    using namespace Clasp::Cli;
+-    SingleOwnerPtr<ClaspOutput> out;
+-    if (claspAppOpts_.outf == ClaspAppOptions::out_none) {
+-        return 0;
+-    }
+-    if (claspAppOpts_.outf != ClaspAppOptions::out_json || claspAppOpts_.onlyPre) {
+-        TextOutput::Format outFormat = TextOutput::format_asp;
+-        if      (f == Problem_t::Sat){ outFormat = TextOutput::format_sat09; }
+-        else if (f == Problem_t::Pb) { outFormat = TextOutput::format_pb09;  }
+-        else if (f == Problem_t::Asp && claspAppOpts_.outf == ClaspAppOptions::out_comp) {
+-            outFormat = TextOutput::format_aspcomp;
+-        }
+-        if (app_->has_printer()) {
+-            out.reset(new CustomTextOutput(grd, *app_, verbose(), outFormat, claspAppOpts_.outAtom.c_str(), claspAppOpts_.ifs));
+-        }
+-        else {
+-            out.reset(new TextOutput(verbose(), outFormat, claspAppOpts_.outAtom.c_str(), claspAppOpts_.ifs));
+-        }
+-        if (claspConfig_.parse.isEnabled(ParserOptions::parse_maxsat) && f == Problem_t::Sat) {
+-            static_cast<TextOutput*>(out.get())->result[TextOutput::res_sat] = "UNKNOWN";
+-        }
+-    }
+-    else {
+-        out.reset(new JsonOutput(verbose()));
+-    }
+-    if (claspAppOpts_.quiet[0] != static_cast<uint8>(UCHAR_MAX)) {
+-        out->setModelQuiet((ClaspOutput::PrintLevel)std::min(uint8(ClaspOutput::print_no), claspAppOpts_.quiet[0]));
+-    }
+-    if (claspAppOpts_.quiet[1] != static_cast<uint8>(UCHAR_MAX)) {
+-        out->setOptQuiet((ClaspOutput::PrintLevel)std::min(uint8(ClaspOutput::print_no), claspAppOpts_.quiet[1]));
+-    }
+-    if (claspAppOpts_.quiet[2] != static_cast<uint8>(UCHAR_MAX)) {
+-        out->setCallQuiet((ClaspOutput::PrintLevel)std::min(uint8(ClaspOutput::print_no), claspAppOpts_.quiet[2]));
+-    }
+-    if (claspAppOpts_.hideAux && clasp_.get()) {
+-        clasp_->ctx.output.setFilter('_');
+-    }
+-    return out.release();
++    return BaseType::createOutput(f);
+ }
+ 
+ void ClingoApp::printHelp(const Potassco::ProgramOptions::OptionContext& root) {
+@@ -294,4 +223,3 @@ void ClingoApp::run(Clasp::ClaspFacade& clasp) {
+ // }}}
+ 
+ } // namespace Gringo
+-
+diff --git a/libclingo/src/control.cc b/libclingo/src/control.cc
+index 935b144..47643d1 100644
+--- a/libclingo/src/control.cc
++++ b/libclingo/src/control.cc
+@@ -1675,16 +1675,6 @@ public:
+         assert(has_log());
+         app_.logger(static_cast<clingo_warning_t>(code), message, data_);
+     }
+-    bool has_printer() const override { return app_.printer; }
+-    void print_model(Model *model, std::function<void()> printer) override {
+-        handleCError(app_.printer(model, [](void *data) {
+-            GRINGO_CLINGO_TRY {
+-                (*static_cast<std::function<void()>*>(data))();
+-            }
+-            GRINGO_CLINGO_CATCH;
+-        }, &printer, data_));
+-    }
+-
+     void register_options(ClingoApp &app) override {
+         if (app_.register_options) {
+             handleCError(app_.register_options(static_cast<clingo_options_t*>(&app), data_));
+diff --git a/libpyclingo/pyclingo.cc b/libpyclingo/pyclingo.cc
+index ec4a33c..e916870 100644
+--- a/libpyclingo/pyclingo.cc
++++ b/libpyclingo/pyclingo.cc
+@@ -9568,39 +9568,6 @@ bool g_app_register_options(clingo_options_t *options, void *data) {
+     }
+ }
+ 
+-PyObject* call_printer(PyObject *data) {
+-    PY_TRY {
+-        auto d = static_cast<std::pair<clingo_default_model_printer_t, void*>*>(PyCapsule_GetPointer(data, nullptr));
+-        if (!d) { return nullptr; }
+-        handle_c_error(d->first(d->second));
+-        Py_RETURN_NONE;
+-    }
+-    PY_CATCH(nullptr);
+-}
+-
+-PyMethodDef call_printer_def = {
+-    "clingo.default_model_printer",
+-    reinterpret_cast<PyCFunction>(call_printer),
+-    METH_NOARGS,
+-    nullptr
+-};
+-
+-bool g_app_model_printer(clingo_model_t const *model, clingo_default_model_printer_t printer, void *printer_data, void *data) {
+-    PyBlock block;
+-    try {
+-        AppData &pyApp = *static_cast<AppData*>(data);
+-        std::pair<clingo_default_model_printer_t, void*> pd{printer, printer_data};
+-        Object ptr = PyCapsule_New(&pd, nullptr, nullptr);
+-        Object pyP = PyCFunction_New(&call_printer_def, ptr.toPy());
+-        pyApp.first.call("print_model", Model::construct(model), pyP);
+-        return true;
+-    }
+-    catch (...) {
+-        handle_cxx_error("<application>", "error during model printing");
+-        return false;
+-    }
+-}
+-
+ bool g_app_validate_options(void *data) {
+     try {
+         AppData &pyApp = *static_cast<AppData*>(data);
+@@ -9645,7 +9612,6 @@ Object clingoMain(Reference args, Reference kwds) {
+         pyApp.hasAttr("message_limit") ? g_app_message_limit : nullptr,
+         g_app_main,
+         pyApp.hasAttr("logger") ? g_app_logger : nullptr,
+-        pyApp.hasAttr("print_model") ? g_app_model_printer : nullptr,
+         pyApp.hasAttr("register_options") ? g_app_register_options : nullptr,
+         pyApp.hasAttr("validate_options") ? g_app_validate_options : nullptr,
+     };

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -239,7 +239,7 @@ class Cmake(Package):
         args.append('-DCMake_TEST_INSTALL=OFF')
 
         # When building our own private copy of curl then we need to properly
-        # enable / disable oepnssl
+        # enable / disable openssl
         if '+ownlibs' in spec:
             args.append('-DCMAKE_USE_OPENSSL=%s' % str('+openssl' in spec))
 

--- a/var/spack/repos/builtin/packages/ganglia/package.py
+++ b/var/spack/repos/builtin/packages/ganglia/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Ganglia(AutotoolsPackage):
     """Ganglia is a scalable distributed monitoring system for high-performance
@@ -31,5 +33,4 @@ class Ganglia(AutotoolsPackage):
     depends_on('expat')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -34,7 +34,8 @@ class Krb5(AutotoolsPackage):
 
     conflicts('%gcc@:4.99',
               when='@1.18:',
-              msg='The CLI option -Wno-maybe-uninitialized is not recognized by a older gcc.')
+              msg='The CLI option -Wno-maybe-uninitialized '
+                  'is not recognized by older gcc versions.')
 
     configure_directory = 'src'
     build_directory = 'src'

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -32,6 +32,10 @@ class Krb5(AutotoolsPackage):
     )
     patch('mit-krb5-1.17-static-libs.patch', level=0)
 
+    conflicts('%gcc@:4.99',
+              when='@1.18:',
+              msg='The CLI option -Wno-maybe-uninitialized is not recognized by a older gcc.')
+
     configure_directory = 'src'
     build_directory = 'src'
 

--- a/var/spack/repos/builtin/packages/libnsl/package.py
+++ b/var/spack/repos/builtin/packages/libnsl/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack import *
 
 
@@ -22,7 +24,8 @@ class Libnsl(AutotoolsPackage):
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('gettext')
     depends_on('rpcsvc-proto')
-    depends_on('libtirpc')
+    # TODO: allow specifying != for negation in 'when=' specs!
+    depends_on('libtirpc', when=(sys.platform != 'darwin'))
 
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')

--- a/var/spack/repos/builtin/packages/lmbench/package.py
+++ b/var/spack/repos/builtin/packages/lmbench/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Lmbench(MakefilePackage):
     """lmbench is a suite of simple, portable, ANSI/C microbenchmarks for
@@ -22,8 +24,7 @@ class Lmbench(MakefilePackage):
     patch('fix_results_path_for_aarch64.patch', sha256='2af57abc9058c56b6dd0697bb01a98902230bef92b117017e318faba148eef60', when='target=aarch64:')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)
 
     def build(self, spec, prefix):
         make('build')

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -19,7 +19,7 @@ class PyPackaging(PythonPackage):
     version('16.8', sha256='5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'))
     depends_on('py-attrs', when='@19.1', type=('build', 'run'))
     depends_on('py-pyparsing@2.0.2:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -36,8 +36,8 @@ class PySetuptools(PythonPackage):
     version('11.3.1', sha256='bd25f17de4ecf00116a9f7368b614a54ca1612d7945d2eafe5d97bc08c138bc5')
 
     depends_on('python@3.5:', type=('build', 'run'), when='@45.0.0:')
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
+    depends_on('python@2.6:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
 
     def url_for_version(self, version):
         url = 'https://pypi.io/packages/source/s/setuptools/setuptools-{0}'

--- a/var/spack/repos/builtin/packages/python/no-dbm.patch
+++ b/var/spack/repos/builtin/packages/python/no-dbm.patch
@@ -1,0 +1,57 @@
+--- a/setup.py	2020-11-29 13:43:26.736062972 -0800
++++ b/setup.py	2020-11-29 13:43:40.166165660 -0800
+@@ -1144,53 +1144,11 @@
+                 missing.append('bsddb185')
+         else:
+             missing.append('bsddb185')
+ 
+         # The standard Unix dbm module:
+-        if platform not in ['cygwin']:
+-            if find_file("ndbm.h", inc_dirs, []) is not None:
+-                # Some systems have -lndbm, others don't
+-                if self.compiler.find_library_file(lib_dirs, 'ndbm'):
+-                    ndbm_libs = ['ndbm']
+-                else:
+-                    ndbm_libs = []
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       define_macros=[('HAVE_NDBM_H',None)],
+-                                       libraries = ndbm_libs ) )
+-            elif self.compiler.find_library_file(lib_dirs, 'gdbm'):
+-                gdbm_libs = ['gdbm']
+-                if self.compiler.find_library_file(lib_dirs, 'gdbm_compat'):
+-                    gdbm_libs.append('gdbm_compat')
+-                if find_file("gdbm/ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                elif find_file("gdbm-ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_DASH_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                else:
+-                    missing.append('dbm')
+-            elif db_incs is not None:
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       library_dirs=dblib_dir,
+-                                       runtime_library_dirs=dblib_dir,
+-                                       include_dirs=db_incs,
+-                                       define_macros=[('HAVE_BERKDB_H',None),
+-                                                      ('DB_DBM_HSEARCH',None)],
+-                                       libraries=dblibs))
+-            else:
+-                missing.append('dbm')
+-
+-        # Anthony Baxter's gdbm module.  GNU dbm(3) will require -lgdbm:
+-        if (self.compiler.find_library_file(lib_dirs, 'gdbm')):
+-            exts.append( Extension('gdbm', ['gdbmmodule.c'],
+-                                   libraries = ['gdbm'] ) )
+-        else:
+-            missing.append('gdbm')
++        # NB: Removed!
+ 
+         # Unix-only modules
+         if platform not in ['mac', 'win32']:
+             # Steen Lumholt's termios module
+             exts.append( Extension('termios', ['termios.c']) )

--- a/var/spack/repos/builtin/packages/python/no-ssl.patch
+++ b/var/spack/repos/builtin/packages/python/no-ssl.patch
@@ -1,0 +1,32 @@
+--- a/setup.py	2020-11-29 13:15:49.676636440 -0800
++++ b/setup.py	2020-11-29 13:43:26.736062972 -0800
+@@ -761,13 +761,12 @@
+             except IOError, msg:
+                 print "IOError while reading opensshv.h:", msg
+                 pass
+ 
+ 
+-        if (ssl_incs is not None and
+-            ssl_libs is not None and
+-            openssl_ver >= 0x00907000):
++        # raise Exception('change this to True!')
++        if False:
+             # The _hashlib module wraps optimized implementations
+             # of hash functions from the OpenSSL library.
+             exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                                    include_dirs = ssl_incs,
+                                    library_dirs = ssl_libs,
+@@ -781,10 +780,13 @@
+             # Message-Digest Algorithm, described in RFC 1321.  The
+             # necessary files md5.c and md5.h are included here.
+             exts.append( Extension('_md5',
+                             sources = ['md5module.c', 'md5.c'],
+                             depends = ['md5.h']) )
++            # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
++            exts.append( Extension('_sha256', ['sha256module.c']) )
++            exts.append( Extension('_sha512', ['sha512module.c']) )
+             missing.append('_hashlib')
+ 
+         if (openssl_ver < 0x00908000):
+             # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
+             exts.append( Extension('_sha256', ['sha256module.c']) )

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -842,7 +842,43 @@ class Python(AutotoolsPackage):
 
     @property
     def libs(self):
-        return find_libraries('libpython*', root=self.get_config_var('LIBPL'), shared=False)
+        # Spack installs libraries into lib, except on openSUSE where it
+        # installs them into lib64. If the user is using an externally
+        # installed package, it may be in either lib or lib64, so we need
+        # to ask Python where its LIBDIR is.
+        libdir = self.get_config_var('LIBDIR')
+
+        # In Ubuntu 16.04.6 and python 2.7.12 from the system, lib could be
+        # in LBPL
+        # https://mail.python.org/pipermail/python-dev/2013-April/125733.html
+        libpl = self.get_config_var('LIBPL')
+
+        # The system Python installation on macOS and Homebrew installations
+        # install libraries into a Frameworks directory
+        frameworkprefix = self.get_config_var('PYTHONFRAMEWORKPREFIX')
+
+        if '+shared' in self.spec:
+            ldlibrary = self.get_config_var('LDLIBRARY')
+
+            if os.path.exists(os.path.join(libdir, ldlibrary)):
+                return LibraryList(os.path.join(libdir, ldlibrary))
+            elif os.path.exists(os.path.join(libpl, ldlibrary)):
+                return LibraryList(os.path.join(libpl, ldlibrary))
+            elif os.path.exists(os.path.join(frameworkprefix, ldlibrary)):
+                return LibraryList(os.path.join(frameworkprefix, ldlibrary))
+            else:
+                msg = 'Unable to locate {0} libraries in {1}'
+                raise RuntimeError(msg.format(ldlibrary, libdir))
+        else:
+            library = self.get_config_var('LIBRARY')
+
+            if os.path.exists(os.path.join(libdir, library)):
+                return LibraryList(os.path.join(libdir, library))
+            elif os.path.exists(os.path.join(frameworkprefix, library)):
+                return LibraryList(os.path.join(frameworkprefix, library))
+            else:
+                msg = 'Unable to locate {0} libraries in {1}'
+                raise RuntimeError(msg.format(library, libdir))
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -195,7 +195,7 @@ class Python(AutotoolsPackage):
     # TODO: There's currently no way to ignore the fact that a single module
     # failed, even if the variant corresponding to that module is deselected.
     # These patches comment out sections of setup.py, specifically for the
-    # purpose of python 2.6 compat.
+    # purpose of python 2.6 compat. They will break if any different python version is used.
     patch('no-ssl.patch', when='@:2.6.99~ssl')
     patch('no-dbm.patch', when='@:2.6.99~dbm')
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -190,6 +190,12 @@ class Python(AutotoolsPackage):
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
+    # TODO: There's currently no way to ignore the fact that a single module failed, even if the
+    # variant corresponding to that module is deselected. These patches comment out sections of
+    # setup.py, specifically for the purpose of python 2.6 compat.
+    patch('no-ssl.patch', when='~ssl')
+    patch('no-dbm.patch', when='~dbm')
+
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
@@ -393,22 +399,30 @@ class Python(AutotoolsPackage):
         # as it scans for the library and headers to build
         link_deps = spec.dependencies('link')
 
+        cppflags = []
+        ldflags = []
         if link_deps:
             # Header files are often included assuming they reside in a
             # subdirectory of prefix.include, e.g. #include <openssl/ssl.h>,
             # which is why we don't use HeaderList here. The header files of
             # libffi reside in prefix.lib but the configure script of Python
             # finds them using pkg-config.
-            cppflags = ' '.join('-I' + spec[dep.name].prefix.include
-                                for dep in link_deps)
+            cppflags.extend('-I' + spec[dep.name].prefix.include for dep in link_deps)
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them
             # using spec.__getitem__.
-            ldflags = ' '.join(spec[dep.name].libs.search_flags
-                               for dep in link_deps)
+            ldflags.extend(spec[dep.name].libs.ld_flags for dep in link_deps)
 
-            config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
+        if 'libtirpc' in spec:
+            cppflags.extend(
+                '-I' + os.path.join(inc, 'tirpc')
+                for inc in spec['libtirpc'].headers.directories)
+
+        config_args.extend([
+            'CPPFLAGS=' + ' '.join(cppflags),
+            'LDFLAGS=' + ' '.join(ldflags),
+        ])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
         if spec.satisfies('@:3.6'):
@@ -968,8 +982,14 @@ class Python(AutotoolsPackage):
         setup_py('install', '--prefix={0}'.format(prefix))"""
 
         module.python = self.command
-        module.setup_py = Executable(
-            self.command.path + ' setup.py --no-user-cfg')
+
+        if self.version.up_to(2).string == '2.6':
+            trailing_args = []
+        else:
+            trailing_args = ['--no-user-cfg']
+        args = ['setup.py', *tuple(trailing_args)]
+        full_cmdline = self.command.path + ' {0}'.format(' '.join(args))
+        module.setup_py = Executable(full_cmdline)
 
         distutil_vars = self._load_distutil_vars()
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -195,7 +195,8 @@ class Python(AutotoolsPackage):
     # TODO: There's currently no way to ignore the fact that a single module
     # failed, even if the variant corresponding to that module is deselected.
     # These patches comment out sections of setup.py, specifically for the
-    # purpose of python 2.6 compat. They will break if any different python version is used.
+    # purpose of python 2.6 compat. They will break if any different python
+    # version is used.
     patch('no-ssl.patch', when='@:2.6.99~ssl')
     patch('no-dbm.patch', when='@:2.6.99~dbm')
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -192,9 +192,10 @@ class Python(AutotoolsPackage):
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
-    # TODO: There's currently no way to ignore the fact that a single module failed, even if the
-    # variant corresponding to that module is deselected. These patches comment out sections of
-    # setup.py, specifically for the purpose of python 2.6 compat.
+    # TODO: There's currently no way to ignore the fact that a single module
+    # failed, even if the variant corresponding to that module is deselected.
+    # These patches comment out sections of setup.py, specifically for the
+    # purpose of python 2.6 compat.
     patch('no-ssl.patch', when='@:2.6.99~ssl')
     patch('no-dbm.patch', when='@:2.6.99~dbm')
 


### PR DESCRIPTION
### Problem

Fixes #20123, subsumes #20218.

**Note:** this PR does **not** attempt to address the problem of actually making spack build clingo on demand in such environments. We will rely on #20207 for that.

### Solution
- Require `clingo+python` to depend on `python+shared` (this was already necessary, but was working because the `python` package defaults to `+shared`).
  - #20116 fixes this.
- Pull in the changes from #20139 and #20218.
- Add support for building clingo on python 2.6.
- **TODO** Add a test for installation in the centos6 test shard.

### Result
1. A bootstrap mechanism is created for `clingo` to bootstrap itself in python 2.6-only environments.
2. Spack is able to avoid sneakily modifying the user's running python version (so no python code breaks because spack installed its own interpreter).
3. This is tested in CI!