### PR TITLE
Add fj Fortran library options

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
@@ -1,7 +1,7 @@
 diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
 --- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -35,9 +35,7 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +    def runtime_library_dir_option(self, dir):
 +        return f'-Wl,-rpath={dir}'
 +    def get_libraries(self):
-+        opt = []
-+        opt.extend(['fj90f', 'fj90i'])
-+        return opt
++        return ['fj90f', 'fj90i', 'fjsrcinfo']
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
@@ -1,7 +1,7 @@
 diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
 --- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,42 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -34,6 +34,10 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
 +        return f'-Wl,-rpath={dir}'
++    def get_libraries(self):
++        opt = []
++        opt.extend(['fj90f', 'fj90i'])
++        return opt
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 17:55:57.608802456 +0900
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -35,9 +35,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    def runtime_library_dir_option(self, dir):
 +        return f'-Wl,-rpath={dir}'
 +    def get_libraries(self):
-+        opt = []
-+        opt.extend(['fj90f', 'fj90i'])
-+        return opt
++        return ['fj90f', 'fj90i', 'fjsrcinfo']
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 17:55:57.608802456 +0900
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,42 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -34,6 +34,10 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
 +        return f'-Wl,-rpath={dir}'
++    def get_libraries(self):
++        opt = []
++        opt.extend(['fj90f', 'fj90i'])
++        return opt
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:30:06.698641953 +0900
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,42 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -34,6 +34,10 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
 +        return '-Wl,-rpath=%s' %dir
++    def get_libraries(self):
++        opt = []
++        opt.extend(['fj90f', 'fj90i'])
++        return opt
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:30:06.698641953 +0900
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -35,9 +35,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    def runtime_library_dir_option(self, dir):
 +        return '-Wl,-rpath=%s' %dir
 +    def get_libraries(self):
-+        opt = []
-+        opt.extend(['fj90f', 'fj90i'])
-+        return opt
++        return ['fj90f', 'fj90i', 'fjsrcinfo']
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:42:47.672297372 +0900
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,42 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -34,6 +34,10 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +        return ['-g']
 +    def runtime_library_dir_option(self, dir):
 +        return '-Wl,-rpath=%s' %dir
++    def get_libraries(self):
++        opt = []
++        opt.extend(['fj90f', 'fj90i'])
++        return opt
 +
 +if __name__ == '__main__':
 +    from distutils import log

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
@@ -1,7 +1,7 @@
 diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
 --- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
 +++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:42:47.672297372 +0900
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
 +compilers = ['FJFCompiler']
@@ -35,9 +35,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    def runtime_library_dir_option(self, dir):
 +        return '-Wl,-rpath=%s' %dir
 +    def get_libraries(self):
-+        opt = []
-+        opt.extend(['fj90f', 'fj90i'])
-+        return opt
++        return ['fj90f', 'fj90i', 'fjsrcinfo']
 +
 +if __name__ == '__main__':
 +    from distutils import log


### PR DESCRIPTION
Add `get_libraries` function to build adequately in `%fj`.
These patches used for `%fj` only.