### PR TITLE
py-xopen: added versions 1.0.1 and 0.8.4

### DIFF
--- a/var/spack/repos/builtin/packages/py-xopen/package.py
+++ b/var/spack/repos/builtin/packages/py-xopen/package.py
@@ -15,7 +15,9 @@ class PyXopen(PythonPackage):
     homepage = "https://github.com/marcelm/xopen"
     url      = "https://pypi.io/packages/source/x/xopen/xopen-0.1.1.tar.gz"
 
+    version('1.0.1', sha256='79d7e425fb0930b0153eb6beba9a540ca3e07ac254ca828577ad2e8fa24105dc')
     version('0.9.0', sha256='1e3918c8a5cd2bd128ba05b3b883ee322349219c99c305e10114638478e3162a')
+    version('0.8.4', sha256='dcd8f5ef5da5564f514a990573a48a0c347ee1fdbb9b6374d31592819868f7ba')
     version('0.8.2', sha256='003749e09af74103a29e9c64c468c03e084aa6dfe6feff4fe22366679a6534f7')
     version('0.5.0', sha256='b097cd25e8afec42b6e1780c1f6315016171b5b6936100cdf307d121e2cbab9f')
     version('0.1.1', sha256='d1320ca46ed464a59db4c27c7a44caf5e268301e68319f0295d06bf6a9afa6f3')


### PR DESCRIPTION
Installation of both versions tested on Ubuntu 14.04

Although i've already closed the issue, this resolves #20238