### PR TITLE
Z3 concretizer WIP (version ranges only, fake data)

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -139,11 +139,42 @@ class PythonPackage(PackageBase):
     def python(self, *args, **kwargs):
         inspect.getmodule(self).python(*args, **kwargs)
 
+    def _is_py26(self):
+        return self.spec['python'].version.up_to(2).string == '2.6'
+
+    def trailing_setup_args(self):
+        if self._is_py26():
+            return []
+        return ['--no-user-cfg']
+
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
+        trailing_args = tuple(self.trailing_setup_args())
         with working_dir(self.build_directory):
-            self.python('-s', setup, '--no-user-cfg', *args, **kwargs)
+            self.python('-s', setup, *trailing_args, *args, **kwargs)
+
+    def _setup_command_available(self, command):
+        """Determines whether or not a setup.py command exists.
+
+        Args:
+            command (str): The command to look for
+
+        Returns:
+            bool: True if the command is found, else False
+        """
+        kwargs = {
+            'output': os.devnull,
+            'error':  os.devnull,
+            'fail_on_error': False
+        }
+
+        python = inspect.getmodule(self).python
+        setup = self.setup_file()
+
+        trailing_args = tuple(self.trailing_setup_args())
+        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        return python.returncode == 0
 
     # The following phases and their descriptions come from:
     #   $ python setup.py --help-commands

