### PR TITLE
libunwind: add version 1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -17,10 +17,8 @@ class Libunwind(AutotoolsPackage):
 
     version('master', branch='master')
     version('1.5-head', branch='v1.5-stable')
-    version('1.5-rc1', sha256='3e0cbc6dee326592097ef06e97cf76ef597987eddd0df8bea49b0594e587627a')
-    version('1.4-head', branch='v1.4-stable')
-    version('1.4.0',   sha256='df59c931bd4d7ebfd83ee481c943edf015138089b8e50abed8d9c57ba9338435', preferred=True)
-    version('1.4-rc1', sha256='1928459139f048f9b4aca4bb5010540cb7718d44220835a2980b85429007fa9f')
+    version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017')
+    version('1.4.0', sha256='df59c931bd4d7ebfd83ee481c943edf015138089b8e50abed8d9c57ba9338435')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8')
     version('1.2.1', sha256='3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb')
     version('1.1', sha256='9dfe0fcae2a866de9d3942c66995e4b460230446887dbdab302d41a8aee8d09a')
@@ -37,10 +35,10 @@ class Libunwind(AutotoolsPackage):
 
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
-    depends_on('autoconf', type='build', when='@master,1.4-head,1.5-head')
-    depends_on('automake', type='build', when='@master,1.4-head,1.5-head')
-    depends_on('libtool',  type='build', when='@master,1.4-head,1.5-head')
-    depends_on('m4',       type='build', when='@master,1.4-head,1.5-head')
+    depends_on('autoconf', type='build', when='@master,1.5-head')
+    depends_on('automake', type='build', when='@master,1.5-head')
+    depends_on('libtool',  type='build', when='@master,1.5-head')
+    depends_on('m4',       type='build', when='@master,1.5-head')
 
     depends_on('xz', type='link', when='+xz')
     depends_on('zlib', type='link', when='+zlib')


### PR DESCRIPTION
Add version 1.5.0, remove 1.4-rc1 (use 1.4.0) and 1.5-rc1 (use 1.5.0).

----------

I grep'd through packages.  The only other package that even mentions
libunwind 1.4 or 1.5 is my package (hpctoolkit).  So, removing the
release candidates should be safe.

Going forward, I plan to keep two moving branches: master and the most
recent stable branch, currently 1.5-stable, plus the point releases.