### PR TITLE
fftw: PGI compiler has trouble with avx2 SIMD support

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -52,3 +52,9 @@ packages:
     permissions:
       read: world
       write: user
+  openmpi:
+    buildable: False
+    externals:
+    - spec: 'openmpi@3.1.6-gcc_9.3.0'
+      modules:
+      - 'openmpi/3.1.6-gcc_9.3.0'

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -105,9 +105,14 @@ class FftwBase(AutotoolsPackage):
             options.append('--enable-mpi')
 
         # Specific SIMD support.
+        # PGI compiler has trouble with avx2: https://github.com/FFTW/fftw3/issues/78
+        if self.spec.satisfies('%pgi'):
+          simd_features = ['sse2', 'avx', 'avx512', 'avx-128-fma',
+                           'kcvi', 'vsx', 'neon']
         # all precisions
-        simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-                         'kcvi', 'vsx', 'neon']
+        else:
+          simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                           'kcvi', 'vsx', 'neon']
         # float only
         float_simd_features = ['altivec', 'sse']
 

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -107,12 +107,12 @@ class FftwBase(AutotoolsPackage):
         # Specific SIMD support.
         # PGI compiler has trouble with avx2: https://github.com/FFTW/fftw3/issues/78
         if self.spec.satisfies('%pgi'):
-          simd_features = ['sse2', 'avx', 'avx512', 'avx-128-fma',
-                           'kcvi', 'vsx', 'neon']
+            simd_features = ['sse2', 'avx', 'avx-128-fma',
+                             'kcvi', 'vsx', 'neon']
         # all precisions
         else:
-          simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-                           'kcvi', 'vsx', 'neon']
+            simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                             'kcvi', 'vsx', 'neon']
         # float only
         float_simd_features = ['altivec', 'sse']
 


### PR DESCRIPTION
There appears to be a [long-standing bug](https://github.com/FFTW/fftw3/issues/78) that prevents compilation of `fftw` with PGI if either the `avx2` or `avx512` SIMD features are enabled.

I confirmed this using PGI 19.7 on an Intel Skylake node. See the attached [Spack build output](https://github.com/spack/spack/files/5732925/spack-build-out_fftw-BROKEN.txt) for details.

This patch simply disables both of these features when `pgi` is in use.