### PR TITLE
fractions.gcd was removed in python 3.9, use math.gcd instead

### DIFF
--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -25,6 +25,10 @@ class XcbProto(AutotoolsPackage):
 
     patch('xcb-proto-1.12-schema-1.patch', when='@1.12')
 
+    ## fractions.gcd has been deprecated since python 3.5
+    ## and is removed starting from python 3.9, breaking xcb-proto
+    patch('python-gcd-fix.patch', when='^python@3.9:')
+
     def url_for_version(self, version):
         if version >= Version('1.14'):
             url = 'https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{0}.tar.xz'

--- a/var/spack/repos/builtin/packages/xcb-proto/python-gcd-fix.patch
+++ b/var/spack/repos/builtin/packages/xcb-proto/python-gcd-fix.patch
@@ -1,0 +1,30 @@
+diff --git a/xcbgen/align.py b/xcbgen/align.py
+index d4c12ee..cc39764 100644
+--- a/xcbgen/align.py
++++ b/xcbgen/align.py
+@@ -2,7 +2,7 @@
+ This module contains helper classes for alignment arithmetic and checks
+ '''
+ 
+-from fractions import gcd
++import math
+ 
+ class Alignment(object):
+ 
+@@ -73,14 +73,14 @@ class Alignment(object):
+     def combine_with(self, other):
+         # returns the alignment that is guaranteed when
+         # both, self or other, can happen
+-        new_align = gcd(self.align, other.align)
++        new_align = math.gcd(self.align, other.align)
+         new_offset_candidate1 = self.offset % new_align
+         new_offset_candidate2 = other.offset % new_align
+         if new_offset_candidate1 == new_offset_candidate2:
+             new_offset = new_offset_candidate1
+         else:
+             offset_diff = abs(new_offset_candidate2 - new_offset_candidate1)
+-            new_align = gcd(new_align, offset_diff)
++            new_align = math.gcd(new_align, offset_diff)
+             new_offset_candidate1 = self.offset % new_align
+             new_offset_candidate2 = other.offset % new_align
+             assert new_offset_candidate1 == new_offset_candidate2


### PR DESCRIPTION
This PR fixes an issue when using xcb-proto in an environment with python 3.9. xcb-proto uses fractions.gcd which has been deprecated since python 3.5 and was removed in python 3.9. 

See
https://docs.python.org/3.5/library/math.html#math.gcd