### PR TITLE
libevent: Remove compiler flags incompatible with NVIDIA HPC SDK

### DIFF
--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -57,3 +57,15 @@ class Libevent(AutotoolsPackage):
             configure_args.append('--disable-openssl')
 
         return configure_args
+
+    def patch(self):
+        if self.spec.satisfies('%nvhpc'):
+            # Remove incompatible compiler flags
+            filter_file(' -Wmissing-declarations', '', 'configure')
+            filter_file(' -Wbad-function-cast', '', 'configure')
+            filter_file(' -Wno-unused-parameter', '', 'configure')
+            filter_file(' -Wmissing-field-initializers', '', 'configure')
+            filter_file(' -Waddress', '', 'configure')
+            filter_file(' -Wnormalized=id', '', 'configure')
+            filter_file(' -Woverride-init', '', 'configure')
+            filter_file(' -Wlogical-op', '', 'configure')


### PR DESCRIPTION
Patch libevent so that it builds successfully with the NVIDIA HPC SDK