### PR TITLE
Kluge to get the gfortran linker to work correctly for SciPy on Big Sur.

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -5,6 +5,7 @@
 
 import platform
 
+
 class PyScipy(PythonPackage):
     """SciPy (pronounced "Sigh Pie") is a Scientific Library for Python.
     It provides many user-friendly and efficient numerical routines such

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -89,6 +89,7 @@ class PyScipy(PythonPackage):
 
         # Kluge to get the gfortran linker to work correctly on Big
         # Sur, at least until a gcc release > 10.2 is out with a fix.
+        # (There is a fix in their development tree.)
         if platform.mac_ver()[0][0:2] == '11':
             env.set('MACOSX_DEPLOYMENT_TARGET', '10.15')
 

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -89,7 +89,7 @@ class PyScipy(PythonPackage):
 
         # Kluge to get the gfortran linker to work correctly on Big
         # Sur, at least until a gcc release > 10.2 is out with a fix.
-        if platform.mac_ver()[0][0 : 2] == '11':
+        if platform.mac_ver()[0][0:2] == '11':
             env.set('MACOSX_DEPLOYMENT_TARGET', '10.15')
 
     def build_args(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
 
 class PyScipy(PythonPackage):
     """SciPy (pronounced "Sigh Pie") is a Scientific Library for Python.
@@ -84,6 +85,11 @@ class PyScipy(PythonPackage):
         # https://github.com/scipy/scipy/issues/11611
         if self.spec.satisfies('@:1.4 %gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+
+        # Kluge to get the gfortran linker to work correctly on Big
+        # Sur, at least until a gcc release > 10.2 is out with a fix.
+        if platform.mac_ver()[0][0 : 2] == '11':
+            env.set('MACOSX_DEPLOYMENT_TARGET', '10.15')
 
     def build_args(self, spec, prefix):
         args = []


### PR DESCRIPTION
On Big Sur, `gcc` can’t detect the macOS version correctly. This causes a linker invocation with `gfortran` to try to link to `libgcc_s.10.4`, which isn’t present on the system. This apparently only happens when `gfortran` is used to link a `.so` library, so it doesn’t affect SciPy’s dependencies: OpenBLAS uses `gfortran` to link, but is producing a `.dylib`; NumPy uses `clang` to link. It looks like the SciPy build system injects the `-mmacosx-version-min` flag (in `_build_utils/compiler_helper.py`) for the C++ compiler, but not for the Fortran compiler.

This PR gets around that by setting the `MACOSX_DEPLOYMENT_TARGET` to 10.15 (Catalina) when on Big Sur. This is incorrect, since it causes `gfortran` to identify the OS as Catalina, but at least it’s close enough that it gets the linked library right. It looks like the `gfortran` behavior is updated for Big Sur in [this commit to the gcc codebase](https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=556ab5125912fa2233986eb19d6cd995cf7de1d2), but that’s not available in a gcc release yet.