### PR TITLE
concretizer: refactor version, compiler version and platform rules

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -507,10 +507,7 @@ class SpackSolverSetup(object):
             #    c) Numeric or string comparison
             v)
 
-        most_to_least_preferred = sorted(
-            self.possible_versions[pkg.name], key=keyfn, reverse=True
-        )
-
+        most_to_least_preferred = sorted(pkg.versions, key=keyfn, reverse=True)
         for i, v in enumerate(most_to_least_preferred):
             self.gen.fact(fn.version_declared(pkg.name, v, i))
 
@@ -519,7 +516,7 @@ class SpackSolverSetup(object):
         spec = specify(spec)
         assert spec.name
 
-        if spec.concrete:
+        if spec.versions.concrete:
             return [fn.version(spec.name, spec.version)]
 
         if spec.versions == ver(":"):
@@ -1418,6 +1415,10 @@ class SpackSolverSetup(object):
             else:
                 clauses = self.spec_clauses(spec)
             for clause in clauses:
+                if clause.name == 'version' and not spec.virtual:
+                    self.gen.fact(
+                        fn.abstract_spec_version_declared(*clause.args)
+                    )
                 self.gen.fact(clause)
 
         self.gen.h1("Variant Values defined in specs")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -6,20 +6,33 @@
 % Version semantics
 %-----------------------------------------------------------------------------
 
-% versions are declared w/priority -- declared with priority implies declared
+% The same version may be declared with multiple weights. Sometimes
+% we just need to know whether it's declared or not.
 version_declared(Package, Version) :- version_declared(Package, Version, _).
 
-% If something is a package, it has only one version and that must be a
-% declared version.
-1 { version(Package, Version) : version_declared(Package, Version) } 1
+% Infer version/2 if version/3 is true
+version(Package, Version) :- version(Package, Version, Weight).
+
+% Each node in the graph must have exactly one version and
+% that must be a declared version.
+1 { version(Package, Version, Weight) : version_declared(Package, Version, Weight) } 1
  :- node(Package).
 
-version_weight(Package, Weight)
- :- version(Package, Version), version_declared(Package, Version, Weight),
-    not preferred_version_declared(Package, Version, _).
+% Having a preferred version declared in packages.yaml declares implicitly
+% a new weight for the version only if the version already exists in package.py
+version_declared(Package, Version, Weight)
+  :- preferred_version_declared(Package, Version, Weight),
+     version_declared(Package, Version, AnotherWeight).
 
-version_weight(Package, Weight)
-  :- version(Package, Version), preferred_version_declared(Package, Version, Weight).
+% If a version is specified on the abstract spec, it is declared implicitly
+% (we want to allow the concretization of any version from the command line)
+version_declared(Package, Version, -100)
+  :- abstract_spec_version_declared(Package, Version),
+     version(Package, Version).
+
+:- version(Package, Version), not version_declared(Package, Version).
+:- version(Package, Version), not version(Package, Version, _).
+:- version(Package, Version1), version(Package, Version2, Weight), Version1 != Version2.
 
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
@@ -28,6 +41,7 @@ version_weight(Package, Weight)
 version_satisfies(Package, Constraint)
   :- version(Package, Version), version_satisfies(Package, Constraint, Version).
 
+#defined abstract_spec_version_declared/2.
 #defined preferred_version_declared/3.
 #defined version_satisfies/3.
 
@@ -273,7 +287,13 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 version_declared(Package, Version, Weight) :- external_version_declared(Package, Version, Weight, _).
 
 % if a package is external its version must be one of the external versions
-1 { version(Package, Version): external_version_declared(Package, Version, _, _) } 1 :- external(Package).
+1 { version(Package, Version, Weight) :
+    external_version_declared(Package, Version, Weight, _) } 1
+  :- external(Package).
+
+:- version(Package, Version, Weight),
+   external_version_declared(Package, Version, Weight, ID),
+   not external_spec(Package, ID).
 
 % if a package is not buildable (external_only), only externals are allowed
 external(Package) :- external_only(Package), node(Package).
@@ -283,12 +303,9 @@ real_node(Package) :- node(Package), not external(Package).
 
 % if an external version is selected, the package is external and
 % we are using the corresponding spec
-external(Package) :-
-    version(Package, Version), version_weight(Package, Weight),
-    external_version_declared(Package, Version, Weight, ID).
-
+external(Package) :- external_spec(Package, ID).
 external_spec(Package, ID) :-
-    version(Package, Version), version_weight(Package, Weight),
+    version(Package, Version, Weight),
     external_version_declared(Package, Version, Weight, ID).
 
 %-----------------------------------------------------------------------------
@@ -669,7 +686,7 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-#minimize { Weight@15 : root(Package),version_weight(Package, Weight)}.
+#minimize { Weight@15 : root(Package),version(Package, Version, Weight)}.
 #minimize {
     Weight@14,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), root(Package)
@@ -718,7 +735,7 @@ root(Dependency, 1) :- not root(Dependency), node(Dependency).
 
 % Choose more recent versions for nodes
 #minimize{
-    Weight@6,Package : version_weight(Package, Weight)
+    Weight@6,Version,Package : version(Package, Version, Weight)
 }.
 
 % Try to use preferred compilers

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -19,7 +19,6 @@
 
 #show variant_not_default/4.
 #show provider_weight/2.
-#show version_weight/2.
 #show compiler_version_match/2.
 #show compiler_weight/2.
 #show node_target_match/2.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1085,3 +1085,17 @@ class TestConcretize(object):
         ).concretized()
 
         assert root.dag_hash() == new_root.dag_hash()
+
+    @pytest.mark.parametrize('spec_str,preferred_versions,expected_version', [
+        ('mpileaks', ['2.2'], '@2.2'),
+        ('mpileaks', ['6.2'], '@2.3'),
+        ('mpileaks', ['6.2', '2.1', '2.2'], '@2.1'),
+    ])
+    def test_preferred_version_is_used_only_if_it_exists_in_package_py(
+            self, spec_str, preferred_versions, expected_version
+    ):
+        with spack.config.override(
+                'packages:mpileaks', {'version': preferred_versions}
+        ):
+            s = Spec(spec_str).concretized()
+            assert s.satisfies(expected_version)


### PR DESCRIPTION
This adds an explicit rule to ensure that concrete versions from an abstract spec are always concretizable.

It also removes `versions_weights` in favor of `version/3` that contains a package, a version and a weights. Using the same function avoids by design to infer the weight from a declaration and the actual version from another.

Require that all selected versions are declared either in `package.py`, `packages.yaml` or in an abstract_spec.

Cardinality constraints on compiler versions and platforms are reworked as integrity constraints, to avoid looping on 2 variables in the grounder.