### PR TITLE
dakota: fix build dependencies 

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -44,7 +44,6 @@ class Dakota(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     depends_on('python')
-    depends_on('perl-data-dumper', type='build', when='@:6.12')
     depends_on('perl-data-dumper', type='build', when='@6.12:')
     depends_on('boost@:1.68.0', when='@:6.12')
     depends_on('cmake@2.8.9:', type='build')

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -45,6 +45,7 @@ class Dakota(CMakePackage):
 
     depends_on('python')
     depends_on('perl-data-dumper', type='build', when='@:6.12')
+    depends_on('perl-data-dumper', type='build', when='@6.12:')
     depends_on('boost@:1.68.0', when='@:6.12')
     depends_on('cmake@2.8.9:', type='build')
 

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -44,7 +44,7 @@ class Dakota(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     depends_on('python')
-    depends_on('perl-data-dumper')
+    depends_on('perl-data-dumper', type='build', when='@:6.12')
     depends_on('boost@:1.68.0', when='@:6.12')
     depends_on('cmake@2.8.9:', type='build')
 

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -44,6 +44,7 @@ class Dakota(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     depends_on('python')
+    depends_on('perl-data-dumper')
     depends_on('boost@:1.68.0', when='@:6.12')
     depends_on('cmake@2.8.9:', type='build')
 


### PR DESCRIPTION
Dakota fails to install without perl-data-dumper on the system
`Can't locate Data/Dumper.pm in @INC (you may need to install the Data::Dumper module)`