### PR TITLE
The latest version of imagemagick needs libtool linking

### DIFF
--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -21,6 +21,7 @@ class Imagemagick(AutotoolsPackage):
     depends_on('jpeg')
     depends_on('pango')
     depends_on('libtool', type='build')
+    depends_on('libtool', when='@7.0.8:', type=('build', 'link'))
     depends_on('libpng')
     depends_on('freetype')
     depends_on('fontconfig')


### PR DESCRIPTION
Imagemagick-7.0.8 needs to link against libltdl. Otherwise, the build will fail with:

```
2 errors found in build log:
     503    checking for libltdl...
     504    checking ltdl.h usability... no
     505    checking ltdl.h presence... no
     506    checking for ltdl.h... no
     507    checking for lt_dlinit in -lltdl... no
     508    checking if libltdl package is complete... no
  >> 509    configure: error: in `/tmp/gpjohnsn/spack-stage/spack-stage-imagemagick-7.0.8-7-4y44gaklhhciiwjzhfpxjfwdj5q
            ltjp3/spack-src':
  >> 510    configure: error: libltdl is required for modules and OpenCL builds
     511    See `config.log' for more details
```