### PR TITLE
Update NEURON simulator package : new versions and cmake build system

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -20,16 +20,10 @@ class Neuron(CMakePackage):
     git      = "https://github.com/neuronsimulator/nrn"
     maintainers = ['pramodk', 'nrnhines', 'iomaganaris', 'alexsavulescu']
 
-    version('develop', branch='master')
-    version("7.8.2", tag="7.8.2")
-    version('7.7', sha256='85a0f999a9cdcc661b0066c32a78239e252f26e74eee5328bf1106393400bfc0')
-    version('7.6', sha256='5a6133bfa818ec3278fc8d0ecd312674805ae42854f71552f8cd47d98ff6ad2d')
-    version('7.5', sha256='67642216a969fdc844da1bd56643edeed5e9f9ab8c2a3049dcbcbcccba29c336')
-    version('7.4', sha256='1403ba16b2b329d2376f4bf007d96e6bf2992fa850f137f1068ad5b22b432de6')
-    version('7.3', sha256='71cff5962966c5cd5d685d90569598a17b4b579d342126b31e2d431128cc8832')
-    version('7.2', sha256='c777d73a58ff17a073e8ea25f140cb603b8b5f0df3c361388af7175e44d85b0e')
+    version('develop', branch='master', submodules='True')
+    version("7.8.2", tag="7.8.2", submodules='True')
+    version("7.8.1", tag="7.8.1", submodules='True')
 
-    variant("cmake",         default=True, description="Build using cmake build system")
     variant("coreneuron",    default=False, description="Enable CoreNEURON as submodule")
     variant("cross-compile", default=False, description="Build for cross-compile environment")
     variant("interviews",    default=False, description="Enable GUI with INTERVIEWS")
@@ -39,12 +33,8 @@ class Neuron(CMakePackage):
     variant("rx3d",          default=False,  description="Enable cython translated 3-d rxd")
     variant("tests",         default=False, description="Enable unit tests")
 
-    depends_on("autoconf",  type="build", when="~cmake")
-    depends_on("automake",  type="build", when="~cmake")
-    depends_on("bison",     type="build", when="+cmake")
-    depends_on("flex",      type="build", when="+cmake")
-    depends_on("libtool",   type="build", when="~cmake")
-    depends_on("pkgconfig", type="build", when="~cmake")
+    depends_on("bison",     type="build")
+    depends_on("flex",      type="build")
     depends_on("py-cython", when="+rx3d", type="build")
 
     depends_on("gettext")
@@ -54,19 +44,10 @@ class Neuron(CMakePackage):
     depends_on("py-pytest",   when="+python+tests")
     depends_on("readline")
 
-    conflicts("+cmake",       when="@0:7.8.0")
-    conflicts("+coreneuron",  when="~cmake")
-    conflicts("+coreneuron",  when="@:7.99")
-    conflicts("+interviews",  when="~cmake")
     conflicts("+rx3d",        when="~python")
 
-    patch("patch-v782-git-cmake.patch", when="@7.8.2+cmake")
+    patch("patch-v782-git-cmake.patch", when="@7.8.2")
 
-    # ==============================================
-    # ==== CMake build system related functions ====
-    # ==============================================
-
-    @when("+cmake")
     def cmake_args(self):
         spec = self.spec
 
@@ -84,9 +65,6 @@ class Neuron(CMakePackage):
                                                        "+tests"]]
         args.append("-DNRN_ENABLE_BINARY_SPECIAL=ON")
 
-        if "+mpi" in spec:
-            args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
-
         if "~mpi" in spec and '+coreneuron' in spec:
             args.append("-DCORENRN_ENABLE_MPI=OFF")
 
@@ -103,147 +81,6 @@ class Neuron(CMakePackage):
             args.append('-DNRN_DYNAMIC_UNITS_USE_LEGACY=ON')
 
         return args
