### PR TITLE
support strict version inequalities in specs

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -38,45 +38,40 @@ class Token(object):
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
-    def __init__(self, lexicon0, mode_switches_01=[],
-                 lexicon1=[], mode_switches_10=[]):
-        self.scanner0 = re.Scanner(lexicon0)
-        self.mode_switches_01 = mode_switches_01
-        self.scanner1 = re.Scanner(lexicon1)
-        self.mode_switches_10 = mode_switches_10
+    def __init__(self, lexicon_and_mode_switches):
+        self.scanners = []
+        self.switchbook = []
+        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners.append(re.Scanner(lexicon))
+            self.switchbook.append(mode_switches_dict)
+
         self.mode = 0
 
     def token(self, type, value=''):
-        if self.mode == 0:
-            return Token(type, value,
-                         self.scanner0.match.start(0),
-                         self.scanner0.match.end(0))
-        else:
-            return Token(type, value,
-                         self.scanner1.match.start(0),
-                         self.scanner1.match.end(0))
+        cur_scanner = self.scanners[self.mode]
+        return Token(type, value,
+                     cur_scanner.match.start(0),
+                     cur_scanner.match.end(0))
 
     def lex_word(self, word):
-        scanner = self.scanner0
-        mode_switches = self.mode_switches_01
-        if self.mode == 1:
-            scanner = self.scanner1
-            mode_switches = self.mode_switches_10
+        scanner = self.scanners[self.mode]
+        mode_switches_dict = self.switchbook[self.mode]
 
         tokens, remainder = scanner.scan(word)
-        remainder_used = 0
+        remainder_was_used = False
 
         for i, t in enumerate(tokens):
-            if t.type in mode_switches:
-                # Combine post-switch tokens with remainder and
-                # scan in other mode
-                self.mode = 1 - self.mode  # swap 0/1
-                remainder_used = 1
-                tokens = tokens[:i + 1] + self.lex_word(
-                    word[word.index(t.value) + len(t.value):])
-                break
+            for other_mode, mode_switches in mode_switches_dict.items():
+                if t.type in mode_switches:
+                    # Combine post-switch tokens with remainder and
+                    # scan in other mode
+                    self.mode = other_mode  # swap 0/1
+                    remainder_was_used = True
+                    tokens = tokens[:i + 1] + self.lex_word(
+                        word[word.index(t.value) + len(t.value):])
+                    break
 
-        if remainder and not remainder_used:
+        if remainder and not remainder_was_used:
             raise LexError("Invalid character", word, word.index(remainder))
 
         return tokens
@@ -166,7 +161,6 @@ class LexError(ParseError):
     """Raised when we don't know how to lex something."""
 
     def __init__(self, message, string, pos):
-        whole_word = string
         bad_char = string[pos]
         printed = dedent("""\
         {0}: '{1}'

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import sys
 import itertools
+from textwrap import dedent
 from six import string_types
 
 import spack.error
@@ -153,7 +154,7 @@ class Parser(object):
 
 
 class ParseError(spack.error.SpackError):
-    """Raised when we don't hit an error while parsing."""
+    """Raised when we hit an error while parsing."""
 
     def __init__(self, message, string, pos):
         super(ParseError, self).__init__(message)
@@ -165,4 +166,12 @@ class LexError(ParseError):
     """Raised when we don't know how to lex something."""
 
     def __init__(self, message, string, pos):
-        super(LexError, self).__init__(message, string, pos)
+        whole_word = string
+        bad_char = string[pos]
+        printed = dedent("""\
+        {0}: '{1}'
+        -------
+        {2}
+        {3}^
+        """).format(message, bad_char, string, pos * ' ')
+        super(LexError, self).__init__(printed, string, pos)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -177,7 +177,7 @@ _separators = '[\\%s]' % '\\'.join(color_formats.keys())
 
 #: Versionlist constant so we don't have to build a list
 #: every time we call str()
-_any_version = vn.VersionList([':'])
+_any_version = vn.VersionList.parse(':')
 
 default_format = '{name}{@version}'
 default_format += '{%compiler.name}{@compiler.version}{compiler_flags}'

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4348,9 +4348,9 @@ class LazySpecCache(collections.defaultdict):
 
 #: These are possible token types in the spec grammar.
 (
-    HASH, DEP, AT, ID, COLON, COMMA, ON, OFF, PCT, EQ, VAL, FILE, LT_COLON, GT_COLON, LT_GT_COLON,
-    ID,
-) = range(16)
+    HASH, DEP, AT, ID, COLON, COMMA, ON, OFF, PCT, EQ, VAL, FILE, LT_COLON, GT_COLON,
+    LT_GT_COLON,
+) = range(15)
 
 # NB: `spec_id_re` currently contains a literal `*` to match against, because
 # we use that same regex for matching version strings, and we want to support
@@ -4684,7 +4684,6 @@ class SpecParser(spack.parse.Parser):
 
             # @:!1.2.3!: (@!=1.2.3) (not equal to)
             if self.accept(GT_COLON):
