### PR TITLE
docs: fix command usage for unit-test pytest help

### DIFF
--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -146,7 +146,7 @@ def add_back_pytest_args(args, unknown_args):
 def unit_test(parser, args, unknown_args):
     if args.pytest_help:
         # make the pytest.main help output more accurate
-        sys.argv[0] = 'spack test'
+        sys.argv[0] = 'spack unit-test'
         return pytest.main(['-h'])
 
     # add back any parsed pytest args we need to pass to pytest


### PR DESCRIPTION
This PR fixes the Spack command output for unit test's pytest help (`spack unit-test -H`), changing the usage line from:

```
usage: spack test [options] [file_or_dir] [file_or_dir] [...]
```

to 

```
usage: spack unit-test [options] [file_or_dir] [file_or_dir] [...]
```

thereby recognizing the change in the unit test command from `spack test` (now used for smoke tests since v0.16) to `spack unit-test`.