### PR TITLE
py-pyscf: update version of dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -29,7 +29,7 @@ class PyPyscf(PythonPackage):
     depends_on('libcint+coulomb_erf+f12')
     depends_on('libxc')
     depends_on('xcfun')
-    depends_on('xcfun@2.0.0a2', when='@:1.7.4')
+    depends_on('xcfun@2.0.0', when='@:1.7.4')
 
     def setup_build_environment(self, env):
         # Tell PSCF where supporting libraries are located."


### PR DESCRIPTION
fixes #20134

xcfun v2.0.0a2 doesn't exist anymore, since v2.0.0 was released. Update py-pyscf dependency accordingly.