### PR TITLE
RFC: make package build reproducible

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -108,7 +108,7 @@ config_defaults = {
         'verify_ssl': True,
         'checksum': True,
         'dirty': False,
-        'build_jobs': min(16, multiprocessing.cpu_count()),
+        'build_jobs': 4,
         'build_stage': '$tempdir/spack-stage',
         'concretizer': 'original',
     }


### PR DESCRIPTION
without this patch, `spack-0.16.0/lib/spack/docs/_build/texinfo/Spack.texi`
varied in

```
@deffn {Data} spack.config.config_defaults = @{'config': @{'build_jobs': 4, 'build_stage': '$tempdir/spack@w{-}stage', 'checksum': True, 'concretizer': 'original', 'connect_timeout': 10, 'debug': False, 'dirty': False, 'verify_ssl': True@}@}
```

that caused resulting `Spack.info` and `spack.1` files to differ as well.

It would probably be more appropriate to drop the `build_jobs`
default value when generating the `Spack.texi` file
but this code was hard to locate.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).