### PR TITLE
likwid: Add variant for Nvidia GPU profiling feature

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -137,7 +137,7 @@ class Likwid(Package):
                         'CUDAINCLUDE = {0}'.format(cudainc),
                         'config.mk')
             cuptihead = HeaderList(find(spec['cuda'].prefix, 'cupti.h',
-                                          recursive=True))
+                                        recursive=True))
             filter_file('^CUPTIINCLUDE.*',
                         'CUPTIINCLUDE = {0}'.format(cuptihead.directories[0]),
                         'config.mk')

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -64,7 +64,7 @@ class Likwid(Package):
             env.append_path('LD_LIBRARY_PATH', self.spec['cuda'].prefix.lib)
             cuptilib = join_path(self.spec['cuda'].prefix,
                                  "extras/CUPTI/lib64")
-            env.append_path('LD_LIBRARY_PATH', cuptilibpath)
+            env.append_path('LD_LIBRARY_PATH', cuptilib)
 
     @run_before('install')
     def filter_sbang(self):

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -62,7 +62,9 @@ class Likwid(Package):
         if "+cuda" in self.spec:
             env.set('CUDA_HOME', self.spec['cuda'].prefix)
             env.append_path('LD_LIBRARY_PATH', self.spec['cuda'].prefix.lib)
-            env.append_path('LD_LIBRARY_PATH', "{0}/extras/CUPTI/lib64".format(self.spec['cuda'].prefix))
+            cuptilib = join_path(self.spec['cuda'].prefix,
+                                 "extras/CUPTI/lib64")
+            env.append_path('LD_LIBRARY_PATH', cuptilibpath)
 
     @run_before('install')
     def filter_sbang(self):
@@ -115,10 +117,9 @@ class Likwid(Package):
                         'FORTRAN_INTERFACE = true',
                         'config.mk')
             if self.compiler.name == 'gcc':
-                filter_file('ifort', 'gfortran',
-                            join_path('make', 'include_GCC.mk'))
-                filter_file('-module', '-I', join_path('make',
-                                                       'include_GCC.mk'))
+                makepath = join_path('make', 'include_GCC.mk')
+                filter_file('ifort', 'gfortran', makepath)
+                filter_file('-module', '-I',  makepath)
         else:
             filter_file('^FORTRAN_INTERFACE .*',
                         'FORTRAN_INTERFACE = false',
@@ -131,12 +132,13 @@ class Likwid(Package):
             filter_file('^BUILDAPPDAEMON.*',
                         'BUILDAPPDAEMON = true',
                         'config.mk')
+            cudainc = spec['cuda'].prefix.include
+            cuptiinc = join_path(spec['cuda'].prefix, "extras/CUPTI/include")
             filter_file('^CUDAINCLUDE.*',
-                        'CUDAINCLUDE = {0}'.format(spec['cuda'].prefix.include),
+                        'CUDAINCLUDE = {0}'.format(cudainc),
                         'config.mk')
-            cuptiinclude = "{0}/extras/CUPTI/include".format(spec['cuda'].prefix)
             filter_file('^CUPTIINCLUDE.*',
-                        'CUPTIINCLUDE = {0}'.format(cuptiinclude),
+                        'CUPTIINCLUDE = {0}'.format(cuptiinc),
                         'config.mk')
         else:
             filter_file('^NVIDIA_INTERFACE.*',

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -62,7 +62,7 @@ class Likwid(Package):
         if "+cuda" in self.spec:
             env.set('CUDA_HOME', self.spec['cuda'].prefix)
             env.append_path('LD_LIBRARY_PATH', self.spec['cuda'].prefix.lib)
-            env.append_path('LD_LIBRARY_PATH', "{0}/extras/CUPTI/include".format(self.spec['cuda'].prefix))
+            env.append_path('LD_LIBRARY_PATH', "{0}/extras/CUPTI/lib64".format(self.spec['cuda'].prefix))
 
     @run_before('install')
     def filter_sbang(self):

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -59,15 +59,12 @@ class Likwid(Package):
         filter_file('^#!/usr/bin/perl -w', '#!/usr/bin/env perl', *files)
         filter_file('^#!/usr/bin/perl', '#!/usr/bin/env perl', *files)
 
-
     def setup_run_environment(self, env):
         if "+cuda" in self.spec:
             libs = find_libraries('libcupti', root=self.spec['cuda'].prefix,
                                   shared=True, recursive=True)
             for lib in libs.directories:
                 env.append_path('LD_LIBRARY_PATH', lib)
-
-
 
     @run_before('install')
     def filter_sbang(self):
@@ -139,10 +136,10 @@ class Likwid(Package):
             filter_file('^CUDAINCLUDE.*',
                         'CUDAINCLUDE = {0}'.format(cudainc),
                         'config.mk')
-            cuptiheader = HeaderList(find(spec['cuda'].prefix, 'cupti.h',
+            cuptihead = HeaderList(find(spec['cuda'].prefix, 'cupti.h',
                                           recursive=True))
             filter_file('^CUPTIINCLUDE.*',
-                        'CUPTIINCLUDE = {0}'.format(cuptiheader.directories[0]),
+                        'CUPTIINCLUDE = {0}'.format(cuptihead.directories[0]),
                         'config.mk')
         else:
             filter_file('^NVIDIA_INTERFACE.*',


### PR DESCRIPTION
With version 5.0, LIKWID got a profiling interface for Nvidia GPUs (based on CUPTI).
With 5.1, the interface was extended to work with the new CUpti Profiling API.
This PR adds a variant switch to activate that feature.

Single issue left: How to find the subfolder below `spec['cuda'].prefix` which includes `cupti.h`? It's not in `spec['cuda'].prefix.include`. Same for `libcupti.so` which is not in `spec['cuda'].prefix.lib`. The hardcoded paths `spec['cuda'].prefix + "extras/CUPTI/{include,lib64}"` probably work but might break in the future. Is there a spack-way to do it or should the standard library be used for this?