### PR TITLE
libc: Return empty libs

### DIFF
--- a/var/spack/repos/builtin/packages/libc/package.py
+++ b/var/spack/repos/builtin/packages/libc/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from llnl.util.filesystem import LibraryList
 
 
 class Libc(Package):
@@ -20,3 +20,7 @@ class Libc(Package):
 
     provides('iconv', when='+iconv')
     provides('rpc', when='+rpc')
+
+    @property
+    def libs(self):
+        return LibraryList([])


### PR DESCRIPTION
The C-Library for the current compiler should already be used by the compiler. So there is no point in returning any libs for this package.

Without this patch: if one uses this as an external package (as intended), then this will can inject system library paths into the build process at the wrong place.