### PR TITLE
slepc: set --with-arpack-dir correctly

### DIFF
--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -96,7 +96,7 @@ class Slepc(Package):
 
         if '+arpack' in spec:
             options.extend([
-                '--with-arpack-dir=%s' % spec['arpack-ng'].prefix.lib,
+                '--with-arpack-dir=%s' % spec['arpack-ng'].prefix,
             ])
             if spec.satisfies('@:3.12.99'):
                 arpackopt = '--with-arpack-flags'


### PR DESCRIPTION
Set `--with-arpack-dir` to the `arpack.prefix` install prefix, not the lib prefix.

See https://slepc.upv.es/documentation/instal.htm for explanation of how `--with-arpack-dir` should be set.

Fixes https://github.com/spack/spack/issues/20323