### PR TITLE
systemtap: Add depend

### DIFF
--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -24,6 +24,8 @@ class Systemtap(AutotoolsPackage):
 
     depends_on('gettext')
     depends_on('elfutils')
+    depends_on('sqlite')
+    depends_on('py-setuptools')
 
     def configure_args(self):
         args = ['LDFLAGS=-lintl']

--- a/var/spack/repos/builtin/packages/systemtap/package.py
+++ b/var/spack/repos/builtin/packages/systemtap/package.py
@@ -23,9 +23,10 @@ class Systemtap(AutotoolsPackage):
     version('4.1', sha256='8efa1ee2b34f1c6b2f33a25313287d59c8ed1b00265e900aea874da8baca1e1d')
 
     depends_on('gettext')
-    depends_on('elfutils')
+    depends_on('elfutils@0.151:')
     depends_on('sqlite')
-    depends_on('py-setuptools')
+    depends_on('py-setuptools', type='build')
+    depends_on('python', type=('build', 'run'))
 
     def configure_args(self):
         args = ['LDFLAGS=-lintl']


### PR DESCRIPTION
When I built this OSS on x86_64 and aarch64 machines, I got the following error:
coveragedb.cxx:20:10: fatal error: sqlite3.h: No such file or directory
     240     #include <sqlite3.h>

I confirmed that it can be built by adding depend of sqlite and py-setuptools.