### PR TITLE
mesa: drop use of shared variant

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -198,7 +198,6 @@ class Mesa(MesonPackage):
         if libs_to_seek:
             return find_libraries(list(libs_to_seek),
                                   root=self.spec.prefix,
-                                  shared='+shared' in self.spec,
                                   recursive=True)
         return LibraryList()
 
@@ -206,19 +205,16 @@ class Mesa(MesonPackage):
     def osmesa_libs(self):
         return find_libraries('libOSMesa',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
                               recursive=True)
 
     @property
     def glx_libs(self):
         return find_libraries('libGL',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
                               recursive=True)
 
     @property
     def gl_libs(self):
         return find_libraries('libGL',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
                               recursive=True)


### PR DESCRIPTION
Mesa no longer supports building static libraries so it doesn't
even make sense to add the variant.

Replaces #20443