### PR TITLE
libtheora: patch for png_sizeof issue

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/dont_use_png_sizeof.patch
+++ b/var/spack/repos/builtin/packages/libtheora/dont_use_png_sizeof.patch
@@ -1,0 +1,19 @@
+diff --git a/examples/png2theora.c b/examples/png2theora.c
+index 71a0d0f..ed24c2a 100644
+--- a/examples/png2theora.c
++++ b/examples/png2theora.c
+@@ -462,9 +462,9 @@ png_read(const char *pathname, unsigned int *w, unsigned int *h, unsigned char *
+   png_set_strip_alpha(png_ptr);
+ 
+   row_data = (png_bytep)png_malloc(png_ptr,
+-    3*height*width*png_sizeof(*row_data));
++    3*height*width*sizeof(*row_data));
+   row_pointers = (png_bytep *)png_malloc(png_ptr,
+-    height*png_sizeof(*row_pointers));
++    height*sizeof(*row_pointers));
+   for(y = 0; y < height; y++) {
+     row_pointers[y] = row_data + y*(3*width);
+   }
+-- 
+2.7.4
+

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -23,6 +23,7 @@ class Libtheora(AutotoolsPackage):
     depends_on('libogg')
 
     patch('exit-prior-to-running-configure.patch', when='@1.1.1')
+    patch('dont_use_png_sizeof.patch', when='@1.1.1')
 
     def autoreconf(self, spec, prefix):
         sh = which('sh')


### PR DESCRIPTION
See

https://gitlab.freedesktop.org/gstreamer/cerbero/blob/master/recipes/libtheora/0004-examples-Don-t-use-png_sizeof.patch

Signed-off-by: Howard Pritchard <howardp@lanl.gov>