### PR TITLE
concretizer: move conditional dependency logic into `concretize.lp`

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1412,6 +1412,13 @@ class SpackSolverSetup(object):
             self.preferred_targets(pkg)
             self.preferred_versions(pkg)
 
+        # Inject dev_path from environment
+        env = spack.environment.get_env(None, None)
+        if env:
+            for spec in sorted(specs):
+                for dep in spec.traverse():
+                    _develop_specs_from_env(dep, env)
+
         self.gen.h1('Spec Constraints')
         for spec in sorted(specs):
             if not spec.virtual:
@@ -1421,10 +1428,6 @@ class SpackSolverSetup(object):
 
             for dep in spec.traverse():
                 self.gen.h2('Spec: %s' % str(dep))
-
-                # Inject dev_path from environment
-                _develop_specs_from_env(dep)
-
                 if dep.virtual:
                     for clause in self.virtual_spec_clauses(dep):
                         self.gen.fact(clause)
@@ -1636,8 +1639,9 @@ class SpecBuilder(object):
         for s in self._specs.values():
             spack.spec.Spec.ensure_external_path_if_external(s)
 
+        env = spack.environment.get_env(None, None)
         for s in self._specs.values():
-            _develop_specs_from_env(s)
+            _develop_specs_from_env(s, env)
 
         for s in self._specs.values():
             s._mark_concrete()
@@ -1648,8 +1652,7 @@ class SpecBuilder(object):
         return self._specs
 
 
-def _develop_specs_from_env(spec):
-    env = spack.environment.get_env(None, None)
+def _develop_specs_from_env(spec, env):
     dev_info = env.dev_specs.get(spec.name, {}) if env else {}
     if not dev_info:
         return

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -728,7 +728,7 @@ class SpackSolverSetup(object):
 
     def package_dependencies_rules(self, pkg, tests):
         """Translate 'depends_on' directives into ASP logic."""
-        for name, conditions in sorted(pkg.dependencies.items()):
+        for _, conditions in sorted(pkg.dependencies.items()):
             for cond_id, (cond, dep) in enumerate(sorted(conditions.items())):
                 named_cond = cond.copy()
                 named_cond.name = named_cond.name or pkg.name
@@ -751,22 +751,19 @@ class SpackSolverSetup(object):
                         continue
 
                     # there is a declared dependency of type t
-
-                    # TODO: this ends up being redundant in the output --
-                    # TODO: not sure if we really need it anymore.
-                    # TODO: Look at simplifying the logic in concretize.lp
                     self.gen.fact(
-                        fn.declared_dependency(dep.pkg.name, dep.spec.name, t))
+                        fn.declared_dependency(dep.pkg.name, dep.spec.name, cond_id, t)
+                    )
 
-                    # if it has conditions, declare them.
-                    conditions = self.spec_clauses(named_cond, body=True)
-                    for cond in conditions:
-                        self.gen.fact(
-                            fn.dep_cond(
-                                dep.pkg.name, dep.spec.name, t, cond_id,
-                                cond.name, *cond.args
-                            )
+                # if it has conditions, declare them.
+                conditions = self.spec_clauses(named_cond, body=True)
+                for cond in conditions:
+                    self.gen.fact(
+                        fn.dep_cond(
+                            dep.pkg.name, dep.spec.name, cond_id,
+                            cond.name, *cond.args
                         )
+                    )
 
                 # add constraints on the dependency from dep spec.
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1031,7 +1031,11 @@ class SpackSolverSetup(object):
         # add all clauses from dependencies
         if transitive:
             for dep in spec.traverse(root=False):
-                clauses.extend(self.spec_clauses(dep, body, transitive=False))
+                if dep.virtual:
+                    clauses.extend(self.virtual_spec_clauses(dep))
+                else:
+                    clauses.extend(
+                        self.spec_clauses(dep, body, transitive=False))
 
         return clauses
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -750,7 +750,7 @@ class SpackSolverSetup(object):
                             )
                         )
                     else:
