### PR TITLE
intel-xed: add version 12.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -36,7 +36,7 @@ class IntelXed(Package):
             description='Compile with position independent code.')
 
     # The current mfile uses python3 by name.
-    depends_on('python+pythoncmd@3.4:', type='build')
+    depends_on('python@3.4:', type='build')
 
     conflicts('target=ppc64:', msg='intel-xed only runs on x86')
     conflicts('target=ppc64le:', msg='intel-xed only runs on x86')

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -13,38 +13,34 @@ class IntelXed(Package):
 
     homepage = "https://intelxed.github.io/"
     git      = "https://github.com/intelxed/xed.git"
+    maintainers = ['mwkrentel']
 
-    # The version name and git commit hashes for the main xed repo and
-    # the mbuild resource.  Xed doesn't have official releases, only
-    # git commits.
+    mbuild_git = 'https://github.com/intelxed/mbuild.git'
 
-    version_list = [('2019.03.01',
-                     'b7231de4c808db821d64f4018d15412640c34113',
-                     '176544e1fb54b6bfb40f596111368981d287e951'),
-                    ('2018.02.14',
-                     '44d06033b69aef2c20ab01bfb518c52cd71bb537',
-                     'bb9123152a330c7fa1ff1a502950dc199c83e177')]
+    # Current versions now have actual releases and tags.
+    version('master', branch='master')
+    version('12.0.1', tag='12.0.1')
+    version('11.2.0', tag='11.2.0')
 
-    version('develop', branch='master')
-    resource(name='mbuild',
-             git='https://github.com/intelxed/mbuild.git',
-             branch='master', placement='mbuild',
-             when='@develop')
+    # The old 2019.03.01 version (before there were tags).
+    version('10.2019.03', commit='b7231de4c808db821d64f4018d15412640c34113')
 
-    for (vers, xed_hash, mbuild_hash) in version_list:
-        version(vers, commit=xed_hash)
-        resource(name='mbuild',
-                 git='https://github.com/intelxed/mbuild.git',
-                 commit=mbuild_hash,
-                 when='@{0}'.format(vers))
+    resource(name='mbuild', placement='mbuild', git=mbuild_git,
+             branch='master', when='@master')
+
+    resource(name='mbuild', placement='mbuild', git=mbuild_git,
+             commit='3e8eb33aada4153c21c4261b35e5f51f6e2019e8', when='@:999')
 
     variant('debug', default=False, description='Enable debug symbols')
+    variant('pic', default=False,
+            description='Compile with position independent code.')
 
-    # python module 'platform.linux_distribution' was removed in python 3.8
-    depends_on('python@2.7:3.7', type='build')
+    # The current mfile uses python3 by name.
+    depends_on('python+pythoncmd@3.4:', type='build')
 
     conflicts('target=ppc64:', msg='intel-xed only runs on x86')
     conflicts('target=ppc64le:', msg='intel-xed only runs on x86')
+    conflicts('target=aarch64:', msg='intel-xed only runs on x86')
 
     mycflags = []
 
@@ -52,6 +48,10 @@ class IntelXed(Package):
     def flag_handler(self, name, flags):
         if name == 'cflags':
             self.mycflags = flags
+
+            if '+pic' in self.spec:
+                flags.append(self.compiler.cc_pic_flag)
+
         return (flags, None, None)
 
     def install(self, spec, prefix):
@@ -93,9 +93,15 @@ class IntelXed(Package):
 
         install(join_path('obj', 'lib*.so'), prefix.lib)
 
-        # Install the xed program
-        install(join_path('obj', 'examples', 'xed'), prefix.bin)
-
-        # Install header files.
-        install(join_path('include', 'public', 'xed', '*.h'), prefix.include)
-        install(join_path('obj', '*.h'), prefix.include)
+        # Starting with 11.x, the install files are moved or copied into
+        # subdirs of obj/wkit.
+        if spec.satisfies('@11.0:'):
+            wkit = join_path('obj', 'wkit')
+            install(join_path(wkit, 'bin', 'xed'), prefix.bin)
+            install(join_path(wkit, 'include', 'xed', '*.h'), prefix.include)
+        else:
+            # Old 2019.03.01 paths.
+            install(join_path('obj', 'examples', 'xed'), prefix.bin)
+            install(join_path('include', 'public', 'xed', '*.h'),
+                    prefix.include)
+            install(join_path('obj', '*.h'), prefix.include)


### PR DESCRIPTION
Rework the version numbers for intel-xed, now that xed has actual
releases and tags.  Add releases 11.2.0 and 12.0.1.  Rename 2019.03.01
to 10.2019.03 as a legacy version that fits in the new order.

Add variant +pic to compile libxed.a with PIC code so that it can be
linked into another shared library.

Add conflict for aarch64.
Add myself as maintainer.

----------

Again, my project (hpctoolkit) is the only other package that
explicitly depends on intel-xed, so reworking the version numbers is
unlikely to cause trouble.