### PR TITLE
Fix PVM dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -33,13 +33,13 @@ class Pvm(MakefilePackage):
         # variable "PVM_ROOT" to the path where PVM resides
         env['PVM_ROOT'] = self.stage.source_path
 
-    def setup_build_environment(self, spack_env):
+    def setup_build_environment(self, env):
         tirpc = self.spec['libtirpc'].prefix
-        spack_env.prepend_path(
+        env.prepend_path(
             'SPACK_INCLUDE_DIRS',
-            join_path(tirpc, 'include', 'tirpc'),
+            tirpc.include.tirpc,
         )
-        spack_env.set('SPACK_LDLIBS', '-ltirpc')
+        env.set('SPACK_LDLIBS', '-ltirpc')
 
     def install(self, spec, prefix):
         pvm_arch = self.pvm_arch

--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -18,6 +18,7 @@ class Pvm(MakefilePackage):
     version('3.4.6', sha256='482665e9bc975d826bcdacf1df1d42e43deda9585a2c430fd3b7b7ed08eada44')
 
     depends_on('m4', type='build')
+    depends_on('libtirpc', type='link')
 
     parallel = False
 
@@ -31,6 +32,14 @@ class Pvm(MakefilePackage):
         # Before building PVM, you must set the environment
         # variable "PVM_ROOT" to the path where PVM resides
         env['PVM_ROOT'] = self.stage.source_path
+
+    def setup_build_environment(self, spack_env):
+        tirpc = self.spec['libtirpc'].prefix
+        spack_env.prepend_path(
+            'SPACK_INCLUDE_DIRS',
+            join_path(tirpc, 'include', 'tirpc'),
+        )
+        spack_env.set('SPACK_LDLIBS', '-ltirpc')
 
     def install(self, spec, prefix):
         pvm_arch = self.pvm_arch

--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -26,7 +26,7 @@ class Pvm(MakefilePackage):
     def pvm_arch(self):
         """Returns the appropriate PVM_ARCH."""
         process = subprocess.Popen(['lib/pvmgetarch'], stdout=subprocess.PIPE)
-        return process.communicate()[0].strip()
+        return process.communicate()[0].strip().decode()
 
     def edit(self, spec, prefix):
         # Before building PVM, you must set the environment

--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -17,6 +17,8 @@ class Pvm(MakefilePackage):
 
     version('3.4.6', sha256='482665e9bc975d826bcdacf1df1d42e43deda9585a2c430fd3b7b7ed08eada44')
 
+    depends_on('m4', type='build')
+
     parallel = False
 
     @property


### PR DESCRIPTION
When installing PVM on a base CentOS7 image, PVM failed. I've updated its dependencies. It should be noted that in the PVM source code there are #include to rpc/<file>. However that rpc folder is one level lower than the libtirpc include directory, so I include it manually.