### PR TITLE
py-regex: add v2020.11.13

### DIFF
--- a/var/spack/repos/builtin/packages/py-regex/package.py
+++ b/var/spack/repos/builtin/packages/py-regex/package.py
@@ -10,9 +10,10 @@ class PyRegex(PythonPackage):
     """Alternative regular expression module, to replace re."""
 
     homepage = "https://pypi.python.org/pypi/regex/"
-    url      = "https://pypi.io/packages/source/r/regex/regex-2017.07.11.tar.gz"
+    url      = "https://pypi.io/packages/source/r/regex/regex-2020.11.13.tar.gz"
 
-    version('2019.11.1', sha256='720e34a539a76a1fedcebe4397290604cc2bdf6f81eca44adb9fb2ea071c0c69')
+    version('2020.11.13', sha256='83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562')
+    version('2019.11.1',  sha256='720e34a539a76a1fedcebe4397290604cc2bdf6f81eca44adb9fb2ea071c0c69')
     version('2017.07.11', sha256='dbda8bdc31a1c85445f1a1b29d04abda46e5c690f8f933a9cc3a85a358969616')
 
-    depends_on('py-setuptools', type='build', when='@2017.07.11')
+    depends_on('py-setuptools', type='build', when='@:2018,2020:')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.