### PR TITLE
linguist: update .gitattributes for better linguist parsing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.py diff=python
+*.lp linguist-language=Prolog
+lib/spack/external/* linguist-vendored


### PR DESCRIPTION
This adds two lines to `.gitattributes`:
- [x] exclude vendored code from GitHub's language calculation
- [x] recognize `.lp` files as Prolog (closest language to ASP that linguist supports)

It looks like there have been two attempts (https://github.com/github/linguist/issues/3867, https://github.com/github/linguist/issues/4860) to add ASP as a language to Linguist, but it's not widespread enough to be standard yet (or at least the people who submitted the PRs haven't been able to show enough stats to prove it). We'll settle for calling ASP "Prolog" for now as that'll get us some syntax highlighting for `concretize.lp`.