### PR TITLE
py-h5py: HDF5_DIR is needed for ~mpi too

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -48,16 +48,17 @@ class PyH5py(PythonPackage):
 
     # MPI dependencies
     depends_on('hdf5+mpi', when='+mpi')
+    depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 
     phases = ['configure', 'install']
 
     def setup_build_environment(self, env):
+        env.set('HDF5_DIR', self.spec['hdf5'].prefix)
         if '+mpi' in self.spec:
             env.set('CC', self.spec['mpi'].mpicc)
             env.set('HDF5_MPI', 'ON')
-            env.set('HDF5_DIR', self.spec['hdf5'].prefix)
 
     @when('@3.0.0:')
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -48,7 +48,6 @@ class PyH5py(PythonPackage):
 
     # MPI dependencies
     depends_on('hdf5+mpi', when='+mpi')
-    depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 


### PR DESCRIPTION
+ While installing a package that requires `py-h5py` but doesn't want mpi, I discovered that the no-mpi variant didn't behave as expected.  Here are the changes that I made to allow `~mpi` to work:
  + This update does not change default behavior.  However, if the `~mpi` variant of `py-h5py` is requested, the concretizer should should pick `hdf5~mpi` to eliminate the `+mpi` dependency that is defaulted to `true` in `hdf5/package.py`.
  + For the `~mpi` variant, the environment variable `HDF5_DIR` is still required.  I moved this command out of the `+mpi` conditional.