### PR TITLE
universal-ctags: added depends_on('libiconv', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -21,3 +21,4 @@ class UniversalCtags(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('libiconv', type='link')


### PR DESCRIPTION
The following error occurred during installation.
Because depends_on('libiconv', type='link') is not enough.

```
6 errors found in build log:
     368      CCLD     packcc
     369    PACKCC     peg/varlink.c
     370      CC       peg/libctags_a-varlink.o
     371      AR       libctags.a
     372      CCLD     ctags
     373      CCLD     mini-geany
  >> 374    /usr/bin/ld: libctags.a(libctags_a-jscript.o): undefined reference
            to symbol 'libiconv_open'
  >> 375    //fefs/home/r1059/spack/opt/spack/linux-rhel8-thunderx2/gcc-8.3.1/l
            ibiconv-1.16-yv2ypzotoapbgh2vulw27f6whjgng5ok/lib/libiconv.so.2: er
            ror adding symbols: DSO missing from command line
  >> 376    collect2: error: ld returned 1 exit status
     377    make[1]: *** [Makefile:1842: ctags] Error 1
     378    make[1]: *** Waiting for unfinished jobs....
  >> 379    /usr/bin/ld: libctags.a(libctags_a-jscript.o): undefined reference
            to symbol 'libiconv_open'
  >> 380    //fefs/home/r1059/spack/opt/spack/linux-rhel8-thunderx2/gcc-8.3.1/l
            ibiconv-1.16-yv2ypzotoapbgh2vulw27f6whjgng5ok/lib/libiconv.so.2: er
            ror adding symbols: DSO missing from command line
  >> 381    collect2: error: ld returned 1 exit status
     382    make[1]: *** [Makefile:1848: mini-geany] Error 1
     383    make[1]: Leaving directory '/tmp/r1059/spack-stage/spack-stage-univ
            ersal-ctags-master-h54naermbm7zautrw72wwsycsq6arjeg/spack-src'
     384    make: *** [Makefile:1309: all] Error 2
```