### PR TITLE
concretizer: also capture all package variant defaults as possible variant values

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -883,6 +883,7 @@ class SpackSolverSetup(object):
         for name, variant in sorted(pkg.variants.items()):
             self.gen.fact(fn.variant(pkg.name, name))
 
+            spec = spack.spec.Spec(pkg.name)
             single_value = not variant.multi
             if single_value:
                 self.gen.fact(fn.variant_single_value(pkg.name, name))
@@ -890,6 +891,9 @@ class SpackSolverSetup(object):
                     fn.variant_default_value_from_package_py(
                         pkg.name, name, variant.default)
                 )
+                spec.update_variant_validate(name, variant.default)
+                self.gen.fact(fn.variant_possible_value(pkg.name, name,
+                                                        variant.default))
             else:
                 spec_variant = variant.make_default()
                 defaults = spec_variant.value
@@ -898,6 +902,9 @@ class SpackSolverSetup(object):
                         fn.variant_default_value_from_package_py(
                             pkg.name, name, val)
                     )
+                    spec.update_variant_validate(name, val)
+                    self.gen.fact(fn.variant_possible_value(pkg.name,
+                                                            name, val))
 
             values = variant.values
             if values is None:

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -84,7 +84,9 @@ class TestConcretizePreferences(object):
         ('multivalue-variant', ['foo=bar,baz', 'fee=bar'],
          {'foo': ('bar', 'baz'), 'fee': 'bar'}),
         ('singlevalue-variant', ['fum=why'],
-         {'fum': 'why'})
+         {'fum': 'why'}),
+        ('singlevalue-variant', [],
+         {'api': 'none'})
     ])
     def test_preferred_variants(
             self, package_name, variant_value, expected_results

--- a/var/spack/repos/builtin.mock/packages/singlevalue-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/singlevalue-variant/package.py
@@ -17,3 +17,4 @@ class SinglevalueVariant(Package):
         values=str,
         multi=False
     )
+    variant('api', default='none', description='choose api compatibility', values=('v114', 'v112', 'v110', 'v18', 'v16'), multi=False)


### PR DESCRIPTION
partially addresses #20171

before:
```console
[aweits@localhost spack]$ spack solve hdf5
==> Best of 0 answers.
==> Optimization: [0, 1, 0, 0, 30, -2, 1, 1, 0, -20, 0]
hdf5@1.10.7%gcc@9.3.0~cxx~debug~fortran~hl~java+mpi+pic+shared~szip~threadsafe api=v16 arch=linux-centos8-skylake_avx512
```

after:
```console
[aweits@localhost spack]$ spack solve hdf5
==> Best of 0 answers.
==> Optimization: [0, 0, 0, 0, 30, -2, 1, 1, 0, -20, 0]
hdf5@1.10.7%gcc@9.3.0~cxx~debug~fortran~hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-centos8-skylake_avx512
```