### PR TITLE
NAMD: FIX build +cuda and mpi ~smp

### DIFF
--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -226,7 +226,7 @@ class Namd(MakefilePackage, CudaPackage):
             self._append_option(opts, 'cuda')
             filter_file('^CUDADIR=.*$',
                         'CUDADIR={0}'.format(spec['cuda'].prefix),
-                        self.arch + '.cuda')
+                        join_path('arch', self.arch + '.cuda'))
 
         config = Executable('./config')
 

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -111,7 +111,7 @@ class Namd(MakefilePackage, CudaPackage):
                 else:
                     optims_opts = {
                         'gcc': m64 + '-O3 -fexpensive-optimizations \
-                                        -ffast-math ' + archopt,
+                                        -ffast-math -lpthread ' + archopt,
                         'intel': '-O2 -ip ' + archopt,
                         'aocc': m64 + '-O3 -ffp-contract=fast \
                                         -ffast-math ' + archopt}


### PR DESCRIPTION
Hi,
If I try to compile NAMD with CUDA support, it fails because cannot find the file `{self.arch}.cuda` because it is under the `arch` folder.

If I try to compile NAMD with MPI and ~smp (`spack install namd ^charmpp backend=mpi ~smp`), it fails:
```
 /usr/bin/ld: /shared/home/vasco/spack/opt/spack/linux-centos7-zen2/gcc-9.2.0/charmpp-6.10.2-mi5x2v26uzsd4fp44mzkpap2ume5u6d5/bin/../lib/libmod
            uleCkLoop.a(CkLoop.o): undefined reference to symbol 'pthread_create@@@@GLIBC_2.2.5'
  >> 782    //usr/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
  >> 783    collect2: error: ld returned 1 exit status
  >> 784    Fatal Error by charmc in directory /dev/shm/vasco/spack-stage/spack-stage-namd-2.15a1-logfiivarcvjf2we7rhmjnb6dne33ptk/spack-src/linux-x86_64-spack
```
Adding the flag `-lpthread` solves the problem

