### PR TITLE
Propagate SCR resource_manager flag to libyogrt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -50,7 +50,8 @@ class Scr(CMakePackage):
 
     variant('libyogrt', default=True,
             description="Build SCR with libyogrt for get_time_remaining.")
-    depends_on('libyogrt', when="+libyogrt")
+    depends_on('libyogrt scheduler=slurm', when="+libyogrt resource_manager=SLURM")
+    depends_on('libyogrt scheduler=lsf', when="+libyogrt resource_manager=LSF")
 
     # MySQL not yet in spack
     # variant('mysql', default=True, decription="MySQL database for logging")

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -52,6 +52,7 @@ class Scr(CMakePackage):
             description="Build SCR with libyogrt for get_time_remaining.")
     depends_on('libyogrt scheduler=slurm', when="+libyogrt resource_manager=SLURM")
     depends_on('libyogrt scheduler=lsf', when="+libyogrt resource_manager=LSF")
+    depends_on('libyogrt', when="+libyogrt")
 
     # MySQL not yet in spack
     # variant('mysql', default=True, decription="MySQL database for logging")


### PR DESCRIPTION
When the SCR spec specifies a resource_manager=SLURM or LSF flag, propagate the spec through to the libyogrt scheduler=slurm or lsf