### PR TITLE
bootstrap a python 2.6 installation

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -171,9 +171,9 @@ class PythonPackage(PackageBase):
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + args
         with working_dir(self.build_directory):
-            self.python('-s', setup, *trailing_args, *args, **kwargs)
+            self.python(*args, **kwargs)
 
     def _setup_command_available(self, command):
         """Determines whether or not a setup.py command exists.
@@ -193,8 +193,11 @@ class PythonPackage(PackageBase):
         python = inspect.getmodule(self).python
         setup = self.setup_file()
 
-        trailing_args = tuple(self.trailing_setup_args())
-        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        args = ('-s', setup) + tuple(self.trailing_setup_args()) + (
+            command,
+            '--help',
+        )
+        python(*args, **kwargs)
         return python.returncode == 0
 
     # The following phases and their descriptions come from:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -160,11 +160,42 @@ class PythonPackage(PackageBase):
     def python(self, *args, **kwargs):
         inspect.getmodule(self).python(*args, **kwargs)
 
+    def _is_py26(self):
+        return self.spec['python'].version.up_to(2).string == '2.6'
+
+    def trailing_setup_args(self):
+        if self._is_py26():
+            return []
+        return ['--no-user-cfg']
+
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
 
+        trailing_args = tuple(self.trailing_setup_args())
         with working_dir(self.build_directory):
-            self.python('-s', setup, '--no-user-cfg', *args, **kwargs)
+            self.python('-s', setup, *trailing_args, *args, **kwargs)
+
+    def _setup_command_available(self, command):
+        """Determines whether or not a setup.py command exists.
+
+        Args:
+            command (str): The command to look for
+
+        Returns:
+            bool: True if the command is found, else False
+        """
+        kwargs = {
+            'output': os.devnull,
+            'error':  os.devnull,
+            'fail_on_error': False
+        }
+
+        python = inspect.getmodule(self).python
+        setup = self.setup_file()
+
+        trailing_args = tuple(self.trailing_setup_args())
+        python('-s', setup, *trailing_args, command, '--help', **kwargs)
+        return python.returncode == 0
 
     # The following phases and their descriptions come from:
     #   $ python setup.py --help-commands

--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -166,7 +166,8 @@ def _check_license(lines, path):
             if error:
                 return error
 
-    print('{0}: the license does not match the expected format'.format(path))
+    print('{0}: the license does not match the expected format. Expected:\n{1}'
+          .format(path, '\n'.join(license_lines)))
     return GENERAL_MISMATCH
 
 

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/util/provides.py
+++ b/lib/spack/spack/util/provides.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+def setup_libtirpc_build_environment(spec, env):
+    if 'libtirpc' in spec:
+        libtirpc = spec['libtirpc']
+        env.prepend_path('CPATH', libtirpc.prefix.include.tirpc)
+        env.append_flags('LDFLAGS', '-ltirpc')

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -98,6 +98,7 @@ check_dependencies() {
             if [[ $spack_package ]]; then
                 echo "To install with Spack, run:"
                 echo "    $ spack install $spack_package"
+                echo "    $ spack load $spack_package"
             fi
 
             if [[ $pip_package ]]; then

--- a/var/spack/repos/builtin/packages/ganglia/package.py
+++ b/var/spack/repos/builtin/packages/ganglia/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Ganglia(AutotoolsPackage):
     """Ganglia is a scalable distributed monitoring system for high-performance
@@ -31,5 +33,4 @@ class Ganglia(AutotoolsPackage):
     depends_on('expat')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)

--- a/var/spack/repos/builtin/packages/libnsl/package.py
+++ b/var/spack/repos/builtin/packages/libnsl/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack import *
 
 
@@ -22,7 +24,8 @@ class Libnsl(AutotoolsPackage):
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('gettext')
     depends_on('rpcsvc-proto')
-    depends_on('libtirpc')
+    # TODO: allow specifying != for negation in 'when=' specs!
+    depends_on('libtirpc', when=(sys.platform != 'darwin'))
 
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')

