### PR TITLE
py-fiscalyear: add v0.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiscalyear/package.py
+++ b/var/spack/repos/builtin/packages/py-fiscalyear/package.py
@@ -8,17 +8,20 @@ from spack import *
 
 class PyFiscalyear(PythonPackage):
     """fiscalyear is a small, lightweight Python module providing helpful
-    utilities for managing the fiscal calendar. It is designed as an extension
-    of the built-in datetime and calendar modules, adding the ability to query
-    the fiscal year and fiscal quarter of a date or datetime object."""
+    utilities for managing the fiscal calendar.
+
+    It is designed as an extension of the built-in datetime and calendar
+    modules, adding the ability to query the fiscal year, fiscal quarter,
+    fiscal month, and fiscal day of a date or datetime object."""
 
     homepage = "https://github.com/adamjstewart/fiscalyear"
     pypi = "fiscalyear/fiscalyear-0.2.0.tar.gz"
-    git      = "https://github.com/adamjstewart/fiscalyear.git"
+    git = "https://github.com/adamjstewart/fiscalyear.git"
 
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('0.3.0', sha256='64f97b3a0ab6b2857d09f0016bd3aae37646a454a5c2c66e907fef03ae54a816')
     version('0.2.0', sha256='f513616aeb03046406c56d7c69cd9e26f6a12963c71c1410cc3d4532a5bfee71')
     version('0.1.0', sha256='3fde4a12eeb72da446beb487e078adf1223a92d130520e589b82d7d1509701a2')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.