-                r_op = self.token.value
                 return vn.VersionRange(
                     end, end,
                     includes_left_endpoint=False,
@@ -4735,7 +4734,6 @@ class SpecParser(spack.parse.Parser):
 
             # @1.2.3!:!1.2.3
             if self.accept(LT_GT_COLON):
-                r_op = self.token.value
                 assert self.accept(ID)
                 end = self.token.value
                 return vn.VersionRange(
@@ -4746,7 +4744,6 @@ class SpecParser(spack.parse.Parser):
 
             # @1.2.3:!1.2.3
             if self.accept(LT_COLON):
-                r_op = self.token.value
                 assert self.accept(ID)
                 end = self.token.value
                 return vn.VersionRange(
@@ -4757,7 +4754,6 @@ class SpecParser(spack.parse.Parser):
 
             # @1.2.3!:(1.2.3 | \epsilon)
             if self.accept(GT_COLON):
-                r_op = self.token.value
                 # @1.2.3!:1.2.3
                 if self.accept(ID):
                     end = self.token.value
@@ -4775,7 +4771,6 @@ class SpecParser(spack.parse.Parser):
 
             # @1.2.3:( 1.2.3 | \epsilon )
             if self.accept(COLON):
-                r_op = self.token.value
                 if self.accept(ID):
                     if self.next and self.next.type is EQ:
                         # This is a start: range followed by a key=value pair
@@ -4796,7 +4791,6 @@ class SpecParser(spack.parse.Parser):
             # No colon and no id: invalid version.
             self.next_token_error("Invalid version specifier")
 
-        description = (start or '') + op + (end or '')
         if start:
             start = vn.Version(start)
         if end:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4684,11 +4684,7 @@ class SpecParser(spack.parse.Parser):
 
             # @:!1.2.3!: (@!=1.2.3) (not equal to)
             if self.accept(GT_COLON):
-                return vn.VersionRange(
-                    end, end,
-                    includes_left_endpoint=False,
-                    includes_right_endpoint=False,
-                )
+                return vn.VersionRange.from_single_version(end.negated())
 
             # @:!1.2.3: => @: (all versions, which is often unexpected)
             if self.accept(COLON):
@@ -4697,11 +4693,7 @@ class SpecParser(spack.parse.Parser):
                     "A @:!{0}: is the same as @: (all versions)!".format(end))
 
             # @:!1.2.3 => @<1.2.3
-            return vn.VersionRange(
-                None, end,
-                includes_left_endpoint=True,
-                includes_right_endpoint=False,
-            )
+            return vn.VersionRange(start=vn.Version.wildcard(), end=end.negated())
 
         # @:( \epsilon | 1.2.3( !: | : | \epsilon ))
         if self.accept(COLON):
@@ -4722,11 +4714,7 @@ class SpecParser(spack.parse.Parser):
                     "A @:{0}: is the same as @: (all versions)!".format(end))
 
             # @:1.2.3 \epsilon => @<=1.2.3
-            return vn.VersionRange(
-                None, end,
-                includes_left_endpoint=True,
-                includes_right_endpoint=True,
-            )
+            return vn.VersionRange(start=vn.Version.wildcard(), end=end)
 
         # @1.2.3( !:!1.2.3 | :!1.2.3 | !:1.2.3 | !: | :1.2.3 | : | \epsilon )
         if self.accept(ID):
@@ -4736,38 +4724,22 @@ class SpecParser(spack.parse.Parser):
             if self.accept(LT_GT_COLON):
                 assert self.accept(ID)
                 end = self.token.value
-                return vn.VersionRange(
-                    start, end,
-                    includes_left_endpoint=False,
-                    includes_right_endpoint=False,
-                )
+                return vn.VersionRange(start=start.negated(), end=end.negated())
 
             # @1.2.3:!1.2.3
             if self.accept(LT_COLON):
                 assert self.accept(ID)
                 end = self.token.value
-                return vn.VersionRange(
-                    start, end,
-                    includes_left_endpoint=True,
-                    includes_right_endpoint=False,
-                )
+                return vn.VersionRange(start=start, end=end.negated())
 
             # @1.2.3!:(1.2.3 | \epsilon)
             if self.accept(GT_COLON):
                 # @1.2.3!:1.2.3
                 if self.accept(ID):
                     end = self.token.value
-                    return vn.VersionRange(
-                        start, end,
-                        includes_left_endpoint=False,
-                        includes_right_endpoint=True,
-                    )
+                    return vn.VersionRange(start=start.negated(), end=end)
                 # @1.2.3!:
-                return vn.VersionRange(
-                    start, None,
-                    includes_left_endpoint=False,
-                    includes_right_endpoint=True,
-                )
+                return vn.VersionRange(start=start.negated(), end=Version.wildcard())
 
             # @1.2.3:( 1.2.3 | \epsilon )
             if self.accept(COLON):
@@ -4777,11 +4749,7 @@ class SpecParser(spack.parse.Parser):
                         self.push_tokens([self.token])
                     else:
                         end = self.token.value
-                return vn.VersionRange(
-                    start, end,
-                    includes_left_endpoint=True,
-                    includes_right_endpoint=True,
-                )
+                return vn.VersionRange(start=start, end=end)
 
         if start:
             # No colon, but there was a version.
@@ -4795,11 +4763,7 @@ class SpecParser(spack.parse.Parser):
             start = vn.Version(start)
         if end:
             end = vn.Version(end)
-        return vn.VersionRange(
-            start, end,
-            includes_left_endpoint=True,
-            includes_right_endpoint=True,
-        )
+        return vn.VersionRange(start=start, end=end)
 
     def version_list(self):
         vlist = []

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -829,20 +829,3 @@ class TestSpecSyntax(object):
         for a, b in itertools.product(specs, repeat=2):
             # Check that we can compare without raising an error
             assert a <= b or b < a
-
-    @pytest.mark.parametrize('canonical_form,spec_string', [
-        ('@:!2', '@<2'),
-        ('@2!:', '@>2'),
-        ('@:2', '@<=2'),
-        ('@2:', '@>=2'),
-        ('@2', '@==2'),
-        ('@2:!3', '@==2.*'),
-        ('@2:!3', '@2.*'),
-        ('@2:!3+a', '@2.*+a'),
-        ('@:!2,3:', '@!=2.*'),
-        ('@2!:!4', '@2!:!4'),
-    ])
-    def test_version_inequalities_canonicalization(
-        self, canonical_form, spec_string,
-    ):
-        self.check_parse(canonical_form, spec_string)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -829,3 +829,20 @@ class TestSpecSyntax(object):
         for a, b in itertools.product(specs, repeat=2):
             # Check that we can compare without raising an error
             assert a <= b or b < a
+
+    @pytest.mark.parametrize('canonical_form,spec_string', [
+        ('@:!2', '@<2'),
+        ('@2!:', '@>2'),
+        ('@:2', '@<=2'),
+        ('@2:', '@>=2'),
+        ('@2', '@==2'),
+        ('@2:!3', '@==2.*'),
+        ('@2:!3', '@2.*'),
+        ('@2:!3+a', '@2.*+a'),
+        ('@:!2,3:', '@!=2.*'),
+        ('@2!:!4', '@2!:!4'),
+    ])
+    def test_version_inequalities_canonicalization(
+        self, canonical_form, spec_string,
+    ):
+        self.check_parse(canonical_form, spec_string)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -9,7 +9,7 @@ where it makes sense.
 """
 import pytest
 
-from spack.version import Version, VersionList, ver
+from spack.version import Version, VersionList, VersionRange, ver
 
 
 def assert_ver_lt(a, b):
@@ -257,6 +257,27 @@ def test_version_ranges():
 
     assert_ver_lt('1.2:1.4', '1.5:1.6')
     assert_ver_gt('1.5:1.6', '1.2:1.4')
+
+    assert_in('1.5', VersionRange('1.5', '1.6'))
+    assert_in('1.6', VersionRange('1.5', '1.6'))
+
+    assert VersionRange('1.5', '1.6') not in VersionRange('1.5', '1.6',
+                                                          includes_right_endpoint=False)
+    assert VersionRange('1.5', '1.6') not in VersionRange('1.5', '1.6',
+                                                          includes_left_endpoint=False)
+    assert VersionRange('1.5', '1.6') < VersionRange('1.5', '1.6',
+                                                     includes_right_endpoint=False)
+    assert VersionRange('1.5', '1.6') < VersionRange('1.5', '1.6',
+                                                     includes_left_endpoint=False)
+
+    assert_in('1.5', VersionRange('1.5', '1.6',
+                                  includes_right_endpoint=False))
+    assert_not_in('1.6', VersionRange('1.5', '1.6',
+                                      includes_right_endpoint=False))
+    assert_not_in('1.5', VersionRange('1.5', '1.6',
+                                      includes_left_endpoint=False))
+    assert_in('1.6', VersionRange('1.5', '1.6',
+                                  includes_left_endpoint=False))
 
 
 def test_contains():
@@ -562,3 +583,12 @@ def test_list_highest():
     assert vl2.highest_numeric() is None
     assert vl2.preferred() == Version('develop')
     assert vl2.lowest() == Version('master')
+
+
+def test_strict_inequalities():
+    assert Version('2') < Version('>2')
+    assert Version('<2') < Version('2')
+    assert ver('2') < ver('2.*')
+    assert ver('2.*') in ver('2')
+    assert ver('3') not in ver('2.*')
+    assert ver('2') in ver('2.*')

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -586,9 +586,38 @@ def test_list_highest():
 
 
 def test_strict_inequalities():
-    assert Version('2') < Version('>2')
-    assert Version('<2') < Version('2')
-    assert ver('2') < ver('2.*')
-    assert ver('2.*') in ver('2')
-    assert ver('3') not in ver('2.*')
-    assert ver('2') in ver('2.*')
+    # (0) !2 => :!2!:
+    assert Version('2') < Version('2').negated()
+    assert Version('2').negated() < Version('2')
+    assert Version('2').negated() > Version('2')
+    assert Version('2').negated() != Version('2')
+    assert Version('2').negated() != Version('2.1')
+    assert Version('2') not in Version('2').negated()
+    assert Version('3') in Version('2').negated()
+
+    # (1) 2:!3
+    assert Version('2') < ver('2:!3')
+    assert Version('3') > ver('2:!3')
+
+    assert ver('2:!3') in Version('2')
+    assert ver('2:!3') not in Version('3')
+    assert Version('3') not in ver('2:!3')
+    assert Version('2') in ver('2:!3')
+
+    # (2) 2!:3
+    assert Version('2') < ver('2!:3')
+    assert Version('3') > ver('2!:3')
+
+    assert ver('2!:3') not in Version('2')
+    assert ver('2!:3') in Version('3')
+    assert Version('3') in ver('2!:3')
+    assert Version('2') not in ver('2!:3')
+
+    # (3) 2!:!3
+    assert Version('2') < ver('2!:!3')
+    assert Version('3') > ver('2!:!3')
+
+    assert ver('2!:!3') in Version('2')
+    assert ver('2!:!3') not in Version('3')
+    assert Version('3') not in ver('2!:!3')
+    assert Version('2') not in ver('2!:!3')

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -261,23 +261,15 @@ def test_version_ranges():
     assert_in('1.5', VersionRange('1.5', '1.6'))
     assert_in('1.6', VersionRange('1.5', '1.6'))
 
-    assert VersionRange('1.5', '1.6') not in VersionRange('1.5', '1.6',
-                                                          includes_right_endpoint=False)
-    assert VersionRange('1.5', '1.6') not in VersionRange('1.5', '1.6',
-                                                          includes_left_endpoint=False)
-    assert VersionRange('1.5', '1.6') < VersionRange('1.5', '1.6',
-                                                     includes_right_endpoint=False)
-    assert VersionRange('1.5', '1.6') < VersionRange('1.5', '1.6',
-                                                     includes_left_endpoint=False)
+    assert VersionRange.parse('1.5:1.6') not in VersionRange.parse('1.5:!1.6')
+    assert VersionRange.parse('1.5:1.6') not in VersionRange.parse('1.5!:1.6')
+    assert VersionRange.parse('1.5:1.6') < VersionRange.parse('1.5:!1.6')
+    assert VersionRange.parse('1.5:1.6') < VersionRange.parse('1.5!:1.6')
 
-    assert_in('1.5', VersionRange('1.5', '1.6',
-                                  includes_right_endpoint=False))
-    assert_not_in('1.6', VersionRange('1.5', '1.6',
-                                      includes_right_endpoint=False))
-    assert_not_in('1.5', VersionRange('1.5', '1.6',
-                                      includes_left_endpoint=False))
-    assert_in('1.6', VersionRange('1.5', '1.6',
-                                  includes_left_endpoint=False))
+    assert_in('1.5', VersionRange.parse('1.5:!1.6'))
+    assert_not_in('1.6', VersionRange.parse('1.5:!1.6'))
+    assert_not_in('1.5', VersionRange.parse('1.5!:1.6'))
+    assert_in('1.6', VersionRange.parse('1.5!:1.6'))
 
 
 def test_contains():

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -25,10 +25,15 @@ be called on any of the types::
   concrete
 """
 import re
-import numbers
+from abc import ABCMeta, abstractmethod, abstractproperty
 from bisect import bisect_left
 from functools import wraps
-from six import string_types
+from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, Iterator, List, Optional, Tuple, Type, TypeVar, Union, cast  # novm
+from typing import overload
+
+from six import add_metaclass, string_types
+
+from llnl.util.lang import memoized
 
 import spack.error
 from spack.util.spack_yaml import syaml_dict
@@ -47,6 +52,7 @@ infinity_versions = ['develop', 'main', 'master', 'head', 'trunk']
 
 
 def int_if_int(string):
+    # type: (str) -> Union[str, int]
     """Convert a string to int if possible.  Otherwise, return a string."""
     try:
         return int(string)
@@ -55,72 +61,233 @@ def int_if_int(string):
 
 
 def coerce_versions(a, b):
+    # type: (Any, Any) -> Tuple[Any, Any]
     """
     Convert both a and b to the 'greatest' type between them, in this order:
            Version < VersionRange < VersionList
     This is used to simplify comparison operations below so that we're always
     comparing things that are of the same type.
     """
-    order = (Version, VersionRange, VersionList)
+    order = (UnsignedVersion, WildcardVersion, Version, VersionRange, VersionList)
     ta, tb = type(a), type(b)
 
     def check_type(t):
+        # type: (Type) -> None
         if t not in order:
-            raise TypeError("coerce_versions cannot be called on %s" % t)
+            raise TypeError(
+                "coerce_versions cannot be called on {0}: need one of {1}"
+                .format(t, order))
     check_type(ta)
     check_type(tb)
 
     if ta == tb:
         return (a, b)
-    elif order.index(ta) > order.index(tb):
+    if order.index(ta) > order.index(tb):
+        if ta == WildcardVersion:
+            assert isinstance(b, UnsignedVersion), b
+            return (a, b)
         if ta == VersionRange:
             assert isinstance(b, Version), b
-            return (a, VersionRange(b, b))
-        else:
-            assert isinstance(b, (Version, VersionRange)), b
-            return (a, VersionList([b]))
-    else:
-        if tb == VersionRange:
-            return (VersionRange(a, a), b)
-        else:
-            return (VersionList([a]), b)
+            return (a, VersionRange.from_single_version(b))
+        assert isinstance(b, (Version, VersionRange)), b
+        return (a, VersionList.from_version_or_range(b))
+    return coerce_versions(b, a)
 
 
-def coerced(method):
-    """Decorator that ensures that argument types of a method are coerced."""
+def _coercing_factory(method, coerce_logic=False):
     @wraps(method)
     def coercing_method(a, b, *args, **kwargs):
-        if type(a) == type(b) or a is None or b is None:
+        assert a is not None, a
+        if coerce_logic and b is None:
+            return False
+        if type(a) == type(b) or b is None:
             return method(a, b, *args, **kwargs)
-        else:
-            ca, cb = coerce_versions(a, b)
-            return getattr(ca, method.__name__)(cb, *args, **kwargs)
+        ca, cb = coerce_versions(a, b)
+        return getattr(ca, method.__name__)(cb, *args, **kwargs)
     return coercing_method
 
 
-class Version(object):
-    """Class to represent versions"""
+_T = TypeVar('_T', bound='Span')
+_U = TypeVar('_U')
 
-    def __init__(self, string):
-        if not isinstance(string, str):
-            string = str(string)
 
-        if not VALID_VERSION.match(string):
-            raise ValueError("Bad characters in version string: %s" % string)
+def coerced(
+        method                       # type: Callable[[_T, _T], _U]
+):
+    # type: (...) -> Callable[[Span[_T], Span[_T]], _U]
+    """Decorator that ensures that argument types of a method are coerced with
+    `coerce_versions()`."""
+    return cast('Callable[[Span[_T], Optional[Span[_T]]], _U]',
+                _coercing_factory(method, coerce_logic=False))
 
-        # preserve the original string, but trimmed.
-        string = string.strip()
-        self.string = string
 
-        # Split version into alphabetical and numeric segments
-        segments = SEGMENT_REGEX.findall(string)
-        self.version = tuple(int_if_int(seg) for seg in segments)
+def coerced_logic(
+        method                                          # type: Callable[[_T, _U], bool]
+):
+    # type: (...) -> Callable[[_T, _U], bool]
+    """Decorator that ensures that argument types of a method are coerced with
+    `coerce_versions()`, and also returns False when the argument is None."""
+    return cast('Callable[[Span[_T], Optional[_U]], bool]',
+                _coercing_factory(method, coerce_logic=True))
 
-        # Store the separators from the original version string as well.
-        self.separators = tuple(SEGMENT_REGEX.split(string)[1:])
+
+def coerced_equals(
+        method                                         # type: Callable[[_T, Any], bool]
+):
+    # type: (...) -> Callable[[Span[_T], Any], bool]
+    """Decorator that ensures that argument types of a method are coerced with
+    `coerce_versions()`, and also returns False when the argument is None."""
+    return cast('Callable[[Span[_T], Any], bool]',
+                _coercing_factory(method, coerce_logic=True))
+
+
+@add_metaclass(ABCMeta)
+class Span(Generic[_T]):
+    """A class that spans some range of versions in some complicated way."""
+
+    @abstractmethod
+    def satisfies(self, other):
+        # type: (_T) -> bool
+        """Return whether any versions matched by this object match `other`."""
+
+    @abstractmethod
+    def overlaps(self, other):
+        # type: (_T) -> bool
+        """Return whether any versions matched by this object match `other`.
+
+        In the case where a Version contains another Version (e.g. '1.1' contains '1'),
+        .overlaps() will return False, while .satisfies() will return True.
+        """
+
+    @abstractmethod
+    def __contains__(self, other):
+        # type: (_T) -> bool
+        """Return whether all versions matched by this object match `other`."""
+
+    @abstractmethod
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        """Return whether `other` matches all the same versions."""
+
+    @abstractmethod
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        pass
+
+    @abstractmethod
+    def __lt__(self, other):
+        # type: (_T) -> bool
+        """Return whether this contains a version lower than anything in `other`."""
+
+    @abstractmethod
+    def __le__(self, other):
+        # type: (_T) -> bool
+        pass
+
+    @abstractmethod
+    def __gt__(self, other):
+        # type: (_T) -> bool
+        """Return whether this contains a version greater than anything in `other`."""
+
+    @abstractmethod
+    def __ge__(self, other):
+        # type: (_T) -> bool
+        pass
+
+    @abstractmethod
+    def __hash__(self):
+        # type: () -> int
+        pass
+
+    @abstractmethod
+    def __str__(self):
+        # type: () -> str
+        """Return a string which returns the original object from .parse()."""
+
+    def __format__(self, format_spec):
+        # type: (str) -> str
+        return str(self).format(format_spec)
+
+
+class VersionPredicate(Span[_T]):
+    """All top-level version-like objects will subclass this."""
+    @classmethod
+    @abstractmethod
+    def parse(cls, string):
+        # type: (str) -> _T
+        """Parse a VersionPredicate object from a string."""
+
+    def __repr__(self):
+        # type: () -> str
+        return '{0}.parse({1!r})'.format(
+            type(self).__name__,
+            str(self),
+        )
+
+    def copy(self):
+        # type: () -> _T
+        """Return a newly allocated object matching the same versions as this object."""
+
+    @abstractmethod
+    def lowest(self):
+        # type: () -> Optional[Version]
+        """Return the lowest version this object matches."""
+
+    @abstractmethod
+    def highest(self):
+        # type: () -> Optional[Version]
+        """Return the highest version this object matches."""
+
+    @abstractproperty
+    def concrete(self):
+        # type: () -> Optional[Version]
+        """If this points to exactly one Version, return it."""
+
+    @abstractmethod
+    def union(self, other):
+        # type: (VersionPredicate) -> VersionPredicate
+        """Return a VersionPredicate matching the union of two of this class."""
+
+    @abstractmethod
+    def intersection(self, other):
+        # type: (VersionPredicate) -> VersionPredicate
+        """Return a VersionPredicate matching the intersection of two of this class."""
+
+
+@add_metaclass(ABCMeta)
+class VersionInterface(Generic[_T]):
+    @abstractmethod
+    def is_predecessor(self, other):
+        # type: (_T) -> bool
+        """True if the other version is the immediate predecessor of this one.
+           That is, NO versions v exist such that:
+           (self < v < other and v not in self).
+        """
+
+    @abstractmethod
+    def is_successor(self, other):
+        # type: (_T) -> bool
+        """Opposite of .is_predecessor()."""
+
+    @abstractproperty
+    def concrete_version(self):
+        # type: () -> Optional[UnsignedVersion]
+        pass
 
     @property
+    def is_wildcard(self):
+        # type: () -> bool
+        return self.concrete_version is None
+
+
+_V = TypeVar('_V', bound='VersionOperations')
+
+
+@add_metaclass(ABCMeta)
+class VersionOperations(Generic[_V]):
+    @abstractproperty
     def dotted(self):
+        # type: () -> _V
         """The dotted representation of the version.
 
         Example:
@@ -131,10 +298,10 @@ class Version(object):
         Returns:
             Version: The version with separator characters replaced by dots
         """
-        return Version(self.string.replace('-', '.').replace('_', '.'))
 
-    @property
+    @abstractproperty
     def underscored(self):
+        # type: () -> _V
         """The underscored representation of the version.
 
         Example:
@@ -146,10 +313,10 @@ class Version(object):
             Version: The version with separator characters replaced by
                 underscores
         """
-        return Version(self.string.replace('.', '_').replace('-', '_'))
 
-    @property
+    @abstractproperty
     def dashed(self):
+        # type: () -> _V
         """The dashed representation of the version.
 
         Example:
@@ -160,10 +327,10 @@ class Version(object):
         Returns:
             Version: The version with separator characters replaced by dashes
         """
-        return Version(self.string.replace('.', '-').replace('_', '-'))
 
-    @property
+    @abstractproperty
     def joined(self):
+        # type: () -> _V
         """The joined representation of the version.
 
         Example:
@@ -174,10 +341,10 @@ class Version(object):
         Returns:
             Version: The version with separator characters removed
         """
-        return Version(
-            self.string.replace('.', '').replace('-', '').replace('_', ''))
 
+    @abstractmethod
     def up_to(self, index):
+        # type: (int) -> _V
         """The version up to the specified component.
 
         Examples:
@@ -200,25 +367,319 @@ class Version(object):
         Returns:
             Version: The first index components of the version
         """
-        return self[:index]
 
-    def lowest(self):
+    @abstractmethod
+    def __len__(self):
+        # type: () -> int
+        """Return the number of components in this version."""
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (int) -> Union[str, int]
+        pass
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (slice) -> _V
+        pass
+
+    @abstractmethod
+    def __getitem__(self, idx):
+        # type: (Union[int, slice]) -> Union[str, int, _V]
+        """Return a prefix of this version."""
+
+    @abstractmethod
+    def isdevelop(self):
+        # type: () -> bool
+        """Triggers on the special case of the `@develop-like` version."""
+
+
+class WildcardVersion(
+        Span[VersionInterface],                             # type: ignore[type-var]
+        VersionInterface[VersionInterface],                 # type: ignore[type-var]
+):
+    @property
+    def concrete_version(self):
+        # type: () -> Optional[UnsignedVersion]
+        return None
+
+    @coerced_logic
+    def is_predecessor(self, other):                  # type: ignore[override]
+        # type: (VersionInterface) -> bool
+        return other.is_wildcard
+
+    @coerced_logic
+    def is_successor(self, other):                    # type: ignore[override]
+        # type: (VersionInterface) -> bool
+        return other.is_wildcard
+
+    def satisfies(self, other):
+        # type: (VersionInterface) -> bool
+        return True
+
+    def overlaps(self, other):
+        # type: (VersionInterface) -> bool
+        return True
+
+    def __contains__(self, other):
+        # type: (VersionInterface) -> bool
+        return True
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, VersionInterface):
+            return NotImplemented
+        return other.is_wildcard
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, VersionInterface):
+            return NotImplemented
+        return not self == other
+
+    def __lt__(self, other):
+        # type: (VersionInterface) -> bool
+        if self == other:
+            return False
+        return True
+
+    def __le__(self, other):
+        # type: (VersionInterface) -> bool
+        return self == other or self < other
+
+    def __gt__(self, other):
+        # type: (VersionInterface) -> bool
+        if self == other:
+            return False
+        return True
+
+    def __ge__(self, other):
+        # type: (VersionInterface) -> bool
+        return self == other or self > other
+
+    def __hash__(self):
+        # type: () -> int
+        return hash(str(self))
+
+    def __str__(self):
+        # type: () -> str
+        return '*'
+
+
+class UnsignedVersion(
+        Span['UnsignedVersion'],
+        VersionOperations['UnsignedVersion'],
+        VersionInterface['UnsignedVersion'],
+):
+    """Class to represent versions"""
+
+    _all_separators = frozenset(['.', '_', '-'])        # type: ClassVar[FrozenSet[str]]
+
+    string = None                                    # type: str
+    version = None                                   # type: Tuple[Union[str, int], ...]
+    separators = None                                # type: Tuple[str, ...]
+
+    def _coerced_separators(self, sep):
+        # type: (str) -> str
+        assert sep in type(self)._all_separators, (sep, type(self._all_separators))
+        rest = type(self)._all_separators - set([sep])
+        assert len(rest) == (len(type(self)._all_separators) - 1), rest
+        string = self.string
+        for s in rest:
+            string = string.replace(s, sep)
+        return string
+
+    def _joined_separators(self):
+        # type: () -> str
+        string = self.string
+        for sep in type(self)._all_separators:
+            string = string.replace(sep, '')
+        return string
+
+    def __init__(self, string):
+        # type: (Any) -> None
+        if not isinstance(string, str):
+            string = str(string)
+
+        if not VALID_VERSION.match(string):
+            raise ValueError("Bad characters in version string: %s" % string)
+
+        # preserve the original string, but trimmed.
+        string = string.strip()
+        self.string = string
+
+        # Split version into alphabetical and numeric segments
+        segments = SEGMENT_REGEX.findall(string)
+        self.version = tuple(int_if_int(seg) for seg in segments)
+
+        # Store the separators from the original version string as well.
+        self.separators = tuple(SEGMENT_REGEX.split(string)[1:])
+
+    @property
+    def concrete_version(self):
+        # type: () -> Optional[UnsignedVersion]
         return self
 
