### PR TITLE
Updated with requirements for openblas dependency

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -29,11 +29,8 @@ class Blaspp(CMakePackage, CudaPackage):
     depends_on('cmake@3.15.0:', type='build')
     depends_on('blas')
 
-    # This will attempt to use a supported version of OpenBLAS
-    depends_on('openblas@:0.3.5', when='^openblas')
-    # In some cases, the spack concretizer will fail to use a supported
-    # version of OpenBLAS.  In this case, present an error message.
-    conflicts('^openblas@0.3.6:', msg='Testing errors in OpenBLAS >=0.3.6')
+    # BLASpp tests require multithreading support for versions of openblas greater than 0.3.5  
+    conflicts('^openblas@0.3.6: threads=none', msg='BLASpp requires openblas multithreading support')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -29,7 +29,7 @@ class Blaspp(CMakePackage, CudaPackage):
     depends_on('cmake@3.15.0:', type='build')
     depends_on('blas')
 
-    # BLASpp tests require multithreading support for versions of openblas greater than 0.3.5  
+    # BLASpp tests will fail when using openblas > 0.3.5 without multithreading support
     conflicts('^openblas@0.3.6: threads=none', msg='BLASpp requires openblas multithreading support')
 
     def cmake_args(self):


### PR DESCRIPTION
This improves communication of the requirements of the package when compiling against openblas.  For openblas versions greater than 0.3.5 we require "threads=openmp" or "threads=pthreads" for the blaspp tests to pass.

@ax3l @mgates3