-
-    # ==============================================
-    # == Autotools build system related functions ==
-    # ==============================================
-
-    # overload cmake phase for legacy Autotools build
-    @when("~cmake")
-    def cmake(self, spec, prefix):
-        return
-
-    # build nmodl separately (in cross compiling environment)
-    def build_nmodl(self, spec, prefix):
-        options = ["--prefix=%s" % prefix, "--with-nmodl-only", "--without-x"]
-        if "cray" in spec.architecture:
-            flags = "-target-cpu=x86_64 -target-network=none"
-            options.extend(["CFLAGS=%s" % flags, "CXXFLAGS=%s" % flags])
-
-        configure = Executable(join_path(self.stage.source_path, "configure"))
-        configure(*options)
-        make()
-        make("install")
-
-    @when("~cmake")
-    def build(self, spec, prefix):
-        # default options
-        options = ["--prefix=%s" % prefix,
-                   "--without-iv",
-                   "--without-x"]
-
-        # build options based on variants
-        specs_to_options = {
-            "+cross-compile": [
-                "cross_compiling=yes",
-                "--without-readline",
-                "--without-memacs",
-                "--without-nmodl",
-            ],
-            "~python": ["--without-nrnpython"],
-            "~readline": ["-with-readline=no"],
-            "~rx3d": ["--disable-rx3d"],
-            "~mpi": ["--without-paranrn"],
-            "+mpi": ["--with-paranrn=dynamic"],
-        }
-
-        for specname, spec_opts in specs_to_options.items():
-            if spec.satisfies(specname):
-                options.extend(spec_opts)
-
-        if "darwin" in spec.architecture:
-            options.append("macdarwin=no")
-
-        # python build options
-        if spec.satisfies("+python"):
-            python_exec = spec["python"].command.path
-            py_inc = spec["python"].headers.directories[0]
-            py_lib = spec["python"].prefix.lib
-
-            if not os.path.isdir(py_lib):
-                py_lib = spec["python"].prefix.lib64
-
-            options.append("--with-nrnpython=%s" % python_exec)
-            options.append("PYINCDIR=%s" % py_inc)
-            options.append("PYLIBDIR=%s" % py_lib)
-
-            # use python dependency if not cross-compiling or on cray system
-            if spec.satisfies("~cross-compile") or "cray" in spec.architecture:
-                options.append("PYTHON_BLD=%s" % python_exec)
-
-        if spec.variants['build_type'].value == 'Debug':
-            flags = "-O0 -g"
-        else:
-            flags = "-O2 -g"
-
-        if spec.satisfies("%pgi"):
-            flags += " " + self.compiler.pic_flag
-
-        options.extend(["CFLAGS=%s" % flags, "CXXFLAGS=%s" % flags])
-
-        if spec.satisfies("+mpi"):
-            options.append("MPICC=%s" % spec["mpi"].mpicc)
-            options.append("MPICXX=%s" % spec["mpi"].mpicxx)
-
-        ld_flags = "LDFLAGS="
-
-        if "readline" in spec:
-            options.append("--with-readline=" + spec["readline"].prefix)
-            ld_flags += " -L{0.prefix.lib} -Wl,-rpath,{0.prefix.lib}".format(
-                spec["readline"]
-            )
-
-        if "ncurses" in spec:
-            options.extend([
-                "CURSES_LIBS={0.ld_flags} -Wl,-rpath,{1}".format(
-                    spec["ncurses"].libs, spec["ncurses"].prefix.lib),
-                "CURSES_CFLAGS={0}".format(spec["ncurses"].prefix.include),
-            ])
-            ld_flags += " {0.libs.ld_flags} -Wl,-rpath,{0.prefix.lib}".format(
-                spec["ncurses"]
-            )
-
-        if spec.satisfies("+mpi"):
-            ld_flags += " -Wl,-rpath," + spec["mpi"].prefix.lib
-
-        options.append(ld_flags)
-
-        build = Executable("./build.sh")
-        build()
-
-        with working_dir("build", create=True):
-            if spec.satisfies("+cross-compile"):
-                self.build_nmodl(spec, prefix)
-            srcpath = self.stage.source_path
-            configure = Executable(join_path(srcpath, "configure"))
-            configure(*options)
-            make()
-
-    @when("~cmake")
-    def install(self, spec, prefix):
-        with working_dir("build"):
-            make("install")
-
-    # ==============================================
-    # ============== Common functions ==============
-    # ==============================================
-
-    @property
-    def basedir(self):
-        """Determine the neuron base directory.
-        NEURON base directory is based on the build system. For
-        cmake the bin and lib folders are in self.prefix and for
-        autotools it is in self.prefix/<arch>.
-        """
-        neuron_basedir = self.prefix
-        if self.spec.satisfies("~cmake"):
-            file_list = find(self.prefix, "*/bin/nrniv_makefile")
-            # check needed as during first evaluation the prefix is empty
-            if file_list:
-                arch_dir = os.path.dirname(file_list[0])
-                neuron_basedir = os.path.dirname(arch_dir)
-
-        return neuron_basedir
 
     @run_after("install")
     def filter_compilers(self):
@@ -264,11 +101,9 @@ class Neuron(CMakePackage):
 
         kwargs = {"backup": False, "string": True}
         nrnmech_makefile = join_path(self.prefix,
-                                     self.basedir,
                                      "./bin/nrnmech_makefile")
 
-        # nrnmech_makefile exists in cmake and autotools
-        assign_operator = "?=" if spec.satisfies("+cmake") else "="
+        assign_operator = "?="
         filter_file("CC {0} {1}".format(assign_operator, env["CC"]),
                     "CC = {0}".format(cc_compiler),
                     nrnmech_makefile,
@@ -278,23 +113,13 @@ class Neuron(CMakePackage):
                     nrnmech_makefile,
                     **kwargs)
 
-        if spec.satisfies("~cmake"):
-            nrniv_makefile = join_path(self.prefix,
-                                       self.basedir,
-                                       "./bin/nrniv_makefile")
-            libtool_makefile = join_path(self.prefix, "share/nrn/libtool")
-            filter_file(env["CC"], cc_compiler, nrniv_makefile, **kwargs)
-            filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
-            filter_file(env["CC"], cc_compiler, libtool_makefile, **kwargs)
-            filter_file(env["CXX"], cxx_compiler, libtool_makefile, **kwargs)
-
         if spec.satisfies("+coreneuron"):
             corenrn_makefile = join_path(self.prefix,
                                          "share/coreneuron/nrnivmodl_core_makefile")
             filter_file(env["CXX"], cxx_compiler, corenrn_makefile, **kwargs)
 
     def setup_run_environment(self, env):
