### PR TITLE
ECP-D&V-SDK: Fix an issue where some variants were not being concatenated correctly

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -69,7 +69,9 @@ class EcpDataVisSdk(BundlePackage):
             state = ['+' if d == '1' else '~' for d in format(i, '0' + str(n) + 'b')]
             [pkg_vars, dep_vars] = [''.join(v) for v in zip(
                 *[(s + pv, s + dv) for s, (pv, dv) in zip(state, variants.items())])]
-            depends_on(dep_spec + dep_vars, when=(pkg_spec + pkg_vars))
+            dependency = ' '.join((dep_spec, dep_vars))
+            predicate = ' '.join((pkg_spec, pkg_vars))
+            depends_on(dependency, when=predicate)
 
     ############################################################
     # Dependencies


### PR DESCRIPTION
Fixes the last concatenations that are done before adding a dependency in `variants2deps`.

Needed to separate boolean variants from enum variants.

e.g.:

Before: `... network=libfabric+hdf5 ...`
After: `... network=libfabric +hdf5 ...`