### PR TITLE
Catch2 has to be a build and test dependency to ensure that LBANN with

### DIFF
--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -160,7 +160,7 @@ class Lbann(CMakePackage, CudaPackage):
     depends_on('py-m2r', type='build', when='+docs')
 
     depends_on('cereal')
-    depends_on('catch2', type='test')
+    depends_on('catch2', type=('build', 'test'))
     depends_on('clara')
 
     depends_on('llvm-openmp', when='%apple-clang')


### PR DESCRIPTION
testing will actually see the package.