### PR TITLE
mfem: link to SUNDIALS nveccuda library when +sundials+cuda

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -723,6 +723,8 @@ class Mfem(Package):
                 sun_comps += ',nvecparallel,nvecmpiplusx'
             else:
                 sun_comps += ',nvecparhyp,nvecparallel'
+        if '+cuda' in self.spec:
+            sun_comps += ',nveccuda'
         return sun_comps
 
     @property


### PR DESCRIPTION
This logic is equivalent to https://github.com/mfem/mfem/blob/caf5d7b471571b2094ccdfd4b2ff772d76fc778c/config/defaults.mk#L219-L221 (which is overridden by the `sun_comps` defined here).
