### PR TITLE
ssht: New version 1.3.4

### DIFF
--- a/var/spack/repos/builtin/packages/ssht/package.py
+++ b/var/spack/repos/builtin/packages/ssht/package.py
@@ -28,7 +28,3 @@ class Ssht(CMakePackage):
     # version('1.2b1', commit='7378ce8853897cbd1b08adebf7ec088c1e40f860')
 
     depends_on('fftw @3.0.0:')
-
-    def cmake_args(self):
-        args = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
-        return args

--- a/var/spack/repos/builtin/packages/ssht/package.py
+++ b/var/spack/repos/builtin/packages/ssht/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Ssht(Package):
+class Ssht(CMakePackage):
     """ssht: Spin spherical harmonic transforms
 
     The SSHT code provides functionality to perform fast and exact
@@ -16,32 +16,19 @@ class Ssht(Package):
     """
 
     homepage = "https://astro-informatics.github.io/ssht/"
+    url      = "https://github.com/astro-informatics/ssht/archive/v1.3.4.tar.gz"
     git      = "https://github.com/astro-informatics/ssht.git"
 
     maintainers = ['eschnett']
 
-    version('1.2b1', commit='7378ce8853897cbd1b08adebf7ec088c1e40f860')
+    version('1.3.4', sha256='dfcceca9a4ffe8973a45e213e8d5331dcee6a504a42601f50fdfa4fd022cce7b')
+    version('1.3.3', sha256='1f3b89e29d89fa79170b9979046a55c81b588d9dd563fd36f37887495b71dd28')
+    version('1.3.2', sha256='6cb3b6f94fb90dff45ba59da30a8ccd9667d8e319bed437f19d2287f59e35dd1')
+    version('1.3.0', sha256='9e2c220a70d662714ff601a121b674c8423866058279e000cbbee532d31dd3c9')
+    # version('1.2b1', commit='7378ce8853897cbd1b08adebf7ec088c1e40f860')
 
-    depends_on('fftw')
+    depends_on('fftw @3.0.0:')
 
-    patch('float_conversion.patch')
-
-    def install(self, spec, prefix):
-        make('default', 'SSHTDIR=.')
-        mkdirp(join_path(prefix, 'include', 'ssht'))
-        install('src/c/ssht.h',
-                join_path(prefix, 'include', 'ssht', 'ssht.h'))
-        install('src/c/ssht_adjoint.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_adjoint.h'))
-        install('src/c/ssht_core.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_core.h'))
-        install('src/c/ssht_dl.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_dl.h'))
-        install('src/c/ssht_error.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_error.h'))
-        install('src/c/ssht_sampling.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_sampling.h'))
-        install('src/c/ssht_types.h',
-                join_path(prefix, 'include', 'ssht', 'ssht_types.h'))
-        install_tree('doc/c', join_path(prefix, 'doc'))
-        install_tree('lib/c', join_path(prefix, 'lib'))
+    def cmake_args(self):
+        args = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
+        return args


### PR DESCRIPTION
ssht changed configuration mechanism from "home-grown" to "cmake. The previously current version 1.2b1 (a beta release) is thus unfortunately not available any more.