### PR TITLE
openssl: remove preprocessor flags incompatible with NVIDIA HPC SDK

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -172,5 +172,13 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
                 os.rmdir(pkg_certs)
                 os.symlink(sys_certs, pkg_certs)
 
+    def patch(self):
+        if self.spec.satisfies('%nvhpc'):
+            # Remove incompatible preprocessor flags
+            filter_file('-MF ', '',
+                        'Configurations/unix-Makefile.tmpl', string=True)
+            filter_file('-MT \$\@ ', '',
+                        'Configurations/unix-Makefile.tmpl', string=True)
+
     def setup_build_environment(self, env):
         env.set('PERL', self.spec['perl'].prefix.bin.perl)

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -177,7 +177,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
             # Remove incompatible preprocessor flags
             filter_file('-MF ', '',
                         'Configurations/unix-Makefile.tmpl', string=True)
-            filter_file('-MT \$\@ ', '',
+            filter_file(r'-MT \$\@ ', '',
                         'Configurations/unix-Makefile.tmpl', string=True)
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
Patch OpenSSL so that it builds successfully with the NVIDIA HPC SDK