### PR TITLE
document cli syntax for environment scopes

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -78,7 +78,7 @@ are six configuration scopes. From lowest to highest:
    If multiple scopes are listed on the command line, they are ordered
    from lowest to highest precedence.
 
-#. **environment**: When using a Spack :ref:`environments`, Spack reads
+#. **environment**: When using Spack :ref:`environments`, Spack reads
    additional configuration from the environment file. See
    :ref:`environment-configuration` for further details on these
    scopes. Environment scopes can be referenced from the command line

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -78,7 +78,7 @@ are six configuration scopes. From lowest to highest:
    If multiple scopes are listed on the command line, they are ordered
    from lowest to highest precedence.
 
-#. **environment**: When using a Spack :ref:`environment`, Spack reads
+#. **environment**: When using a Spack :ref:`environments`, Spack reads
    additional configuration from the environment file. See
    :ref:`environment-configuration` for further details on these
    scopes. Environment scopes can be referenced from the command line

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -78,6 +78,13 @@ are six configuration scopes. From lowest to highest:
    If multiple scopes are listed on the command line, they are ordered
    from lowest to highest precedence.
 
+#. **environment**: When using a Spack :ref:`environment`, Spack reads
+   additional configuration from the environment file. See
+   :ref:`environment-configuration` for further details on these
+   scopes. Environment scopes can be referenced from the command line
+   as ``env:name`` (to reference environment ``foo``, use
+   ``env:foo``).
+
 #. **command line**: Build settings specified on the command line take
    precedence over all other scopes.
 
@@ -192,10 +199,11 @@ with MPICH. You can create different configuration scopes for use with
 Platform-specific Scopes
 ------------------------
 
-For each scope above, there can also be platform-specific settings.
-For example, on most platforms, GCC is the preferred compiler.
-However, on macOS (darwin), Clang often works for more packages,
-and is set as the default compiler. This configuration is set in
+For each scope above (excluding environment scopes), there can also be
+platform-specific settings.  For example, on most platforms, GCC is
+the preferred compiler.  However, on macOS (darwin), Clang often works
+for more packages, and is set as the default compiler. This
+configuration is set in
 ``$(prefix)/etc/spack/defaults/darwin/packages.yaml``. It will take
 precedence over settings in the ``defaults`` scope, but can still be
 overridden by settings in ``system``, ``system/darwin``, ``site``,

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -399,6 +399,12 @@ There are two ways to include configuration information in a Spack Environment:
 
 #. Included in the ``spack.yaml`` file from another file.
 
+Many Spack commands also affect configuration information in files
+automatically. Those commands take a ``--scope`` argument, and the
+environment can be specified by ``env:NAME`` (to affect environment
+``foo``, set ``--scope env:foo``). These commands will automatically
+manipulate configuration inline in the ``spack.yaml`` file.
+
 """""""""""""""""""""
 Inline configurations
 """""""""""""""""""""


### PR DESCRIPTION
@davidbeckingsale pointed out on slack that there is no documentation for the CLI syntax to refer to environment config scopes. This PR fixes that.