### PR TITLE
libzmq: Add libbsd as a dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -38,6 +38,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('libtool', type='build', when='@develop')
     depends_on('pkgconfig', type='build')
 
+    depends_on('libbsd', type='link', when='@4.3.3:')
+
     conflicts('%gcc@8:', when='@:4.2.2')
 
     def url_for_version(self, version):


### PR DESCRIPTION
For example, if you load py-sphinx and then spack install libzmq, you will get the following error:

>> 414    /usr/bin/ld: warning: libbsd.so.0, needed by src/.libs/libzmq.so, not found (try using -rpath or -rpath-link)
>> 415    src/.libs/libzmq.so: undefined reference to `strlcpy@@LIBBSD_0.0'
>> 416    collect2: error: ld returned 1 exit status

It seems that libzmq 4.3.3 started using strlcpy.
In libzmq 4.3.2, this does not happen.

Therefore, add libbsd to the dependency.