### PR TITLE
frontistr: add v5.1.1, need trilinos version 12

### DIFF
--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -15,6 +15,7 @@ class Frontistr(CMakePackage):
     git      = "https://gitlab.com/FrontISTR-Commons/FrontISTR.git"
     maintainers = ['hiroshi.okuda', 'kgoto', 'morita', 'inagaki', 'michioga']
 
+    version('5.1.1', tag='v5.1.1')
     version('5.1', tag='v5.1')
     version('5.0', tag='v5.0')
     version('master', tag='master')

--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -31,7 +31,7 @@ class Frontistr(CMakePackage):
     # depends_on('revocap-coupler')
     depends_on('metis')
     depends_on('mumps')
-    depends_on('trilinos')
+    depends_on('trilinos@:12.18.1')
 
     def cmake_args(self):
         define = CMakePackage.define


### PR DESCRIPTION
Add v5.1.1. and
To install frontistr, you need trilinos version 12.
If you have trilinos version 13, the installation of frontistr will fail.

```
     944    In file included from /home/denpo/work/20201029/spack/opt/spack/linux-centos8-a64fx/gcc-8.3.1/trilin
            os-13.0.1-zskzyqlhkmhujicn5kpbwymkqrecrkxd/include/ml_include.h:46,
     945                     from /home/denpo/spack-stage/spack-stage-frontistr-5.1-4o24gpbgcvemfjxe3dieubzsilwk
            4mxb/spack-src/hecmw1/src/solver/precond/nn/hecmw_ML_wrapper.c:13:
     946    /home/denpo/work/20201029/spack/opt/spack/linux-centos8-a64fx/gcc-8.3.1/trilinos-13.0.1-zskzyqlhkmhu
            jicn5kpbwymkqrecrkxd/include/ml_amesos.h:64:5: note: declared here
     947     int ML_Gen_Smoother_Amesos(ML *ml, int nl, int AmesosSolver,
     948
 >> 949    make[2]: *** [hecmw1/CMakeFiles/hecmw.dir/build.make:2022: hecmw1/CMakeFiles/hecmw.dir/src/solver/pr
            econd/nn/hecmw_ML_wrapper.c.o] Error 1
     950    make[2]: *** Waiting for unfinished jobs....
     951    make[2]: Leaving directory '/home/denpo/spack-stage/spack-stage-frontistr-5.1-4o24gpbgcvemfjxe3dieub
            zsilwk4mxb/spack-build-4o24gpb'
  >> 952    make[1]: *** [CMakeFiles/Makefile2:208: hecmw1/CMakeFiles/hecmw.dir/all] Error 2
     953    make[1]: Leaving directory '/home/denpo/spack-stage/spack-stage-frontistr-5.1-4o24gpbgcvemfjxe3dieub
            zsilwk4mxb/spack-build-4o24gpb'
     954    make: *** [Makefile:185: all] Error 2
```