### PR TITLE
replace margo pkg with updated mochi-margo pkg

### DIFF
--- a/var/spack/repos/builtin/packages/margo/package.py
+++ b/var/spack/repos/builtin/packages/margo/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -6,10 +6,9 @@
 from spack import *
 
 
-class Margo(AutotoolsPackage):
+class MochiMargo(AutotoolsPackage):
     """A library that provides Argobots bindings to the Mercury RPC
-    implementation.  This name will be deprecated soon; please use the
-    mochi-margo package instead."""
+    implementation."""
 
     homepage = 'https://xgitlab.cels.anl.gov/sds/margo'
     git = 'https://xgitlab.cels.anl.gov/sds/margo.git'


### PR DESCRIPTION
- advance from v0.4.3 to v0.9 of margo
- change spack package name to "mochi-margo" to match preferred naming convention
- add stub mochi package as placeholder for deprecated name