### PR TITLE
Oneapi modulevars

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -62,11 +62,11 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 subprocess.call(['patchelf', '--set-rpath', rpath, file])
 
     def setup_run_environment(self, env):
-        env.prepend_path('PATH', join_path(self.prefix, 
+        env.prepend_path('PATH', join_path(self.prefix,
                          'compiler', 'latest', 'linux', 'bin'))
-        env.prepend_path('CPATH', join_path(self.prefix, 
+        env.prepend_path('CPATH', join_path(self.prefix,
                          'compiler', 'latest', 'linux', 'include'))
-        env.prepend_path('LIBRARY_PATH', join_path(self.prefix, 
+        env.prepend_path('LIBRARY_PATH', join_path(self.prefix,
                          'compiler', 'latest', 'linux', 'lib'))
         env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix,
                          'compiler', 'latest', 'linux', 'lib'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -60,3 +60,13 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched
                 subprocess.call(['patchelf', '--set-rpath', rpath, file])
+
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', join_path(self.prefix, 
+                         'compiler', 'latest', 'linux', 'bin'))
+        env.prepend_path('CPATH', join_path(self.prefix, 
+                         'compiler', 'latest', 'linux', 'include'))
+        env.prepend_path('LIBRARY_PATH', join_path(self.prefix, 
+                         'compiler', 'latest', 'linux', 'lib'))
+        env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix,
+                         'compiler', 'latest', 'linux', 'lib'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -60,3 +60,9 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched
                 subprocess.call(['patchelf', '--set-rpath', rpath, file])
+
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', join_path(self.prefix, 'compiler', 'latest', 'linux', 'bin'))
+        env.prepend_path('CPATH', join_path(self.prefix, 'compiler', 'latest', 'linux', 'include'))
+        env.prepend_path('LIBRARY_PATH', join_path(self.prefix, 'compiler', 'latest', 'linux', 'lib'))
+        env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix, 'compiler', 'latest', 'linux', 'lib'))


### PR DESCRIPTION
I added some variables to the generated module:
```
prepend-path    PATH /soft/spack/opt/spack/linux-opensuse_leap15-cascadelake/gcc-10.1.0/intel-oneapi-compilers-2021.1.0-wgzjfktx5hsx75gghtd6k2qxad5vnot2/compiler/latest/linux/bin
prepend-path    CPATH /soft/spack/opt/spack/linux-opensuse_leap15-cascadelake/gcc-10.1.0/intel-oneapi-compilers-2021.1.0-wgzjfktx5hsx75gghtd6k2qxad5vnot2/compiler/latest/linux/include
prepend-path    LIBRARY_PATH /soft/spack/opt/spack/linux-opensuse_leap15-cascadelake/gcc-10.1.0/intel-oneapi-compilers-2021.1.0-wgzjfktx5hsx75gghtd6k2qxad5vnot2/compiler/latest/linux/lib
prepend-path    LD_LIBRARY_PATH /soft/spack/opt/spack/linux-opensuse_leap15-cascadelake/gcc-10.1.0/intel-oneapi-compilers-2021.1.0-wgzjfktx5hsx75gghtd6k2qxad5vnot2/compiler/latest/linux/lib
```
This will make the compiler immediately usable after `spack load` or `module load` 

@rscohn2 @scheibelp please let me know what you think.