### PR TITLE
[lcio, sio] Add newest versions and add variants

### DIFF
--- a/var/spack/repos/builtin/packages/lcio/package.py
+++ b/var/spack/repos/builtin/packages/lcio/package.py
@@ -19,6 +19,8 @@ class Lcio(CMakePackage):
     maintainers = ['gaede', 'vvolkl']
 
     version('master', branch='master')
+    version('2.16',   sha256='aff7707750d821f31cbae3d7529fd8e22457f48d759e834ec01aa9389b5dbf1a')
+    version('2.15.4', sha256='720c8130762d445df44d2c245da01c0a1ca807d7ed62362cebf7b3a99f9a37d7')
     version('2.15.3', sha256='a00f9e1e8fc98151e88e603bbfca8088ded21ae3daca5c91869628a19af0cefb')
     version('2.15.2', sha256='9886c6f5c275c1c51bde978e4f5514bb4ea9588239f1d3ee95a76ef4b686e69d')
     version('2.15.1', sha256='32921feb162408357d00a81cdd489c374b3ed8ab6f442d798b22835de7243d32')
@@ -41,6 +43,9 @@ class Lcio(CMakePackage):
             description="Turn on to build/install ROOT dictionary.")
     variant("examples", default=False,
             description="Turn on to build LCIO examples")
+
+    depends_on('sio@0.0.2:', when='@2.14:')
+    depends_on('sio@0.0.4:', when='@2.16:')
 
     depends_on('root@6.04:', when="+rootdict")
     depends_on('openjdk', when="+jar")

--- a/var/spack/repos/builtin/packages/sio/package.py
+++ b/var/spack/repos/builtin/packages/sio/package.py
@@ -19,8 +19,27 @@ class Sio(CMakePackage):
     maintainers = ['vvolkl', 'tmadlener']
 
     version('master', branch='master')
+    version('0.0.4', sha256='72e96e6a1cc8dd3641d3e2bb9876e75bf6af8074e1617220da9e52df522ef5c0')
     version('0.0.3', sha256='4c8b9c08480fb53cd10abb0e1260071a8c3f68d06a8acfd373f6560a916155cc')
     version('0.0.2', sha256='e4cd2aeaeaa23c1da2c20c5c08a9b72a31b16b7a8f5aa6d480dcd561ef667657')
+
+    variant('builtin_zlib', default=True,
+            description='Use and statically link against a builtin version of zlib')
+    variant('cxxstd', default='17',
+            values=('11', '14', '17', '20'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    depends_on('zlib', when='~builtin_zlib')
+
+    def cmake_args(self):
+        return [
+            self.define('CMAKE_CXX_STANDARD', self.spec.variants['cxxstd'].value),
+            # Examples are built this way, but if the examples are built they
+            # are also used for tests
+            self.define('SIO_EXAMPLES', self.run_tests),
+            self.define_from_variant('SIO_BUILTIN_ZLIB', 'builtin_zlib')
+        ]
 
     def url_for_version(self, version):
         """Translate version numbers to ilcsoft conventions.


### PR DESCRIPTION
- Adding newest versions for LCIO
- Add the dependency on sio (starting from LCIO version 2.14)
- Add newest versions for sio
- Expose the `SIO_BUILTIN_ZLIB` cmake option via the `builtin_zlib` variant

@vvolkl @gaede can you have a look if this is OK?