--- a/lib/spack/spack/solver/z3.py
+++ b/lib/spack/spack/solver/z3.py
@@ -1,0 +1,869 @@
+from __future__ import absolute_import, print_function
+
+import abc
+import code
+import collections
+import functools
+import itertools
+import re
+from contextlib import contextmanager
+# from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+import six
+from z3 import *
+
+import llnl.util.lang
+from spack.version import Version, VersionRange, VersionList, ver
+from spack.solver.asp import Timer as _Timer
+
+
+class Timer(_Timer):
+    def __init__(self):
+        _Timer.__init__(self)
+        self.superphase = ''
+
+    def phase(self, name, sep='/'):
+        return _Timer.phase(self, self.superphase + sep + name)
+
+    @contextmanager
+    def nested_phase(self, subname, sep='/'):
+        orig = self.superphase
+        self.superphase += sep
+        self.superphase += subname
+        try:
+            self.phase('', sep=sep)
+            yield self
+        finally:
+            self.superphase = orig
+            self.phase('')
+
+### Generate the model.
+
+# From ExprRef.__doc__ in z3.py:
+"""Constraints, formulas and terms are expressions in Z3.
+
+Expressions are ASTs. Every expression has a sort.
+There are three main kinds of expressions:
+function applications, quantifiers and bounded variables.
+A constant is a function application with 0 arguments.
+For quantifier free problems, all expressions are
+function applications.
+"""
+# Z3Expr = Any
+# Z3Sort = Any
+
+# _Z = TypeVar('_Z', bound=Z3Sort)
+# class IntoZ3(Generic[_Z]):
+@six.add_metaclass(abc.ABCMeta)
+class IntoZ3(object):
+    SORT = None  # type: ClassVar[Type[_Z]]
+
+    def into_z3(self):
+        # type: () -> _Z
+        return self.extract_z3_expr(self)
+
+    @abc.abstractmethod
+    def convert_to_z3(self):
+        # type: () -> _Z
+        pass
+
+    @classmethod
+    @llnl.util.lang.memoized
+    def extract_z3_expr(cls, instance):
+        # type: (IntoZ3[T]) -> T
+        if not is_sort(cls.SORT):
+            raise TypeError('{}.SORT was not a z3 sort: {}'.format(cls.__name__, cls.SORT))
+        z3_instance = instance.convert_to_z3()
+        if not is_expr(z3_instance):
+            raise TypeError('Not a z3 instance: {}'.format(z3_instance))
+        if not z3_instance.sort() == cls.SORT:
+            raise TypeError('Returned z3 object of unexpected sort: {} (sort {}). Expected was {}, from {}.SORT. Instance was: {}.'
+                            .format(z3_instance, z3_instance.sort(), cls.SORT, cls.__name__, instance))
+        return z3_instance
+
+
+def assert_no_duplicates(all_values):
+    # type: (Iterable[Z3Expr]) -> List[Z3Expr]
+    all_values = list(all_values)
+    assert len(frozenset(all_values)) == len(all_values), all_values
+    return all_values
+
+
+def ordered_dict(pairs):
+    # type: (Iterable[T]) -> collections.OrderedDict[K, T]
+    return collections.OrderedDict(pairs)
+
+
+def wraps(inner_cls):
+    def receive_class(outer_cls):
+        outer_cls.__doc__ = inner_cls.__doc__
+        outer_cls.__name__ = inner_cls.__name__
+        return outer_cls
+    return receive_class
+
+def enum_type(all_values):
+    # type: (Iterable[Z3Expr]) -> Callablee[[Type], Type[IntoZ3]]
+    all_values = assert_no_duplicates(all_values)
+    def receive_class(cls):
+        @delegate_eq_hash(['inner'])
+        @wraps(cls)
+        class Generated(cls, IntoZ3):
+            def __init__(self, inner):
+                assert inner in all_values, (inner, all_values)
+                self.inner = inner
+            def convert_to_z3(self):
+                return self.inner
+            def __str__(self):
+                return str(self.inner)
+            def __repr__(self):
+                return '{}({!r})'.format(type(self).__name__,
+                                         self.inner)
+        return Generated
+    return receive_class
+
+
+def tuple_type(fields):
+    # type: (collections.OrderedDict[K, IntoZ3]) -> Callable[[Type], Type[IntoZ3[_Z]]]
+
+    def receive_class(cls):
+        # type: (Type) -> Type[NamedTuple]
+        field_names = list(fields.keys())
+
+        tup = collections.namedtuple(cls.__name__, field_names)
+
+        @wraps(cls)
+        class Generated(
+            tup,
+            cls,
+            IntoZ3,
+        ):
+            # constructor: ClassVar[Callable[[...], _Z]] = None
+            def __new__(cls, *args, **kwargs):
+                ret = tup.__new__(cls, *args, **kwargs)
+                for f_name in field_names:
+                    f_cls = fields[f_name]
+                    assert hasattr(f_cls, 'convert_to_z3'), f_cls
+                    f_val = getattr(ret, f_name)
+                    assert isinstance(f_val, f_cls), (f_val, f_cls, cls)
+                return ret
+
+            def convert_to_z3(self):
+                fields_as_args = tuple(getattr(self, f_name).into_z3() for f_name in field_names)
+                return self.constructor(*fields_as_args)
+
+            def __repr__(self):
+                return ('{}({})'
+                        .format(type(self).__name__,
+                                ', '.join(
+                                    '{}={!r}'.format(k, getattr(self, k))
+                                    for k in field_names
+                                )))
+
+        return Generated
+
+    return receive_class
+
+
+def delegate_eq_hash(field_names):
+    # type: (Iterable[str]) -> Callable[[Type], Type]
+    field_names = assert_no_duplicates(field_names)
+    def receive_class(cls):
+        @wraps(cls)
+        class Generated(cls):
+            def __eq__(self, other):
+                return isinstance(other, type(self)) and all(
+                    getattr(self, f_name) == getattr(other, f_name)
+                    for f_name in field_names
+                )
+            def __hash__(self):
+                return hash(tuple(hash(getattr(self, f_name))
+                                  for f_name in field_names))
+        return Generated
+    return receive_class
+
+
+def delegate_iter(field):
+    # type: (str) -> Callable[[Type], Type]
+    def receive_class(cls):
+        @wraps(cls)
+        class Generated(cls):
+            def __iter__(self):
+                return iter(getattr(self, field))
+        return Generated
+    return receive_class
+
+
+RepoSort, repos = EnumSort('RepoSort', ['spack', 'pypi', 'sonatype'])
+(spack, pypi, sonatype) = repos
+
+@enum_type(repos)
+class Repo(object):
+    SORT = RepoSort
+
+PackageNameSort = StringSort()
+
+@delegate_eq_hash(['name'])
+class PackageName(IntoZ3):
+    SORT = PackageNameSort
+
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name
+
+    def convert_to_z3(self):
+        return StringVal(self.name)
+
+    def version_pin_spec(self, version):
+        # type: (SpackVersion) -> str
+        return '{}@{}'.format(self, version)
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return 'PackageName({!r})'.format(self.name)
+
+name_try_repo_map = {
+    Repo(spack): ['a', 'b'],
+    Repo(pypi): ['c'],
+    Repo(sonatype): [],
+}
+
+# T = TypeVar('T')
+
+def assume_unique(along, condition_expr_fn, gen_expr_fn,
+                  fmt=(lambda x: "∃!x∈{} s.t. {}. Case of: x = {}."
+                       .format(list(along), gen_expr_fn(x), x))):
+    # type: (Iterable[T], Callable[[], Z3Expr], Callable[[T], Z3Expr], str) -> List[Z3Expr]
+    along = list(along)
+
+    # See https://stackoverflow.com/questions/43081929/k-out-of-n-constraint-in-z3py/43081930#43081930.
+    assumptions = []  # type: List[T]
+    bvars = [Bool(six.ensure_str(fmt(x))) for x in along]
+    assumptions.extend(
+        gen_expr_fn(x) == bv
+        for x, bv in zip(along, bvars)
+    )
+    assumptions.append(
+        condition_expr_fn() == PbEq([(bv,1) for bv in bvars],
+                                    k=1)
+    )
+    return (assumptions, bvars)
+
+
+def parse_single_version(version_string):
+    # type: (str) -> Version
+    ret = ver(version_string)
+    if isinstance(ret, Version):
+        return ret
+    assert isinstance(ret, (VersionRange, VersionList)), ret
+    raise TypeError('received version range or list where a *precise* string was expected: {}'
+                    .format(version_string))
+
+SpackVersionSort, mk_version, (ver_string) = TupleSort('SpackVersionSort', [StringSort()])
+
+@delegate_eq_hash(['version'])
+class SpackVersion(IntoZ3):
+    SORT = SpackVersionSort
+
+    def __init__(self, version):
+        assert isinstance(version, Version), version
+        self.version = version
+
+    def convert_to_z3(self):
+        return mk_version(StringVal(self.version.string))
+
+    def into_spack_version(self):
+        # type: () -> Version
+        return self.version
+
+    def __repr__(self):
+        return '{}({!r})'.format(type(self).__name__, self.version)
+
+    def __str__(self):
+        return self.version.string
+
+
+DepSpecStrategySort, strategies = EnumSort('DepSpecStrategySort', ['low', 'high', 'neither'])
+(low, high, neither) = strategies
+
+@enum_type(strategies)
+class DepSpecStrategy(object):
+    SORT = DepSpecStrategySort
+
+DepSpecSort, mk_dep_spec, (get_name, get_low, get_high, get_strategy) = TupleSort(
+    'DepSpecSort',
+    [PackageNameSort, SpackVersionSort, SpackVersionSort, DepSpecStrategySort],
+)
+
+@tuple_type(ordered_dict([('dep_name', PackageName),
+                          ('low', SpackVersion),
+                          ('high', SpackVersion),
+                          ('strategy', DepSpecStrategy)]))
+class DepSpec(object):
+    SORT = DepSpecSort
+    constructor = mk_dep_spec
+
+
+@delegate_iter('dep_specs')
+class DepSet(IntoZ3):
+    SORT = SeqSort(DepSpecSort)
+
+    def __init__(self, dep_specs):
+        # type: (Iterable[DepSpec]) -> None
+        self.dep_specs = list(dep_specs)
+
+    def convert_to_z3(self):
+        seq_expr = Empty(SeqSort(DepSpecSort))
+        for dep_spec in self.dep_specs:
+            dep_expr = self.extract_z3_expr(dep_spec)
+            seq_expr += Unit(dep_expr)
+        return seq_expr
+
+
+ConflictSpecSort, mk_conflict_spec, (get_conflict_name, get_conflict_version,) = TupleSort(
+    'ConflictSpecSort',
+    [PackageNameSort, SpackVersionSort],
+)
+
+@tuple_type(ordered_dict([('name', PackageName),
+                          ('version', SpackVersion)]))
+class ConflictSpec(object):
+    SORT = ConflictSpecSort
+    constructor = mk_conflict_spec
+
+
+@delegate_iter('conflicts')
+class ConflictSet(IntoZ3):
+    SORT = SeqSort(ConflictSpecSort)
+
+    @classmethod
+    def empty(cls):
+        # type: () -> ConflictSet
+        return cls([])
+
+    def __init__(self, conflicts):
+        # type: (Iterable[ConflictSpec]) -> None
+        self.conflicts = list(conflicts)
+
+    def convert_to_z3(self):
+        seq_expr = Empty(SeqSort(ConflictSpecSort))
+        for conflict in self.conflicts:
+            conflict_expr = self.extract_z3_expr(conflict)
+            seq_expr += Unit(conflict_expr)
+        return seq_expr
+
+
+
+version_dependency_try_map = {
+    'a': {
+        '0.0.1': {
+            'dependencies': {
+                'b': {
+                    'low': '1.0.0',
+                    'high': '2.0.0',
+                    'prefer': low,
+                },
+            },
+        },
+        '1.0.0': {
+            'dependencies': {
+                'b': {
+                    'low': '1.0.0',
+                    'high': '2.0.0',
+                    'prefer': low,
+                },
+            },
+        },
+        '1.5.2': {
+            'dependencies': {
+                'b': {
+                    'low': '2.1.3',
+                    'high': '2.1.3',
+                    'prefer': neither,
+                },
+            },
+            'conflicts': {
+                'c': '3.1.3',
+            },
+        },
+    },
+    'b': {
+        '1.0.0': {
+            'dependencies': {
+                'c': {
+                    'low': '2.0.0',
+                    'high': '3.0.0',
+                    'prefer': low,
+                },
+            },
+        },
+        '1.0.1': {
+            'dependencies': {
+                'c': {
+                    'low': '3.0.0',
+                    'high': '4.0.0',
+                    'prefer': low,
+                },
+            },
+        },
+        '2.0.0': {
+            'dependencies': {
+                'c': {
+                    'low': '3.1.2',
+                    'high': '3.1.2',
+                    'prefer': neither,
+                },
+            },
+            'conflicts': {
+                'c': '3.0.0',
+            },
+        },
+        '2.1.3': {
+            'dependencies': {
+                'c': {
+                    'low': '3.1.3',
+                    'high': '3.1.3',
+                    'prefer': neither,
+                },
+            },
+        },
+    },
+    'c': {
+        '2.3.5': {
+            'dependencies': {},
+        },
+        '3.0.0': {
+            'dependencies': {},
+        },
+        '3.1.2': {
+            'dependencies': {},
+        },
+        '3.1.3': {
+            'dependencies': {},
+        },
+    },
+}
+
+package_version_try_map = dict(
+    (k, [parse_single_version(v) for v in ver.keys()])
+    for k, ver in version_dependency_try_map.items()
+)
+
+PackageIdentitySort, mk_pkg_identity, (get_id_string,) = TupleSort(
+    'PackageIdentitySort', [StringSort()]
+)
+
+@delegate_eq_hash(['hash_string'])
+@six.add_metaclass(abc.ABCMeta)
+class PackageIdentity(IntoZ3):
+    SORT = PackageIdentitySort
+
+    def __init__(self, hash_string):
+        assert isinstance(hash_string, str), hash_string
+        self.hash_string = hash_string
+
+    def convert_to_z3(self):
+        return mk_pkg_identity(StringVal(self.hash_string))
+
+    @classmethod
+    @abc.abstractmethod
+    def from_package_descriptor(cls, pkg_descriptor):
+        # type: (Any) -> PackageIdentity
+        raise NotImplemented
+
+    def __str__(self):
+        return self.hash_string
+
+    def __repr__(self):
+        return '{}({!r})'.format(type(self).__name__, self.hash_string)
+
+
+package_associate_name = Function('package_associate_name',
+                                  PackageIdentitySort, PackageNameSort)
+package_associate_version = Function('package_associate_version',
+                                     PackageIdentitySort, SpackVersionSort)
+
+dependency_matches_version_spec = Function('dependency_matches_version_spec',
+                                           DepSpecSort, SpackVersionSort, BoolSort())
+use_this_dependency = Function('use_this_dependency',
+                               PackageIdentitySort, PackageIdentitySort, BoolSort())
+
+# get_dep_specs = Function('get_dep_specs', PackageIdentitySort, SetSort(DepSpecSort))
+
+use_package = Function('use_package', PackageIdentitySort, BoolSort())
+
+repo_has_package = Function('repo_has_package', PackageIdentitySort, RepoSort, BoolSort())
+use_repo_package = Function('use_repo_package', PackageIdentitySort, RepoSort, BoolSort())
+
+
+@six.add_metaclass(abc.ABCMeta)
+class VersionSolverSetup(object):
+
+    def __init__(self):
+        self._name_mapping = {}  # type: Dict[PackageIdentity, PackageName]
+        self._version_mapping = {}  # type: Dict[PackageIdentity, SpackVersion]
+        self._owning_bool_mapping = {}  # type: Dict[PackageIdentity, Bool]
+        self._dep_set_mapping = {}  # type: Dict[PackageIdentity, DepSet]
+        self._conflict_set_mapping = {}  # type: Dict[PackageIdentity, ConflictSet]
+
+        # type: Dict[PackageName, Dict[SpackVersion, List[PackageIdentity]]]
+        self._reverse_lookup = collections.defaultdict(lambda: collections.defaultdict(list))
+
+    def register_package(self, pkg, name, version, owning_bool, dep_set, conflict_set):
+        # type: (PackageIdentity, PackageName, SpackVersion, Bool, DepSet, ConflictSet) -> None
+        assert isinstance(name, PackageName), name
+        self._name_mapping[pkg] = name
+        assert isinstance(version, SpackVersion), version
+        self._version_mapping[pkg] = version
+        assert is_bool(owning_bool), owning_bool
+        self._owning_bool_mapping[pkg] = owning_bool
+        assert isinstance(dep_set, DepSet), dep_set
+        self._dep_set_mapping[pkg] = dep_set
+        assert isinstance(conflict_set, ConflictSet), conflict_set
+        self._conflict_set_mapping[pkg] = conflict_set
+
+        # Add to the reverse lookup table.
+        self._reverse_lookup[name][version].append(pkg)
+
+    @abc.abstractmethod
+    def all_repos(self):
+        # type: () -> Iterable[Repo]
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def all_repo_packages(self, repo):
+        # type: (RepoSort) -> Iterator[PackageIdentity]
+        raise NotImplemented
+
+    def extract_package_details(self, pkg):
+        # type: (PackageIdentity) -> Tuple[PackageName, SpackVersion, Bool, DepSet, ConflictSet]
+        name = self._name_mapping[pkg]
+        version = self._version_mapping[pkg]
+        owning_bool = self._owning_bool_mapping[pkg]
+        dep_set = self._dep_set_mapping[pkg]
+        conflict_set = self._conflict_set_mapping[pkg]
+        return (name, version, owning_bool, dep_set, conflict_set)
+
+    def reverse_lookup_packages(self, name):
+        # type: (str) -> Iterable[Tuple[SpackVersion, List[PackageIdentity]]]
+        return self._reverse_lookup[name].items()
+
+    def reverse_lookup_package_version(self, name, version):
+        # type: (PackageName, SpackVersion) -> Iterable[PackageIdentity]
+        return self._reverse_lookup[name][version]
+
+
+class StaticVersionSolverSetup(VersionSolverSetup):
+
+    def all_repos(self):
+        return [Repo(r) for r in repos]
+
+    class StaticPackageIdentity(PackageIdentity):
+        @classmethod
+        def from_package_descriptor(cls, pkg_descriptor):
+            # type: (Tuple[PackageName, SpackVersion]) -> StaticPackageIdentity
+            name, version = pkg_descriptor
+            s = 'FAKE::[{}]'.format(name.version_pin_spec(version))
+            return cls(s)
+
+    def all_repo_packages(self, repo, with_conflict=False):
+        repo_names = frozenset(PackageName(n) for n in name_try_repo_map[repo])
+        for name, version_map in version_dependency_try_map.items():
+            name = PackageName(name)
+            if name not in repo_names:
+                continue
+            for version_string, dep_var_spec in version_map.items():
+                v_spack_ver = parse_single_version(version_string)
+                version = SpackVersion(v_spack_ver)
+
+                deps = dep_var_spec['dependencies']
+                dep_specs = []  # type: List[DepSpec]
+                for dep_name, this_dep_spec in deps.items():
+                    low_spack_ver = SpackVersion(parse_single_version(this_dep_spec['low']))
+                    high_spack_ver = SpackVersion(parse_single_version(this_dep_spec['high']))
+                    prefer_strategy = DepSpecStrategy(this_dep_spec['prefer'])
+                    single_dep_spec = DepSpec(dep_name=PackageName(dep_name),
+                                              low=low_spack_ver,
+                                              high=high_spack_ver,
+                                              strategy=prefer_strategy)
+                    print(single_dep_spec)
+                    dep_specs.append(single_dep_spec)
+                dep_set = DepSet(dep_specs)
+
+                if with_conflict:
+                    conflicts = dep_var_spec.get('conflicts', {})
+                    all_conflicts = []
+                    for p_name, p_version_string in conflicts.items():
+                        p_version = SpackVersion(parse_single_version(p_version_string))
+                        current_conflict = ConflictSpec(p_name, p_version)
+                        all_conflicts.append(current_conflict)
+                        # conflicts_table[pkg][p_name].append(p_version)
+                    conflict_set = ConflictSet(all_conflicts)
+                else:
+                    conflict_set = ConflictSet.empty()
+
+                var_string = name.version_pin_spec(version)
+                pkg = (
+                    StaticVersionSolverSetup
+                    .StaticPackageIdentity
+                    .from_package_descriptor(
+                        (name, version_string)))
+                pkg_bool_var = Bool(var_string)
+
+                # Registers the package so the ground variables can be set up!
+                self.register_package(pkg, name, version, pkg_bool_var, dep_set, conflict_set)
+
+                yield pkg
+
+
+def generate_fake_input(
+    assumptions,  # type: List[Z3Expr]
+    with_conflict=False,  # type: bool
+):
+    # type: (...) -> VersionSolverSetup
+    solver_setup = StaticVersionSolverSetup()
+    repo_by_pkg = collections.defaultdict(set)  # type: Dict[Repo, Set[PackageIdentity]]
+    repos = frozenset(solver_setup.all_repos())
+    for repo in repos:
+        for pkg in solver_setup.all_repo_packages(repo):
+            repo_by_pkg[pkg].add(repo)
+    all_packages = list(repo_by_pkg.keys())  # type: List[PackageIdentity]
+
+    for pkg in all_packages:
+        (name, version, owning, dep_set, conflict_set) = solver_setup.extract_package_details(pkg)
+        # Ensure that using a package flips on or off the Bool variable previously created for
+        # this package.
+        assumptions.append(owning == use_package(pkg.into_z3()))
+
+        for dep_spec in dep_set:
+            dep_name = dep_spec.dep_name
+            low_end = dep_spec.low
+            low_version = low_end.into_spack_version()
+            high_end = dep_spec.high
+            high_version = high_end.into_spack_version()
+            strategy = dep_spec.strategy.into_z3()
+
+            all_matching_deps = []  # type: List[PackageIdentity]
+            # Here's where we provide dependency ranges!
+            for other, dep_pkgs in solver_setup.reverse_lookup_packages(dep_name):
+                other_version = other.into_spack_version()
+                # Determine whether `other_version` matches the `dep_spec`.
+                dep_matched_version = False
+                if strategy == low:
+                    dep_matched_version = (other_version >= low_version) and (other_version < high_version)
+                elif strategy == high:
+                    dep_matched_version = (other_version <= high_version) and (other_version >  low_version)
+                else:
+                    assert strategy == neither, strategy
+                    dep_matched_version = (other_version == low_version) and (low_version == high_version)
+                # Fill in the now-known value of dependency_matches_version_spec()!
+                # print(dep_spec)
+                # print(other)
+                assumptions.append(
+                    dependency_matches_version_spec(dep_spec.into_z3(), other.into_z3()) == dep_matched_version
+                )
+
+                # TODO: Convert this into a Spec satisfying any result with that version!
+                # dep_pkg = mk_package_metadata(dep_name, other_version)
+                for dep_pkg in dep_pkgs:
+                    # Require the version to have matched to satisfy the dependency!
+                    if dep_matched_version:
+                        all_matching_deps.append(dep_pkg)
+                        assumptions.append(
+                            Implies(use_this_dependency(pkg.into_z3(), dep_pkg.into_z3()),
+                                    dependency_matches_version_spec(dep_spec.into_z3(), other.into_z3()))
+                        )
+                    else:
+                        # TODO: determine if this is an optimization at all.
+                        assumptions.append(
+                            use_this_dependency(pkg.into_z3(), dep_pkg.into_z3()) == False
+                        )
+
+            # Assume only a single other package is chosen (for this particular package).
+            unique_dependency_assumptions, _bvars = assume_unique(
+                all_matching_deps,
+                condition_expr_fn=(lambda: use_package(pkg.into_z3())),
+                gen_expr_fn=(lambda dep_pkg: use_this_dependency(pkg.into_z3(), dep_pkg.into_z3())),
+                fmt=(lambda dep_pkg: (
+                    "use_package(p = {}) => ∃!d∈{{P_dependencies(p)}} s.t. "
+                    "use_this_dependency(p, d). case of: d = {}."
+                    .format(pkg, dep_pkg)
+                    .encode('utf-8'))),
+            )
+            assumptions.extend(unique_dependency_assumptions)
+
+            # TODO: Here's where we try to make a set!
+            # assumptions.append(
+            #     Iff(
+            #         And([use_package(pkg), use_package(dep_pkg)]),
+            #         IsMember(dep_spec, get_dep_specs(pkg)),
+            #     )
+            # )
+
+        for conflict_spec in conflict_set:
+            c_name = conflict_spec.name
+            c_version = conflict_spec.version
+            conflict_pkgs = list(solver_setup.reverse_lookup_package_version(c_name, c_version))
+            assumptions.append(
+                Implies(
+                    use_package(pkg.into_z3()),
+                    Not(Or([
+                        use_package(conflict_pkg.into_z3())
+                        for conflict_pkg in conflict_pkgs
+                    ])),
+                )
+            )
+
+    for pkg, pkg_repos in repo_by_pkg.items():
+        # The repo must contain the package in order for us to use it!
+        assumptions.extend(
+            Implies(
+                use_repo_package(pkg.into_z3(), r.into_z3()),
+                repo_has_package(pkg.into_z3(), r.into_z3()),
+            ) for r in pkg_repos
+        )
+        for r in repos:
+            assumptions.append(
+                repo_has_package(pkg.into_z3(), r.into_z3()) == BoolVal(r in pkg_repos)
+            )
+
+        # Checking that any package we consume comes from exactly one repo.
+        unique_repo_assumptions, _bvars = assume_unique(
+            pkg_repos,
+            condition_expr_fn=(lambda: use_package(pkg.into_z3())),
+            gen_expr_fn=(lambda repo: use_repo_package(pkg.into_z3(), repo.into_z3())),
+            fmt=(lambda repo: (
+                "use_package(p = {}) => ∃!r∈{{Repo}} s.t. use_repo_package(p, r). "
+                "case of: r = {}."
+                .format(pkg, repo)
+                .decode('utf-8').encode('utf-8'))),
+        )
+        assumptions.extend(unique_repo_assumptions)
+
+    return solver_setup
+
+
+def build_assumptions(with_conflict=False):
+    assumptions = []  # type: List[Z3Expr]
+
+    # Iterate over every package!
+    solver_setup = generate_fake_input(
+        assumptions=assumptions,
+        with_conflict=with_conflict,
+    )
+
+    return (assumptions, solver_setup)
+
+
+### Execute the model.
+
+def install_check(problems, timer=Timer(), solver=None):
+    # type: (Iterable[Z3Expr], Optional[Solver]) -> Solver
+    with timer.nested_phase('solve'):
+        if solver is None:
+            solver = Solver()
+        try:
+            # NB: Providing the problems all at once is necessary to have `.unsat_core()` reflect
+            # them (this seems arbitrary).
+            result = solver.check(problems)
+        except Z3Exception:
+            # But, if one of the problems is malformed (e.g. a non-boolean expression), this will at
+            # least narrow down the issue.
+            for problem in problems:
+                print(problem)
+                solver.add(problem)
+            raise
+        truths = []
+        unsat_core = []
+        if result == sat:
+            m = solver.model()
+            for x in m:
+                if is_true(m[x]):
+                    # x is a Z3 declaration
+                    # x() returns the Z3 expression
+                    # x.name() returns a string
+                    if x.name() == str(x()):
+                        truth = x.name()
+                    else:
+                        truth = "name: {name} == value: {value}".format(name=x.name(), value=x())
+                    truths.append(truth)
+        elif result == unsat:
+            unsat_core = solver.unsat_core()
+        return (solver, result, truths, unsat_core)
+
+
+def ground_check(grounder, solver=None, timer=Timer(), with_conflict=False):
+    # type: (List[Z3Expr], Optional[Solver], bool) -> Tuple[BoolVarsDict, List[Bool], Solver]
+    with timer.nested_phase('build assumptions'):
+        (assumptions, solver_setup) = build_assumptions(with_conflict=with_conflict)
+    with timer.nested_phase('install check'):
+        grounds_maybe = list(grounder(solver_setup))
+        print('grounds: {}'.format(grounds_maybe))
+        all_exprs = assumptions + grounds_maybe
+        print('\n----\n'.join(str(e).decode('utf-8').encode('utf-8') for e in all_exprs))
+        (s, result, truths, unsat_core) = install_check(all_exprs, timer=timer, solver=solver)
+        if result == sat:
+            print('TRUTHS:\n{}'.format('\n'.join(truths)))
+        elif result == unknown:
+            print('UNKNOWN:\n{}'.format(s.reason_unknown()))
+        elif result == unsat:
+            print('UNSAT_CORE():\n{}'.format(s.unsat_core()))
+        else:
+            raise OSError('unrecognized result {}'.format(result))
+        return (s, all_exprs, result, truths, unsat_core, grounds_maybe, solver_setup)
+
+
+def solve(timer=Timer(), interact=False):
+    # TODO: this only makes it fail to find solutions for all tactics I've tried.
+    # robust_tactic = Then(
+    #                      Tactic('macro-finder'),
+    #                      Tactic('smt'),
+    #                      Tactic('symmetry-reduce'),
+    #                      Tactic('smt'),
+    # )
+
+    def get_ground_exprs(version_solver_setup):
+        # type: (VersionSolverSetup) -> Iterable[Z3Expr]
+        a_1_5 = list(version_solver_setup.reverse_lookup_package_version(
+            PackageName('a'),
+            SpackVersion(parse_single_version('1.5.2')),
+        ))[0]
+        return [use_package(a_1_5.into_z3())]
+
+    with timer.nested_phase('solve 1'):
+        s1, e1, r1, tr1, u1, g1, ss1 = ground_check(
+            get_ground_exprs,
+            timer=timer,
+            # solver=robust_tactic.solver(),
+            with_conflict=False)
+        with timer.nested_phase('check 1'):
+            if not r1 == sat:
+                if interact:
+                    print('ERROR: NOT SAT! SHOULD BE!')
+                    # code.interact(local=locals())
+                else:
+                    assert r1 == sat, r1
+
+    with timer.nested_phase('solve 2'):
+        s2, e2, r2, tr2, u2, g2, ss2 = ground_check(
+            get_ground_exprs,
+            timer=timer,
+            # solver=robust_tactic.solver(),
+            with_conflict=True)
+        with timer.nested_phase('check 2'):
+            # TODO: make this correct!
+            if not r2 == unsat:
+                if interact:
+                    print('ERROR: NOT \'unsat\'! SHOULD  BE!')
+                    # code.interact(local=locals())
+                else:
+                    assert r2 == unsat
+
+    timer.write()
+
+    if interact:
+        code.interact(local=locals())
+
+if __name__ == '__main__':
+    solve(interact=True)

