### PR TITLE
Remove ascent gitlab trigger

### DIFF
--- a/share/spack/gitlab/ascent_pipeline.yml
+++ b/share/spack/gitlab/ascent_pipeline.yml
@@ -1,9 +1,0 @@
-merge_pipeline:
-  only:
-  - develop
-  variables:
-    SPACK_REPO: ${CI_PROJECT_URL}
-    SPACK_REF: ${CI_COMMIT_SHA}
-  trigger:
-    project: ecpcitest/e4s
-    strategy: depend


### PR DESCRIPTION
This is to remove the ORNL Ascent gitlab trigger.  CI will be done internally via periodic builds.