### PR TITLE
mysql 8.0.19: cxxstd mismatch for boost

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -81,7 +81,7 @@ class Mysql(CMakePackage):
     # 8.0.19+
     depends_on('boost@1.70.0 cxxstd=98', type='build', when='@8.0.19: cxxstd=98')
     depends_on('boost@1.70.0 cxxstd=11', type='build', when='@8.0.19: cxxstd=11')
-    depends_on('boost@1.70.0 cxxstd=11', type='build', when='@8.0.19: cxxstd=14')
+    depends_on('boost@1.70.0 cxxstd=14', type='build', when='@8.0.19: cxxstd=14')
     depends_on('boost@1.70.0 cxxstd=17', type='build', when='@8.0.19: cxxstd=17')
     # 8.0.16--8.0.18
     depends_on('boost@1.69.0 cxxstd=98', type='build', when='@8.0.16:8.0.18 cxxstd=98')


### PR DESCRIPTION
mysql 8.0.19+ should require boost at cxxstd=14 if cxxstd=14 is selected, not cxxstd=11, right?

I don't see anything in https://github.com/spack/spack/pull/17045 that would explain this mismatch otherwise.

