### PR TITLE
Fix installation error of automake@1.16.3 #20454

### DIFF
--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -38,9 +38,14 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
         files_to_be_patched_fmt = 'bin/{0}.in'
         if '@:1.15.1' in self.spec:
             files_to_be_patched_fmt = 't/wrap/{0}.in'
+        
+        if '@1.16.3' in self.spec:
+            shebang_string = '^#!@PERL@'
+        else:
+            shebang_string = '^#!@PERL@ -w'
 
         for file in ('aclocal', 'automake'):
-            filter_file('^#!@PERL@ -w',
+            filter_file(shebang_string,
                         '#!/usr/bin/env perl',
                         files_to_be_patched_fmt.format(file))
 

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -38,7 +38,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
         files_to_be_patched_fmt = 'bin/{0}.in'
         if '@:1.15.1' in self.spec:
             files_to_be_patched_fmt = 't/wrap/{0}.in'
-        
+
         if '@1.16.3' in self.spec:
             shebang_string = '^#!@PERL@'
         else:

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -39,7 +39,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
         if '@:1.15.1' in self.spec:
             files_to_be_patched_fmt = 't/wrap/{0}.in'
 
-        if '@1.16.3' in self.spec:
+        if '@1.16.3:' in self.spec:
             shebang_string = '^#!@PERL@'
         else:
             shebang_string = '^#!@PERL@ -w'


### PR DESCRIPTION
fixes #20454

In the version 1.16.3 of automake, the shebang is changed to `#!@PERL@` by deleting the option `-w`. This results in the patch function failure. 