--- a/var/spack/repos/builtin/packages/lmbench/package.py
+++ b/var/spack/repos/builtin/packages/lmbench/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+from spack.util.provides import setup_libtirpc_build_environment
+
 
 class Lmbench(MakefilePackage):
     """lmbench is a suite of simple, portable, ANSI/C microbenchmarks for
@@ -22,8 +24,7 @@ class Lmbench(MakefilePackage):
     patch('fix_results_path_for_aarch64.patch', sha256='2af57abc9058c56b6dd0697bb01a98902230bef92b117017e318faba148eef60', when='target=aarch64:')
 
     def setup_build_environment(self, env):
-        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
-        env.append_flags('LDFLAGS', '-ltirpc')
+        setup_libtirpc_build_environment(self.spec, env)
 
     def build(self, spec, prefix):
         make('build')

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -19,7 +19,7 @@ class PyPackaging(PythonPackage):
     version('16.8', sha256='5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e')
 
     depends_on('py-setuptools', type='build')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'))
     depends_on('py-attrs', when='@19.1', type=('build', 'run'))
     depends_on('py-pyparsing@2.0.2:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -36,8 +36,8 @@ class PySetuptools(PythonPackage):
     version('11.3.1', sha256='bd25f17de4ecf00116a9f7368b614a54ca1612d7945d2eafe5d97bc08c138bc5')
 
     depends_on('python@3.5:', type=('build', 'run'), when='@45.0.0:')
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
+    depends_on('python@2.6:2.8,3.5:', type=('build', 'run'), when='@44.0.0:44.99.99')
+    depends_on('python@2.6:2.8,3.4:', type=('build', 'run'), when='@:43.99.99')
 
     def url_for_version(self, version):
         url = 'https://pypi.io/packages/source/s/setuptools/setuptools-{0}'

--- a/var/spack/repos/builtin/packages/python/no-dbm.patch
+++ b/var/spack/repos/builtin/packages/python/no-dbm.patch
@@ -1,0 +1,57 @@
+--- a/setup.py	2020-11-29 13:43:26.736062972 -0800
++++ b/setup.py	2020-11-29 13:43:40.166165660 -0800
+@@ -1144,53 +1144,11 @@
+                 missing.append('bsddb185')
+         else:
+             missing.append('bsddb185')
+ 
+         # The standard Unix dbm module:
+-        if platform not in ['cygwin']:
+-            if find_file("ndbm.h", inc_dirs, []) is not None:
+-                # Some systems have -lndbm, others don't
+-                if self.compiler.find_library_file(lib_dirs, 'ndbm'):
+-                    ndbm_libs = ['ndbm']
+-                else:
+-                    ndbm_libs = []
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       define_macros=[('HAVE_NDBM_H',None)],
+-                                       libraries = ndbm_libs ) )
+-            elif self.compiler.find_library_file(lib_dirs, 'gdbm'):
+-                gdbm_libs = ['gdbm']
+-                if self.compiler.find_library_file(lib_dirs, 'gdbm_compat'):
+-                    gdbm_libs.append('gdbm_compat')
+-                if find_file("gdbm/ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                elif find_file("gdbm-ndbm.h", inc_dirs, []) is not None:
+-                    exts.append( Extension(
+-                        'dbm', ['dbmmodule.c'],
+-                        define_macros=[('HAVE_GDBM_DASH_NDBM_H',None)],
+-                        libraries = gdbm_libs ) )
+-                else:
+-                    missing.append('dbm')
+-            elif db_incs is not None:
+-                exts.append( Extension('dbm', ['dbmmodule.c'],
+-                                       library_dirs=dblib_dir,
+-                                       runtime_library_dirs=dblib_dir,
+-                                       include_dirs=db_incs,
+-                                       define_macros=[('HAVE_BERKDB_H',None),
+-                                                      ('DB_DBM_HSEARCH',None)],
+-                                       libraries=dblibs))
+-            else:
+-                missing.append('dbm')
+-
+-        # Anthony Baxter's gdbm module.  GNU dbm(3) will require -lgdbm:
+-        if (self.compiler.find_library_file(lib_dirs, 'gdbm')):
+-            exts.append( Extension('gdbm', ['gdbmmodule.c'],
+-                                   libraries = ['gdbm'] ) )
+-        else:
+-            missing.append('gdbm')
++        # NB: Removed!
+ 
+         # Unix-only modules
+         if platform not in ['mac', 'win32']:
+             # Steen Lumholt's termios module
+             exts.append( Extension('termios', ['termios.c']) )

--- a/var/spack/repos/builtin/packages/python/no-ssl.patch
+++ b/var/spack/repos/builtin/packages/python/no-ssl.patch
@@ -1,0 +1,32 @@
+--- a/setup.py	2020-11-29 13:15:49.676636440 -0800
++++ b/setup.py	2020-11-29 13:43:26.736062972 -0800
+@@ -761,13 +761,12 @@
+             except IOError, msg:
+                 print "IOError while reading opensshv.h:", msg
+                 pass
+ 
+ 
+-        if (ssl_incs is not None and
+-            ssl_libs is not None and
+-            openssl_ver >= 0x00907000):
++        # raise Exception('change this to True!')
++        if False:
+             # The _hashlib module wraps optimized implementations
+             # of hash functions from the OpenSSL library.
+             exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                                    include_dirs = ssl_incs,
+                                    library_dirs = ssl_libs,
+@@ -781,10 +780,13 @@
+             # Message-Digest Algorithm, described in RFC 1321.  The
+             # necessary files md5.c and md5.h are included here.
+             exts.append( Extension('_md5',
+                             sources = ['md5module.c', 'md5.c'],
+                             depends = ['md5.h']) )
++            # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
++            exts.append( Extension('_sha256', ['sha256module.c']) )
++            exts.append( Extension('_sha512', ['sha512module.c']) )
+             missing.append('_hashlib')
+ 
+         if (openssl_ver < 0x00908000):
+             # OpenSSL doesn't do these until 0.9.8 so we'll bring our own hash
+             exts.append( Extension('_sha256', ['sha256module.c']) )

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -185,6 +185,12 @@ class Python(AutotoolsPackage):
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
+    # TODO: There's currently no way to ignore the fact that a single module failed, even if the
+    # variant corresponding to that module is deselected. These patches comment out sections of
+    # setup.py, specifically for the purpose of python 2.6 compat.
+    patch('no-ssl.patch', when='~ssl')
+    patch('no-dbm.patch', when='~dbm')
+
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
@@ -388,22 +394,30 @@ class Python(AutotoolsPackage):
         # as it scans for the library and headers to build
         link_deps = spec.dependencies('link')
 
+        cppflags = []
+        ldflags = []
         if link_deps:
             # Header files are often included assuming they reside in a
             # subdirectory of prefix.include, e.g. #include <openssl/ssl.h>,
             # which is why we don't use HeaderList here. The header files of
             # libffi reside in prefix.lib but the configure script of Python
             # finds them using pkg-config.
-            cppflags = ' '.join('-I' + spec[dep.name].prefix.include
-                                for dep in link_deps)
+            cppflags.extend('-I' + spec[dep.name].prefix.include for dep in link_deps)
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them
             # using spec.__getitem__.
-            ldflags = ' '.join(spec[dep.name].libs.search_flags
-                               for dep in link_deps)
+            ldflags.extend(spec[dep.name].libs.ld_flags for dep in link_deps)
 
-            config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
+        if 'libtirpc' in spec:
+            cppflags.extend(
+                '-I' + os.path.join(inc, 'tirpc')
+                for inc in spec['libtirpc'].headers.directories)
+
+        config_args.extend([
+            'CPPFLAGS=' + ' '.join(cppflags),
+            'LDFLAGS=' + ' '.join(ldflags),
+        ])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
         if spec.satisfies('@:3.6'):
@@ -970,8 +984,14 @@ class Python(AutotoolsPackage):
         setup_py('install', '--prefix={0}'.format(prefix))"""
 
         module.python = self.command
