### PR TITLE
py-pathspec: add v0.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pathspec/package.py
+++ b/var/spack/repos/builtin/packages/py-pathspec/package.py
@@ -11,8 +11,10 @@ class PyPathspec(PythonPackage):
     making it easier to write, find and run tests."""
 
     homepage = "https://pypi.python.org/pypi/pathspec"
-    url      = "https://pypi.io/packages/source/p/pathspec/pathspec-0.3.4.tar.gz"
+    url      = "https://pypi.io/packages/source/p/pathspec/pathspec-0.8.1.tar.gz"
 
+    version('0.8.1', sha256='86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd')
     version('0.3.4', sha256='7605ca5c26f554766afe1d177164a2275a85bb803b76eba3428f422972f66728')
 
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.