### PR TITLE
libzmq: add drafts variant

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -30,6 +30,9 @@ class Libzmq(AutotoolsPackage):
     variant("libsodium", default=True,
             description="Build with message encryption support via libsodium")
 
+    variant("drafts", default=False,
+            description="Build and install draft classes and methods")
+
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')
 
@@ -54,6 +57,9 @@ class Libzmq(AutotoolsPackage):
 
     def configure_args(self):
         config_args = []
+
+        config_args.extend(self.enable_or_disable("drafts"))
+
         if '+libsodium' in self.spec:
             config_args.append('--with-libsodium')
         if 'clang' in self.compiler.cc:


### PR DESCRIPTION
I think it is worth exposing it as variant, making it more transparent to the user.

This option is set by default to ON when building from a git repo, otherwise it is OFF. Without this variant, we don't have control over this option and we have to rely on default values.

In particular, this may create problems building dependent libraries, e.g. `cppzmq`. In fact, if `libzmq` is built from `tar.gz` while `cppzmq` is built from a git branch, the default values for the option diverges resulting in linking problems. https://github.com/zeromq/cppzmq/issues/430#issuecomment-753460584

I started doing the same for `cppzmq`, but I don't have knowledge about version mapping between `libzmq` and `cppzmq`. But, that's another problem I may address elsewhere.