### PR TITLE
concretizer: restrict maximizing variant values to MV variants

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -508,7 +508,9 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 % need to maximize their number below to ensure they're all set
 #maximize {
     1@13,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight), root(Package)
+    : variant_not_default(Package, Variant, Value, Weight),
+    not variant_single_value(Package, Variant),
+    root(Package)
 }.
 #minimize{
     Weight@13,Provider
@@ -531,7 +533,9 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 % need to maximize their number below to ensure they're all set
 #maximize {
     1@8,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight), not root(Package)
+    : variant_not_default(Package, Variant, Value, Weight),
+    not variant_single_value(Package, Variant),
+    not root(Package)
 }.
 
 % Try to maximize the number of compiler matches in the DAG,

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -975,3 +975,7 @@ class TestConcretize(object):
         spec.concretize()
         assert ((uuidpatch, localpatch) ==
                 spec['libelf'].variants['patches'].value)
+
+    def test_dont_select_version_that_brings_more_variants_in(self):
+        s = Spec('dep-with-variants-if-develop-root').concretized()
+        assert s['dep-with-variants-if-develop'].satisfies('@1.0')

--- a/var/spack/repos/builtin.mock/packages/dep-with-variants-if-develop-root/package.py
+++ b/var/spack/repos/builtin.mock/packages/dep-with-variants-if-develop-root/package.py
@@ -1,0 +1,11 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class DepWithVariantsIfDevelopRoot(Package):
+    """Package that adds a dependency with many variants only at @develop"""
+    homepage = "https://dev.null"
+
+    version('1.0')
+
+    depends_on('dep-with-variants-if-develop')

--- a/var/spack/repos/builtin.mock/packages/dep-with-variants-if-develop/package.py
+++ b/var/spack/repos/builtin.mock/packages/dep-with-variants-if-develop/package.py
@@ -1,0 +1,12 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class DepWithVariantsIfDevelop(Package):
+    """Package that adds a dependency with many variants only at @develop"""
+    homepage = "https://dev.null"
+
+    version('develop')
+    version('1.0')
+
+    depends_on('dep-with-variants', when='@develop')


### PR DESCRIPTION
Fixes the issue reported in #20176