### PR TITLE
py-protobuf: Link to libprotobuf when building +cpp variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -58,6 +58,11 @@ class PyProtobuf(PythonPackage):
             return '.'
 
     @when('+cpp')
+    def setup_build_environment(self, env):
+        protobuf_dir = self.spec['protobuf'].libs.directories[0]
+        env.prepend_path('LIBRARY_PATH', protobuf_dir)
+
+    @when('+cpp')
     def build_args(self, spec, prefix):
         return ['--cpp_implementation']
 


### PR DESCRIPTION
Under certain circumstances (e.g. when I build Python with Spack), I get a linking error to `-lprotobuf` when building the `+cpp` variant of py-protobuf. I've fixed this by manipulating the environment so the linker has access to the protobuf install directory.