### PR TITLE
ci: fix issue with latest sphinx

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -118,7 +118,11 @@ class SpackNamespace(types.ModuleType):
     def __getattr__(self, name):
         """Getattr lazily loads modules if they're not already loaded."""
         submodule = self.__package__ + '.' + name
-        setattr(self, name, __import__(submodule))
+        try:
+            setattr(self, name, __import__(submodule))
+        except ImportError:
+            msg = "'{0}' object has no attribute {1}"
+            raise AttributeError(msg.format(type(self), name))
         return getattr(self, name)
 
 

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -67,3 +67,15 @@ def test_repo_invisibles(mutable_mock_repo, extra_repo):
     with open(os.path.join(extra_repo.root, 'packages', '.invisible'), 'w'):
         pass
     extra_repo.all_package_names()
+
+
+@pytest.mark.parametrize('attr_name,exists', [
+    ('cmake', True),
+    ('__sphinx_mock__', False)
+])
+@pytest.mark.regression('20661')
+def test_namespace_hasattr(attr_name, exists, mutable_mock_repo):
+    # Check that we don't fail on 'hasattr' checks because
+    # of a custom __getattr__ implementation
+    nms = spack.repo.SpackNamespace('spack.pkg.builtin.mock')
+    assert hasattr(nms, attr_name) == exists


### PR DESCRIPTION
The latest Sphinx / autodoc combination searches classes for attributes that are relevant to the documentation tool only by using `hasattr`. This fails on one of our classes that implements a `__getattr__` method. The PR fixes the issue by raising the expected `AttributeError` if the custom `__getattr__` operation fails.