### PR TITLE
fftw: PGI compiler has trouble with avx2/avx-512 SIMD support 

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -52,3 +52,9 @@ packages:
     permissions:
       read: world
       write: user
+  openmpi:
+    buildable: False
+    externals:
+    - spec: 'openmpi@3.1.6-gcc_9.3.0'
+      modules:
+      - 'openmpi/3.1.6-gcc_9.3.0'

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -52,9 +52,3 @@ packages:
     permissions:
       read: world
       write: user
-  openmpi:
-    buildable: False
-    externals:
-    - spec: 'openmpi@3.1.6-gcc_9.3.0'
-      modules:
-      - 'openmpi/3.1.6-gcc_9.3.0'

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -111,9 +111,14 @@ class FftwBase(AutotoolsPackage):
         # float only
         float_simd_features = ['altivec', 'sse']
 
-        # Workaround NVIDIA compiler bug when avx512 is enabled
-        if spec.satisfies('%nvhpc') and 'avx512' in simd_features:
-            simd_features.remove('avx512')
+        # Workaround PGI compiler bug when avx2 is enabled
+        if spec.satisfies('%pgi') and 'avx2' in simd_features:
+            simd_features.remove('avx2')
+
+        # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
+        if spec.satisfies('%nvhpc') or spec.satisfies('%pgi'):
+            if 'avx512' in simd_features:
+                simd_features.remove('avx512')
 
         # NVIDIA compiler does not support Altivec intrinsics
         if spec.satisfies('%nvhpc') and 'vsx' in simd_features:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -105,9 +105,14 @@ class FftwBase(AutotoolsPackage):
             options.append('--enable-mpi')
 
         # Specific SIMD support.
+        # PGI compiler has trouble with avx2: https://github.com/FFTW/fftw3/issues/78
+        if self.spec.satisfies('%pgi'):
+          simd_features = ['sse2', 'avx', 'avx512', 'avx-128-fma',
+                           'kcvi', 'vsx', 'neon']
         # all precisions
-        simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-                         'kcvi', 'vsx', 'neon']
+        else:
+          simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                           'kcvi', 'vsx', 'neon']
         # float only
         float_simd_features = ['altivec', 'sse']
 

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -111,14 +111,9 @@ class FftwBase(AutotoolsPackage):
         # float only
         float_simd_features = ['altivec', 'sse']
 
-        # Workaround PGI compiler bug when avx2 is enabled
-        if spec.satisfies('%pgi') and 'avx2' in simd_features:
-            simd_features.remove('avx2')
-
-        # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
-        if spec.satisfies('%nvhpc') or spec.satisfies('%pgi'):
-            if 'avx512' in simd_features:
-                simd_features.remove('avx512')
+        # Workaround NVIDIA compiler bug when avx512 is enabled
+        if spec.satisfies('%nvhpc') and 'avx512' in simd_features:
+            simd_features.remove('avx512')
 
         # NVIDIA compiler does not support Altivec intrinsics
         if spec.satisfies('%nvhpc') and 'vsx' in simd_features:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -116,9 +116,9 @@ class FftwBase(AutotoolsPackage):
             simd_features.remove('avx2')
 
         # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
-        if (spec.satisfies('%nvhpc') or (spec.satisfies('%pgi'))) and
-            ('avx512' in simd_features):
-            simd_features.remove('avx512')
+        if spec.satisfies('%nvhpc') or spec.satisfies('%pgi'):
+            if 'avx512' in simd_features:
+                simd_features.remove('avx512')
 
         # NVIDIA compiler does not support Altivec intrinsics
         if spec.satisfies('%nvhpc') and 'vsx' in simd_features:

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -105,19 +105,18 @@ class FftwBase(AutotoolsPackage):
             options.append('--enable-mpi')
 
         # Specific SIMD support.
-        # PGI compiler has trouble with avx2: https://github.com/FFTW/fftw3/issues/78
-        if self.spec.satisfies('%pgi'):
-            simd_features = ['sse2', 'avx', 'avx-128-fma',
-                             'kcvi', 'vsx', 'neon']
         # all precisions
-        else:
-            simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-                             'kcvi', 'vsx', 'neon']
+        simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                         'kcvi', 'vsx', 'neon']
         # float only
         float_simd_features = ['altivec', 'sse']
 
-        # Workaround NVIDIA compiler bug when avx512 is enabled
-        if spec.satisfies('%nvhpc') and 'avx512' in simd_features:
+        # Workaround PGI compiler bug when avx2 is enabled
+        if spec.satisfies('%pgi') and 'avx2' in simd_features:
+            simd_features.remove('avx2')
+
+        # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
+        if (spec.satisfies('%nvhpc') or (spec.satisfies('%pgi'))) and ('avx512' in simd_features):
             simd_features.remove('avx512')
 
         # NVIDIA compiler does not support Altivec intrinsics

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -116,7 +116,8 @@ class FftwBase(AutotoolsPackage):
             simd_features.remove('avx2')
 
         # Workaround NVIDIA/PGI compiler bug when avx512 is enabled
-        if (spec.satisfies('%nvhpc') or (spec.satisfies('%pgi'))) and ('avx512' in simd_features):
+        if (spec.satisfies('%nvhpc') or (spec.satisfies('%pgi'))) and
+            ('avx512' in simd_features):
             simd_features.remove('avx512')
 
         # NVIDIA compiler does not support Altivec intrinsics

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -107,12 +107,12 @@ class FftwBase(AutotoolsPackage):
         # Specific SIMD support.
         # PGI compiler has trouble with avx2: https://github.com/FFTW/fftw3/issues/78
         if self.spec.satisfies('%pgi'):
-          simd_features = ['sse2', 'avx', 'avx512', 'avx-128-fma',
-                           'kcvi', 'vsx', 'neon']
+            simd_features = ['sse2', 'avx', 'avx-128-fma',
+                             'kcvi', 'vsx', 'neon']
         # all precisions
         else:
-          simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
-                           'kcvi', 'vsx', 'neon']
+            simd_features = ['sse2', 'avx', 'avx2', 'avx512', 'avx-128-fma',
+                             'kcvi', 'vsx', 'neon']
         # float only
         float_simd_features = ['altivec', 'sse']
 


### PR DESCRIPTION
There appears to be a [long-standing bug](https://github.com/FFTW/fftw3/issues/78) that prevents compilation of `fftw` with PGI if either the `avx2` or `avx512` SIMD features are enabled.

I confirmed this using PGI 19.7 on an Intel Skylake node. See the attached [Spack build output](https://github.com/spack/spack/files/5740447/spack-build-out_fftw-BROKEN.txt) for details.

This patch simply disables both of these features when `pgi` is in use.