### PR TITLE
libconfig: Add texinfo depend

### DIFF
--- a/var/spack/repos/builtin/packages/libconfig/package.py
+++ b/var/spack/repos/builtin/packages/libconfig/package.py
@@ -22,3 +22,4 @@ class Libconfig(AutotoolsPackage):
     depends_on('autoconf', type=('build'))
     depends_on('automake', type=('build'))
     depends_on('libtool', type=('build'))
+    depends_on('texinfo', type='build')


### PR DESCRIPTION
I have fixed the following issues:
makeinfo: command not found