### PR TITLE
comgr: disable hip compile test from /opt/rocm

### DIFF
--- a/var/spack/repos/builtin/packages/comgr/hip-tests.patch
+++ b/var/spack/repos/builtin/packages/comgr/hip-tests.patch
@@ -1,0 +1,11 @@
+diff -Naurb ROCm-CompilerSupport-rocm-3.10.0.orig/lib/comgr/test/CMakeLists.txt ROCm-CompilerSupport-rocm-3.10.0/lib/comgr/test/CMakeLists.txt
+--- ROCm-CompilerSupport-rocm-3.10.0.orig/lib/comgr/test/CMakeLists.txt	2020-09-16 14:17:12.000000000 -0500
++++ ROCm-CompilerSupport-rocm-3.10.0/lib/comgr/test/CMakeLists.txt	2020-12-14 10:11:56.609584283 -0600
+@@ -120,7 +120,6 @@
+ add_comgr_test(include_subdirectory_test)
+ add_comgr_test(options_test)
+ # Test : Compile HIP only if HIP-Clang is installed.
+-find_package(hip CONFIG PATHS /opt/rocm/hip QUIET)
+ if (DEFINED HIP_COMPILER AND "${HIP_COMPILER}" STREQUAL "clang")
+   add_comgr_test(compile_hip_test)
+   add_comgr_test(compile_hip_test_in_process)

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -24,13 +24,22 @@ class Comgr(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
+    depends_on('cmake@3.2.0:',  type='build', when='@:3.8.99')
+    depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
+
     depends_on('zlib', type='link')
     depends_on('z3', type='link')
     depends_on('ncurses', type='link')
-    depends_on('cmake@3:', type='build')
+    
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0']:
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
-    root_cmakelists_dir = 'lib/comgr'
+    root_cmakelists_dir = join_path('lib', 'comgr')
+
+    # Disable the hip compile tests.  Spack should not be using
+    # /opt/rocm, and this breaks the build when /opt/rocm exists.
+    def patch(self):
+        filter_file(r'(find_package.*)PATHS\s*/opt/rocm[^ )]*', r'\1',
+                    join_path('lib', 'comgr', 'test', 'CMakeLists.txt'))

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -24,6 +24,10 @@ class Comgr(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
+    # Disable the hip compile tests.  Spack should not be using
+    # /opt/rocm, and this breaks the build when /opt/rocm exists.
+    patch('hip-tests.patch')
+
     depends_on('cmake@3.2.0:',  type='build', when='@:3.8.99')
     depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
 
@@ -37,9 +41,3 @@ class Comgr(CMakePackage):
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     root_cmakelists_dir = join_path('lib', 'comgr')
-
-    # Disable the hip compile tests.  Spack should not be using
-    # /opt/rocm, and this breaks the build when /opt/rocm exists.
-    def patch(self):
-        filter_file(r'(find_package.*)PATHS\s*/opt/rocm[^ )]*', r'\1',
-                    join_path('lib', 'comgr', 'test', 'CMakeLists.txt'))

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -30,7 +30,7 @@ class Comgr(CMakePackage):
     depends_on('zlib', type='link')
     depends_on('z3', type='link')
     depends_on('ncurses', type='link')
-    
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0']:
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)


### PR DESCRIPTION
Fixes #20132

Filter comgr/test/CMakeLists.txt to remove 'PATHS /opt/rocm/hip' from
find_package().  Spack should not be using /opt/rocm, and this breaks
the build when /opt/rocm exitst.

Tighten the cmake dependency versions.

ping @srekolam @haampie for review.

----------

The effect of filter_file on test/CMakeLists.txt is this diff:

```
--- CMakeLists.txt~	2020-12-10 17:12:07.066654363 -0600
+++ CMakeLists.txt	2020-12-10 17:12:07.066654363 -0600
@@ -119,7 +119,7 @@
 add_comgr_test(include_subdirectory_test)
 add_comgr_test(options_test)
 # Test : Compile HIP only if HIP-Clang is installed.
-find_package(hip CONFIG PATHS /opt/rocm/hip QUIET)
+find_package(hip CONFIG  QUIET)
 if (DEFINED HIP_COMPILER AND "${HIP_COMPILER}" STREQUAL "clang")
   add_comgr_test(compile_hip_test)
   add_comgr_test(compile_hip_test_in_process)
```