### PR TITLE
vasp: fix build with gfortran 10 and add version 6.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -162,7 +162,7 @@ class Vasp(MakefilePackage):
         if '+cuda' in self.spec:
             make('gpu', 'gpu_ncl')
         else:
-            make()
+            make('std', 'gam', 'ncl')
 
     def install(self, spec, prefix):
         install_tree('bin/', prefix.bin)

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -76,6 +76,9 @@ class Vasp(MakefilePackage):
         filter_file('^CPP_OPTIONS[ ]{0,}=[ ]{0,}',
                     'CPP_OPTIONS ?= ',
                     'makefile.include')
+        filter_file('^FFLAGS[ ]{0,}=[ ]{0,}',
+                    'FFLAGS ?= ',
+                    'makefile.include')
 
         filter_file('^LIBDIR[ ]{0,}=.*$', '', 'makefile.include')
         filter_file('^BLAS[ ]{0,}=.*$', 'BLAS ?=', 'makefile.include')
@@ -115,6 +118,9 @@ class Vasp(MakefilePackage):
             cpp_options.append('-DHOST=\\"LinuxGNU\\"')
 
         cflags = ['-fPIC', '-DADD_']
+        fflags = []
+        if '%gcc' in spec or '%intel' in spec:
+            fflags.append('-w')
 
         spack_env.set('BLAS', spec['blas'].libs.ld_flags)
         spack_env.set('LAPACK', spec['lapack'].libs.ld_flags)
@@ -141,9 +147,13 @@ class Vasp(MakefilePackage):
         if '+vaspsol' in spec:
             cpp_options.append('-Dsol_compat')
 
+        if self.spec.satisfies('%gcc@10:'):
+            fflags.append('-fallow-argument-mismatch')
+
         # Finally
         spack_env.set('CPP_OPTIONS', ' '.join(cpp_options))
         spack_env.set('CFLAGS', ' '.join(cflags))
+        spack_env.set('FFLAGS', ' '.join(fflags))
 
     def build(self, spec, prefix):
         if '+cuda' in self.spec:

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -18,6 +18,7 @@ class Vasp(MakefilePackage):
     homepage = "http://vasp.at"
     url      = "file://{0}/vasp.5.4.4.pl2.tgz".format(os.getcwd())
 
+    version('6.1.1', sha256='e37a4dfad09d3ad0410833bcd55af6b599179a085299026992c2d8e319bf6927')
     version('5.4.4.pl2', sha256='98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e')
     version('5.4.4', sha256='5bd2449462386f01e575f9adf629c08cb03a13142806ffb6a71309ca4431cfb3')
 
@@ -116,6 +117,8 @@ class Vasp(MakefilePackage):
                                 '-Dqd_emulate'])
         else:
             cpp_options.append('-DHOST=\\"LinuxGNU\\"')
+        if self.spec.satisfies('@6:'):
+            cpp_options.append('-Dvasp6')
 
         cflags = ['-fPIC', '-DADD_']
         fflags = []
@@ -147,7 +150,7 @@ class Vasp(MakefilePackage):
         if '+vaspsol' in spec:
             cpp_options.append('-Dsol_compat')
 
-        if self.spec.satisfies('%gcc@10:'):
+        if spec.satisfies('%gcc@10:'):
             fflags.append('-fallow-argument-mismatch')
 
         # Finally


### PR DESCRIPTION
- Avoid `Error: Type mismatch between actual argument at (1) and actual argument at (2)`
- Add version 6.1.1
- Version 6 builds the GPU targets during `make` even if CUDA is disabled, so specify the non-GPU targets explicitly