### PR TITLE
Mesa: use auto when llvm is built shared

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -84,6 +84,8 @@ class Mesa(MesonPackage):
     # OpenGL ES requires OpenGL
     conflicts('~opengl +opengles')
 
+    # 'auto' needed when shared llvm is built
+    @when('^llvm~shared_libs')
     def patch(self):
         filter_file(
             r"_llvm_method = 'auto'",


### PR DESCRIPTION
@hppritcha @chuckatkins @v-dobrev @tuxfan 

This lets meson use 'auto' when building shared llvm. Fixes problem in https://github.com/spack/spack/pull/20451#issuecomment-749833836 . 