### PR TITLE
py-healpy: Add version 1.14.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-healpy/package.py
+++ b/var/spack/repos/builtin/packages/py-healpy/package.py
@@ -12,6 +12,7 @@ class PyHealpy(PythonPackage):
     homepage = "https://healpy.readthedocs.io/"
     pypi = "healpy/healpy-1.13.0.tar.gz"
 
+    version('1.14.0', sha256='2720b5f96c314bdfdd20b6ffc0643ac8091faefcf8fd20a4083cedff85a66c5e')
     version('1.13.0', sha256='d0ae02791c2404002a09c643e9e50bc58e3d258f702c736dc1f39ce1e6526f73')
     version('1.7.4', sha256='3cca7ed7786ffcca70e2f39f58844667ffb8521180ac890d4da651b459f51442')
 


### PR DESCRIPTION
1.14.0 compiles with gcc@10.2.0, while 1.13.0 doesn't