### PR TITLE
Nek5000: Improve support for OpenMPI without legacy launchers.

### DIFF
--- a/var/spack/repos/builtin/packages/nek5000/package.py
+++ b/var/spack/repos/builtin/packages/nek5000/package.py
@@ -94,6 +94,11 @@ class Nek5000(Package):
             else:
                 filter_file(r'^#MPI=0', 'MPI=0', 'makenek')
 
+            # Make sure nekmpi wrapper uses srun when we know OpenMPI
+            # is not built with mpiexec
+            if '^openmpi~legacylaunchers' in spec:
+                filter_file(r'mpiexec -np', 'srun -n', 'nekmpi')
+
             if '+profiling' not in spec:
                 filter_file(r'^#PROFILING=0', 'PROFILING=0', 'makenek')
 


### PR DESCRIPTION
Use "srun" for the nekmpi wrapper when we know "mpiexec" won't be available.