-                        clauses = self.spec_traverse_clauses(named_cond)
+                        clauses = self.spec_clauses(named_cond, body=True)
 
                         self.gen.rule(
                             fn.declared_dependency(
@@ -776,16 +776,10 @@ class SpackSolverSetup(object):
                             clause,
                             self.gen._and(
                                 fn.depends_on(dep.pkg.name, dep.spec.name),
-                                *self.spec_traverse_clauses(named_cond)
+                                *self.spec_clauses(named_cond, body=True)
                             )
                         )
             self.gen.newline()
-
-    def spec_traverse_clauses(self, named_cond):
-        clauses = []
-        for d in named_cond.traverse():
-            clauses.extend(self.spec_clauses(d, body=True))
-        return clauses
 
     def virtual_preferences(self, pkg_name, func):
         """Call func(vspec, provider, i) for each of pkg's provider prefs."""
@@ -957,13 +951,15 @@ class SpackSolverSetup(object):
                     self.gen.fact(fn.compiler_version_flag(
                         compiler.name, compiler.version, name, flag))
 
-    def spec_clauses(self, spec, body=False):
+    def spec_clauses(self, spec, body=False, transitive=True):
         """Return a list of clauses for a spec mandates are true.
 
         Arguments:
             spec (Spec): the spec to analyze
             body (bool): if True, generate clauses to be used in rule bodies
                 (final values) instead of rule heads (setters).
+            transitive (bool): if False, don't generate clauses from
+                 dependencies (default True)
         """
         clauses = []
 
@@ -1049,8 +1045,17 @@ class SpackSolverSetup(object):
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
 
-        # TODO
-        # namespace
+        # TODO: namespace
+
+        # dependencies
+        if spec.concrete:
+            clauses.append(fn.concrete(spec.name))
+            # TODO: add concrete depends_on() facts for concrete dependencies
+
+        # add all clauses from dependencies
+        if transitive:
+            for dep in spec.traverse(root=False):
+                clauses.extend(self.spec_clauses(dep, body, transitive=False))
 
         return clauses
 
@@ -1265,6 +1270,7 @@ class SpackSolverSetup(object):
     def define_virtual_constraints(self):
         for vspec_str in sorted(self.virtual_constraints):
             vspec = spack.spec.Spec(vspec_str)
+
             self.gen.h2("Virtual spec: {0}".format(vspec_str))
             providers = spack.repo.path.providers_for(vspec_str)
             candidates = self.providers_by_vspec_name[vspec.name]
@@ -1426,15 +1432,13 @@ class SpackSolverSetup(object):
             else:
                 self.gen.fact(fn.virtual_root(spec.name))
 
-            for dep in spec.traverse():
-                self.gen.h2('Spec: %s' % str(dep))
-                if dep.virtual:
-                    for clause in self.virtual_spec_clauses(dep):
-                        self.gen.fact(clause)
-                    continue
-
-                for clause in self.spec_clauses(dep):
-                    self.gen.fact(clause)
+            self.gen.h2('Spec: %s' % str(spec))
+            if spec.virtual:
+                clauses = self.virtual_spec_clauses(spec)
+            else:
+                clauses = self.spec_clauses(spec)
+            for clause in clauses:
+                self.gen.fact(clause)
 
         self.gen.h1("Variant Values defined in specs")
         self.define_variant_values()

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -59,6 +59,8 @@ dependency_conditions(P, D, T) :-
   dependency_conditions_hold(P, D, I),
   dependency_type(I, T).
 
+#defined dependency_type/2.
+
 % collect all the dependency conditions into a single conditional rule
 dependency_conditions_hold(Package, Dependency, ID) :-
   version(Package, Version)
@@ -81,6 +83,32 @@ dependency_conditions_hold(Package, Dependency, ID) :-
     : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
   dependency_condition(Package, Dependency, ID);
   node(Package).
+
+#defined dependency_condition/3.
+#defined required_dependency_condition/3.
+#defined required_dependency_condition/4.
+#defined required_dependency_condition/5.
+#defined required_dependency_condition/5.
+
+% general rules for conflicts
+:- node(Package) : conflict_condition(ID, "node", Package);
+   not external(Package) : conflict_condition(ID, "node", Package);
+   version(Package, Version) : conflict_condition(ID, "version", Package, Version);
+   version_satisfies(Package, Constraint) : conflict_condition(ID, "version_satisfies", Package, Constraint);
+   node_platform(Package, Platform) : conflict_condition(ID, "node_platform", Package, Platform);
+   node_os(Package, OS) : conflict_condition(ID, "node_os", Package, OS);
+   node_target(Package, Target) : conflict_condition(ID, "node_target", Package, Target);
+   variant_value(Package, Variant, Value) : conflict_condition(ID, "variant_value", Package, Variant, Value);
+   node_compiler(Package, Compiler) : conflict_condition(ID, "node_compiler", Package, Compiler);
+   node_compiler_version(Package, Compiler, Version) : conflict_condition(ID, "node_compiler_version", Package, Compiler, Version);
+   node_compiler_version_satisfies(Package, Compiler, Version) : conflict_condition(ID, "node_compiler_version_satisfies", Package, Compiler, Version);
+   node_flag(Package, FlagType, Flag) : conflict_condition(ID, "node_flag", Package, FlagType, Flag);
+   conflict(ID, Package).
+
+#defined conflict/2.
+#defined conflict_condition/3.
+#defined conflict_condition/4.
+#defined conflict_condition/5.
 
 % Implications from matching a dependency condition
 node(Dependency) :-
@@ -136,6 +164,9 @@ node_flag(Dependency, FlagType, Flag) :-
   dependency_conditions_hold(Package, Dependency, ID),
   depends_on(Package, Dependency),
   imposed_dependency_condition(ID, "node_flag", Dependency, FlagType, Flag).
+
+#defined imposed_dependency_condition/4.
+#defined imposed_dependency_condition/5.
 
 % if a virtual was required by some root spec, one provider is in the DAG
 1 { node(Package) : provides_virtual(Package, Virtual) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -40,8 +40,7 @@ depends_on(Package, Dependency) :- depends_on(Package, Dependency, _).
 % declared dependencies are real if they're not virtual AND
 % the package is not an external
 depends_on(Package, Dependency, Type)
- :- declared_dependency(Package, Dependency, Type),
-    node(Package),
+ :- dependency_conditions(Package, Dependency, Type),
     not virtual(Dependency),
     not external(Package).
 
@@ -51,10 +50,38 @@ depends_on(Package, Dependency, Type)
   depends_on(Package, Provider, Type)
   : provides_virtual(Provider, Virtual)
 } 1
- :- declared_dependency(Package, Virtual, Type),
+ :- dependency_conditions(Package, Virtual, Type),
     virtual(Virtual),
-    not external(Package),
-    node(Package).
+    not external(Package).
+
+% if any individual condition below is true, trigger the dependency.
+dependency_conditions(P, D, T) :- dependency_conditions(P, D, T, _).
+
+% collect all the dependency condtions into a single conditional rule
+dependency_conditions(P, D, T, I) :-
+  node(Package)
+    : dep_cond(P, D, T, I, "node", Package);
+  version(Package, Version)
+    : dep_cond(P, D, T, I, "version", Package, Version);
+  version_satisfies(Package, Constraint)
+    : dep_cond(P, D, T, I, "version_satisfies", Package, Constraint);
+  node_platform(Package, Platform)
+    : dep_cond(P, D, T, I, "node_platform", Package, Platform);
+  node_os(Package, OS)
+    : dep_cond(P, D, T, I, "node_os", Package, OS);
+  node_target(Package, Target)
+    : dep_cond(P, D, T, I, "node_target", Package, Target);
+  variant_value(Package, Variant, Value)
+    : dep_cond(P, D, T, I, "variant_value", Package, Variant, Value);
+  node_compiler(Package, Compiler)
+    : dep_cond(P, D, T, I, "node_compiler", Package, Compiler);
+  node_compiler_version(Package, Compiler, Version)
+    : dep_cond(P, D, T, I, "node_compiler_version", Package, Compiler, Version);
+  node_flag(Package, FlagType, Flag)
+    : dep_cond(P, D, T, I, "node_flag", Package, FlagType, Flag);
+  dependency_condition(P, D, I);
+  declared_dependency(P, D, T);
+  node(P).
 
 % if a virtual was required by some root spec, one provider is in the DAG
 1 { node(Package) : provides_virtual(Package, Virtual) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -62,7 +62,15 @@ dependency_conditions(P, D, T) :-
 #defined dependency_type/2.
 
 % collect all the dependency conditions into a single conditional rule
-dependency_conditions_hold(Package, Dependency, ID) :-
+% distinguishing between Parent and Package is needed to account for
+% conditions like:
+%
+% depends_on('patchelf@0.9', when='@1.0:1.1 ^python@:2')
+%
+% that include dependencies
+dependency_conditions_hold(Parent, Dependency, ID) :-
+  node(Package)
+    : required_dependency_condition(ID, "node", Package);
   version(Package, Version)
     : required_dependency_condition(ID, "version", Package, Version);
   version_satisfies(Package, Constraint)
@@ -79,10 +87,12 @@ dependency_conditions_hold(Package, Dependency, ID) :-
     : required_dependency_condition(ID, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
     : required_dependency_condition(ID, "node_compiler_version", Package, Compiler, Version);
+  node_compiler_version_satisfies(Package, Compiler, Version)
+    : required_dependency_condition(ID, "node_compiler_version_satisfies", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
     : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
-  dependency_condition(Package, Dependency, ID);
-  node(Package).
+  dependency_condition(Parent, Dependency, ID);
+  node(Parent).
 
 #defined dependency_condition/3.
 #defined required_dependency_condition/3.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -139,6 +139,8 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 #defined external_only/1.
 #defined pkg_provider_preference/4.
 #defined default_provider_preference/3.
+#defined version_satisfies/2.
+#defined node_compiler_version_satisfies/3.
 #defined root/1.
 
 %-----------------------------------------------------------------------------

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -56,32 +56,86 @@ depends_on(Package, Dependency, Type)
 
 % if any individual condition below is true, trigger the dependency.
 dependency_conditions(P, D, T) :-
-  dependency_conditions_hold(P, D, I), declared_dependency(P, D, I, T).
+  dependency_conditions_hold(P, D, I),
+  dependency_type(I, T).
 
-% collect all the dependency condtions into a single conditional rule
-dependency_conditions_hold(P, D, I) :-
-  node(Package)
-    : dep_cond(P, D, I, "node", Package);
+% collect all the dependency conditions into a single conditional rule
+dependency_conditions_hold(Package, Dependency, ID) :-
   version(Package, Version)
-    : dep_cond(P, D, I, "version", Package, Version);
+    : required_dependency_condition(ID, "version", Package, Version);
   version_satisfies(Package, Constraint)
-    : dep_cond(P, D, I, "version_satisfies", Package, Constraint);
+    : required_dependency_condition(ID, "version_satisfies", Package, Constraint);
   node_platform(Package, Platform)
-    : dep_cond(P, D, I, "node_platform", Package, Platform);
+    : required_dependency_condition(ID, "node_platform", Package, Platform);
   node_os(Package, OS)
-    : dep_cond(P, D, I, "node_os", Package, OS);
+    : required_dependency_condition(ID, "node_os", Package, OS);
   node_target(Package, Target)
-    : dep_cond(P, D, I, "node_target", Package, Target);
+    : required_dependency_condition(ID, "node_target", Package, Target);
   variant_value(Package, Variant, Value)
-    : dep_cond(P, D, I, "variant_value", Package, Variant, Value);
+    : required_dependency_condition(ID, "variant_value", Package, Variant, Value);
   node_compiler(Package, Compiler)
-    : dep_cond(P, D, I, "node_compiler", Package, Compiler);
+    : required_dependency_condition(ID, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
-    : dep_cond(P, D, I, "node_compiler_version", Package, Compiler, Version);
+    : required_dependency_condition(ID, "node_compiler_version", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
-    : dep_cond(P, D, I, "node_flag", Package, FlagType, Flag);
-  dependency_condition(P, D, I);
-  node(P).
+    : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
+  dependency_condition(Package, Dependency, ID);
+  node(Package).
+
+% Implications from matching a dependency condition
+node(Dependency) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency).
+
+version(Dependency, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "version", Dependency, Version).
+
+version_satisfies(Dependency, Constraint) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "version_satisfies", Dependency, Constraint).
+
+node_platform(Dependency, Platform) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_platform", Dependency, Platform).
+
+node_os(Dependency, OS) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_os", Dependency, OS).
+
+node_target(Dependency, Target) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_target", Dependency, Target).
+
+variant_set(Dependency, Variant, Value) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "variant_set", Dependency, Variant, Value).
+
+node_compiler(Dependency, Compiler) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler", Dependency, Compiler).
+
+node_compiler_version(Dependency, Compiler, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler_version", Dependency, Compiler, Version).
+
+node_compiler_version_satisfies(Dependency, Compiler, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler_version_satisfies", Dependency, Compiler, Version).
+
+node_flag(Dependency, FlagType, Flag) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_flag", Dependency, FlagType, Flag).
 
 % if a virtual was required by some root spec, one provider is in the DAG
 1 { node(Package) : provides_virtual(Package, Virtual) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -55,32 +55,32 @@ depends_on(Package, Dependency, Type)
     not external(Package).
 
 % if any individual condition below is true, trigger the dependency.
-dependency_conditions(P, D, T) :- dependency_conditions(P, D, T, _).
+dependency_conditions(P, D, T) :-
+  dependency_conditions_hold(P, D, I), declared_dependency(P, D, I, T).
 
 % collect all the dependency condtions into a single conditional rule
-dependency_conditions(P, D, T, I) :-
+dependency_conditions_hold(P, D, I) :-
   node(Package)
-    : dep_cond(P, D, T, I, "node", Package);
+    : dep_cond(P, D, I, "node", Package);
   version(Package, Version)
-    : dep_cond(P, D, T, I, "version", Package, Version);
+    : dep_cond(P, D, I, "version", Package, Version);
   version_satisfies(Package, Constraint)
-    : dep_cond(P, D, T, I, "version_satisfies", Package, Constraint);
+    : dep_cond(P, D, I, "version_satisfies", Package, Constraint);
   node_platform(Package, Platform)
-    : dep_cond(P, D, T, I, "node_platform", Package, Platform);
+    : dep_cond(P, D, I, "node_platform", Package, Platform);
   node_os(Package, OS)
-    : dep_cond(P, D, T, I, "node_os", Package, OS);
+    : dep_cond(P, D, I, "node_os", Package, OS);
   node_target(Package, Target)
-    : dep_cond(P, D, T, I, "node_target", Package, Target);
+    : dep_cond(P, D, I, "node_target", Package, Target);
   variant_value(Package, Variant, Value)
-    : dep_cond(P, D, T, I, "variant_value", Package, Variant, Value);
+    : dep_cond(P, D, I, "variant_value", Package, Variant, Value);
   node_compiler(Package, Compiler)
-    : dep_cond(P, D, T, I, "node_compiler", Package, Compiler);
+    : dep_cond(P, D, I, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
-    : dep_cond(P, D, T, I, "node_compiler_version", Package, Compiler, Version);
+    : dep_cond(P, D, I, "node_compiler_version", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
-    : dep_cond(P, D, T, I, "node_flag", Package, FlagType, Flag);
+    : dep_cond(P, D, I, "node_flag", Package, FlagType, Flag);
   dependency_condition(P, D, I);
-  declared_dependency(P, D, T);
   node(P).
 
 % if a virtual was required by some root spec, one provider is in the DAG


### PR DESCRIPTION
Continuing to convert everything in `asp.py` into facts, make the generation of ground rules for conditional dependencies use facts, and move the semantics into `concretize.lp`.

This is probably the most complex logic in Spack, as dependencies can be conditional on anything, and we need conditional ASP rules to accumulate and map all the dependency conditions to spec attributes.

The logic looks complicated, but essentially it accumulates any constraints associated with particular conditions into a fact associated with the condition by id. Then, if *any* condition id's fact is True, we trigger the dependency.  This simplifies the way `declared_dependency()` works -- the dependency is now declared regardless of whether it is conditional, and the conditions are handled by `dependency_condition()` facts.

There's a nit in the loop structure here: we currently emit a bunch of extra `declared_dependency` facts.  Need to think about how best to remove those.

- [x] simplify by making `spec_clauses` transitive by default
- [x] move conditional dependency logic into `concretize.lp`, including:
  - [x] conditions from `when=` clauses
  - [x] constraints imposed on the dependency (e.g., `@1.0` in `depends_on("foo@1.0")`)
- [x] don't generate so many `declared_dependency` facts
- [x] `depends_on` clauses are numbered globally and identified only by ID, to simplify grounding