### PR TITLE
minizip: fix build with Apple Clang 12

### DIFF
--- a/var/spack/repos/builtin/packages/minizip/implicit.patch
+++ b/var/spack/repos/builtin/packages/minizip/implicit.patch
@@ -1,0 +1,10 @@
+--- a/contrib/minizip/miniunz.c	2010-07-18 11:04:24.000000000 -0500
++++ b/contrib/minizip/miniunz.c	2020-12-25 21:39:19.000000000 -0600
+@@ -45,6 +45,7 @@
+ #include <time.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <sys/stat.h>
+ 
+ #ifdef _WIN32
+ # include <direct.h>

--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -22,6 +22,13 @@ class Minizip(AutotoolsPackage):
     depends_on('m4', type='build')
     depends_on('zlib')
 
+    # error: implicit declaration of function 'mkdir' is invalid in C99
+    patch('implicit.patch', when='%apple-clang@12:')
+
+    # statically link to libz.a
+    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/minizip.rb
+    patch('static.patch')
+
     # build minizip and miniunz
     @run_before('autoreconf')
     def build_minizip_binary(self):

--- a/var/spack/repos/builtin/packages/minizip/static.patch
+++ b/var/spack/repos/builtin/packages/minizip/static.patch
@@ -1,0 +1,26 @@
+--- a/contrib/minizip/Makefile.am	2012-03-26 22:17:41.000000000 -0500
++++ b/contrib/minizip/Makefile.am	2020-12-26 12:48:31.000000000 -0600
+@@ -8,7 +8,7 @@
+ zlib_top_builddir = $(top_builddir)/../..
+ 
+ AM_CPPFLAGS = -I$(zlib_top_srcdir)
+-AM_LDFLAGS = -L$(zlib_top_builddir)
++AM_LDFLAGS = $(zlib_top_builddir)/libz.a
+ 
+ if WIN32
+ iowin32_src = iowin32.c
+@@ -22,7 +22,7 @@
+ 	zip.c \
+ 	${iowin32_src}
+ 
+-libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
++libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0
+ 
+ minizip_includedir = $(includedir)/minizip
+ minizip_include_HEADERS = \
+@@ -42,4 +42,4 @@
+ miniunzip_LDADD = libminizip.la
+ 
+ minizip_SOURCES = minizip.c
+-minizip_LDADD = libminizip.la -lz
++minizip_LDADD = libminizip.la


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Apple Clang 12.0.0.

This PR adds two patches to the `minizip` package. The first fixes the build with Apple Clang 12 (not sure if any other compilers are affected). The second fixes a linking problem:

### Before
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-h6c3eij7wmgqmocsntskyjcomqmuz5np/lib/libminizip.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-h6c3eij7wmgqmocsntskyjcomqmuz5np/lib/libminizip.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-h6c3eij7wmgqmocsntskyjcomqmuz5np/lib/libminizip.1.dylib (compatibility version 2.0.0, current version 2.0.0)
	/usr/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
### After
```console
$ otool -L /Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-sqhqyin66yah7mjvczdcyzzgyjaugfsi/lib/libminizip.dylib 
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-sqhqyin66yah7mjvczdcyzzgyjaugfsi/lib/libminizip.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/minizip-1.2.11-sqhqyin66yah7mjvczdcyzzgyjaugfsi/lib/libminizip.1.dylib (compatibility version 2.0.0, current version 2.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
The linking problem was causing errors for upstream Python packages that depend on it. Instead of statically linking, we could also figure out how to correctly link to Spack's `zlib` installation. We could also consider replacing `minizip` with this fork: https://github.com/nmoinvaz/minizip. Homebrew has a `minizip2` package that uses this, but there seems to be a compatibility layer between them. Currently, `libkml` is the only package that depends on `minizip`, so we have some flexibility on this.