### PR TITLE
improve documentation for Rocm (hip amd builds)

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -30,6 +30,8 @@
 #        environment: {}
 #        extra_rpaths: []
 #
+#    It is advisable to replace /rocm/ in the paths above with /rocm-version/
+#    to ensure reproducible results.
 #
 # 2. hip and its dependencies are currently NOT picked up by spack
 #    automatically, and should therefore be added to packages.yaml by hand:
@@ -37,7 +39,7 @@
 #    in packages.yaml:
 #    hip:
 #      externals:
-#      - spec: hip@3.8.20371-d1886b0b
+#      - spec: hip
 #        prefix: /opt/rocm/hip
 #        extra_attributes:
 #          compilers:
@@ -63,6 +65,9 @@
 #            c: /opt/rocm/llvm/bin/clang++
 #            cxx: /opt/rocm/llvm/bin/clang++
 #      buildable: false
+#
+#    It is advisable to replace /rocm/ in the paths above with /rocm-version/
+#    to ensure reproducible results.
 #
 # 3. In part 2, DO NOT list the path to hsa as /opt/rocm/hsa ! You want spack
 #    to find hsa in /opt/rocm/include/hsa/hsa.h . The directory of

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -31,7 +31,7 @@
 #        extra_rpaths: []
 #
 #    It is advisable to replace /rocm/ in the paths above with /rocm-version/
-#    to ensure reproducible results.
+#    and introduce spec version numbers to ensure reproducible results.
 #
 # 2. hip and its dependencies are currently NOT picked up by spack
 #    automatically, and should therefore be added to packages.yaml by hand:
@@ -67,7 +67,7 @@
 #      buildable: false
 #
 #    It is advisable to replace /rocm/ in the paths above with /rocm-version/
-#    to ensure reproducible results.
+#    and introduce spec version numbers to ensure reproducible results.
 #
 # 3. In part 2, DO NOT list the path to hsa as /opt/rocm/hsa ! You want spack
 #    to find hsa in /opt/rocm/include/hsa/hsa.h . The directory of


### PR DESCRIPTION
This documentation change is being made due to a user issue. A user copied the changes to compilers.yaml and packages.yaml without altering version numbers for consistency. I made some changes to clarify this for future users.

Kostas is making another bugfix that will benefit users here: https://github.com/spack/spack/pull/20715 to ensure version consistency elsewhere.