### PR TITLE
[WIP] Packages can add dynamic dependencies

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2520,6 +2520,9 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 msg = 'RUN-TESTS: method not implemented [{0}]'
                 tty.warn(msg.format(name))
 
+    def dynamic_dependencies(self):
+        return []
+
 
 def test_process(pkg, kwargs):
     with tty.log.log_output(pkg.test_log_file) as logger:
@@ -2584,9 +2587,6 @@ def test_process(pkg, kwargs):
         finally:
             # reset debug level
             tty.set_debug(old_debug)
-
-    def dynamic_dependencies(self):
-        return []
 
 
 inject_flags = PackageBase.inject_flags

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2585,6 +2585,9 @@ def test_process(pkg, kwargs):
             # reset debug level
             tty.set_debug(old_debug)
 
+    def dynamic_dependencies(self):
+        return []
+
 
 inject_flags = PackageBase.inject_flags
 env_flags = PackageBase.env_flags

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2822,6 +2822,10 @@ class Spec(object):
                     if merge:
                         changed |= self._merge_dependency(
                             dep, visited, spec_deps, provider_index, tests)
+            for spec in self.package.dynamic_dependencies():
+                dependency = dp.Dependency(spec.name, spec, type=())
+                changed |= self._merge_dependency(
+                    dependency, visited, spec_deps, provider_index, tests)
             any_change |= changed
 
         return any_change

--- a/lib/spack/spack/util/mock_package.py
+++ b/lib/spack/spack/util/mock_package.py
@@ -23,8 +23,7 @@ class MockPackageBase(object):
     """
     virtual = False
 
-    def __init__(self, dependencies, dependency_types,
-                 conditions=None, versions=None):
+    def __init__(self, spec):
         """Instantiate a new MockPackageBase.
 
         This is not for general use; it needs to be constructed by a
@@ -32,7 +31,7 @@ class MockPackageBase(object):
         to find possible depenencies.
 
         """
-        self.spec = None
+        self.spec = spec
         self._installed_upstream = False
 
     def provides(self, vname):
@@ -74,6 +73,9 @@ class MockPackageBase(object):
         # package.py file; in that sense, the content_hash is always the same.
         return self.__class__.__name__
 
+    def dynamic_dependencies(self):
+        return []
+
 
 class MockPackageMultiRepo(object):
     """Mock package repository, mimicking ``spack.repo.Repo``."""
@@ -86,7 +88,7 @@ class MockPackageMultiRepo(object):
             spec = Spec(spec)
         if spec.name not in self.spec_to_pkg:
             raise spack.repo.UnknownPackageError(spec.fullname)
-        return self.spec_to_pkg[spec.name]
+        return self.spec_to_pkg[spec.name](spec)
 
     def get_pkg_class(self, name):
         return self.spec_to_pkg[name]
@@ -165,9 +167,7 @@ class MockPackageMultiRepo(object):
         MockPackage.conflicts = {}
         MockPackage.patches = {}
 
-        mock_package = MockPackage(
-            dependencies, dependency_types, conditions, versions)
-        self.spec_to_pkg[name] = mock_package
-        self.spec_to_pkg["mockrepo." + name] = mock_package
+        self.spec_to_pkg[name] = MockPackage
+        self.spec_to_pkg["mockrepo." + name] = MockPackage
 
-        return mock_package
+        return MockPackage


### PR DESCRIPTION
A package object can implement `dynamic_deps` to inspect its associated spec and add dependencies accordingly.

This is an alternative to https://github.com/spack/spack/pull/20502. Unlike #20502, this does not modify the hashing algorithm, but for the same use case it requires defining new package classes (both this PR and #20502 include a new test in `spec_deps` addressing the same use case, so you can see the work involved in each case).

This PR takes inspiration from https://github.com/alalazo/spack/commit/d130a6943ee663bf65b6565b656f1611c15067d9, although this PR differs in that it leaves the package class untouched.

@tgamblin FYI