### PR TITLE
concretizer: call inject_patches_variants() on the roots of the specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1826,8 +1826,8 @@ class SpecBuilder(object):
         # fix flags after all specs are constructed
         self.reorder_flags()
 
-        for s in self._specs.values():
-            spack.spec.Spec.inject_patches_variant(s)
+        for root in set([spec.root for spec in self._specs.values()]):
+            spack.spec.Spec.inject_patches_variant(root)
 
         # Add external paths to specs with just external modules
         for s in self._specs.values():

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -23,7 +23,8 @@ def test_immediate_dependents(mock_packages):
         'libdwarf',
         'patch-a-dependency',
         'patch-several-dependencies',
-        'quantum-espresso'
+        'quantum-espresso',
+        'conditionally-patch-dependency'
     ])
 
 
@@ -38,7 +39,8 @@ def test_transitive_dependents(mock_packages):
         'multivalue-variant',
         'singlevalue-variant-dependent',
         'patch-a-dependency', 'patch-several-dependencies',
-        'quantum-espresso'
+        'quantum-espresso',
+        'conditionally-patch-dependency'
     ])
 
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -967,3 +967,11 @@ class TestConcretize(object):
 
         s = Spec('a %gcc@foo os=redhat6').concretized()
         assert '%gcc@foo' in s
+
+    def test_all_patches_applied(self):
+        uuidpatch = 'a60a42b73e03f207433c5579de207c6ed61d58e4d12dd3b5142eb525728d89ea'
+        localpatch = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        spec = spack.spec.Spec('conditionally-patch-dependency+jasper')
+        spec.concretize()
+        assert ((uuidpatch, localpatch) ==
+                spec['libelf'].variants['patches'].value)

--- a/var/spack/repos/builtin.mock/packages/conditionally-patch-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditionally-patch-dependency/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class ConditionallyPatchDependency(Package):
+    """Package that conditionally requries a patched version
+    of a dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-a-dependency-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+    variant('jasper', default=False)
+    depends_on('libelf@0.8.10', patches=[patch('uuid.patch')], when='+jasper')

--- a/var/spack/repos/builtin.mock/packages/conditionally-patch-dependency/uuid.patch
+++ b/var/spack/repos/builtin.mock/packages/conditionally-patch-dependency/uuid.patch
@@ -1,0 +1,1 @@
+patchadep


### PR DESCRIPTION
As was done in the old concretizer. Fixes an issue where patches in conditional
dependencies did not show up in spec (gdal+jasper)

Before:
```console
[aweits@localhost spack]$ spack solve gdal+jasper | grep jasper
gdal@3.2.0%gcc@9.3.0~armadillo~cfitsio~crypto~cryptopp~curl~expat~geos~gif~grib~hdf4~hdf5+jasper~java+jpeg~kea~libiconv~libkml+liblzma+libtool+libz~mdb~netcdf~odbc~opencl~openjpeg~pcre~perl~pg~png~poppler+proj~python~qhull~sosi~sqlite3~xerces~xml2~zstd arch=linux-centos8-skylake_avx512
    ^jasper@1.900.1%gcc@9.3.0+jpeg~opengl+shared build_type=Release patches=db104400a2e72f610b8fa4d061a32282254819c70b024ef1cf99fef64aca67e3 arch=linux-centos8-skylake_avx512

```
After:
```console
[aweits@localhost spack]$ spack solve gdal+jasper | grep jasper
gdal@3.2.0%gcc@9.3.0~armadillo~cfitsio~crypto~cryptopp~curl~expat~geos~gif~grib~hdf4~hdf5+jasper~java+jpeg~kea~libiconv~libkml+liblzma+libtool+libz~mdb~netcdf~odbc~opencl~openjpeg~pcre~perl~pg~png~poppler+proj~python~qhull~sosi~sqlite3~xerces~xml2~zstd arch=linux-centos8-skylake_avx512
    ^jasper@1.900.1%gcc@9.3.0+jpeg~opengl+shared build_type=Release patches=95a654159688eaffdf035a467914c5953068ad0fd62d18229de5779a17ec380b,db104400a2e72f610b8fa4d061a32282254819c70b024ef1cf99fef64aca67e3 arch=linux-centos8-skylake_avx512
```