### PR TITLE
pugixml: add 1.11 and update variants

### DIFF
--- a/var/spack/repos/builtin/packages/pugixml/package.py
+++ b/var/spack/repos/builtin/packages/pugixml/package.py
@@ -13,16 +13,18 @@ class Pugixml(CMakePackage):
     homepage = "http://pugixml.org/"
     url      = "https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz"
 
-    version('1.8.1', sha256='929c4657c207260f8cc28e5b788b7499dffdba60d83d59f55ea33d873d729cd4')
+    version('1.11', sha256='26913d3e63b9c07431401cf826df17ed832a20d19333d043991e611d23beaa2c')
     version('1.10', sha256='55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a')
+    version('1.8.1', sha256='929c4657c207260f8cc28e5b788b7499dffdba60d83d59f55ea33d873d729cd4')
 
-    variant('shared', default=True, description='Enable shared libraries')
+    variant('pic', default=True, description='Build position-independent code')
+    variant('shared', default=True, description='Build shared libraries')
+
+    conflicts('+shared', when='~pic')
 
     def cmake_args(self):
-        args = [
-            '-DBUILD_SHARED_AND_STATIC_LIBS:BOOL=OFF',
-            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in self.spec else 'OFF')]
-
-        return args
+        return [
+            self.define('BUILD_SHARED_AND_STATIC_LIBS', False),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
+        ]


### PR DESCRIPTION
- Add version 1.11
- Add pic variant for when shared is disabled (modeled after existing packages, though I think there have been numerous discussions about how best to do the static/static+pic/shared/static+shared variants)