### PR TITLE
Fix logging error

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -832,9 +832,6 @@ def _setup_pkg_and_run(serialized_pkg, function, kwargs, child_pipe,
                        input_multiprocess_fd):
 
     context = kwargs.get('context', 'build')
-    # Restore the working directory from the passed-in arguments
-    if not spack.main.spack_working_dir:
-        spack.main.spack_working_dir = kwargs['spack_main_working_dir']
 
     try:
         # We are in the child process. Python sets sys.stdin to
@@ -947,9 +944,6 @@ def start_build_process(pkg, function, kwargs):
         if sys.stdin.isatty() and hasattr(sys.stdin, 'fileno'):
             input_fd = os.dup(sys.stdin.fileno())
             input_multiprocess_fd = MultiProcessFd(input_fd)
-
-        # Pass the working directory through the kwargs for debug logging
-        kwargs['spack_main_working_dir'] = spack.main.spack_working_dir
 
         p = multiprocessing.Process(
             target=_setup_pkg_and_run,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -832,6 +832,9 @@ def _setup_pkg_and_run(serialized_pkg, function, kwargs, child_pipe,
                        input_multiprocess_fd):
 
     context = kwargs.get('context', 'build')
+    # Restore the working directory from the passed-in arguments
+    if not spack.main.spack_working_dir:
+        spack.main.spack_working_dir = kwargs['spack_main_working_dir']
 
     try:
         # We are in the child process. Python sets sys.stdin to
@@ -944,6 +947,9 @@ def start_build_process(pkg, function, kwargs):
         if sys.stdin.isatty() and hasattr(sys.stdin, 'fileno'):
             input_fd = os.dup(sys.stdin.fileno())
             input_multiprocess_fd = MultiProcessFd(input_fd)
+
+        # Pass the working directory through the kwargs for debug logging
+        kwargs['spack_main_working_dir'] = spack.main.spack_working_dir
 
         p = multiprocessing.Process(
             target=_setup_pkg_and_run,

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -69,10 +69,12 @@ class PackageInstallContext(object):
             self.serialized_pkg = serialize(pkg)
         else:
             self.pkg = pkg
+        self.spack_working_dir = spack.main.spack_working_dir
         self.test_state = TestState()
 
     def restore(self):
         self.test_state.restore()
+        spack.main.spack_working_dir = self.spack_working_dir
         if _serialize:
             return pickle.load(self.serialized_pkg)
         else:


### PR DESCRIPTION
This fixes a logging error, observed on macOS 11.0.1 (Big Sur). Running Spack in debugging mode, for instance `spack -dd install py-scipy`, results in log files from the compiler wrappers not getting written, instead printing errors such as “No such file or directory: None/<log file name>.” This is because the log file directory gets set from `spack.main.spack_working_dir`, but that variable is not set in the spawned process. This PR passes the working directory into the subprocess through `kwargs`, and then assigns `spack.main.spack_working_dir` to it, so that the logging directory is set correctly.