--- a/lib/spack/spack/solver/z3.py
+++ b/lib/spack/spack/solver/z3.py
@@ -239,7 +239,7 @@ def assume_unique(along, condition_expr_fn, gen_expr_fn,
 
     # See https://stackoverflow.com/questions/43081929/k-out-of-n-constraint-in-z3py/43081930#43081930.
     assumptions = []  # type: List[T]
-    bvars = [Bool(six.ensure_str(fmt(x))) for x in along]
+    bvars = [Bool(six.binary_type(fmt(x))) for x in along]
     assumptions.extend(
         gen_expr_fn(x) == bv
         for x, bv in zip(along, bvars)
@@ -686,10 +686,9 @@ def generate_fake_input(
                 condition_expr_fn=(lambda: use_package(pkg.into_z3())),
                 gen_expr_fn=(lambda dep_pkg: use_this_dependency(pkg.into_z3(), dep_pkg.into_z3())),
                 fmt=(lambda dep_pkg: (
-                    "use_package(p = {}) => ∃!d∈{{P_dependencies(p)}} s.t. "
+                    "use_package(p = {}) => \existsuniq! d \in {{P_dependencies(p)}} s.t. "
                     "use_this_dependency(p, d). case of: d = {}."
-                    .format(pkg, dep_pkg)
-                    .encode('utf-8'))),
+                    .format(pkg, dep_pkg))),
             )
             assumptions.extend(unique_dependency_assumptions)
 
