### PR TITLE
Pipelines: DAG Pruning

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1322,7 +1322,7 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
             os.remove(filename)
 
 
-def try_direct_fetch(spec, force=False, full_hash_match=False, mirrors=None):
+def try_direct_fetch(spec, full_hash_match=False, mirrors=None):
     """
     Try to find the spec directly on the configured mirrors
     """
@@ -1360,11 +1360,26 @@ def try_direct_fetch(spec, force=False, full_hash_match=False, mirrors=None):
     return found_specs
 
 
-def get_mirrors_for_spec(spec=None, force=False, full_hash_match=False,
-                         mirrors_to_check=None):
+def get_mirrors_for_spec(spec=None, full_hash_match=False,
+                         mirrors_to_check=None, index_only=False):
     """
     Check if concrete spec exists on mirrors and return a list
     indicating the mirrors on which it can be found
+
+    Args:
+        spec (Spec): The spec to look for in binary mirrors
+        full_hash_match (bool): If True, only includes mirrors where the spec
+            full hash matches the locally computed full hash of the ``spec``
+            argument.  If False, any mirror which has a matching DAG hash
+            is included in the results.
+        mirrors_to_check (dict): Optionally override the configured mirrors
+            with the mirrors in this dictionary.
+        index_only (bool): Do not attempt direct fetching of ``spec.yaml``
+            files from remote mirrors, only consider the indices.
+
+    Return:
+        A list of objects, each containing a ``mirror_url`` and ``spec`` key
+            indicating all mirrors where the spec can be found.
     """
     if spec is None:
         return []
