### PR TITLE
hdf-eos5: new package (HDF for Earth Observing Sytem using hdf v5)

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos5/hdf-eos5.nondarwin-no-single_module.patch
+++ b/var/spack/repos/builtin/packages/hdf-eos5/hdf-eos5.nondarwin-no-single_module.patch
@@ -1,0 +1,28 @@
+# This patch removes the default(?) setting of passing -single_module
+# flag to the loader.  From what I can gather, only the Darwin loader
+# supports that, so this patch allows building on non-Darwin systems
+
+diff -Naur spack-src/src/Makefile.am spack-src.patched/src/Makefile.am
+--- spack-src/src/Makefile.am	2007-03-29 12:59:47.000000000 -0400
++++ spack-src.patched/src/Makefile.am	2020-12-04 11:25:50.789164073 -0500
+@@ -10,7 +10,7 @@
+ 
+ # Set LDFLAGS to allow the HDF-EOS library to use extern variables from
+ # HDF5
+-LDFLAGS=-Wl,-single_module
++#LDFLAGS=-Wl,-single_module
+ 
+ # Build HDF-EOS5
+ lib_LTLIBRARIES=libhe5_hdfeos.la
+diff -Naur spack-src/src/Makefile.in spack-src.patched/src/Makefile.in
+--- spack-src/src/Makefile.in	2010-08-30 11:47:05.000000000 -0400
++++ spack-src.patched/src/Makefile.in	2020-12-04 11:26:00.201443245 -0500
+@@ -126,7 +126,7 @@
+ 
+ # Set LDFLAGS to allow the HDF-EOS library to use extern variables from
+ # HDF5
+-LDFLAGS = -Wl,-single_module
++#LDFLAGS = -Wl,-single_module
+ LIBOBJS = @LIBOBJS@
+ LIBS = @LIBS@
+ LIBTOOL = @LIBTOOL@

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -1,0 +1,104 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import sys
+
+
+class HdfEos5(AutotoolsPackage):
+    """HDF-EOS (Hierarchical Data Format - Earth Observing System) is a
+    self-describing file format based upon HDF for standard data products
+    that are derived from EOS missions.  HDF-EOS5 is based upon HDF5.
+    """
+
+    homepage = "https://hdfeos.org"
+    # The download URLs are messing, and include sha256 checksum.
+    # This is just a template.  See version_list and url_for_version below
+    # Template for url_for_version. 0 is sha256 checksum, 1 is filename
+    url = "https://git.earthdata.nasa.gov/rest/git-lfs/storage/DAS/hdfeos5/{0}?response-content-disposition=attachment%3B%20filename%3D%22{1}%22%3B%20filename*%3Dutf-8%27%27{1}"
+
+    # Crazy URL scheme, differing with each version, and including the
+    # sha256 checksum in the URL.  Yuck
+    # The data in version_list is used to generate versions and urls
+    # In basename expansions, 0 is raw version,
+    # 1 is for version with dots => underscores
+    version_list = [
+            {'version': '5.1.16',
+                'sha256': '7054de24b90b6d9533329ef8dc89912c5227c83fb447792103279364e13dd452',
+                'basename': 'HDF-EOS{0}.tar.Z'
+            },
+            {'version': '5.1.15',
+                'sha256': 'fbf4d085f9bf6ffad259aee1e9f60cf060e7e99c447894ad8955df02de83c92c',
+                'basename': 'hdfeos{1}.zip'
+            }
+        ]
+
+    for vrec in version_list:
+        ver = vrec['version']
+        sha256 = vrec['sha256']
+        version(ver, sha256=sha256)
+
+    variant('shared', default=True,
+            description='Build shared libraries (can be used with +static)')
+    variant('static', default=True,
+            description='Build shared libraries (can be used with +shared)')
+
+    conflicts('~static', when='~shared',
+              msg='At least one of +static or +shared must be set')
+
+    # Build dependencies
+    depends_on('hdf5')
+
+    # The standard Makefile.am, etc. add a --single_module flag to LDFLAGS
+    # to pass to the linker.
+    # That appears to be only recognized by the Darwin linker, remove it
+    # if we are not running on darwin/
+    if sys.platform != "darwin":
+        patch('hdf-eos5.nondarwin-no-single_module.patch')
+
+    def url_for_version(self, version):
+        vrec = [x for x in self.version_list
+                if x['version'] == version.dotted.string]
+        if vrec:
+            fname = vrec[0]['basename'].format(version.dotted,
+                                               version.underscored)
+            sha256 = vrec[0]['sha256']
+            myurl = self.url.format(sha256, fname)
+            return myurl
+        else:
+            sys.exit('ERROR: cannot generate URL for version {0};'
+                     'version/checksum not found in version_list'.format(
+                         version))
+
+    def configure_args(self):
+        extra_args = []
+
+        # Package really wants h5cc to be used
+        if self.spec['mpi']:
+            extra_args.append('CC={0}/bin/h5pcc'.format(
+                self.spec['hdf5'].prefix))
+        else:
+            extra_args.append('CC={0}/bin/h5cc'.format(
+                self.spec['hdf5'].prefix))
+
+        # We always build PIC code
+        extra_args.append('--with-pic')
+        # We always enable installation of include directories
+        extra_args.append('--enable-install-include')
+
+        # Set shared/static appropriately
+        extra_args.extend(self.enable_or_disable('shared'))
+        extra_args.extend(self.enable_or_disable('static'))
+
+        # Provide config args for dependencies
+        extra_args.append('--with-hdf5={0}'.format(self.spec['hdf5'].prefix))
+        if self.spec['zlib']:
+            extra_args.append('--with-zlib={0}'.format(
+                self.spec['zlib'].prefix))
+        if self.spec['szip']:
+            extra_args.append('--with-szlib={0}'.format(
+                self.spec['szip'].prefix))
+
+        return extra_args

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -25,14 +25,14 @@ class HdfEos5(AutotoolsPackage):
     # In basename expansions, 0 is raw version,
     # 1 is for version with dots => underscores
     version_list = [
-            {'version': '5.1.16',
-                'sha256': '7054de24b90b6d9533329ef8dc89912c5227c83fb447792103279364e13dd452',
-                'basename': 'HDF-EOS{0}.tar.Z'
-            },
-            {'version': '5.1.15',
-                'sha256': 'fbf4d085f9bf6ffad259aee1e9f60cf060e7e99c447894ad8955df02de83c92c',
-                'basename': 'hdfeos{1}.zip'
-            }
+        {'version': '5.1.16',
+            'sha256': '7054de24b90b6d9533329ef8dc89912c5227c83fb447792103279364e13dd452',
+            'basename': 'HDF-EOS{0}.tar.Z'
+        },
+        {'version': '5.1.15',
+            'sha256': 'fbf4d085f9bf6ffad259aee1e9f60cf060e7e99c447894ad8955df02de83c92c',
+            'basename': 'hdfeos{1}.zip'
+        }
         ]
 
     for vrec in version_list:

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -27,12 +27,10 @@ class HdfEos5(AutotoolsPackage):
     version_list = [
         {'version': '5.1.16',
             'sha256': '7054de24b90b6d9533329ef8dc89912c5227c83fb447792103279364e13dd452',
-            'basename': 'HDF-EOS{0}.tar.Z'
-        },
+            'basename': 'HDF-EOS{0}.tar.Z'},
         {'version': '5.1.15',
             'sha256': 'fbf4d085f9bf6ffad259aee1e9f60cf060e7e99c447894ad8955df02de83c92c',
-            'basename': 'hdfeos{1}.zip'
-        }
+            'basename': 'hdfeos{1}.zip'}
         ]
 
     for vrec in version_list:

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -31,7 +31,7 @@ class HdfEos5(AutotoolsPackage):
         {'version': '5.1.15',
             'sha256': 'fbf4d085f9bf6ffad259aee1e9f60cf060e7e99c447894ad8955df02de83c92c',
             'basename': 'hdfeos{1}.zip'}
-        ]
+    ]
 
     for vrec in version_list:
         ver = vrec['version']

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -75,10 +75,10 @@ class HdfEos5(AutotoolsPackage):
 
         # Package really wants h5cc to be used
         if self.spec['mpi']:
-            extra_args.append('CC={0}/bin/h5pcc'.format(
+            extra_args.append('CC={0}/bin/h5pcc -Df2cFortran'.format(
                 self.spec['hdf5'].prefix))
         else:
-            extra_args.append('CC={0}/bin/h5cc'.format(
+            extra_args.append('CC={0}/bin/h5cc -Df2cFortran'.format(
                 self.spec['hdf5'].prefix))
 
         # We always build PIC code


### PR DESCRIPTION
New package: hdf-eos5: Hierarchical Data Format for Earth Observing System based on hdf5

The URL structure for downloads uses the checksum of file as part of the path, and also the name format changed between last two versions (not sure if that is an one-time thing or if we should expect changes with every version change).  To compensate, creating a list with version and checksum, etc. which is used both for generating version specific URLs but also for the version()
method.