@@ -734,10 +733,9 @@ def generate_fake_input(
             condition_expr_fn=(lambda: use_package(pkg.into_z3())),
             gen_expr_fn=(lambda repo: use_repo_package(pkg.into_z3(), repo.into_z3())),
             fmt=(lambda repo: (
-                "use_package(p = {}) => ∃!r∈{{Repo}} s.t. use_repo_package(p, r). "
+                "use_package(p = {}) => \existsuniq! r \in {{Repo}} s.t. use_repo_package(p, r). "
                 "case of: r = {}."
-                .format(pkg, repo)
-                .decode('utf-8').encode('utf-8'))),
+                .format(pkg, repo))),
         )
         assumptions.extend(unique_repo_assumptions)
 

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+def setup_libtirpc_build_environment(spec, env):
+    if 'libtirpc' in spec:
+        libtirpc = spec['libtirpc']
+        env.prepend_path('CPATH', libtirpc.prefix.include.tirpc)
+        env.append_flags('LDFLAGS', '-ltirpc')

--- a/var/spack/repos/builtin/packages/ganglia/package.py
+++ b/var/spack/repos/builtin/packages/ganglia/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Ganglia(AutotoolsPackage):
     """Ganglia is a scalable distributed monitoring system for high-performance
@@ -31,5 +33,4 @@ class Ganglia(AutotoolsPackage):
     depends_on('expat')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)

--- a/var/spack/repos/builtin/packages/lmbench/package.py
+++ b/var/spack/repos/builtin/packages/lmbench/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Lmbench(MakefilePackage):
     """lmbench is a suite of simple, portable, ANSI/C microbenchmarks for