-        env.prepend_path("PATH", join_path(self.basedir, "bin"))
-        env.prepend_path("LD_LIBRARY_PATH", join_path(self.basedir, "lib"))
+        env.prepend_path("PATH", join_path(self.prefix, "bin"))
+        env.prepend_path("LD_LIBRARY_PATH", join_path(self.prefix, "lib"))
         if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -7,181 +7,296 @@ import os
 from spack import *
 
 
-class Neuron(Package):
+class Neuron(CMakePackage):
     """NEURON is a simulation environment for single and networks of neurons.
-
     NEURON is a simulation environment for modeling individual and networks of
     neurons. NEURON models individual neurons via the use of sections that are
     automatically subdivided into individual compartments, instead of
-    requiring the user to manually create compartments. The primary scripting
-    language is hoc but a Python interface is also available.
+    requiring the user to manually create compartments.
     """
 
     homepage = "https://www.neuron.yale.edu/"
-    url      = "http://www.neuron.yale.edu/ftp/neuron/versions/v7.5/nrn-7.5.tar.gz"
-    git      = "https://github.com/nrnhines/nrn.git"
+    url      = "https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.tar.gz"
+    git      = "https://github.com/neuronsimulator/nrn"
+    maintainers = ['pramodk', 'nrnhines', 'iomaganaris', 'alexsavulescu']
 
     version('develop', branch='master')
+    version("7.8.2", tag="7.8.2")
+    version('7.7', sha256='85a0f999a9cdcc661b0066c32a78239e252f26e74eee5328bf1106393400bfc0')
+    version('7.6', sha256='5a6133bfa818ec3278fc8d0ecd312674805ae42854f71552f8cd47d98ff6ad2d')
     version('7.5', sha256='67642216a969fdc844da1bd56643edeed5e9f9ab8c2a3049dcbcbcccba29c336')
     version('7.4', sha256='1403ba16b2b329d2376f4bf007d96e6bf2992fa850f137f1068ad5b22b432de6')
     version('7.3', sha256='71cff5962966c5cd5d685d90569598a17b4b579d342126b31e2d431128cc8832')
     version('7.2', sha256='c777d73a58ff17a073e8ea25f140cb603b8b5f0df3c361388af7175e44d85b0e')
 
-    variant('mpi',           default=True,  description='Enable MPI parallelism')
-    variant('python',        default=True,  description='Enable python')
-    variant('shared',        default=False, description='Build shared libraries')
-    variant('cross-compile', default=False, description='Build for cross-compile environment')
-    variant('multisend',     default=True,  description="Enable multi-send spike exchange")
-    variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
+    variant("cmake",         default=True, description="Build using cmake build system")
+    variant("coreneuron",    default=False, description="Enable CoreNEURON as submodule")
+    variant("cross-compile", default=False, description="Build for cross-compile environment")
+    variant("interviews",    default=False, description="Enable GUI with INTERVIEWS")
+    variant("legacy-unit",   default=False, description="Enable legacy units")
+    variant("gpu",           default=False, description="Enable GPU support via CoreNEURON")
+    variant("mpi",           default=True,  description="Enable MPI parallelism")
+    variant("python",        default=True,  description="Enable python")
+    variant("rx3d",          default=False,  description="Enable cython translated 3-d rxd")
+    variant("tests",         default=False, description="Enable unit tests")
 
-    depends_on('flex',       type='build')
-    depends_on('bison',      type='build')
-    depends_on('automake',   type='build')
-    depends_on('automake',   type='build')
-    depends_on('autoconf',   type='build')
-    depends_on('libtool',    type='build')
-    depends_on('pkgconfig',  type='build')
+    depends_on("autoconf",  type="build", when="~cmake")
+    depends_on("automake",  type="build", when="~cmake")
+    depends_on("bison",     type="build", when="+cmake")
+    depends_on("flex",      type="build", when="+cmake")
+    depends_on("libtool",   type="build", when="~cmake")
+    depends_on("pkgconfig", type="build", when="~cmake")
+    depends_on("py-cython", when="+rx3d", type="build")
 
-    depends_on('mpi',         when='+mpi')
-    depends_on('python@2.6:', when='+python')
-    depends_on('ncurses',     when='~cross-compile')
+    depends_on("cuda@8:",     when="+gpu")
+    depends_on("gettext")
+    depends_on("mpi",         when="+mpi")
+    depends_on("ncurses")
+    depends_on("python@2.7:", when="+python")
+    depends_on("py-pytest",   when="+python+tests")
+    depends_on("readline")
 
-    conflicts('~shared', when='+python')
+    conflicts("+cmake",       when="@0:7.8.0")
+    conflicts("+coreneuron",  when="~cmake")
+    conflicts("+gpu",         when="@:7.99")
+    conflicts("+gpu",         when="~coreneuron")
+    conflicts("+interviews",  when="~cmake")
+    conflicts("+rx3d",        when="~python")
 
-    filter_compiler_wrappers('*/bin/nrniv_makefile')
+    patch("patch-v782-git-cmake.patch", when="@7.8.2+cmake")
 
