### PR TITLE
r-sf: fix dependency error

### DIFF
--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -29,4 +29,4 @@ class RSf(RPackage):
     depends_on('gdal@2.0.1:')
     depends_on('geos@3.4.0:')
     depends_on('proj@4.8.0:5', when='@:0.7-3')
-    depends_on('proj@4.8.0:6', when='@0.7-4:')
+    depends_on('proj@4.8.0:6.999', when='@0.7-4:')


### PR DESCRIPTION
According to https://github.com/spack/spack/pull/19386#issuecomment-759892846
we need fix the `proj` version to `6.999`