### PR TITLE
Kokkos package: rocm support

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -147,6 +147,14 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         'gfx906': 'vega906',
         'gfx908': 'vega908'
     }
+    amd_support_conflict_msg = (
+        '{0} is not supported; '
+        'Kokkos supports the following AMD GPU targets: '
+        + ', '.join(amdgpu_arch_map.keys()))
+    for arch in ROCmPackage.amdgpu_targets:
+        if arch not in amdgpu_arch_map:
+            conflicts('+rocm', when='amdgpu_target={0}'.format(arch),
+                      msg=amd_support_conflict_msg.format(arch))
 
     devices_values = list(devices_variants.keys())
     for dev in devices_variants:
@@ -237,6 +245,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
                         spack_microarches.append(
                             self.amdgpu_arch_map[amdgpu_target])
                     else:
+                        # Note that conflict declarations should prevent
+                        # choosing an unsupported AMD GPU target
                         raise SpackError("Unsupported target: {0}".format(
                             amdgpu_target))
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -5,7 +5,7 @@
 from spack import *
 
 
-class Kokkos(CMakePackage, CudaPackage):
+class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     """Kokkos implements a programming model in C++ for writing performance
     portable applications targeting all major HPC platforms."""
 
@@ -247,13 +247,12 @@ class Kokkos(CMakePackage, CudaPackage):
             if var in self.spec:
                 options.append("-D%s_DIR=%s" % (tpl, spec[tpl].prefix))
 
-        # we do not need the compiler wrapper from Spack
-        # set the compiler explicitly (may be Spack wrapper or nvcc-wrapper)
-        try:
+        if '+rocm' in self.spec:
+            options.append('-DCMAKE_CXX_COMPILER=%s' %
+                           self.spec['hip'].hipcc)
+        elif '+wrapper' in self.spec:
             options.append("-DCMAKE_CXX_COMPILER=%s" %
                            self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
-        except Exception:
-            options.append("-DCMAKE_CXX_COMPILER=%s" % spack_cxx)
 
         # Set the C++ standard to use
         options.append("-DKokkos_CXX_STANDARD=%s" %


### PR DESCRIPTION
@eugeneswalker 

* Subclass `ROCmPackage` (which adds necessary dependencies)
* Remove conflicting HIP support that existed before `ROCmPackage` was added

With this for example I can build:

`spack install kokkos+rocm amdgpu_target=gfx906`
