### PR TITLE
povray: add mkl depend and conflict

### DIFF
--- a/var/spack/repos/builtin/packages/povray/package.py
+++ b/var/spack/repos/builtin/packages/povray/package.py
@@ -38,7 +38,7 @@ class Povray(AutotoolsPackage):
     variant('jpeg', default=True, description='Build with jpeg support')
     variant('libpng', default=True, description='Build with libpng support')
     variant('libtiff', default=True, description='Build with libtiff support')
-    variant('mkl', default=True, description='Build with Intel MKL support, Ignored if not Intel')
+    variant('mkl', default=True, description='Build with Intel MKL support')
     variant('openexr', default=True, description='Build with OpenEXR support')
     variant('profile', default=False,
             description='Enable program execution profiling')
@@ -63,8 +63,16 @@ class Povray(AutotoolsPackage):
     depends_on('libpng@1.2.5:', when='+libpng')
     depends_on('jpeg', when='+jpeg')
     depends_on('libtiff@3.6.1:', when='+libtiff')
-    depends_on('mkl', when='+mkl target=x86_64:')
+    depends_on('mkl', when='+mkl')
     depends_on('openexr@1.2:', when='+openexr')
+
+    # MKL conflicts
+    conflicts('+mkl', when='target=aarch64:',
+              msg='Intel MKL only runs on x86')
+    conflicts('+mkl', when='target=ppc64:',
+              msg='Intel MKL only runs on x86')
+    conflicts('+mkl', when='target=ppc64le:',
+              msg='Intel MKL only runs on x86')
 
     # This patch enables prebuild.sh to be invoked from any directory
     # (it immediately cds to the directory containing prebuild.sh)
@@ -121,7 +129,7 @@ class Povray(AutotoolsPackage):
         else:
             extra_args.append('--without-libtiff')
 
-        if '+mkl' in self.spec and self.spec.satisfies('target=x86_64:'):
+        if '+mkl' in self.spec:
             extra_args.append('--with-libmkl={0}'.format(
                 self.spec['mkl'].prefix))
         else:

--- a/var/spack/repos/builtin/packages/povray/package.py
+++ b/var/spack/repos/builtin/packages/povray/package.py
@@ -38,7 +38,7 @@ class Povray(AutotoolsPackage):
     variant('jpeg', default=True, description='Build with jpeg support')
     variant('libpng', default=True, description='Build with libpng support')
     variant('libtiff', default=True, description='Build with libtiff support')
-    variant('mkl', default=True, description='Build with Intel MKL support')
+    variant('mkl', default=True, description='Build with Intel MKL support, Ignored if not Intel')
     variant('openexr', default=True, description='Build with OpenEXR support')
     variant('profile', default=False,
             description='Enable program execution profiling')
@@ -63,6 +63,7 @@ class Povray(AutotoolsPackage):
     depends_on('libpng@1.2.5:', when='+libpng')
     depends_on('jpeg', when='+jpeg')
     depends_on('libtiff@3.6.1:', when='+libtiff')
+    depends_on('mkl', when='+mkl target=x86_64:')
     depends_on('openexr@1.2:', when='+openexr')
 
     # This patch enables prebuild.sh to be invoked from any directory
@@ -120,7 +121,7 @@ class Povray(AutotoolsPackage):
         else:
             extra_args.append('--without-libtiff')
 
-        if '+mkl' in self.spec:
+        if '+mkl' in self.spec and self.spec.satisfies('target=x86_64:'):
             extra_args.append('--with-libmkl={0}'.format(
                 self.spec['mkl'].prefix))
         else:


### PR DESCRIPTION
1. Add mkl dependency
Build in x86_64 failed due to missing `mkl`.
So I added `depend_on`

2. Add conflict
Intel MKL run only in Intel CPU.
So I added conflicts(+mkl)