### PR TITLE
freeglut: prevent linking to system deps

### DIFF
--- a/var/spack/repos/builtin/packages/freeglut/package.py
+++ b/var/spack/repos/builtin/packages/freeglut/package.py
@@ -12,13 +12,29 @@ class Freeglut(CMakePackage, SourceforgePackage):
 
     homepage = "http://freeglut.sourceforge.net/"
     sourceforge_mirror_path = "freeglut/freeglut-3.2.1.tar.gz"
+
     version('3.2.1', sha256='d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68')
     version('3.0.0', sha256='2a43be8515b01ea82bcfa17d29ae0d40bd128342f0930cd1f375f1ff999f76a2')
-    patch('common-gcc10.patch', when="@3.2.1: %gcc@10.0:")
+
+    depends_on('pkgconfig', type='build')
     depends_on('gl')
     depends_on('glu')
     depends_on('libx11')
     depends_on('libxrandr')
     depends_on('libxi')
+    depends_on('libxxf86vm')
     depends_on('xrandr')
     depends_on('inputproto')
+
+    patch('common-gcc10.patch', when="@3.2.1: %gcc@10.0:")
+
+    def cmake_args(self):
+        return [
+            '-DFREEGLUT_BUILD_DEMOS=OFF',
+            '-DOPENGL_gl_LIBRARY=' + self.spec['gl'].libs[0],
+            '-DOPENGL_glu_LIBRARY=' + self.spec['glu'].libs[0],
+            '-DX11_X11_LIB=' + self.spec['libx11'].libs[0],
+            '-DX11_Xrandr_LIB=' + self.spec['libxrandr'].libs[0],
+            '-DX11_Xi_LIB=' + self.spec['libxi'].libs[0],
+            '-DX11_Xxf86vm_LIB=' + self.spec['libxxf86vm'].libs[0],
+        ]


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 12.0.0 and Ubuntu 18.04 with GCC 7.5.0.

- [x] Add missing dependencies
- [x] Explicitly tell CMake where to find dependencies