### PR TITLE
sortmerna: Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/sortmerna/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/sortmerna/for_aarch64.patch
@@ -1,0 +1,22 @@
+--- spack-src/src/sortmerna/ssw.c.bak	2021-01-15 15:52:23.000000000 +0900
++++ spack-src/src/sortmerna/ssw.c	2021-01-15 16:20:53.863003152 +0900
+@@ -42,7 +42,7 @@
+  *            July 10, 2013
+  */
+ 
+-#include <emmintrin.h>
++#include <sse2neon.h>
+ #include <stdint.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+--- spack-src/include/ssw.h.bak	2021-01-15 15:52:22.000000000 +0900
++++ spack-src/include/ssw.h	2021-01-15 16:16:51.383025096 +0900
+@@ -21,7 +21,7 @@
+ #include <stdio.h>
+ #include <stdint.h>
+ #include <string.h>
+-#include <emmintrin.h>
++#include <sse2neon.h>
+ 
+ extern const char map_nt[122];
+ /*!	@typedef	structure of the query profile	*/

--- a/var/spack/repos/builtin/packages/sortmerna/package.py
+++ b/var/spack/repos/builtin/packages/sortmerna/package.py
@@ -20,8 +20,6 @@ class Sortmerna(CMakePackage):
 
     patch('for_aarch64.patch', when='target=aarch64:')
 
-    build_directory = 'spack-build'
-
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir(join_path(self.build_directory, 'src', 'indexdb')):

--- a/var/spack/repos/builtin/packages/sortmerna/package.py
+++ b/var/spack/repos/builtin/packages/sortmerna/package.py
@@ -16,6 +16,11 @@ class Sortmerna(CMakePackage):
     version('2017-07-13', commit='8bde6fa113a5d99a23ae81b48eeea6760e966094')
 
     depends_on('zlib')
+    depends_on('sse2neon', when='target=aarch64:')
+
+    patch('for_aarch64.patch', when='target=aarch64:')
+
+    build_directory = 'spack-build'
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/sortmerna/package.py
+++ b/var/spack/repos/builtin/packages/sortmerna/package.py
@@ -24,7 +24,7 @@ class Sortmerna(CMakePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        with working_dir(join_path('spack-build', 'src', 'indexdb')):
+        with working_dir(join_path(self.build_directory, 'src', 'indexdb')):
             install('indexdb', prefix.bin)
-        with working_dir(join_path('spack-build', 'src', 'sortmerna')):
+        with working_dir(join_path(self.build_directory, 'src', 'sortmerna')):
             install('sortmerna', prefix.bin)


### PR DESCRIPTION
I made a fix to be able to install on aarch64.
I also fixed the following installation error that was also occurring on x86_64.
```
         20    def install(self, spec, prefix):
         21        mkdirp(prefix.bin)
　　  22        with working_dir(join_path('spack-build', 'src', 'indexdb')):
         23            install('indexdb', prefix.bin)
```