### PR TITLE
zoltan: improved installation of Zoltan with parmetis and int64

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -39,6 +39,7 @@ class Zoltan(AutotoolsPackage):
 
     depends_on('mpi', when='+mpi')
 
+    depends_on('parmetis@4: +int64', when='+parmetis+int64')
     depends_on('parmetis@4:', when='+parmetis')
     depends_on('metis+int64', when='+parmetis+int64')
     depends_on('metis', when='+parmetis')


### PR DESCRIPTION
fixed #20545
* Imposed int64 constrain on parmetis when a Zoltan spec is
constrained with both parmetis and int64