### PR TITLE
LBANN FFT and HWLOC variants

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -42,6 +42,7 @@ class Aluminum(CMakePackage, CudaPackage):
     depends_on('mpi')
     depends_on('nccl', when='+nccl')
     depends_on('hwloc@1.11:')
+    depends_on('hwloc +cuda +nvml', when='+cuda')
     depends_on('cub', when='@:0.1,0.6.0: +cuda ^cuda@:10.99')
 
     generator = 'Ninja'

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -67,6 +67,7 @@ class Hydrogen(CMakePackage, CudaPackage):
     depends_on('cmake@3.17.0:', type='build')
     depends_on('mpi')
     depends_on('hwloc@1.11:')
+    depends_on('hwloc +cuda +nvml', when='+cuda')
 
     # Note that #1712 forces us to enumerate the different blas variants
     depends_on('openblas', when='blas=openblas')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -55,6 +55,7 @@ class Lbann(CMakePackage, CudaPackage):
     variant('fft', default=False, description='Support for FFT operations')
     variant('half', default=False,
             description='Builds with support for FP16 precision data types')
+    variant('hwloc', default=True, description='Add support for topology aware algorithms')
     variant('nvprof', default=False, description='Build with region annotations for NVPROF')
     variant('opencv', default=True,
             description='Builds with support for image processing with OpenCV')
@@ -62,8 +63,9 @@ class Lbann(CMakePackage, CudaPackage):
 
     # Variant Conflicts
     conflicts('@:0.90,0.99:', when='~conduit')
-    conflicts('@:0.90,0.102:', when='+fft')
+    conflicts('@0.90:0.101.99', when='+fft')
     conflicts('~cuda', when='+nvprof')
+    conflicts('~hwloc', when='+al')
 
     depends_on('cmake@3.17.0:', type='build')
 
@@ -117,12 +119,13 @@ class Lbann(CMakePackage, CudaPackage):
     depends_on('cudnn@8.0.2:', when='@:0.90,0.101: +cuda')
     depends_on('cub', when='@0.94:0.98.2 +cuda ^cuda@:10.99')
     depends_on('mpi')
-    depends_on('hwloc@1.11:', when='@:0.90,0.102:')
-    depends_on('hwloc@1.11:1.11.99', when='@0.95:0.101.99')
+    depends_on('hwloc@1.11:', when='@:0.90,0.102: +hwloc')
+    depends_on('hwloc@1.11:1.11.99', when='@0.95:0.101.99 +hwloc')
+    depends_on('hwloc +cuda +nvml', when='+cuda')
 
     depends_on('half', when='+half')
 
-    depends_on('fftw +openmp +mpi', when='+fft')
+    depends_on('fftw@3.3: +openmp', when='+fft')
 
     # LBANN wraps OpenCV calls in OpenMP parallel loops, build without OpenMP
     # Additionally disable video related options, they incorrectly link in a


### PR DESCRIPTION
Add support for building with an FFT layer in LBANN.  Updated the
HWLOC requirements to properly include CUDA and NVML variants as
appropriate.