### PR TITLE
adding ipython interpreter option for developers

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -396,6 +396,23 @@ other Spack modules:
    True
    >>>
 
+If you prefer using an ipython interpreter, given that ipython is installed
+you can specify the interpreter with ``-i``:
+
+.. code-block:: console
+
+   $ spack python -i ipython
+   Python 3.8.3 (default, May 19 2020, 18:47:26) 
+   Type 'copyright', 'credits' or 'license' for more information
+   IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.
+
+
+   Spack version 0.16.0
+   Python 3.8.3, Linux x86_64
+
+   In [1]:
+
+
 You can also run a single command:
 
 .. code-block:: console
@@ -409,7 +426,10 @@ or a file:
 
    $ spack python ~/test_fetching.py
 
-just like you would with the normal ``python`` command.
+just like you would with the normal ``python`` command. Note that for both
+commands and files, the default will always be the python interpreter,
+as ipython is intended for interactive use cases.
+
 
 .. _cmd-spack-url:
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -413,29 +413,24 @@ you can specify the interpreter with ``-i``:
    In [1]:
 
 
-Currently, there is only support for the current Python interpreter (default) 
-along with an IPython interpreter (shown above). With the Python interpreter
-you can run a single command:
+With either interpreter you can run a single command:
 
 .. code-block:: console
 
    $ spack python -c 'import distro; distro.linux_distribution()'
-   ('Fedora', '25', 'Workstation Edition')
+   ('Ubuntu', '18.04', 'Bionic Beaver')
+
+   $ spack python -i ipython -c 'import distro; distro.linux_distribution()'
+   Out[1]: ('Ubuntu', '18.04', 'Bionic Beaver')
 
 or a file:
 
 .. code-block:: console
 
    $ spack python ~/test_fetching.py
+   $ spack python -i ipython ~/test_fetching.py
 
-just like you would with the normal ``python`` command. Note that for both
-commands and files, your only option is the Python interpreter. 
-If you try using IPython, you'll get an error message.
-
-.. code-block:: console
-
-   $spack python -i ipython script.py 
-   ==> Error: Use the default python interpreter for args/commands.
+just like you would with the normal ``python`` command. 
 
 
 .. _cmd-spack-url:

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -414,8 +414,8 @@ you can specify the interpreter with ``-i``:
 
 
 Currently, there is only support for the current Python interpreter (default) 
-along with an IPython interpreter (``-i python``). With the Python interpreter
-(which is not interactive) you can run a single command:
+along with an IPython interpreter (shown above). With the Python interpreter
+you can run a single command:
 
 .. code-block:: console
 
@@ -429,8 +429,8 @@ or a file:
    $ spack python ~/test_fetching.py
 
 just like you would with the normal ``python`` command. Note that for both
-commands and files, your only option is the Python interpreter, as it is 
-non-interactive. If you try using IPython, you'll get an error message.
+commands and files, your only option is the Python interpreter. 
+If you try using IPython, you'll get an error message.
 
 .. code-block:: console
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -396,7 +396,7 @@ other Spack modules:
    True
    >>>
 
-If you prefer using an ipython interpreter, given that ipython is installed
+If you prefer using an IPython interpreter, given that IPython is installed
 you can specify the interpreter with ``-i``:
 
 .. code-block:: console
@@ -413,7 +413,9 @@ you can specify the interpreter with ``-i``:
    In [1]:
 
 
-You can also run a single command:
+Currently, there is only support for the current Python interpreter (default) 
+along with an IPython interpreter (``-i python``). With the Python interpreter
+(which is not interactive) you can run a single command:
 
 .. code-block:: console
 
@@ -427,8 +429,13 @@ or a file:
    $ spack python ~/test_fetching.py
 
 just like you would with the normal ``python`` command. Note that for both
-commands and files, the default will always be the python interpreter,
-as ipython is intended for interactive use cases.
+commands and files, your only option is the Python interpreter, as it is 
+non-interactive. If you try using IPython, you'll get an error message.
+
+.. code-block:: console
+
+   $spack python -i ipython script.py 
+   ==> Error: Use the default python interpreter for args/commands.
 
 
 .. _cmd-spack-url:

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -51,9 +51,10 @@ def python(parser, args, unknown_args):
     if unknown_args:
         tty.die("Unknown arguments:", " ".join(unknown_args))
 
