### PR TITLE
[podio] Make sure sio library is properly propagated

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -42,7 +42,7 @@ class Podio(CMakePackage):
     depends_on('python', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-jinja2@2.10.1:', type=('build', 'run'), when='@0.12.0:')
-    depends_on('sio', type=('build', 'run'), when='+sio')
+    depends_on('sio', type=('build', 'link'), when='+sio')
 
     conflicts('+sio', when='@:0.12', msg='sio support requires at least podio@0.13')
 


### PR DESCRIPTION
It seems that without this packages that depend on a package that depends on `podio` will no longer be able find `sio` in the CMake stage. From reading the documentation, it seems that `link` is necessary to have `sio` appear in the environment such that a call to `find_package` is able to actually find the appropriate one.