### PR TITLE
[acts] Add version 3

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -37,6 +37,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version('master', branch='master')
+    version('3.00.0', commit='e20260fccb469f4253519d3f0ddb3191b7046db3')
     version('2.00.0', commit='8708eae2b2ccdf57ab7b451cfbba413daa1fc43c')
     version('1.02.1', commit='f6ebeb9a28297ba8c54fd08b700057dd4ff2a311')
     version('1.02.0', commit='e69b95acc9a264e63aded7d1714632066e090542')


### PR DESCRIPTION
This packages the semi-recently released [acts v3.0](https://github.com/acts-project/acts/releases/tag/v3.0.0).

From the changelog, no build system changes are expected, but I'll wait for my ongoing build to be sure.