### PR TITLE
molden: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/molden/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/molden/for_aarch64.patch
@@ -1,0 +1,8 @@
+--- spack-src/src/xwin.c.bak	2020-09-18 19:13:33.000000000 +0900
++++ spack-src/src/xwin.c	2020-12-23 16:06:13.764560722 +0900
+@@ -1,4 +1,4 @@
+-#ifndef DARWIN
++#if 0
+ __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+ __asm__(".symver memmove,memmove@GLIBC_2.2.5");
+ __asm__(".symver log,log@GLIBC_2.2.5");

--- a/var/spack/repos/builtin/packages/molden/package.py
+++ b/var/spack/repos/builtin/packages/molden/package.py
@@ -24,6 +24,9 @@ class Molden(MakefilePackage):
     depends_on('makedepend', type='build')
 
     parallel = False  # building in parallel is broken
+    build_targets = ['clean', 'all']
+
+    patch('for_aarch64.patch', when='target=aarch64:')
 
     def edit(self, spec, prefix):
         makefile = FileFilter('makefile')
@@ -52,6 +55,10 @@ class Molden(MakefilePackage):
 
         makefile.filter(r'CFLAGS = (.*)', r'CFLAGS = {0} \1'.format(cflags))
         makefile.filter(r'FFLAGS = (.*)', r'FFLAGS = {0} \1'.format(fflags))
+
+        if spec.target.family == 'aarch64':
+            makefile.filter(r'AFLAG=*', r'AFLAG=')
+            makefile.filter(r'rm -f src/', r'rm -f ')
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)


### PR DESCRIPTION
I made a fix to be able to install on aarch64.
In this OSS, atomsdens.o created by x86_64 exists.
You need to clean it once to build with aarch64.