### PR TITLE
libyogrt: remove conflicts triggered by an invalid value

### DIFF
--- a/var/spack/repos/builtin/packages/libyogrt/package.py
+++ b/var/spack/repos/builtin/packages/libyogrt/package.py
@@ -34,12 +34,10 @@ class Libyogrt(AutotoolsPackage):
     variant('scheduler', default='system',
             description="Select scheduler integration",
             values=['system', 'slurm'], multi=False)
-    depends_on('slurm', when='scheduler=slurm')
-
-    conflicts('scheduler=lsf', when='@:1.22')
-
     variant('static', default='False',
             description="build static library")
+
+    depends_on('slurm', when='scheduler=slurm')
 
     def url_for_version(self, version):
         if version < Version(1.21):


### PR DESCRIPTION
fixes #20611

The conflict was triggered by an invalid value of the `scheduler` variant. This causes Spack to error when `libyogrt` facts are validated by the ASP-based concretizer.