### PR TITLE
Adding AOCC support for WRF4.2

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -261,6 +261,9 @@ class Wrf(Package):
                         ofh.write(line)
 
         if self.spec.satisfies("@4.2 %aocc"):
+            """
+            change in naming of configure.defaults is related to WRF version
+            """
             rename(
                 "./arch/configure.defaults",
                 "./arch/configure.defaults.bak",

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -261,9 +261,7 @@ class Wrf(Package):
                         ofh.write(line)
 
         if self.spec.satisfies("@4.2 %aocc"):
-            """
-            change in naming of configure.defaults is related to WRF version
-            """
+            # Change in naming of configure.defaults is related to WRF version
             rename(
                 "./arch/configure.defaults",
                 "./arch/configure.defaults.bak",

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -261,7 +261,8 @@ class Wrf(Package):
                         ofh.write(line)
 
         if self.spec.satisfies("@4.2 %aocc"):
-            # Change in naming of configure.defaults is related to WRF version
+            # In version 4.2 the file to be patched is called configure.defaults, while 
+            # in earlier versions it's configure_new.defaults
             rename(
                 "./arch/configure.defaults",
                 "./arch/configure.defaults.bak",

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -261,8 +261,8 @@ class Wrf(Package):
                         ofh.write(line)
 
         if self.spec.satisfies("@4.2 %aocc"):
-            # In version 4.2 the file to be patched is called 
-            # configure.defaults, while in earlier versions 
+            # In version 4.2 the file to be patched is called
+            # configure.defaults, while in earlier versions
             # it's configure_new.defaults
             rename(
                 "./arch/configure.defaults",

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -261,8 +261,9 @@ class Wrf(Package):
                         ofh.write(line)
 
         if self.spec.satisfies("@4.2 %aocc"):
-            # In version 4.2 the file to be patched is called configure.defaults, while 
-            # in earlier versions it's configure_new.defaults
+            # In version 4.2 the file to be patched is called 
+            # configure.defaults, while in earlier versions 
+            # it's configure_new.defaults
             rename(
                 "./arch/configure.defaults",
                 "./arch/configure.defaults.bak",

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -130,6 +130,8 @@ class Wrf(Package):
     patch("patches/4.2/Makefile.patch", when="@4.2")
     patch("patches/4.2/tirpc_detect.patch", when="@4.2")
     patch("patches/4.2/add_aarch64.patch", when="@4.2")
+    patch("patches/4.2/configure4.2_aocc.patch", when="@4.2 %aocc@:3.0")
+    patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc@:3.0")
 
     depends_on("pkgconfig", type=("build"))
     depends_on("libtirpc")
@@ -246,6 +248,25 @@ class Wrf(Package):
             )
             with open("./arch/configure_new.defaults.bak", "rt") as ifh:
                 with open("./arch/configure_new.defaults", "wt") as ofh:
+                    for line in ifh:
+                        if line.startswith("DM_"):
+                            line = line.replace(
+                                "mpif90 -DMPI2_SUPPORT",
+                                self.spec['mpi'].mpifc + " -DMPI2_SUPPORT"
+                            )
+                            line = line.replace(
+                                "mpicc -DMPI2_SUPPORT",
+                                self.spec['mpi'].mpicc + " -DMPI2_SUPPORT"
+                            )
+                        ofh.write(line)
+
+        if self.spec.satisfies("@4.2 %aocc"):
+            rename(
+                "./arch/configure.defaults",
+                "./arch/configure.defaults.bak",
+            )
+            with open("./arch/configure.defaults.bak", "rt") as ifh:
+                with open("./arch/configure.defaults", "wt") as ofh:
                     for line in ifh:
                         if line.startswith("DM_"):
                             line = line.replace(

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/configure4.2_aocc.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/configure4.2_aocc.patch
@@ -1,10 +1,10 @@
---- WRF-3.9.1.1/arch/configure_new.defaults	2017-08-29 01:59:47.000000000 +0530
-+++ WRF-3.9.1.1/arch/configure_391_aocc22.defaults	2020-12-23 10:06:29.764955610 +0530
-@@ -1917,6 +1917,52 @@
- CC_TOOLS        =      $(SCC) 
+--- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
++++ WRF-4.2/arch/configure_42_aocc22.defaults	2020-12-28 08:22:49.253214150 +0530
+@@ -1975,6 +1975,51 @@
+                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
  
  #insert new stanza here
-+############################################################
++#############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
 +DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
@@ -17,7 +17,7 @@
 +CCOMP           =       clang
 +DM_FC           =       mpif90 -DMPI2_SUPPORT
 +DM_CC           =       mpicc -DMPI2_SUPPORT
-+FC              =       $(DM_FC)
++FC              =       time $(DM_FC)
 +CC              =       $(DM_CC) -DFSEEKO64_OK
 +LD              =       $(FC)
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
@@ -25,21 +25,21 @@
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
 +LIBMVEC         =       -mllvm -vector-library=LIBMVEC
 +AMDARCHOPT      =       -march=native
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math $(AMDARCHOPT)
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -g $(AMDARCHOPT)
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 +FCOPTIM         =       $(AOCCOPT) -fopenmp
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCNOOPT         =       -O0 -ffast-math
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) -ffast-math
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P
@@ -49,7 +49,6 @@
 +RANLIB          =       llvm-ranlib
 +RLFLAGS         =
 +CC_TOOLS        =       $(SCC)
-+
  
  ###########################################################
  #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/derf_fix.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/derf_fix.patch
@@ -1,0 +1,11 @@
+--- WRF-4.2/phys/module_mp_SBM_polar_radar.F	2020-04-23 22:38:37.000000000 +0530
++++ WRF-4.2/phys/module_mp_SBM_polar_radar_aocc.F	2020-12-29 11:45:52.329495585 +0530
+@@ -1534,7 +1534,7 @@
+                     (1.0d0-(1.0d0-fract_volume_water)*ratc))
+ ! new change 18.01.09                                         (start)
+       if(fract_volume_water.gt.1.0d-10) then
+-         t=derf((1.0d0-fract_volume_water)/fract_volume_water-0.2d0)
++         t=erf((1.0d0-fract_volume_water)/fract_volume_water-0.2d0)
+       else
+          t=1.0d0
+       endif


### PR DESCRIPTION
- Updated Package.py for WRF 4.2 with AOCC support

provided patch for WRF-4.2/phys/module_mp_SBM_polar_radar_aocc.F
with reference from https://github.com/wrf-model/WRF/pull/1183