### PR TITLE
silo: HDF5 1.10.0+ introduces a new "terminate" member in the H5FD_class_t structure

### DIFF
--- a/var/spack/repos/builtin/packages/silo/H5FD_class_t-terminate.patch
+++ b/var/spack/repos/builtin/packages/silo/H5FD_class_t-terminate.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hdf5_drv/H5FDsilo.c b/src/hdf5_drv/H5FDsilo.c
+index 840dfd0..0d09147 100644
+--- a/src/hdf5_drv/H5FDsilo.c
++++ b/src/hdf5_drv/H5FDsilo.c
+@@ -500,6 +500,7 @@ static const H5FD_class_t H5FD_silo_g = {
+     "silo",				        /*name			*/
+     MAXADDR,				        /*maxaddr		*/
+     H5F_CLOSE_WEAK,				/* fc_degree		*/
++    NULL,                                       /*terminate             */
+     H5FD_silo_sb_size,                          /*sb_size               */
+     H5FD_silo_sb_encode,                        /*sb_encode             */
+     H5FD_silo_sb_decode,                        /*sb_decode             */

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -38,6 +38,7 @@ class Silo(AutotoolsPackage):
     depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
+    patch('H5FD_class_t-terminate.patch', when='^hdf5@1.10.0:')
 
     def flag_handler(self, name, flags):
         spec = self.spec


### PR DESCRIPTION
Starting with HDF5 1.10.0, the `H5FD_class_t` structure has a new `terminate` member.  This patch adds that and initializes it to `NULL`.

Without this patch, `silo` fails to build using PGI 19.7 (see the [attached Spack build output](https://github.com/spack/spack/files/5733183/spack-build-out_silo-BROKEN.txt) for details).