### PR TITLE
llvm-amdgpu: add variant: openmp (bool)

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -25,12 +25,15 @@ class LlvmAmdgpu(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
+    variant('openmp', default=True, description='Enable OpenMP')
+
     depends_on('cmake@3.4.3:',  type='build', when='@:3.8.99')
     depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
     depends_on('python', type='build')
     depends_on('z3', type='link')
     depends_on('zlib', type='link')
     depends_on('ncurses+termlib', type='link')
+    depends_on('libelf', type='link', when='+openmp')
 
     # Will likely only be fixed in LLVM 12 upstream
     patch('fix-system-zlib-ncurses.patch', when='@3.5.0:3.8.0')
@@ -43,8 +46,18 @@ class LlvmAmdgpu(CMakePackage):
     install_targets = ['clang-tidy', 'install']
 
     def cmake_args(self):
+        llvm_projects = [
+            'clang',
+            'lld',
+            'clang-tools-extra',
+            'compiler-rt'
+        ]
+
+        if '+openmp' in self.spec:
+            llvm_projects.append('openmp')
+
         args = [
-            '-DLLVM_ENABLE_PROJECTS=clang;lld;clang-tools-extra;compiler-rt',
+            '-DLLVM_ENABLE_PROJECTS={0}'.format(';'.join(llvm_projects)),
             '-DLLVM_ENABLE_ASSERTIONS=1'
         ]
 


### PR DESCRIPTION
Add `+openmp` variant to `llvm-amdgpu` to enable the `openmp` LLVM sub-project.

@wspear 