### PR TITLE
fdupes: Add pcre2 depend

### DIFF
--- a/var/spack/repos/builtin/packages/fdupes/package.py
+++ b/var/spack/repos/builtin/packages/fdupes/package.py
@@ -20,6 +20,7 @@ class Fdupes(AutotoolsPackage):
     variant('ncurses', default=True, description='ncurses support')
 
     depends_on('ncurses', when='+ncurses')
+    depends_on('pcre2', type='link')
 
     def configure_args(self):
         return self.with_or_without('ncurses')

--- a/var/spack/repos/builtin/packages/fdupes/package.py
+++ b/var/spack/repos/builtin/packages/fdupes/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -20,7 +20,7 @@ class Fdupes(AutotoolsPackage):
     variant('ncurses', default=True, description='ncurses support')
 
     depends_on('ncurses', when='+ncurses')
-    depends_on('pcre2', type='link')
+    depends_on('pcre2', when='+ncurses')
 
     def configure_args(self):
         return self.with_or_without('ncurses')


### PR DESCRIPTION
I've confirmed that the error is occurring on machines on x86_64 and aarch64, and I've also confirmed that it has been fixed.