### PR TITLE
Fix mesa18 libs finding

### DIFF
--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -185,7 +185,7 @@ class Mesa18(AutotoolsPackage):
         if libs_to_seek:
             return find_libraries(list(libs_to_seek),
                                   root=self.spec.prefix,
-                                  shared='+shared' in self.spec,
+                                  shared=True,
                                   recursive=True)
         return LibraryList()
 
@@ -193,19 +193,19 @@ class Mesa18(AutotoolsPackage):
     def osmesa_libs(self):
         return find_libraries('libOSMesa',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
+                              shared=True,
                               recursive=True)
 
     @property
     def glx_libs(self):
         return find_libraries('libGL',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
+                              shared=True,
                               recursive=True)
 
     @property
     def gl_libs(self):
         return find_libraries('libGL',
                               root=self.spec.prefix,
-                              shared='+shared' in self.spec,
+                              shared=True,
                               recursive=True)


### PR DESCRIPTION
I tried to install `freeglut` using `mesa18` as provider for `gl` and ran into the following problem:

```
==> freeglut: Executing phase: 'cmake'
==> Error: IndexError: list index out of range

/home/tmadlener/work/spack/var/spack/repos/builtin/packages/freeglut/package.py:34, in cmake_args:
         31    def cmake_args(self):
         32        return [
         33            '-DFREEGLUT_BUILD_DEMOS=OFF',
  >>     34            '-DOPENGL_gl_LIBRARY=' + self.spec['gl'].libs[0],
         35            '-DOPENGL_glu_LIBRARY=' + self.spec['glu'].libs[0],
         36            '-DX11_X11_LIB=' + self.spec['libx11'].libs[0],
         37            '-DX11_Xrandr_LIB=' + self.spec['libxrandr'].libs[0],

```

After some debugging, I found that `mesa18` was not populating its libs correctly, because it used `+shared` to determine whether to look for shared libraries in `find_libraries`. However, since it doesn't have a `shared` variant, this will always be false. Checking the rest of the package definition it seems that simply setting `shared=True` seems to be the right choice.

Pinging @chuckatkins and @v-dobrev to make sure that this is indeed a valid fix.