### PR TITLE
libzmq: Add platform conditions to the previously modified dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -38,7 +38,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('libtool', type='build', when='@develop')
     depends_on('pkgconfig', type='build')
 
-    depends_on('libbsd', type='link', when='@4.3.3:')
+    depends_on('libbsd', type='link', when='@4.3.3: platform=linux')
+    depends_on('libbsd', type='link', when='@4.3.3: platform=cray')
 
     conflicts('%gcc@8:', when='@:4.2.2')
 


### PR DESCRIPTION
Added libbsd dependency in #20828.
However, libbsd is subject to conflict on MacOS.
Therefore, the problem was pointed out in #20828.
Add platform conditions to this dependency.