### PR TITLE
Mapsplice2: Add new package

### DIFF
--- a/var/spack/repos/builtin/packages/mapsplice2/Makefile.patch
+++ b/var/spack/repos/builtin/packages/mapsplice2/Makefile.patch
@@ -1,0 +1,53 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-all: FilterFusionAlignmentsByFilteredFusions filterremappedfusion FilterFusionAlignmentsByFilteredFusions MPSSam2fq collectstats SetUnmappedBitFlag sam2fq recover_fusion_alignments_order SepSamUnmapped swap_dRanger_and_MPS_matched comp_fusiondb_offset sepdRangerfusion sepMPSfusion generate_fusiongene_convert_coordinate_trim generate_fusiongene_convert_coordinate_trim_dRanger junc2bed SeparateNormalFromFusionJunc search_fusion_gene AddFusionStrandConsistent gtf2genetab FilterFusionByNormalPaired load_fusion_chrom_seq_std matchfusion2normal filteroriginalfusion Convert2FusionAlignment generate_combined_sequence DNA2StdRegion search_unmapped_reads reads2unmappedsam junc_db_fusion bsb4 mapsplice_multi_thread bowtie check_reads_format alignmenthandler_multi parseCluster cluster junc_db filterjuncbyROCarguNonCanonical filter_1hits newsam2junc fusionsam2junc_filteranchor_newfmt read_chromo_size find_mate_sam_fq alignmenthandler SepSam RemovePairNo check_index_consistency samtools
++all: FilterFusionAlignmentsByFilteredFusions filterremappedfusion FilterFusionAlignmentsByFilteredFusions MPSSam2fq collectstats SetUnmappedBitFlag sam2fq recover_fusion_alignments_order SepSamUnmapped swap_dRanger_and_MPS_matched comp_fusiondb_offset sepdRangerfusion sepMPSfusion generate_fusiongene_convert_coordinate_trim generate_fusiongene_convert_coordinate_trim_dRanger junc2bed SeparateNormalFromFusionJunc search_fusion_gene AddFusionStrandConsistent gtf2genetab FilterFusionByNormalPaired load_fusion_chrom_seq_std matchfusion2normal filteroriginalfusion Convert2FusionAlignment generate_combined_sequence DNA2StdRegion search_unmapped_reads reads2unmappedsam junc_db_fusion bsb4 mapsplice_multi_thread check_reads_format alignmenthandler_multi parseCluster cluster junc_db filterjuncbyROCarguNonCanonical filter_1hits newsam2junc fusionsam2junc_filteranchor_newfmt read_chromo_size find_mate_sam_fq alignmenthandler SepSam RemovePairNo check_index_consistency
+ 
+ OPTFLAGS = -O3
+ 
+@@ -75,24 +75,24 @@ gtf2genetab:
+ bsb4:
+ 	g++ $(CFLAGS) -o bin/bsb4 src/bsb4/bsb4.cpp $(ERRLOG)
+ 
+-samtools:
+-	cd ./samtools-0.1.9;make
++#samtools:
++#	cd ./samtools-0.1.9;make
+ 
+-	cp ./samtools-0.1.9/samtools ./bin/
++#	cp ./samtools-0.1.9/samtools ./bin/
+ 
+ mapsplice_multi_thread:
+ 	cd ./src/MapSplice;make
+ 
+ 	cp ./src/MapSplice/bowtie ./bin/mapsplice_multi_thread
+ 
+-bowtie:
+-	cd ./src/bowtie; make
++#bowtie:
++#	cd ./src/bowtie; make
+ 
+-	cp ./src/bowtie/bowtie ./bin/bowtie
++#	cp ./src/bowtie/bowtie ./bin/bowtie
+ 
+-	cp ./src/bowtie/bowtie-build ./bin/bowtie-build
++#	cp ./src/bowtie/bowtie-build ./bin/bowtie-build
+ 
+-	cp ./src/bowtie/bowtie-inspect ./bin/bowtie-inspect
++#	cp ./src/bowtie/bowtie-inspect ./bin/bowtie-inspect
+ 
+ reads2unmappedsam:
+ 	g++ $(CFLAGS) -o bin/reads2unmappedsam src/reads2unmappedsam/reads2unmappedsam.cpp $(ERRLOG)
+@@ -167,7 +167,7 @@ RemovePairNo:
+ 	g++ $(CFLAGS) -o bin/RemovePairNo src/RemovePairNo/remove_pair_no.cpp $(ERRLOG)
+ 
+ clean:
+-	cd ./samtools-0.1.9 ; make clean-recur
++#	cd ./samtools-0.1.9 ; make clean-recur
+ 	cd ./src/MapSplice ; make clean
+-	cd ./src/bowtie ; make clean
+-	rm -f bin/FilterFusionAlignmentsByFilteredFusions bin/filterremappedfusion bin/MPSSam2fq bin/comp_fusiondb_offset bin/SeparateNormalFromFusionJunc bin/collectstats bin/SetUnmappedBitFlag bin/sam2fq bin/recover_fusion_alignments_order bin/SepSamUnmapped bin/swap_dRanger_and_MPS_matched bin/sepdRangerfusion bin/sepMPSfusion bin/generate_fusiongene_convert_coordinate_trim_dRanger bin/generate_fusiongene_convert_coordinate_trim bin/junc2bed bin/search_fusion_gene bin/AddFusionStrandConsistent bin/gtf2genetab bin/FilterFusionByNormalPaired bin/load_fusion_chrom_seq_std bin/matchfusion2normal bin/filteroriginalfusion bin/DNA2StdRegion bin/generate_combined_sequence bin/Convert2FusionAlignment bin/search_unmapped_reads bin/reads2unmappedsam bin/junc_db_fusion bin/bsb4 bin/fusionsam2junc_filteranchor_newfmt bin/mapsplice_multi_thread bin/bowtie-build bin/bowtie bin/bowtie-inspect bin/check_reads_format bin/samtools bin/alignment_handler_multi bin/parseCluster bin/cluster bin/junc_db bin/filterjuncbyROCarguNonCanonical bin/filter_1hits bin/newsam2junc bin/read_chromo_size bin/find_mate_sam_fq bin/alignment_handler bin/SepSam bin/RemovePairNo bin/check_index_consistency log
+\ No newline at end of file
++#	cd ./src/bowtie ; make clean
++	rm -f bin/FilterFusionAlignmentsByFilteredFusions bin/filterremappedfusion bin/MPSSam2fq bin/comp_fusiondb_offset bin/SeparateNormalFromFusionJunc bin/collectstats bin/SetUnmappedBitFlag bin/sam2fq bin/recover_fusion_alignments_order bin/SepSamUnmapped bin/swap_dRanger_and_MPS_matched bin/sepdRangerfusion bin/sepMPSfusion bin/generate_fusiongene_convert_coordinate_trim_dRanger bin/generate_fusiongene_convert_coordinate_trim bin/junc2bed bin/search_fusion_gene bin/AddFusionStrandConsistent bin/gtf2genetab bin/FilterFusionByNormalPaired bin/load_fusion_chrom_seq_std bin/matchfusion2normal bin/filteroriginalfusion bin/DNA2StdRegion bin/generate_combined_sequence bin/Convert2FusionAlignment bin/search_unmapped_reads bin/reads2unmappedsam bin/junc_db_fusion bin/bsb4 bin/fusionsam2junc_filteranchor_newfmt bin/mapsplice_multi_thread bin/check_reads_format bin/alignment_handler_multi bin/parseCluster bin/cluster bin/junc_db bin/filterjuncbyROCarguNonCanonical bin/filter_1hits bin/newsam2junc bin/read_chromo_size bin/find_mate_sam_fq bin/alignment_handler bin/SepSam bin/RemovePairNo bin/check_index_consistency log