@@ -1390,10 +1405,9 @@ def get_mirrors_for_spec(spec=None, force=False, full_hash_match=False,
         results = filter_candidates(candidates)
 
     # Maybe we just didn't have the latest information from the mirror, so
-    # try to fetch directly.
-    if not results:
+    # try to fetch directly, unless we are only considering the indices.
+    if not results and not index_only:
         results = try_direct_fetch(spec,
-                                   force=force,
                                    full_hash_match=full_hash_match,
                                    mirrors=mirrors_to_check)
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -959,10 +959,10 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
 
         if 'script' not in noop_job:
             noop_job['script'] = [
-                'echo "Nothing to do"',
+                'echo "All specs already up to date, nothing to rebuild."',
             ]
 
-        sorted_output = {'noop': noop_job}
+        sorted_output = {'no-specs-to-rebuild': noop_job}
 
     with open(output_file, 'w') as outf:
         outf.write(syaml.dump_config(sorted_output, default_flow_style=True))

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -736,10 +736,9 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
                         # purposes, so we only get the direct dependencies.
                         dep_jobs = []
                         for dep_label in dependencies[spec_label]:
-                            if spec_labels[dep_label]['needs_rebuild']:
-                                dep_pkg = pkg_name_from_spec_label(dep_label)
-                                dep_root = spec_labels[dep_label]['rootSpec']
-                                dep_jobs.append(dep_root[dep_pkg])
+                            dep_pkg = pkg_name_from_spec_label(dep_label)
+                            dep_root = spec_labels[dep_label]['rootSpec']
+                            dep_jobs.append(dep_root[dep_pkg])
 
                     job_dependencies.extend(
                         format_job_needs(phase_name, strip_compilers,

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -869,8 +869,9 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
     tty.debug('{0} build jobs generated in {1} stages'.format(
         job_id, stage_id))
 
-    tty.debug('The max_needs_job is {0}, with {1} needs'.format(
-        max_needs_job, max_length_needs))
+    if job_id > 0:
+        tty.debug('The max_needs_job is {0}, with {1} needs'.format(
+            max_needs_job, max_length_needs))
 
     # Use "all_job_names" to populate the build group for this set
     if enable_cdash_reporting and cdash_auth_token:
@@ -882,7 +883,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
     else:
         tty.warn('Unable to populate buildgroup without CDash credentials')
 
-    if final_job_config and not is_pr_pipeline:
+    if final_job_config and not is_pr_pipeline and job_id > 0:
         # Add an extra, final job to regenerate the index
         final_stage = 'stage-rebuild-index'
         final_job = {

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -719,7 +719,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
                     'SPACK_JOB_SPEC_PKG_NAME': release_spec.name,
                     'SPACK_COMPILER_ACTION': compiler_action,
                     'SPACK_IS_PR_PIPELINE': str(is_pr_pipeline),
-                    'SPACK_SPEC_NEEDS_REBUILD': spec_needs_rebuild,
+                    'SPACK_SPEC_NEEDS_REBUILD': str(spec_needs_rebuild),
                 }
 
                 job_dependencies = []

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -769,24 +769,28 @@ def buildcache_copy(args):
         shutil.copyfile(cdashid_src_path, cdashid_dest_path)
 
 
+def update_index(mirror_url, update_keys=False):
+    mirror = spack.mirror.MirrorCollection().lookup(mirror_url)
+    outdir = url_util.format(mirror.push_url)
+
+    bindist.generate_package_index(
+        url_util.join(outdir, bindist.build_cache_relative_path()))
+
+    if update_keys:
+        keys_url = url_util.join(outdir,
+                                 bindist.build_cache_relative_path(),
+                                 bindist.build_cache_keys_relative_path())
+
+        bindist.generate_key_index(keys_url)
+
+
 def buildcache_update_index(args):
     """Update a buildcache index."""
     outdir = '.'
     if args.mirror_url:
         outdir = args.mirror_url
 
-    mirror = spack.mirror.MirrorCollection().lookup(outdir)
-    outdir = url_util.format(mirror.push_url)
-
-    bindist.generate_package_index(
-        url_util.join(outdir, bindist.build_cache_relative_path()))
-
-    if args.keys:
-        keys_url = url_util.join(outdir,
-                                 bindist.build_cache_relative_path(),
-                                 bindist.build_cache_keys_relative_path())
-
-        bindist.generate_key_index(keys_url)
+    update_index(outdir, update_keys=args.keys)
 
 
 def buildcache(parser, args):

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -426,7 +426,7 @@ def ci_rebuild(args):
                     artifact_mirror_url or pr_mirror_url or remote_mirror_url)
 
 
-def ci_reindex(parser, args):
+def ci_reindex(args):
     """Rebuild the buildcache index associated with the mirror in the
        active, gitlab-enabled environment. """
     env = ev.get_env(args, 'ci rebuild-index', required=True)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -54,6 +54,18 @@ def setup_parser(subparser):
         '--dependencies', action='store_true', default=False,
         help="(Experimental) disable DAG scheduling; use "
              ' "plain" dependencies.')
+    prune_group = generate.add_mutually_exclusive_group()
+    prune_group.add_argument(
+        '--prune-dag', action='store_true', dest='prune_dag',
+        default=True, help="""Do not generate jobs for specs already up to
+date on the mirror""")
+    prune_group.add_argument(
+        '--no-prune-dag', action='store_false', dest='prune_dag',
+        default=True, help="""Generate jobs for specs already up to date
+on the mirror.  Useful when relying on artifacts buildcache, generated
+jobs just copy target speck buildcache files from remote mirror into a
+local directory.
+""")
     generate.set_defaults(func=ci_generate)
 
     # Check a spec against mirror. Rebuild, create buildcache and push to
@@ -75,6 +87,7 @@ def ci_generate(args):
     copy_yaml_to = args.copy_to
     run_optimizer = args.optimize
     use_dependencies = args.dependencies
+    prune_dag = args.prune_dag
 
     if not output_file:
         output_file = os.path.abspath(".gitlab-ci.yml")
@@ -86,8 +99,8 @@ def ci_generate(args):
 
     # Generate the jobs
     spack_ci.generate_gitlab_ci_yaml(
-        env, True, output_file, run_optimizer=run_optimizer,
-        use_dependencies=use_dependencies)
+        env, True, output_file, prune_dag=prune_dag,
+        run_optimizer=run_optimizer, use_dependencies=use_dependencies)
 
     if copy_yaml_to:
         copy_to_dir = os.path.dirname(copy_yaml_to)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -432,13 +432,12 @@ def ci_reindex(args):
     env = ev.get_env(args, 'ci rebuild-index', required=True)
     yaml_root = ev.config_dict(env.yaml)
 
