### PR TITLE
R: add maintainer(s)

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -25,6 +25,8 @@ class RPackage(PackageBase):
     """
     phases = ['install']
 
+    maintainers = ['glennpj']
+
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'RPackage'

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -21,6 +21,8 @@ class R(AutotoolsPackage):
 
     extendable = True
 
+    maintainers = ['glennpj']
+
     version('4.0.3', sha256='09983a8a78d5fb6bc45d27b1c55f9ba5265f78fa54a55c13ae691f87c5bb9e0d')
     version('4.0.2', sha256='d3bceab364da0876625e4097808b42512395fdf41292f4915ab1fd257c1bbe75')
     version('4.0.1', sha256='95fe24a4d8d8f8f888460c8f5fe4311cec656e7a1722d233218bc03861bc6f32')


### PR DESCRIPTION
I talked to @glennpj and he offered to be a maintainer for Spack's R recipe and R packages.

Would anyone else like to join him? You don't have to be a Spack expert, it just gives us someone to ping when users report build issues or submit PRs related to R or R packages. You can also choose to maintain only a subset of R packages if you don't want to maintain all of them.

Pinging some other known Spack + R users: @HenrikBengtsson @JavierCVilla @codeandkey @odoublewen @hartzell @cosmicexplorer 

Some ideas for future work related to R:

* Create a `cran` attribute similar to #17587 to simplify homepage/url/list_url
* Add package tests similar to #20023 to test installations
* Create bundle packages for Bioconductor so you can install `bioconductor@3.12`
* Automate adding new packages/versions or integrate with the builtin package manager

P.S. If you get a chance, take a look at https://github.com/spack/spack/labels/r and see if you can close any of these issues