### PR TITLE
SEACAS: New version v2021-01-20

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -26,6 +26,7 @@ class Seacas(CMakePackage):
 
     # ###################### Versions ##########################
     version('master', branch='master')
+    version('2021-01-20', sha256='7814e81981d03009b6816be3eb4ed3845fd02cc69e006ee008a2cbc85d508246')
     version('2021-01-06', sha256='b233502a7dc3e5ab69466054cf358eb033e593b8679c6721bf630b03999bd7e5')
     version('2020-08-13', sha256='e5eaf203eb2dbfb33c61ccde26deea459d058aaea79b0847e2f4bdb0cef1ddcb')
     version('2020-05-12', sha256='7fc6915f60568b36e052ba07a77d691c99abe42eaba6ae8a6dc74bb33490ed60')
@@ -166,8 +167,10 @@ class Seacas(CMakePackage):
                     '-DSEACASProj_ENABLE_SEACASGrepos:BOOL=%s' % (
                         'ON' if '+fortran' in spec else 'OFF'),
                     '-DSEACASProj_ENABLE_SEACASMat2exo:BOOL=ON',
+                    '-DSEACASProj_ENABLE_SEACASNas2exo:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNemslice:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNemspread:BOOL=ON',
+                    '-DSEACASProj_ENABLE_SEACASSlice:BOOL=ON',
                 ])
 
             if '+legacy' in spec:


### PR DESCRIPTION
Added a new version due to new application `nas2exo` and also adding the build of `slice` if `+applications` is specified.