### PR TITLE
hdf: build with gcc10

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -144,6 +144,14 @@ class Hdf(AutotoolsPackage):
             # We should not specify '--disable-hdf4-xdr' due to a bug in the
             # configure script.
             config_args.append('LIBS=%s' % self.spec['rpc'].libs.link_flags)
+
+        # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
+        if self.spec.satisfies('%gcc@10:'):
+            config_args.extend([
+                'FFLAGS=-fallow-argument-mismatch',
+                'FCFLAGS=-fallow-argument-mismatch']
+            )
+
         return config_args
 
     # Otherwise, we randomly get:


### PR DESCRIPTION
fix hdf build to work with gcc10. parallels to what was done with netcdf. 
e.g. [spack parallel-netcdf](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/parallel-netcdf/package.py)