### PR TITLE
VTK: add -no-ipo for builds using intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -305,8 +305,8 @@ class Vtk(CMakePackage):
         if compile_flags:
             compile_flags = ' '.join(compile_flags)
             cmake_args.extend([
-                '-DCMAKE_C_FLAGS="{}"'.format(compile_flags),
-                '-DCMAKE_CXX_FLAGS="{}"'.format(compile_flags)
+                '-DCMAKE_C_FLAGS={0}'.format(compile_flags),
+                '-DCMAKE_CXX_FLAGS={0}'.format(compile_flags)
             ])
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -265,11 +265,10 @@ class Vtk(CMakePackage):
                     '-DVTK_USE_X:BOOL=ON',
                     '-DVTK_USE_COCOA:BOOL=OFF'])
 
+        compile_flags = []
+
         if spec.satisfies('@:6.1.0'):
-            cmake_args.extend([
-                '-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY',
-                '-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY'
-            ])
+            compile_flags.append('-DGLX_GLXEXT_LEGACY')
 
             # VTK 6.1.0 (and possibly earlier) does not use
             # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
@@ -297,5 +296,17 @@ class Vtk(CMakePackage):
             if '%intel' in spec and spec.version >= Version('8.2'):
                 cmake_args.append(
                     '-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF')
+
+        # -no-ipo prevents an internal compiler error from multi-file
+        # optimization (https://github.com/spack/spack/issues/20471)
+        if '%intel' in spec:
+            compile_flags.append('-no-ipo')
+
+        if compile_flags:
+            compile_flags = ' '.join(compile_flags)
+            cmake_args.extend([
+                '-DCMAKE_C_FLAGS="{}"'.format(compile_flags),
+                '-DCMAKE_CXX_FLAGS="{}"'.format(compile_flags)
+            ])
 
         return cmake_args


### PR DESCRIPTION
Fixes #20471, avoiding an internal compiler error.