### PR TITLE
py-pycairo: update version and fix setup.py test error

### DIFF
--- a/var/spack/repos/builtin/packages/py-pycairo/package.py
+++ b/var/spack/repos/builtin/packages/py-pycairo/package.py
@@ -17,7 +17,8 @@ class PyPycairo(PythonPackage):
     version('1.18.1', sha256='70172e58b6bad7572a3518c26729b074acdde15e6fee6cbab6d3528ad552b786')
     version('1.17.1', sha256='0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698')
 
-    depends_on('cairo@1.13.1: +pdf')
+    depends_on('cairo@1.15.10: +pdf', when='@1.20.0:')
+    depends_on('cairo@1.13.1: +pdf', when='@:1.18.1')
     depends_on('pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('python@2.7:2.8,3.3:', when='@:1.17.1',  type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pycairo/package.py
+++ b/var/spack/repos/builtin/packages/py-pycairo/package.py
@@ -13,14 +13,16 @@ class PyPycairo(PythonPackage):
     homepage = "https://www.cairographics.org/pycairo/"
     pypi = "pycairo/pycairo-1.17.1.tar.gz"
 
+    version('1.20.0', sha256='5695a10cb7f9ae0d01f665b56602a845b0a8cb17e2123bfece10c2e58552468c')
     version('1.18.1', sha256='70172e58b6bad7572a3518c26729b074acdde15e6fee6cbab6d3528ad552b786')
     version('1.17.1', sha256='0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698')
 
-    depends_on('cairo@1.13.1:')
+    depends_on('cairo@1.13.1: +pdf')
     depends_on('pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('python@2.7:2.8,3.3:', when='@:1.17.1',  type=('build', 'run'))
-    depends_on('python@2.7:2.8,3.4:', when='@1.18.1:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:3.7.999', when='@1.18.1:1.19.999', type=('build', 'run'))
+    depends_on('python@3.6:3.999', when='@1.20.0:', type=('build', 'run'))
 
     @run_after('install')
     def post_install(self):


### PR DESCRIPTION
There are two issues for this package:
1. pycairo fails to build with Python 3.8
https://bugzilla.redhat.com/show_bug.cgi?id=1717658
2. run `python setup.py test` fail:
![image](https://user-images.githubusercontent.com/29532367/104799100-3c066700-5807-11eb-93be-747b1d860f48.png)

So, we need update pycairo to using the latest python and open `cairo` `pdf` variant.