### PR TITLE
py-contextily: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-contextily/package.py
+++ b/var/spack/repos/builtin/packages/py-contextily/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyContextily(PythonPackage):
+    """Context geo-tiles in Python."""
+
+    homepage = "https://github.com/darribas/contextily"
+    url      = "https://pypi.io/packages/source/c/contextily/contextily-1.0.1.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('1.0.1', sha256='f7dc25dbc8e01163be6cdeedb49a56da9cd0d586c838861f442ef2ee45eba9d4')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-geopy', type=('build', 'run'))
+    depends_on('py-matplotlib', type=('build', 'run'))
+    depends_on('py-mercantile', type=('build', 'run'))
+    depends_on('pil', type=('build', 'run'))
+    depends_on('py-rasterio', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'))
+    depends_on('py-joblib', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs and passes import tests on macOS 10.15.7 with Python 3.8.6 and Apple Clang 12.0.0.

Depends on #20601 #20598