### PR TITLE
libmonitor: add version 2020.10.15

### DIFF
--- a/var/spack/repos/builtin/packages/libmonitor/package.py
+++ b/var/spack/repos/builtin/packages/libmonitor/package.py
@@ -16,6 +16,7 @@ class Libmonitor(AutotoolsPackage):
     maintainers = ['mwkrentel']
 
     version('master', branch='master')
+    version('2020.10.15', commit='36e5cb7ebeadfff01476b79ff04f6ec772ba831d')
     version('2019.05.31', commit='c9767087d52e58a719aa7f149136b101e499db44')
     version('2018.07.18', commit='d28cc1d3c08c02013a68a022a57a6ac73db88166')
     version('2013.02.18', commit='4f2311e413fd90583263d6f20453bbe552ccfef3')
@@ -27,6 +28,9 @@ class Libmonitor(AutotoolsPackage):
     # Configure for Krell and OpenSpeedshop.
     variant('krellpatch', default=False,
             description="Build with openspeedshop based patch.")
+
+    variant('dlopen', default=True,
+            description='Override dlopen and dlclose')
 
     patch('libmonitorkrell-0000.patch', when='@2013.02.18+krellpatch')
     patch('libmonitorkrell-0001.patch', when='@2013.02.18+krellpatch')
@@ -54,5 +58,10 @@ class Libmonitor(AutotoolsPackage):
 
         if '+hpctoolkit' in self.spec:
             args.append('--enable-client-signals=%s' % self.signals)
+
+        if '+dlopen' in self.spec:
+            args.append('--enable-dlfcn')
+        else:
+            args.append('--disable-dlfcn')
 
         return args


### PR DESCRIPTION
Add version 2020.10.15, and add variant +dlopen to control overriding
dlopen and dlclose.