-    def get_neuron_archdir(self):
-        """Determine the architecture-specific neuron base directory.
+    # ==============================================
+    # ==== CMake build system related functions ====
+    # ==============================================
 
-        Instead of recreating the logic of the neuron's configure
-        we dynamically find the architecture-specific directory by
-        looking for a specific binary.
-        """
-        file_list = find(self.prefix, '*/bin/nrniv_makefile')
-        # check needed as when initially evaluated the prefix is empty
-        if file_list:
-            neuron_archdir = os.path.dirname(os.path.dirname(file_list[0]))
-        else:
-            neuron_archdir = self.prefix
+    @when("+cmake")
+    def cmake_args(self):
+        spec = self.spec
+        def cmake_enable_option(spec_options):
+            value = "TRUE" if spec_options in spec else "FALSE"
+            cmake_name = spec_options[1:].upper().replace("-", "_")
+            return "-DNRN_ENABLE_" + cmake_name + ":BOOL=" + value
 
-        return neuron_archdir
+        args = [cmake_enable_option(variant) for variant in ["+coreneuron",
+                                                             "+interviews",
+                                                             "+mpi",
+                                                             "+python",
+                                                             "+rx3d",
+                                                             "+coreneuron",
+                                                             "+tests"]]
+        args.append("-DNRN_ENABLE_BINARY_SPECIAL=ON")
 
-    def patch(self):
-        # aclocal need complete include path (especially on os x)
-        pkgconf_inc = '-I %s/share/aclocal/' % (self.spec['pkgconfig'].prefix)
-        libtool_inc = '-I %s/share/aclocal/' % (self.spec['libtool'].prefix)
-        newpath = 'aclocal -I m4 %s %s' % (pkgconf_inc, libtool_inc)
-        filter_file(r'aclocal -I m4', r'%s' % newpath, "build.sh")
+        if "+gpu" in spec:
+            args.append("-DCORENRN_ENABLE_GPU=ON")
 
-    def get_arch_options(self, spec):
-        options = []
+        if "+mpi" in spec:
+            args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
 
-        if spec.satisfies('+cross-compile'):
-            options.extend(['cross_compiling=yes',
-                            '--without-memacs',
-                            '--without-nmodl'])
+        if "+python" in spec:
+            args.append("-DPYTHON_EXECUTABLE:FILEPATH="
+                        + spec["python"].command.path)
 
-        # on os-x disable building carbon 'click' utility
-        if 'darwin' in self.spec.architecture:
-            options.append('macdarwin=no')
+        if spec.variants['build_type'].value == 'Debug':
+            args.append("-DCMAKE_C_FLAGS=-g -O0")
+            args.append("-DCMAKE_CXX_FLAGS=-g -O0")
+            args.append("-DCMAKE_BUILD_TYPE=Custom")
 
-        return options
+        if "+legacy-unit" in spec:
+            args.append('-DNRN_DYNAMIC_UNITS_USE_LEGACY=ON')
 
-    def get_python_options(self, spec):
-        options = []
+        return args
 
-        if spec.satisfies('+python'):
-            python_exec = spec['python'].command.path
-            py_inc = spec['python'].headers.directories[0]
-            py_lib = spec['python'].prefix.lib
 
-            if not os.path.isdir(py_lib):
-                py_lib = spec['python'].prefix.lib64
+    # ==============================================
+    # == Autotools build system related functions ==
+    # ==============================================
 
-            options.extend(['--with-nrnpython=%s' % python_exec,
-                            '--disable-pysetup',
-                            'PYINCDIR=%s' % py_inc,
-                            'PYLIBDIR=%s' % py_lib])
+    # overload cmake phase for legacy Autotools build
+    @when("~cmake")
+    def cmake(self, spec, prefix):
+        return
 
-            if spec.satisfies('~cross-compile'):
-                options.append('PYTHON_BLD=%s' % python_exec)
-
-        else:
-            options.append('--without-nrnpython')
-
-        return options
-
-    def get_compiler_options(self, spec):
-        flags = '-O2 -g'
-
-        if self.spec.satisfies('%pgi'):
-            flags += ' ' + self.compiler.cc_pic_flag
-
-        return ['CFLAGS=%s' % flags,
-                'CXXFLAGS=%s' % flags]
-
+    # build nmodl separately (in cross compiling environment)
     def build_nmodl(self, spec, prefix):
-        # build components for front-end arch in cross compiling environment
-        options = ['--prefix=%s' % prefix,
-                   '--with-nmodl-only',
-                   '--without-x']
+        options = ["--prefix=%s" % prefix, "--with-nmodl-only", "--without-x"]
+        if "cray" in spec.architecture:
+            flags = "-target-cpu=x86_64 -target-network=none"
+            options.extend(["CFLAGS=%s" % flags, "CXXFLAGS=%s" % flags])
 
-        if 'cray' in self.spec.architecture:
-            flags = '-target-cpu=x86_64 -target-network=none'
-            options.extend(['CFLAGS=%s' % flags,
-                            'CXXFLAGS=%s' % flags])
-
-        configure = Executable(join_path(self.stage.source_path, 'configure'))
+        configure = Executable(join_path(self.stage.source_path, "configure"))
         configure(*options)
         make()
-        make('install')
+        make("install")
 
-    def install(self, spec, prefix):
+    @when("~cmake")
+    def build(self, spec, prefix):
+        # default options
+        options = ["--prefix=%s" % prefix,
+                   "--without-iv",
+                   "--without-x"]
 
