### PR TITLE
bugfix: environments/views on separate mounts

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -553,9 +553,10 @@ class ViewDescriptor(object):
             # that cannot be resolved or have repos that have been removed
             # we always regenerate the view from scratch. We must first make
             # sure the root directory exists for the very first time though.
-            root = self.root
-            if not os.path.isabs(root):
-                root = os.path.normpath(os.path.join(self.base, self.root))
+            root = os.path.normpath(
+                self.root if os.path.isabs(self.root) else os.path.join(
+                    self.base, self.root)
+            )
             fs.mkdirp(root)
 
             # The tempdir for the directory transaction must be in the same

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -558,9 +558,13 @@ class ViewDescriptor(object):
                 root = os.path.normpath(os.path.join(self.base, self.root))
             fs.mkdirp(root)
 
-            # The tempdir for the directory transaction must be in the same 
-            # filesystem mount as the view, so that view creation fails to 
-            # symlink only when the finished view would fail as well
+            # The tempdir for the directory transaction must be in the same
+            # filesystem mount as the view for symlinks to work. Provide
+            # dirname(root) as the tempdir for the
+            # replace_directory_transaction because it must be on the same
+            # filesystem mount as the view itself. Otherwise it may be
+            # impossible to construct the view in the tempdir even when it can
+            # be constructed in-place.
             with fs.replace_directory_transaction(root, os.path.dirname(root)):
                 view = self.view()
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -557,7 +557,8 @@ class ViewDescriptor(object):
             if not os.path.isabs(root):
                 root = os.path.normpath(os.path.join(self.base, self.root))
             fs.mkdirp(root)
-            with fs.replace_directory_transaction(root):
+
+            with fs.replace_directory_transaction(root, os.path.dirname(root)):
                 view = self.view()
 
                 view.clean()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -558,6 +558,9 @@ class ViewDescriptor(object):
                 root = os.path.normpath(os.path.join(self.base, self.root))
             fs.mkdirp(root)
 
+            # The tempdir for the directory transaction must be in the same 
+            # filesystem mount as the view, so that view creation fails to 
+            # symlink only when the finished view would fail as well
             with fs.replace_directory_transaction(root, os.path.dirname(root)):
                 view = self.view()
 


### PR DESCRIPTION
Fixes a bug discovered at Livermore:

Environment views fail when the tmpdir used for view generation is on a separate mount from the install_tree because the files cannot by symlinked between the two. The fix is to use an alternative tmpdir located alongside the view.