### PR TITLE
Fix cuda arch conflicts in asp concretizer for dbcsr and cp2k

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -161,8 +161,10 @@ class Cp2k(MakefilePackage, CudaPackage):
 
     conflicts('~openmp', when='@8:', msg='Building without OpenMP is not supported in CP2K 8+')
 
-    # we only support specific cuda_archs for which we have parameter files
-    # for optimal kernels
+    # We only support specific cuda_archs for which we have parameter files
+    # for optimal kernels. Note that we don't override the cuda_archs property
+    # from the parent class, since the parent class defines constraints for all
+    # versions. Instead just mark all unsupported cuda archs as conflicting.
     dbcsr_cuda_archs = ('none', '35', '37', '60', '70')
 
     for arch in CudaPackage.cuda_arch_values:

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -165,13 +165,14 @@ class Cp2k(MakefilePackage, CudaPackage):
     # for optimal kernels. Note that we don't override the cuda_archs property
     # from the parent class, since the parent class defines constraints for all
     # versions. Instead just mark all unsupported cuda archs as conflicting.
-    dbcsr_cuda_archs = ('none', '35', '37', '60', '70')
+    dbcsr_cuda_archs = ('35', '37', '60', '70')
+    cuda_msg = 'cp2k only supports cuda_arch {0}'.format(dbcsr_cuda_archs)
 
     for arch in CudaPackage.cuda_arch_values:
         if arch not in dbcsr_cuda_archs:
-            conflicts('+cuda', when='cuda_arch={0}'.format(arch),
-                      msg='cp2k only supports cuda_arch {0}'.format(
-                          dbcsr_cuda_archs))
+            conflicts('+cuda', when='cuda_arch={0}'.format(arch), msg=cuda_msg)
+
+    conflicts('+cuda', when='cuda_arch=none', msg=cuda_msg)
 
     @property
     def makefile_architecture(self):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -585,6 +585,9 @@ class Cp2k(MakefilePackage, CudaPackage):
         ]
 
     def build(self, spec, prefix):
+        if len(spec.variants['cuda_arch'].value) > 1:
+            raise InstallError("cp2k supports only one cuda_arch at a time")
+
         # Apparently the Makefile bases its paths on PWD
         # so we need to set PWD = self.build_directory
         with spack.util.environment.set_env(PWD=self.build_directory):

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -52,13 +52,17 @@ class Dbcsr(CMakePackage, CudaPackage):
     depends_on('ninja@1.10:', type='build')
 
     def cmake_args(self):
+        spec = self.spec
+
+        if len(spec.variants['cuda_arch'].value) > 1:
+            raise InstallError("dbcsr supports only one cuda_arch at a time")
+
         if ('+openmp' in self.spec
             and '^openblas' in self.spec
             and '^openblas threads=openmp' not in self.spec):
             raise InstallError(
                 '^openblas threads=openmp required for dbcsr+openmp')
 
-        spec = self.spec
         args = [
             '-DUSE_SMM=%s' % ('libxsmm' if 'smm=libxsmm' in spec else 'blas'),
             '-DUSE_MPI=%s' % ('ON' if '+mpi' in spec else 'OFF'),

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -40,13 +40,14 @@ class Dbcsr(CMakePackage, CudaPackage):
     # for optimal kernels. Note that we don't override the cuda_archs property
     # from the parent class, since the parent class defines constraints for all
     # versions. Instead just mark all unsupported cuda archs as conflicting.
-    dbcsr_cuda_archs = ('none', '35', '37', '60', '70')
+    dbcsr_cuda_archs = ('35', '37', '60', '70')
+    cuda_msg = 'dbcsr only supports cuda_arch {0}'.format(dbcsr_cuda_archs)
 
     for arch in CudaPackage.cuda_arch_values:
         if arch not in dbcsr_cuda_archs:
-            conflicts('+cuda', when='cuda_arch={0}'.format(arch),
-                      msg='dbcsr only supports cuda_arch {0}'.format(
-                          dbcsr_cuda_archs))
+            conflicts('+cuda', when='cuda_arch={0}'.format(arch), msg=cuda_msg)
+
+    conflicts('+cuda', when='cuda_arch=none', msg=cuda_msg)
 
     generator = 'Ninja'
     depends_on('ninja@1.10:', type='build')

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -36,8 +36,10 @@ class Dbcsr(CMakePackage, CudaPackage):
     depends_on('pkgconfig', type='build')
     depends_on('python@3.6:', type='build', when='+cuda')
 
-    # we only support specific cuda_archs for which we have parameter files
-    # for optimal kernels
+    # We only support specific cuda_archs for which we have parameter files
+    # for optimal kernels. Note that we don't override the cuda_archs property
+    # from the parent class, since the parent class defines constraints for all
+    # versions. Instead just mark all unsupported cuda archs as conflicting.
     dbcsr_cuda_archs = ('none', '35', '37', '60', '70')
 
     for arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
Ping @dev-zero. Currently on develop there's a problem with the new concretizer and dbcsr:

```bash
$ spack solve dbcsr
==> Error: invalid values for variant "cuda_arch" in package "dbcsr": ['10']
```

I've tracked it down to 1343a815c02421fb94ddb2b80af76d35760bf4c4, and the advise was to no redefine `cuda_arch` and instead use conflicts, so that the conflicts regarding `cuda_arch=10` in the parent class `CudaPackage` would still make sense.
