### PR TITLE
PCL: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/pcl/package.py
+++ b/var/spack/repos/builtin/packages/pcl/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Pcl(CMakePackage):
+    """The Point Cloud Library (PCL) is a standalone, large scale,
+    open project for 2D/3D image and point cloud processing."""
+
+    homepage = "https://pointclouds.org/"
+    url      = "https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.11.1/source.tar.gz"
+
+    version('1.11.1', sha256='19d1a0bee2bc153de47c05da54fc6feb23393f306ab2dea2e25419654000336e')
+
+    depends_on('cmake@3.5:', type='build')
+    depends_on('eigen@3.1:')
+    depends_on('flann@1.7:')
+    depends_on('boost@1.55:+filesystem+date_time+iostreams+system')
+
+    def cmake_args(self):
+        # FIXME: Add arguments other than
+        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/pcl/package.py
+++ b/var/spack/repos/builtin/packages/pcl/package.py
@@ -19,10 +19,3 @@ class Pcl(CMakePackage):
     depends_on('eigen@3.1:')
     depends_on('flann@1.7:')
     depends_on('boost@1.55:+filesystem+date_time+iostreams+system')
-
-    def cmake_args(self):
-        # FIXME: Add arguments other than
-        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
-        # FIXME: If not needed delete this function
-        args = []
-        return args


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.

This is a reboot of #4188. There are a lot of optional dependencies that can be added, but I didn't want to get too sucked into this package. #4188 has great comments if anyone ever wants to expand on this package.