### PR TITLE
zoltan: Add PGI runtime libs to LDFLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -90,6 +90,10 @@ class Zoltan(AutotoolsPackage):
             '-g' if '+debug' in spec else '',
         ]
 
+        config_ldflags = []
+        # PGI runtime libraries
+        if '%pgi' in spec:
+            config_ldflags.append('-pgf90libs')
         if '+shared' in spec:
             config_args.extend([
                 'RANLIB=echo',
@@ -142,7 +146,8 @@ class Zoltan(AutotoolsPackage):
         config_args.extend([
             '--with-cflags={0}'.format(' '.join(config_cflags)),
             '--with-cxxflags={0}'.format(' '.join(config_cflags)),
-            '--with-fcflags={0}'.format(' '.join(config_fcflags))
+            '--with-fcflags={0}'.format(' '.join(config_fcflags)),
+            '--with-ldflags={0}'.format(' '.join(config_ldflags))
         ])
         return config_args
 

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -90,6 +90,13 @@ class Zoltan(AutotoolsPackage):
             '-g' if '+debug' in spec else '',
         ]
 
+        config_ldflags = []
+        # PGI runtime libraries
+        if '%pgi' in spec:
+            config_ldflags.append('-pgf90libs')
+        if '+parmetis' in spec:
+            config_ldflags.append('-L{0}'.format(spec['metis'].prefix.lib))
+
         if '+shared' in spec:
             config_args.extend([
                 'RANLIB=echo',
@@ -111,7 +118,6 @@ class Zoltan(AutotoolsPackage):
                 '--with-parmetis-libdir={0}'.format(parmetis_prefix.lib),
                 '--with-parmetis-incdir={0}'.format(parmetis_prefix.include),
                 '--with-incdirs=-I{0}'.format(spec['metis'].prefix.include),
-                '--with-ldflags=-L{0}'.format(spec['metis'].prefix.lib)
             ])
             if '+int64' in spec['metis']:
                 config_args.append('--with-id-type=ulong')
@@ -142,7 +148,8 @@ class Zoltan(AutotoolsPackage):
         config_args.extend([
             '--with-cflags={0}'.format(' '.join(config_cflags)),
             '--with-cxxflags={0}'.format(' '.join(config_cflags)),
-            '--with-fcflags={0}'.format(' '.join(config_fcflags))
+            '--with-fcflags={0}'.format(' '.join(config_fcflags)),
+            '--with-ldflags={0}'.format(' '.join(config_ldflags))
         ])
         return config_args
 

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -90,13 +90,6 @@ class Zoltan(AutotoolsPackage):
             '-g' if '+debug' in spec else '',
         ]
 
-        config_ldflags = []
-        # PGI runtime libraries
-        if '%pgi' in spec:
-            config_ldflags.append('-pgf90libs')
-        if '+parmetis' in spec:
-            config_ldflags.append('-L{0}'.format(spec['metis'].prefix.lib))
-
         if '+shared' in spec:
             config_args.extend([
                 'RANLIB=echo',
@@ -118,6 +111,7 @@ class Zoltan(AutotoolsPackage):
                 '--with-parmetis-libdir={0}'.format(parmetis_prefix.lib),
                 '--with-parmetis-incdir={0}'.format(parmetis_prefix.include),
                 '--with-incdirs=-I{0}'.format(spec['metis'].prefix.include),
+                '--with-ldflags=-L{0}'.format(spec['metis'].prefix.lib)
             ])
             if '+int64' in spec['metis']:
                 config_args.append('--with-id-type=ulong')
@@ -148,8 +142,7 @@ class Zoltan(AutotoolsPackage):
         config_args.extend([
             '--with-cflags={0}'.format(' '.join(config_cflags)),
             '--with-cxxflags={0}'.format(' '.join(config_cflags)),
-            '--with-fcflags={0}'.format(' '.join(config_fcflags)),
-            '--with-ldflags={0}'.format(' '.join(config_ldflags))
+            '--with-fcflags={0}'.format(' '.join(config_fcflags))
         ])
         return config_args
 


### PR DESCRIPTION
`zoltan` fails to compile with PGI 19.7 unless provided with the PGI runtime libraries. This is similar to an old [Nvidia forum issue](https://forums.developer.nvidia.com/t/petsc-on-linux86-64/130306)

This patch adds PGI runtime libraries to LDFLAGS when '%pgi' is the case.