### PR TITLE
OpenMPI: Depends on hwlock & libevent

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -266,6 +266,8 @@ class Openmpi(AutotoolsPackage):
 
     depends_on('pkgconfig', type='build')
 
+    depends_on('libevent@2.0:')
+
     depends_on('hwloc@2.0:', when='@4:')
     # ompi@:3.0.0 doesn't support newer hwloc releases:
     # "configure: error: OMPI does not currently support hwloc v2 API"
@@ -676,6 +678,8 @@ class Openmpi(AutotoolsPackage):
         if spec.satisfies('+lustre'):
             lustre_opt = '--with-lustre={0}'.format(spec['lustre'].prefix)
             config_args.append(lustre_opt)
+        # external libevent
+        config_args.append('--with-libevent={0}'.format(spec['libevent'].prefix))
         # Hwloc support
         if spec.satisfies('@1.5.2:'):
             config_args.append('--with-hwloc={0}'.format(spec['hwloc'].prefix))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -266,7 +266,7 @@ class Openmpi(AutotoolsPackage):
 
     depends_on('pkgconfig', type='build')
 
-    depends_on('libevent@2.0:')
+    depends_on('libevent@2.0:', when='@4:')
 
     depends_on('hwloc@2.0:', when='@4:')
     # ompi@:3.0.0 doesn't support newer hwloc releases:
@@ -679,7 +679,8 @@ class Openmpi(AutotoolsPackage):
             lustre_opt = '--with-lustre={0}'.format(spec['lustre'].prefix)
             config_args.append(lustre_opt)
         # external libevent
-        config_args.append('--with-libevent={0}'.format(spec['libevent'].prefix))
+        if spec.satisfies('@4.0.0:'):
+            config_args.append('--with-libevent={0}'.format(spec['libevent'].prefix))
         # Hwloc support
         if spec.satisfies('@1.5.2:'):
             config_args.append('--with-hwloc={0}'.format(spec['hwloc'].prefix))


### PR DESCRIPTION
Both hwlock & libevent are required dependencies of Open MPI. While they are also shipped internally, newer releases (>=4.0) will start looking for external packages by default.

This caused build issues of Open MPI 4.0.5 with Fortran on macOS 10.15.

cc @hppritcha

Proposal to fix #20656

Note: I need a macOS user to test this, since I only saw this in my QA scripts on an Azure Cloud instance.