### PR TITLE
Fix usage of PythonPackage.test outside of PythonPackage

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -20,6 +20,7 @@ class Gdal(AutotoolsPackage):
     list_depth = 1
 
     maintainers = ['adamjstewart']
+    import_modules = ['osgeo', 'osgeo.utils']
 
     version('3.2.0',  sha256='b051f852600ffdf07e337a7f15673da23f9201a9dbb482bd513756a3e5a196a6')
     version('3.1.4',  sha256='7b82486f71c71cec61f9b237116212ce18ef6b90f068cbbf9f7de4fc50b576a8')
@@ -557,5 +558,13 @@ class Gdal(AutotoolsPackage):
             fix_darwin_install_name(self.prefix.lib)
 
     def test(self):
+        """Attempts to import modules of the installed package."""
+
         if '+python' in self.spec:
-            PythonPackage.test(self)
+            # Make sure we are importing the installed modules,
+            # not the ones in the source directory
+            for module in self.import_modules:
+                self.run_test(self.spec['python'].command.path,
+                              ['-c', 'import {0}'.format(module)],
+                              purpose='checking import of {0}'.format(module),
+                              work_dir='spack-test')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -15,6 +15,7 @@ class PyTensorflow(Package, CudaPackage):
     url      = "https://github.com/tensorflow/tensorflow/archive/v2.3.1.tar.gz"
 
     maintainers = ['adamjstewart', 'aweits']
+    import_modules = ['tensorflow']
 
     version('2.3.1',  sha256='ee534dd31a811f7a759453567257d1e643f216d8d55a25c32d2fbfff8153a1ac')
     version('2.3.0',  sha256='2595a5c401521f20a2734c4e5d54120996f8391f00bb62a57267d930bce95350')
@@ -272,9 +273,6 @@ class PyTensorflow(Package, CudaPackage):
     patch('contrib_cloud_1.1.patch', when='@1.1:1.3')
 
     phases = ['configure', 'build', 'install']
-
-    import_modules = PythonPackage.import_modules
-    test = PythonPackage.test
 
     # https://www.tensorflow.org/install/source
     def setup_build_environment(self, env):
@@ -749,3 +747,14 @@ class PyTensorflow(Package, CudaPackage):
             setup_py('install', '--prefix={0}'.format(prefix),
                      '--single-version-externally-managed', '--root=/')
         remove_linked_tree(tmp_path)
+
+    def test(self):
+        """Attempts to import modules of the installed package."""
+
+        # Make sure we are importing the installed modules,
+        # not the ones in the source directory
+        for module in self.import_modules:
+            self.run_test(self.spec['python'].command.path,
+                          ['-c', 'import {0}'.format(module)],
+                          purpose='checking import of {0}'.format(module),
+                          work_dir='spack-test')


### PR DESCRIPTION
Unfortunately, my hack to reuse the `import_modules` and `test` functions from `PythonPackage` in other packages doesn't work. This means that we need to duplicate the tests and explicitly declare `import_modules` for other build systems.

Tested that `gdal+python` now passes its tests. Previous behavior:
```
==> Testing package gdal-3.2.0-c5vyq6z
==> Error: TypeError: unbound method test() must be called with PythonPackage instance as first argument (got Gdal instance instead)

/Users/Adam/spack/var/spack/repos/builtin/packages/gdal/package.py:561, in test:
        559    def test(self):
        560        if '+python' in self.spec:
  >>    561            PythonPackage.test(self)

See test log for details:
  /Users/Adam/.spack/test/74n2cbqzyhgx3bcpmld3lkdc35jyb4vz/gdal-3.2.0-c5vyq6z-test-out.txt
```