### PR TITLE
libQGLViewer: add new package

### DIFF
--- a/lib/spack/docs/build_systems/qmakepackage.rst
+++ b/lib/spack/docs/build_systems/qmakepackage.rst
@@ -108,6 +108,19 @@ override the ``qmake_args`` method like so:
 
 This method can be used to pass flags as well as variables.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``*.pro`` file in a sub-directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the ``*.pro`` file used to tell QMake how to build the package is
+found in a sub-directory, you can tell Spack to run all phases in this
+sub-directory by adding the following to the package:
+
+.. code-block:: python
+
+   build_directory = 'src'
+
+
 ^^^^^^^^^^^^^^^^^^^^^^
 External documentation
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -6,6 +6,7 @@
 
 import inspect
 
+from llnl.util.filesystem import working_dir
 from spack.directives import depends_on
 from spack.package import PackageBase, run_after
 
@@ -37,6 +38,11 @@ class QMakePackage(PackageBase):
 
     depends_on('qt', type='build')
 
+    @property
+    def build_directory(self):
+        """The directory containing the ``*.pro`` file."""
+        return self.stage.source_path
+
     def qmake_args(self):
         """Produces a list containing all the arguments that must be passed to
         qmake
@@ -45,22 +51,30 @@ class QMakePackage(PackageBase):
 
     def qmake(self, spec, prefix):
         """Run ``qmake`` to configure the project and generate a Makefile."""
-        inspect.getmodule(self).qmake(*self.qmake_args())
+
+        with working_dir(self.build_directory):
+            inspect.getmodule(self).qmake(*self.qmake_args())
 
     def build(self, spec, prefix):
         """Make the build targets"""
-        inspect.getmodule(self).make()
+
+        with working_dir(self.build_directory):
+            inspect.getmodule(self).make()
 
     def install(self, spec, prefix):
         """Make the install targets"""
-        inspect.getmodule(self).make('install')
+
+        with working_dir(self.build_directory):
+            inspect.getmodule(self).make('install')
 
     # Tests
 
     def check(self):
         """Searches the Makefile for a ``check:`` target and runs it if found.
         """
-        self._if_make_target_execute('check')
+
+        with working_dir(self.build_directory):
+            self._if_make_target_execute('check')
 
     run_after('build')(PackageBase._run_default_build_time_test_callbacks)
 

--- a/var/spack/repos/builtin/packages/libqglviewer/package.py
+++ b/var/spack/repos/builtin/packages/libqglviewer/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Libqglviewer(QMakePackage):
+    """libQGLViewer is a C++ library based on Qt that eases the creation of
+    OpenGL 3D viewers."""
+
+    homepage = "http://libqglviewer.com/"
+    url      = "http://libqglviewer.com/src/libQGLViewer-2.7.2.tar.gz"
+    git      = "https://github.com/GillesDebunne/libQGLViewer.git"
+
+    version('2.7.2', sha256='e2d2799dec5cff74548e951556a1fa06a11d9bcde2ce6593f9c27a17543b7c08')
+
+    # http://libqglviewer.com/installUnix.html
+
+    depends_on('qt+opengl')
+    depends_on('freeglut', when='^qt@:3.0')
+
+    build_directory = 'QGLViewer'
+
+    def qmake_args(self):
+        return ['PREFIX=' + self.prefix]


### PR DESCRIPTION
Successfully builds on macOS 10.15.6 with Apple Clang 12.0.0 and on Ubuntu 18.04 with GCC 7.5.0.

I had to add a bit of functionality to the `QMakePackage` base class to enable building in a sub-directory.

@sethrj I see that you are listed as a maintainer for `qt`. You may be interested in this PR. Let me know if you want to maintain the `QMakePackage` base class as well. So far, the following packages use it:
```console
$ grep QMakePackage */package.py
cbtf-argonavis-gui/package.py:class CbtfArgonavisGui(QMakePackage):
gatepet2stir/package.py:class Gatepet2stir(QMakePackage):
libqglviewer/package.py:class Libqglviewer(QMakePackage):
qcachegrind/package.py:class Qcachegrind(QMakePackage):
qscintilla/package.py:class Qscintilla(QMakePackage):
qt-creator/package.py:class QtCreator(QMakePackage):
qtgraph/package.py:class Qtgraph(QMakePackage):
qwt/package.py:class Qwt(QMakePackage):
qwtpolar/package.py:class Qwtpolar(QMakePackage):
texstudio/package.py:class Texstudio(QMakePackage):
```