### PR TITLE
completion/zsh: fix sourcing from other emulations

### DIFF
--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -38,12 +38,22 @@
 # See `man bash` for more details.
 
 if test -n "${ZSH_VERSION:-}" ; then
-  if [[ "$(emulate)" = zsh ]] ; then
+  _spack_zsh_completion_init() {
+    emulate -L zsh
+    if test -n "${SPACK_ROOT:-}" ; then
+      SELF="${SPACK_ROOT}/share/spack/spack-completion.bash"
+    else
+      # try to get self from zsh, $0:A doesn't work in a function
+      SELF="${(%):-%x}"
+    fi
     # ensure base completion support is enabled, ignore insecure directories
     autoload -U +X compinit && compinit -i
     # ensure bash compatible completion support is enabled
     autoload -U +X bashcompinit && bashcompinit
-    emulate sh -c "source '$0:A'"
+    emulate sh -c "source '$SELF'"
+  }
+  if ! typeset -f complete > /dev/null ; then
+    _spack_zsh_completion_init "$(emulate)"
     return # stop interpreting file
   fi
 fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -38,12 +38,22 @@
 # See `man bash` for more details.
 
 if test -n "${ZSH_VERSION:-}" ; then
-  if [[ "$(emulate)" = zsh ]] ; then
+  _spack_zsh_completion_init() {
+    emulate -L zsh
+    if test -n "${SPACK_ROOT:-}" ; then
+      SELF="${SPACK_ROOT}/share/spack/spack-completion.bash"
+    else
+      # try to get self from zsh, $0:A doesn't work in a function
+      SELF="${(%):-%x}"
+    fi
     # ensure base completion support is enabled, ignore insecure directories
     autoload -U +X compinit && compinit -i
     # ensure bash compatible completion support is enabled
     autoload -U +X bashcompinit && bashcompinit
-    emulate sh -c "source '$0:A'"
+    emulate sh -c "source '$SELF'"
+  }
+  if ! typeset -f complete > /dev/null ; then
+    _spack_zsh_completion_init "$(emulate)"
     return # stop interpreting file
   fi
 fi


### PR DESCRIPTION
When sourced in an emulation mode other than zsh, the zsh setup code in
spack-completion.bash wasn't correctly initializing completion and bash
completion before using commands defined only after that's done.  This
ensures that we detect that case by checking for the bash `complete`
function, and if that is missing we initialize the completion stack and
re-source.  Otherwise, if it's already there, just load the rest of the
file and be done.  Should be slightly faster as well as correct in more
cases.

fixes #20551