-        module.setup_py = Executable(
-            self.command.path + ' setup.py --no-user-cfg')
+
+        if self.version.up_to(2).string == '2.6':
+            trailing_args = []
+        else:
+            trailing_args = ['--no-user-cfg']
+        args = ['setup.py', *tuple(trailing_args)]
+        full_cmdline = self.command.path + ' {0}'.format(' '.join(args))
+        module.setup_py = Executable(full_cmdline)
 
         distutil_vars = self._load_distutil_vars()
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -17,6 +17,7 @@ import spack.store
 import spack.util.spack_json as sjson
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
+from spack.util.provides import setup_libtirpc_build_environment
 from spack import *
 
 
@@ -155,6 +156,7 @@ class Python(AutotoolsPackage):
     # https://raw.githubusercontent.com/python/cpython/84471935ed2f62b8c5758fd544c7d37076fe0fa5/Misc/NEWS
     # https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-4rc1
     depends_on('openssl@:1.0.2z', when='@:2.7.13,3.0.0:3.5.2+ssl')
+    depends_on('openssl@1.0.2u', when='@:2.6.99+ssl')
     depends_on('openssl@1.0.2:', when='@3.7:+ssl')  # https://docs.python.org/3/whatsnew/3.7.html#build-changes
     depends_on('sqlite@3.0.8:', when='+sqlite3')
     depends_on('gdbm', when='+dbm')  # alternatively ndbm or berkeley-db
@@ -185,9 +187,10 @@ class Python(AutotoolsPackage):
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
-    # TODO: There's currently no way to ignore the fact that a single module failed, even if the
-    # variant corresponding to that module is deselected. These patches comment out sections of
-    # setup.py, specifically for the purpose of python 2.6 compat.
+    # TODO: There's currently no way to ignore the fact that a single module
+    # failed, even if the variant corresponding to that module is
+    # deselected. These patches comment out sections of setup.py, specifically
+    # for the purpose of python 2.6 compat.
     patch('no-ssl.patch', when='~ssl')
     patch('no-dbm.patch', when='~dbm')
 
