### PR TITLE
package magma: Remove -W args from CMakeLists.txt

### DIFF
--- a/var/spack/repos/builtin/packages/magma/cmake-W.patch
+++ b/var/spack/repos/builtin/packages/magma/cmake-W.patch
@@ -1,0 +1,12 @@
+diff -ru magma-2.5.0-orig/CMakeLists.txt magma-2.5.0/CMakeLists.txt
+--- magma-2.5.0-orig/CMakeLists.txt	2019-01-02 11:18:39.000000000 -0800
++++ magma-2.5.0/CMakeLists.txt	2019-04-03 15:58:01.871234891 -0700
+@@ -363,8 +363,6 @@
+ else()
+     # Primarily for gcc / nvcc:
+     # Ignore unused static functions in headers.
+-    set( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -Wall -Wno-unused-function" )
+-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function" )
+ endif()
+ 
+ if (CMAKE_HOST_APPLE)

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -52,6 +52,7 @@ class Magma(CMakePackage, CudaPackage):
     patch('magma-2.3.0-gcc-4.8.patch', when='@2.3.0%gcc@:4.8')
     patch('magma-2.5.0.patch', when='@2.5.0')
     patch('magma-2.5.0-cmake.patch', when='@2.5.0')
+    patch('cmake-W.patch', when='@2.5.0:%nvhpc')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
The cmake buildsystem of magma (2.5.x) explicitly adds `-Wno-unused-function` to `CXXFLAGS` and `CFLAGS`. The `-W*` are compiler specific, but the compiler is not checked. For me this broke installing it using NVHP/PGI.

As compiler warnings are usually not interesting for spack users (who could also add them if needed), this PR adds a patch to the magma which removes the offending lines.