### PR TITLE
Bugfix: Install font-util

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -72,8 +72,8 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
 
-        conflicts('fonts=font-bh-tff', when='platform=cray')
-        conflicts('fonts=font-bh-tff', when='arch=linux-rhel7-broadwell')
+        conflicts('fonts=font-bh-ttf', when='platform=cray')
+        conflicts('fonts=font-bh-ttf', when='arch=linux-rhel7-broadwell')
 
         if f != 'font-bh-tff':
             default_fonts.append(f)

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -73,7 +73,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
                  sha256=f_r[2], destination=f, when='fonts=' + f)
 
         conflicts('fonts=font-bh-tff', when='platform=cray')
-        conflicts('font=font-bh-tff', when='arch=linux-rhel7-broadwell')
+        conflicts('fonts=font-bh-tff', when='arch=linux-rhel7-broadwell')
 
         if f != 'font-bh-tff':
             default_fonts.append(f)

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -72,7 +72,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
 
-        conflicts('font=font-bh-tff', when='platform=cray')
+        conflicts('fonts=font-bh-tff', when='platform=cray')
         conflicts('font=font-bh-tff', when='arch=linux-rhel7-broadwell')
 
         if f != 'font-bh-tff':

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -25,7 +25,6 @@ class FontUtil(AutotoolsPackage, XorgPackage):
     depends_on('mkfontscale', type='build')
     depends_on('mkfontdir', type='build')
 
-
     font_baseurl = 'https://www.x.org/archive/individual/font/'
     default_fonts = []
     fonts = []

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -70,8 +70,9 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         f = f_r[0]
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
-        fonts.append(f)
+        #fonts.append(f)
 
+    fonts = [f_r[0] for f_r in fonts_resource]
     conflicts('font=font-bh-tff', when='platform=cray')
     default_fonts = [f for f in fonts if f[0] != 'font-bh-tff']
 

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -73,7 +73,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         fonts.append(f)
 
     conflicts('font=font-bh-tff', when='platform=cray')