@@ -354,14 +357,6 @@ class Python(AutotoolsPackage):
     def setup_build_environment(self, env):
         spec = self.spec
 
-        # TODO: The '--no-user-cfg' option for Python installation is only in
-        # Python v2.7 and v3.4+ (see https://bugs.python.org/issue1180) and
-        # adding support for ignoring user configuration will require
-        # significant changes to this package for other Python versions.
-        if not spec.satisfies('@2.7:2.8,3.4:'):
-            tty.warn(('Python v{0} may not install properly if Python '
-                      'user configurations are present.').format(self.version))
-
         # TODO: Python has incomplete support for Python modules with mixed
         # C/C++ source, and patches are required to enable building for these
         # modules. All Python versions without a viable patch are installed
@@ -376,6 +371,8 @@ class Python(AutotoolsPackage):
 
         env.unset('PYTHONPATH')
         env.unset('PYTHONHOME')
+
+        setup_libtirpc_build_environment(spec, env)
 
     def flag_handler(self, name, flags):
         # python 3.8 requires -fwrapv when compiled with intel
@@ -394,30 +391,22 @@ class Python(AutotoolsPackage):
         # as it scans for the library and headers to build
         link_deps = spec.dependencies('link')
 
-        cppflags = []
-        ldflags = []
         if link_deps:
             # Header files are often included assuming they reside in a
             # subdirectory of prefix.include, e.g. #include <openssl/ssl.h>,
             # which is why we don't use HeaderList here. The header files of
             # libffi reside in prefix.lib but the configure script of Python
             # finds them using pkg-config.
-            cppflags.extend('-I' + spec[dep.name].prefix.include for dep in link_deps)
+            cppflags = ' '.join('-I' + spec[dep.name].prefix.include
+                                for dep in link_deps)
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them
             # using spec.__getitem__.
-            ldflags.extend(spec[dep.name].libs.ld_flags for dep in link_deps)
+            ldflags = ' '.join(spec[dep.name].libs.search_flags
+                               for dep in link_deps)
 
-        if 'libtirpc' in spec:
-            cppflags.extend(
-                '-I' + os.path.join(inc, 'tirpc')
-                for inc in spec['libtirpc'].headers.directories)
-
-        config_args.extend([
-            'CPPFLAGS=' + ' '.join(cppflags),
-            'LDFLAGS=' + ' '.join(ldflags),
-        ])
+            config_args.extend(['CPPFLAGS=' + cppflags, 'LDFLAGS=' + ldflags])
 
         # https://docs.python.org/3/whatsnew/3.7.html#build-changes
         if spec.satisfies('@:3.6'):
@@ -976,6 +965,14 @@ class Python(AutotoolsPackage):
         pythonpath = ':'.join(python_paths)
         env.prepend_path('PYTHONPATH', pythonpath)
 
+    def _is_py26(self):
+        return self.version.up_to(2).string == '2.6'
+
+    def trailing_setup_args(self):
+        if self._is_py26():
+            return []
+        return ['--no-user-cfg']
+
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods.
 
@@ -985,11 +982,7 @@ class Python(AutotoolsPackage):
 
         module.python = self.command
 
-        if self.version.up_to(2).string == '2.6':
-            trailing_args = []
-        else:
-            trailing_args = ['--no-user-cfg']
-        args = ['setup.py', *tuple(trailing_args)]
+        args = ['setup.py'] + list(self.trailing_setup_args())
         full_cmdline = self.command.path + ' {0}'.format(' '.join(args))
         module.setup_py = Executable(full_cmdline)
 


### PR DESCRIPTION
*This was copied from #20218, because github won't let me reopen it.*

**This needs to be refactored to:**
- [ ] Inject a Python.h file if one is not found.
- [ ] Remove the need for the double bootstrapping in #20159.

### Problem

We would like to ensure that clingo is able to bootstrap from a python 2.6-only, C++11-only environment in #20159.

### Solution

- Add multiple patches which will allow python 2.6 to be built even with `~ssl` and `~dbm`.
- Modify the `libtirpc` transitive dependency so that its headers are visible to python (this is necessary to make the build pass).
- Pass `--no-user-cfg` only if the python version is >2.6.

### Result

- These modifications to the `python` package allow it to be built within spack (tested on CentOS 6 with the x86 architecture).
- This makes it easier to test python 2.6 compatibility in arbitrary environments.

### TODO
- [ ] **This should be added to spack CI.** I'm not 100% sure how to do that yet, but I think that basing this on top of #20207 might be a way to get started on it.