### PR TITLE
[gcc] Explicitly disable libs when they are not required

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -490,6 +490,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         # More info at: https://gcc.gnu.org/install/configure.html
         for dep_str in ('mpfr', 'gmp', 'mpc', 'isl'):
             if dep_str not in spec:
+                options.append('--without-{0}'.format(dep_str))
                 continue
 
             dep_spec = spec[dep_str]


### PR DESCRIPTION
This is to make sure that the build system doesn't pick up a library that
would happen to be available.