### PR TITLE
branson: dropped parmetis dependency in 0.82 release

### DIFF
--- a/var/spack/repos/builtin/packages/branson/package.py
+++ b/var/spack/repos/builtin/packages/branson/package.py
@@ -27,7 +27,7 @@ class Branson(CMakePackage):
     depends_on('mpi@2:')
     depends_on('boost', when='@:0.81')
     depends_on('metis')
-    depends_on('parmetis', when='@:0.82')
+    depends_on('parmetis', when='@:0.81')
 
     root_cmakelists_dir = 'src'
 


### PR DESCRIPTION
Branson's 0.82 release (latest release) removed the ParMetis dependency entirely 