### PR TITLE
apr: add depends_on ('libuuid', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -17,3 +17,6 @@ class Apr(AutotoolsPackage):
     version('1.5.2', sha256='1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb')
 
     patch('missing_includes.patch', when='@1.7.0')
+
+    depends_on('libuuid', type='link')    
+

--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -18,5 +18,4 @@ class Apr(AutotoolsPackage):
 
     patch('missing_includes.patch', when='@1.7.0')
 
-    depends_on('libuuid', type='link')    
-
+    depends_on('libuuid', type='link')


### PR DESCRIPTION
"gpdb" installation failed.
Because "apr" package.py is missing "libuuid".

```
==> Installing gpdb
==> No binary for gpdb found: installing from source
==> Fetching https://postk-web.r-ccs.riken.jp/spack.mirror/_source-cache/archive/60/60c81d71665d623ea98a0e9bd8e6df7fecf6b30eb60a5881ccef781ff5214438.tar.gz
==> gpdb: Executing phase: 'autoreconf'
==> gpdb: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/home/users/ea01/ea0108/spack-stage/spack-stage-gpdb-6.2.1-wtodpn5nifmgr2irb7qkbhtrjnn4juod/spack-src/configure' '--prefix=/home/users/ea01/ea0108/all-test/gcc/spack/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/gpdb-6.2.1-wtodpn5nifmgr2irb7qkbhtrjnn4juod' '--with-python' '--disable-orca' '--enable-depend' '--with-libxml'

1 error found in build log:
     144    checking for library containing readline... -lreadline
     145    checking for inflate in -lz... yes
     146    checking for ZSTD_compressCCtx in -lzstd... yes
     147    checking for apr-1-config... /home/users/ea01/ea0108/all-test/gcc/s
            pack/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/apr-1.7.0-46sesgs4ve2zm4
            iuav23t6qo3jwc2fs2/bin/apr-1-config
     148    configure: using apr-1-config 1.7.0
     149    checking for library containing apr_getopt_long... no
  >> 150    configure: error: libapr-1 is required by gpfdist and gpperfmon
```

An error was recorded in config.log in the spack-sorce directory.

```
spack-stage/spack-stage-gpdb-6.2.1-wtodpn5nifmgr2irb7qkbhtrjnn4juod/spack-src/config.log
"libapr-1.so: undefined reference to `uuid_generate@UUID_1.0"
```

After adding dpends_on to "apr", the installation of "gpdb" was successful.
