### PR TITLE
concretizer: each external version is allowed by definition

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1060,6 +1060,7 @@ class SpackSolverSetup(object):
             for id, spec in enumerate(external_specs):
                 self.gen.newline()
                 spec_id = fn.external_spec(pkg_name, id)
+                self.possible_versions[spec.name].add(spec.version)
                 clauses = self.spec_clauses(spec, body=True)
                 # This is an iff below, wish it could be written in a
                 # more compact form

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -979,3 +979,14 @@ class TestConcretize(object):
     def test_dont_select_version_that_brings_more_variants_in(self):
         s = Spec('dep-with-variants-if-develop-root').concretized()
         assert s['dep-with-variants-if-develop'].satisfies('@1.0')
+
+    @pytest.mark.regression('20244')
+    @pytest.mark.parametrize('spec_str,expected_version', [
+        ('externaltool@1.0', '@1.0'),
+        ('externaltool@0.9', '@0.9'),
+        ('externaltool@0_8', '@0_8'),
+    ])
+    def test_external_package_versions(self, spec_str, expected_version):
+        s = Spec(spec_str).concretized()
+        assert s.external
+        assert s.satisfies(expected_version)

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -29,3 +29,8 @@ packages:
     externals:
     - spec:  requires-virtual@2.0
       prefix: /usr
+  'external-buildable-with-variant':
+    buildable: True
+    externals:
+      - spec: external-buildable-with-variant@1.1.special +baz
+        prefix: /usr

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -9,6 +9,8 @@ packages:
       prefix: /path/to/external_tool
     - spec: externaltool@0.9%gcc@4.5.0
       prefix: /usr
+    - spec: externaltool@0_8%gcc@4.5.0
+      prefix: /usr
   externalvirtual:
     buildable: False
     externals:

--- a/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ExternalBuildableWithVariant(Package):
+    homepage = "http://somewhere.com"
+    url = "http://somewhere.com/module-1.0.tar.gz"
+
+    version('1.0', '1234567890abcdef1234567890abcdef')
+
+    variant('baz', default=False, description='nope')

--- a/var/spack/repos/builtin.mock/packages/externaltool/package.py
+++ b/var/spack/repos/builtin.mock/packages/externaltool/package.py
@@ -12,5 +12,6 @@ class Externaltool(Package):
 
     version('1.0', '1234567890abcdef1234567890abcdef')
     version('0.9', '1234567890abcdef1234567890abcdef')
+    version('0.8.1', '1234567890abcdef1234567890abcdef')
 
     depends_on('externalprereq')


### PR DESCRIPTION
fixes #20244

Registering external versions among the lists of allowed ones generates the correct rules for `version_satisfies`