-    if 'mirrors' in yaml_root:
-        ci_mirrors = yaml_root['mirrors']
-        mirror_urls = [url for url in ci_mirrors.values()]
-        remote_mirror_url = mirror_urls[0]
+    if 'mirrors' not in yaml_root or len(yaml_root['mirrors'].values()) < 1:
+        tty.die('spack ci rebuild-index requires an env containing a mirror')
 
-    if not remote_mirror_url:
-        tty.die('spack ci rebuild requires an env containing a mirror')
+    ci_mirrors = yaml_root['mirrors']
+    mirror_urls = [url for url in ci_mirrors.values()]
+    remote_mirror_url = mirror_urls[0]
 
     buildcache.update_index(remote_mirror_url, update_keys=True)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -392,7 +392,7 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False,
     pkg_id = package_id(pkg)
     tty.debug('Searching for binary cache of {0}'.format(pkg_id))
     matches = binary_distribution.get_mirrors_for_spec(
-        pkg.spec, force=False, full_hash_match=full_hash_match)
+        pkg.spec, full_hash_match=full_hash_match)
 
     if not matches:
         return False

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -9,6 +9,8 @@
    :lines: 13-
 """
 
+from llnl.util.lang import union_dicts
+
 image_schema = {
     'oneOf': [
         {
@@ -28,127 +30,110 @@ image_schema = {
     ],
 }
 
+runner_attributes_schema_items = {
+    'image': image_schema,
+    'tags': {
+        'type': 'array',
+        'items': {'type': 'string'}
+    },
+    'variables': {
+        'type': 'object',
+        'patternProperties': {
+            r'[\w\d\-_\.]+': {
+                'type': 'string',
+            },
+        },
+    },
+}
+
+customizable_job_schema_items = {
+    'before_script': {
+        'type': 'array',
+        'items': {'type': 'string'}
+    },
+    'script': {
+        'type': 'array',
+        'items': {'type': 'string'}
+    },
+    'after_script': {
+        'type': 'array',
+        'items': {'type': 'string'}
+    },
+}
+
+runner_selector_schema = {
+    'type': 'object',
+    'additionalProperties': False,
+    'required': ['tags'],
+    'properties': runner_attributes_schema_items,
+}
+
 #: Properties for inclusion in other schemas
 properties = {
     'gitlab-ci': {
         'type': 'object',
         'additionalProperties': False,
         'required': ['mappings'],
-        'patternProperties': {
-            'bootstrap': {
-                'type': 'array',
-                'items': {
-                    'anyOf': [
-                        {
-                            'type': 'string',
-                        }, {
-                            'type': 'object',
-                            'additionalProperties': False,
-                            'required': ['name'],
-                            'properties': {
-                                'name': {
-                                    'type': 'string',
-                                },
-                                'compiler-agnostic': {
-                                    'type': 'boolean',
-                                    'default': False,
-                                },
-                            },
-                        },
-                    ],
-                },
-            },
-            'mappings': {
-                'type': 'array',
-                'items': {
-                    'type': 'object',
-                    'additionalProperties': False,
-                    'required': ['match'],
-                    'properties': {
-                        'match': {
-                            'type': 'array',
-                            'items': {
+        'patternProperties': union_dicts(
+            runner_attributes_schema_items,
+            customizable_job_schema_items,
+            {
+                'bootstrap': {
+                    'type': 'array',
+                    'items': {
+                        'anyOf': [
+                            {
                                 'type': 'string',
-                            },
-                        },
-                        'runner-attributes': {
-                            'type': 'object',
-                            'additionalProperties': True,
-                            'required': ['tags'],
-                            'properties': {
-                                'image': image_schema,
-                                'tags': {
-                                    'type': 'array',
-                                    'items': {'type': 'string'}
-                                },
-                                'variables': {
-                                    'type': 'object',
-                                    'patternProperties': {
-                                        r'[\w\d\-_\.]+': {
-                                            'type': 'string',
-                                        },
+                            }, {
+                                'type': 'object',
+                                'additionalProperties': False,
+                                'required': ['name'],
+                                'properties': {
+                                    'name': {
+                                        'type': 'string',
+                                    },
+                                    'compiler-agnostic': {
+                                        'type': 'boolean',
+                                        'default': False,
                                     },
                                 },
-                                'before_script': {
-                                    'type': 'array',
-                                    'items': {'type': 'string'}
+                            },
+                        ],
+                    },
+                },
+                'mappings': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'required': ['match'],
+                        'properties': {
+                            'match': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
                                 },
-                                'script': {
-                                    'type': 'array',
-                                    'items': {'type': 'string'}
-                                },
-                                'after_script': {
-                                    'type': 'array',
-                                    'items': {'type': 'string'}
-                                },
+                            },
+                            'runner-attributes': {
+                                'type': 'object',
+                                'additionalProperties': True,
+                                'required': ['tags'],
+                                'properties': union_dicts(
+                                    runner_attributes_schema_items,
+                                    customizable_job_schema_items
+                                ),
                             },
                         },
                     },
                 },
-            },
-            'image': image_schema,
-            'tags': {
-                'type': 'array',
-                'items': {'type': 'string'}
-            },
-            'variables': {
-                'type': 'object',
-                'patternProperties': {
-                    r'[\w\d\-_\.]+': {
-                        'type': 'string',
-                    },
+                'enable-artifacts-buildcache': {
+                    'type': 'boolean',
+                    'default': False,
                 },
-            },
-            'before_script': {
-                'type': 'array',
-                'items': {'type': 'string'}
-            },
-            'script': {
-                'type': 'array',
-                'items': {'type': 'string'}
-            },
-            'after_script': {
-                'type': 'array',
-                'items': {'type': 'string'}
-            },
-            'enable-artifacts-buildcache': {
-                'type': 'boolean',
-                'default': False,
-            },
-            'final-stage-rebuild-index': {
-                'type': 'object',
-                'additionalProperties': False,
-                'required': ['tags'],
-                'properties': {
-                    'image': image_schema,
-                    'tags': {
-                        'type': 'array',
-                        'default': [],
-                        'items': {'type': 'string'}
-                    },
-                },
-            },
-        },
+                'final-stage-rebuild-index': runner_selector_schema,
+                'noop-pipeline-job-attributes': runner_selector_schema,
+            }
+        ),
     },
 }
 

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -65,7 +65,10 @@ runner_selector_schema = {
     'type': 'object',
     'additionalProperties': False,
     'required': ['tags'],
-    'properties': runner_attributes_schema_items,
+    'properties': union_dicts(
+        runner_attributes_schema_items,
+        customizable_job_schema_items
+    ),
 }
 
 #: Properties for inclusion in other schemas
@@ -114,23 +117,11 @@ properties = {
                                     'type': 'string',
                                 },
                             },
-                            'runner-attributes': {
-                                'type': 'object',
-                                'additionalProperties': True,
-                                'required': ['tags'],
-                                'properties': union_dicts(
-                                    runner_attributes_schema_items,
-                                    customizable_job_schema_items
-                                ),
-                            },
+                            'runner-attributes': runner_selector_schema,
                         },
                     },
                 },
                 'enable-artifacts-buildcache': {
-                    'type': 'boolean',
-                    'default': False,
-                },
-                'rebuild-index': {
                     'type': 'boolean',
                     'default': False,
                 },

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -118,7 +118,8 @@ properties = {
                     'type': 'boolean',
                     'default': False,
                 },
-                'nonbuild-job-attributes': runner_selector_schema,
+                'service-job-attributes': runner_selector_schema,
+                'rebuild-index': {'type': 'boolean'},
             }
         ),
     },

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -44,9 +44,6 @@ runner_attributes_schema_items = {
             },
         },
     },
-}
-
-customizable_job_schema_items = {
     'before_script': {
         'type': 'array',
         'items': {'type': 'string'}
@@ -65,10 +62,7 @@ runner_selector_schema = {
     'type': 'object',
     'additionalProperties': False,
     'required': ['tags'],
-    'properties': union_dicts(
-        runner_attributes_schema_items,
-        customizable_job_schema_items
-    ),
+    'properties': runner_attributes_schema_items,
 }
 
 #: Properties for inclusion in other schemas
@@ -79,7 +73,6 @@ properties = {
         'required': ['mappings'],
         'patternProperties': union_dicts(
             runner_attributes_schema_items,
-            customizable_job_schema_items,
             {
                 'bootstrap': {
                     'type': 'array',

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -130,8 +130,11 @@ properties = {
                     'type': 'boolean',
                     'default': False,
                 },
-                'final-stage-rebuild-index': runner_selector_schema,
-                'noop-pipeline-job-attributes': runner_selector_schema,
+                'rebuild-index': {
+                    'type': 'boolean',
+                    'default': False,
+                },
+                'nonbuild-job-attributes': runner_selector_schema,
             }
         ),
     },

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -772,10 +772,10 @@ spack:
             with open(outputfile_pruned) as f:
                 contents = f.read()
                 yaml_contents = syaml.load(contents)
-                assert('noop' in yaml_contents)
+                assert('no-specs-to-rebuild' in yaml_contents)
                 # Make sure there are no other spec jobs
                 assert(len(yaml_contents.keys()) == 1)
-                the_elt = yaml_contents['noop']
+                the_elt = yaml_contents['no-specs-to-rebuild']
                 assert('tags' in the_elt)
                 assert('nonbuildtag' in the_elt['tags'])
                 assert('image' in the_elt)
@@ -1194,7 +1194,7 @@ spack:
             # without the monkeypatch, everything appears up to date and no
             # rebuild jobs are generated.
             assert(original_yaml_contents)
-            assert('noop' in original_yaml_contents)
+            assert('no-specs-to-rebuild' in original_yaml_contents)
 
             monkeypatch.setattr(spack.binary_distribution,
                                 'get_mirrors_for_spec',

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1237,7 +1237,8 @@ spack:
 
 
 def test_ci_subcommands_without_mirror(tmpdir, mutable_mock_env_path,
-                                       env_deactivate, mock_packages):
+                                       env_deactivate, mock_packages,
+                                       install_mockery):
     """Make sure we catch if there is not a mirror and report an error"""
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1166,9 +1166,8 @@ spack:
     # nothing in the environment needs rebuilding.  With the monkeypatch, the
     # process sees the compiler as needing a rebuild, which should then result
     # in the specs built with that compiler needing a rebuild too.
-    def fake_get_mirrors_for_spec(spec=None, force=False,
-                                  full_hash_match=False,
-                                  mirrors_to_check=None):
+    def fake_get_mirrors_for_spec(spec=None, full_hash_match=False,
+                                  mirrors_to_check=None, index_only=False):
         if spec.name == 'gcc':
             return []
         else:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1022,8 +1022,7 @@ spack:
         with ev.read('test'):
             monkeypatch.setattr(
                 ci, 'SPACK_PR_MIRRORS_ROOT_URL', r"file:///fake/mirror")
-            ci_cmd('generate', '--output-file', outputfile, '--optimize',
-                   '--dependencies')
+            ci_cmd('generate', '--output-file', outputfile, '--dependencies')
 
             with open(outputfile) as f:
                 contents = f.read()
@@ -1037,6 +1036,5 @@ spack:
                         job_obj = yaml_contents[ci_key]
                         assert('needs' not in job_obj)
                         assert('dependencies' in job_obj)
-                        assert('SPACK_ROOT_SPEC' not in job_obj['variables'])
 
                 assert(found_one is True)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -796,7 +796,7 @@ spack:
                         assert('variables' in the_elt)
                         job_vars = the_elt['variables']
                         assert('SPACK_SPEC_NEEDS_REBUILD' in job_vars)
-                        assert(job_vars['SPACK_SPEC_NEEDS_REBUILD'] is False)
+                        assert(job_vars['SPACK_SPEC_NEEDS_REBUILD'] == 'False')
                         found_spec_job = True
 
                 assert(found_spec_job)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -533,7 +533,7 @@ spack:
 
 def test_ci_generate_for_pr_pipeline(tmpdir, mutable_mock_env_path,
                                      env_deactivate, install_mockery,
-                                     mock_packages):
+                                     mock_packages, monkeypatch):
     """Test that PR pipelines do not include a final stage job for
     rebuilding the mirror index, even if that job is specifically
     configured"""
@@ -569,6 +569,9 @@ spack:
 
         with ev.read('test'):
             os.environ['SPACK_IS_PR_PIPELINE'] = 'True'
+            os.environ['SPACK_PR_BRANCH'] = 'fake-test-branch'
+            monkeypatch.setattr(
+                ci, 'SPACK_PR_MIRRORS_ROOT_URL', r"file:///fake/mirror")
             ci_cmd('generate', '--output-file', outputfile)
 
         with open(outputfile) as f:
@@ -582,7 +585,7 @@ spack:
 
 def test_ci_generate_with_external_pkg(tmpdir, mutable_mock_env_path,
                                        env_deactivate, install_mockery,
-                                       mock_packages):
+                                       mock_packages, monkeypatch):
     """Make sure we do not generate jobs for external pkgs"""
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:
@@ -609,6 +612,8 @@ spack:
         outputfile = str(tmpdir.join('.gitlab-ci.yml'))
 
         with ev.read('test'):
+            monkeypatch.setattr(
+                ci, 'SPACK_PR_MIRRORS_ROOT_URL', r"file:///fake/mirror")
             ci_cmd('generate', '--output-file', outputfile)
 
         with open(outputfile) as f:
@@ -851,6 +856,8 @@ spack:
         with ev.read('test'):
             monkeypatch.setattr(
                 spack.main, 'get_version', lambda: '0.15.3-416-12ad69eb1')
+            monkeypatch.setattr(
+                ci, 'SPACK_PR_MIRRORS_ROOT_URL', r"file:///fake/mirror")
             ci_cmd('generate', '--output-file', outputfile)
 
         with open(outputfile) as f:

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -231,7 +231,7 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
 def test_try_install_from_binary_cache(install_mockery, mock_packages,
                                        monkeypatch, capsys):
     """Tests SystemExit path for_try_install_from_binary_cache."""
-    def _mirrors_for_spec(spec, force, full_hash_match=False):
+    def _mirrors_for_spec(spec, full_hash_match=False):
         spec = spack.spec.Spec('mpi').concretized()
         return [{
             'mirror_url': 'notused',

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -473,7 +473,7 @@ _spack_ci() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="generate rebuild"
+        SPACK_COMPREPLY="generate rebuild rebuild-index"
     fi
 }
 
@@ -482,6 +482,10 @@ _spack_ci_generate() {
 }
 
 _spack_ci_rebuild() {
+    SPACK_COMPREPLY="-h --help"
+}
+
+_spack_ci_rebuild_index() {
     SPACK_COMPREPLY="-h --help"
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -478,7 +478,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies"
+    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag"
 }
 
 _spack_ci_rebuild() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -478,7 +478,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag"
+    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag --check-index-only"
 }
 
 _spack_ci_rebuild() {


### PR DESCRIPTION
Check specs against configured mirrors during the staging process, so we avoid scheduling them in the pipeline if they are already up to date on at least one of the mirrors.

Still TODO:

- [x] Make sure per-PR mirror is configured and available during pipeline generation
- [ ] ~Fix the stages (currently we don't account for stages going away)~ - This is not necessary for pipeline correctness.
- [x] Make sure something sensible happens if an empty pipeline is generated
- [x] Make this functionality optional via a cli arg
- [x] Finish updating `pipelines.rst` to describe changes, especially DAG pruning.
- [x] Fix whatever is wrong with restructured text and breaking the docs
- [x] Add some tests
- [x] Test that this behaves as expected in the presence of compiler bootstrapping
- [x] Clean up