### PR TITLE
clingo: added a package with option for bootstrapping clingo

### DIFF
--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -11,6 +11,10 @@ class ClingoBootstrap(Clingo):
     """Clingo with some options used for bootstrapping"""
     variant('build_type', default='Release', values=('Release',),
             description='CMake build type')
+
+    # CMake at version 3.16.0 or higher has the possibility to force the
+    # Python interpreter, which is crucial to build against external Python
+    # in environment where more than one interpreter is in the same prefix
     depends_on('cmake@3.16.0:', type='build')
 
     # On Linux we bootstrap with GCC
@@ -33,20 +37,6 @@ class ClingoBootstrap(Clingo):
 
     # Clingo needs the Python module to be usable by Spack
     conflicts('~python', msg='Python support is required to bootstrap Spack')
-
-    @property
-    def cmake_python_hints(self):
-        """Return standard CMake defines to ensure that the
-        current spec is the one found by CMake find_package(Python, ...)
-        """
-        return [
-            '-DPython_EXECUTABLE={0}'.format(str(self.spec['python'].command))
-        ]
-
-    def cmake_args(self):
-        args = super(ClingoBootstrap, self).cmake_args()
-        args += self.cmake_python_hints
-        return args
 
     def setup_build_environment(self, env):
         if '%apple-clang platform=darwin' in self.spec:

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -4,12 +4,43 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack.pkg.builtin.clingo import Clingo
 
+import spack.compilers
+
 
 class ClingoBootstrap(Clingo):
     """Clingo with some options used for bootstrapping"""
     variant('build_type', default='Release', values=('Release',),
             description='CMake build type')
 
+    # On Linux we bootstrap with GCC
+    for compiler_spec in [
+        c for c in spack.compilers.supported_compilers()
+        if c != 'gcc'
+    ]:
+        conflicts('%{0}'.format(compiler_spec), when='platform=linux',
+                  msg='GCC is required to bootstrap clingo on Linux')
+    conflicts('%gcc@:5.99.99', when='platform=linux',
+              msg='C++14 support is required to bootstrap clingo on Linux')
+
+    # On Darwin we bootstrap with Apple Clang
+    for compiler_spec in [
+        c for c in spack.compilers.supported_compilers()
+        if c != 'apple-clang'
+    ]:
+        conflicts('%{0}'.format(compiler_spec), when='platform=darwin',
+                  msg='Apple-clang is required to bootstrap clingo on MacOS')
+
+    # Clingo needs the Python module to be usable by Spack
+    conflicts('~python', msg='Python support is required to bootstrap Spack')
+
     def setup_build_environment(self, env):
-        env.set('CXXFLAGS', '-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL')
-        env.set('LDFLAGS', '-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL')
+        if '%apple-clang platform=darwin' in self.spec:
+            opts = '-mmacosx-version-min=10.13'
+        elif '%gcc platform=linux' in self.spec:
+            opts = '-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL'
+        else:
+            msg = 'unexpected compiler for spec "{0}"'.format(self.spec)
+            raise RuntimeError(msg)
+
+        env.set('CXXFLAGS', opts)
+        env.set('LDFLAGS', opts)

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.pkg.builtin.clingo import Clingo
+
+
+class ClingoBootstrap(Clingo):
+    """Clingo with some options used for bootstrapping"""
+    variant('build_type', default='Release', values=('Release',),
+            description='CMake build type')
+
+    def setup_build_environment(self, env):
+        env.set('CXXFLAGS', '-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL')
+        env.set('LDFLAGS', '-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL')

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -11,6 +11,7 @@ class ClingoBootstrap(Clingo):
     """Clingo with some options used for bootstrapping"""
     variant('build_type', default='Release', values=('Release',),
             description='CMake build type')
+    depends_on('cmake@3.16.0:', type='build')
 
     # On Linux we bootstrap with GCC
     for compiler_spec in [
@@ -32,6 +33,20 @@ class ClingoBootstrap(Clingo):
 
     # Clingo needs the Python module to be usable by Spack
     conflicts('~python', msg='Python support is required to bootstrap Spack')
+
+    @property
+    def cmake_python_hints(self):
+        """Return standard CMake defines to ensure that the
+        current spec is the one found by CMake find_package(Python, ...)
+        """
+        return [
+            '-DPython_EXECUTABLE={0}'.format(str(self.spec['python'].command))
+        ]
+
+    def cmake_args(self):
+        args = super(ClingoBootstrap, self).cmake_args()
+        args += self.cmake_python_hints
+        return args
 
     def setup_build_environment(self, env):
         if '%apple-clang platform=darwin' in self.spec:

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -51,13 +51,22 @@ class Clingo(CMakePackage):
                         'clasp/CMakeLists.txt',
                         'clasp/libpotassco/CMakeLists.txt')
 
