### PR TITLE
concretizer: emit facts for imposed dependencies

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1024,7 +1024,10 @@ class SpackSolverSetup(object):
         # add all clauses from dependencies
         if transitive:
             for dep in spec.traverse(root=False):
-                clauses.extend(self.spec_clauses(dep, body, transitive=False))
+                if dep.virtual:
+                    clauses.extend(self.virtual_spec_clauses(dep))
+                else:
+                    clauses.extend(self.spec_clauses(dep, body, transitive=False))
 
         return clauses
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -356,39 +356,6 @@ class PyclingoDriver(object):
             [atoms[s] for s in body_symbols] + rule_atoms
         )
 
-    def integrity_constraint(self, clauses, default_negated=None):
-        """Add an integrity constraint to the solver.
-
-        Args:
-            clauses: clauses to be added to the integrity constraint
-            default_negated: clauses to be added to the integrity
-                constraint after with a default negation
-        """
-        symbols, negated_symbols, atoms = _normalize(clauses), [], {}
-        if default_negated:
-            negated_symbols = _normalize(default_negated)
-
-        for s in symbols + negated_symbols:
-            atoms[s] = self.backend.add_atom(s)
-
-        symbols_str = ",".join(str(a) for a in symbols)
-        if negated_symbols:
-            negated_symbols_str = ",".join(
-                "not " + str(a) for a in negated_symbols
-            )
-            symbols_str += ",{0}".format(negated_symbols_str)
-        rule_str = ":- {0}.".format(symbols_str)
-        rule_atoms = self._register_rule_for_cores(rule_str)
-
-        # print rule before adding
-        self.out.write("{0}\n".format(rule_str))
-        self.backend.add_rule(
-            [],
-            [atoms[s] for s in symbols] +
-            [-atoms[s] for s in negated_symbols]
-            + rule_atoms
-        )
-
     def solve(
             self, solver_setup, specs, dump=None, nmodels=0,
             timers=False, stats=False, tests=False
@@ -585,11 +552,16 @@ class SpackSolverSetup(object):
                 # TODO: of a rule and filter unwanted functions.
                 to_be_filtered = ['node_compiler_hard']
                 clauses = [x for x in clauses if x.name not in to_be_filtered]
-                external = fn.external(pkg.name)
 
-                self.gen.integrity_constraint(
-                    AspAnd(*clauses), AspAnd(external)
-                )
+                # Emit facts based on clauses
+                cond_id = self._condition_id_counter
+                self._condition_id_counter += 1
+                self.gen.fact(fn.conflict(cond_id, pkg.name))
+                for clause in clauses:
+                    self.gen.fact(fn.conflict_condition(
+                        cond_id, clause.name, *clause.args
+                    ))
+                self.gen.newline()
 
     def available_compilers(self):
         """Facts about available compilers."""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -496,6 +496,7 @@ class SpackSolverSetup(object):
 
         # id for dummy variables
         self.card = 0
+        self._condition_id_counter = 0
 
     def pkg_version_rules(self, pkg):
         """Output declared versions of a package.
@@ -726,16 +727,16 @@ class SpackSolverSetup(object):
     def package_dependencies_rules(self, pkg, tests):
         """Translate 'depends_on' directives into ASP logic."""
         for _, conditions in sorted(pkg.dependencies.items()):
-            for cond_id, (cond, dep) in enumerate(sorted(conditions.items())):
+            for cond, dep in sorted(conditions.items()):
+                global_condition_id = self._condition_id_counter
+                self._condition_id_counter += 1
                 named_cond = cond.copy()
                 named_cond.name = named_cond.name or pkg.name
 
                 # each independent condition has an id
-                self.gen.fact(
-                    fn.dependency_condition(
-                        dep.pkg.name, dep.spec.name, cond_id
-                    )
-                )
+                self.gen.fact(fn.dependency_condition(
+                    dep.pkg.name, dep.spec.name, global_condition_id
+                ))
 
                 for t in sorted(dep.type):
                     # Skip test dependencies if they're not requested at all
@@ -748,19 +749,14 @@ class SpackSolverSetup(object):
                         continue
 
                     # there is a declared dependency of type t
-                    self.gen.fact(
-                        fn.declared_dependency(dep.pkg.name, dep.spec.name, cond_id, t)
-                    )
+                    self.gen.fact(fn.dependency_type(global_condition_id, t))
 
                 # if it has conditions, declare them.
                 conditions = self.spec_clauses(named_cond, body=True)
                 for cond in conditions:
-                    self.gen.fact(
-                        fn.dep_cond(
-                            dep.pkg.name, dep.spec.name, cond_id,
-                            cond.name, *cond.args
-                        )
-                    )
+                    self.gen.fact(fn.required_dependency_condition(
+                        global_condition_id, cond.name, *cond.args
+                    ))
 
                 # add constraints on the dependency from dep spec.
 
@@ -780,13 +776,9 @@ class SpackSolverSetup(object):
                 else:
                     clauses = self.spec_clauses(dep.spec)
                     for clause in clauses:
-                        self.gen.rule(
-                            clause,
-                            self.gen._and(
-                                fn.depends_on(dep.pkg.name, dep.spec.name),
-                                *self.spec_clauses(named_cond, body=True)
-                            )
-                        )
+                        self.gen.fact(fn.imposed_dependency_condition(
+                            global_condition_id, clause.name, *clause.args
+                        ))
 
                 self.gen.newline()
 
@@ -1363,6 +1355,7 @@ class SpackSolverSetup(object):
             specs (list): list of Specs to solve
 
         """
+        self._condition_id_counter = 0
         # preliminary checks
         check_packages_exist(specs)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -725,7 +725,7 @@ class SpackSolverSetup(object):
 
     def package_dependencies_rules(self, pkg, tests):
         """Translate 'depends_on' directives into ASP logic."""
-        for name, conditions in sorted(pkg.dependencies.items()):
+        for _, conditions in sorted(pkg.dependencies.items()):
             for cond_id, (cond, dep) in enumerate(sorted(conditions.items())):
                 named_cond = cond.copy()
                 named_cond.name = named_cond.name or pkg.name
@@ -748,22 +748,19 @@ class SpackSolverSetup(object):
                         continue
 
                     # there is a declared dependency of type t
-
-                    # TODO: this ends up being redundant in the output --
-                    # TODO: not sure if we really need it anymore.
-                    # TODO: Look at simplifying the logic in concretize.lp
                     self.gen.fact(
-                        fn.declared_dependency(dep.pkg.name, dep.spec.name, t))
+                        fn.declared_dependency(dep.pkg.name, dep.spec.name, cond_id, t)
+                    )
 
