### PR TITLE
libjpeg-turbo: New version 2.0.6

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -17,6 +17,8 @@ class LibjpegTurbo(Package):
     homepage = "https://libjpeg-turbo.org/"
     url = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.3.tar.gz"
 
+    version('2.0.6', sha256='005aee2fcdca252cee42271f7f90574dda64ca6505d9f8b86ae61abc2b426371')
+    version('2.0.5', sha256='b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7')
     version('2.0.4', sha256='7777c3c19762940cff42b3ba4d7cd5c52d1671b39a79532050c85efb99079064')
     version('2.0.3', sha256='a69598bf079463b34d45ca7268462a18b6507fdaa62bb1dfd212f02041499b5d')
     version('2.0.2', sha256='b45255bd476c19c7c6b198c07c0487e8b8536373b82f2b38346b32b4fa7bb942')


### PR DESCRIPTION
New versions 2.0.5 and 2.0.6