### PR TITLE
openmpi: if using external slurm and +pmi, libevent is external as well

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -620,6 +620,8 @@ class Openmpi(AutotoolsPackage):
         # Presumably future versions after 11/2018 should support slurm+static
         if spec.satisfies('schedulers=slurm'):
             config_args.append('--with-pmi={0}'.format(spec['slurm'].prefix))
+            if spec['slurm'].external:
+                config_args.append('--with-libevent=external')
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):
                 if '+static' in spec:
                     config_args.append('--enable-static')


### PR DESCRIPTION
needed to build 4.0.5 in our environment (NOTE: not yet run-tested) @hppritcha

without this, build failure will look as follows:

```console
1 error found in build log:
     1825    --- MCA component pmix:ext3x (m4 configuration macro)
     1826    checking for MCA component pmix:ext3x compile mode... static
     1827    checking if external component is version 3.x... yes
     1828    configure: WARNING: EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT
     1829    configure: WARNING: LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED
     1830    configure: WARNING: TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT
  >> 1831    configure: error: PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD
```