### PR TITLE
Fix git svn modules

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -311,7 +311,7 @@ class Git(AutotoolsPackage):
         # Libs from perl-alien-svn and apr-util are required in
         # LD_LIBRARY_PATH
         # TODO: extend to other platforms
-        if "+svn" in self.spec and sys.platform.startswith('linux'):
+        if "+svn platform=linux" in self.spec:
             perl_svn = self.spec['perl-alien-svn']
             env.prepend_path('LD_LIBRARY_PATH', join_path(
                 perl_svn.prefix, 'lib', 'perl5', 'x86_64-linux-thread-multi',

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -305,3 +305,14 @@ class Git(AutotoolsPackage):
             install_tree('man1', prefix.share.man.man1)
             install_tree('man5', prefix.share.man.man5)
             install_tree('man7', prefix.share.man.man7)
+
+    def setup_run_environment(self, env):
+        # Setup run environment if using SVN extension
+        # Libs from perl-alien-svn and apr-util are required in
+        # LD_LIBRARY_PATH
+        # TODO: extend to other platforms
+        if "+svn" in self.spec and sys.platform.startswith('linux'):
+            perl_svn = self.spec['perl-alien-svn']
+            env.prepend_path('LD_LIBRARY_PATH', join_path(
+                perl_svn.prefix, 'lib', 'perl5', 'x86_64-linux-thread-multi',
+                'Alien', 'SVN'))

--- a/var/spack/repos/builtin/packages/perl-alien-svn/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-svn/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 
 from spack import *
 
@@ -23,7 +24,7 @@ class PerlAlienSvn(PerlPackage):
 
     depends_on('perl-module-build', type='build')
     depends_on('apr@1.6.2', type='build')
-    depends_on('apr-util', type='build')
+    depends_on('apr-util', type=('build', 'link'))
     depends_on('sqlite', type='build')
     depends_on('zlib')
     depends_on('libbsd')
@@ -34,6 +35,8 @@ class PerlAlienSvn(PerlPackage):
 
     def setup_run_environment(self, env):
         # SVN libs are not RPATHed correctly...
-        env.prepend_path('LD_LIBRARY_PATH', join_path(
-            self.prefix, 'lib', 'perl5', 'x86_64-linux-thread-multi',
-            'Alien', 'SVN'))
+        # TODO: extend to other plaforms
+        if sys.platform.startswith('linux'):
+            env.prepend_path('LD_LIBRARY_PATH', join_path(
+                self.prefix, 'lib', 'perl4', 'x86_64-linux-thread-multi',
+                'Alien', 'SVN'))


### PR DESCRIPTION
Fixes behavior when module/spack loading git when using the +svn variant. The run env for Git was updated to point to the location of the dynamic libs to load. In addition apr-util needed to be type link as well in the perl-alien-svn recipe. A change was also made to highlight that the path stitching for LD_LIBRARY_PATH is only valid on linux platforms.