### PR TITLE
dealii: fix compilation for boost@1.72:

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -218,6 +218,12 @@ class Dealii(CMakePackage, CudaPackage):
           sha256='6f876dc8eadafe2c4ec2a6673864fb451c6627ca80511b6e16f3c401946fdf33',
           when='@9.0.0:9.1.1')
 
+    # Explicitly include a boost header, otherwise deal.II fails to compile
+    # https://github.com/dealii/dealii/pull/11438
+    patch('https://github.com/dealii/dealii/commit/3b815e21c4bfd82c792ba80e4d90314c8bb9edc9.patch',
+          sha256='5f9f411ab9336bf49d8293b9936344bad6e1cf720955b9d8e8b29883593b0ed9',
+          when='@9.2.0 ^boost@1.72.0:')
+
     # Check for sufficiently modern versions
     conflicts('cxxstd=11', when='@9.3:')
 


### PR DESCRIPTION
Make sure 9.2 can compile with newer versions of boost.