### PR TITLE
Change the NEST official releases archives url to the current one.

### DIFF
--- a/var/spack/repos/builtin/packages/nest/package.py
+++ b/var/spack/repos/builtin/packages/nest/package.py
@@ -13,7 +13,7 @@ class Nest(CMakePackage):
     than on the exact morphology of individual neurons."""
 
     homepage = "http://www.nest-simulator.org"
-    url      = "https://github.com/nest/nest-simulator/releases/download/v2.12.0/nest-2.12.0.tar.gz"
+    url      = "https://github.com/nest/nest-simulator/archive/v2.12.0.tar.gz"
 
     version('2.20.0', sha256='40e33187c22d6e843d80095b221fa7fd5ebe4dbc0116765a91fc5c425dd0eca4')
     version('2.14.0', sha256='d6316d6c9153100a3220488abfa738958c4b65bf2622bd15540e4aa81e79f17f')


### PR DESCRIPTION
The NEST development community has changed the `url` to the new one. To build the latest and older
releases set the `url` to an appropriate one.