### PR TITLE
Add libs properties to a few packages

### DIFF
--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -25,3 +25,8 @@ class Libxi(AutotoolsPackage, XorgPackage):
     depends_on('xproto@7.0.13:', type='build')
     depends_on('xextproto@7.0.3:', type='build')
     depends_on('inputproto@2.2.99.1:', type='build')
+
+    @property
+    def libs(self):
+        return find_libraries(
+            'libXi', self.prefix, shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -23,3 +23,8 @@ class Libxrandr(AutotoolsPackage, XorgPackage):
     depends_on('renderproto', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+
+    @property
+    def libs(self):
+        return find_libraries(
+            'libXrandr', self.prefix, shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -22,3 +22,8 @@ class Libxxf86vm(AutotoolsPackage, XorgPackage):
     depends_on('xf86vidmodeproto@2.2.99.1:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+
+    @property
+    def libs(self):
+        return find_libraries(
+            'libXxf86vm', self.prefix, shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -91,8 +91,5 @@ class Opengl(Package):
 
     @property
     def libs(self):
-        for dir in ['lib64', 'lib']:
-            libs = find_libraries('libGL', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
-            if libs:
-                return libs
+        return find_libraries(
+            'libGL', self.prefix, shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/openglu/package.py
+++ b/var/spack/repos/builtin/packages/openglu/package.py
@@ -61,8 +61,5 @@ class Openglu(Package):
 
     @property
     def libs(self):
-        for dir in ['lib64', 'lib']:
-            libs = find_libraries('libGLU', join_path(self.prefix, dir),
-                                  shared=True, recursive=False)
-            if libs:
-                return libs
+        return find_libraries(
+            'libGLU', self.prefix, shared=True, recursive=True)


### PR DESCRIPTION
The following packages weren't detected because the default glob is case-sensitive:

* libxi
* libxrandr
* libxxf86vm

The following packages weren't detected on Ubuntu because the libraries are found in `/usr/lib/x86_64-linux-gnu`:

* opengl
* openglu

With this PR, the `spec['foo'].libs` property works as expected for all of these packages.