-        options = ['--prefix=%s' % prefix,
-                   '--without-iv',
-                   '--without-x',
-                   '--without-readline']
+        # build options based on variants
+        specs_to_options = {
+            "+cross-compile": [
+                "cross_compiling=yes",
+                "--without-readline",
+                "--without-memacs",
+                "--without-nmodl",
+            ],
+            "~python": ["--without-nrnpython"],
+            "~readline": ["-with-readline=no"],
+            "~rx3d": ["--disable-rx3d"],
+            "~mpi": ["--without-paranrn"],
+            "+mpi": ["--with-paranrn=dynamic"],
+        }
 
-        if spec.satisfies('+multisend'):
-            options.append('--with-multisend')
+        for specname, spec_opts in specs_to_options.items():
+            if spec.satisfies(specname):
+                options.extend(spec_opts)
 
-        if spec.satisfies('~rx3d'):
-            options.append('--disable-rx3d')
+        if "darwin" in spec.architecture:
+            options.append("macdarwin=no")
 
-        if spec.satisfies('+mpi'):
-            options.extend(['MPICC=%s' % spec['mpi'].mpicc,
-                            'MPICXX=%s' % spec['mpi'].mpicxx,
-                            '--with-paranrn'])
+        # python build options
+        if spec.satisfies("+python"):
+            python_exec = spec["python"].command.path
+            py_inc = spec["python"].headers.directories[0]
+            py_lib = spec["python"].prefix.lib
+
+            if not os.path.isdir(py_lib):
+                py_lib = spec["python"].prefix.lib64
+
+            options.append("--with-nrnpython=%s" % python_exec)
+            options.append("PYINCDIR=%s" % py_inc)
+            options.append("PYLIBDIR=%s" % py_lib)
+
+            # use python dependency if not cross-compiling or on cray system
+            if spec.satisfies("~cross-compile") or "cray" in spec.architecture:
+                options.append("PYTHON_BLD=%s" % python_exec)
+
+        if spec.variants['build_type'].value == 'Debug':
+            flags = "-O0 -g"
         else:
-            options.append('--without-paranrn')
+            flags = "-O2 -g"
 
-        if spec.satisfies('~shared'):
-            options.extend(['--disable-shared',
-                            'linux_nrnmech=no'])
+        if spec.satisfies("%pgi"):
+            flags += " " + self.compiler.pic_flag
 
-        options.extend(self.get_arch_options(spec))
-        options.extend(self.get_python_options(spec))
-        options.extend(self.get_compiler_options(spec))
+        options.extend(["CFLAGS=%s" % flags, "CXXFLAGS=%s" % flags])
 
-        build = Executable('./build.sh')
+        if spec.satisfies("+mpi"):
+            options.append("MPICC=%s" % spec["mpi"].mpicc)
+            options.append("MPICXX=%s" % spec["mpi"].mpicxx)
+
+
+        ld_flags = "LDFLAGS="
+
+        if "readline" in spec:
+            options.append("--with-readline=" + spec["readline"].prefix)
+            ld_flags += " -L{0.prefix.lib} -Wl,-rpath,{0.prefix.lib}".format(
+                spec["readline"]
+            )
+
+        if "ncurses" in spec:
+            options.extend(
+                [
+                    "CURSES_LIBS={0.libs.ld_flags} -Wl,-rpath,{0.prefix.lib}".format(
+                        spec["ncurses"]
+                    ),
+                    "CURSES_CFLAGS={0}".format(spec["ncurses"].prefix.include),
+                ]
+            )
+            ld_flags += " {0.libs.ld_flags} -Wl,-rpath,{0.prefix.lib}".format(
+                spec["ncurses"]
+            )
+
+        if spec.satisfies("+mpi"):
+            ld_flags += " -Wl,-rpath," + spec["mpi"].prefix.lib
+
+        options.append(ld_flags)
+
+        build = Executable("./build.sh")
         build()
 
-        with working_dir('build', create=True):
-            if spec.satisfies('+cross-compile'):
+        with working_dir("build", create=True):
+            if spec.satisfies("+cross-compile"):
                 self.build_nmodl(spec, prefix)
             srcpath = self.stage.source_path
-            configure = Executable(join_path(srcpath, 'configure'))
+            configure = Executable(join_path(srcpath, "configure"))
             configure(*options)
