### PR TITLE
libidn2: https -> http

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -8,6 +8,7 @@ class BerkeleyDb(AutotoolsPackage):
     """Oracle Berkeley DB"""
 
     homepage = "https://www.oracle.com/database/technologies/related/berkeleydb.html"
+    # URL must remain http:// so Spack can bootstrap curl
     url      = "http://download.oracle.com/berkeley-db/db-18.1.40.tar.gz"
 
     version("18.1.40", sha256="0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8")

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -12,7 +12,8 @@ class Libidn2(AutotoolsPackage):
     names."""
 
     homepage = "https://gitlab.com/libidn/libidn2"
-    url      = "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"
+    # URL must remain http:// so Spack can bootstrap curl
+    url      = "http://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"
 
     version('2.3.0',  sha256='e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5')
     version('2.1.1a', sha256='57666bcf6ecf54230d7bac95c392379561954b57a673903aed4d3336b3048b72')

--- a/var/spack/repos/builtin/packages/libidn2/package.py
+++ b/var/spack/repos/builtin/packages/libidn2/package.py
@@ -6,14 +6,14 @@
 from spack import *
 
 
-class Libidn2(AutotoolsPackage):
+class Libidn2(AutotoolsPackage, GNUMirrorPackage):
     """Libidn2 is a free software implementation of IDNA2008, Punycode and
     TR46. Its purpose is to encode and decode internationalized domain
     names."""
 
     homepage = "https://gitlab.com/libidn/libidn2"
     # URL must remain http:// so Spack can bootstrap curl
-    url      = "http://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"
+    gnu_mirror_path = "libidn/libidn2-2.0.5.tar.gz"
 
     version('2.3.0',  sha256='e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5')
     version('2.1.1a', sha256='57666bcf6ecf54230d7bac95c392379561954b57a673903aed4d3336b3048b72')

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -11,6 +11,7 @@ class PkgConfig(AutotoolsPackage):
     and libraries"""
 
     homepage = "http://www.freedesktop.org/wiki/Software/pkg-config/"
+    # URL must remain http:// so Spack can bootstrap curl
     url = "http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
 
     version('0.29.2', sha256='6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591')


### PR DESCRIPTION
The following packages must download from `http://` in order to bootstrap `curl`:
```console
$ spack spec curl~darwinssl
Input spec
--------------------------------
curl~darwinssl

Concretized
--------------------------------
curl@7.74.0%apple-clang@12.0.0~darwinssl~gssapi~libssh~libssh2~nghttp2 arch=darwin-catalina-x86_64
    ^libidn2@2.3.0%apple-clang@12.0.0 arch=darwin-catalina-x86_64
        ^libunistring@0.9.10%apple-clang@12.0.0 arch=darwin-catalina-x86_64
            ^libiconv@1.16%apple-clang@12.0.0 arch=darwin-catalina-x86_64
    ^openssl@1.1.1i%apple-clang@12.0.0+systemcerts arch=darwin-catalina-x86_64
        ^perl@5.32.0%apple-clang@12.0.0+cpanm+shared+threads patches=517afe8ca1cb12f798f20b21583d91463fe3f4fa9244c6c8e054a92c8135da8f arch=darwin-catalina-x86_64
            ^berkeley-db@18.1.40%apple-clang@12.0.0 arch=darwin-catalina-x86_64
            ^gdbm@1.18.1%apple-clang@12.0.0 arch=darwin-catalina-x86_64
                ^readline@8.0%apple-clang@12.0.0 arch=darwin-catalina-x86_64
                    ^ncurses@6.2%apple-clang@12.0.0~symlinks+termlib arch=darwin-catalina-x86_64
                        ^pkgconf@1.7.3%apple-clang@12.0.0 arch=darwin-catalina-x86_64
        ^zlib@1.2.11%apple-clang@12.0.0+optimize+pic+shared arch=darwin-catalina-x86_64
```
@mlawsonca