### PR TITLE
libsm: don't link to libuuid on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import sys
 
 
 class Libsm(AutotoolsPackage, XorgPackage):
@@ -16,10 +16,12 @@ class Libsm(AutotoolsPackage, XorgPackage):
     version('1.2.2', sha256='14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4')
 
     depends_on('libice@1.0.5:')
-    depends_on('libuuid')
+    if sys.platform != 'darwin':
+        # On macOS systems, Spack's libuuid conflicts with the system-installed
+        # version and breaks anything linked against Cocoa/Carbon.
+        depends_on('libuuid')
 
     depends_on('xproto', type='build')
     depends_on('xtrans', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
-    depends_on('libuuid')


### PR DESCRIPTION
We already do this in the `python` package. We should really be doing this for every package that depends on `libuuid`, but this is the specific package that broke my build. See https://github.com/spack/spack/pull/18322#issuecomment-743919707 for a better long-term solution.