### PR TITLE
py-fiona: add v1.8.18 and master

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiona/package.py
+++ b/var/spack/repos/builtin/packages/py-fiona/package.py
@@ -7,23 +7,28 @@ from spack import *
 
 
 class PyFiona(PythonPackage):
-    """Alternative Python binding for OGR"""
+    """Fiona reads and writes spatial data files."""
 
-    homepage = "http://toblerity.org/fiona/"
-    url      = "https://pypi.io/packages/source/F/Fiona/Fiona-1.8.6.tar.gz"
+    homepage = "https://github.com/Toblerity/Fiona"
+    url      = "https://pypi.io/packages/source/F/Fiona/Fiona-1.8.18.tar.gz"
+    git      = "https://github.com/Toblerity/Fiona.git"
 
     maintainers = ['adamjstewart']
 
+    version('master', branch='master')
+    version('1.8.18', sha256='b732ece0ff8886a29c439723a3e1fc382718804bb057519d537a81308854967a')
     version('1.8.6',  sha256='fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e')
     version('1.7.12', sha256='8b54eb8422d7c502bb7776b184018186bede1a489cf438a7a47f992ade6a0e51')
 
-    depends_on('python@3:', type=('build', 'run'), when='@1.9:')
+    depends_on('python@3.6:', type=('build', 'run'), when='@1.9:')
     depends_on('python@2.6:', type=('build', 'run'))
+    depends_on('gdal@1.11:', type=('build', 'run'), when='@1.9:')
     depends_on('gdal@1.8:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython', type='build')
+    depends_on('py-cython', type='build', when='@master')
     depends_on('py-attrs@17:', type=('build', 'run'))
+    depends_on('py-certifi', type=('build', 'run'), when='@1.8.18')
     depends_on('py-click@4:7', type=('build', 'run'))
     depends_on('py-cligj@0.5:', type=('build', 'run'))
     depends_on('py-click-plugins@1:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.