### PR TITLE
spec: return early from concretization if a spec is already concrete

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2442,6 +2442,9 @@ class Spec(object):
             raise spack.error.SpecError(
                 "Spec has no name; cannot concretize an anonymous spec")
 
+        if self._concrete:
+            return
+
         result = spack.solver.asp.solve([self], tests=tests)
         if not result.satisfiable:
             result.print_cores()


### PR DESCRIPTION
closes #20192
fixes #20191

This mimics what is done for the original concretizer.