### PR TITLE
bazel: add latest versions up to 3.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -17,7 +17,10 @@ class Bazel(Package):
     url      = "https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-dist.zip"
 
     maintainers = ['adamjstewart']
-
+    version('3.7.1',  sha256='c9244e5905df6b0190113e26082c72d58b56b1b0dec66d076f083ce4089b0307')
+    version('3.7.0',  sha256='63873623917c756d1be49ff4d5fc23049736180e6b9a7d5236c6f204eddae3cc')
+    version('3.6.0',  sha256='3a18f24febb5203f11b0985b27e120ac623058d1d5ca79cd6df992e67d57240a')
+    version('3.5.1',  sha256='67eae714578b22d24192b0eb3a2d35b07578bbd57a33c50f1e74f8acd6378b3c')
     version('3.5.0',  sha256='334429059cf82e222ca8a9d9dbbd26f8e1eb308613463c2b8655dd4201b127ec')
     version('3.4.1',  sha256='27af1f11c8f23436915925b25cf6e1fb07fccf2d2a193a307c93437c60f63ba8')
     version('3.4.0',  sha256='7583abf8905ba9dd5394294e815e8873635ac4e5067e63392e8a33b397e450d8')


### PR DESCRIPTION
Adds the latest bazel versions 3.5.1, 3.6.0, 3.7.0, and 3.7.1