### PR TITLE
wps: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/wps/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/wps/for_aarch64.patch
@@ -1,0 +1,11 @@
+--- spack-src/arch/configure.defaults.bak	2020-04-24 04:31:06.000000000 +0900
++++ spack-src/arch/configure.defaults	2020-12-11 15:33:51.215405970 +0900
+@@ -168,7 +168,7 @@
+ RANLIB              = ranlib
+ 
+ ########################################################################################################################
+-#ARCH    Linux x86_64, gfortran   # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
++#ARCH    Linux aarch64, gfortran   # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
+ #
+ COMPRESSION_LIBS    = CONFIGURE_COMP_L
+ COMPRESSION_INC     = CONFIGURE_COMP_I

--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -45,6 +45,8 @@ class Wps(Package):
     depends_on('jasper')
     phases = ['configure', 'build', 'install']
 
+    patch('for_aarch64.patch', when='target=aarch64:')
+
     def setup_build_environment(self, env):
         env.set('WRF_DIR', self.spec['wrf'].prefix)
         env.set('NETCDF', self.spec['netcdf-c'].prefix)


### PR DESCRIPTION
I modified it so that it can be installed on aarch64 using the gcc compiler.