### PR TITLE
restore ability of dev-build to skip patches

### DIFF
--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -112,6 +112,7 @@ def dev_build(self, args):
         verbose=not args.quiet,
         dirty=args.dirty,
         stop_before=args.before,
+        skip_patch=args.skip_patch,
         stop_at=args.until)
 
     # drop into the build environment of the package?


### PR DESCRIPTION
At some point in the past, the skip_patch argument was removed
from the call to package.do_install() this broke the --skip-patch
flag on the dev-build command.