### PR TITLE
concretizer: dependency conditions cannot hold if package is external

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -93,7 +93,8 @@ dependency_conditions_hold(ID, Parent, Dependency) :-
   attr(Name, Arg1, Arg2)       : required_dependency_condition(ID, Name, Arg1, Arg2);
   attr(Name, Arg1, Arg2, Arg3) : required_dependency_condition(ID, Name, Arg1, Arg2, Arg3);
   dependency_condition(ID, Parent, Dependency);
-  node(Parent).
+  node(Parent);
+  not external(Parent).
 
 #defined dependency_condition/3.
 #defined required_dependency_condition/3.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -93,6 +93,9 @@ dependency_conditions_hold(ID, Parent, Dependency) :-
   attr(Name, Arg1, Arg2)       : required_dependency_condition(ID, Name, Arg1, Arg2);
   attr(Name, Arg1, Arg2, Arg3) : required_dependency_condition(ID, Name, Arg1, Arg2, Arg3);
   dependency_condition(ID, Parent, Dependency);
+  % There must be at least a dependency type declared,
+  % otherwise the dependency doesn't hold
+  dependency_type(ID, _);
   node(Parent);
   not external(Parent).
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1090,3 +1090,11 @@ class TestConcretize(object):
         ).concretized()
 
         assert root.dag_hash() == new_root.dag_hash()
+
+    @pytest.mark.regression('20784')
+    def test_concretization_of_test_dependencies(self):
+        # With clingo we emit dependency_conditions regardless of the type
+        # of the dependency. We need to ensure that there's at least one
+        # dependency type declared to infer that the dependency holds.
+        s = Spec('test-dep-with-imposed-conditions').concretized()
+        assert 'c' not in s

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1044,7 +1044,7 @@ class TestConcretize(object):
         s = Spec('dep-with-variants-if-develop-root').concretized()
         assert s['dep-with-variants-if-develop'].satisfies('@1.0')
 
-    @pytest.mark.regression('20244')
+    @pytest.mark.regression('20244,20736')
     @pytest.mark.parametrize('spec_str,is_external,expected', [
         # These are all externals, and 0_8 is a version not in package.py
         ('externaltool@1.0', True, '@1.0'),
@@ -1056,6 +1056,10 @@ class TestConcretize(object):
         ('external-buildable-with-variant +baz', True, '@1.1.special +baz'),
         ('external-buildable-with-variant ~baz', False, '@1.0 ~baz'),
         ('external-buildable-with-variant@1.0: ~baz', False, '@1.0 ~baz'),
+        # This uses an external version that meets the condition for
+        # having an additional dependency, but the dependency shouldn't
+        # appear in the answer set
+        ('external-buildable-with-variant@0.9 +baz', True, '@0.9'),
     ])
     def test_external_package_versions(self, spec_str, is_external, expected):
         s = Spec(spec_str).concretized()

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -34,3 +34,5 @@ packages:
     externals:
       - spec: external-buildable-with-variant@1.1.special +baz
         prefix: /usr
+      - spec: external-buildable-with-variant@0.9 +baz
+        prefix: /usr

--- a/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
@@ -11,5 +11,8 @@ class ExternalBuildableWithVariant(Package):
     url = "http://somewhere.com/module-1.0.tar.gz"
 
     version('1.0', '1234567890abcdef1234567890abcdef')
+    version('0.9', '1234567890abcdef1234567890abcdef')
 
     variant('baz', default=False, description='nope')
+
+    depends_on('c@1.0', when='@0.9')

--- a/var/spack/repos/builtin.mock/packages/test-dep-with-imposed-conditions/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-dep-with-imposed-conditions/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class TestDepWithImposedConditions(Package):
+    """Simple package with no dependencies"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/e-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('c@1.0', type='test')


### PR DESCRIPTION
fixes #20736

Before this one line fix we were erroneously deducing that dependency conditions hold even if a package was external. This may result in answer sets that contain imposed conditions on a node without the node being present in the DAG, hence #20736.