### PR TITLE
libcap-ng: fix detect python.

### DIFF
--- a/var/spack/repos/builtin/packages/libcap-ng/package.py
+++ b/var/spack/repos/builtin/packages/libcap-ng/package.py
@@ -35,9 +35,9 @@ class LibcapNg(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies('+python'):
             if spec.satisfies('^python@3:'):
-                args.extend([ '-without-python', '-with-python3'])
+                args.extend(['-without-python', '-with-python3'])
             else:
-                args.extend([ '-with-python', '-without-python3'])
+                args.extend(['-with-python', '-without-python3'])
         else:
-            args.extend([ '-without-python', '-without-python3'])
+            args.extend(['-without-python', '-without-python3'])
         return args

--- a/var/spack/repos/builtin/packages/libcap-ng/package.py
+++ b/var/spack/repos/builtin/packages/libcap-ng/package.py
@@ -21,4 +21,23 @@ class LibcapNg(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('attr',     type='build')
-    depends_on('python',   type=('build', 'run'))
+    depends_on('swig',     type='build')
+    depends_on('python@2.7:',   type=('build', 'link', 'run'), when='+python')
+
+    extends('python', when='+python')
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies('+python'):
+            env.set('PYTHON', self.spec['python'].command.path)
+
+    def configure_args(self):
+        args = []
+        spec = self.spec
+        if spec.satisfies('+python'):
+            if spec.satisfies('^python@3:'):
+                args.extend([ '-without-python', '-with-python3'])
+            else:
+                args.extend([ '-with-python', '-without-python3'])
+        else:
+            args.extend([ '-without-python', '-without-python3'])
+        return args

--- a/var/spack/repos/builtin/packages/libcap-ng/package.py
+++ b/var/spack/repos/builtin/packages/libcap-ng/package.py
@@ -24,6 +24,8 @@ class LibcapNg(AutotoolsPackage):
     depends_on('swig',     type='build')
     depends_on('python@2.7:',   type=('build', 'link', 'run'), when='+python')
 
+    variant('python', default=True, description='Enable python')
+
     extends('python', when='+python')
 
     def setup_build_environment(self, env):
@@ -35,9 +37,9 @@ class LibcapNg(AutotoolsPackage):
         spec = self.spec
         if spec.satisfies('+python'):
             if spec.satisfies('^python@3:'):
-                args.extend(['-without-python', '-with-python3'])
+                args.extend(['--without-python', '--with-python3'])
             else:
-                args.extend(['-with-python', '-without-python3'])
+                args.extend(['--with-python', '--without-python3'])
         else:
-            args.extend(['-without-python', '-without-python3'])
+            args.extend(['--without-python', '--without-python3'])
         return args


### PR DESCRIPTION
- add python variant.
- add --with-python and --with-python3 configure option.