### PR TITLE
py-black: add v20.8b1

### DIFF
--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -13,8 +13,9 @@ class PyBlack(PythonPackage):
     """
 
     homepage = "https://github.com/psf/black"
-    url      = "https://pypi.io/packages/source/b/black/black-18.9b0.tar.gz"
+    url      = "https://pypi.io/packages/source/b/black/black-20.8b1.tar.gz"
 
+    version('20.8b1', sha256='1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea')
     version('19.3b0', sha256='68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c')
     version('18.9b0', sha256='e030a9a28f542debc08acceb273f228ac422798e5215ba2a791a6ddeaaca22a5')
 
@@ -26,10 +27,18 @@ class PyBlack(PythonPackage):
     depends_on('py-setuptools', type=('build', 'run'))
     # Translated from black's setup.py:
     # https://github.com/ambv/black/blob/master/setup.py
-    depends_on('py-attrs@18.1.0:', type=('build', 'run'))
     depends_on('py-click@6.5:', type=('build', 'run'))
+    depends_on('py-click@7.1.2:', when='@20.8b1:', type=('build', 'run'))
+    depends_on('py-attrs@18.1.0:', when='@:20.8b0', type=('build', 'run'))
     depends_on('py-appdirs', type=('build', 'run'))
     depends_on('py-toml@0.9.4:', type=('build', 'run'))
+    depends_on('py-toml@0.10.1:', when='@20.8b1:', type=('build', 'run'))
+    depends_on('py-typed-ast@1.4.0:', when='@19.10b0:', type=('build', 'run'))
+    depends_on('py-regex@2020.1.8:', when='@20.8b0:', type=('build', 'run'))
+    depends_on('py-pathspec@0.6:0.999', when='@19.10b0:', type=('build', 'run'))
+    depends_on('py-dataclasses@0.6:', when='@20.8b0:^python@:3.6', type=('build', 'run'))
+    depends_on('py-typing-extensions@3.7.4:', when='@20.8b0:', type=('build', 'run'))
+    depends_on('py-mypy-extensions@0.4.3:', when='@20.8b0:', type=('build', 'run'))
     depends_on('py-aiohttp@3.3.2:', when='+d', type=('build', 'run'))
     depends_on('py-aiohttp-cors', when='+d', type=('build', 'run'))
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.

Depends on #20562, #20563, #20564