-    def highest(self):
-        return self
+    @property
+    def dotted(self):
+        # type: () -> UnsignedVersion
+        """The dotted representation of the version.
+
+        Example:
+        >>> version = Version('1-2-3b')
+        >>> version.dotted
+        Version('1.2.3b')
+
+        Returns:
+            Version: The version with separator characters replaced by dots
+        """
+        return type(self)(self._coerced_separators('.'))
+
+    @property
+    def underscored(self):
+        # type: () -> UnsignedVersion
+        """The underscored representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3b')
+        >>> version.underscored
+        Version('1_2_3b')
+
+        Returns:
+            Version: The version with separator characters replaced by
+                underscores
+        """
+        return type(self)(self._coerced_separators('_'))
+
+    @property
+    def dashed(self):
+        # type: () -> UnsignedVersion
+        """The dashed representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3b')
+        >>> version.dashed
+        Version('1-2-3b')
+
+        Returns:
+            Version: The version with separator characters replaced by dashes
+        """
+        return type(self)(self._coerced_separators('-'))
+
+    @property
+    def joined(self):
+        # type: () -> UnsignedVersion
+        """The joined representation of the version.
+
+        Example:
+        >>> version = Version('1.2.3b')
+        >>> version.joined
+        Version('123b')
+
+        Returns:
+            Version: The version with separator characters removed
+        """
+        return type(self)(self._joined_separators())
+
+    def up_to(self, index):
+        # type: (int) -> UnsignedVersion
+        """The version up to the specified component.
+
+        Examples:
+        >>> version = Version('1.23-4b')
+        >>> version.up_to(1)
+        Version('1')
+        >>> version.up_to(2)
+        Version('1.23')
+        >>> version.up_to(3)
+        Version('1.23-4')
+        >>> version.up_to(4)
+        Version('1.23-4b')
+        >>> version.up_to(-1)
+        Version('1.23-4')
+        >>> version.up_to(-2)
+        Version('1.23')
+        >>> version.up_to(-3)
+        Version('1')
+
+        Returns:
+            Version: The first index components of the version
+        """
+        return cast(UnsignedVersion, self[:index])
+
+    def __iter__(self):
+        # type: () -> Iterator[Union[str, int]]
+        # NB: This does not override anything!
+        return iter(self.version)
+
+    def __len__(self):
+        # type: () -> int
+        return len(self.version)
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (int) -> Union[str, int]
+        pass
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (slice) -> UnsignedVersion
+        pass
+
+    def __getitem__(self, idx):
+        # type: (Union[int, slice]) -> Union[str, int, UnsignedVersion]
+        cls = type(self)
+
+        if isinstance(idx, int):
+            return self.version[idx]
+
+        elif isinstance(idx, slice):
+            string_arg = []  # type: List[str]
+
+            pairs = zip(self.version[idx], self.separators[idx])
+            for token, sep in pairs:
+                string_arg.append(str(token))
+                string_arg.append(str(sep))
+
+            string_arg.pop()  # We don't need the last separator
+            return cls(''.join(string_arg))
+
+        message = '{cls.__name__} indices must be integers'
+        raise TypeError(message.format(cls=cls))
 
     def isdevelop(self):
