### PR TITLE
libquo: Add +pic variant to help support PGI compilation

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -52,3 +52,9 @@ packages:
     permissions:
       read: world
       write: user
+  openmpi:
+    buildable: False
+    externals:
+    - spec: 'openmpi@3.1.6-gcc_9.3.0'
+      modules:
+      - 'openmpi/3.1.6-gcc_9.3.0'

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -52,9 +52,3 @@ packages:
     permissions:
       read: world
       write: user
-  openmpi:
-    buildable: False
-    externals:
-    - spec: 'openmpi@3.1.6-gcc_9.3.0'
-      modules:
-      - 'openmpi/3.1.6-gcc_9.3.0'

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -34,7 +34,11 @@ class Libquo(AutotoolsPackage):
         bash('./autogen')
 
     def configure_args(self):
-        return [
+        config_args = [
             'CC={0}'.format(self.spec['mpi'].mpicc),
             'FC={0}'.format(self.spec['mpi'].mpifc)
         ]
+        if '%pgi' in self.spec:
+            config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
+            config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
+        return config_args

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -41,6 +41,6 @@ class Libquo(AutotoolsPackage):
             'FC={0}'.format(self.spec['mpi'].mpifc),
         ]
         if '+pic' in self.spec:
-          config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
-          config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
+            config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
+            config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
         return config_args

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -28,22 +28,13 @@ class Libquo(AutotoolsPackage):
     depends_on('automake', when='@develop', type='build')
     depends_on('libtool',  when='@develop', type='build')
 
-    variant('force-pic', default=False,
-            description='Force the production of position-independent code for '
-                        'shared libs (libtool sometimes requires this extra push '
-                        'when dealing with particular compilers like PGI).')
-
     @when('@develop')
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen')
 
     def configure_args(self):
-        config_args = [
+        return [
             'CC={0}'.format(self.spec['mpi'].mpicc),
-            'FC={0}'.format(self.spec['mpi'].mpifc),
+            'FC={0}'.format(self.spec['mpi'].mpifc)
         ]
-        if '+force-pic' in self.spec:
-            config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
-            config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
-        return config_args

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -28,13 +28,19 @@ class Libquo(AutotoolsPackage):
     depends_on('automake', when='@develop', type='build')
     depends_on('libtool',  when='@develop', type='build')
 
+    variant('pic', default=False, description='Produce position-independent code for shared libs.')
+
     @when('@develop')
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen')
 
     def configure_args(self):
-        return [
+        config_args = [
             'CC={0}'.format(self.spec['mpi'].mpicc),
-            'FC={0}'.format(self.spec['mpi'].mpifc)
+            'FC={0}'.format(self.spec['mpi'].mpifc),
         ]
+        if '+pic' in self.spec:
+          config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
+          config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
+        return config_args

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -28,7 +28,10 @@ class Libquo(AutotoolsPackage):
     depends_on('automake', when='@develop', type='build')
     depends_on('libtool',  when='@develop', type='build')
 
-    variant('pic', default=False, description='Produce position-independent code for shared libs.')
+    variant('force-pic', default=False,
+            description='Force the production of position-independent code for '
+                        'shared libs (libtool sometimes requires this extra push '
+                        'when dealing with particular compilers like PGI).')
 
     @when('@develop')
     def autoreconf(self, spec, prefix):
@@ -40,7 +43,7 @@ class Libquo(AutotoolsPackage):
             'CC={0}'.format(self.spec['mpi'].mpicc),
             'FC={0}'.format(self.spec['mpi'].mpifc),
         ]
-        if '+pic' in self.spec:
+        if '+force-pic' in self.spec:
             config_args.append('CFLAGS={0}'.format(self.compiler.cc_pic_flag))
             config_args.append('FCFLAGS={0}'.format(self.compiler.fc_pic_flag))
         return config_args


### PR DESCRIPTION
[PGI compilation of libquo fails unless PIC is explicitly enabled](https://github.com/lanl/libquo/issues/41).

I confirmed this using PGI 19.7 on an Intel Skylake node. See the attached [Spack build output](https://github.com/spack/spack/files/5733058/spack-build-out_libquo-BROKEN.txt) for details.

This patch adds a `+pic` variant to `libquo`. Mentioning package maintainer @samuelkgutierrez so he can weigh in on this.