### PR TITLE
fix build failure due to #20759 change

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -25,7 +25,7 @@ class LlvmAmdgpu(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
-    variant('openmp', default=True, description='Enable OpenMP')
+    variant('openmp', default=False, description='Enable OpenMP')
 
     depends_on('cmake@3.4.3:',  type='build', when='@:3.8.99')
     depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -62,7 +62,16 @@ class LlvmAmdgpu(CMakePackage):
         ]
 
         if self.compiler.name == "gcc":
-            gcc_prefix = ancestor(self.compiler.cc, 2)
+            compiler = Executable(self.compiler.cc)
+            gcc_output = compiler('-print-search-dirs', output=str, error=str)
+
+            for line in gcc_output.splitlines():
+                if line.startswith("install:"):
+                    # Get path and strip any whitespace
+                    # (causes oddity with ancestor)
+                    gcc_prefix = line.split(":")[1].strip()
+                    gcc_prefix = ancestor(gcc_prefix, 4)
+                    break
             args.append("-DGCC_INSTALL_PREFIX=" + gcc_prefix)
 
         return args

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -25,7 +25,7 @@ class LlvmAmdgpu(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
-    variant('openmp', default=False, description='Enable OpenMP')
+    variant('openmp', default=True, description='Enable OpenMP')
 
     depends_on('cmake@3.4.3:',  type='build', when='@:3.8.99')
     depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
@@ -33,6 +33,9 @@ class LlvmAmdgpu(CMakePackage):
     depends_on('z3', type='link')
     depends_on('zlib', type='link')
     depends_on('ncurses+termlib', type='link')
+    # openmp dependencies
+    depends_on("perl-data-dumper", type=("build"), when='+openmp')
+    depends_on("hwloc", when='+openmp')
     depends_on('libelf', type='link', when='+openmp')
 
     # Will likely only be fixed in LLVM 12 upstream


### PR DESCRIPTION
i see a build failure due to recent change from #20759  . making the openmp default=false for now.

here is log i see on my environment-
make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-build-54alfhy'
make: *** [Makefile:174: all] Error 2
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

2 errors found in build log:
     3149    cd /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-build-54alfhy/projects/com
             piler-rt/lib/sanitizer_common && /spack/lib/spack/env/gcc/g++ -DHAVE_RPC_XDR_H=0 -D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTAN
             T_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyuco
             e7rq5iciquq7whocreu2/spack-build-54alfhy/projects/compiler-rt/lib/sanitizer_common -I/tmp/root/spack-stage/spack-stage-l
             lvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common -I/tmp/root/spack-stage/spa
             ck-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-build-54alfhy/include -I/tmp/root/spack-stage/spack-st
             age-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/llvm/include -I/tmp/root/spack-stage/spack-stage-llvm-a
             mdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common/.. -fPIC -fvisibility-inlines-hi
             dden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -
             pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-noexcept-type -Wdelete
             -non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -Wall -std=c++14 -Wno-unused-parameter -O3   -m64 -fP
             IC -fno-builtin -fno-exceptions -fomit-frame-pointer -funwind-tables -fno-stack-protector -fvisibility=hidden -fno-lto -
             O3 -g -Wno-variadic-macros -Wno-non-virtual-dtor -fno-rtti -Wframe-larger-than=570 -DSANITIZER_SUPPORTS_WEAK_HOOKS=0 -UN
             DEBUG -std=c++14 -o CMakeFiles/RTSanitizerCommonNoHooks.x86_64.dir/sanitizer_netbsd.cpp.o -c /tmp/root/spack-stage/spack
             -stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cp
             p
     3150    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-b
             uild-54alfhy'
     3151    Can't locate Data/Dumper.pm in @INC (you may need to install the Data::Dumper module) (@INC contains: /tmp/root/spack-st
             age/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/openmp/runtime/tools/lib /usr/local/lib64/p
             erl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5)
              at /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/openmp/runtime/tools/
             lib/tools.pm line 80.
     3152    BEGIN failed--compilation aborted at /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu
             2/spack-src/openmp/runtime/tools/lib/tools.pm line 80.
     3153    Compilation failed in require at /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/sp
             ack-src/openmp/runtime/tools/message-converter.pl line 22.
     3154    BEGIN failed--compilation aborted at /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu
             2/spack-src/openmp/runtime/tools/message-converter.pl line 22.
  >> 3155    make[2]: *** [projects/openmp/runtime/src/CMakeFiles/libomp-needed-headers.dir/build.make:85: projects/openmp/runtime/sr
             c/kmp_i18n_id.inc] Error 2
     3156    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-b
             uild-54alfhy'
  >> 3157    make[1]: *** [CMakeFiles/Makefile2:42528: projects/openmp/runtime/src/CMakeFiles/libomp-needed-headers.dir/all] Error 2
     3158    make[1]: *** Waiting for unfinished jobs....
     3159    [  8%] Built target RTFuzzerTest.x86_64
     3160    [  8%] Building CXX object projects/compiler-rt/lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoHooks.x86_64.dir/sani
             tizer_openbsd.cpp.o
     3161    [  8%] Building CXX object projects/compiler-rt/lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoHooks.x86_64.dir/sani
             tizer_persistent_allocator.cpp.o
     3162    cd /tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-build-54alfhy/projects/com
             piler-rt/lib/sanitizer_common && /spack/lib/spack/env/gcc/g++ -DHAVE_RPC_XDR_H=0 -D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTAN
             T_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/tmp/root/spack-stage/spack-stage-llvm-amdgpu-4.0.0-54alfhyqyuco
             e7rq5iciquq7whocreu2/spack-build-54alfhy/projects/compiler-rt/lib/sanitizer_common -I/tmp/root/spack-stage/spack-stage-l
             lvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common -I/tmp/root/spack-stage/spa
             ck-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-build-54alfhy/include -I/tmp/root/spack-stage/spack-st
             age-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/llvm/include -I/tmp/root/spack-stage/spack-stage-llvm-a
             mdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common/.. -fPIC -fvisibility-inlines-hi
             dden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -
             pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-noexcept-type -Wdelete
             -non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -Wall -std=c++14 -Wno-unused-parameter -O3   -m64 -fP
             IC -fno-builtin -fno-exceptions -fomit-frame-pointer -funwind-tables -fno-stack-protector -fvisibility=hidden -fno-lto -
             O3 -g -Wno-variadic-macros -Wno-non-virtual-dtor -fno-rtti -Wframe-larger-than=570 -DSANITIZER_SUPPORTS_WEAK_HOOKS=0 -UN
             DEBUG -std=c++14 -o CMakeFiles/RTSanitizerCommonNoHooks.x86_64.dir/sanitizer_openbsd.cpp.o -c /tmp/root/spack-stage/spac
             k-stage-llvm-amdgpu-4.0.0-54alfhyqyucoe7rq5iciquq7whocreu2/spack-src/compiler-rt/lib/sanitizer_common/sanitizer_openbsd.
             cpp
