### PR TITLE
clingo: prefer master branch

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -22,7 +22,7 @@ class Clingo(CMakePackage):
 
     maintainers = ["tgamblin"]
 
-    version('master', branch='master', submodules=True)
+    version('master', branch='master', submodules=True, preferred=True)
     version('spack', commit='2ab2e81bcb24f6070b7efce30a754d74ef52ee2d', submodules=True)
 
     version('5.4.0', sha256='e2de331ee0a6d254193aab5995338a621372517adcf91568092be8ac511c18f3')


### PR DESCRIPTION
Most people installing `clingo` with Spack are going to be doing it to use the new concretizer, and that requires the `master` branch for unsatisfiable core support.

- [x] make `master` the default so we don't have to keep telling people to install `clingo@master`. We'll update the preferred version when there's a new release.