### PR TITLE
PFAPACK: Add new package

### DIFF
--- a/var/spack/repos/builtin/packages/pfapack/package.py
+++ b/var/spack/repos/builtin/packages/pfapack/package.py
@@ -1,0 +1,63 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Pfapack(MakefilePackage):
+    """A library for numerically computing the Pfaffian of
+       a real or complex skew-symmetric matrix. This is based on
+       computing the tridiagonal form of the matrix under
+       unitary congruence transformations."""
+
+    homepage = "https://michaelwimmer.org/downloads.html"
+    url      = "https://michaelwimmer.org/pfapack.tgz"
+
+    version('2014-09-17', sha256='b68fc35dda23ee24c358641b1a92ef701c4ffa0b3f0b0808b24e68afeb58ef07')
+    
+    depends_on('lapack')
+    depends_on('blas')
+    depends_on('python')
+    depends_on('py-numpy')
+    depends_on('py-scipy')
+
+    def edit(self, spec, prefix):
+        filter_file('FORT =.*', 'FORT = {0}'.format(spack_fc),
+                    join_path('fortran','makefile'))
+        filter_file('CC =.*', 'CC = {0}'.format(spack_cc),
+                    join_path('c_interface', 'makefile'))
+    
+    def build(self, spec, prefix):
+        source_directory = self.stage.source_path
+        with working_dir(join_path(source_directory, 'fortran')):
+            make()
+        with working_dir(join_path(source_directory, 'c_interface')):
+            make()
+
+    def install(self, spec, prefix):
+        source_directory = self.stage.source_path
+        mkdirp(prefix.fortran)
+        install(join_path(source_directory, 'fortran', 'libpfapack.a'),
+                prefix.fortran)
+        install(join_path(source_directory, 'fortran', '*.mod'),
+                prefix.fortran)
+        install_tree(join_path(source_directory, 'fortran', 'EXAMPLES'),
+                     prefix.fortran.EXAMPLES)
+        install_tree(join_path(source_directory, 'fortran', 'TESTING'),
+                     prefix.fortran.TESTING)
+        mkdirp(prefix.c_interface)
+        install(join_path(source_directory, 'c_interface', 'libcpfapack.a'),
+                prefix.c_interface)
+        install(join_path(source_directory, 'c_interface', 'fortran.h'),
+                prefix.c_interface)
+        install(join_path(source_directory, 'c_interface', 'fortran_pfapack.h'),
+                prefix.c_interface)
+        install(join_path(source_directory, 'c_interface', 'pfapack.h'),
+                prefix.c_interface)
+        install_tree(join_path(source_directory, 'c_interface', 'EXAMPLES'),
+                     prefix.c_interface.EXAMPLES)
+        install_tree(join_path(source_directory, 'c_interface', 'TESTING'),
+                     prefix.c_interface.TESTING)
+        install_tree(join_path(source_directory, 'python'), prefix.python)

--- a/var/spack/repos/builtin/packages/pfapack/package.py
+++ b/var/spack/repos/builtin/packages/pfapack/package.py
@@ -19,9 +19,9 @@ class Pfapack(MakefilePackage):
 
     depends_on('lapack')
     depends_on('blas')
-    depends_on('python')
-    depends_on('py-numpy')
-    depends_on('py-scipy')
+    depends_on('python', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
 
     def edit(self, spec, prefix):
         filter_file('FORT =.*', 'FORT = {0}'.format(spack_fc),

--- a/var/spack/repos/builtin/packages/pfapack/package.py
+++ b/var/spack/repos/builtin/packages/pfapack/package.py
@@ -16,7 +16,7 @@ class Pfapack(MakefilePackage):
     url      = "https://michaelwimmer.org/pfapack.tgz"
 
     version('2014-09-17', sha256='b68fc35dda23ee24c358641b1a92ef701c4ffa0b3f0b0808b24e68afeb58ef07')
-    
+
     depends_on('lapack')
     depends_on('blas')
     depends_on('python')
@@ -25,10 +25,10 @@ class Pfapack(MakefilePackage):
 
     def edit(self, spec, prefix):
         filter_file('FORT =.*', 'FORT = {0}'.format(spack_fc),
-                    join_path('fortran','makefile'))
+                    join_path('fortran', 'makefile'))
         filter_file('CC =.*', 'CC = {0}'.format(spack_cc),
                     join_path('c_interface', 'makefile'))
-    
+
     def build(self, spec, prefix):
         source_directory = self.stage.source_path
         with working_dir(join_path(source_directory, 'fortran')):
@@ -52,7 +52,8 @@ class Pfapack(MakefilePackage):
                 prefix.c_interface)
         install(join_path(source_directory, 'c_interface', 'fortran.h'),
                 prefix.c_interface)
-        install(join_path(source_directory, 'c_interface', 'fortran_pfapack.h'),
+        install(join_path(source_directory, 'c_interface',
+                          'fortran_pfapack.h'),
                 prefix.c_interface)
         install(join_path(source_directory, 'c_interface', 'pfapack.h'),
                 prefix.c_interface)


### PR DESCRIPTION
Add new package : PFAPACK
A library for numerically computing the Pfaffian of a real or complex skew-symmetric matrix. This is based on computing the tridiagonal form of the matrix under unitary congruence transformations.
The theory behind the implementation is explained in ACM Trans. Math. Software 38 30 (2012) (also on arxiv). Please cite this paper if you use the PFAPACK library in your work.

ACM Trans. : http://dl.acm.org/citation.cfm?id=2331138
arxiv : http://arxiv.org/abs/1102.3440