### PR TITLE
change to Autotools

### DIFF
--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Openexr(Package):
+class Openexr(AutotoolsPackage):
     """OpenEXR Graphics Tools (high dynamic-range image file format)"""
 
     homepage = "http://www.openexr.com/"
@@ -39,9 +39,9 @@ class Openexr(Package):
     depends_on('ilmbase')
     depends_on('zlib', type=('build', 'link'))
 
-    def install(self, spec, prefix):
-        configure_options = ['--prefix={0}'.format(prefix)]
-        if '+debug' not in spec:
-            configure_options.append('--disable-debug')
-        configure(*configure_options)
-        make('install')
+    def configure_args(self):
+        configure_options = []
+
+        configure_options += self.enable_or_disable('debug')
+
+        return configure_options


### PR DESCRIPTION
`spack install openexr%fj` failed.  The problem was similar to #19217 and #19303.
In fact, `openexr` uses Autotools.
So I changed base class to `AutotoolsPackage`.