-                    # if it has conditions, declare them.
-                    conditions = self.spec_clauses(named_cond, body=True)
-                    for cond in conditions:
-                        self.gen.fact(
-                            fn.dep_cond(
-                                dep.pkg.name, dep.spec.name, t, cond_id,
-                                cond.name, *cond.args
-                            )
+                # if it has conditions, declare them.
+                conditions = self.spec_clauses(named_cond, body=True)
+                for cond in conditions:
+                    self.gen.fact(
+                        fn.dep_cond(
+                            dep.pkg.name, dep.spec.name, cond_id,
+                            cond.name, *cond.args
                         )
+                    )
 
                 # add constraints on the dependency from dep spec.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -59,6 +59,8 @@ dependency_conditions(P, D, T) :-
   dependency_conditions_hold(P, D, I),
   dependency_type(I, T).
 
+#defined dependency_type/2.
+
 % collect all the dependency conditions into a single conditional rule
 dependency_conditions_hold(Package, Dependency, ID) :-
   version(Package, Version)
@@ -81,6 +83,32 @@ dependency_conditions_hold(Package, Dependency, ID) :-
     : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
   dependency_condition(Package, Dependency, ID);
   node(Package).
+
+#defined dependency_condition/3.
+#defined required_dependency_condition/3.
+#defined required_dependency_condition/4.
+#defined required_dependency_condition/5.
+#defined required_dependency_condition/5.
+
+% general rules for conflicts
+:- node(Package) : conflict_condition(ID, "node", Package);
+   not external(Package) : conflict_condition(ID, "node", Package);
+   version(Package, Version) : conflict_condition(ID, "version", Package, Version);
+   version_satisfies(Package, Constraint) : conflict_condition(ID, "version_satisfies", Package, Constraint);
+   node_platform(Package, Platform) : conflict_condition(ID, "node_platform", Package, Platform);
+   node_os(Package, OS) : conflict_condition(ID, "node_os", Package, OS);
+   node_target(Package, Target) : conflict_condition(ID, "node_target", Package, Target);
+   variant_value(Package, Variant, Value) : conflict_condition(ID, "variant_value", Package, Variant, Value);
+   node_compiler(Package, Compiler) : conflict_condition(ID, "node_compiler", Package, Compiler);
+   node_compiler_version(Package, Compiler, Version) : conflict_condition(ID, "node_compiler_version", Package, Compiler, Version);
+   node_compiler_version_satisfies(Package, Compiler, Version) : conflict_condition(ID, "node_compiler_version_satisfies", Package, Compiler, Version);
+   node_flag(Package, FlagType, Flag) : conflict_condition(ID, "node_flag", Package, FlagType, Flag);
+   conflict(ID, Package).
+
+#defined conflict/2.
+#defined conflict_condition/3.
+#defined conflict_condition/4.
+#defined conflict_condition/5.
 
 % Implications from matching a dependency condition
 node(Dependency) :-
@@ -136,6 +164,9 @@ node_flag(Dependency, FlagType, Flag) :-
   dependency_conditions_hold(Package, Dependency, ID),
   depends_on(Package, Dependency),
   imposed_dependency_condition(ID, "node_flag", Dependency, FlagType, Flag).
+
+#defined imposed_dependency_condition/4.
+#defined imposed_dependency_condition/5.
 
 % if a virtual was required by some root spec, one provider is in the DAG
 1 { node(Package) : provides_virtual(Package, Virtual) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -62,7 +62,15 @@ dependency_conditions(P, D, T) :-
 #defined dependency_type/2.
 
 % collect all the dependency conditions into a single conditional rule
-dependency_conditions_hold(Package, Dependency, ID) :-
+% distinguishing between Parent and Package is needed to account for
+% conditions like:
+%
+% depends_on('patchelf@0.9', when='@1.0:1.1 ^python@:2')
+%
+% that include dependencies
+dependency_conditions_hold(Parent, Dependency, ID) :-
+  node(Package)
+    : required_dependency_condition(ID, "node", Package);
   version(Package, Version)
     : required_dependency_condition(ID, "version", Package, Version);
   version_satisfies(Package, Constraint)
@@ -79,10 +87,12 @@ dependency_conditions_hold(Package, Dependency, ID) :-
     : required_dependency_condition(ID, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
     : required_dependency_condition(ID, "node_compiler_version", Package, Compiler, Version);
+  node_compiler_version_satisfies(Package, Compiler, Version)
+    : required_dependency_condition(ID, "node_compiler_version_satisfies", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
     : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
-  dependency_condition(Package, Dependency, ID);
-  node(Package).
+  dependency_condition(Parent, Dependency, ID);
+  node(Parent).
 
 #defined dependency_condition/3.
 #defined required_dependency_condition/3.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -56,32 +56,86 @@ depends_on(Package, Dependency, Type)
 
 % if any individual condition below is true, trigger the dependency.
 dependency_conditions(P, D, T) :-
-  dependency_conditions_hold(P, D, I), declared_dependency(P, D, I, T).
+  dependency_conditions_hold(P, D, I),
+  dependency_type(I, T).
 
-% collect all the dependency condtions into a single conditional rule
-dependency_conditions_hold(P, D, I) :-
-  node(Package)
-    : dep_cond(P, D, I, "node", Package);
+% collect all the dependency conditions into a single conditional rule
+dependency_conditions_hold(Package, Dependency, ID) :-
   version(Package, Version)
-    : dep_cond(P, D, I, "version", Package, Version);
+    : required_dependency_condition(ID, "version", Package, Version);
   version_satisfies(Package, Constraint)
-    : dep_cond(P, D, I, "version_satisfies", Package, Constraint);
+    : required_dependency_condition(ID, "version_satisfies", Package, Constraint);
   node_platform(Package, Platform)
-    : dep_cond(P, D, I, "node_platform", Package, Platform);
+    : required_dependency_condition(ID, "node_platform", Package, Platform);
   node_os(Package, OS)
-    : dep_cond(P, D, I, "node_os", Package, OS);
+    : required_dependency_condition(ID, "node_os", Package, OS);
   node_target(Package, Target)
-    : dep_cond(P, D, I, "node_target", Package, Target);
+    : required_dependency_condition(ID, "node_target", Package, Target);
   variant_value(Package, Variant, Value)
-    : dep_cond(P, D, I, "variant_value", Package, Variant, Value);
+    : required_dependency_condition(ID, "variant_value", Package, Variant, Value);
   node_compiler(Package, Compiler)
-    : dep_cond(P, D, I, "node_compiler", Package, Compiler);
+    : required_dependency_condition(ID, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
-    : dep_cond(P, D, I, "node_compiler_version", Package, Compiler, Version);
+    : required_dependency_condition(ID, "node_compiler_version", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
-    : dep_cond(P, D, I, "node_flag", Package, FlagType, Flag);
-  dependency_condition(P, D, I);
-  node(P).
+    : required_dependency_condition(ID, "node_flag", Package, FlagType, Flag);
+  dependency_condition(Package, Dependency, ID);
+  node(Package).
+
+% Implications from matching a dependency condition
+node(Dependency) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency).
+
+version(Dependency, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "version", Dependency, Version).
+
+version_satisfies(Dependency, Constraint) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "version_satisfies", Dependency, Constraint).
+
+node_platform(Dependency, Platform) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_platform", Dependency, Platform).
+
+node_os(Dependency, OS) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_os", Dependency, OS).
+
+node_target(Dependency, Target) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_target", Dependency, Target).
+
+variant_set(Dependency, Variant, Value) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "variant_set", Dependency, Variant, Value).
+
+node_compiler(Dependency, Compiler) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler", Dependency, Compiler).
+
+node_compiler_version(Dependency, Compiler, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler_version", Dependency, Compiler, Version).
+
+node_compiler_version_satisfies(Dependency, Compiler, Version) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_compiler_version_satisfies", Dependency, Compiler, Version).
+
+node_flag(Dependency, FlagType, Flag) :-
+  dependency_conditions_hold(Package, Dependency, ID),
+  depends_on(Package, Dependency),
+  imposed_dependency_condition(ID, "node_flag", Dependency, FlagType, Flag).
 
 % if a virtual was required by some root spec, one provider is in the DAG
 1 { node(Package) : provides_virtual(Package, Virtual) } 1

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -55,32 +55,32 @@ depends_on(Package, Dependency, Type)
     not external(Package).
 
 % if any individual condition below is true, trigger the dependency.
-dependency_conditions(P, D, T) :- dependency_conditions(P, D, T, _).
+dependency_conditions(P, D, T) :-
+  dependency_conditions_hold(P, D, I), declared_dependency(P, D, I, T).
 
 % collect all the dependency condtions into a single conditional rule
-dependency_conditions(P, D, T, I) :-
+dependency_conditions_hold(P, D, I) :-
   node(Package)
-    : dep_cond(P, D, T, I, "node", Package);
+    : dep_cond(P, D, I, "node", Package);
   version(Package, Version)
-    : dep_cond(P, D, T, I, "version", Package, Version);
+    : dep_cond(P, D, I, "version", Package, Version);
   version_satisfies(Package, Constraint)
-    : dep_cond(P, D, T, I, "version_satisfies", Package, Constraint);
+    : dep_cond(P, D, I, "version_satisfies", Package, Constraint);
   node_platform(Package, Platform)
-    : dep_cond(P, D, T, I, "node_platform", Package, Platform);
+    : dep_cond(P, D, I, "node_platform", Package, Platform);
   node_os(Package, OS)
-    : dep_cond(P, D, T, I, "node_os", Package, OS);
+    : dep_cond(P, D, I, "node_os", Package, OS);
   node_target(Package, Target)
-    : dep_cond(P, D, T, I, "node_target", Package, Target);
+    : dep_cond(P, D, I, "node_target", Package, Target);
   variant_value(Package, Variant, Value)
-    : dep_cond(P, D, T, I, "variant_value", Package, Variant, Value);
+    : dep_cond(P, D, I, "variant_value", Package, Variant, Value);
   node_compiler(Package, Compiler)
-    : dep_cond(P, D, T, I, "node_compiler", Package, Compiler);
+    : dep_cond(P, D, I, "node_compiler", Package, Compiler);
   node_compiler_version(Package, Compiler, Version)
-    : dep_cond(P, D, T, I, "node_compiler_version", Package, Compiler, Version);
+    : dep_cond(P, D, I, "node_compiler_version", Package, Compiler, Version);
   node_flag(Package, FlagType, Flag)
-    : dep_cond(P, D, T, I, "node_flag", Package, FlagType, Flag);
+    : dep_cond(P, D, I, "node_flag", Package, FlagType, Flag);
   dependency_condition(P, D, I);
-  declared_dependency(P, D, T);
   node(P).
 
 % if a virtual was required by some root spec, one provider is in the DAG


### PR DESCRIPTION
I tried a couple of the suggestions I had for #20423 The main modifications here are:

- [x] Simplified and renamed a few ASP functions
- [x] `depends_on` clauses are numbered globally and identified only by ID
- [x] constraints imposed on the dependency are also turned into facts