### PR TITLE
mpich: add 3.4

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -24,6 +24,7 @@ class Mpich(AutotoolsPackage):
     executables = ['^mpichversion$']
 
     version('develop', submodules=True)
+    version('3.4',   sha256='ce5e238f0c3c13ab94a64936060cff9964225e3af99df1ea11b130f20036c24b')
     version('3.3.2', sha256='4bfaf8837a54771d3e4922c84071ef80ffebddbb6971a006038d91ee7ef959b9')
     version('3.3.1', sha256='fe551ef29c8eea8978f679484441ed8bb1d943f6ad25b63c235d4b9243d551e5')
     version('3.3',   sha256='329ee02fe6c3d101b6b30a7b6fb97ddf6e82b28844306771fa9dd8845108fa0b')
@@ -51,15 +52,16 @@ class Mpich(AutotoolsPackage):
     )
     variant(
         'device',
-        default='ch3',
+        default='ch4',
         description='''Abstract Device Interface (ADI)
-implementation. The ch4 device is currently in experimental state''',
+implementation. The ch4 device is in experimental state for versions
+before 3.4.''',
         values=('ch3', 'ch4'),
         multi=False
     )
     variant(
         'netmod',
-        default='tcp',
+        default='ofi',
         description='''Network module. Only single netmod builds are
 supported. For ch3 device configurations, this presumes the
 ch3:nemesis communication channel. ch3:sock is not supported by this


### PR DESCRIPTION
This also switches the default device to ch4 and the default netmod to ofi (tcp does not exist for ch4).

cc @raffenet @yfguo