### PR TITLE
genfit: Define new version, update dependency

### DIFF
--- a/var/spack/repos/builtin/packages/genfit/package.py
+++ b/var/spack/repos/builtin/packages/genfit/package.py
@@ -7,7 +7,8 @@ from spack import *
 
 
 class Genfit(CMakePackage):
-    """GenFit is a tracking framework in particle and nuclear physics."""
+    """GenFit is an experiment-independent framework for track reconstruction in
+        particle and nuclear physics"""
 
     homepage = "https://github.com/GenFit/GenFit"
     url      = "https://github.com/GenFit/GenFit/archive/02-00-00.tar.gz"
@@ -19,8 +20,12 @@ class Genfit(CMakePackage):
 
     version('master', branch='master')
     version('02-00-00', sha256='0bfd5dd152ad0573daa4153a731945824e0ce266f844988b6a8bebafb7f2dacc')
+    # Untagged version from 2017-06-23 known to work with root@6.16.00
+    version('b496504a', sha256='e1582b35782118ade08498adc03f3fda01979ff8bed61e0520edae46d7bfe477')
 
     depends_on('root')
+    depends_on('root@:6.16.00', when='@b496504a')
+    depends_on('eigen')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
- Add dependency on eigen package
- Add last version known to work with root <6.18

  The GenFit project lacks any release or tag versions, therefore, we are forced
  to use date versions for now

- Update title wording and default archive type (tar.gz compression prevails over zip)