-            make('VERBOSE=1')
-            make('install')
+            make()
+
+    @when("~cmake")
+    def install(self, spec, prefix):
+        with working_dir("build"):
+            make("install")
+
+    # ==============================================
+    # ============== Common functions ==============
+    # ==============================================
+
+    @property
+    def basedir(self):
+        """Determine the neuron base directory.
+        NEURON base directory is based on the build system. For
+        cmake the bin and lib folders are in self.prefix and for
+        autotools it is in self.prefix/<arch>.
+        """
+        neuron_basedir = self.prefix
+        if self.spec.satisfies("~cmake"):
+            file_list = find(self.prefix, "*/bin/nrniv_makefile")
+            # check needed as during first evaluation the prefix is empty
+            if file_list:
+                neuron_basedir = os.path.dirname(os.path.dirname(file_list[0]))
+
+        return neuron_basedir
+
+    @run_after("install")
+    def filter_compilers(self):
+        """run after install to avoid spack compiler wrappers
+        getting embded into nrnivmodl script"""
+
+        spec = self.spec
+
+        if "cray" in spec.architecture:
+            cc_compiler = "cc"
+            cxx_compiler = "CC"
+        elif spec.satisfies("+mpi"):
+            cc_compiler = spec["mpi"].mpicc
+            cxx_compiler = spec["mpi"].mpicxx
+        else:
+            cc_compiler = self.compiler.cc
+            cxx_compiler = self.compiler.cxx
+
+
+        kwargs = {"backup": False, "string": True}
+        nrnmech_makefile = join_path(self.prefix,
+                                     self.basedir,
+                                     "./bin/nrnmech_makefile")
+
+        # nrnmech_makefile exists in cmake and autotools but with different syntax
+        assign_operator = "?=" if spec.satisfies("+cmake") else "="
+        filter_file("CC {0} {1}".format(assign_operator, env["CC"]),
+                    "CC = {0}".format(cc_compiler),
+                    nrnmech_makefile,
+                    **kwargs)
+        filter_file("CXX {0} {1}".format(assign_operator, env["CXX"]),
+                    "CXX = {0}".format(cxx_compiler),
+                    nrnmech_makefile,
+                    **kwargs)
+
+        if spec.satisfies("~cmake"):
+            nrniv_makefile = join_path(self.prefix,
+                                       self.basedir,
+                                       "./bin/nrniv_makefile")
+            libtool_makefile = join_path(self.prefix, "share/nrn/libtool")
+            filter_file(env["CC"], cc_compiler, nrniv_makefile, **kwargs)
+            filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
+            filter_file(env["CC"], cc_compiler, libtool_makefile, **kwargs)
+            filter_file(env["CXX"], cxx_compiler, libtool_makefile, **kwargs)
 
     def setup_run_environment(self, env):