+        # type: () -> bool
         """Triggers on the special case of the `@develop-like` version."""
         for inf in infinity_versions:
             for v in self.version:
                 if v == inf:
                     return True
-
         return False
 
-    @coerced
+    @coerced_logic
+    def is_predecessor(self, other):
+        # type: (UnsignedVersion) -> bool
+        """True if the other version is the immediate predecessor of this one.
+           That is, NO versions v exist such that:
+           (self < v < other and v not in self).
+        """
+        if len(self.version) != len(other.version):
+            return False
+
+        sl = self.version[-1]
+        ol = other.version[-1]
+        if isinstance(sl, int) and isinstance(ol, int):
+            return ol - sl == 1
+        return False
+
+    @coerced_logic
+    def is_successor(self, other):
+        # type: (UnsignedVersion) -> bool
+        return other.is_predecessor(self)
+
+    @coerced_logic
     def satisfies(self, other):
+        # type: (UnsignedVersion) -> bool
         """A Version 'satisfies' another if it is at least as specific and has
         a common prefix.  e.g., we want gcc@4.7.3 to satisfy a request for
         gcc@4.7 so that when a user asks to build with gcc@4.7, we can find
@@ -227,57 +688,25 @@ class Version(object):
         return ((len(other.version) <= len(self.version)) and
                 (self in other))
 
-    def __iter__(self):
-        return iter(self.version)
+    @coerced_logic
+    def overlaps(self, other):
+        # type: (UnsignedVersion) -> bool
+        return self in other or other in self
 
-    def __len__(self):
-        return len(self.version)
-
-    def __getitem__(self, idx):
-        cls = type(self)
-
-        if isinstance(idx, numbers.Integral):
-            return self.version[idx]
-
-        elif isinstance(idx, slice):
-            string_arg = []
-
-            pairs = zip(self.version[idx], self.separators[idx])
-            for token, sep in pairs:
-                string_arg.append(str(token))
-                string_arg.append(str(sep))
-
-            string_arg.pop()  # We don't need the last separator
-            string_arg = ''.join(string_arg)
-            return cls(string_arg)
-
-        message = '{cls.__name__} indices must be integers'
-        raise TypeError(message.format(cls=cls))
-
-    def __repr__(self):
-        return 'Version(' + repr(self.string) + ')'
-
-    def __str__(self):
-        return self.string
-
-    def __format__(self, format_spec):
-        return self.string.format(format_spec)
-
-    @property
-    def concrete(self):
-        return self
+    @coerced_logic
+    def __contains__(self, other):
+        # type: (UnsignedVersion) -> bool
+        return other.version[:len(self.version)] == self.version
 
     # TODO: consider @memoized since we impl __hash__?
-    @coerced
-    def __lt__(self, other):
+    @coerced_logic
+    def __lt__(self, other):                           # type: ignore[has-type]
+        # type: (UnsignedVersion) -> bool
         """Version comparison is designed for consistency with the way RPM
            does things.  If you need more complicated versions in installed
            packages, you should override your package's version string to
            express it more sensibly.
         """
-        if other is None:
-            return False
-
         # Coerce if other is not a Version
         # simple equality test first.
         if self.version == other.version:
@@ -290,8 +719,8 @@ class Version(object):
             else:
                 if a in infinity_versions:
                     if b in infinity_versions:
-                        return (infinity_versions.index(a) >
-                                infinity_versions.index(b))
+                        return (infinity_versions.index(a) >  # type: ignore[arg-type]
+                                infinity_versions.index(b))   # type: ignore[arg-type]
                     else:
                         return False
                 if b in infinity_versions:
@@ -307,104 +736,349 @@ class Version(object):
                 if type(a) != type(b):
                     return type(b) == int
                 else:
-                    return a < b
+                    return a < b                            # type: ignore[operator]
 
         # If the common prefix is equal, the one
         # with more segments is bigger.
         return len(self.version) < len(other.version)
 
-    @coerced
+    @coerced_equals
     def __eq__(self, other):
-        return (other is not None and
-                type(other) == Version and self.version == other.version)
+        # type: (Any) -> bool
+        if not isinstance(other, UnsignedVersion):
+            return NotImplemented
+        return self.version == other.version
 
-    @coerced
+    @coerced_equals
     def __ne__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, UnsignedVersion):
+            return NotImplemented
         return not (self == other)
 
-    @coerced
-    def __le__(self, other):
+    @coerced_logic
+    def __le__(self, other):                           # type: ignore[has-type]
+        # type: (UnsignedVersion) -> bool
         return self == other or self < other
 
-    @coerced
+    @coerced_logic
     def __ge__(self, other):
+        # type: (UnsignedVersion) -> bool
         return not (self < other)
 
-    @coerced
+    @coerced_logic
     def __gt__(self, other):
+        # type: (UnsignedVersion) -> bool
         return not (self == other) and not (self < other)
 
     def __hash__(self):
+        # type: () -> int
         return hash(self.version)
 
-    @coerced
-    def __contains__(self, other):
-        if other is None:
-            return False
-        return other.version[:len(self.version)] == self.version
+    def __str__(self):
+        # type: () -> str
+        return self.string
 
+
+class Version(
+        VersionPredicate['Version'],
+        VersionOperations['Version'],
+        VersionInterface['Version'],
+):
+    _unsigned_version = None  # type: Union[WildcardVersion, UnsignedVersion]
+    _negate = None            # type: bool
+
+    @classmethod
+    def parse(cls, string):
+        # type: (str) -> Version
+        if string.startswith('!'):
+            string = string[1:]
+            negate = True
+        else:
+            negate = False
+        inner = (WildcardVersion() if string == '*'
+                 else UnsignedVersion(string)
+                 )  # type: Union[WildcardVersion, UnsignedVersion]
+        return cls(inner, negate=negate)
+
+    @classmethod
+    def wildcard(cls):
+        # type: () -> Version
+        return cls(unsigned_version=WildcardVersion(), negate=False)
+
+    def __init__(self, unsigned_version, negate=False):
+        # type: (Union[str, WildcardVersion, UnsignedVersion], bool) -> None
+        if isinstance(unsigned_version, str):
+            unsigned_version = UnsignedVersion(unsigned_version)
+        self._unsigned_version = unsigned_version
+        self._negate = negate
+
+    @property
+    def polarity(self):
+        # type: () -> bool
+        return not self._negate
+
+    @property
+    def unsigned_form(self):
+        # type: () -> Union[WildcardVersion, UnsignedVersion]
+        return self._unsigned_version
+
+    @property
+    def string(self):
+        # type: () -> str
+        return str(self.unsigned_form)
+
+    def _wildcard_defaulted(self, default, fun):
+        # type: (_U, Callable[[UnsignedVersion], _U]) -> _U
+        if self.is_wildcard:
+            return default
+        assert isinstance(self.unsigned_form, UnsignedVersion), self
+        return fun(self.unsigned_form)
+
+    @property
+    def version(self):
+        # type: () -> Tuple[Union[str, int], ...]
+        return self._wildcard_defaulted((), lambda u: u.version)
+
+    @property
+    def separators(self):
+        # type: () -> Tuple[str, ...]
+        return self._wildcard_defaulted((), lambda u: u.separators)
+
+    @property
+    def concrete_version(self):
+        # type: () -> Optional[UnsignedVersion]
+        return self.unsigned_form.concrete_version
+
+    def lowest(self):
+        # type: () -> Optional[Version]
+        if self.is_wildcard:
+            return None
+        return self
+
+    def highest(self):
+        # type: () -> Optional[Version]
+        if self.is_wildcard:
+            return None
+        return self
+
+    @property
+    def concrete(self):
+        # type: () -> Optional[Version]
+        if self.is_wildcard:
+            return None
+        return self
+
+    def _copy(self, unsigned_version):
+        # type: (Union[UnsignedVersion, WildcardVersion]) -> Version
+        return type(self)(unsigned_version=unsigned_version,
+                          negate=self._negate)
+
+    def copy(self):
+        # type: () -> Version
+        return self._copy(self.unsigned_form)
+
+    @property
+    def dotted(self):
+        # type: () -> Version
+        return self._wildcard_defaulted(self, lambda u: self._copy(u.dotted))
+
+    @property
+    def underscored(self):
+        # type: () -> Version
+        return self._wildcard_defaulted(self, lambda u: self._copy(u.underscored))
+
+    @property
+    def dashed(self):
+        # type: () -> Version
+        return self._wildcard_defaulted(self, lambda u: self._copy(u.dashed))
+
+    @property
+    def joined(self):
+        # type: () -> Version
+        return self._wildcard_defaulted(self, lambda u: self._copy(u.joined))
+
+    def up_to(self, index):
+        # type: (int) -> Version
+        return self._wildcard_defaulted(self, lambda u: self._copy(u.up_to(index)))
+
+    def __len__(self):
+        # type: () -> int
+        return self._wildcard_defaulted(0, len)
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (int) -> Union[str, int]
+        pass
+
+    @overload
+    def __getitem__(self, idx):
+        # type: (slice) -> Version
+        pass
+
+    def __getitem__(self, idx):
+        # type: (Union[int, slice]) -> Union[str, int, Version]
+        if self.is_wildcard:
+            if isinstance(idx, int):
+                raise TypeError(
+                    'cannot fetch individual index {0} from wildcard version: {1}'
+                    .format(idx, self))
+            return self
+        assert isinstance(self.unsigned_form, UnsignedVersion), self
+        if isinstance(idx, int):
+            return self.unsigned_form[idx]
+        new_unsigned = self.unsigned_form[idx]
+        assert isinstance(new_unsigned, UnsignedVersion), new_unsigned
+        return self._copy(new_unsigned)
+
+    def isdevelop(self):
+        # type: () -> bool
+        return self._wildcard_defaulted(False, lambda u: u.isdevelop())
+
+    @coerced_logic
     def is_predecessor(self, other):
-        """True if the other version is the immediate predecessor of this one.
-           That is, NO versions v exist such that:
-           (self < v < other and v not in self).
-        """
-        if len(self.version) != len(other.version):
-            return False
+        # type: (Version) -> bool
+        if self.polarity == other.polarity:
+            return self.unsigned_form.is_predecessor(
+                other.unsigned_form)                        # type: ignore[arg-type]
+        if self.polarity:
+            assert not other.polarity
+            return other.unsigned_form in self.unsigned_form  # type: ignore[operator]
+        return False
 
-        sl = self.version[-1]
-        ol = other.version[-1]
-        return type(sl) == int and type(ol) == int and (ol - sl == 1)
-
+    @coerced_logic
     def is_successor(self, other):
-        return other.is_predecessor(self)
+        # type: (Version) -> bool
+        if self.polarity == other.polarity:
+            return self.unsigned_form.is_successor(
+                other.unsigned_form)                        # type: ignore[arg-type]
+        if other.polarity:
+            assert not self.polarity
+            return self.unsigned_form in other.unsigned_form  # type: ignore[operator]
+        return False
 
-    @coerced
+    @coerced_logic
+    def satisfies(self, other):
+        # type: (Version) -> bool
+        return (
+            self.unsigned_form.satisfies(
+                other.unsigned_form) ^                      # type: ignore[arg-type]
+            self.polarity ^ other.polarity)
+
+    @coerced_logic
     def overlaps(self, other):
-        return self in other or other in self
+        # type: (Version) -> bool
+        return (
+            self.unsigned_form.overlaps(
+                other.unsigned_form) ^                      # type: ignore[arg-type]
+            self.polarity ^ other.polarity)
+
+    @coerced_logic
+    def __contains__(self, other):
+        # type: (Version) -> bool
+        return (
+            (other.unsigned_form in self.unsigned_form) ^   # type: ignore[operator]
+            self.polarity ^ other.polarity)
+
+    @coerced_logic
+    def __lt__(self, other):                                # type: ignore[has-type]
+        # type: (Version) -> bool
+        return ((self.unsigned_form < other.unsigned_form) ^
+                self.polarity ^ other.polarity)
+
+    @coerced_equals
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, Version):
+            return NotImplemented
+        return (self.unsigned_form == other.unsigned_form and
+                self.polarity == other.polarity)
+
+    @coerced_equals
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, Version):
+            return NotImplemented
+        return not self == other
+
+    @coerced_logic
+    def __le__(self, other):                                # type: ignore[has-type]
+        # type: (Version) -> bool
+        return self == other or self < other
+
+    @coerced_logic
+    def __ge__(self, other):
+        # type: (Version) -> bool
+        return self == other or self > other
+
+    @coerced_logic
+    def __gt__(self, other):
+        # type: (Version) -> bool
+        return ((self.unsigned_form > other.unsigned_form) ^
+                self.polarity ^ other.polarity)
+
+    def __hash__(self):
+        # type: () -> int
+        return hash((self.unsigned_form, self.polarity))
+
+    def __str__(self):
+        # type: () -> str
+        negated_mark = '!' if self._negate else ''
+        return '{0}{1}'.format(negated_mark, self.unsigned_form)
+
+    def negated(self):
+        # type: () -> Version
+        return type(self)(unsigned_version=self.unsigned_form,
+                          negate=not self._negate)
 
     @coerced
     def union(self, other):
+        # type: (Version) -> VersionPredicate
         if self == other or other in self:
             return self
-        elif self in other:
+        if self in other:
             return other
-        else:
-            return VersionList([self, other])
+        return VersionList([self, other])
 
     @coerced
     def intersection(self, other):
+        # type: (Version) -> VersionPredicate
         if self == other:
             return self
-        else:
-            return VersionList()
+        return VersionList.empty()
 
 
 def _endpoint_only(fun):
+    # type: (Callable[[_VersionEndpoint, _VersionEndpoint], bool]) -> Callable[[_VersionEndpoint, _VersionEndpoint], bool]
     """We want to avoid logic that handles any type of version range, just endpoints."""
     @wraps(fun)
     def validate_endpoint_argument(self, other):
+        # type: (_VersionEndpoint, _VersionEndpoint) -> bool
         assert isinstance(other, _VersionEndpoint), (
             "required two _VersionEndpoint arguments, received {0} and {1}"
             .format(self, other))
-        assert self.location == other.location, (
-            "two _VersionEndpoint arguments with different locations "
-            "is a programming bug: received {0} and {1}".format(self, other))
         return fun(self, other)
     return validate_endpoint_argument
 
 
-class _VersionEndpoint(object):
+class _VersionEndpoint(Span['_VersionEndpoint']):
+    value = None                                            # type: Version
+    location = None                                         # type: str
+    includes_endpoint = None                                # type: bool
 
-    _valid_endpoint_locations = frozenset(['left', 'right'])
+    _valid_endpoint_locations = frozenset([
+        'left', 'right',
+    ])                                                  # type: ClassVar[FrozenSet[str]]
 
     def __init__(self, value, location, includes_endpoint):
-        assert (value is None) or isinstance(value, Version), value
+        # type: (Optional[Version], str, bool) -> None
+        assert isinstance(value, Version), value
         assert location in self._valid_endpoint_locations, location
         assert isinstance(includes_endpoint, bool)
 
         # We arbitrarily decide this is a nonsensical state, consistent with
         # VersionRange.__init__().
-        if value is None:
+        if value.is_wildcard:
             assert includes_endpoint, (
                 "infinite (None) value is incompatible with includes_endpoint=False")
 
@@ -413,96 +1087,256 @@ class _VersionEndpoint(object):
         self.includes_endpoint = includes_endpoint
 
     def __repr__(self):
+        # type: () -> str
         return ("_VersionEndpoint(value={0!r}, location={1!r}, includes_endpoint={2!r})"
                 .format(self.value, self.location, self.includes_endpoint))
 
+    def __str__(self):
+        # type: () -> str
+        raise NotImplementedError(self)
+
+    def overlaps(self, other):
+        # type: (_VersionEndpoint) -> bool
+        raise NotImplementedError(self)
+
+    def satisfies(self, other):
+        # type: (_VersionEndpoint) -> bool
+        raise NotImplementedError(self)
+
     def __hash__(self):
+        # type: () -> int
         return hash((self.value, self.location, self.includes_endpoint))
+
+    def _contains_impl(self, other, strict_equal):
+        # type: (_VersionEndpoint, bool) -> bool
+        # (1) Infinite endpoints.
+        if self.value.is_wildcard:
+            return True
+        if other.value.is_wildcard:
+            return False
+        # (2) Containing endpoints.
+        matched_endpoint = False
+        if strict_equal:
+            if self.value == other.value:
+                matched_endpoint = True
+        else:
+            if other.value in self.value:
+                matched_endpoint = True
+        if matched_endpoint:
+            if self.includes_endpoint:
+                if self.location == other.location:
+                    return True
+                if other.includes_endpoint:
+                    return True
+        # (3) Separate endpoints.
+        if (self.location == 'left') and (self.value < other.value):
+            return True
+        if (self.location == 'right') and (self.value > other.value):
+            return True
+        # (4) Otherwise, no.
+        return False
 
     @_endpoint_only
     def __contains__(self, other):
-        return ((self == other) or
-                (self.value is not None and
-                 other.value is not None and
-                 other.value in self.value and
-                 self.includes_endpoint and
-                 other.includes_endpoint) or
-                ((self.location == 'left') and self < other) or
-                ((self.location == 'right') and self > other))
+        # type: (_VersionEndpoint) -> bool
+        return self._contains_impl(other, strict_equal=False)
 
     @_endpoint_only
+    def contains_strict(self, other):
+        # type: (_VersionEndpoint) -> bool
+        return self._contains_impl(other, strict_equal=True)
+
+    def lowest(self):
+        # type: () -> Optional[Version]
+        if self.location == 'left' and not self.value.is_wildcard:
+            if self.includes_endpoint:
+                return self.value
+            return self.value.negated()
+        return None
+
+    def highest(self):
+        # type: () -> Optional[Version]
+        if self.location == 'right' and not self.value.is_wildcard:
+            if self.includes_endpoint:
+                return self.value
+            return self.value.negated()
+        return None
+
     def __eq__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, _VersionEndpoint):
+            return NotImplemented
         return (self.value == other.value and
-                # Note that this is already checked by @_endpoint_only.
                 self.location == other.location and
                 self.includes_endpoint == other.includes_endpoint)
 
     # TODO: consider @memoized since we impl __hash__?
     @_endpoint_only
     def __lt__(self, other):
-        s, o = self, other
-
-        # (1) Check whether both are the same finite value, or both are the same
-        #     infinite value (None).
-        if s.value == o.value:
-            # Same version, so we check whether one and not the other contains
-            # the endpoint.
-            if s.includes_endpoint != o.includes_endpoint:
-                return s.includes_endpoint
-            # Cannot prove strict '<', so False.
+        # type: (_VersionEndpoint) -> bool
+        # (1) Infinite endpoints.
+        if self.location == 'right':                        # <
+            if other.location == 'left':                    # >
+                return True
             return False
+        if other.location == 'right':                       # <
+            return False
+        # (2) Containing endpoints.
+        if other.value in self.value:
+            if self.includes_endpoint and not other.includes_endpoint:
+                return True
+            if self.value in other.value:
+                if self.value == other.value:
+                    return False
+            return True
+        # (3) Unequal endpoints.
+        return self.value < other.value
 
-        # (2) We now know they aren't *both* infinite, since they're not
-        #     equal, so we have to see if *one* is, and assume it is less/greater
-        #     than the other regardless of the other's value.
-        # TODO: This is already checked by @_endpoint_only.
-        assert self.location == other.location
-        if self.location == 'left':
-            infinite_left_wins = True
-        else:
-            # TODO: This is already checked by __init__.
-            assert self.location == 'right'
-            infinite_left_wins = False
-        if s.value is None:
-            return infinite_left_wins
-        if o.value is None:
-            return not infinite_left_wins
-
-        return s.value < o.value
-
-    @_endpoint_only
     def __ne__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, _VersionEndpoint):
+            return NotImplemented
         return not (self == other)
 
     @_endpoint_only
     def __le__(self, other):
+        # type: (_VersionEndpoint) -> bool
         return self == other or self < other
 
     @_endpoint_only
     def __ge__(self, other):
-        return not (self < other)
+        # type: (_VersionEndpoint) -> bool
+        return self == other or self < other
 
     @_endpoint_only
     def __gt__(self, other):
-        return not (self == other) and not (self < other)
+        # type: (_VersionEndpoint) -> bool
+        # (1) Infinite endpoints.
+        if self.location == 'left':                        # >
+            if other.location == 'right':                  # <
+                return True
+            return False
+        if other.location == 'left':                       # >
+            return False
+        # (2) Containing endpoints.
+        if other.value in self.value:
+            if self.includes_endpoint and not other.includes_endpoint:
+                return True
+            if self.value in other.value:
+                assert self.value == other.value
+                return False
+            return True
+        # (3) Unequal endpoints.
+        return self.value > other.value
 
 
-class VersionRange(object):
-    def __init__(self, start, end, includes_left_endpoint=True,
-                 includes_right_endpoint=True):
+class _EndpointContainment(object):
+    low_contained = None          # type: bool
+    low_contained_strict = None   # type: bool
+    high_contained = None         # type: bool
+    high_contained_strict = None  # type: bool
+
+    def __init__(
+            self,
+            self_low,                                       # type: _VersionEndpoint
+            self_high,                                      # type: _VersionEndpoint
+            other_low,                                      # type: _VersionEndpoint
+            other_high,                                     # type: _VersionEndpoint
+    ):
+        # type: (...) -> None
+        assert isinstance(self_low, _VersionEndpoint) and self_low.location == 'left'
+        assert isinstance(self_high, _VersionEndpoint) and self_high.location == 'right'
+        assert isinstance(other_low, _VersionEndpoint) and other_low.location == 'left'
+        assert (isinstance(other_high, _VersionEndpoint) and
+                other_high.location == 'right')
+        self.low_contained = ((other_low in self_low) and (other_low in self_high))
+        self.low_contained_strict = ((self_low.contains_strict(other_low)) and
+                                     (self_high.contains_strict(other_low)))
+        self.high_contained = ((other_high in self_low) and (other_high in self_low))
+        self.high_contained_strict = ((self_low.contains_strict(other_high)) and
+                                      (self_high.contains_strict(other_high)))
+
+
+class VersionRange(VersionPredicate['VersionRange']):
+    start = None                    # type: Version
+    end = None                      # type: Version
+    includes_left_endpoint = None   # type: bool
+    includes_right_endpoint = None  # type: bool
+
+    @classmethod
+    def from_single_version(cls, version):
+        # type: (Version) -> VersionRange
+        new_version = Version(version.unsigned_form)
+        return cls(start=new_version, end=new_version,
+                   includes_left_endpoint=version.polarity,
+                   includes_right_endpoint=version.polarity)
+
+    @classmethod
+    def parse(cls, string):
+        # type: (str) -> VersionRange
+        if string.startswith(':'):
+            if string.startswith(':!'):
+                if string.endswith('!:'):
+                    # :!<x>!:
+                    version = Version.parse(string[2:-2])
+                    return VersionRange.from_single_version(version.negated())
+                assert not string.endswith(':'), string
+                # :!<x>
+                version = Version.parse(string[2:])
+                return VersionRange(start=Version.wildcard(), end=version,
+                                    includes_right_endpoint=False)
+            if string.endswith(':'):
+                # :
+                # We ban :!<x>: and :<x>:.
+                assert string == ':', string
+                return VersionRange(start=Version.wildcard(),
+                                    end=Version.wildcard())
+            # :<x>
+            version = Version.parse(string[1:])
+            return VersionRange(start=Version.wildcard(), end=version)
+        if string.endswith(':'):
+            if string.endswith('!:'):
+                # <x>!:
+                version = Version.parse(string[:-2])
+                return VersionRange(start=version, end=Version.wildcard(),
+                                    includes_left_endpoint=False)
+            # <x>:
+            version = Version.parse(string[:-1])
+            return VersionRange(start=version, end=Version.wildcard())
+        # <x>:<x>
+        if ':' in string:
+            start, end = tuple(string.split(':'))
+            return VersionRange(start=Version.parse(start), end=Version.parse(end))
+        # <x>
+        version = Version.parse(string)
+        return VersionRange.from_single_version(version)
+
+    def __init__(
+            self,
+            start,                                 # type: Optional[Union[str, Version]]
+            end,                                   # type: Optional[Union[str, Version]]
+            includes_left_endpoint=True,           # type: bool
+            includes_right_endpoint=True,          # type: bool
+    ):
         if isinstance(start, string_types):
-            start = Version(start)
+            start = Version.parse(start)
+        elif isinstance(start, Version):
+            assert start.polarity, start
+        elif start is None:
+            start = Version.wildcard()
         if isinstance(end, string_types):
-            end = Version(end)
+            end = Version.parse(end)
+        elif isinstance(end, Version):
+            assert end.polarity, end
+        elif end is None:
+            end = Version.wildcard()
+
+        if not start.is_wildcard and not end.is_wildcard and end < start:
+            raise ValueError("Invalid Version range: {0}: end must be before start"
+                             .format(self))
 
         self.start = start
         self.end = end
-
-        if start and end and end < start:
-            raise ValueError("Invalid Version range: %s" % self)
-
-        assert isinstance(includes_left_endpoint, bool)
-        assert isinstance(includes_right_endpoint, bool)
 
         self.includes_left_endpoint = includes_left_endpoint
         self.includes_right_endpoint = includes_right_endpoint
@@ -510,92 +1344,104 @@ class VersionRange(object):
         # We don't enforce this anywhere except implicitly when parsing
         # a version string, but it is an assumption we have made so far, so we
         # might as well check it.
-        if start is None:
-            assert includes_left_endpoint
-        if end is None:
-            assert includes_right_endpoint
+        if start.is_wildcard:
+            assert includes_left_endpoint, self
+        if end.is_wildcard:
+            assert includes_right_endpoint, self
 
     def lowest(self):
-        return self.start
+        # type: () -> Optional[Version]
+        return self._low_endpoint().lowest()
 
+    @memoized
     def _low_endpoint(self):
-        return _VersionEndpoint(self.lowest(), 'left', self.includes_left_endpoint)
+        # type: () -> _VersionEndpoint
+        return _VersionEndpoint(self.start, 'left', self.includes_left_endpoint)
 
     def highest(self):
-        return self.end
+        # type: () -> Optional[Version]
+        return self._high_endpoint().highest()
 
+    @memoized
     def _high_endpoint(self):
-        return _VersionEndpoint(self.highest(), 'right', self.includes_right_endpoint)
+        # type: () -> _VersionEndpoint
+        return _VersionEndpoint(self.end, 'right', self.includes_right_endpoint)
 
-    @coerced
-    def __lt__(self, other):
+    @memoized
+    def _endpoint_containment(self, other):
+        # type: (VersionRange) -> _EndpointContainment
+        return _EndpointContainment(
+            self_low=self._low_endpoint(),
+            self_high=self._high_endpoint(),
+            other_low=other._low_endpoint(),
+            other_high=other._high_endpoint(),
+        )
+
+    @coerced_logic
+    def __lt__(self, other):                              # type: ignore[has-type]
+        # type: (VersionRange) -> bool
         """Sort VersionRanges lexicographically so that they are ordered first
            by start and then by end.  None denotes an open range, so None in
            the start position is less than everything except None, and None in
            the end position is greater than everything but None.
         """
-        if other is None:
-            return False
+        return self._low_endpoint() < other._low_endpoint()
 
-        s, o = self, other
-
-        # Check left endpoint.
-        if s._low_endpoint() < o._low_endpoint():
-            return True
-
-        # Check right endpoint.
-        return s._high_endpoint() < o._high_endpoint()
-
-    @coerced
+    @coerced_equals
     def __eq__(self, other):
-        return (other is not None and
-                type(other) == VersionRange and
-                self.start == other.start and self.end == other.end and
+        # type: (Any) -> bool
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return (self.start == other.start and
+                self.end == other.end and
                 self.includes_left_endpoint == other.includes_left_endpoint and
                 self.includes_right_endpoint == other.includes_right_endpoint)
 
-    @coerced
+    @coerced_equals
     def __ne__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, VersionRange):
+            return NotImplemented
         return not (self == other)
 
-    @coerced
-    def __le__(self, other):
+    @coerced_logic
+    def __le__(self, other):                              # type: ignore[has-type]
+        # type: (VersionRange) -> bool
         return self == other or self < other
 
-    @coerced
+    @coerced_logic
     def __ge__(self, other):
-        return not (self < other)
+        # type: (VersionRange) -> bool
+        return self == other or self > other
 
-    @coerced
+    @coerced_logic
     def __gt__(self, other):
-        return not (self == other) and not (self < other)
+        # type: (VersionRange) -> bool
+        return self._high_endpoint() > other._high_endpoint()
+
+    def _is_single_version(self):
+        # type: () -> bool
+        return (self.includes_left_endpoint and self.includes_right_endpoint and
+                self.start == self.end and
+                not self.start.is_wildcard and
+                not self.end.is_wildcard)
 
     @property
     def concrete(self):
-        if self.start != self.end:
-            return None
-        # :
-        if self.start is None:
-            assert self.end is None
-            return None
-        # {0}
-        if self.includes_left_endpoint or self.includes_right_endpoint:
-            # Recall that :!1.2.3: => :.
-            assert self.includes_left_endpoint == self.includes_right_endpoint
+        # type: () -> Optional[Version]
+        if self._is_single_version():
             return self.start
-        # :!{0}!:
         return None
 
-    @coerced
+    @coerced_logic
     def __contains__(self, other):
-        if other is None:
-            return False
+        # type: (VersionRange) -> bool
+        containment = self._endpoint_containment(other)
+        return containment.low_contained and containment.high_contained
 
-        return ((other._low_endpoint() in self._low_endpoint()) and
-                (other._high_endpoint() in self._high_endpoint()))
-
-    @coerced
+    @coerced_logic
     def satisfies(self, other):
+        # type: (VersionRange) -> bool
         """A VersionRange satisfies another if some version in this range
         would satisfy some version in the other range.  To do this it must
         either:
