### PR TITLE
process-in-process: Add systemtap depend

### DIFF
--- a/var/spack/repos/builtin/packages/process-in-process/package.py
+++ b/var/spack/repos/builtin/packages/process-in-process/package.py
@@ -29,6 +29,7 @@ class ProcessInProcess(Package):
 
     # packages required for building PiP-gdb
     depends_on('texinfo', type='build')
+    depends_on('systemtap')
 
     # resources for PiP version 2
     #  PiP-glibc resource


### PR DESCRIPTION
I fixed the following error.

conftest.c:12:10: fatal error: sys/sdt.h: No such file or directory
 #include <sys/sdt.h>