### PR TITLE
py-sphinxcontrib-*: fix recursive imports

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-applehelp/package.py
@@ -13,6 +13,10 @@ class PySphinxcontribApplehelp(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-1.0.1.tar.gz"
 
+    # Sphinx requires sphinxcontrib-applehelp at build-time, but
+    # sphinxcontrib-applehelp requires sphinx at run-time
+    import_modules = []
+
     version('1.0.1', sha256='edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897')
 
     depends_on('python@3.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-devhelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-devhelp/package.py
@@ -13,6 +13,10 @@ class PySphinxcontribDevhelp(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-devhelp/sphinxcontrib-devhelp-1.0.1.tar.gz"
 
+    # Sphinx requires sphinxcontrib-devhelp at build-time, but
+    # sphinxcontrib-devhelp requires sphinx at run-time
+    import_modules = []
+
     version('1.0.1', sha256='6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34')
 
     depends_on('python@3.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
@@ -13,6 +13,10 @@ class PySphinxcontribHtmlhelp(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-1.0.2.tar.gz"
 
+    # Sphinx requires sphinxcontrib-htmlhelp at build-time, but
+    # sphinxcontrib-htmlhelp requires sphinx at run-time
+    import_modules = []
+
     version('1.0.2', sha256='4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422')
 
     depends_on('python@3.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-jsmath/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-jsmath/package.py
@@ -12,6 +12,10 @@ class PySphinxcontribJsmath(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-jsmath/sphinxcontrib-jsmath-1.0.1.tar.gz"
 
+    # Sphinx requires sphinxcontrib-jsmath at build-time, but
+    # sphinxcontrib-jsmath requires sphinx at run-time
+    import_modules = []
+
     version('1.0.1', sha256='a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8')
 
     depends_on('python@3.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-qthelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-qthelp/package.py
@@ -13,6 +13,10 @@ class PySphinxcontribQthelp(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-1.0.2.tar.gz"
 
+    # Sphinx requires sphinxcontrib-qthelp at build-time, but
+    # sphinxcontrib-qthelp requires sphinx at run-time
+    import_modules = []
+
     version('1.0.2', sha256='79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f')
 
     depends_on('python@3.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-serializinghtml/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-serializinghtml/package.py
@@ -13,6 +13,10 @@ class PySphinxcontribSerializinghtml(PythonPackage):
     homepage = "http://sphinx-doc.org/"
     url      = "https://pypi.io/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-1.1.3.tar.gz"
 
+    # Sphinx requires sphinxcontrib-serializinghtml at build-time, but
+    # sphinxcontrib-serializinghtml requires sphinx at run-time
+    import_modules = []
+
     version('1.1.3', sha256='c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227')
 
     depends_on('python@3.5:', type=('build', 'run'))


### PR DESCRIPTION
Sphinx extensions can be installed without Sphinx, but can't be used without Sphinx. Since Sphinx depends on many of these extensions, we can't add a circular dependency on them. This PR skips the import tests for these packages.