@@ -22,8 +24,7 @@ class Lmbench(MakefilePackage):
     patch('fix_results_path_for_aarch64.patch', sha256='2af57abc9058c56b6dd0697bb01a98902230bef92b117017e318faba148eef60', when='target=aarch64:')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)
 
     def build(self, spec, prefix):
         make('build')

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -19,7 +19,7 @@ class PyPackaging(PythonPackage):
     version('16.8', sha256='5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'))
     depends_on('py-attrs', when='@19.1', type=('build', 'run'))
     depends_on('py-pyparsing@2.0.2:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -36,8 +36,8 @@ class PySetuptools(PythonPackage):
     version('11.3.1', sha256='bd25f17de4ecf00116a9f7368b614a54ca1612d7945d2eafe5d97bc08c138bc5')
 
     depends_on('python@3.5:', type=('build', 'run'), when='@45.0.0:')
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
+    depends_on('python@2.6:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
 
     def url_for_version(self, version):
         url = 'https://pypi.io/packages/source/s/setuptools/setuptools-{0}'

--- a/var/spack/repos/builtin/packages/python/no-dbm.patch
+++ b/var/spack/repos/builtin/packages/python/no-dbm.patch
@@ -1,0 +1,57 @@
+--- a/setup.py	2020-11-29 13:43:26.736062972 -0800
++++ b/setup.py	2020-11-29 13:43:40.166165660 -0800
+@@ -1144,53 +1144,11 @@
+                 missing.append('bsddb185')
+         else:
+             missing.append('bsddb185')
+ 
+         # The standard Unix dbm module:
+-        if platform not in ['cygwin']:
+-            if find_file("ndbm.h", inc_dirs, []) is not None:
+-                # Some systems have -lndbm, others don't
+-                if self.compiler.find_library_file(lib_dirs, 'ndbm'):
+-                    ndbm_libs = ['ndbm']
+-                else:
+-                    ndbm_libs = []
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       define_macros=[('HAVE_NDBM_H',None)],
+-                                       libraries = ndbm_libs ) )
+-            elif self.compiler.find_library_file(lib_dirs, 'gdbm'):
+-                gdbm_libs = ['gdbm']
+-                if self.compiler.find_library_file(lib_dirs, 'gdbm_compat'):
+-                    gdbm_libs.append('gdbm_compat')
+-                if find_file("gdbm/ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                elif find_file("gdbm-ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_DASH_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                else:
+-                    missing.append('dbm')
+-            elif db_incs is not None:
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       library_dirs=dblib_dir,
+-                                       runtime_library_dirs=dblib_dir,
+-                                       include_dirs=db_incs,
+-                                       define_macros=[('HAVE_BERKDB_H',None),
+-                                                      ('DB_DBM_HSEARCH',None)],
+-                                       libraries=dblibs))
+-            else:
+-                missing.append('dbm')
+-
+-        # Anthony Baxter's gdbm module.  GNU dbm(3) will require -lgdbm:
+-        if (self.compiler.find_library_file(lib_dirs, 'gdbm')):
+-            exts.append( Extension('gdbm', ['gdbmmodule.c'],
+-                                   libraries = ['gdbm'] ) )
+-        else:
+-            missing.append('gdbm')
++        # NB: Removed!
+ 
+         # Unix-only modules
+         if platform not in ['mac', 'win32']:
+             # Steen Lumholt's termios module
+             exts.append( Extension('termios', ['termios.c']) )

--- a/var/spack/repos/builtin/packages/python/no-ssl.patch
+++ b/var/spack/repos/builtin/packages/python/no-ssl.patch
@@ -1,0 +1,32 @@
+--- a/setup.py	2020-11-29 13:15:49.676636440 -0800
++++ b/setup.py	2020-11-29 13:43:26.736062972 -0800
+@@ -761,13 +761,12 @@
+             except IOError, msg:
+                 print "IOError while reading opensshv.h:", msg
+                 pass
+ 
+ 
+-        if (ssl_incs is not None and
+-            ssl_libs is not None and
+-            openssl_ver >= 0x00907000):
++        # raise Exception('change this to True!')
++        if False:
+             # The _hashlib module wraps optimized implementations
+             # of hash functions from the OpenSSL library.
+             exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                                    include_dirs = ssl_incs,
+                                    library_dirs = ssl_libs,
+@@ -781,10 +780,13 @@
+             # Message-Digest Algorithm, described in RFC 1321.  The
+             # necessary files md5.c and md5.h are included here.
+             exts.append( Extension('_md5',
+                             sources = ['md5module.c', 'md5.c'],
+                             depends = ['md5.h']) )
++            # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
++            exts.append( Extension('_sha256', ['sha256module.c']) )
++            exts.append( Extension('_sha512', ['sha512module.c']) )
+             missing.append('_hashlib')
+ 
+         if (openssl_ver < 0x00908000):
+             # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
+             exts.append( Extension('_sha256', ['sha256module.c']) )

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -190,6 +190,12 @@ class Python(AutotoolsPackage):
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
+    # TODO: There's currently no way to ignore the fact that a single module failed, even if the
+    # variant corresponding to that module is deselected. These patches comment out sections of
+    # setup.py, specifically for the purpose of python 2.6 compat.
+    patch('no-ssl.patch', when='~ssl')
+    patch('no-dbm.patch', when='~dbm')
+
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
@@ -393,22 +399,30 @@ class Python(AutotoolsPackage):
         # as it scans for the library and headers to build
         link_deps = spec.dependencies('link')
 
+        cppflags = []
+        ldflags = []
         if link_deps:
             # Header files are often included assuming they reside in a
             # subdirectory of prefix.include, e.g. #include <openssl/ssl.h>,
             # which is why we don't use HeaderList here. The header files of
             # libffi reside in prefix.lib but the configure script of Python
             # finds them using pkg-config.
-            cppflags = ' '.join('-I' + spec[dep.name].prefix.include
-                                for dep in link_deps)
+            cppflags.extend('-I' + spec[dep.name].prefix.include for dep in link_deps)
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them
             # using spec.__getitem__.
-            ldflags = ' '.join(spec[dep.name].libs.search_flags
-                               for dep in link_deps)
+            ldflags.extend(spec[dep.name].libs.ld_flags for dep in link_deps)
 
-            config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
+        if 'libtirpc' in spec:
+            cppflags.extend(
+                '-I' + os.path.join(inc, 'tirpc')
+                for inc in spec['libtirpc'].headers.directories)
+
+        config_args.extend([
+            'CPPFLAGS=' + ' '.join(cppflags),
+            'LDFLAGS=' + ' '.join(ldflags),
+        ])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
         if spec.satisfies('@:3.6'):