-    # If arguments or a command are provided, just use python
-    if args.python_args or args.python_command:
-        args.python_interpreter = "python"
+    # Only python has support for arguments / commands
+    has_command = args.python_args or args.python_command
+    if has_command and args.python_interpreter != "python":
+        tty.die("Use the default python interpreter for args/commands.")
 
     # Run user choose of interpreter
     if args.python_interpreter == "ipython":
@@ -69,8 +70,7 @@ def ipython_interpreter(args):
     try:
         import IPython
     except ImportError:
-        tty.warning("ipython is not installed, using python.")
-        return spack.cmd.python.python_interpreter(args)
+        tty.die("ipython is not installed, install and try again.")
 
     if "PYTHONSTARTUP" in os.environ:
         startup_file = os.environ["PYTHONSTARTUP"]

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -56,7 +56,7 @@ def python(parser, args, unknown_args):
     if has_command and args.python_interpreter != "python":
         tty.die("Use the default python interpreter for args/commands.")
 
-    # Run user choose of interpreter
+    # Run user choice of interpreter
     if args.python_interpreter == "ipython":
         return spack.cmd.python.ipython_interpreter(args)
     return spack.cmd.python.python_interpreter(args)

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -66,7 +66,6 @@ def ipython_interpreter(args):
     """An ipython interpreter is intended to be interactive, so it doesn't
     support running a script or arguments
     """
-    # If the user doesn't have ipython, fallback to python
     try:
         import IPython
     except ImportError:

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -51,6 +51,10 @@ def python(parser, args, unknown_args):
     if unknown_args:
         tty.die("Unknown arguments:", " ".join(unknown_args))
 
+    # Unexpected behavior from supplying both
+    if args.python_command and args.python_args:
+        tty.die("You can only specify a command OR script, but not both.")
+
     # Run user choice of interpreter
     if args.python_interpreter == "ipython":
         return spack.cmd.python.ipython_interpreter(args)
@@ -73,9 +77,7 @@ def ipython_interpreter(args):
                 exec(startup.read())
 
     # IPython can also support running a script OR command, not both
-    if args.python_command and args.python_args:
-        tty.die("ipython only supports a script OR command with -c, not both.")
-    elif args.python_args:
+    if args.python_args:
         IPython.start_ipython(argv=args.python_args)
     elif args.python_command:
         IPython.start_ipython(argv=['-c', args.python_command])

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -59,7 +59,7 @@ def python(parser, args, unknown_args):
     if args.python_interpreter == "ipython":
         return spack.cmd.python.ipython_interpreter(args)
     return spack.cmd.python.python_interpreter(args)
-     
+
 
 def ipython_interpreter(args):
     """An ipython interpreter is intended to be interactive, so it doesn't
@@ -79,10 +79,10 @@ def ipython_interpreter(args):
                 exec(startup.read())
 
     header = ("Spack version %s\nPython %s, %s %s"
-                         % (spack.spack_version, platform.python_version(),
-                            platform.system(), platform.machine()))
+              % (spack.spack_version, platform.python_version(),
+                 platform.system(), platform.machine()))
 
-    __name__ = "__main__"
+    __name__ = "__main__"  # noqa
     IPython.embed(module="__main__", header=header)
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1356,7 +1356,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -V --version -c -m"
+        SPACK_COMPREPLY="-h --help -V --version -c -i -m"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
This is a small pull request to add an option to use an ipython interpreter for developers, which is my preference (and maybe others too?) Basically, you can specify it like this:

```bash
$ spack python -i ipython
Python 3.8.3 (default, May 19 2020, 18:47:26) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.


Spack version 0.16.0
Python 3.8.3, Linux x86_64

In [1]:
```
I replaced the console.runsource with a simple exec, since embed() essentially includes all the locals anyway. For running commands/files I force the user to use python, because while it works to use ipython, it doesn't make sense for a non-interactive use case. 

This is my first PR in a long time so I suspect the formatting will be wrong, I'll follow up with fixes when the CI tells me I'm a wet noodle.