### PR TITLE
Added @property stdcxx_libs to return -lstdc++ for AOCC compiler

### DIFF
--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -114,3 +114,7 @@ class Aocc(Compiler):
     @classmethod
     def f77_version(cls, f77):
         return cls.fc_version(f77)
+
+    @property
+    def stdcxx_libs(self):
+        return ('-lstdc++', )

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -453,6 +453,8 @@ def test_aocc_flags():
                          '-Os', '-Oz', '-Og',
                          '-O', '-O4'],
                         'aocc@2.2.0')
+
+    supported_flag_test("stdcxx_libs", ("-lstdc++",), "aocc@2.2.0")
     supported_flag_test("openmp_flag", "-fopenmp", "aocc@2.2.0")
     supported_flag_test("cxx11_flag", "-std=c++11", "aocc@2.2.0")
     supported_flag_test("cxx14_flag", "-std=c++14", "aocc@2.2.0")


### PR DESCRIPTION
Please note that we have added  - @property stdcxx_libs to return -lstdc++ for AOCC compiler
Kindly review and let us know for any changes.