--- a/var/spack/repos/builtin/packages/mapsplice2/mapsplice_ebwt.patch
+++ b/var/spack/repos/builtin/packages/mapsplice2/mapsplice_ebwt.patch
@@ -1,0 +1,20 @@
+--- a/src/MapSplice/ebwt.h
++++ b/src/MapSplice/ebwt.h
+@@ -430,7 +430,7 @@ public:
+ 	     vector<uint32_t>& plens,
+ 	     uint32_t sztot,
+ 	     const RefReadInParams& refparams,
+-	     uint32_t seed,
++	     uint32_t seed = 0,
+ 	     int32_t __overrideOffRate = -1,
+ 	     int32_t __overrideIsaRate = -1,
+ 	     bool verbose = false,
+@@ -3942,7 +3942,7 @@ void Ebwt<TStr>::joinToDisk(
+ 	TStr& ret,
+ 	ostream& out1,
+ 	ostream& out2,
+-	uint32_t seed = 0)
++	uint32_t seed /* = 0 */ )
+ {
+ 	RandomSource rand; // reproducible given same seed
+ 	rand.init(seed);

--- a/var/spack/repos/builtin/packages/mapsplice2/package.py
+++ b/var/spack/repos/builtin/packages/mapsplice2/package.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Mapsplice2(MakefilePackage):
+    """MapSplice is a software for mapping RNA-seq data to reference genome
+       for splice junction discovery that depends only on reference genome,
+       and not on any further annotations."""
+
+    homepage = "http://www.netlab.uky.edu/p/bioinfo/MapSplice2"
+    url = "http://protocols.netlab.uky.edu/~zeng/MapSplice-v2.2.1.zip"
+
+    version(
+        "2.2.1",
+        sha256="4f3c1cb49ba0abcfc952de5946ee0b56db28c51f4f4d4f5abca66b4461ca7d05",
+    )
+
+    patch("Makefile.patch")
+    patch("mapsplice_ebwt.patch")
+
+    depends_on("bowtie")
+    depends_on("ncurses", type="link")
+    depends_on("samtools", type="link")
+    depends_on("python", type="run")
+
+    def edit(self, spec, prefix):
+        for iscan in find(
+            "src",
+            [
+                "SamRec.*",
+                "AlignmentHandler.cpp",
+                "JunctionHandler.cpp",
+                "FusionSamRec.*",
+            ],
+            recursive=True,
+        ):
+            m = FileFilter(iscan)
+            m.filter(r"iscanonical", "iscanonical2")
+
+        for makefile in find(".", "[Mm]akefile", recursive=True):
+            m = FileFilter(makefile)
+            m.filter("g++", "{0}".format(spack_cxx), string=True)
+            m.filter(r"CC =.*", "CC = {0}".format(spack_cc))
+            m.filter(r"CPP =.*", "CPP = {0}".format(spack_cxx))
+            m.filter(r"CXX =.*", "CXX = {0}".format(spack_cxx))
+
+    def install(self, spec, prefix):
+        install("mapsplice.py", prefix)
+        install_tree("bin", prefix.bin)


### PR DESCRIPTION
Add new package : Mapsplice2
MapSplice is a software for mapping RNA-seq data to reference genome for splice junction discovery that depends only on reference genome, and not on any further annotations.