### PR TITLE
Gromacs: Fix hwloc dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -102,9 +102,6 @@ class Gromacs(CMakePackage):
     depends_on('lapack', when='+lapack')
     depends_on('blas', when='+blas')
 
-    # TODO: openmpi constraint; remove when concretizer is fixed
-    depends_on('hwloc@:1.999', when='@:3.0.0')
-
     patch('gmxDetectCpu-cmake-3.14.patch', when='@2018:2019.3^cmake@3.14.0:')
     patch('gmxDetectSimd-cmake-3.14.patch', when='@:2017.99^cmake@3.14.0:')
 


### PR DESCRIPTION
Newer versions of hwloc work with OpenMPI 4.X.Y.

Additionally the new experimental concretizer is now available for testing.