### PR TITLE
py-mercantile: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-mercantile/package.py
+++ b/var/spack/repos/builtin/packages/py-mercantile/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyMercantile(PythonPackage):
+    """Web mercator XYZ tile utilities."""
+
+    homepage = "https://github.com/mapbox/mercantile"
+    url      = "https://pypi.io/packages/source/m/mercantile/mercantile-1.1.6.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('1.1.6', sha256='0dff4cbc2c92ceca0e0dfbb3dc74392a96d33cfa29afb1bdfcc80283d3ef4207')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-click@3.0:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs and passes import tests on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.