### PR TITLE
Make git fetching even quieter

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -776,6 +776,10 @@ class GitFetchStrategy(VCSFetchStrategy):
         if not self._git:
             self._git = which('git', required=True)
 
+            # Disable advice for a quieter fetch
+            self._git.add_default_arg('-c')
+            self._git.add_default_arg('advice.detachedHead=false')
+
             # If the user asked for insecure fetching, make that work
             # with git as well.
             if not spack.config.get('config:verify_ssl'):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -777,8 +777,10 @@ class GitFetchStrategy(VCSFetchStrategy):
             self._git = which('git', required=True)
 
             # Disable advice for a quieter fetch
-            self._git.add_default_arg('-c')
-            self._git.add_default_arg('advice.detachedHead=false')
+            # https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.2.txt
+            if self.git_version >= Version('1.7.2'):
+                self._git.add_default_arg('-c')
+                self._git.add_default_arg('advice.detachedHead=false')
 
             # If the user asked for insecure fetching, make that work
             # with git as well.


### PR DESCRIPTION
Follow-up to #3180
Closes #3179 

@BarrySmith @davydden 

Not sure what versions of git this flag is supported for.

### Before

```console
$ spack fetch py-torch
Note: switching to '57bffc3a8e4fee0cce31e1ff1f662ccf7b16db57'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

```

### After
```console
$ spack fetch py-torch
```