### PR TITLE
util-linux: Add ncurses depend

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -27,6 +27,7 @@ class UtilLinux(AutotoolsPackage):
 
     depends_on('python@2.7:', type='build')
     depends_on('pkgconfig', type='build')
+    depends_on('ncurses', type='link')
 
     variant('bash', default=False, description='Install bash completion scripts')
 


### PR DESCRIPTION
I fixed the following error.
/usr/bin/ld: cannot find -ltinfo