### PR TITLE
Zoltan: source code location change

### DIFF
--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -22,7 +22,7 @@ class Zoltan(AutotoolsPackage):
     homepage = "http://www.cs.sandia.gov/zoltan"
     url      = "https://github.com/sandialabs/Zoltan/archive/v3.83.tar.gz"
 
-    version('3.83', sha256='d0d78fdeab7a385c87d3666b8a8dc748994ff04d3fd846872a4845e12d79c1bb')
+    version('3.83', sha256='17320a9f08e47f30f6f3846a74d15bfea6f3c1b937ca93c0ab759ca02c40e56c')
 
     patch('notparallel.patch', when='@3.8')
 

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -20,12 +20,9 @@ class Zoltan(AutotoolsPackage):
     """
 
     homepage = "http://www.cs.sandia.gov/zoltan"
-    url      = "http://www.cs.sandia.gov/~kddevin/Zoltan_Distributions/zoltan_distrib_v3.83.tar.gz"
+    url      = "https://github.com/sandialabs/Zoltan/archive/v3.83.tar.gz"
 
     version('3.83', sha256='d0d78fdeab7a385c87d3666b8a8dc748994ff04d3fd846872a4845e12d79c1bb')
-    version('3.8', sha256='5bdd46548fb9c73b225bbcf3d206c558c318cb292f0b19645e536315d14aafb7')
-    version('3.6', sha256='d2cb41e5fb72ca564b24bc5f21d82d9f7992f2c977bc82b243a01a8a8ee4eb9c')
-    version('3.3', sha256='8a90585674ab1bbd011dab29f778b9816519712c78d0aab4cdde9c68f02b30dc')
 
     patch('notparallel.patch', when='@3.8')
 

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -20,7 +20,7 @@ class Zoltan(AutotoolsPackage):
     """
 
     homepage = "http://www.cs.sandia.gov/zoltan"
-    url      = "http://www.cs.sandia.gov/~kddevin/Zoltan_Distributions/zoltan_distrib_v3.83.tar.gz"
+    url      = "https://github.com/sandialabs/Zoltan/raw/main/zoltan_distrib_v3.83.tar.gz"
 
     version('3.83', sha256='d0d78fdeab7a385c87d3666b8a8dc748994ff04d3fd846872a4845e12d79c1bb')
     version('3.8', sha256='5bdd46548fb9c73b225bbcf3d206c558c318cb292f0b19645e536315d14aafb7')

--- a/var/spack/repos/builtin/packages/zoltan/package.py
+++ b/var/spack/repos/builtin/packages/zoltan/package.py
@@ -20,7 +20,7 @@ class Zoltan(AutotoolsPackage):
     """
 
     homepage = "http://www.cs.sandia.gov/zoltan"
-    url      = "https://github.com/sandialabs/Zoltan/raw/main/zoltan_distrib_v3.83.tar.gz"
+    url      = "http://www.cs.sandia.gov/~kddevin/Zoltan_Distributions/zoltan_distrib_v3.83.tar.gz"
 
     version('3.83', sha256='d0d78fdeab7a385c87d3666b8a8dc748994ff04d3fd846872a4845e12d79c1bb')
     version('3.8', sha256='5bdd46548fb9c73b225bbcf3d206c558c318cb292f0b19645e536315d14aafb7')


### PR DESCRIPTION
Zoltan source code has been moved to GitHub. The old URL is no longer alive:

```shell
[quellyn@darwin-fe3 spack]$ spack stage zoltan
==> Fetching http://www.cs.sandia.gov/~kddevin/Zoltan_Distributions/zoltan_distrib_v3.83.tar.gz
######################################################################## 100.0%
==> Warning: The contents of the archive look like HTML.  Either the URL you are trying to use does not exist or you have an internet gateway issue.  You can remove the bad archive using 'spack clean <package>', then try again using the correct URL.
==> Error: sha256 checksum failed for /tmp/quellyn/spack-stage/spack-stage-zoltan-3.83-spri6lp5qiu4wov4mrj5k6rjys2urgs4/zoltan_distrib_v3.83.tar.gz
Expected d0d78fdeab7a385c87d3666b8a8dc748994ff04d3fd846872a4845e12d79c1bb but got 6680eb0d927e377c65177e20758407e42970f9a5036c73d7bd5121150edc0406
```

Thanks!
Quellyn