### PR TITLE
rdma-core: require GCC 10+

### DIFF
--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -30,6 +30,7 @@ class RdmaCore(CMakePackage):
     depends_on('libnl')
     conflicts('platform=darwin', msg='rdma-core requires FreeBSD or Linux')
     conflicts('%intel', msg='rdma-core cannot be built with intel (use gcc instead)')
+    conflicts('%gcc@:10', msg='rdma-core requires GCC 10 or later')
 
 # NOTE: specify CMAKE_INSTALL_RUNDIR explicitly to prevent rdma-core from
 #       using the spack staging build dir (which may be a very long file


### PR DESCRIPTION
I believe rdma-core requires gcc 10 because symver attribute was added in GCC 10.
Related links:
 - https://gcc.gnu.org/onlinedocs/gcc-10.2.0/gcc/Common-Function-Attributes.html
 - https://github.com/linux-rdma/rdma-core/commit/f03f7022901466b6d6ead01e48a7057fa574cc3b

Not sure if this should be limited to some specific versions.