### PR TITLE
CMake should be a build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -26,7 +26,7 @@ class Bcl2fastq2(Package):
               msg='malloc.h/etc requirements break build on macs')
 
     depends_on('boost@1.54.0')
-    depends_on('cmake@2.8.9:')
+    depends_on('cmake@2.8.9:', type='build')
     depends_on('libxml2@2.7.8')
     depends_on('libxslt@1.1.26~crypto')
     depends_on('libgcrypt')

--- a/var/spack/repos/builtin/packages/clamr/package.py
+++ b/var/spack/repos/builtin/packages/clamr/package.py
@@ -27,7 +27,7 @@ class Clamr(CMakePackage):
         values=('single', 'mixed', 'full'),
         description='single, mixed, or full double precision values')
 
-    depends_on('cmake@3.1:')
+    depends_on('cmake@3.1:', type='build')
     depends_on('mpi')
     depends_on('mpe', when='graphics=mpe')
 

--- a/var/spack/repos/builtin/packages/ghost/package.py
+++ b/var/spack/repos/builtin/packages/ghost/package.py
@@ -32,7 +32,7 @@ class Ghost(CMakePackage, CudaPackage):
     # ###################### Dependencies ##########################
 
     # Everything should be compiled position independent (-fpic)
-    depends_on('cmake@3.5:')
+    depends_on('cmake@3.5:', type='build')
     depends_on('hwloc')
     depends_on('blas')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/glog/package.py
+++ b/var/spack/repos/builtin/packages/glog/package.py
@@ -18,7 +18,7 @@ class Glog(Package):
     version('0.3.3', sha256='544e178644bd9b454768c2c91716c3b8365cc5d47adfbdbaecd8cf3fa17adfcb')
 
     depends_on('gflags')
-    depends_on('cmake', when="@0.3.5:")
+    depends_on('cmake', when="@0.3.5:", type='build')
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/repos/builtin/packages/heaptrack/package.py
+++ b/var/spack/repos/builtin/packages/heaptrack/package.py
@@ -16,7 +16,7 @@ class Heaptrack(CMakePackage):
     version('1.1.0', sha256='bd247ac67d1ecf023ec7e2a2888764bfc03e2f8b24876928ca6aa0cdb3a07309')
 
     depends_on('boost@1.41:')
-    depends_on('cmake@2.8.9:')
+    depends_on('cmake@2.8.9:', type='build')
     depends_on('elfutils')
     depends_on('libunwind')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/hyphy/package.py
+++ b/var/spack/repos/builtin/packages/hyphy/package.py
@@ -14,7 +14,7 @@ class Hyphy(CMakePackage):
 
     version('2.3.14', sha256='9e6c817cb649986e3fe944bcaf88be3533e7e62968b9a486c719e951e5ed1cf6')
 
-    depends_on('cmake@3.0:')
+    depends_on('cmake@3.0:', type='build')
     depends_on('curl')
 
     conflicts('%gcc@:4.8')

--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -21,7 +21,7 @@ class Nut(CMakePackage):
     version('master', branch='master')
     version('0.1.1', sha256='9f1dca4a9d7003b170fd57d6720228ff25471616cf884e033652e90c49c089bb')
 
-    depends_on('cmake@3.0:')
+    depends_on('cmake@3.0:', type='build')
     depends_on('random123')
 
     conflicts('%intel', when='@serial')

--- a/var/spack/repos/builtin/packages/py-awkward1/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward1/package.py
@@ -25,4 +25,4 @@ class PyAwkward1(PythonPackage):
     depends_on('py-numpy@1.13.1:')
     depends_on('py-pybind11')
     depends_on('rapidjson')
-    depends_on('cmake')
+    depends_on('cmake', type='build')

--- a/var/spack/repos/builtin/packages/shiny-server/package.py
+++ b/var/spack/repos/builtin/packages/shiny-server/package.py
@@ -26,7 +26,7 @@ class ShinyServer(CMakePackage):
     version('1.5.3.838', sha256='6fd1b12cd1cbe5c64cacbec4accefe955353f9c675e5feff809c0e911a382141')
 
     depends_on('python@:2.8')  # docs say: "Really.  3.x will not work"
-    depends_on('cmake@2.8.10:')
+    depends_on('cmake@2.8.10:', type='build')
     depends_on('git')
     depends_on('r+X')
     depends_on('openssl')

--- a/var/spack/repos/builtin/packages/strelka/package.py
+++ b/var/spack/repos/builtin/packages/strelka/package.py
@@ -31,5 +31,5 @@ class Strelka(CMakePackage):
     depends_on('python@2.4:2.7')
     depends_on('zlib')
     depends_on('bzip2')
-    depends_on('cmake@2.8.5:')
+    depends_on('cmake@2.8.5:', type='build')
     depends_on('boost@1.56.0:')

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -64,8 +64,8 @@ class VtkM(CMakePackage, CudaPackage):
     variant('amdgpu_target', default='none', multi=True, values=amdgpu_targets)
     conflicts("+hip", when="amdgpu_target=none")
 
-    depends_on("cmake@3.12:", type="build")         # CMake >= 3.12
-    depends_on("cmake@3.18:", when="+hip")          # CMake >= 3.18
+    depends_on("cmake@3.12:", type="build")               # CMake >= 3.12
+    depends_on("cmake@3.18:", when="+hip", type="build")  # CMake >= 3.18
 
     depends_on('cuda@10.2.0:', when='+cuda')
     depends_on("tbb", when="+tbb")


### PR DESCRIPTION
When I changed my version of CMake, I had to rebuild all of these packages if they appear in my DAG. I don't think any of these packages link to CMake.

Maintainer ping: @kmorel  @robertmaynard  @vicentebolea  @vvolkl