### PR TITLE
outputs: restore default output of fetch/build/total times

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1682,11 +1682,10 @@ def build_process(pkg, kwargs):
     pkg._total_time = time.time() - start_time
     build_time = pkg._total_time - pkg._fetch_time
 
-    tty.debug('{0} Successfully installed {1}'
-              .format(pre, pkg_id),
-              'Fetch: {0}.  Build: {1}.  Total: {2}.'
-              .format(_hms(pkg._fetch_time), _hms(build_time),
-                      _hms(pkg._total_time)))
+    tty.msg('{0} Successfully installed {1}'.format(pre, pkg_id),
+            'Fetch: {0}.  Build: {1}.  Total: {2}.'
+            .format(_hms(pkg._fetch_time), _hms(build_time),
+                    _hms(pkg._total_time)))
     _print_installed_pkg(pkg.prefix)
 
     # preserve verbosity across runs


### PR DESCRIPTION
Per request posted to the `general` slack channel, this PR restores the default output of the fetch+build+total time during installs.

Before this change you had to use the debug option to get output messages like:
```
==> libsigsegv: Successfully installed libsigsegv-2.12-ifc2oc4r34po2jokvyjhbl4kewmne6d4
  Fetch: 0.01s.  Build: 11.10s.  Total: 11.11s.
```

This PR restores outputting the message by default.