### PR TITLE
py-scikit-learn: do parallel builds of C extension

### DIFF
--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -62,6 +62,9 @@ class PyScikitLearn(PythonPackage):
     conflicts('~openmp', when='@:999', msg='Only master supports ~openmp')
 
     def setup_build_environment(self, env):
+        # enable parallel builds of the sklearn backend
+        env.append_flags("SKLEARN_BUILD_PARALLEL", str(make_jobs))
+
         # https://scikit-learn.org/stable/developers/advanced_installation.html#building-from-source
         if self.spec.satisfies('~openmp'):
             env.set('SKLEARN_NO_OPENMP', 'True')


### PR DESCRIPTION
@adamjstewart 

Enabled parallel builds of the C-extension upto the parallelism allowed
by spack.

https://scikit-learn.org/stable/developers/advanced_installation.html#parallel-builds

On my machine with 12 cores, this is about a 2.56x improvement in build times.

+ from :   Fetch: 0.03s.  Build: 6m 40.19s.  Total: 6m 40.22s.
+ to:   Fetch: 0.02s.  Build: 2m 24.34s.  Total: 2m 24.36s.