### PR TITLE
mumps: Fix dependency issues in shared licenses

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/mumps.src-makefile.patch
+++ b/var/spack/repos/builtin/packages/mumps/mumps.src-makefile.patch
@@ -1,0 +1,29 @@
+# This patchfile modifies src/Makefile to allow for extra libraries to be
+# added to lib[cdsz]mumps.so (e.g,. libmumps_common.so and possible libmpiseq.so)
+#
+# It also adds flags to produce PIC code
+
+diff -Naur spack-src/src/Makefile spack-src.patched/src/Makefile
+--- spack-src/src/Makefile	2019-04-18 05:55:07.000000000 -0400
++++ spack-src.patched/src/Makefile	2020-10-31 15:19:49.927297524 -0400
+@@ -182,7 +182,7 @@
+ 	$(RANLIB) $@
+ 
+ $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
+-	$(AR)$@ $?
++	$(AR)$@ $? $(EXTRA_LIBS4MUMPS)
+ 	$(RANLIB) $@
+ 
+ # Dependencies between modules:
+@@ -378,9 +378,9 @@
+ 
+ .SUFFIXES: .c .F .o
+ .F.o:
+-	$(FC) $(OPTF) $(INCS) $(IORDERINGSF) $(ORDERINGSF) -I. -I../include -c $*.F $(OUTF)$*.o
++	$(FC) $(OPTF) $(FC_PIC_FLAG) $(INCS) $(IORDERINGSF) $(ORDERINGSF) -I. -I../include -c $*.F $(OUTF)$*.o
+ .c.o:
+-	$(CC) $(OPTC) $(INCS) -I../include $(CDEFS) $(IORDERINGSC) $(ORDERINGSC) -c $*.c $(OUTC)$*.o
++	$(CC) $(OPTC) $(CC_PIC_FLAG) $(INCS) -I../include $(CDEFS) $(IORDERINGSC) $(ORDERINGSC) -c $*.c $(OUTC)$*.o
+ 
+ $(ARITH)mumps_c.o:	mumps_c.c
+ 	$(CC) $(OPTC) $(INCS) $(CDEFS) -DMUMPS_ARITH=MUMPS_ARITH_$(ARITH) \

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -53,6 +53,9 @@ class Mumps(Package):
 
     patch('examples.patch', when='@5.1.1%clang^spectrum-mpi')
     patch('gfortran8.patch', when='@5.1.2')
+    # The following patches src/Makefile to fix some dependency
+    # issues in lib[cdsz]mumps.so
+    patch('mumps.src-makefile.patch', when='+shared')
 
     def write_makefile_inc(self):
         if ('+parmetis' in self.spec or '+ptscotch' in self.spec) and (
@@ -74,6 +77,8 @@ class Mumps(Package):
                          lapack_blas.ld_flags if not shared else '']
 
         orderings = ['-Dpord']
+        # All of the lib[cdsz]mumps.* libs depend on mumps_common
+        extra_libs4mumps = ['-L$(topdir)/lib', '-lmumps_common']
 
         if '+ptscotch' in self.spec or '+scotch' in self.spec:
             makefile_conf.extend([
@@ -130,6 +135,10 @@ class Mumps(Package):
         # TODO: test this part, it needs a full blas, scalapack and
         # partitionning environment with 64bit integers
 
+        # The mumps.src-makefile.patch wants us to set these PIC variables
+        makefile_conf.append('FC_PIC_FLAG={0}'.format(fpic))
+        makefile_conf.append('CC_PIC_FLAG={0}'.format(cpic))
+
         opt_level = '3' if using_xl else ''
 
         if '+int64' in self.spec:
@@ -177,6 +186,8 @@ class Mumps(Package):
                  "FC = {0}".format(spack_fc),
                  "FL = {0}".format(spack_fc),
                  "MUMPS_TYPE = seq"])
+            # For sequential MUMPS, we need to link to a fake MPI lib
+            extra_libs4mumps += ['-L$(topdir)/libseq', '-lmpiseq']
 
         # TODO: change the value to the correct one according to the
         # compiler possible values are -DAdd_, -DAdd__ and/or -DUPPER
@@ -246,6 +257,10 @@ class Mumps(Package):
                 'RANLIB = ranlib'
             ])
 
+        # The mumps.src-makefile.patch wants EXTRA_LIBS4MUMPS defined
+        makefile_conf.extend([
+            'EXTRA_LIBS4MUMPS = {0}'.format(' '.join(extra_libs4mumps))
+        ])
         makefile_inc_template = join_path(
             os.path.dirname(self.module.__file__), 'Makefile.inc')
         with open(makefile_inc_template, "r") as fh:


### PR DESCRIPTION
See issue #19644
This script makes lib[cdsz]mumps.so explicitly depend on
libmumps_common.so (and libmpiseq.so if ~mpi)