### PR TITLE
Tests: enable re-use of post-install tests in smoke tests

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -750,6 +750,9 @@ def setup_package(pkg, dirty, context='build'):
     elif context == 'test':
         import spack.user_environment as uenv  # avoid circular import
         env.extend(uenv.environment_modifications_for_spec(pkg.spec))
+        env.extend(
+            modifications_from_dependencies(pkg.spec, context=context)
+        )
         set_module_variables_for_package(pkg)
         env.prepend_path('PATH', '.')
 
@@ -814,7 +817,8 @@ def modifications_from_dependencies(spec, context):
     }
     deptype, method = deptype_and_method[context]
 
-    for dspec in spec.traverse(order='post', root=False, deptype=deptype):
+    root = context == 'test'
+    for dspec in spec.traverse(order='post', root=root, deptype=deptype):
         dpkg = dspec.package
         set_module_variables_for_package(dpkg)
         # Allow dependencies to modify the module

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -20,6 +20,8 @@ class Hdf5(AutotoolsPackage):
     git      = "https://bitbucket.hdfgroup.org/scm/hdffv/hdf5.git"
     maintainers = ['lrknox']
 
+    test_requires_compiler = True
+
     version('develop', branch='develop')
 
     version('1.12.0', sha256='a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a')
@@ -426,5 +428,4 @@ HDF5 version {version} {version}
         self._test_example()
 
         # Run existing install check
-        # TODO: Restore once address built vs. installed state
-        # self._check_install()
+        self._check_install()


### PR DESCRIPTION
This PR ensures smoke tests have environment set up to allow re-using post-install tests.  The fix is manually tested on the `hdf5` package.

(Thanks becker33 for quick advice on the fix.)