### PR TITLE
suite-sparse: compile options for Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -119,8 +119,8 @@ class SuiteSparse(Package):
         # SuiteSparse defaults to using '-fno-common -fexceptions' in
         # CFLAGS, but not all compilers use the same flags for these
         # optimizations
-        if any([x in spec
-                for x in ('%apple-clang', '%clang', '%gcc', '%intel')]):
+        if any([x in spec for x in
+                ('%apple-clang', '%clang', '%gcc', '%intel', '%fj')]):
             make_args += ['CFLAGS+=-fno-common -fexceptions']
         elif '%pgi' in spec:
             make_args += ['CFLAGS+=--exceptions']


### PR DESCRIPTION
Use compile options equal to `%gcc` or `%clang` for `%fj`