### PR TITLE
py-greenlet: add version 0.4.17

### DIFF
--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -10,6 +10,7 @@ class PyGreenlet(PythonPackage):
     """Lightweight in-process concurrent programming"""
 
     homepage = "https://github.com/python-greenlet/greenlet"
-    url      = "https://pypi.io/packages/source/g/greenlet/greenlet-0.4.13.tar.gz"
+    url      = "https://pypi.io/packages/source/g/greenlet/greenlet-0.4.17.tar.gz"
 
+    version('0.4.17', sha256='41d8835c69a78de718e466dd0e6bfd4b46125f21a67c3ff6d76d8d8059868d6b')
     version('0.4.13', sha256='0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4')

--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -14,3 +14,5 @@ class PyGreenlet(PythonPackage):
 
     version('0.4.17', sha256='41d8835c69a78de718e466dd0e6bfd4b46125f21a67c3ff6d76d8d8059868d6b')
     version('0.4.13', sha256='0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4')
+
+    depends_on('python', type=('build', 'link', 'run'))


### PR DESCRIPTION
Add `py-greenlet@0.4.17`.

Version `0.4.17` incorporates changes not present in `0.4.13` which allow `py-greenlet` to build on ppc64le.

Fixes https://github.com/spack/spack/issues/20456