### PR TITLE
boost: Backport python3 import problem

### DIFF
--- a/var/spack/repos/builtin/packages/boost/boost_218.patch
+++ b/var/spack/repos/builtin/packages/boost/boost_218.patch
@@ -1,0 +1,10 @@
+--- a/libs/python/src/numpy/numpy.cpp
++++ b/libs/python/src/numpy/numpy.cpp
+@@ -19,6 +19,7 @@ static void wrap_import_array()
+ static void * wrap_import_array()
+ {
+   import_array();
++  return NULL;
+ }
+ #endif
+

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -255,6 +255,10 @@ class Boost(Package):
     # See https://github.com/boostorg/build/pull/154
     patch('boost_154.patch', when='@:1.63.99')
 
+    # Backport Python3 import problem
+    # See https://github.com/boostorg/build/pull/218
+    patch('boost_218.patch', when='@:1.67.99')
+
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler
         if self.spec.satisfies('%nvhpc'):

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -256,7 +256,7 @@ class Boost(Package):
     patch('boost_154.patch', when='@:1.63.99')
 
     # Backport Python3 import problem
-    # See https://github.com/boostorg/build/pull/218
+    # See https://github.com/boostorg/python/pull/218
     patch('boost_218.patch', when='@:1.67.99')
 
     def patch(self):


### PR DESCRIPTION
While testing `alps`, I encountered such errors.

> RuntimeError: FATAL: module compiled as little endian, but detected
different endianness at runtime
ImportError: numpy.core._multiarray_umath failed to import

This error solved by this patch. So I back-ported it.
https://github.com/boostorg/python/issues/209
https://github.com/boostorg/python/pull/218