### PR TITLE
superlu depends on tcsh for build

### DIFF
--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -18,6 +18,7 @@ class Superlu(Package):
     variant('pic',    default=True,
             description='Build with position independent code')
 
+    depends_on('tcsh', type='build')
     depends_on('cmake', when='@5.2.1:', type='build')
     depends_on('blas')
 


### PR DESCRIPTION
`superlu` depends on `csh` from the `tcsh` package for build.

Fixes https://github.com/spack/spack/issues/20380