### PR TITLE
gengetopt: Add texinfo depend

### DIFF
--- a/var/spack/repos/builtin/packages/gengetopt/package.py
+++ b/var/spack/repos/builtin/packages/gengetopt/package.py
@@ -25,6 +25,8 @@ class Gengetopt(AutotoolsPackage):
     version('2.21',   sha256='355a32310b2fee5e7289d6d6e89eddd13275a7c85a243dc5dd293a6cb5bb047e')
     version('2.20',   sha256='4c8b3b42cecff579f5f9de5ccad47e0849e0245e325a04ff5985c248141af1a4')
 
+    depends_on('texinfo', type='build')
+
     parallel = False
 
     def url_for_version(self, version):


### PR DESCRIPTION
I have fixed the following issues:
makeinfo: command not found