-    default_fonts = [f for f in fonts if f[0] != 'font-bh-tff']
+    default_fonts = [f for f in fonts if f != 'font-bh-tff']
 
     variant('fonts',
             description='Installs fonts',

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -70,10 +70,12 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         f = f_r[0]
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
-        fonts.append(f)
+        conflicts('font=font-bh-tff', when='platform=cray')
 
-    conflicts('font=font-bh-tff', when='platform=cray')
-    default_fonts = [f for f in fonts if f != 'font-bh-tff']
+        if f != 'font-bh-tff':
+            default_fonts.append(f)
+
+        fonts.append(f)
 
     variant('fonts',
             description='Installs fonts',

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -71,7 +71,9 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         f = f_r[0]
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
+
         conflicts('font=font-bh-tff', when='platform=cray')
+        conflicts('font=font-bh-tff', when='arch=linux-rhel7-broadwell')
 
         if f != 'font-bh-tff':
             default_fonts.append(f)

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -70,9 +70,8 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         f = f_r[0]
         resource(name=f, url=font_baseurl + f + '-' + f_r[1] + '.tar.gz',
                  sha256=f_r[2], destination=f, when='fonts=' + f)
-        #fonts.append(f)
+        fonts.append(f)
 
-    fonts = [f_r[0] for f_r in fonts_resource]
     conflicts('font=font-bh-tff', when='platform=cray')
     default_fonts = [f for f in fonts if f[0] != 'font-bh-tff']
 

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -39,7 +39,6 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         ['font-arabic-misc', '1.0.3', '3022b6b124f4cc6aade961f8d1306f67ff42e3b7922fb2244847f287344aefea'],
         ['font-bh-100dpi', '1.0.3', '817703372f080d6508cf109011b17f3572ff31047559fe82d93b487ca4e4e2d9'],
         ['font-bh-75dpi', '1.0.3', '720b6a513894bfc09a163951ec3dd8311201e08ee40e8891547b6c129ffb5fce'],
-        #['font-bh-ttf', '1.0.3', 'c583b4b968ffae6ea30d5b74041afeac83126682c490a9624b770d60d0e63d59'],
         ['font-bh-type1', '1.0.3', 'd5602f1d749ccd31d3bc1bb6f0c5d77400de0e5e3ac5abebd2a867aa2a4081a4'],
         ['font-bh-lucidatypewriter-100dpi', '1.0.3', '5e05a642182ec6a77bd7cacb913d3c86b364429329a5f223b69792d418f90ae9'],
         ['font-bh-lucidatypewriter-75dpi', '1.0.3', '38301bbdb6374494f30c0b44acc7052ed8fc2289e917e648ca566fc591f0a9e0'],

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -39,7 +39,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         ['font-arabic-misc', '1.0.3', '3022b6b124f4cc6aade961f8d1306f67ff42e3b7922fb2244847f287344aefea'],
         ['font-bh-100dpi', '1.0.3', '817703372f080d6508cf109011b17f3572ff31047559fe82d93b487ca4e4e2d9'],
         ['font-bh-75dpi', '1.0.3', '720b6a513894bfc09a163951ec3dd8311201e08ee40e8891547b6c129ffb5fce'],
-        ['font-bh-ttf', '1.0.3', 'c583b4b968ffae6ea30d5b74041afeac83126682c490a9624b770d60d0e63d59'],
+        #['font-bh-ttf', '1.0.3', 'c583b4b968ffae6ea30d5b74041afeac83126682c490a9624b770d60d0e63d59'],
         ['font-bh-type1', '1.0.3', 'd5602f1d749ccd31d3bc1bb6f0c5d77400de0e5e3ac5abebd2a867aa2a4081a4'],
         ['font-bh-lucidatypewriter-100dpi', '1.0.3', '5e05a642182ec6a77bd7cacb913d3c86b364429329a5f223b69792d418f90ae9'],
         ['font-bh-lucidatypewriter-75dpi', '1.0.3', '38301bbdb6374494f30c0b44acc7052ed8fc2289e917e648ca566fc591f0a9e0'],

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -25,7 +25,9 @@ class FontUtil(AutotoolsPackage, XorgPackage):
     depends_on('mkfontscale', type='build')
     depends_on('mkfontdir', type='build')
 
+
     font_baseurl = 'https://www.x.org/archive/individual/font/'
+    default_fonts = []
     fonts = []
     # name, version, sha256
     fonts_resource = [

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -39,6 +39,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         ['font-arabic-misc', '1.0.3', '3022b6b124f4cc6aade961f8d1306f67ff42e3b7922fb2244847f287344aefea'],
         ['font-bh-100dpi', '1.0.3', '817703372f080d6508cf109011b17f3572ff31047559fe82d93b487ca4e4e2d9'],
         ['font-bh-75dpi', '1.0.3', '720b6a513894bfc09a163951ec3dd8311201e08ee40e8891547b6c129ffb5fce'],
+        ['font-bh-ttf', '1.0.3', 'c583b4b968ffae6ea30d5b74041afeac83126682c490a9624b770d60d0e63d59'],
         ['font-bh-type1', '1.0.3', 'd5602f1d749ccd31d3bc1bb6f0c5d77400de0e5e3ac5abebd2a867aa2a4081a4'],
         ['font-bh-lucidatypewriter-100dpi', '1.0.3', '5e05a642182ec6a77bd7cacb913d3c86b364429329a5f223b69792d418f90ae9'],
         ['font-bh-lucidatypewriter-75dpi', '1.0.3', '38301bbdb6374494f30c0b44acc7052ed8fc2289e917e648ca566fc591f0a9e0'],
@@ -71,10 +72,13 @@ class FontUtil(AutotoolsPackage, XorgPackage):
                  sha256=f_r[2], destination=f, when='fonts=' + f)
         fonts.append(f)
 
+    conflicts('font=font-bh-tff', when='platform=cray')
+    default_fonts = [f for f in fonts if f[0] != 'font-bh-tff']
+
     variant('fonts',
             description='Installs fonts',
             values=fonts,
-            default=','.join(fonts),
+            default=','.join(default_fonts),
             multi=True)
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
Resolves [Issue 12547](https://github.com/spack/spack/issues/12547)

`spack install font-util arch=cray-sles15-x86_64 ` leads to a Permission Denied Error on cray machines
