### PR TITLE
minimal zsh completion

### DIFF
--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -117,7 +117,7 @@ _bash_completion_spack() {
     #_test_vars >> temp
 
     # Make sure function exists before calling it
-    if [[ "$(type -t $subfunction)" == "function" ]]
+    if [[ "$(type $subfunction)" =~ "$subfunction.*function.*" ]]
     then
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -37,6 +37,17 @@
 #
 # See `man bash` for more details.
 
+if test -n "${ZSH_VERSION:-}" ; then
+  if [[ "$(emulate)" = zsh ]] ; then
+    # ensure base completion support is enabled
+    autoload -U +X compinit && compinit
+    # ensure bash compatible completion support is enabled
+    autoload -U +X bashcompinit && bashcompinit
+    emulate sh -c "source '$0:A'"
+    return # stop interpreting file
+  fi
+fi
+
 # Bash programmable completion for Spack
 _bash_completion_spack() {
     # In all following examples, let the cursor be denoted by brackets, i.e. []
@@ -117,7 +128,9 @@ _bash_completion_spack() {
     #_test_vars >> temp
 
     # Make sure function exists before calling it
-    if [[ "$(type $subfunction)" =~ "$subfunction.*function.*" ]]
+    local rgx #this dance is necessary to cover bash and zsh regex
+    rgx="$subfunction.*function.* "
+    if [[ "$(type $subfunction 2>&1)" =~ $rgx ]]
     then
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -39,7 +39,7 @@
 
 if test -n "${ZSH_VERSION:-}" ; then
   if [[ "$(emulate)" = zsh ]] ; then
-    # ensure base completion support is enabled
+    # ensure base completion support is enabled, ignore insecure directories
     autoload -U +X compinit && compinit -i
     # ensure bash compatible completion support is enabled
     autoload -U +X bashcompinit && bashcompinit

--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -40,7 +40,7 @@
 if test -n "${ZSH_VERSION:-}" ; then
   if [[ "$(emulate)" = zsh ]] ; then
     # ensure base completion support is enabled
-    autoload -U +X compinit && compinit
+    autoload -U +X compinit && compinit -i
     # ensure bash compatible completion support is enabled
     autoload -U +X bashcompinit && bashcompinit
     emulate sh -c "source '$0:A'"

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -63,32 +63,39 @@ contains 'hdf5' _spack_completions spack install -v ''
 # XFAIL: Fails for Python 2.6 because pkg_resources not found?
 #contains 'compilers.py' _spack_completions spack unit-test ''
 
-title 'Testing debugging functions'
+_test_debug_functions() {
+    title 'Testing debugging functions'
 
-# This is a particularly tricky case that involves the following situation:
-#     `spack -d [] install `
-# Here, [] represents the cursor, which is in the middle of the line.
-# We should tab-complete optional flags for `spack`, not optional flags for
-# `spack install` or package names.
-COMP_LINE='spack -d  install '
-COMP_POINT=9
-COMP_WORDS=(spack -d install)
-COMP_CWORD=2
-COMP_KEY=9
-COMP_TYPE=64
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        emulate -L sh
+    fi
 
-_bash_completion_spack
-contains "--all-help" echo "${COMPREPLY[@]}"
+    # This is a particularly tricky case that involves the following situation:
+    #     `spack -d [] install `
+    # Here, [] represents the cursor, which is in the middle of the line.
+    # We should tab-complete optional flags for `spack`, not optional flags for
+    # `spack install` or package names.
+    COMP_LINE='spack -d  install '
+    COMP_POINT=9
+    COMP_WORDS=(spack -d install)
+    COMP_CWORD=2
+    COMP_KEY=9
+    COMP_TYPE=64
 
-contains "['spack', '-d', 'install', '']" _pretty_print COMP_WORDS[@]
+    _bash_completion_spack
+    contains "--all-help" echo "${COMPREPLY[@]}"
 
-# Set the rest of the intermediate variables manually
-COMP_WORDS_NO_FLAGS=(spack install)
-COMP_CWORD_NO_FLAGS=1
-subfunction=_spack
-cur=
+    contains "['spack', '-d', 'install', '']" _pretty_print COMP_WORDS[@]
 
-list_options=true
-contains "'True'" _test_vars
-list_options=false
-contains "'False'" _test_vars
+    # Set the rest of the intermediate variables manually
+    COMP_WORDS_NO_FLAGS=(spack install)
+    COMP_CWORD_NO_FLAGS=1
+    subfunction=_spack
+    cur=
+
+    list_options=true
+    contains "'True'" _test_vars
+    list_options=false
+    contains "'False'" _test_vars
+}
+_test_debug_functions

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -31,13 +31,18 @@ title "Testing spack-completion.$_sp_shell with $_sp_shell"
 succeeds which spack
 
 title 'Testing all subcommands'
-while IFS= read -r line
+# read line into an array portably
+READ="read -ra line"
+if [ -n "${ZSH_VERSION:-}" ]; then
+  READ=(read -rA line)
+fi
+while IFS=' ' $READ
 do
     # Test that completion with no args works
-    succeeds _spack_completions ${line[*]} ''
+    succeeds _spack_completions "${line[@]}" ''
 
     # Test that completion with flags works
-    contains '-h --help' _spack_completions ${line[*]} -
+    contains '-h --help' _spack_completions "${line[@]}" -
 done <<- EOF
     $(spack commands --aliases --format=subcommands)
 EOF

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -43,6 +43,7 @@ fi
 
 # Run the test scripts for their output (these will print nicely)
 zsh  "$QA_DIR/setup-env-test.sh"
+zsh "$QA_DIR/completion-test.sh"
 dash "$QA_DIR/setup-env-test.sh"
 
 # Run fish tests

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -371,7 +371,7 @@ _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"
 
 # Add programmable tab completion for Bash
 #
-if [ "$_sp_shell" = bash ]; then
+if test "$_sp_shell" = bash || test -n "${ZSH_VERSION:-}"; then
     source $_sp_share_dir/spack-completion.bash
 fi
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -37,6 +37,17 @@
 #
 # See `man bash` for more details.
 
+if test -n "${ZSH_VERSION:-}" ; then
+  if [[ "$(emulate)" = zsh ]] ; then
+    # ensure base completion support is enabled
+    autoload -U +X compinit && compinit
+    # ensure bash compatible completion support is enabled
+    autoload -U +X bashcompinit && bashcompinit
+    emulate sh -c "source '$0:A'"
+    return # stop interpreting file
+  fi
+fi
+
 # Bash programmable completion for Spack
 _bash_completion_spack() {
     # In all following examples, let the cursor be denoted by brackets, i.e. []
@@ -117,7 +128,9 @@ _bash_completion_spack() {
     #_test_vars >> temp
 
     # Make sure function exists before calling it
-    if [[ "$(type $subfunction)" =~ "$subfunction.*function.*" ]]
+    local rgx #this dance is necessary to cover bash and zsh regex
+    rgx="$subfunction.*function.* "
+    if [[ "$(type $subfunction 2>&1)" =~ $rgx ]]
     then
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))
@@ -310,6 +323,7 @@ complete -o bashdefault -o default -F _bash_completion_spack spacktivate
 _spacktivate() {
   _spack_env_activate
 }
+
 
 # Spack commands
 #
@@ -1771,3 +1785,4 @@ _spack_view_check() {
         _all_packages
     fi
 }
+

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -117,7 +117,7 @@ _bash_completion_spack() {
     #_test_vars >> temp
 
     # Make sure function exists before calling it
-    if [[ "$(type -t $subfunction)" == "function" ]]
+    if [[ "$(type $subfunction)" =~ "$subfunction.*function.*" ]]
     then
         $subfunction
         COMPREPLY=($(compgen -W "$SPACK_COMPREPLY" -- "$cur"))

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -324,7 +324,6 @@ _spacktivate() {
   _spack_env_activate
 }
 
-
 # Spack commands
 #
 # Everything below here is auto-generated.
@@ -1785,4 +1784,3 @@ _spack_view_check() {
         _all_packages
     fi
 }
-

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -39,8 +39,8 @@
 
 if test -n "${ZSH_VERSION:-}" ; then
   if [[ "$(emulate)" = zsh ]] ; then
-    # ensure base completion support is enabled
-    autoload -U +X compinit && compinit
+    # ensure base completion support is enabled, ignore insecure directories
+    autoload -U +X compinit && compinit -i
     # ensure bash compatible completion support is enabled
     autoload -U +X bashcompinit && bashcompinit
     emulate sh -c "source '$0:A'"


### PR DESCRIPTION
Since zsh can load bash completion files natively, seems reasonable to just turn this on.  The only changes are to switch from `type -t` which zsh doesn't support to using `type` with a regex and adding a new arm to the sourcing of the completions to allow it to work for zsh as well as bash.

Could use more bash/dash/etc testing probably, but everything I've thought to try has worked so far.