### PR TITLE
geant4, geant4-data: versions 10.6.3 and 10.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -17,6 +17,7 @@ class G4emlow(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('7.13', sha256='374896b649be776c6c10fea80abe6cf32f9136df0b6ab7c7236d571d49fb8c69')
     version('7.9.1', sha256='820c106e501c64c617df6c9e33a0f0a3822ffad059871930f74b8cc37f043ccb')
     version('7.9', sha256='4abf9aa6cda91e4612676ce4d2d8a73b91184533aa66f9aad19a53a8c4dc3aff')
     version('7.7', sha256='16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663')

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -17,6 +17,7 @@ class G4ensdfstate(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('2.3', sha256='9444c5e0820791abd3ccaace105b0e47790fadce286e11149834e79c4a8e9203')
     version('2.2', sha256='dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6')
     version('2.1', sha256='933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9')
 

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -18,6 +18,7 @@ class G4particlexs(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('3.1', sha256='404da84ead165e5cccc0bb795222f6270c9bf491ef4a0fd65195128b27f0e9cd')
     version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')
     version('1.1', sha256='100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62')
 

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -17,6 +17,7 @@ class G4photonevaporation(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('5.7', sha256='761e42e56ffdde3d9839f9f9d8102607c6b4c0329151ee518206f4ee9e77e7e5')
     version('5.5', sha256='5995dda126c18bd7f68861efde87b4af438c329ecbe849572031ceed8f5e76d7')
     version('5.3', sha256='d47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8')
     version('5.2', sha256='83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f')

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -17,6 +17,7 @@ class G4radioactivedecay(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('5.6', sha256='3886077c9c8e5a98783e6718e1c32567899eeb2dbb33e402d4476bc2fe4f0df1')
     version('5.4', sha256='240779da7d13f5bf0db250f472298c3804513e8aca6cae301db97f5ccdcc4a61')
     version('5.3', sha256='5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1')
     version('5.2', sha256='99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d')

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -17,6 +17,7 @@ class G4realsurface(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('2.2', sha256='9954dee0012f5331267f783690e912e72db5bf52ea9babecd12ea22282176820')
     version('2.1.1', sha256='90481ff97a7c3fa792b7a2a21c9ed80a40e6be386e581a39950c844b2dd06f50')
     version('2.1', sha256='2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
     version('1.0', sha256='3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -17,6 +17,8 @@ class Geant4Data(BundlePackage):
 
     tags = ['hep']
 
+    version('10.7.0')
+    version('10.6.3')
     version('10.6.2')
     version('10.6.1')
     version('10.6.0')
@@ -31,6 +33,19 @@ class Geant4Data(BundlePackage):
     # For clarity, declare deps on a Major-Minor version basis as
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
+    # geant4@10.7.X
+    depends_on("g4ndl@4.6", when='@10.7.0:10.7.9999')
+    depends_on("g4emlow@7.13", when='@10.7.0:10.7.9999')
+    depends_on("g4photonevaporation@5.7", when='@10.7.0:10.7.9999')
+    depends_on("g4radioactivedecay@5.6", when='@10.7.0:10.7.9999')
+    depends_on("g4particlexs@3.1", when='@10.7.0:10.7.9999')
+    depends_on("g4pii@1.3", when='@10.7.0:10.7.9999')
+    depends_on("g4realsurface@2.2", when='@10.7.0:10.7.9999')
+    depends_on("g4saiddata@2.0", when='@10.7.0:10.7.9999')
+    depends_on("g4abla@3.1", when='@10.7.0:10.7.9999')
+    depends_on("g4incl@1.0", when='@10.7.0:10.7.9999')
+    depends_on("g4ensdfstate@2.3", when='@10.7.0:10.7.9999')
+
     # geant4@10.6.X
     depends_on("g4ndl@4.6", when='@10.6.0:10.6.9999')
     depends_on("g4emlow@7.9", when='@10.6.0')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -19,7 +19,6 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
-
     version('10.7.0', sha256='c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4')
     version('10.6.3', sha256='bf96d6d38e6a0deabb6fb6232eb00e46153134da645715d636b9b7b4490193d3')
     version('10.6.2', sha256='e381e04c02aeade1ed8cdd9fdbe7dcf5d6f0f9b3837a417976b839318a005dbd')
@@ -117,8 +116,7 @@ class Geant4(CMakePackage):
 
         # Core options
         options = [
-            '-DGEANT4_BUILD_CXXSTD={0}'.format(
-                self.spec.variants['cxxstd'].value),
+            self.define_from_variant('GEANT4_BUILD_CXXSTD', 'cxxstd'),
             '-DGEANT4_USE_SYSTEM_CLHEP=ON',
             '-DGEANT4_USE_SYSTEM_EXPAT=ON',
             '-DGEANT4_USE_SYSTEM_ZLIB=ON',

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -19,6 +19,9 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+
+    version('10.7.0', sha256='c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4')
+    version('10.6.3', sha256='bf96d6d38e6a0deabb6fb6232eb00e46153134da645715d636b9b7b4490193d3')
     version('10.6.2', sha256='e381e04c02aeade1ed8cdd9fdbe7dcf5d6f0f9b3837a417976b839318a005dbd')
     version('10.6.1', sha256='4fd64149ae26952672a81ce5579d3806fda4bd251d486897093ac57633a42b7e')
     version('10.6.0', sha256='eebe6a170546064ff81ab3b00f513ccd1d4122a026514982368d503ac55a4ee4')
@@ -45,6 +48,8 @@ class Geant4(CMakePackage):
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
 
+    depends_on('geant4-data@10.7.0', when='@10.7.0')
+    depends_on('geant4-data@10.6.3', when='@10.6.3')
     depends_on('geant4-data@10.6.2', when='@10.6.2')
     depends_on('geant4-data@10.6.1', when='@10.6.1')
     depends_on('geant4-data@10.6.0', when='@10.6.0')
@@ -60,17 +65,22 @@ class Geant4(CMakePackage):
     depends_on('python@3:', when='+python')
     extends('python', when='+python')
     conflicts('+python', when='@:10.6.1',
-              msg='Geant4 <= 10.6.1 cannont be built with Python bindings')
+              msg='Geant4 <= 10.6.1 cannot be built with Python bindings')
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed
+        depends_on('clhep@2.4.4.0: cxxstd=' + std,
+                   when='@10.7.0: cxxstd=' + std)
+
         depends_on('clhep@2.3.3.0: cxxstd=' + std,
-                   when='@10.3.3: cxxstd=' + std)
+                   when='@10.3.3:10.6.99 cxxstd=' + std)
 
         # Spack only supports Xerces-c 3 and above, so no version req
         depends_on('xerces-c netaccessor=curl cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom specific versions for each Geant4 version
+        depends_on('vecgeom@1.1.8 cxxstd=' + std,
+                   when='@10.7.0: +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.5 cxxstd=' + std,
                    when='@10.6.0:10.6.99 +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.0 cxxstd=' + std,
@@ -107,7 +117,7 @@ class Geant4(CMakePackage):
 
         # Core options
         options = [
-            '-DGEANT4_BUILD_CXXSTD=c++{0}'.format(
+            '-DGEANT4_BUILD_CXXSTD={0}'.format(
                 self.spec.variants['cxxstd'].value),
             '-DGEANT4_USE_SYSTEM_CLHEP=ON',
             '-DGEANT4_USE_SYSTEM_EXPAT=ON',
@@ -116,6 +126,11 @@ class Geant4(CMakePackage):
             '-DGEANT4_USE_GDML=ON',
             '-DXERCESC_ROOT_DIR={0}'.format(spec['xerces-c'].prefix)
         ]
+
+        # Don't install the package cache file as Spack will set
+        # up CMAKE_PREFIX_PATH etc for the dependencies
+        if spec.version > Version('10.5.99'):
+            options.append('-DGEANT4_INSTALL_PACKAGE_CACHE=OFF')
 
         # Multithreading
         options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED',


### PR DESCRIPTION
Update geant4-data and individual datasets for Geant4 versions 10.6.3 and 10.7.0.

Update geant4 package with new versions 10.6.3 and 10.7.0. Update dependencies on CLHEP and VecGeom with versions required for Geant4 10.7.

Add `GEANT4_INSTALL_PACKAGE_CACHE=OFF` to CMake args for 10.6 onwards. Prevents install of the "package cache" file that contains hard-coded paths for dependencies, improving relocatability. It relies on Spack setting CMAKE_PREFIX_PATH correctly in build/use environments that consume the geant4 package. This has been tested locally in a simple environment to build a Geant4 example, and appears to function correctly.

Reviewers requested, also pinging @vvolkl and @ChristianTackeGSI for their info.