### PR TITLE
libjson: Fix install parameters

### DIFF
--- a/var/spack/repos/builtin/packages/libjson/package.py
+++ b/var/spack/repos/builtin/packages/libjson/package.py
@@ -20,5 +20,8 @@ class Libjson(MakefilePackage):
     version('0.5', sha256='d19e149118c01c4a1f4cd16be3ce54bfc97a7210b6f0d76a3f8ef75bf70e8acd')
     version('0.4', sha256='9b3ebbeb1940dbd8664524d27e66d991fedc00cca9f403f9aa9c2f28104ca81b')
 
+    def edit(self, spec, prefix):
+        filter_file('-o root -g root', '', 'Makefile')
+
     def install(self, spec, prefix):
         make('install', 'PREFIX={0}'.format(prefix))


### PR DESCRIPTION
I've confirmed that the error is occurring on machines on x86_64 and aarch64, and I've also confirmed that it has been fixed.