### PR TITLE
py-networkit/libnetworkit: update to 8.0

### DIFF
--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -22,6 +22,7 @@ class Libnetworkit(CMakePackage):
 
     maintainers = ['fabratu']
 
+    version('8.0', sha256='cdf9571043edbe76c447622ed33efe9cba2880f887ca231d98f6d3c22027e20e')
     version('7.1', sha256='60026c3be581ae9d5c919c861605082fcb9c8205758b3ddfcde2408153ae166e')
     version('7.0', sha256='4faf16c5fae3e14d3c1b6f30e25c6e093dcf6a3dbf021235f3161ac2a527f682')
     version('6.1', sha256='22c953ea1054c356663b31c77114c2f0c8fec17e0e707aeec23026241beab9b2')

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -20,12 +20,16 @@ class PyNetworkit(PythonPackage):
     homepage = "https://networkit.github.io/"
     url      = "https://pypi.io/packages/source/n/networkit/networkit-6.1.tar.gz"
 
+    maintainers = ['fabratu']
+
+    version('8.0', sha256='36c30e894e835bf93f0aa0fb0b526758234e74318150820911e024ffe5ec1fd2')
     version('7.1', sha256='8609dc7a574a8a82d8880b8b1e3dfdd9c59ad67cd02135628e675c482fe98a96')
     version('7.0', sha256='eea4b5e565d6990b674e1c7f4d598be9377d57b61d0d82883ecc39edabaf3631')
     version('6.1', sha256='f7fcb50dec66a8253f85c10ff9314100de013c7578d531c81d3f71bc6cf8f093')
 
     # Required dependencies
     depends_on('cmake', type='build')
+    depends_on('libnetworkit@8.0', type=('build', 'link'), when='@8.0')
     depends_on('libnetworkit@7.1', type=('build', 'link'), when='@7.1')
     depends_on('libnetworkit@7.0', type=('build', 'link'), when='@7.0')
     depends_on('libnetworkit@6.1', type=('build', 'link'), when='@6.1')
@@ -35,6 +39,7 @@ class PyNetworkit(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('python@3:', type=('build', 'run'))
 
     phases = ['build_ext', 'install']
 


### PR DESCRIPTION
This updates package `py-networkit` and its dependency `libnetworkit` to 8.0.