### PR TITLE
nbdkit: Fix configure arg

### DIFF
--- a/var/spack/repos/builtin/packages/nbdkit/package.py
+++ b/var/spack/repos/builtin/packages/nbdkit/package.py
@@ -24,3 +24,7 @@ class Nbdkit(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+
+    def configure_args(self):
+        args = ['bashcompdir={0}'.format(prefix)]
+        return args


### PR DESCRIPTION
I have fixed the following installation error.
　/usr/bin/install: cannot create regular file '/usr/share/bash-completion/completions/nbdkit': Permission denied

I have confirmed that it can be built on x86_64 and aarch64 machines.