### PR TITLE
Avoid re-concretizing if the spec is already concrete

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -566,7 +566,8 @@ def check_binaries(args):
         sys.exit(0)
 
     for spec in specs:
-        spec.concretize()
+        if not spec.concrete:
+            spec.concretize()
 
     # Next see if there are any configured binary mirrors
     configured_mirrors = spack.config.get('mirrors', scope=args.scope)
@@ -642,7 +643,8 @@ def get_concrete_spec(args):
     if spec_str:
         try:
             spec = find_matching_specs(spec_str)[0]
-            spec.concretize()
+            if not spec.concrete:
+                spec.concretize()
         except SpecError as spec_error:
             tty.error('Unable to concrectize spec {0}'.format(args.spec))
             tty.debug(spec_error)


### PR DESCRIPTION
This fixes a problem we could see where asking spack to check a buildcache using a hash resulted in re-concretization and subsequent checking of a buildcache with a *different* hash.

E.g.:

```
spack buildcache check --rebuild-on-error --mirror-url https://some.location/mirror -s "/yrnbhxf"
...
==> [2020-11-30-23:29:12.399675] Error: Unable to determine whether spla@1.2.1%gcc@9.3.0+cuda~ipo+openmp~rocm~static build_type=Release arch=linux-ubuntu20.04-x86_64/2b2hcaq needs rebuilding, caught exception attempting to read from https://some.location/mirror/build_cache/linux-ubuntu20.04-x86_64-gcc-9.3.0-spla-1.2.1-2b2hcaqr2khzjvsu27ek767o3fnjdbtm.spec.yaml.
```

Notice how spack actually looked for `/2b2hcaq` rather than `/yrnbhxf`, which was what we asked it to look for.
