### PR TITLE
Fix: Renamed new vtk-m test method so picked up as a smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -197,7 +197,7 @@ class VtkM(CMakePackage, CudaPackage):
 
             return options
 
-    def smoke_test(self):
+    def test(self):
         print("Checking VTK-m installation...")
         spec = self.spec
         checkdir = "spack-check"
@@ -363,4 +363,4 @@ Ran tests on: """ + expected_device + "\n"
     def check_install(self):
         spec = self.spec
         if "@master" in spec:
-            self.smoke_test()
+            self.test()


### PR DESCRIPTION
The package's smoke test won't be run by Spack as a smoke test -- though it will during installation -- due to the name given to the method.  This PR simply renames the method.

This PR depends on #20298 to test whether renaming is sufficient to actually execute the test.

UPDATE: Making the information available to the test requires more changes to Spack to retain build dependencies for this purposes.  The LLNL Spack team has begun discussing options.