### PR TITLE
Add a variant for Fortran support ('-DWITH_FORTRAN').

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -53,6 +53,8 @@ class Caliper(CMakePackage):
             description='Enable sampling support on Linux')
     variant('sosflow', default=False,
             description='Enable SOSflow support')
+    variant('fortran', default=False,
+            description='Enable Fortran support')
 
     depends_on('adiak@0.1:0.99', when='@2.2: +adiak')
 
@@ -98,7 +100,8 @@ class Caliper(CMakePackage):
             '-DWITH_LIBPFM=%s'   % ('On' if '+libpfm'   in spec else 'Off'),
             '-DWITH_SOSFLOW=%s'  % ('On' if '+sosflow'  in spec else 'Off'),
             '-DWITH_SAMPLER=%s'  % ('On' if '+sampler'  in spec else 'Off'),
-            '-DWITH_MPI=%s'      % ('On' if '+mpi'      in spec else 'Off')
+            '-DWITH_MPI=%s'      % ('On' if '+mpi'      in spec else 'Off'),
+            '-DWITH_FORTRAN=%s'  % ('On' if '+fortran'  in spec else 'Off')
         ]
 
         if '+papi' in spec:


### PR DESCRIPTION
This PR adds a variant to enable Fortran support (via the -DWITH_FORTRAN cmake arg).