@@ -968,8 +982,14 @@ class Python(AutotoolsPackage):
         setup_py('install', '--prefix={0}'.format(prefix))"""
 
         module.python = self.command
-        module.setup_py = Executable(
-            self.command.path + ' setup.py --no-user-cfg')
+
+        if self.version.up_to(2).string == '2.6':
+            trailing_args = []
+        else:
+            trailing_args = ['--no-user-cfg']
+        args = ['setup.py', *tuple(trailing_args)]
+        full_cmdline = self.command.path + ' {0}'.format(' '.join(args))
+        module.setup_py = Executable(full_cmdline)
 
         distutil_vars = self._load_distutil_vars()
 

--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -22,17 +22,23 @@ class Z3(MakefilePackage):
     phases = ['bootstrap', 'build', 'install']
 
     variant('python', default=True, description='Enable python binding')
-    depends_on('python', type=('build', 'run'))
-    depends_on('py-setuptools', type=('run'), when='+python')
+    depends_on('python+shared', type=('build', 'run'), when="+python")
     extends('python', when='+python')
 
     # Referenced: https://github.com/Z3Prover/z3/issues/1016
     patch('fix_1016_1.patch', when='@:4.4.1')
     patch('fix_1016_2.patch', when='@4.5.0')
 
+    using_py26 = "^python@:2.6.99"
+    patch('py26-1.patch', when=using_py26)
+    patch('py26-2.patch', when=using_py26)
+    patch('py26-3.patch', when=using_py26)
+    depends_on('py-argparse', type=('build', 'run'), when=using_py26)
+    depends_on('py-setuptools@:25.2.0', type=('build', 'run'), when=using_py26)
+
     build_directory = 'build'
 
-    def configure_args(self):
+    def configure_args(self, prefix):
         spec = self.spec
 
         args = []
@@ -48,5 +54,5 @@ class Z3(MakefilePackage):
         return args
 
     def bootstrap(self, spec, prefix):
-        options = ['--prefix={0}'.format(prefix)] + self.configure_args()
+        options = ['--prefix={0}'.format(prefix)] + self.configure_args(prefix)
         spec['python'].command('scripts/mk_make.py', *options)

--- a/var/spack/repos/builtin/packages/z3/py26-1.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-1.patch
@@ -1,0 +1,381 @@
+--- a/scripts/mk_util.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/mk_util.py	2020-11-29 19:40:56.342800585 -0800
+@@ -535,12 +535,12 @@
+ def get_version():
+     return (VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
+ 
+ def get_version_string(n):
+     if n == 3:
+-        return "{}.{}.{}".format(VER_MAJOR,VER_MINOR,VER_BUILD)
+-    return "{}.{}.{}.{}".format(VER_MAJOR,VER_MINOR,VER_BUILD,VER_TWEAK)
++        return "{0}.{1}.{2}".format(VER_MAJOR,VER_MINOR,VER_BUILD)
++    return "{0}.{1}.{2}.{3}".format(VER_MAJOR,VER_MINOR,VER_BUILD,VER_TWEAK)
+ 
+ def build_static_lib():
+     return STATIC_LIB
+ 
+ def build_static_bin():
+@@ -611,11 +611,11 @@
+         IS_MSYS2=True
+         if os.uname()[4] == 'x86_64':
+             LINUX_X64=True
+         else:
+             LINUX_X64=False
+-            
++
+ 
+ def display_help(exit_code):
+     print("mk_make.py: Z3 Makefile generator\n")
+     print("This script generates the Makefile for the Z3 theorem prover.")
+     print("It must be executed from the Z3 root directory.")
+@@ -778,11 +778,11 @@
+ 
+     f = io.open(fname, encoding='utf-8', mode='r')
+     linenum = 1
+     for line in f:
+         m1 = std_inc_pat.match(line)
+-        if m1: 
++        if m1:
+             root_file_name = m1.group(1)
+             slash_pos =  root_file_name.rfind('/')
+             if slash_pos >= 0  and root_file_name.find("..") < 0 : #it is a hack for lp include files that behave as continued from "src"
+                 # print(root_file_name)
+                 root_file_name = root_file_name[slash_pos+1:]
+@@ -1497,12 +1497,12 @@
+             self.pythonPkgDir = strip_path_prefix(PYTHON_PACKAGE_DIR, PREFIX)
+         else:
+             # Use path inside the prefix (should be the normal case on Linux)
+             # CMW: Also normal on *BSD?
+             if not PYTHON_PACKAGE_DIR.startswith(PREFIX):
+-                raise MKException(('The python package directory ({}) must live ' +
+-                    'under the install prefix ({}) to install the python bindings.' +
++                raise MKException(('The python package directory ({0}) must live ' +
++                    'under the install prefix ({1}) to install the python bindings.' +
+                     'Use --pypkgdir and --prefix to set the python package directory ' +
+                     'and install prefix respectively. Note that the python package ' +
+                     'directory does not need to exist and will be created if ' +
+                     'necessary during install.').format(
+                         PYTHON_PACKAGE_DIR,
+@@ -1612,11 +1612,11 @@
+        elif os.path.isfile(os.path.join(self.src_dir, self.key_file)):
+            self.key_file = os.path.abspath(os.path.join(self.src_dir, self.key_file))
+        else:
+            print("Keyfile '%s' could not be found; %s.dll will be unsigned." % (self.key_file, self.dll_name))
+            self.key_file = None
+-    
++
+ 
+ # build for dotnet core
+ class DotNetDLLComponent(Component):
+     def __init__(self, name, dll_name, path, deps, assembly_info_dir, default_key_file):
+         Component.__init__(self, name, path, deps)
+@@ -1626,11 +1626,11 @@
+             assembly_info_dir = "."
+         self.dll_name          = dll_name
+         self.assembly_info_dir = assembly_info_dir
+         self.key_file = default_key_file
+ 
+-    
++
+     def mk_makefile(self, out):
+         if not is_dotnet_core_enabled():
+             return
+         cs_fp_files = []
+         for cs_file in get_cs_files(self.src_dir):
+@@ -1642,11 +1642,11 @@
+         out.write('%s: %s$(SO_EXT)' % (dllfile, get_component(Z3_DLL_COMPONENT).dll_name))
+         for cs_file in cs_fp_files:
+             out.write(' ')
+             out.write(cs_file)
+         out.write('\n')
+-        
++
+         set_key_file(self)
+         key = ""
+         if not self.key_file is None:
+             key = "<AssemblyOriginatorKeyFile>%s</AssemblyOriginatorKeyFile>" % self.key_file
+             key += "\n<SignAssembly>true</SignAssembly>"
+@@ -1684,34 +1684,34 @@
+         csproj = os.path.join('dotnet', 'z3.csproj')
+         with open(os.path.join(BUILD_DIR, csproj), 'w') as ous:
+             ous.write(core_csproj_str)
+ 
+         dotnetCmdLine = [DOTNET, "build", csproj]
+-        
++
+         dotnetCmdLine.extend(['-c'])
+         if DEBUG_MODE:
+             dotnetCmdLine.extend(['Debug'])
+         else:
+             dotnetCmdLine.extend(['Release'])
+ 
+         path = os.path.join(os.path.abspath(BUILD_DIR), ".")
+         dotnetCmdLine.extend(['-o', path])
+-            
++
+         MakeRuleCmd.write_cmd(out, ' '.join(dotnetCmdLine))
+         self.sign_esrp(out)
+-        out.write('\n')        
++        out.write('\n')
+         out.write('%s: %s\n\n' % (self.name, dllfile))
+ 
+     def sign_esrp(self, out):
+         global ESRP_SIGNx
+         print("esrp-sign", ESRP_SIGN)
+         if not ESRP_SIGN:
+             return
+-        
++
+         import uuid
+         guid = str(uuid.uuid4())
+-        path = os.path.abspath(BUILD_DIR).replace("\\","\\\\")        
++        path = os.path.abspath(BUILD_DIR).replace("\\","\\\\")
+         assemblySignStr = """
+ {
+   "Version": "1.0.0",
+   "SignBatches"
+   :
+@@ -1770,16 +1770,16 @@
+         MakeRuleCmd.write_cmd(out, "move /Y C:\\esrp\\output\\Microsoft.Z3.dll .")
+ 
+ 
+     def main_component(self):
+         return is_dotnet_core_enabled()
+-    
++
+     def has_assembly_info(self):
+         # TBD: is this required for dotnet core given that version numbers are in z3.csproj file?
+         return False
+ 
+-    
++
+     def mk_win_dist(self, build_path, dist_path):
+         if is_dotnet_core_enabled():
+             mk_dir(os.path.join(dist_path, INSTALL_BIN_DIR))
+             shutil.copy('%s.dll' % os.path.join(build_path, self.dll_name),
+                         '%s.dll' % os.path.join(dist_path, INSTALL_BIN_DIR, self.dll_name))
+@@ -1899,18 +1899,18 @@
+ 
+     def mk_install(self, out):
+         if is_java_enabled() and self.install:
+             dllfile = '%s$(SO_EXT)' % self.dll_name
+             MakeRuleCmd.install_files(out, dllfile, os.path.join(INSTALL_LIB_DIR, dllfile))
+-            jarfile = '{}.jar'.format(self.package_name)
++            jarfile = '{0}.jar'.format(self.package_name)
+             MakeRuleCmd.install_files(out, jarfile, os.path.join(INSTALL_LIB_DIR, jarfile))
+ 
+     def mk_uninstall(self, out):
+         if is_java_enabled() and self.install:
+             dllfile = '%s$(SO_EXT)' % self.dll_name
+             MakeRuleCmd.remove_installed_files(out, os.path.join(INSTALL_LIB_DIR, dllfile))
+-            jarfile = '{}.jar'.format(self.package_name)
++            jarfile = '{0}.jar'.format(self.package_name)
+             MakeRuleCmd.remove_installed_files(out, os.path.join(INSTALL_LIB_DIR, jarfile))
+ 
+ class MLComponent(Component):
+ 
+     def __init__(self, name, lib_name, path, deps):
+@@ -1976,16 +1976,16 @@
+ 
+             src_dir = self.to_src_dir
+             mk_dir(os.path.join(BUILD_DIR, self.sub_dir))
+             api_src = get_component(API_COMPONENT).to_src_dir
+             # remove /GL and -std=c++11; the ocaml tools don't like them.
+-            if IS_WINDOWS:                
++            if IS_WINDOWS:
+                 out.write('CXXFLAGS_OCAML=$(CXXFLAGS:/GL=)\n')
+             else:
+                 out.write('CXXFLAGS_OCAML=$(subst -std=c++11,,$(CXXFLAGS))\n')
+ 
+-            substitutions = { 'VERSION': "{}.{}.{}.{}".format(VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK) }
++            substitutions = { 'VERSION': "{0}.{1}.{2}.{3}".format(VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK) }
+ 
+             configure_file(os.path.join(self.src_dir, 'META.in'),
+                            os.path.join(BUILD_DIR, self.sub_dir, 'META'),
+                            substitutions)
+ 
+@@ -2774,21 +2774,21 @@
+         for f in files:
+             if f.endswith('.pyg'):
+                 script = os.path.join(root, f)
+                 generated_file = mk_genfile_common.mk_hpp_from_pyg(script, root)
+                 if is_verbose():
+-                    print("Generated '{}'".format(generated_file))
++                    print("Generated '{0}'".format(generated_file))
+ 
+ # TODO: delete after src/ast/pattern/expr_pattern_match
+ # database.smt ==> database.h
+ def mk_pat_db():
+     c = get_component(PATTERN_COMPONENT)
+     fin  = os.path.join(c.src_dir, 'database.smt2')
+     fout = os.path.join(c.src_dir, 'database.h')
+     mk_genfile_common.mk_pat_db_internal(fin, fout)
+     if VERBOSE:
+-        print("Generated '{}'".format(fout))
++        print("Generated '{0}'".format(fout))
+ 
+ # Update version numbers
+ def update_version():
+     major = VER_MAJOR
+     minor = VER_MINOR
+@@ -2852,11 +2852,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_install_tactic_cpp_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_install_tactic_cpps():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_install_tactics():
+@@ -2871,11 +2871,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_mem_initializer_cpp_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_mem_initializer_cpps():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_mem_initializer():
+@@ -2890,11 +2890,11 @@
+         c = get_component(cname)
+         component_src_dirs.append(c.src_dir)
+     h_files_full_path = get_header_files_for_components(component_src_dirs)
+     generated_file = mk_genfile_common.mk_gparams_register_modules_internal(h_files_full_path, path)
+     if VERBOSE:
+-        print("Generated '{}'".format(generated_file))
++        print("Generated '{0}'".format(generated_file))
+ 
+ def mk_all_gparams_register_modules():
+     if not ONLY_MAKEFILES:
+         for c in get_components():
+             if c.require_mem_initializer():
+@@ -3020,11 +3020,11 @@
+         api_file_c = api_dll.find_file(api_file, api_dll.name)
+         api_file   = os.path.join(api_file_c.src_dir, api_file)
+         full_path_api_files.append(api_file)
+     generated_file = mk_genfile_common.mk_z3consts_py_internal(full_path_api_files, Z3PY_SRC_DIR)
+     if VERBOSE:
+-        print("Generated '{}".format(generated_file))
++        print("Generated '{0}".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add .Net definitions
+ def mk_z3consts_dotnet(api_files, output_dir):
+     dotnet = get_component(DOTNET_COMPONENT)
+     if not dotnet:
+@@ -3034,11 +3034,11 @@
+         api_file_c = dotnet.find_file(api_file, dotnet.name)
+         api_file   = os.path.join(api_file_c.src_dir, api_file)
+         full_path_api_files.append(api_file)
+     generated_file = mk_genfile_common.mk_z3consts_dotnet_internal(full_path_api_files, output_dir)
+     if VERBOSE:
+-        print("Generated '{}".format(generated_file))
++        print("Generated '{0}".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add Java definitions
+ def mk_z3consts_java(api_files):
+     java = get_component(JAVA_COMPONENT)
+     full_path_api_files = []
+@@ -3050,11 +3050,11 @@
+         full_path_api_files,
+         java.package_name,
+         java.src_dir)
+     if VERBOSE:
+         for generated_file in generated_files:
+-            print("Generated '{}'".format(generated_file))
++            print("Generated '{0}'".format(generated_file))
+ 
+ # Extract enumeration types from z3_api.h, and add ML definitions
+ def mk_z3consts_ml(api_files):
+     ml = get_component(ML_COMPONENT)
+     full_path_api_files = []
+@@ -3078,11 +3078,11 @@
+     lline = lines[-1]
+     tokens = lline.split('.')
+     if len(tokens) < 2:
+         return default
+     else:
+-        if tokens[0] == "15": 
++        if tokens[0] == "15":
+             # Visual Studio 2017 reports 15.* but the PlatformToolsetVersion is 141
+             return "v141"
+         else:
+             return 'v' + tokens[0] + tokens[1]
+ 
+@@ -3287,11 +3287,12 @@
+         # Note: DESTDIR is to support staged installs
+         return "$(DESTDIR)$(PREFIX)/"
+ 
+     @classmethod
+     def _is_str(cls, obj):
+-        if sys.version_info.major > 2:
++        # TODO: py26 compat, or we would use '.major'.
++        if sys.version_info[0] > 2:
+             # Python 3 or newer. Strings are always unicode and of type str
+             return isinstance(obj, str)
+         else:
+             # Python 2. Has byte-string and unicode representation, allow both
+             return isinstance(obj, str) or isinstance(obj, unicode)
+@@ -3300,13 +3301,13 @@
+     def _install_root(cls, path, in_prefix, out, is_install=True):
+         if not in_prefix:
+             # The Python bindings on OSX are sometimes not installed inside the prefix.
+             install_root = "$(DESTDIR)"
+             action_string = 'install' if is_install else 'uninstall'
+-            cls.write_cmd(out, 'echo "WARNING: {}ing files/directories ({}) that are not in the install prefix ($(PREFIX))."'.format(
++            cls.write_cmd(out, 'echo "WARNING: {0}ing files/directories ({1}) that are not in the install prefix ($(PREFIX))."'.format(
+                     action_string, path))
+-            #print("WARNING: Generating makefile rule that {}s {} '{}' which is outside the installation prefix '{}'.".format(
++            #print("WARNING: Generating makefile rule that {0}s {1} '{2}' which is outside the installation prefix '{0}'.".format(
+             #        action_string, 'to' if is_install else 'from', path, PREFIX))
+         else:
+             # assert not os.path.isabs(path)
+             install_root = cls.install_root()
+         return install_root
+@@ -3428,11 +3429,11 @@
+     # ``$(Verb)`` and have it set to ``@`` or empty at build time depending on
+     # a variable (e.g. ``VERBOSE``) passed to the ``make`` invocation. This
+     # would be very helpful for debugging.
+     @classmethod
+     def write_cmd(cls, out, line):
+-        out.write("\t@{}\n".format(line))
++        out.write("\t@{0}\n".format(line))
+ 
+ def strip_path_prefix(path, prefix):
+     if path.startswith(prefix):
+         stripped_path = path[len(prefix):]
+         stripped_path.replace('//','/')
+@@ -3456,23 +3457,23 @@
+     assert isinstance(template_file_path, str)
+     assert isinstance(output_file_path, str)
+     assert isinstance(substitutions, dict)
+     assert len(template_file_path) > 0
+     assert len(output_file_path) > 0
+-    print("Generating {} from {}".format(output_file_path, template_file_path))
++    print("Generating {0} from {1}".format(output_file_path, template_file_path))
+ 
+     if not os.path.exists(template_file_path):
+-        raise MKException('Could not find template file "{}"'.format(template_file_path))
++        raise MKException('Could not find template file "{0}"'.format(template_file_path))
+ 
+     # Read whole template file into string
+     template_string = None
+     with open(template_file_path, 'r') as f:
+         template_string = f.read()
+ 
+     # Do replacements
+     for (old_string, replacement) in substitutions.items():
+-        template_string = template_string.replace('@{}@'.format(old_string), replacement)
++        template_string = template_string.replace('@{0}@'.format(old_string), replacement)
+ 
+     # Write the string to the file
+     with open(output_file_path, 'w') as f:
+         f.write(template_string)
+ 

--- a/var/spack/repos/builtin/packages/z3/py26-2.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-2.patch
@@ -1,0 +1,124 @@
+--- a/scripts/mk_genfile_common.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/mk_genfile_common.py	2020-11-29 19:41:01.152833632 -0800
+@@ -26,19 +26,19 @@
+     """
+         Returns ``True`` if ``output_dir`` exists, otherwise
+         returns ``False``.
+     """
+     if not os.path.isdir(output_dir):
+-        _logger.error('"{}" is not an existing directory'.format(output_dir))
++        _logger.error('"{0}" is not an existing directory'.format(output_dir))
+         return False
+     return True
+ 
+ def check_files_exist(files):
+     assert isinstance(files, list)
+     for f in files:
+         if not os.path.exists(f):
+-            _logger.error('"{}" does not exist'.format(f))
++            _logger.error('"{0}" does not exist'.format(f))
+             return False
+     return True
+ 
+ def sorted_headers_by_component(l):
+     """
+@@ -53,11 +53,11 @@
+       and ``<build_dir>`` prefixes so that we can match the Python build
+       system's behaviour.
+     """
+     assert isinstance(l, list)
+     def get_key(path):
+-        _logger.debug("get_key({})".format(path))
++        _logger.debug("get_key({0})".format(path))
+         path_components = []
+         stripped_path = path
+         assert 'src' in stripped_path.split(os.path.sep) or 'src' in stripped_path.split('/')
+         # Keep stripping off directory components until we hit ``src``
+         while os.path.basename(stripped_path) != 'src':
+@@ -67,14 +67,14 @@
+         path_components.reverse()
+         # For consistency across platforms use ``/`` rather than ``os.sep``.
+         # This is a sorting key so it doesn't need to a platform suitable
+         # path
+         r = '/'.join(path_components)
+-        _logger.debug("return key:'{}'".format(r))
++        _logger.debug("return key:'{0}'".format(r))
+         return r
+     sorted_headers = sorted(l, key=get_key)
+-    _logger.debug('sorted headers:{}'.format(pprint.pformat(sorted_headers)))
++    _logger.debug('sorted headers:{0}'.format(pprint.pformat(sorted_headers)))
+     return sorted_headers
+ 
+ 
+ 
+ ###############################################################################
+@@ -593,11 +593,11 @@
+     h_file = h_file.replace("\\","/")
+     idx = h_file.rfind("src/")
+     if idx == -1:
+         return h_file
+     return h_file[idx + 4:]
+-            
++
+ def mk_gparams_register_modules_internal(h_files_full_path, path):
+     """
+         Generate a ``gparams_register_modules.cpp`` file in the directory ``path``.
+         Returns the path to the generated file.
+ 
+@@ -609,11 +609,11 @@
+ 
+         This procedure is invoked by gparams::init()
+     """
+     assert isinstance(h_files_full_path, list)
+     assert check_dir_exists(path)
+-    cmds = []    
++    cmds = []
+     mod_cmds = []
+     mod_descrs = []
+     fullname = os.path.join(path, 'gparams_register_modules.cpp')
+     fout  = open(fullname, 'w')
+     fout.write('// Automatically generated file.\n')
+@@ -691,38 +691,38 @@
+     fout.write('// Automatically generated file.\n')
+     fout.write('#include "tactic/tactic.h"\n')
+     fout.write('#include "cmd_context/tactic_cmds.h"\n')
+     fout.write('#include "cmd_context/cmd_context.h"\n')
+     tactic_pat   = re.compile('[ \t]*ADD_TACTIC\(.*\)')
+-    probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')   
++    probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')
+     for h_file in sorted_headers_by_component(h_files_full_path):
+         added_include = False
+         try:
+             with io.open(h_file, encoding='utf-8', mode='r') as fin:
+                 for line in fin:
+                     if tactic_pat.match(line):
+                         if not added_include:
+-                            added_include = True                        
++                            added_include = True
+                             fout.write('#include "%s"\n' % path_after_src(h_file))
+                         try:
+                             eval(line.strip('\n '), eval_globals, None)
+                         except Exception as e:
+-                            _logger.error("Failed processing ADD_TACTIC command at '{}'\n{}".format(
++                            _logger.error("Failed processing ADD_TACTIC command at '{0}'\n{1}".format(
+                                 fullname, line))
+                             raise e
+                     if probe_pat.match(line):
+                         if not added_include:
+                             added_include = True
+                             fout.write('#include "%s"\n' % path_after_src(h_file))
+                         try:
+                             eval(line.strip('\n '), eval_globals, None)
+                         except Exception as e:
+-                            _logger.error("Failed processing ADD_PROBE command at '{}'\n{}".format(
++                            _logger.error("Failed processing ADD_PROBE command at '{0}'\n{1}".format(
+                                 fullname, line))
+                             raise e
+         except Exception as e:
+-           _logger.error("Failed to read file {}\n".format(h_file))
++           _logger.error("Failed to read file {0}\n".format(h_file))
+            raise e
+     # First pass will just generate the tactic factories
+     fout.write('#define ADD_TACTIC_CMD(NAME, DESCR, CODE) ctx.insert(alloc(tactic_cmd, symbol(NAME), DESCR, [](ast_manager &m, const params_ref &p) { return CODE; }))\n')
+     fout.write('#define ADD_PROBE(NAME, DESCR, PROBE) ctx.insert(alloc(probe_info, symbol(NAME), DESCR, PROBE))\n')
+     fout.write('void install_tactics(tactic_manager & ctx) {\n')

--- a/var/spack/repos/builtin/packages/z3/py26-3.patch
+++ b/var/spack/repos/builtin/packages/z3/py26-3.patch
@@ -1,0 +1,109 @@
+--- a/scripts/update_api.py	2019-11-19 12:58:44.000000000 -0800
++++ b/scripts/update_api.py	2020-11-29 19:40:54.949457677 -0800
+@@ -778,11 +778,11 @@
+        ous.write("  \"api\": [\n")
+        for name, result, params in _dotnet_decls:
+            ous.write("    {\n")
+            ous.write("       \"name\": \"%s\",\n" % name)
+            ous.write("       \"c_type\": \"%s\",\n" % Type2Str[result])
+-           ous.write("       \"napi_type\": \"%s\",\n" % type2napi(result))                       
++           ous.write("       \"napi_type\": \"%s\",\n" % type2napi(result))
+            ous.write("       \"arg_list\": [")
+            first = True
+            for p in params:
+                if first:
+                   first = False
+@@ -791,11 +791,11 @@
+                   ous.write(",\n         {\n")
+                t = param_type(p)
+                k = t
+                ous.write("            \"name\": \"%s\",\n" % "")                        # TBD
+                ous.write("            \"c_type\": \"%s\",\n" % type2str(t))
+-               ous.write("            \"napi_type\": \"%s\",\n" % type2napi(t))        
++               ous.write("            \"napi_type\": \"%s\",\n" % type2napi(t))
+                ous.write("            \"napi_builder\": \"%s\"\n" % type2napibuilder(t))
+                ous.write(  "         }")
+            ous.write("],\n")
+            ous.write("       \"napi_builder\": \"%s\"\n" % type2napibuilder(result))
+            ous.write("    },\n")
+@@ -1717,11 +1717,11 @@
+ del _lib
+ del _default_dirs
+ del _all_dirs
+ del _ext
+ """)
+-    
++
+ def write_core_py_preamble(core_py):
+   core_py.write(
+ """
+ # Automatically generated file
+ import sys, os
+@@ -1790,11 +1790,11 @@
+     print("    builtins.Z3_LIB_DIRS = [ '/path/to/libz3.%s' ] " % _ext)
+   raise Z3Exception("libz3.%s not found." % _ext)
+ 
+ def _to_ascii(s):
+   if isinstance(s, str):
+-    try: 
++    try:
+       return s.encode('ascii')
+     except:
+       # kick the bucket down the road.  :-J
+       return s
+   else:
+@@ -1871,11 +1871,11 @@
+     if output_dir != None:
+       assert os.path.exists(output_dir) and os.path.isdir(output_dir)
+       return open(os.path.join(output_dir, file_name), mode)
+     else:
+       # Return a file that we can write to without caring
+-      print("Faking emission of '{}'".format(file_name))
++      print("Faking emission of '{0}'".format(file_name))
+       import tempfile
+       return tempfile.TemporaryFile(mode=mode)
+ 
+   with mk_file_or_temp(api_output_dir, 'api_log_macros.h') as log_h:
+     with mk_file_or_temp(api_output_dir, 'api_log_macros.cpp') as log_c:
+@@ -1893,22 +1893,22 @@
+           mk_bindings(exe_c)
+           mk_py_wrappers()
+           write_core_py_post(core_py)
+ 
+           if mk_util.is_verbose():
+-            print("Generated '{}'".format(log_h.name))
+-            print("Generated '{}'".format(log_c.name))
+-            print("Generated '{}'".format(exe_c.name))
+-            print("Generated '{}'".format(core_py.name))
++            print("Generated '{0}'".format(log_h.name))
++            print("Generated '{0}'".format(log_c.name))
++            print("Generated '{0}'".format(exe_c.name))
++            print("Generated '{0}'".format(core_py.name))
+ 
+   if dotnet_output_dir:
+     with open(os.path.join(dotnet_output_dir, 'Native.cs'), 'w') as dotnet_file:
+       mk_dotnet(dotnet_file)
+       mk_dotnet_wrappers(dotnet_file)
+       if mk_util.is_verbose():
+-        print("Generated '{}'".format(dotnet_file.name))
+-        
++        print("Generated '{0}'".format(dotnet_file.name))
++
+   if java_output_dir:
+     mk_java(java_output_dir, java_package_name)
+ 
+   if ml_output_dir:
+     assert not ml_src_dir is None
+@@ -1966,11 +1966,11 @@
+       logging.error('--ml-src-dir must be specified')
+       return 1
+ 
+   for api_file in pargs.api_files:
+     if not os.path.exists(api_file):
+-      logging.error('"{}" does not exist'.format(api_file))
++      logging.error('"{0}" does not exist'.format(api_file))
+       return 1
+ 
+   generate_files(api_files=pargs.api_files,
+                  api_output_dir=pargs.api_output_dir,
+                  z3py_output_dir=pargs.z3py_output_dir,


### PR DESCRIPTION
#20221 describes how we're looking to determine whether SMT constraint solving even works for a packager like spack, and then whether it might be faster even than ASP. #20501 ups the ante to describe some of the main disparities between the ASP and SMT methods -- and how to use a technique from ASP to help the SMT solution.

Right now, this is being executed against fake data defined within the new file `z3.py`. This is currently being tested using the [pex](github.com/pantsbuild/pex/) tool:
```bash
> pex --interpreter-constraint='CPython<3' z3-solver six setuptools -D lib/spack -D lib/spack/external -o z3-setup.pex
> PYTHONIOENCODING='utf-8' ./z3-setup.pex lib/spack/spack/solver/z3.py
...
UNSAT_CORE():
[use_package(PackageIdentitySort("FAKE::[b@1.0.0]")) ==
 False,
 use_package(PackageIdentitySort("FAKE::[a@1.0.0]")),
 use_this_dependency(PackageIdentitySort("FAKE::[a@1.0.0]"),
                     PackageIdentitySort("FAKE::[b@1.0.1]")) ==
 use_package(p = FAKE::[a@1.0.0]) => \existsuniq! d \in {P_dependencies(p)} s.t. use_this_dependency(p, d). case of: d = FAKE::[b@1.0.1].,
 use_this_dependency(PackageIdentitySort("FAKE::[a@1.0.0]"),
                     PackageIdentitySort("FAKE::[b@1.0.0]")) ==
 use_package(p = FAKE::[a@1.0.0]) => \existsuniq! d \in {P_dependencies(p)} s.t. use_this_dependency(p, d). case of: d = FAKE::[b@1.0.0].,
 Implies(use_this_dependency(PackageIdentitySort("FAKE::[a@1.0.0]"),
                             PackageIdentitySort("FAKE::[b@1.0.1]")),
         use_package(PackageIdentitySort("FAKE::[b@1.0.1]"))),
 Implies(use_this_dependency(PackageIdentitySort("FAKE::[a@1.0.0]"),
                             PackageIdentitySort("FAKE::[b@1.0.0]")),
         use_package(PackageIdentitySort("FAKE::[b@1.0.0]"))),
 use_package(PackageIdentitySort("FAKE::[a@1.0.0]")) ==
 PbEq(((use_package(p = FAKE::[a@1.0.0]) => \existsuniq! d \in {P_dependencies(p)} s.t. use_this_dependency(p, d). case of: d = FAKE::[b@1.0.1].,
        1),
       (use_package(p = FAKE::[a@1.0.0]) => \existsuniq! d \in {P_dependencies(p)} s.t. use_this_dependency(p, d). case of: d = FAKE::[b@1.0.0].,
        1)),
      1),
 use_package(PackageIdentitySort("FAKE::[b@1.0.1]")) ==
 False]
phase /solve 2/ starting with previous value 0.11166882515
phase /solve 2/check 2/ starting with previous value 0
SUCCESS: UNSAT!!!!!
...
```

In this PR we attempt to build a concretizer which:
- [ ] Pulls data from spack packages like the ASP concretizer (it's currently using fake data).
- [ ] Can process every feature of spack specs (currently can only process versions
- [ ] Can solve small specs (which?) seemingly correctly.
- [ ] Gets the same (?) results as the ASP concretizer for all test cases.
    - If different, how? Where? 
- [ ] Isn't atrociously slow.