### PR TITLE
Add missing setuptools dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-bleach/package.py
+++ b/var/spack/repos/builtin/packages/py-bleach/package.py
@@ -16,6 +16,6 @@ class PyBleach(PythonPackage):
     version('1.5.0', sha256='978e758599b54cd3caa2e160d74102879b230ea8dc93871d0783721eef58bc65')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-six@1.9.0:', type=('build', 'run'))
     depends_on('py-webencodings', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-joblib/package.py
+++ b/var/spack/repos/builtin/packages/py-joblib/package.py
@@ -24,4 +24,4 @@ class PyJoblib(PythonPackage):
     version('0.10.2', sha256='3123553bdad83b143428033537c9e1939caf4a4d8813dade6a2246948c94494b')
     version('0.10.0', sha256='49b3a0ba956eaa2f077e1ebd230b3c8d7b98afc67520207ada20a4d8b8efd071')
 
-    depends_on('py-setuptools', when='@0.14:', type='build')
+    depends_on('py-setuptools', when='@0.14:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pytest-runner/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-runner/package.py
@@ -15,5 +15,5 @@ class PyPytestRunner(PythonPackage):
     version('5.1',    sha256='25a013c8d84f0ca60bb01bd11913a3bcab420f601f0f236de4423074af656e7a')
     version('2.11.1', sha256='983a31eab45e375240e250161a556163bc8d250edaba97960909338c273a89b3')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-setuptools-scm@1.15:', type='build')

--- a/var/spack/repos/builtin/packages/py-snuggs/package.py
+++ b/var/spack/repos/builtin/packages/py-snuggs/package.py
@@ -14,6 +14,7 @@ class PySnuggs(PythonPackage):
 
     version('1.4.1', sha256='b37ed4e11c5f372695dc6fe66fce6cede124c90a920fe4726c970c9293b71233')
 
+    depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-click', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))


### PR DESCRIPTION
These missing dependencies were discovered by `spack test run`. All packages now install and pass their import tests.