### PR TITLE
python: improve building with Intel

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -417,8 +417,8 @@ class Python(AutotoolsPackage):
             config_args.append('--disable-toolbox-glue')
 
         if spec.satisfies('%intel', strict=True) and \
-                spec.satisfies('@2.7.12:2.8,3.5.2:', strict=True):
-            config_args.append('--with-icc')
+                spec.satisfies('@2.7.12:2.8,3.5.2:3.7', strict=True):
+            config_args.append('--with-icc={0}'.format(spack_cc))
 
         if '+debug' in spec:
             config_args.append('--with-pydebug')


### PR DESCRIPTION
There is no `--with-icc` configure option starting version 3.8.0: https://github.com/python/cpython/commit/98929b545e86e7c7296c912d8f34e8e8d3fd6439.

For older versions that have the option, setting it without an argument sets the values of `CC` and `CXX` to `icc` and `icpc`, respectively: https://github.com/python/cpython/blob/117830de332c8dfbd9a437c0968e16e11aa7e6a1/configure.ac#L586-L587. These values are then stored in the `sysconfigdata`, which leads to extensions being built with the compilers in the `PATH`, instead of the compilers that Python was built with.

Basically, with this PR we get the same behaviour for `intel` as we already have for `gcc`.