@@ -621,142 +1467,121 @@ class VersionRange(object):
         Note further that overlaps() is a symmetric operation, while
         satisfies() is not.
         """
-        return (self.overlaps(other) or
-                (self.start is not None and
-                 other.end is not None and
-                 (self.start in other.end) and
-                 self.includes_left_endpoint and
-                 other.includes_right_endpoint))
+        containment = self._endpoint_containment(other)
+        return containment.low_contained or containment.high_contained
 
-    @coerced
+    @coerced_logic
     def overlaps(self, other):
-        # TODO: factor this out more into _VersionEndpoint!
-        return ((self.start is None or other.end is None or
-                 self.start < other.end or
-                 (self.includes_left_endpoint and
-                  other.includes_right_endpoint and
-                  (self.start == other.end or
-                   other.end in self.start or
-                   self.start in other.end))) and
-                (other.start is None or self.end is None or
-                 other.start < self.end or
-                 (self.includes_right_endpoint and
-                  other.includes_left_endpoint and
-                  (other.start == self.end or
-                   other.start in self.end or
-                   self.end in other.start))))
+        # type: (VersionRange) -> bool
+        containment = self._endpoint_containment(other)
+        return containment.low_contained_strict or containment.high_contained_strict
 
     @coerced
     def union(self, other):
+        # type: (VersionRange) -> VersionPredicate
         if not self.overlaps(other):
-            if (self.end is not None and other.start is not None and
-                    self.end.is_predecessor(other.start)):
+            if self.end.is_predecessor(other.start):
                 return VersionRange(self.start, other.end)
 
-            if (other.end is not None and self.start is not None and
-                    other.end.is_predecessor(self.start)):
+            if other.end.is_predecessor(self.start):
                 return VersionRange(other.start, self.end)
 
             return VersionList([self, other])
 
         # if we're here, then we know the ranges overlap.
-        if self.start is None or other.start is None:
-            start = None
+        if self.start.is_wildcard or other.start.is_wildcard:
+            start = Version.wildcard()
         else:
             start = self.start
-            # TODO: See note in intersection() about < and in discrepancy.
-            if self.start in other.start or other.start < self.start:
-                start = other.start
 
-        if self.end is None or other.end is None:
-            end = None
+        # TODO: See note in intersection() about < and in discrepancy.
+        if self.start in other.start or other.start < self.start:
+            start = other.start
+
+        if self.end.is_wildcard or other.end.is_wildcard:
+            end = Version.wildcard()
         else:
             end = self.end
-            # TODO: See note in intersection() about < and in discrepancy.
-            if other.end not in self.end:
-                if end in other.end or other.end > self.end:
-                    end = other.end
+
+        # TODO: See note in intersection() about < and in discrepancy.
+        if other.end not in self.end:
+            if end in other.end or other.end > self.end:
+                end = other.end
 
         return VersionRange(start, end)
 
     @coerced
     def intersection(self, other):
+        # type: (VersionRange) -> VersionPredicate
         if self.overlaps(other):
-            if self.start is None:
+            if self.start.is_wildcard:
                 start = other.start
             else:
                 start = self.start
-                if other.start is not None:
-                    if other.start > start or other.start in start:
-                        start = other.start
 
-            if self.end is None:
+            if other.start > start or other.start in start:
+                start = other.start
+
+            if self.end.is_wildcard:
                 end = other.end
             else:
                 end = self.end
-                # TODO: does this make sense?
-                # This is tricky:
-                #     1.6.5 in 1.6 = True  (1.6.5 is more specific)
-                #     1.6 < 1.6.5  = True  (lexicographic)
-                # Should 1.6 NOT be less than 1.6.5?  Hmm.
-                # Here we test (not end in other.end) first to avoid paradox.
-                # FIXME: this seems to make perfect sense? Has this code ever
-                # stopped any error?
-                if other.end is not None and end not in other.end:
-                    if other.end < end or other.end in end:
-                        end = other.end
+
+            # TODO: does this make sense?
+            # This is tricky:
+            #     1.6.5 in 1.6 = True  (1.6.5 is more specific)
+            #     1.6 < 1.6.5  = True  (lexicographic)
+            # Should 1.6 NOT be less than 1.6.5?  Hmm.
+            # Here we test (not end in other.end) first to avoid paradox.
+            # FIXME: this seems to make perfect sense? Has this code ever
+            # stopped any error?
+            if end not in other.end:
+                if other.end < end or other.end in end:
+                    end = other.end
 
             return VersionRange(start, end)
-
-        else:
-            return VersionList()
+        return VersionList.empty()
 
     def __hash__(self):
-        return hash((self.start, self.end))
-
-    def __repr__(self):
-        return self.__str__()
+        return hash((
+            self.start,
+            self.end,
+            self.includes_left_endpoint,
+            self.includes_right_endpoint,
+        ))
 
     def __str__(self):
-        # ( :!1.2.3!: | 1.2.3 | : )
+        # ( :!<x>!: | <x> | : )
         if self.start == self.end:
-            # :
-            if self.start is None:
-                assert self.end is None
+            assert self.includes_left_endpoint == self.includes_right_endpoint, self
+            if self.start.is_wildcard or self.end.is_wildcard:
+                # :
+                assert self.start.is_wildcard and self.end.is_wildcard, self.end
                 return ':'
-            assert self.includes_left_endpoint == self.includes_right_endpoint
-            # 1.2.3
+            # <x>
             if self.includes_left_endpoint:
-                assert self.includes_right_endpoint
                 return str(self.start)
-            # :!1.2.3!:
+            # :!<x>!:
             return ":!{0}!:".format(self.start)
-
-        # ( :!1.2.3 | :1.2.3 )
-        if self.start is None:
+        # ( :!<x> | :<x> )
+        if self.start.is_wildcard:
             # Checked that self.start == self.end above.
-            assert self.end is not None
-            assert self.includes_left_endpoint
-            # :1.2.3
+            assert not self.end.is_wildcard, self.end
+            assert self.includes_left_endpoint, self
+            # :<x>
             if self.includes_right_endpoint:
                 return ':{0}'.format(self.end)
-            # :!1.2.3
+            # :!<x>
             return ':!{0}'.format(self.end)
-
-        # ( 1.2.3: | 1.2.3!: )
-        if self.end is None:
-            assert self.start is not None
-            assert self.includes_right_endpoint
-            # 1.2.3:
+        # ( <x>: | <x>!: )
+        if self.end.is_wildcard:
+            assert not self.start.is_wildcard, self.start
+            assert self.includes_right_endpoint, self
+            # <x>:
             if self.includes_left_endpoint:
                 return '{0}:'.format(self.start)
-            # 1.2.3!:
+            # <x>!:
             return '{0}!:'.format(self.start)
-
-        assert (self.start is not None and
-                self.end is not None and
-                self.start != self.end)
-
         # {0}!:!{1} => {0} < x < {1}
         if (not self.includes_left_endpoint and
             not self.includes_right_endpoint):
@@ -772,21 +1597,51 @@ class VersionRange(object):
         return "{0}:{1}".format(self.start, self.end)
 
 
-class VersionList(object):
+class VersionList(VersionPredicate['VersionList']):
     """Sorted, non-redundant list of Versions and VersionRanges."""
+    versions = None  # type: List[Union[Version, VersionRange]]
+
+    @classmethod
+    def from_version_or_range(cls, version_or_range):
+        # type: (Union[Version, VersionRange]) -> VersionList
+        return cls([version_or_range])
+
+    @classmethod
+    def empty(cls):
+        # type: () -> VersionList
+        return cls(vlist=None)
+
+    @classmethod
+    def parse(cls, string):
+        # type: (str) -> VersionList
+
+        def parse_version_or_range(el):
+            # type: (str) -> Union[Version, VersionRange]
+            if ':' in el:
+                return VersionRange.parse(el)
+            return Version.parse(el)
+        if ',' in string:
+            elements = string.split(',')
+            versions_or_ranges = [parse_version_or_range(el) for el in elements]
+            return cls(versions_or_ranges)
+        if string:
+            return cls([parse_version_or_range(string)])
+        return cls.empty()
 
     def __init__(self, vlist=None):
-        self.versions = []
+        # type: (Optional[Union[VersionList, str, Version, VersionRange, List[Union[Version, VersionRange]]]]) -> None
+        self.versions = []  # type: List[Union[Version, VersionRange]]
         if vlist is not None:
             if isinstance(vlist, string_types):
-                vlist = _string_to_version(vlist)
-                if type(vlist) == VersionList:
-                    self.versions = vlist.versions
+                vv = _string_to_version(
+                    vlist)             # type: Union[Version, VersionRange, VersionList]
+                if isinstance(vv, VersionList):
+                    self.versions = vv.versions
                 else:
-                    self.versions = [vlist]
+                    self.versions = [vv]
             else:
-                vlist = list(vlist)
-                for v in vlist:
+                vs = list(vlist)                            # type: ignore[arg-type]
+                for v in vs:
                     self.add(ver(v))
 
     def add(self, version):
@@ -817,15 +1672,18 @@ class VersionList(object):
 
     @property
     def concrete(self):
+        # type: () -> Optional[Version]
         if len(self) == 1:
             return self[0].concrete
         else:
             return None
 
     def copy(self):
+        # type: () -> VersionList
         return VersionList(self)
 
     def lowest(self):
+        # type: () -> Optional[Version]
         """Get the lowest version in the list."""
         if not self:
             return None
@@ -833,6 +1691,7 @@ class VersionList(object):
             return self[0].lowest()
 
     def highest(self):
+        # type: () -> Optional[Version]
         """Get the highest version in the list."""
         if not self:
             return None
@@ -840,6 +1699,7 @@ class VersionList(object):
             return self[-1].highest()
 
     def highest_numeric(self):
+        # type: () -> Optional[Version]
         """Get the highest numeric version in the list."""
         numeric_versions = list(filter(
             lambda v: str(v) not in infinity_versions,
@@ -850,14 +1710,16 @@ class VersionList(object):
             return numeric_versions[-1].highest()
 
     def preferred(self):
+        # type: () -> Optional[Version]
         """Get the preferred (latest) version in the list."""
         latest = self.highest_numeric()
         if latest is None:
             latest = self.highest()
         return latest
 
-    @coerced
+    @coerced_logic
     def overlaps(self, other):
+        # type: (VersionList) -> bool
         if not other or not self:
             return False
 
@@ -872,6 +1734,7 @@ class VersionList(object):
         return False
 
     def to_dict(self):
+        # type: () -> Dict[str, Union[str, List[str]]]
         """Generate human-readable dict for YAML."""
         if self.concrete:
             return syaml_dict([
@@ -884,16 +1747,18 @@ class VersionList(object):
 
     @staticmethod
     def from_dict(dictionary):
+        # type: (Dict[str, Union[str, List[str]]]) -> VersionList
         """Parse dict from to_dict."""
         if 'versions' in dictionary:
-            return VersionList(dictionary['versions'])
+            return VersionList(dictionary['versions'])      # type: ignore[arg-type]
         elif 'version' in dictionary:
-            return VersionList([dictionary['version']])
+            return VersionList([dictionary['version']])     # type: ignore[list-item]
         else:
             raise ValueError("Dict must have 'version' or 'versions' in it.")
 
-    @coerced
+    @coerced_logic
     def satisfies(self, other, strict=False):
+        # type: (VersionList, bool) -> bool
         """A VersionList satisfies another if some version in the list
            would satisfy some version in the other list.  This uses
            essentially the same algorithm as overlaps() does for
