### PR TITLE
Berkeley-DB: Fix compilation with NVIDIA HPC Compilers on Red Hat 8.

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -27,6 +27,8 @@ class BerkeleyDb(AutotoolsPackage):
             filter_file(r'gsg_db_server', '', 'dist/Makefile.in')
 
     def configure_args(self):
+        spec = self.spec
+
         config_args = [
             '--disable-static',
             '--enable-cxx',
@@ -39,9 +41,10 @@ class BerkeleyDb(AutotoolsPackage):
             '--with-repmgr-ssl=no',
         ]
 
-        # The default glibc provided by CentOS 7 does not provide proper
-        # atomic support when using the NVIDIA compilers
-        if self.spec.satisfies('%nvhpc os=centos7'):
+        # The default glibc provided by CentOS 7 and Red Hat 8 does not provide
+        # proper atomic support when using the NVIDIA compilers
+        if (spec.satisfies('%nvhpc')
+                and (spec.satisfies('os=centos7') or spec.satisfies('os=rhel8'))):
             config_args.append('--disable-atomicsupport')
 
         return config_args


### PR DESCRIPTION
As far as I know there is currently no way to express an `or` relationship using the "spec language".