### PR TITLE
add patches to bootstrap z3 with python 2.6

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -123,9 +123,9 @@ class PythonPackage(PackageBase):
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + args
         with working_dir(self.build_directory):
-            self.python('-s', setup, *trailing_args, *args, **kwargs)
+            self.python(*args, **kwargs)
 
     def _setup_command_available(self, command):
         """Determines whether or not a setup.py command exists.
@@ -145,8 +145,11 @@ class PythonPackage(PackageBase):
         python = inspect.getmodule(self).python
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
-        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + (
+            command,
+            '--help',
+        )
+        python(*args, **kwargs)
         return python.returncode == 0
 
     # The following phases and their descriptions come from:

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+def setup_libtirpc_build_environment(spec, env):
+    if 'libtirpc' in spec:
+        libtirpc = spec['libtirpc']
+        env.prepend_path('CPATH', libtirpc.prefix.include.tirpc)
+        env.append_flags('LDFLAGS', '-ltirpc')

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -94,6 +94,7 @@ check_dependencies() {
             if [[ $spack_package ]]; then
                 echo "To install with Spack, run:"
                 echo "    $ spack install $spack_package"
+                echo "    $ spack load $spack_package"
             fi
 
             if [[ $pip_package ]]; then

--- a/var/spack/repos/builtin/packages/ganglia/package.py
+++ b/var/spack/repos/builtin/packages/ganglia/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Ganglia(AutotoolsPackage):
     """Ganglia is a scalable distributed monitoring system for high-performance
@@ -31,5 +33,4 @@ class Ganglia(AutotoolsPackage):
     depends_on('expat')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)

--- a/var/spack/repos/builtin/packages/libnsl/package.py
+++ b/var/spack/repos/builtin/packages/libnsl/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack import *
 
 
@@ -22,7 +24,8 @@ class Libnsl(AutotoolsPackage):
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('gettext')
     depends_on('rpcsvc-proto')
-    depends_on('libtirpc')
+    # TODO: allow specifying != for negation in 'when=' specs!
+    depends_on('libtirpc', when=(sys.platform != 'darwin'))
 
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')

