### PR TITLE
abi.py: avoid circular import

### DIFF
--- a/lib/spack/spack/abi.py
+++ b/lib/spack/spack/abi.py
@@ -8,7 +8,6 @@ import os
 from llnl.util.lang import memoized
 
 import spack.spec
-from spack.build_environment import dso_suffix
 from spack.spec import CompilerSpec
 from spack.util.executable import Executable, ProcessError
 from spack.compilers.clang import Clang
@@ -30,6 +29,7 @@ class ABI(object):
     def _gcc_get_libstdcxx_version(self, version):
         """Returns gcc ABI compatibility info by getting the library version of
            a compiler's libstdc++ or libgcc_s"""
+        from spack.build_environment import dso_suffix
         spec = CompilerSpec("gcc", version)
         compilers = spack.compilers.compilers_for_spec(spec)
         if not compilers:


### PR DESCRIPTION
There was a circular import in abi.py under some circumstances. It seems that Spack itself doesn't ever hit the code path that triggers this, but a user on slack reported they ran into it in their scripting. Making build_environment.dso_suffix a local import in the method that uses it resolved the error for the user.