### PR TITLE
Fix: Bowtie2 installs into /usr/local/bin

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -66,4 +66,7 @@ class Bowtie2(MakefilePackage):
 
     @property
     def install_targets(self):
-        return ['prefix={0}'.format(self.prefix), 'install']
+        if self.spec.satisfies('@:2.3.9'):
+            return ['prefix={0}'.format(self.prefix), 'install']
+        else:
+            return ['PREFIX={0}'.format(self.prefix), 'install']

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -66,4 +66,4 @@ class Bowtie2(MakefilePackage):
 
     @property
     def install_targets(self):
-        return ['PREFIX={0}'.format(self.prefix), 'install']
+        return ['prefix={0}'.format(self.prefix), 'install']


### PR DESCRIPTION
The bowtie2 Makefile uses `prefix`, not `PREFIX`.  As is the package was trying to install into `/usr/local/bin`.  On my AWS instance I'm not allowed to do that, in a Docker container that succeeded but the Spack sanity check failed with:

```
==> Error: InstallError: Install failed for bowtie2.  Nothing was installed!
```

Tested on CentOS 7.