### PR TITLE
blitz: add support for Fujitsu compilers and python3

### DIFF
--- a/var/spack/repos/builtin/packages/blitz/fj.patch
+++ b/var/spack/repos/builtin/packages/blitz/fj.patch
@@ -1,0 +1,12 @@
+diff -ruN orig/blitz-1.0.1/configure blitz-1.0.1/configure
+--- orig/blitz-1.0.1/configure	2017-10-03 01:04:43.000000000 +0900
++++ blitz-1.0.1/configure	2020-12-18 22:04:17.000000000 +0900
+@@ -5974,7 +5974,7 @@
+ ac_config_commands="$ac_config_commands blitz/hp/bzconfig.h"
+ 
+                 COMPILER_SPECIFIC_HEADER="hp/bzconfig.h" ;;
+-  *g++*|*c++*)
++  *g++*|*c++*|*FCC)
+ ac_config_commands="$ac_config_commands blitz/gnu/bzconfig.h"
+ 
+                 COMPILER_SPECIFIC_HEADER="gnu/bzconfig.h" ;;

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -14,6 +14,9 @@ class Blitz(AutotoolsPackage):
     version('1.0.1', sha256='b62fc3f07b64b264307b01fec5e4f2793e09a68dcb5378984aedbc2e4b3adcef')
     version('1.0.0', sha256='79c06ea9a0585ba0e290c8140300e3ad19491c45c1d90feb52819abc3b58a0c1')
 
+    patch('https://github.com/blitzpp/blitz/commit/27915941905d4429d4ed803535573b02cd9285a3.patch', sha256='229709e5d1d83f199a3c3f986b5ae6a7d3c04b94201af4952dc5a423448ac4ba', when='@1.0.1')
+    patch('fj.patch', when='%fj')
+
     build_targets = ['lib']
 
     def check(self):


### PR DESCRIPTION
 - use a "print" syntax that is also valid in python3
 - add support for Fujitsu compilers (FCC is GNU compatible)