### PR TITLE
Fix hip patch version number

### DIFF
--- a/var/spack/repos/builtin/packages/hip/0003-Improve-compilation-without-git-repo.patch
+++ b/var/spack/repos/builtin/packages/hip/0003-Improve-compilation-without-git-repo.patch
@@ -1,0 +1,56 @@
+From 3a05d9ee5af2d318d27ee4b8e81542e2c81b9d5a Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Mon, 11 Jan 2021 16:38:14 +0100
+Subject: [PATCH] Improve compilation without git repo
+
+---
+ CMakeLists.txt | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7831bb4d..c0c7a536 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,9 +42,17 @@ string(REPLACE "." ";" VERSION_LIST ${HIP_BASE_VERSION})
+ list(GET VERSION_LIST 0 HIP_VERSION_MAJOR)
+ list(GET VERSION_LIST 1 HIP_VERSION_MINOR)
+ 
+-find_package(Git)
++# only look for git when we have a git repo
++if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
++  find_package(Git)
++endif()
+ 
+ # FIXME: Two different version strings used.
++
++set(HIP_PACKAGING_VERSION_PATCH "0")
++set(HIP_VERSION_GITDATE "0")
++set(HIP_VERSION_PATCH "0")
++
+ if(GIT_FOUND)
+   # get date information based on UTC
+   # use the last two digits of year + week number + day in the week as HIP_VERSION_GITDATE
+@@ -88,9 +96,6 @@ if(GIT_FOUND)
+   else()
+     set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_GITDATE}.${HIP_VERSION_GITCOUNT}-${HIP_VERSION_GITHASH})
+   endif()
+-else()
+-  # FIXME: Some parts depend on this being set.
+-  set(HIP_PACKAGING_VERSION_PATCH "0")
+ endif()
+ 
+ ## Debian package specific variables
+@@ -488,10 +493,6 @@ endif()
+ # Generate .hipVersion
+ file(WRITE "${PROJECT_BINARY_DIR}/.hipVersion" ${_versionInfo})
+ 
+-if(NOT DEFINED HIP_VERSION_GITDATE)
+-  set(HIP_VERSION_GITDATE 0)
+-endif()
+-
+ # Build doxygen documentation
+ find_program(DOXYGEN_EXE doxygen)
+ if(DOXYGEN_EXE)
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -51,6 +51,9 @@ class Hip(CMakePackage):
     # See https://github.com/ROCm-Developer-Tools/HIP/pull/2141
     patch('0002-Fix-detection-of-HIP_CLANG_ROOT.patch', when='@:3.9.0')
 
+    # See https://github.com/ROCm-Developer-Tools/HIP/pull/2218
+    patch('0003-Improve-compilation-without-git-repo.patch', when='@4.0.0:')
+
     def get_rocm_prefix_info(self):
         # External packages in Spack do not currently contain dependency
         # information. External installations of hip therefore must compute


### PR DESCRIPTION
Ping @srekolam. Currently builds of hip result in shared libs having suffixes like `libamdhip.so.x.y.z-` with a trailing dash. This is because hip insists on using git to set the patch version number. The problem is there is no git repo to use when downloading tarballs. This resulted in build errors in some cases when using targets from `hip-config.cmake`.

Upstream PR: https://github.com/ROCm-Developer-Tools/HIP/pull/2218