### PR TITLE
babelflow: Add spec

### DIFF
--- a/var/spack/repos/builtin/packages/babelflow/package.py
+++ b/var/spack/repos/builtin/packages/babelflow/package.py
@@ -25,6 +25,7 @@ class Babelflow(CMakePackage):
     variant("shared", default=True, description="Build Babelflow as shared libs")
 
     def cmake_args(self):
+        spec = self.spec
         args = [
             '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
                 'ON' if '+shared' in spec else 'OFF')]


### PR DESCRIPTION
I fixed the following error.
==> Error: NameError: name 'spec' is not defined

I have confirmed that it can be built on x86_64 and aarch64 machines.