@@ -921,26 +1786,30 @@ class VersionList(object):
 
     @coerced
     def update(self, other):
+        # type: (VersionList) -> None
         for v in other.versions:
             self.add(v)
 
     @coerced
     def union(self, other):
+        # type: (VersionList) -> VersionList
         result = self.copy()
         result.update(other)
         return result
 
     @coerced
     def intersection(self, other):
+        # type: (VersionList) -> VersionList
         # TODO: make this faster.  This is O(n^2).
         result = VersionList()
         for s in self:
             for o in other:
-                result.add(s.intersection(o))
+                result.add(s.intersection(o))               # type: ignore[arg-type]
         return result
 
     @coerced
     def intersect(self, other):
+        # type: (VersionList) -> bool
         """Intersect this spec's list with other.
 
         Return True if the spec changed as a result; False otherwise
@@ -950,95 +1819,108 @@ class VersionList(object):
         self.versions = isection.versions
         return changed
 
-    @coerced
+    @coerced_logic
     def __contains__(self, other):
+        # type: (VersionList) -> bool
         if len(self) == 0:
             return False
 
         for version in other:
-            i = bisect_left(self, other)
+            i = bisect_left(self, other)                    # type: ignore[arg-type]
             if i == 0:
                 if version not in self[0]:
                     return False
-            elif all(version not in v for v in self[i - 1:]):
+            elif all(
+                    version not in v for v in self[i - 1:]  # type: ignore[attr-defined]
+            ):
                 return False
 
         return True
 
     def __getitem__(self, index):
-        return self.versions[index]
+        # type: (Union[int, slice]) -> VersionPredicate
+        return self.versions[index]                         # type: ignore[return-value]
 
     def __iter__(self):
+        # type: () -> Iterator[Union[Version, VersionRange]]
         return iter(self.versions)
 
     def __reversed__(self):
+        # type: () -> Iterator[Union[Version, VersionRange]]
         return reversed(self.versions)
 
     def __len__(self):
+        # type: () -> int
         return len(self.versions)
 
     def __bool__(self):
+        # type: () -> bool
         return bool(self.versions)
 
-    @coerced
+    @coerced_equals
     def __eq__(self, other):
-        return other is not None and self.versions == other.versions
+        # type: (Any) -> bool
+        if not isinstance(other, VersionList):
+            return NotImplemented
+        return self.versions == other.versions
 
-    @coerced
+    @coerced_equals
     def __ne__(self, other):
+        # type: (VersionList) -> bool
+        if not isinstance(other, VersionList):
+            return NotImplemented
         return not (self == other)
 
-    @coerced
-    def __lt__(self, other):
-        return other is not None and self.versions < other.versions
+    @coerced_logic
+    def __lt__(self, other):                               # type: ignore[has-type]
+        # type: (VersionList) -> bool
+        return self.versions < other.versions
 
-    @coerced
-    def __le__(self, other):
+    @coerced_logic
+    def __le__(self, other):                               # type: ignore[has-type]
+        # type: (VersionList) -> bool
         return self == other or self < other
 
-    @coerced
+    @coerced_logic
     def __ge__(self, other):
-        return not (self < other)
+        # type: (VersionList) -> bool
+        return self == other or self > other
 
-    @coerced
+    @coerced_logic
     def __gt__(self, other):
-        return not (self == other) and not (self < other)
+        # type: (VersionList) -> bool
+        return tuple(reversed(self)) > tuple(reversed(other))
 
     def __hash__(self):
+        # type: () -> int
         return hash(tuple(self.versions))
 
     def __str__(self):
+        # type: () -> str
         return ",".join(str(v) for v in self.versions)
-
-    def __repr__(self):
-        return str(self.versions)
 
 
 def _string_to_version(string):
+    # type: (str) -> Union[Version, VersionRange, VersionList]
     """Converts a string to a Version, VersionList, or VersionRange.
        This is private.  Client code should use ver().
     """
     string = string.replace(' ', '')
 
     if ',' in string:
-        return VersionList(string.split(','))
-
+        return VersionList.parse(string)
     elif ':' in string:
-        s, e = string.split(':')
-        start = Version(s) if s else None
-        end = Version(e) if e else None
-        return VersionRange(start, end)
-
-    else:
-        return Version(string)
+        return VersionRange.parse(string)
+    return Version.parse(string)
 
 
 def ver(obj):
+    # type: (Any) -> Union[Version, VersionRange, VersionList]
     """Parses a Version, VersionRange, or VersionList from a string
        or list of strings.
     """
     if isinstance(obj, (list, tuple)):
-        return VersionList(obj)
+        return VersionList(obj)                             # type: ignore[arg-type]
     elif isinstance(obj, string_types):
         return ver(_string_to_version(obj))
     elif isinstance(obj, (int, float)):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -30,8 +30,6 @@ from bisect import bisect_left
 from functools import wraps
 from six import string_types
 
-from llnl.util.lang import memoized
-
 import spack.error
 from spack.util.spack_yaml import syaml_dict
 
@@ -385,8 +383,12 @@ def _endpoint_only(fun):
     """We want to avoid logic that handles any type of version range, just endpoints."""
     @wraps(fun)
     def validate_endpoint_argument(self, other):
-        assert isinstance(other, _VersionEndpoint), "required two _VersionEndpoint arguments, received {0} and {1}".format(self, other)
-        assert self.location == other.location, "two _VersionEndpoint arguments with different locations is a programming bug: received {0} and {1}".format(self, other)
+        assert isinstance(other, _VersionEndpoint), (
+            "required two _VersionEndpoint arguments, received {0} and {1}"
+            .format(self, other))
+        assert self.location == other.location, (
+            "two _VersionEndpoint arguments with different locations "
+            "is a programming bug: received {0} and {1}".format(self, other))
         return fun(self, other)
     return validate_endpoint_argument
 
@@ -403,16 +405,16 @@ class _VersionEndpoint(object):
         # We arbitrarily decide this is a nonsensical state, consistent with
         # VersionRange.__init__().
         if value is None:
-            assert includes_endpoint, "infinite (None) value is incompatible with includes_endpoint=False"
+            assert includes_endpoint, (
+                "infinite (None) value is incompatible with includes_endpoint=False")
 
         self.value = value
         self.location = location
         self.includes_endpoint = includes_endpoint
 
     def __repr__(self):
-        return "_VersionEndpoint(value={0!r}, location={1!r}, includes_endpoint={2!r})".format(
-            self.value, self.location, self.includes_endpoint
-        )
+        return ("_VersionEndpoint(value={0!r}, location={1!r}, includes_endpoint={2!r})"
+                .format(self.value, self.location, self.includes_endpoint))
 
     def __hash__(self):
         return hash((self.value, self.location, self.includes_endpoint))

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -377,10 +377,6 @@ class Version(object):
         if self == other:
             return self
         else:
-            # FIXME: I don't agree with this definition. If a comma-separated
-            # list is an OR, and intersection is an AND, the intersection of
-            # two lists should be defined the same as if the two lists were
-            # actually set()s.
             return VersionList()
 
 

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -42,4 +42,4 @@ spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 #-----------------------------------------------------------
 # Run unit tests with code coverage
 #-----------------------------------------------------------
-$coverage_run $(which spack) unit-test -x --verbose
+$coverage_run $(which spack) unit-test -x --verbose "$@"


### PR DESCRIPTION
### Problem

This is phase 1 of proposed extensions for the spec syntax: see https://github.com/spack/spack/issues/20256#issuecomment-739434724:

> 1. Support pip requirements.txt version comparators and wildcards:
>    - <=,=>, and == already exist.
>    - ==9.2.* => >=9.2,<9.3 (reduce to subproblem)
>    - !=9.2.0 => <9.2.0,>9.2.0 (reduce to subproblem)
>    - imprecise:
>        - <9.2.0 => :9.1.999
>        - >9.2.0 => 9.2.0.0.0.1
>        - **Spack is unable to represent strict inequalities (<,>) without this feature.**
>    - Breakage: none.

### Solution
- Extend the Spec parser to process all of the above new inequality notations.
- Extend the Lexer to allow for more than 2 modes (this is useful setup for any further work on the spec syntax).
- Extend VersionRange a bit to support the notion of "including the left/right endpoint", which is used to ensure `__contains__` and `__lt__` still work on the new edge cases.
- Add testing.

### Result
`@:!3` and `@3!:` should let users avoid needing to type out the `.999.999` or `.0.0.0.1` suffixes (which I personally find difficult to maintain and ultimately incorrect).