### PR TITLE
New versions of opencl-c-headers, opencl-clhpp and ocl-icd

### DIFF
--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -13,6 +13,7 @@ OpenCL ICD loaders."""
     homepage = "https://github.com/OCL-dev/ocl-icd"
     url      = "https://github.com/OCL-dev/ocl-icd/archive/v2.2.12.tar.gz"
 
+    version('2.2.14', sha256='46df23608605ad548e80b11f4ba0e590cef6397a079d2f19adf707a7c2fbfe1b')
     version('2.2.13', sha256='f85d59f3e8327f15637b91e4ae8df0829e94daeff68c647b2927b8376b1f8d92')
     version('2.2.12', sha256='17500e5788304eef5b52dbe784cec197bdae64e05eecf38317840d2d05484272')
     version('2.2.11', sha256='c1865ef7701b8201ebc6930ed3ac757c7e5cb30f3aa4c1e742a6bc022f4f2292')
@@ -34,9 +35,10 @@ OpenCL ICD loaders."""
     depends_on('ruby',     type='build')
     depends_on('asciidoc-py3', type='build')
     depends_on('xmlto',    type='build')
-    depends_on('opencl-headers@2.2:', when='+headers')
+    depends_on('opencl-headers@3.0:', when='+headers')
 
-    provides('opencl@:2.2', when='@2.2.12:+headers')
+    provides('opencl@:3.0', when='@2.2.13:+headers')
+    provides('opencl@:2.2', when='@2.2.12+headers')
     provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 

--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -14,6 +14,7 @@ class OpenclCHeaders(Package):
     homepage = "https://www.khronos.org/registry/OpenCL/"
     url      = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.06.16.tar.gz"
 
+    version('2020.12.18', sha256='5dad6d436c0d7646ef62a39ef6cd1f3eba0a98fc9157808dfc1d808f3705ebc2')
     version('2020.06.16', sha256='2f5a60e5ac4b127650618c58a7e3b35a84dbf23c1a0ac72eb5e7baf221600e06')
     version('2020.03.13', sha256='664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476')
 

--- a/var/spack/repos/builtin/packages/opencl-clhpp/package.py
+++ b/var/spack/repos/builtin/packages/opencl-clhpp/package.py
@@ -14,6 +14,7 @@ class OpenclClhpp(CMakePackage):
     homepage = "https://www.khronos.org/registry/OpenCL/"
     url      = "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/v2.0.12.tar.gz"
 
+    version('2.0.13', sha256='8ff0d0cd94d728edd30c876db546bf13e370ee7863629b4b9b5e2ef8e130d23c')
     version('2.0.12', sha256='20b28709ce74d3602f1a946d78a2024c1f6b0ef51358b9686612669897a58719')
     version('2.0.11', sha256='ffc2ca08cf4ae90ee55f14ea3735ccc388f454f4422b69498b2e9b93a1d45181')
     version('2.0.10', sha256='fa27456295c3fa534ce824eb0314190a8b3ebd3ba4d93a0b1270fc65bf378f2b')

--- a/var/spack/repos/builtin/packages/opencl-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-headers/package.py
@@ -12,10 +12,13 @@ class OpenclHeaders(BundlePackage):
 
     homepage = "https://www.khronos.org/registry/OpenCL/"
 
+    version('3.0')
     version('2.2')
     version('2.1')
     version('2.0')
 
-    depends_on('opencl-c-headers@2020.03.13:')
-    depends_on('opencl-clhpp@2.0.11:', when='@2.1:')
+    depends_on('opencl-c-headers@2020.12.18:', when='@3.0:')
+    depends_on('opencl-c-headers@2020.03.13:', when='@2.0:2.2')
+    depends_on('opencl-clhpp@2.0.13:', when='@3.0:')
+    depends_on('opencl-clhpp@2.0.11:', when='@2.1:2.2')
     depends_on('opencl-clhpp@2.0.9:', when='@2.0')


### PR DESCRIPTION
This PR updates the OpenCL header packages `opencl-c-headers` and `opencl-clhpp`. The bundled package `opencl-headers` now supports completely OpenCL 3.0. Also it updates `ocl-icd` which now can provide together with the `opencl-headers` OpenCL 3.0