### PR TITLE
fix list_url for r packages

### DIFF
--- a/var/spack/repos/builtin/packages/r-lifecycle/package.py
+++ b/var/spack/repos/builtin/packages/r-lifecycle/package.py
@@ -20,7 +20,7 @@ class RLifecycle(RPackage):
 
     homepage = "https://lifecycle.r-lib.org/"
     url      = "https://cloud.r-project.org/src/contrib/lifecycle_0.2.0.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/lifecycle"
+    list_url = "https://cloud.r-project.org/src/contrib/Archive/lifecycle"
 
     version('0.2.0', sha256='29746e8dee05d4e36f9c612e8c7a903a4f648a36b3b94c9776e518c38a412224')
 

--- a/var/spack/repos/builtin/packages/r-pixmap/package.py
+++ b/var/spack/repos/builtin/packages/r-pixmap/package.py
@@ -14,6 +14,6 @@ class RPixmap(RPackage):
 
     homepage = "https://cloud.r-project.org/package=pixmap"
     url      = "https://cloud.r-project.org/src/contrib/pixmap_0.4-11.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/pixmap"
+    list_url = "https://cloud.r-project.org/src/contrib/Archive/pixmap"
 
     version('0.4-11', sha256='6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412')

--- a/var/spack/repos/builtin/packages/r-rle/package.py
+++ b/var/spack/repos/builtin/packages/r-rle/package.py
@@ -14,7 +14,7 @@ class RRle(RPackage):
 
     homepage = "https://cloud.r-project.org/package=rle"
     url      = "https://cloud.r-project.org/src/contrib/rle_0.9.2.tar.gz"
-    list_url = "https://cran.r-project.org/src/contrib/Archive/rle"
+    list_url = "https://cloud.r-project.org/src/contrib/Archive/rle"
 
     version('0.9.2', sha256='803cbe310af6e882e27be61d37d660dbe5910ac1ee1eff61a480bcf724a04f69')
 


### PR DESCRIPTION
Change the list_url from cran.r-project.org to cloud.r-project.org for
the following recently created packages:

- r-lifecycle
- r-pixmap
- r-rle