-        neuron_archdir = self.get_neuron_archdir()
-        env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
-        env.prepend_path('LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        neuron_archdir = self.get_neuron_archdir()
-        env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
-        env.prepend_path('LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
+        env.prepend_path("PATH", join_path(self.basedir, "bin"))
+        env.prepend_path("LD_LIBRARY_PATH", join_path(self.basedir, "lib"))
+        if self.spec.satisfies("+python"):
+            env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -45,7 +45,7 @@ class Neuron(CMakePackage):
 
     conflicts("+rx3d",        when="~python")
 
-    patch("patch-v782-git-cmake.patch", when="@7.8.2")
+    patch("patch-v782-git-cmake-avx512.patch", when="@7.8.2")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -69,6 +69,7 @@ class Neuron(CMakePackage):
     @when("+cmake")
     def cmake_args(self):
         spec = self.spec
+
         def cmake_options(spec_options):
             value = "TRUE" if spec_options in spec else "FALSE"
             cmake_name = spec_options[1:].upper().replace("-", "_")
@@ -184,7 +185,6 @@ class Neuron(CMakePackage):
             options.append("MPICC=%s" % spec["mpi"].mpicc)
             options.append("MPICXX=%s" % spec["mpi"].mpicxx)
 
-
         ld_flags = "LDFLAGS="
 
         if "readline" in spec:
@@ -195,9 +195,9 @@ class Neuron(CMakePackage):
 
         if "ncurses" in spec:
             options.extend([
-              "CURSES_LIBS={0.libs.ld_flags} -Wl,-rpath,{0.prefix.lib}".format(
-                spec["ncurses"]),
-              "CURSES_CFLAGS={0}".format(spec["ncurses"].prefix.include),
+                "CURSES_LIBS={0.ld_flags} -Wl,-rpath,{1}".format(
+                    spec["ncurses"].libs, spec["ncurses"].prefix.lib),
+                "CURSES_CFLAGS={0}".format(spec["ncurses"].prefix.include),
             ])
             ld_flags += " {0.libs.ld_flags} -Wl,-rpath,{0.prefix.lib}".format(
                 spec["ncurses"]
@@ -290,7 +290,7 @@ class Neuron(CMakePackage):
 
         if spec.satisfies("+coreneuron"):
             corenrn_makefile = join_path(self.prefix,
-                                 "share/coreneuron/nrnivmodl_core_makefile")
+                                         "share/coreneuron/nrnivmodl_core_makefile")
             filter_file(env["CXX"], cxx_compiler, corenrn_makefile, **kwargs)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -8,6 +8,7 @@ from spack import *
 
 class Neuron(CMakePackage):
     """NEURON is a simulation environment for single and networks of neurons.
+
     NEURON is a simulation environment for modeling individual and networks of
     neurons. NEURON models individual neurons via the use of sections that are
     automatically subdivided into individual compartments, instead of

--- a/var/spack/repos/builtin/packages/neuron/patch-v782-git-cmake-avx512.patch
+++ b/var/spack/repos/builtin/packages/neuron/patch-v782-git-cmake-avx512.patch
@@ -1,25 +1,8 @@
-From e6334e5542440111d299e8d4f1dd8b436a6447dc Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Alexandru=20S=C4=83vulescu?= <alexandru.savulescu@epfl.ch>
-Date: Mon, 30 Nov 2020 16:06:52 +0100
-Subject: [PATCH] nrnversion fails when not in git (#831)
-
-More useful build error message with building from archive file.
-
-nrnversion details are unknown when no git metadata.
-
-This reverts commit c777da1ba5c72f36ef815b18ab71b018c82ff095.
----
- CONTRIBUTING.md                   |  2 +-
- cmake/ExternalProjectHelper.cmake | 15 ++++++++++++++-
- git2nrnversion_h.sh               |  9 ++++-----
- src/nrniv/CMakeLists.txt          |  3 ++-
- 4 files changed, 21 insertions(+), 8 deletions(-)
-
 diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
-index 04dac980..9ab399c8 100644
+index 391d4daa..20b8b571 100644
 --- a/CONTRIBUTING.md
 +++ b/CONTRIBUTING.md
-@@ -100,7 +100,7 @@ Currently we have enabled CMake code formatting using [cmake-format](https://git
+@@ -98,7 +98,7 @@ Currently we have enabled CMake code formatting using [cmake-format](https://git
  * Make sure to install cmake-format utility with Python version you are using:
  
  ```
@@ -86,11 +69,65 @@ index d62b7410..4d8e4015 100755
 +        echo "#define GIT_DESCRIBE \"${PROJECT_VERSION}.dev0\""
  fi
  
+diff --git a/src/ivoc/ivocvect.cpp b/src/ivoc/ivocvect.cpp
+index 4884614a..4da9e17e 100644
+--- a/src/ivoc/ivocvect.cpp
++++ b/src/ivoc/ivocvect.cpp
+@@ -67,7 +67,26 @@ extern "C" {
+ #define FRead(arg1,arg2,arg3,arg4) if (fread(arg1,arg2,arg3,arg4) != arg3) {}
+ #endif
+ 
+-static double dmaxint_;
++/**
++ * As all parameters are passed from hoc as double, we need
++ * to calculate max integer that can fit into double variable.
++ *
++ * With IEEE 64-bit double has 52 bits of mantissa, so it's 2^53.
++ * calculating it with approach `while (dbl + 1 != dbl) dbl++;`
++ * has issues with SSE and other 32 bits platform. So we are using
++ * direct value here.
++ *
++ * The maximum mantissa 0xFFFFFFFFFFFFF which is 52 bits all 1.
++ * In Python it's:
++ *
++ *  >>> (2.**53).hex()
++ *   '0x1.0000000000000p+53'
++ *  >>> (2.**53)
++ *   9007199254740992.0
++ *
++ * See https://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double
++ */
++static double dmaxint_ = 9007199254740992;
+ 
+ // Definitions allow machine independent write and read
+ // note that must include BYTEHEADER at head of routine
+@@ -3776,20 +3795,7 @@ static void steer_x(void* v) {
+ }
+ 
+ void Vector_reg() {
+-	dmaxint_ = 1073741824.;
+-	for(;;) {
+-		if (dmaxint_*2. == double(int(dmaxint_*2.))) {
+-			dmaxint_ *= 2.;
+-		}else{
+-			if (dmaxint_*2. - 1. == double(int(dmaxint_*2. - 1.))) {
+-				dmaxint_ = 2.*dmaxint_ - 1.;
+-			}
+-			break;
+-		}
+-	}		
+-	//printf("dmaxint=%30.20g   %d\n", dmaxint_, (long)dmaxint_);
+-        class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members,
+-        	v_retstr_members);
++	class2oc("Vector", v_cons, v_destruct, v_members, NULL, v_retobj_members, v_retstr_members);
+ 	svec_ = hoc_lookup("Vector");
+ 	// now make the x variable an actual double
+ 	Symbol* sv = hoc_lookup("Vector");
 diff --git a/src/nrniv/CMakeLists.txt b/src/nrniv/CMakeLists.txt
-index ccd28e35..aaaf53b4 100644
+index 30024d6e..26f76a98 100644
 --- a/src/nrniv/CMakeLists.txt
 +++ b/src/nrniv/CMakeLists.txt
-@@ -140,7 +140,8 @@ set(NRN_INCLUDE_DIRS
+@@ -139,7 +139,8 @@ set(NRN_INCLUDE_DIRS
  # is different from the contents of nrnversion.h
  # ~~~
  add_custom_target(
@@ -100,6 +137,3 @@ index ccd28e35..aaaf53b4 100644
    COMMAND ${CMAKE_COMMAND} -E copy_if_different nrnversion.h.tmp ${NRN_NRNOC_SRC_DIR}/nrnversion.h
    DEPENDS ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh)
  
--- 
-2.29.2
-

--- a/var/spack/repos/builtin/packages/neuron/patch-v782-git-cmake.patch
+++ b/var/spack/repos/builtin/packages/neuron/patch-v782-git-cmake.patch
@@ -1,0 +1,105 @@
+From e6334e5542440111d299e8d4f1dd8b436a6447dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexandru=20S=C4=83vulescu?= <alexandru.savulescu@epfl.ch>
+Date: Mon, 30 Nov 2020 16:06:52 +0100
+Subject: [PATCH] nrnversion fails when not in git (#831)
+
+More useful build error message with building from archive file.
+
+nrnversion details are unknown when no git metadata.
+
+This reverts commit c777da1ba5c72f36ef815b18ab71b018c82ff095.
+---
+ CONTRIBUTING.md                   |  2 +-
+ cmake/ExternalProjectHelper.cmake | 15 ++++++++++++++-
+ git2nrnversion_h.sh               |  9 ++++-----
+ src/nrniv/CMakeLists.txt          |  3 ++-
+ 4 files changed, 21 insertions(+), 8 deletions(-)
+
+diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
+index 04dac980..9ab399c8 100644
+--- a/CONTRIBUTING.md
++++ b/CONTRIBUTING.md
+@@ -100,7 +100,7 @@ Currently we have enabled CMake code formatting using [cmake-format](https://git
+ * Make sure to install cmake-format utility with Python version you are using:
+ 
+ ```
+-pip3.7 install cmake-format==0.6.0 --user
++pip3.7 install cmake-format==0.6.0 pyyaml --user
+ ```
+ Now you should have `cmake-format` command available.
+ 
+diff --git a/cmake/ExternalProjectHelper.cmake b/cmake/ExternalProjectHelper.cmake
+index 57094e7e..eeb6dfc2 100644
+--- a/cmake/ExternalProjectHelper.cmake
++++ b/cmake/ExternalProjectHelper.cmake
+@@ -1,5 +1,15 @@
+ find_package(Git QUIET)
+ 
++if(${GIT_FOUND} AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
++  execute_process(
++    COMMAND ${GIT_EXECUTABLE} --git-dir=.git describe --all
++    RESULT_VARIABLE NOT_A_GIT_REPO
++    ERROR_QUIET
++    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
++else()
++  set(NOT_A_GIT_REPO "NotAGitRepo")
++endif()
++
+ # initialize submodule with given path
+ function(initialize_submodule path)
+   if(NOT ${GIT_FOUND})
+@@ -9,7 +19,7 @@ function(initialize_submodule path)
+   message(STATUS "Sub-module : missing ${path} : running git submodule update --init --recursive")
+   execute_process(
+     COMMAND
+-      git submodule update --init --recursive -- ${path}
++      ${GIT_EXECUTABLE}  submodule update --init --recursive -- ${path}
+     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+ endfunction()
+ 
+@@ -20,6 +30,9 @@ function(add_external_project name)
+     NAMES CMakeLists.txt
+     PATHS "${PROJECT_SOURCE_DIR}/external/${name}")
+   if(NOT EXISTS ${${name}_PATH})
++    if(NOT_A_GIT_REPO)
++      message(FATAL_ERROR "Looks like you are building from source. Git needed for ${name} feature.")
++    endif()
+     initialize_submodule(external/${name})
+   else()
+     message(STATUS "Sub-project : using ${name} from from external/${name}")
+diff --git a/git2nrnversion_h.sh b/git2nrnversion_h.sh
+index d62b7410..4d8e4015 100755
+--- a/git2nrnversion_h.sh
++++ b/git2nrnversion_h.sh
+@@ -20,10 +20,9 @@ if git log > /dev/null && test -d .git ; then
+ elif test -f src/nrnoc/nrnversion.h ; then
+         sed -n '1,$p' src/nrnoc/nrnversion.h
+ else
+-        echo "#define GIT_DATE \"1999-12-31\""
+-        echo "#define GIT_BRANCH \"?\""
+-        echo "#define GIT_CHANGESET \"?\""
+-        echo "#define GIT_DESCRIBE \"?\""
+-        exit 1
++        echo "#define GIT_DATE \"Build Time: $(date "+%Y-%m-%d-%H:%M:%S")\""
++        echo "#define GIT_BRANCH \"unknown branch\""
++        echo "#define GIT_CHANGESET \"unknown commit id\""
++        echo "#define GIT_DESCRIBE \"${PROJECT_VERSION}.dev0\""
+ fi
+ 
+diff --git a/src/nrniv/CMakeLists.txt b/src/nrniv/CMakeLists.txt
+index ccd28e35..aaaf53b4 100644
+--- a/src/nrniv/CMakeLists.txt
++++ b/src/nrniv/CMakeLists.txt
+@@ -140,7 +140,8 @@ set(NRN_INCLUDE_DIRS
+ # is different from the contents of nrnversion.h
+ # ~~~
+ add_custom_target(
+-  nrnversion_h ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} > nrnversion.h.tmp
++  nrnversion_h
++  COMMAND ${CMAKE_COMMAND} -E env PROJECT_VERSION=${PROJECT_VERSION} $ENV{SHELL} ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh ${PROJECT_SOURCE_DIR} > nrnversion.h.tmp
+   COMMAND ${CMAKE_COMMAND} -E copy_if_different nrnversion.h.tmp ${NRN_NRNOC_SRC_DIR}/nrnversion.h
+   DEPENDS ${PROJECT_SOURCE_DIR}/git2nrnversion_h.sh)
+ 
+-- 
+2.29.2
+


### PR DESCRIPTION
* Newer version of NEURON supports CMake (preferred build system)
* Updated recipe for CMake, still keep autotools for older versions
* Updated variants and dependencies
* Removed legacy bluegene options
* Added CoreNEURON variant (CPU only for now)
* Added patch for last release 7.8.2  (see neuronsimulator/nrn/pull/831)
* Added maintainers 


(see neuronsimulator/nrn/issues/886)
