### PR TITLE
fix oneapi mpi lib paths, add virtual provides

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -19,6 +19,8 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
 
     version('2021.1.1', sha256='2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86', expand=False)
 
+    provides('ipp')
+
     def __init__(self, spec):
         self.component_info(dir_name='ipp',
                             components='intel.oneapi.lin.ipp.devel',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -19,6 +19,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     version('2021.1.1', sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c', expand=False)
 
+    provides('fftw-api@3')
+    provides('scalapack')
+    provides('mkl')
+    provides('lapack')
+    provides('blas')
+
     def __init__(self, spec):
         self.component_info(dir_name='mkl',
                             components='intel.oneapi.lin.mkl.devel',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -19,9 +19,20 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     version('2021.1.1', sha256='8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe', expand=False)
 
+    provides('mpi@:3')
+
     def __init__(self, spec):
         self.component_info(dir_name='mpi',
                             components='intel.oneapi.lin.mpi.devel',
                             releases=releases,
                             url_name='mpi_oneapi')
         super(IntelOneapiMpi, self).__init__(spec)
+
+    @property
+    def libs(self):
+        libs = []
+        for dir in ['lib/release_mt', 'lib', 'libfabric/lib']:
+            lib_path = '{0}/{1}/latest/{2}'.format(self.prefix, self._dir_name, dir)
+            ldir = find_libraries('*', root=lib_path, shared=True, recursive=False)
+            libs += ldir
+        return libs

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -19,6 +19,8 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
 
     version('2021.1.1', sha256='535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b', expand=False)
 
+    provides('tbb')
+
     def __init__(self, spec):
         self.component_info(dir_name='tbb',
                             components='intel.oneapi.lin.tbb.devel',


### PR DESCRIPTION
Added virtual provides to the oneapi packages that match the previous intel packages.

For MPI, we were missing the directory that contains libfabric. Fixed

I have added some tests to this repo: https://github.com/rscohn2/oneapi-spack-tests

It will pass after this commit is merged.