### PR TITLE
Match master version instead of develop for PARAVIEW_VTK_DIR

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -158,7 +158,7 @@ class Paraview(CMakePackage, CudaPackage):
     @property
     def paraview_subdir(self):
         """The paraview subdirectory name as paraview-major.minor"""
-        if self.spec.version == Version('develop'):
+        if self.spec.version == Version('master'):
             return 'paraview-5.9'
         else:
             return 'paraview-{0}'.format(self.spec.version.up_to(2))


### PR DESCRIPTION
@chuckatkins @danlipsa please review

Changes check for PARAVIEW_VTK_DIR to `master` instead of `develop` 