### PR TITLE
bugfix/numactl: use package supplied autogen.sh

### DIFF
--- a/var/spack/repos/builtin/packages/numactl/package.py
+++ b/var/spack/repos/builtin/packages/numactl/package.py
@@ -12,6 +12,8 @@ class Numactl(AutotoolsPackage):
     homepage = "http://oss.sgi.com/projects/libnuma/"
     url      = "https://github.com/numactl/numactl/archive/v2.0.11.tar.gz"
 
+    force_autoreconf = True
+
     version('2.0.14', sha256='1ee27abd07ff6ba140aaf9bc6379b37825e54496e01d6f7343330cf1a4487035')
     version('2.0.12', sha256='7c3e819c2bdeb883de68bafe88776a01356f7ef565e75ba866c4b49a087c6bdf')
     version('2.0.11', sha256='3e099a59b2c527bcdbddd34e1952ca87462d2cef4c93da9b0bc03f02903f7089')
@@ -24,6 +26,10 @@ class Numactl(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+
+    def autoreconf(self, spec, prefix):
+        bash = which('bash')
+        bash('./autogen.sh')
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler


### PR DESCRIPTION
Trying to build numactl with the Spack default autoreconf leads to syntax errors in the generated configure script.
Switching to the package supplied `autogen.sh` script generates a valid configure and install completes normally.

Error detail:

```
==> Installing numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvld
==> No binary for numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvld found: installing from source
==> Using cached archive: /home/phil/repos/spack/var/spack/cache/_source-cache/archive/1e/1ee27abd07ff6ba140aaf9bc6379b37825e54496e01d6f7343330cf1a4487035.tar.gz
==> numactl: Executing phase: 'autoreconf'
==> numactl: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 2:
    '/tmp/spack/phil/spack-stage-numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvld/spack-src/configure' '--prefix=/opt/spack/linux-gentoo2-zen2/gcc-10.2.0/numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvld'

1 error found in build log:
     112    checking whether we are using the GNU C compiler... (cached) yes
     113    checking whether /home/phil/repos/spack/lib/spack/env/gcc/gcc accepts -g..
            . (cached) yes
     114    checking for /home/phil/repos/spack/lib/spack/env/gcc/gcc option to accept
             ISO C89... (cached) none needed
     115    checking whether /home/phil/repos/spack/lib/spack/env/gcc/gcc understands 
            -c and -o together... (cached) yes
     116    checking dependency style of /home/phil/repos/spack/lib/spack/env/gcc/gcc.
            .. (cached) gcc3
     117    checking for thread local storage (TLS) class... _Thread_local
  >> 118    /tmp/spack/phil/spack-stage-numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvl
            d/spack-src/configure: line 9439: syntax error near unexpected token `fi'
     119    /tmp/spack/phil/spack-stage-numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvl
            d/spack-src/configure: line 9439: `fi'

See build log for details:
  /tmp/spack/phil/spack-stage-numactl-2.0.14-4moy4pl5tvpw2xlbfqziqn2es77nvvld/spack-build-out.txt
```

[spack-build-out.txt](https://github.com/spack/spack/files/5672576/spack-build-out.txt)
[spack-build-env.txt](https://github.com/spack/spack/files/5672588/spack-build-env.txt)