+    @property
+    def cmake_python_hints(self):
+        """Return standard CMake defines to ensure that the
+        current spec is the one found by CMake find_package(Python, ...)
+        """
+        return [
+            '-DPython_EXECUTABLE={0}'.format(str(self.spec['python'].command))
+        ]
+
     def cmake_args(self):
         try:
             self.compiler.cxx14_flag
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
-        return [
+        args = [
             '-DCLINGO_REQUIRE_PYTHON=ON',
             '-DCLINGO_BUILD_WITH_PYTHON=ON',
             '-DCLINGO_BUILD_PY_SHARED=ON',
@@ -65,3 +74,7 @@ class Clingo(CMakePackage):
             '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
             '-DCLINGO_BUILD_WITH_LUA=OFF'
         ]
+        if self.spec['cmake'].satisfies('@3.16.0:'):
+            args += self.cmake_python_hints
+
+        return args

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -24,7 +24,7 @@ class Clingo(CMakePackage):
     maintainers = ["tgamblin"]
 
     version('master', branch='master', submodules=True, preferred=True)
-    version('spack', commit='2ab2e81bcb24f6070b7efce30a754d74ef52ee2d', submodules=True)
+    version('spack', commit='2a025667090d71b2c9dce60fe924feb6bde8f667', submodules=True)
 
     version('5.4.0', sha256='e2de331ee0a6d254193aab5995338a621372517adcf91568092be8ac511c18f3')
     version('5.3.0', sha256='b0d406d2809352caef7fccf69e8864d55e81ee84f4888b0744894977f703f976')
@@ -57,7 +57,7 @@ class Clingo(CMakePackage):
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
-        return [
+        args = [
             '-DCLINGO_REQUIRE_PYTHON=ON',
             '-DCLINGO_BUILD_WITH_PYTHON=ON',
             '-DCLINGO_BUILD_PY_SHARED=ON',
@@ -65,3 +65,8 @@ class Clingo(CMakePackage):
             '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
             '-DCLINGO_BUILD_WITH_LUA=OFF'
         ]
+
+        if '+python' in self.spec:
+            args += self.spec['python'].cmake_hints
+
+        return args

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -57,7 +57,7 @@ class Clingo(CMakePackage):
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
-        args = [
+        return [
             '-DCLINGO_REQUIRE_PYTHON=ON',
             '-DCLINGO_BUILD_WITH_PYTHON=ON',
             '-DCLINGO_BUILD_PY_SHARED=ON',
@@ -65,8 +65,3 @@ class Clingo(CMakePackage):
             '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
             '-DCLINGO_BUILD_WITH_LUA=OFF'
         ]
-
-        if '+python' in self.spec:
-            args += self.spec['python'].cmake_hints
-
-        return args

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -945,6 +945,7 @@ class Python(AutotoolsPackage):
                                              self.site_packages_dir)
 
         self.spec.home = self.home
+        self.spec.cmake_hints = self.cmake_hints
 
         # Make the site packages directory for extensions
         if dependent_spec.package.is_extension:
@@ -1111,3 +1112,12 @@ class Python(AutotoolsPackage):
         options = ['-c', 'import sys; {0}'.format(print_str)]
         self.run_test(exe, options=options, expected=[self.spec.prefix],
                       installed=True, purpose=reason)
+
+    @property
+    def cmake_hints(self):
+        """Return standard CMake defines to ensure that the
+        current spec is the one found by CMake find_package(Python, ...)
+        """
+        return [
+            '-DPython_EXECUTABLE={0}'.format(str(self.command))
+        ]

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -945,7 +945,6 @@ class Python(AutotoolsPackage):
                                              self.site_packages_dir)
 
         self.spec.home = self.home
-        self.spec.cmake_hints = self.cmake_hints
 
         # Make the site packages directory for extensions
         if dependent_spec.package.is_extension:
@@ -1112,12 +1111,3 @@ class Python(AutotoolsPackage):
         options = ['-c', 'import sys; {0}'.format(print_str)]
         self.run_test(exe, options=options, expected=[self.spec.prefix],
                       installed=True, purpose=reason)
-
-    @property
-    def cmake_hints(self):
-        """Return standard CMake defines to ensure that the
-        current spec is the one found by CMake find_package(Python, ...)
-        """
-        return [
-            '-DPython_EXECUTABLE={0}'.format(str(self.command))
-        ]


### PR DESCRIPTION
As of now `clingo-bootstrap`:
- [x] is built in Release mode 
- [x] uses GCC options to link libstdc++ and libgcc statically on Linux
- [x] uses Apple Clang `-mmacosx-min-version` option on Darwin 
- [x] points CMake to the Python executable associated with the python spec in the DAG (requires CMake >= 3.16.0)
