### PR TITLE
openipmi: fix dependency and add version 2.0.29

### DIFF
--- a/var/spack/repos/builtin/packages/openipmi/package.py
+++ b/var/spack/repos/builtin/packages/openipmi/package.py
@@ -14,13 +14,18 @@ class Openipmi(AutotoolsPackage):
     homepage = "https://sourceforge.net/projects/openipmi/"
     url      = "https://sourceforge.net/projects/openipmi/files/OpenIPMI%202.0%20Library/OpenIPMI-2.0.29.tar.gz"
 
+    version('2.0.29', sha256='2244124579afb14e569f34393e9ac61e658a28b6ffa8e5c0d2c1c12a8ce695cd')
     version('2.0.28', sha256='8e8b1de2a9a041b419133ecb21f956e999841cf2e759e973eeba9a36f8b40996')
     version('2.0.27', sha256='f3b1fafaaec2e2bac32fec5a86941ad8b8cb64543470bd6d819d7b166713d20b')
 
-    depends_on('popt')
-    depends_on('python')
-    depends_on('termcap')
-    depends_on('ncurses')
+    depends_on('popt', type='link')
+    depends_on('python', type=('build', 'link', 'run'))
+    depends_on('perl', type=('build', 'link', 'run'))
+    depends_on('termcap', type='link')
+    depends_on('ncurses', type='link')
+    depends_on('readline', type='link')
+
+    patch('readline.patch', when='@2.0.27')
 
     def configure_args(self):
         args = ['LIBS=' + self.spec['ncurses'].libs.link_flags]

--- a/var/spack/repos/builtin/packages/openipmi/readline.patch
+++ b/var/spack/repos/builtin/packages/openipmi/readline.patch
@@ -1,0 +1,11 @@
+--- spack-src/sample/ipmi_serial_bmc_emu.c.org	2020-12-07 17:08:39.907878381 +0900
++++ spack-src/sample/ipmi_serial_bmc_emu.c	2020-12-07 17:08:56.713276894 +0900
+@@ -42,7 +42,7 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <sys/select.h>
+-#include <editline/readline.h>
++#include <readline/readline.h>
+ 
+ #define _GNU_SOURCE
+ #include <getopt.h>


### PR DESCRIPTION
- Add perl and readline dependency
- fix dependency type
- Fix readline bug in 2.0.27 (https://sourceforge.net/p/openipmi/code/ci/d1dd570cf77cb2c63bc32bef12d5353e3a197146/)
- Add version 2.0.29