--- a/var/spack/repos/builtin/packages/lmbench/package.py
+++ b/var/spack/repos/builtin/packages/lmbench/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Lmbench(MakefilePackage):
     """lmbench is a suite of simple, portable, ANSI/C microbenchmarks for
@@ -22,8 +24,7 @@ class Lmbench(MakefilePackage):
     patch('fix_results_path_for_aarch64.patch', sha256='2af57abc9058c56b6dd0697bb01a98902230bef92b117017e318faba148eef60', when='target=aarch64:')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)
 
     def build(self, spec, prefix):
         make('build')

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -20,7 +20,7 @@ class PyPackaging(PythonPackage):
     version('17.1', sha256='f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b')
     version('16.8', sha256='5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'))
     depends_on('py-attrs', when='@19.1', type=('build', 'run'))
     depends_on('py-pyparsing@2.0.2:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -47,8 +47,8 @@ class PySetuptools(PythonPackage):
     version('11.3.1', sha256='bd25f17de4ecf00116a9f7368b614a54ca1612d7945d2eafe5d97bc08c138bc5')
 
     depends_on('python@3.5:', type=('build', 'run'), when='@45.0.0:')
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
+    depends_on('python@2.6:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
 
     # Previously, setuptools vendored all of its dependencies to allow
     # easy bootstrapping. As of version 34.0.0, this is no longer done

--- a/var/spack/repos/builtin/packages/python/no-dbm.patch
+++ b/var/spack/repos/builtin/packages/python/no-dbm.patch
@@ -1,0 +1,57 @@
+--- a/setup.py	2020-11-29 13:43:26.736062972 -0800
++++ b/setup.py	2020-11-29 13:43:40.166165660 -0800
+@@ -1144,53 +1144,11 @@
+                 missing.append('bsddb185')
+         else:
+             missing.append('bsddb185')
+ 
+         # The standard Unix dbm module:
+-        if platform not in ['cygwin']:
+-            if find_file("ndbm.h", inc_dirs, []) is not None:
+-                # Some systems have -lndbm, others don't
+-                if self.compiler.find_library_file(lib_dirs, 'ndbm'):
+-                    ndbm_libs = ['ndbm']
+-                else:
+-                    ndbm_libs = []
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       define_macros=[('HAVE_NDBM_H',None)],
+-                                       libraries = ndbm_libs ) )
+-            elif self.compiler.find_library_file(lib_dirs, 'gdbm'):
+-                gdbm_libs = ['gdbm']
+-                if self.compiler.find_library_file(lib_dirs, 'gdbm_compat'):
+-                    gdbm_libs.append('gdbm_compat')
+-                if find_file("gdbm/ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                elif find_file("gdbm-ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_DASH_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                else:
+-                    missing.append('dbm')
+-            elif db_incs is not None:
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       library_dirs=dblib_dir,
+-                                       runtime_library_dirs=dblib_dir,
+-                                       include_dirs=db_incs,
+-                                       define_macros=[('HAVE_BERKDB_H',None),
+-                                                      ('DB_DBM_HSEARCH',None)],
+-                                       libraries=dblibs))
+-            else:
+-                missing.append('dbm')
+-
+-        # Anthony Baxter's gdbm module.  GNU dbm(3) will require -lgdbm:
+-        if (self.compiler.find_library_file(lib_dirs, 'gdbm')):
+-            exts.append( Extension('gdbm', ['gdbmmodule.c'],
+-                                   libraries = ['gdbm'] ) )
+-        else:
+-            missing.append('gdbm')
++        # NB: Removed!
+ 
+         # Unix-only modules
+         if platform not in ['mac', 'win32']:
+             # Steen Lumholt's termios module
+             exts.append( Extension('termios', ['termios.c']) )

--- a/var/spack/repos/builtin/packages/python/no-ssl.patch
+++ b/var/spack/repos/builtin/packages/python/no-ssl.patch
@@ -1,0 +1,32 @@
+--- a/setup.py	2020-11-29 13:15:49.676636440 -0800
++++ b/setup.py	2020-11-29 13:43:26.736062972 -0800
+@@ -761,13 +761,12 @@
+             except IOError, msg:
+                 print "IOError while reading opensshv.h:", msg
+                 pass
+ 
+ 
+-        if (ssl_incs is not None and
+-            ssl_libs is not None and
+-            openssl_ver >= 0x00907000):
++        # raise Exception('change this to True!')
++        if False:
+             # The _hashlib module wraps optimized implementations
+             # of hash functions from the OpenSSL library.
+             exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                                    include_dirs = ssl_incs,
+                                    library_dirs = ssl_libs,
+@@ -781,10 +780,13 @@
+             # Message-Digest Algorithm, described in RFC 1321.  The
+             # necessary files md5.c and md5.h are included here.
+             exts.append( Extension('_md5',
+                             sources = ['md5module.c', 'md5.c'],
+                             depends = ['md5.h']) )
++            # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
++            exts.append( Extension('_sha256', ['sha256module.c']) )
++            exts.append( Extension('_sha512', ['sha512module.c']) )
+             missing.append('_hashlib')
+ 
+         if (openssl_ver < 0x00908000):
+             # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
+             exts.append( Extension('_sha256', ['sha256module.c']) )

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -18,6 +18,7 @@ import spack.store
 import spack.util.spack_json as sjson
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
+from spack.util.provides import setup_libtirpc_build_environment
 from spack import *
 
 
@@ -154,6 +155,7 @@ class Python(AutotoolsPackage):
     # https://raw.githubusercontent.com/python/cpython/84471935ed2f62b8c5758fd544c7d37076fe0fa5/Misc/NEWS
     # https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-4rc1
     depends_on('openssl@:1.0.2z', when='@:2.7.13,3.0.0:3.5.2+ssl')
+    depends_on('openssl@1.0.2u', when='@:2.6.99+ssl')
     depends_on('openssl@1.0.2:', when='@3.7:+ssl')  # https://docs.python.org/3/whatsnew/3.7.html#build-changes
     depends_on('sqlite@3.0.8:', when='+sqlite3')
     depends_on('gdbm', when='+dbm')  # alternatively ndbm or berkeley-db
@@ -359,14 +361,6 @@ class Python(AutotoolsPackage):
     def setup_build_environment(self, env):
         spec = self.spec
 
-        # TODO: The '--no-user-cfg' option for Python installation is only in
-        # Python v2.7 and v3.4+ (see https://bugs.python.org/issue1180) and
-        # adding support for ignoring user configuration will require
-        # significant changes to this package for other Python versions.
-        if not spec.satisfies('@2.7:2.8,3.4:'):
-            tty.warn(('Python v{0} may not install properly if Python '
-                      'user configurations are present.').format(self.version))
-
         # TODO: Python has incomplete support for Python modules with mixed
         # C/C++ source, and patches are required to enable building for these
         # modules. All Python versions without a viable patch are installed
@@ -381,6 +375,8 @@ class Python(AutotoolsPackage):
 
         env.unset('PYTHONPATH')
         env.unset('PYTHONHOME')
+
+        setup_libtirpc_build_environment(spec, env)
 
     def flag_handler(self, name, flags):
         # python 3.8 requires -fwrapv when compiled with intel
@@ -399,30 +395,22 @@ class Python(AutotoolsPackage):
         # as it scans for the library and headers to build
         link_deps = spec.dependencies('link')
 
-        cppflags = []
-        ldflags = []
         if link_deps:
             # Header files are often included assuming they reside in a
             # subdirectory of prefix.include, e.g. #include <openssl/ssl.h>,
             # which is why we don't use HeaderList here. The header files of
             # libffi reside in prefix.lib but the configure script of Python
             # finds them using pkg-config.
-            cppflags.extend('-I' + spec[dep.name].prefix.include for dep in link_deps)
+            cppflags = ' '.join('-I' + spec[dep.name].prefix.include
+                                for dep in link_deps)
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them
             # using spec.__getitem__.
-            ldflags.extend(spec[dep.name].libs.ld_flags for dep in link_deps)
+            ldflags = ' '.join(spec[dep.name].libs.search_flags
+                               for dep in link_deps)
 
-        if 'libtirpc' in spec:
-            cppflags.extend(
-                '-I' + os.path.join(inc, 'tirpc')
-                for inc in spec['libtirpc'].headers.directories)
-
-        config_args.extend([
-            'CPPFLAGS=' + ' '.join(cppflags),
-            'LDFLAGS=' + ' '.join(ldflags),
-        ])
+            config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
         if spec.satisfies('@:3.6'):
@@ -967,6 +955,14 @@ class Python(AutotoolsPackage):
                     dependent_spec.prefix, lib,
                     'python' + str(self.version.up_to(2)), 'site-packages'))
 
+    def _is_py26(self):
+        return self.version.up_to(2).string == '2.6'
+
+    def trailing_setup_args(self):
+        if self._is_py26():
+            return []
+        return ['--no-user-cfg']
+
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods.
 
@@ -976,11 +972,7 @@ class Python(AutotoolsPackage):
 
         module.python = self.command
 
-        if self.version.up_to(2).string == '2.6':
-            trailing_args = []
-        else:
-            trailing_args = ['--no-user-cfg']
-        args = ['setup.py', *tuple(trailing_args)]
+        args = ['setup.py'] + list(self.trailing_setup_args())
         full_cmdline = self.command.path + ' {0}'.format(' '.join(args))
         module.setup_py = Executable(full_cmdline)
 

--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -22,17 +22,23 @@ class Z3(MakefilePackage):
     phases = ['bootstrap', 'build', 'install']
 
     variant('python', default=True, description='Enable python binding')
-    depends_on('python', type=('build', 'run'))
-    depends_on('py-setuptools', type=('run'), when='+python')
+    depends_on('python+shared', type=('build', 'run'), when="+python")
     extends('python', when='+python')
 
     # Referenced: https://github.com/Z3Prover/z3/issues/1016
     patch('fix_1016_1.patch', when='@:4.4.1')
     patch('fix_1016_2.patch', when='@4.5.0')
 
+    using_py26 = "^python@:2.6.99"
+    patch('py26-1.patch', when=using_py26)
+    patch('py26-2.patch', when=using_py26)
+    patch('py26-3.patch', when=using_py26)
+    depends_on('py-argparse', type=('build', 'run'), when=using_py26)
+    depends_on('py-setuptools@:25.2.0', type=('build', 'run'), when=using_py26)
+
     build_directory = 'build'
 
-    def configure_args(self):
+    def configure_args(self, prefix):
         spec = self.spec
 
         args = []
@@ -48,5 +54,5 @@ class Z3(MakefilePackage):
         return args
 
     def bootstrap(self, spec, prefix):
-        options = ['--prefix={0}'.format(prefix)] + self.configure_args()
+        options = ['--prefix={0}'.format(prefix)] + self.configure_args(prefix)
         spec['python'].command('scripts/mk_make.py', *options)

--- a/var/spack/repos/builtin/packages/z3/py26-1.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-1.patch
@@ -1,0 +1,381 @@
+--- a/scripts/mk_util.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/mk_util.py	2020-11-29 19:40:56.342800585 -0800
+@@ -535,12 +535,12 @@
+ def get_version():
+     return (VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
+ 
+ def get_version_string(n):
+     if n == 3:
+-        return "{}.{}.{}".format(VER_MAJOR,VER_MINOR,VER_BUILD)
+-    return "{}.{}.{}.{}".format(VER_MAJOR,VER_MINOR,VER_BUILD,VER_TWEAK)
++        return "{0}.{1}.{2}".format(VER_MAJOR,VER_MINOR,VER_BUILD)
++    return "{0}.{1}.{2}.{3}".format(VER_MAJOR,VER_MINOR,VER_BUILD,VER_TWEAK)
+ 
+ def build_static_lib():
+     return STATIC_LIB
+ 
+ def build_static_bin():
+@@ -611,11 +611,11 @@
+         IS_MSYS2=True
+         if os.uname()[4] == 'x86_64':
+             LINUX_X64=True
+         else:
+             LINUX_X64=False
+-            
++
+ 
+ def display_help(exit_code):
+     print("mk_make.py: Z3 Makefile generator\n")
+     print("This script generates the Makefile for the Z3 theorem prover.")
+     print("It must be executed from the Z3 root directory.")
+@@ -778,11 +778,11 @@
+ 
+     f = io.open(fname, encoding='utf-8', mode='r')
+     linenum = 1
+     for line in f:
+         m1 = std_inc_pat.match(line)
+-        if m1: 
++        if m1:
+             root_file_name = m1.group(1)
+             slash_pos =  root_file_name.rfind('/')
+             if slash_pos >= 0  and root_file_name.find("..") < 0 : #it is a hack for lp include files that behave as continued from "src"
+                 # print(root_file_name)
+                 root_file_name = root_file_name[slash_pos+1:]
+@@ -1497,12 +1497,12 @@
+             self.pythonPkgDir = strip_path_prefix(PYTHON_PACKAGE_DIR, PREFIX)
+         else:
+             # Use path inside the prefix (should be the normal case on Linux)
+             # CMW: Also normal on *BSD?
+             if not PYTHON_PACKAGE_DIR.startswith(PREFIX):
+-                raise MKException(('The python package directory ({}) must live ' +
+-                    'under the install prefix ({}) to install the python bindings.' +
++                raise MKException(('The python package directory ({0}) must live ' +
++                    'under the install prefix ({1}) to install the python bindings.' +
+                     'Use --pypkgdir and --prefix to set the python package directory ' +
+                     'and install prefix respectively. Note that the python package ' +
+                     'directory does not need to exist and will be created if ' +
+                     'necessary during install.').format(
+                         PYTHON_PACKAGE_DIR,
+@@ -1612,11 +1612,11 @@
+        elif os.path.isfile(os.path.join(self.src_dir, self.key_file)):
+            self.key_file = os.path.abspath(os.path.join(self.src_dir, self.key_file))
+        else:
+            print("Keyfile '%s' could not be found; %s.dll will be unsigned." % (self.key_file, self.dll_name))
+            self.key_file = None
+-    
++
+ 
+ # build for dotnet core
+ class DotNetDLLComponent(Component):
+     def __init__(self, name, dll_name, path, deps, assembly_info_dir, default_key_file):
+         Component.__init__(self, name, path, deps)
+@@ -1626,11 +1626,11 @@
+             assembly_info_dir = "."
+         self.dll_name          = dll_name
+         self.assembly_info_dir = assembly_info_dir
+         self.key_file = default_key_file
+ 
+-    
++
+     def mk_makefile(self, out):
+         if not is_dotnet_core_enabled():
+             return
+         cs_fp_files = []
+         for cs_file in get_cs_files(self.src_dir):
+@@ -1642,11 +1642,11 @@
+         out.write('%s: %s$(SO_EXT)' % (dllfile, get_component(Z3_DLL_COMPONENT).dll_name))
+         for cs_file in cs_fp_files:
+             out.write(' ')
+             out.write(cs_file)
+         out.write('\n')
+-        
++
+         set_key_file(self)
+         key = ""
+         if not self.key_file is None:
+             key = "<AssemblyOriginatorKeyFile>%s</AssemblyOriginatorKeyFile>" % self.key_file
+             key += "\n<SignAssembly>true</SignAssembly>"
+@@ -1684,34 +1684,34 @@
+         csproj = os.path.join('dotnet', 'z3.csproj')
+         with open(os.path.join(BUILD_DIR, csproj), 'w') as ous:
+             ous.write(core_csproj_str)
+ 
+         dotnetCmdLine = [DOTNET, "build", csproj]
+-        
++
+         dotnetCmdLine.extend(['-c'])
+         if DEBUG_MODE:
+             dotnetCmdLine.extend(['Debug'])
+         else:
+             dotnetCmdLine.extend(['Release'])
+ 
+         path = os.path.join(os.path.abspath(BUILD_DIR), ".")
+         dotnetCmdLine.extend(['-o', path])
+-            
++
+         MakeRuleCmd.write_cmd(out, ' '.join(dotnetCmdLine))
+         self.sign_esrp(out)
+-        out.write('\n')        
++        out.write('\n')
+         out.write('%s: %s\n\n' % (self.name, dllfile))
+ 
+     def sign_esrp(self, out):
+         global ESRP_SIGNx
+         print("esrp-sign", ESRP_SIGN)
+         if not ESRP_SIGN:
+             return
+-        
++
+         import uuid
+         guid = str(uuid.uuid4())
+-        path = os.path.abspath(BUILD_DIR).replace("\\","\\\\")        
++        path = os.path.abspath(BUILD_DIR).replace("\\","\\\\")
+         assemblySignStr = """
+ {
+   "Version": "1.0.0",
+   "SignBatches"
+   :
+@@ -1770,16 +1770,16 @@
+         MakeRuleCmd.write_cmd(out, "move /Y C:\\esrp\\output\\Microsoft.Z3.dll .")
+ 
+ 
+     def main_component(self):
+         return is_dotnet_core_enabled()
+-    
++
+     def has_assembly_info(self):
+         # TBD: is this required for dotnet core given that version numbers are in z3.csproj file?
+         return False
+ 
+-    
++
+     def mk_win_dist(self, build_path, dist_path):
+         if is_dotnet_core_enabled():
+             mk_dir(os.path.join(dist_path, INSTALL_BIN_DIR))
+             shutil.copy('%s.dll' % os.path.join(build_path, self.dll_name),
+                         '%s.dll' % os.path.join(dist_path, INSTALL_BIN_DIR, self.dll_name))
+@@ -1899,18 +1899,18 @@
+ 
+     def mk_install(self, out):
+         if is_java_enabled() and self.install:
+             dllfile = '%s$(SO_EXT)' % self.dll_name
+             MakeRuleCmd.install_files(out, dllfile, os.path.join(INSTALL_LIB_DIR, dllfile))
+-            jarfile = '{}.jar'.format(self.package_name)
++            jarfile = '{0}.jar'.format(self.package_name)
+             MakeRuleCmd.install_files(out, jarfile, os.path.join(INSTALL_LIB_DIR, jarfile))
+ 
+     def mk_uninstall(self, out):
+         if is_java_enabled() and self.install:
+             dllfile = '%s$(SO_EXT)' % self.dll_name
+             MakeRuleCmd.remove_installed_files(out, os.path.join(INSTALL_LIB_DIR, dllfile))
+-            jarfile = '{}.jar'.format(self.package_name)
++            jarfile = '{0}.jar'.format(self.package_name)
+             MakeRuleCmd.remove_installed_files(out, os.path.join(INSTALL_LIB_DIR, jarfile))
+ 
+ class MLComponent(Component):
+ 
+     def __init__(self, name, lib_name, path, deps):
+@@ -1976,16 +1976,16 @@
+ 
+             src_dir = self.to_src_dir
+             mk_dir(os.path.join(BUILD_DIR, self.sub_dir))
+             api_src = get_component(API_COMPONENT).to_src_dir
+             # remove /GL and -std=c++11; the ocaml tools don't like them.
+-            if IS_WINDOWS:                
++            if IS_WINDOWS:
+                 out.write('CXXFLAGS_OCAML=$(CXXFLAGS:/GL=)\n')
+             else:
+                 out.write('CXXFLAGS_OCAML=$(subst -std=c++11,,$(CXXFLAGS))\n')
+ 
+-            substitutions = { 'VERSION': "{}.{}.{}.{}".format(VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK) }
++            substitutions = { 'VERSION': "{0}.{1}.{2}.{3}".format(VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK) }
+ 
+             configure_file(os.path.join(self.src_dir, 'META.in'),
+                            os.path.join(BUILD_DIR, self.sub_dir, 'META'),
+                            substitutions)
+ 
+@@ -2774,21 +2774,21 @@
+         for f in files:
+             if f.endswith('.pyg'):
+                 script = os.path.join(root, f)
+                 generated_file = mk_genfile_common.mk_hpp_from_pyg(script, root)
+                 if is_verbose():
+-                    print("Generated '{}'".format(generated_file))
++                    print("Generated '{0}'".format(generated_file))
+ 
+ # TODO: delete after src/ast/pattern/expr_pattern_match
+ # database.smt ==> database.h
+ def mk_pat_db():
+     c = get_component(PATTERN_COMPONENT)
+     fin  = os.path.join(c.src_dir, 'database.smt2')
+     fout = os.path.join(c.src_dir, 'database.h')
+     mk_genfile_common.mk_pat_db_internal(fin, fout)
+     if VERBOSE:
+-        print("Generated '{}'".format(fout))
++        print("Generated '{0}'".format(fout))
+ 
+ # Update version numbers
+ def update_version():
+     major = VER_MAJOR
+     minor = VER_MINOR
+@@ -2852,11 +2852,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_install_tactic_cpp_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_install_tactic_cpps():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_install_tactics():
+@@ -2871,11 +2871,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_mem_initializer_cpp_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_mem_initializer_cpps():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_mem_initializer():
+@@ -2890,11 +2890,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_gparams_register_modules_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_gparams_register_modules():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_mem_initializer():
+@@ -3020,11 +3020,11 @@
+         api_file_c = api_dll.find_file(api_file, api_dll.name)
+         api_file   = os.path.join(api_file_c.src_dir, api_file)
+         full_path_api_files.append(api_file)
+     generated_file = mk_genfile_common.mk_z3consts_py_internal(full_path_api_files, Z3PY_SRC_DIR)
+     if VERBOSE:
+-        print("Generated '{}".format(generated_file))
++        print("Generated '{0}".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add .Net definitions
+ def mk_z3consts_dotnet(api_files, output_dir):
+     dotnet = get_component(DOTNET_COMPONENT)
+     if not dotnet:
+@@ -3034,11 +3034,11 @@
+         api_file_c = dotnet.find_file(api_file, dotnet.name)
+         api_file   = os.path.join(api_file_c.src_dir, api_file)
+         full_path_api_files.append(api_file)
+     generated_file = mk_genfile_common.mk_z3consts_dotnet_internal(full_path_api_files, output_dir)
+     if VERBOSE:
+-        print("Generated '{}".format(generated_file))
++        print("Generated '{0}".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add Java definitions
+ def mk_z3consts_java(api_files):
+     java = get_component(JAVA_COMPONENT)
+     full_path_api_files = []
+@@ -3050,11 +3050,11 @@
+         full_path_api_files,
+         java.package_name,
+         java.src_dir)
+     if VERBOSE:
+         for generated_file in generated_files:
+-            print("Generated '{}'".format(generated_file))
++            print("Generated '{0}'".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add ML definitions
+ def mk_z3consts_ml(api_files):
+     ml = get_component(ML_COMPONENT)
+     full_path_api_files = []
+@@ -3078,11 +3078,11 @@
+     lline = lines[-1]
+     tokens = lline.split('.')
+     if len(tokens) < 2:
+         return default
+     else:
+-        if tokens[0] == "15": 
++        if tokens[0] == "15":
+             # Visual Studio 2017 reports 15.* but the PlatformToolsetVersion is 141
+             return "v141"
+         else:
+             return 'v' + tokens[0] + tokens[1]
+ 
+@@ -3287,11 +3287,12 @@
+         # Note: DESTDIR is to support staged installs
+         return "$(DESTDIR)$(PREFIX)/"
+ 
+     @classmethod
+     def _is_str(cls, obj):
+-        if sys.version_info.major > 2:
++        # TODO: py26 compat, or we would use '.major'.
++        if sys.version_info[0] > 2:
+             # Python 3 or newer. Strings are always unicode and of type str
+             return isinstance(obj, str)
+         else:
+             # Python 2. Has byte-string and unicode representation, allow both
+             return isinstance(obj, str) or isinstance(obj, unicode)
+@@ -3300,13 +3301,13 @@
+     def _install_root(cls, path, in_prefix, out, is_install=True):
+         if not in_prefix:
+             # The Python bindings on OSX are sometimes not installed inside the prefix.
+             install_root = "$(DESTDIR)"
+             action_string = 'install' if is_install else 'uninstall'
+-            cls.write_cmd(out, 'echo "WARNING: {}ing files/directories ({}) that are not in the install prefix ($(PREFIX))."'.format(
++            cls.write_cmd(out, 'echo "WARNING: {0}ing files/directories ({1}) that are not in the install prefix ($(PREFIX))."'.format(
+                     action_string, path))
+-            #print("WARNING: Generating makefile rule that {}s {} '{}' which is outside the installation prefix '{}'.".format(
++            #print("WARNING: Generating makefile rule that {0}s {1} '{2}' which is outside the installation prefix '{0}'.".format(
+             #        action_string, 'to' if is_install else 'from', path, PREFIX))
+         else:
+             # assert not os.path.isabs(path)
+             install_root = cls.install_root()
+         return install_root
+@@ -3428,11 +3429,11 @@
+     # ``$(Verb)`` and have it set to ``@`` or empty at build time depending on
+     # a variable (e.g. ``VERBOSE``) passed to the ``make`` invocation. This
+     # would be very helpful for debugging.
+     @classmethod
+     def write_cmd(cls, out, line):
+-        out.write("\t@{}\n".format(line))
++        out.write("\t@{0}\n".format(line))
+ 
+ def strip_path_prefix(path, prefix):
+     if path.startswith(prefix):
+         stripped_path = path[len(prefix):]
+         stripped_path.replace('//','/')
+@@ -3456,23 +3457,23 @@
+     assert isinstance(template_file_path, str)
+     assert isinstance(output_file_path, str)
+     assert isinstance(substitutions, dict)
+     assert len(template_file_path) > 0
+     assert len(output_file_path) > 0
+-    print("Generating {} from {}".format(output_file_path, template_file_path))
++    print("Generating {0} from {1}".format(output_file_path, template_file_path))
+ 
+     if not os.path.exists(template_file_path):
+-        raise MKException('Could not find template file "{}"'.format(template_file_path))
++        raise MKException('Could not find template file "{0}"'.format(template_file_path))
+ 
+     # Read whole template file into string
+     template_string = None
+     with open(template_file_path, 'r') as f:
+         template_string = f.read()
+ 
+     # Do replacements
+     for (old_string, replacement) in substitutions.items():
+-        template_string = template_string.replace('@{}@'.format(old_string), replacement)
++        template_string = template_string.replace('@{0}@'.format(old_string), replacement)
+ 
+     # Write the string to the file
+     with open(output_file_path, 'w') as f:
+         f.write(template_string)
+ 

--- a/var/spack/repos/builtin/packages/z3/py26-2.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-2.patch
@@ -1,0 +1,124 @@
+--- a/scripts/mk_genfile_common.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/mk_genfile_common.py	2020-11-29 19:41:01.152833632 -0800
+@@ -26,19 +26,19 @@
+     """
+         Returns ``True`` if ``output_dir`` exists, otherwise
+         returns ``False``.
+     """
+     if not os.path.isdir(output_dir):
+-        _logger.error('"{}" is not an existing directory'.format(output_dir))
++        _logger.error('"{0}" is not an existing directory'.format(output_dir))
+         return False
+     return True
+ 
+ def check_files_exist(files):
+     assert isinstance(files, list)
+     for f in files:
+         if not os.path.exists(f):
+-            _logger.error('"{}" does not exist'.format(f))
++            _logger.error('"{0}" does not exist'.format(f))
+             return False
+     return True
+ 
+ def sorted_headers_by_component(l):
+     """
+@@ -53,11 +53,11 @@
+       and ``<build_dir>`` prefixes so that we can match the Python build
+       system's behaviour.
+     """
+     assert isinstance(l, list)
+     def get_key(path):
+-        _logger.debug("get_key({})".format(path))
++        _logger.debug("get_key({0})".format(path))
+         path_components = []
+         stripped_path = path
+         assert 'src' in stripped_path.split(os.path.sep) or 'src' in stripped_path.split('/')
+         # Keep stripping off directory components until we hit ``src``
+         while os.path.basename(stripped_path) != 'src':
+@@ -67,14 +67,14 @@
+         path_components.reverse()
+         # For consistency across platforms use ``/`` rather than ``os.sep``.
+         # This is a sorting key so it doesn't need to a platform suitable
+         # path
+         r = '/'.join(path_components)
+-        _logger.debug("return key:'{}'".format(r))
++        _logger.debug("return key:'{0}'".format(r))
+         return r
+     sorted_headers = sorted(l, key=get_key)
+-    _logger.debug('sorted headers:{}'.format(pprint.pformat(sorted_headers)))
++    _logger.debug('sorted headers:{0}'.format(pprint.pformat(sorted_headers)))
+     return sorted_headers
+ 
+ 
+ 
+ ###############################################################################
+@@ -593,11 +593,11 @@
+     h_file = h_file.replace("\\","/")
+     idx = h_file.rfind("src/")
+     if idx == -1:
+         return h_file
+     return h_file[idx + 4:]
+-            
++
+ def mk_gparams_register_modules_internal(h_files_full_path, path):
+     """
+         Generate a ``gparams_register_modules.cpp`` file in the directory ``path``.
+         Returns the path to the generated file.
+ 
+@@ -609,11 +609,11 @@
+ 
+         This procedure is invoked by gparams::init()
+     """
+     assert isinstance(h_files_full_path, list)
+     assert check_dir_exists(path)
+-    cmds = []    
++    cmds = []
+     mod_cmds = []
+     mod_descrs = []
+     fullname = os.path.join(path, 'gparams_register_modules.cpp')
+     fout  = open(fullname, 'w')
+     fout.write('// Automatically generated file.\n')
+@@ -691,38 +691,38 @@
+     fout.write('// Automatically generated file.\n')
+     fout.write('#include "tactic/tactic.h"\n')
+     fout.write('#include "cmd_context/tactic_cmds.h"\n')
+     fout.write('#include "cmd_context/cmd_context.h"\n')
+     tactic_pat   = re.compile('[ \t]*ADD_TACTIC\(.*\)')
+-    probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')   
++    probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')
+     for h_file in sorted_headers_by_component(h_files_full_path):
+         added_include = False
+         try:
+             with io.open(h_file, encoding='utf-8', mode='r') as fin:
+                 for line in fin:
+                     if tactic_pat.match(line):
+                         if not added_include:
+-                            added_include = True                        
++                            added_include = True
+                             fout.write('#include "%s"\n' % path_after_src(h_file))
+                         try:
+                             eval(line.strip('\n '), eval_globals, None)
+                         except Exception as e:
+-                            _logger.error("Failed processing ADD_TACTIC command at '{}'\n{}".format(
++                            _logger.error("Failed processing ADD_TACTIC command at '{0}'\n{1}".format(
+                                 fullname, line))
+                             raise e
+                     if probe_pat.match(line):
+                         if not added_include:
+                             added_include = True
+                             fout.write('#include "%s"\n' % path_after_src(h_file))
+                         try:
+                             eval(line.strip('\n '), eval_globals, None)
+                         except Exception as e:
+-                            _logger.error("Failed processing ADD_PROBE command at '{}'\n{}".format(
++                            _logger.error("Failed processing ADD_PROBE command at '{0}'\n{1}".format(
+                                 fullname, line))
+                             raise e
+         except Exception as e:
+-           _logger.error("Failed to read file {}\n".format(h_file))
++           _logger.error("Failed to read file {0}\n".format(h_file))
+            raise e
+     # First pass will just generate the tactic factories
+     fout.write('#define ADD_TACTIC_CMD(NAME, DESCR, CODE) ctx.insert(alloc(tactic_cmd, symbol(NAME), DESCR, [](ast_manager &m, const params_ref &p) { return CODE; }))\n')
+     fout.write('#define ADD_PROBE(NAME, DESCR, PROBE) ctx.insert(alloc(probe_info, symbol(NAME), DESCR, PROBE))\n')
+     fout.write('void install_tactics(tactic_manager & ctx) {\n')

--- a/var/spack/repos/builtin/packages/z3/py26-3.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-3.patch
@@ -1,0 +1,109 @@
+--- a/scripts/update_api.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/update_api.py	2020-11-29 19:40:54.949457677 -0800
+@@ -778,11 +778,11 @@
+        ous.write("  \"api\": [\n")
+        for name, result, params in _dotnet_decls:
+            ous.write("    {\n")
+            ous.write("       \"name\": \"%s\",\n" % name)
+            ous.write("       \"c_type\": \"%s\",\n" % Type2Str[result])
+-           ous.write("       \"napi_type\": \"%s\",\n" % type2napi(result))                       
++           ous.write("       \"napi_type\": \"%s\",\n" % type2napi(result))
+            ous.write("       \"arg_list\": [")
+            first = True
+            for p in params:
+                if first:
+                   first = False
+@@ -791,11 +791,11 @@
+                   ous.write(",\n         {\n")
+                t = param_type(p)
+                k = t
+                ous.write("            \"name\": \"%s\",\n" % "")                        # TBD
+                ous.write("            \"c_type\": \"%s\",\n" % type2str(t))
+-               ous.write("            \"napi_type\": \"%s\",\n" % type2napi(t))        
++               ous.write("            \"napi_type\": \"%s\",\n" % type2napi(t))
+                ous.write("            \"napi_builder\": \"%s\"\n" % type2napibuilder(t))
+                ous.write(  "         }")
+            ous.write("],\n")
+            ous.write("       \"napi_builder\": \"%s\"\n" % type2napibuilder(result))
+            ous.write("    },\n")
+@@ -1717,11 +1717,11 @@
+ del _lib
+ del _default_dirs
+ del _all_dirs
+ del _ext
+ """)
+-    
++
+ def write_core_py_preamble(core_py):
+   core_py.write(
+ """
+ # Automatically generated file
+ import sys, os
+@@ -1790,11 +1790,11 @@
+     print("    builtins.Z3_LIB_DIRS = [ '/path/to/libz3.%s' ] " % _ext)
+   raise Z3Exception("libz3.%s not found." % _ext)
+ 
+ def _to_ascii(s):
+   if isinstance(s, str):
+-    try: 
++    try:
+       return s.encode('ascii')
+     except:
+       # kick the bucket down the road.  :-J
+       return s
+   else:
+@@ -1871,11 +1871,11 @@
+     if output_dir != None:
+       assert os.path.exists(output_dir) and os.path.isdir(output_dir)
+       return open(os.path.join(output_dir, file_name), mode)
+     else:
+       # Return a file that we can write to without caring
+-      print("Faking emission of '{}'".format(file_name))
++      print("Faking emission of '{0}'".format(file_name))
+       import tempfile
+       return tempfile.TemporaryFile(mode=mode)
+ 
+   with mk_file_or_temp(api_output_dir, 'api_log_macros.h') as log_h:
+     with mk_file_or_temp(api_output_dir, 'api_log_macros.cpp') as log_c:
+@@ -1893,22 +1893,22 @@
+           mk_bindings(exe_c)
+           mk_py_wrappers()
+           write_core_py_post(core_py)
+ 
+           if mk_util.is_verbose():
+-            print("Generated '{}'".format(log_h.name))
+-            print("Generated '{}'".format(log_c.name))
+-            print("Generated '{}'".format(exe_c.name))
+-            print("Generated '{}'".format(core_py.name))
++            print("Generated '{0}'".format(log_h.name))
++            print("Generated '{0}'".format(log_c.name))
++            print("Generated '{0}'".format(exe_c.name))
++            print("Generated '{0}'".format(core_py.name))
+ 
+   if dotnet_output_dir:
+     with open(os.path.join(dotnet_output_dir, 'Native.cs'), 'w') as dotnet_file:
+       mk_dotnet(dotnet_file)
+       mk_dotnet_wrappers(dotnet_file)
+       if mk_util.is_verbose():
+-        print("Generated '{}'".format(dotnet_file.name))
+-        
++        print("Generated '{0}'".format(dotnet_file.name))
++
+   if java_output_dir:
+     mk_java(java_output_dir, java_package_name)
+ 
+   if ml_output_dir:
+     assert not ml_src_dir is None
+@@ -1966,11 +1966,11 @@
+       logging.error('--ml-src-dir must be specified')
+       return 1
+ 
+   for api_file in pargs.api_files:
+     if not os.path.exists(api_file):
+-      logging.error('"{}" does not exist'.format(api_file))
++      logging.error('"{0}" does not exist'.format(api_file))
+       return 1
+ 
+   generate_files(api_files=pargs.api_files,
+                  api_output_dir=pargs.api_output_dir,
+                  z3py_output_dir=pargs.z3py_output_dir,


### PR DESCRIPTION
### Problem

We are currently investigating whether z3 can be used instead of clingo for the new concretizer (from #19501). That work is on https://github.com/spack/spack/tree/z3-concretizer -- it doesn't work yet. If we *do* use z3, some changes will be necessary to support building with python 2.6.

*This diff is on top of #20218, see https://github.com/spack/spack/compare/py26-bootstrap...z3-bootstrap-2.6?expand=1 for the diff on top of that change.*

### Solution

- Add several patches to remove `'{}'.format(...)` calls, which must be converted to `'{0}'.format(...)` for python 2.6.

### Result

- z3 *should* be bootstrappable in an environment with only python 2.6 and a C++ compiler. However, this PR should be closed if we find that it is infeasible to use z3 for the new concretizer.

### TODO
- [ ] **Demonstrate a working z3 implementation of the ASP concretizer from #19501.**