### PR TITLE
Add a new NEST version, 2.20.0.

### DIFF
--- a/var/spack/repos/builtin/packages/nest/package.py
+++ b/var/spack/repos/builtin/packages/nest/package.py
@@ -15,6 +15,7 @@ class Nest(CMakePackage):
     homepage = "http://www.nest-simulator.org"
     url      = "https://github.com/nest/nest-simulator/releases/download/v2.12.0/nest-2.12.0.tar.gz"
 
+    version('2.20.0', sha256='40e33187c22d6e843d80095b221fa7fd5ebe4dbc0116765a91fc5c425dd0eca4')
     version('2.14.0', sha256='d6316d6c9153100a3220488abfa738958c4b65bf2622bd15540e4aa81e79f17f')
     version('2.12.0', sha256='bac578f38bb0621618ee9d5f2f1febfee60cddc000ff32e51a5f5470bb3df40d')
     version('2.10.0', sha256='2b6fc562cd6362e812d94bb742562a5a685fb1c7e08403765dbe123d59b0996c')

--- a/var/spack/repos/builtin/packages/scalasca/package.py
+++ b/var/spack/repos/builtin/packages/scalasca/package.py
@@ -30,7 +30,7 @@ class Scalasca(AutotoolsPackage):
 
     # version 2.4+
     depends_on('cubew@4.4:', when='@2.4:')
-    depends_on('scorep@6.0:', when='@2.4:')
+    depends_on('scorep@6.0:', when='@2.4:', type=('run'))
 
     # version 2.3+
     depends_on('otf2@2:', when='@2.3:')


### PR DESCRIPTION
Just a one-liner addition, so that a new release can get built with Spack