### PR TITLE
Feature: deployment mode

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -29,6 +29,13 @@ config:
     # padded_length: 128
 
 
+  # Spack has a restricted "deployment" mode that adds security features for a
+  # setuid Spack deployment model. Enable those features by setting
+  # mode: deployment. This setting can only be controlled at the `defaults` or
+  # `site` scopes, for security reasons.
+  mode: standard
+
+
   # Locations where templates should be found
   template_dirs:
     - $spack/share/spack/templates

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -7,6 +7,7 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 from spack.filesystem_view import YamlFilesystemView
 
@@ -26,6 +27,8 @@ def setup_parser(subparser):
 
 
 def activate(parser, args):
+    deployment.confirm_command_if_deployment('activate')
+
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
         tty.die("activate requires one spec.  %d given." % len(specs))

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -7,6 +7,7 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 
 
@@ -23,6 +24,7 @@ def setup_parser(subparser):
 
 
 def add(parser, args):
+    deployment.confirm_command_if_deployment('add')
     env = ev.get_env(args, 'add', required=True)
 
     with env.write_transaction():

--- a/lib/spack/spack/cmd/build_env.py
+++ b/lib/spack/spack/cmd/build_env.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.cmd.common.deployment as deployment
 import spack.cmd.common.env_utility as env_utility
 
 description = "run a command in a spec's install environment, " \
@@ -13,4 +14,5 @@ setup_parser = env_utility.setup_parser
 
 
 def build_env(parser, args):
+    deployment.die_if_deployment('build-env')
     env_utility.emulate_env_utility('build-env', 'build', args)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -12,6 +12,7 @@ import spack.architecture
 import spack.binary_distribution as bindist
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.mirror
@@ -472,6 +473,8 @@ def createtarball(args):
 
 def installtarball(args):
     """install from a binary package"""
+    deployment.die_if_deployment('buildcache install')
+
     if not args.specs:
         tty.die("build cache file installation requires" +
                 " at least one package spec argument")
@@ -528,6 +531,7 @@ def listspecs(args):
 
 def getkeys(args):
     """get public keys available on mirrors"""
+    deployment.die_if_deployment('keys')
     bindist.get_keys(args.install, args.trust, args.force)
 
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -531,7 +531,7 @@ def listspecs(args):
 
 def getkeys(args):
     """get public keys available on mirrors"""
-    deployment.die_if_deployment('keys')
+    deployment.die_if_deployment('buildcache keys')
     bindist.get_keys(args.install, args.trust, args.force)
 
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -13,6 +13,7 @@ import llnl.util.tty as tty
 
 import spack.binary_distribution as bindist
 import spack.ci as spack_ci
+import spack.cmd.common.deployment as deployment
 import spack.cmd.buildcache as buildcache
 import spack.environment as ev
 import spack.hash_types as ht
@@ -409,5 +410,7 @@ def ci_rebuild(args):
 
 
 def ci(parser, args):
+    deployment.die_if_deployment('ci')
+
     if args.func:
         args.func(args)

--- a/lib/spack/spack/cmd/common/deployment.py
+++ b/lib/spack/spack/cmd/common/deployment.py
@@ -22,7 +22,7 @@ def setup_deployment_args(command, args, required):
 
     Arguments:
         command (str): command name
-        args ( ): Argparse arguments
+        args (Namespace): Argparse arguments
         required (dict): Arguments to override and new values
     Returns:
         None

--- a/lib/spack/spack/cmd/common/deployment.py
+++ b/lib/spack/spack/cmd/common/deployment.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+import spack.config
+
+
+def die_if_deployment(command):
+    """Die if Spack is in deployment mode."""
+    mode = spack.config.restricted_config.get('config:mode', 'standard')
+    if isinstance(mode, dict) and 'deployment' in mode:
+        msg = "For security reasons, Spack cannot run the `%s`" % command
+        msg += " command in deployment mode."
+        tty.die(msg)
+
+
+def setup_deployment_args(command, args, required):
+    """
+    Setup required arguments in deployment mode
+
+    Arguments:
+        command (str): command name
+        args ( ): Argparse arguments
+        required (dict): Arguments to override and new values
+    Returns:
+        None
+
+    This method modifies the object passed as args.
+    """
+    mode = spack.config.restricted_config.get('config:mode', 'standard')
+    if isinstance(mode, dict) and 'deployment' in mode:
+        msg = "Spack is in deployment mode. Setting the following values"
+        msg += " for the `%s` command:\n" % command
+        for arg_name, new_value in required.items():
+            msg += "        %s = %s\n" % (arg_name, new_value)
+            setattr(args, arg_name, new_value)
+        tty.warn(msg)
+
+
+def confirm_command_if_deployment(command):
+    """
+    Warn the user and prompt for confirmation
+
+    Commands that modify the environment (but not configuration) are allowed
+    in deployment mode but require confirmation.
+    """
+    mode = spack.config.restricted_config.get('config:mode', 'standard')
+    if isinstance(mode, dict) and 'deployment' in mode:
+        env_name = mode['deployment']['env']
+        msg = 'Attempting to run command `%s` in environment' % command
+        msg += ' %s while in deployment mode.' % env_name
+        tty.mgs(msg)
+        answer = tty.get_yes_or_no('do you want to proceed?', default=False)
+        if not answer:
+            tty.die('Aborting `%s` command' % command)

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -10,6 +10,7 @@ import sys
 from six import iteritems
 
 import llnl.util.tty as tty
+import spack.cmd.common.deployment as deployment
 import spack.compilers
 import spack.config
 import spack.spec
@@ -73,6 +74,8 @@ def compiler_find(args):
        add them to Spack's configuration.
 
     """
+    deployment.die_if_deployment('compiler find')
+
     # None signals spack.compiler.find_compilers to use its default logic
     paths = args.add_paths or None
 
@@ -108,6 +111,8 @@ def compiler_find(args):
 
 
 def compiler_remove(args):
+    deployment.die_if_deployment('compiler remove')
+
     cspec = CompilerSpec(args.compiler_spec)
     compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
     if not compilers:

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 
 description = 'concretize an environment and write a lockfile'
@@ -17,6 +17,9 @@ def setup_parser(subparser):
 
 
 def concretize(parser, args):
+    if args.force:
+        deployment.confirm_command_if_deployment('concretize -f')
+
     env = ev.get_env(args, 'concretize', required=True)
     with env.write_transaction():
         concretized_specs = env.concretize(force=args.force)

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -12,6 +12,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import spack.config
 import spack.cmd.common.arguments
+import spack.cmd.common.deployment as deployment
 import spack.schema.env
 import spack.environment as ev
 import spack.schema.packages
@@ -157,6 +158,8 @@ def config_edit(args):
     With no arguments and an active environment, edit the spack.yaml for
     the active environment.
     """
+    deployment.die_if_deployment('config edit')
+
     scope, section = _get_scope_and_section(args)
     if not scope and not section:
         tty.die('`spack config edit` requires a section argument '
@@ -181,6 +184,8 @@ def config_add(args):
     """Add the given configuration to the specified config scope
 
     This is a stateful operation that edits the config files."""
+    deployment.die_if_deployment('config add')
+
     if not (args.file or args.path):
         tty.error("No changes requested. Specify a file or value.")
         setup_parser.add_parser.print_help()
@@ -259,6 +264,8 @@ def config_remove(args):
     """Remove the given configuration from the specified config scope
 
     This is a stateful operation that edits the config files."""
+    deployment.die_if_deployment('config remove')
+
     scope, _ = _get_scope_and_section(args)
 
     path, _, value = args.path.rpartition(':')

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -297,6 +297,8 @@ def _can_update_config_file(scope_dir, cfg_file):
 
 
 def config_update(args):
+    deployment.die_if_deployment('config update')
+
     # Read the configuration files
     spack.config.config.get_config(args.section, scope=args.scope)
     updates = spack.config.config.format_updates[args.section]
@@ -383,6 +385,8 @@ def _can_revert_update(scope_dir, cfg_file, bkp_file):
 
 
 def config_revert(args):
+    deployment.die_if_deployment('config revert')
+
     scopes = [args.scope] if args.scope else [
         x.name for x in spack.config.config.file_scopes
     ]

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -11,6 +11,7 @@ import re
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
 
+import spack.cmd.common.deployment as deployment
 import spack.util.web
 import spack.repo
 import spack.stage
@@ -801,6 +802,8 @@ def get_repository(args, name):
 
 
 def create(parser, args):
+    deployment.die_if_deployment('create')
+
     # Gather information about the package to be created
     name = get_name(args)
     url = get_url(args)

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -7,6 +7,7 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 import spack.store
 from spack.filesystem_view import YamlFilesystemView
@@ -32,6 +33,8 @@ def setup_parser(subparser):
 
 
 def deactivate(parser, args):
+    deployment.confirm_command_if_deployment('deactivate')
+
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
         tty.die("deactivate requires one spec.  %d given." % len(specs))

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -20,6 +20,7 @@ import os
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.deployment as deployment
 import spack.store
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
@@ -73,6 +74,11 @@ def deprecate(parser, args):
     """Deprecate one spec in favor of another"""
     env = ev.get_env(args, 'deprecate')
     specs = spack.cmd.parse_specs(args.specs)
+
+    # Enforce restrictions on Spack in deployment mode
+    deployment_required_args = {'yes_to_all': False}
+    deployment.setup_deployment_args(
+        'deprecate', args, deployment_required_args)
 
     if len(specs) != 2:
         raise SpackError('spack deprecate requires exactly two specs')

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -11,6 +11,7 @@ import llnl.util.tty as tty
 import spack.config
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.repo
 
 description = "developer build: build from code in current working directory"
@@ -61,6 +62,8 @@ packages. If neither are chosen, don't run tests for any packages.""")
 
 
 def dev_build(self, args):
+    deployment.die_if_deployment('dev-build')
+
     if not args.spec:
         tty.die("spack dev-build requires a package spec argument.")
 

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -9,6 +9,7 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 
 from spack.error import SpackError
@@ -38,6 +39,8 @@ def setup_parser(subparser):
 
 
 def develop(parser, args):
+    deployment.die_if_deployment('develop')
+
     env = ev.get_env(args, 'develop', required=True)
 
     if not args.spec:

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -9,6 +9,7 @@ import glob
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.cmd.common.deployment as deployment
 import spack.paths
 import spack.repo
 from spack.spec import Spec
@@ -88,6 +89,8 @@ def setup_parser(subparser):
 
 
 def edit(parser, args):
+    deployment.die_if_deployment('edit')
+
     name = args.package
 
     # By default, edit package files

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -83,7 +83,7 @@ def env_activate_setup_parser(subparser):
 
 
 def env_activate(args):
-    deployment.die_if_deployemtn('env activate')
+    deployment.die_if_deployment('env activate')
 
     env = args.activate_env
     if not args.shell:

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -16,6 +16,7 @@ from llnl.util.tty.color import colorize
 import spack.config
 import spack.schema.env
 import spack.cmd.common.arguments
+import spack.cmd.common.deployment as deployment
 import spack.cmd.install
 import spack.cmd.uninstall
 import spack.cmd.modules
@@ -82,6 +83,8 @@ def env_activate_setup_parser(subparser):
 
 
 def env_activate(args):
+    deployment.die_if_deployemtn('env activate')
+
     env = args.activate_env
     if not args.shell:
         spack.cmd.common.shell_init_instructions(
@@ -133,6 +136,8 @@ def env_deactivate_setup_parser(subparser):
 
 
 def env_deactivate(args):
+    deployment.die_if_deployment('env deactivate')
+
     if not args.shell:
         spack.cmd.common.shell_init_instructions(
             "spack env deactivate",
@@ -233,6 +238,8 @@ def env_remove(args):
     and `spack.yaml` files embedded in repositories should be removed
     manually.
     """
+    deployment.die_if_deployment('env remove')
+
     read_envs = []
     for env_name in args.rm_env:
         env = ev.read(env_name)
@@ -313,6 +320,7 @@ def env_view(args):
         if args.action == ViewAction.regenerate:
             env.regenerate_views()
         elif args.action == ViewAction.enable:
+            deployment.die_if_deployment('env view enable')
             if args.view_path:
                 view_path = args.view_path
             else:
@@ -320,6 +328,7 @@ def env_view(args):
             env.update_default_view(view_path)
             env.write()
         elif args.action == ViewAction.disable:
+            deployment.die_if_deployment('env view disable')
             env.update_default_view(None)
             env.write()
     else:
@@ -394,6 +403,8 @@ def env_update_setup_parser(subparser):
 
 
 def env_update(args):
+    deployment.die_if_deployment('env update')
+
     manifest_file = ev.manifest_file(args.env)
     backup_file = manifest_file + ".bkp"
     needs_update = not ev.is_latest_format(manifest_file)
@@ -430,6 +441,8 @@ def env_revert_setup_parser(subparser):
 
 
 def env_revert(args):
+    deployment.die_if_deployment('env revert')
+
     manifest_file = ev.manifest_file(args.env)
     backup_file = manifest_file + ".bkp"
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -16,6 +16,7 @@ import llnl.util.tty.colify as colify
 import six
 import spack
 import spack.cmd
+import spack.cmd.common.deployment as deployment
 import spack.error
 import spack.util.environment
 import spack.util.spack_yaml as syaml
@@ -148,6 +149,8 @@ def _spec_is_valid(spec):
 
 
 def external_find(args):
+    deployment.die_if_deployment('external find')
+
     if args.packages:
         packages_to_check = list(spack.repo.get(pkg) for pkg in args.packages)
     else:

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -8,6 +8,7 @@ import argparse
 
 import spack.binary_distribution
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.paths
 import spack.util.gpg
 
@@ -112,6 +113,8 @@ def setup_parser(subparser):
 
 def gpg_create(args):
     """create a new key"""
+    deployment.die_if_deployment('gpg create')
+
     if args.export:
         old_sec_keys = spack.util.gpg.signing_keys()
     spack.util.gpg.create(name=args.name, email=args.email,
@@ -124,6 +127,8 @@ def gpg_create(args):
 
 def gpg_export(args):
     """export a secret key"""
+    deployment.die_if_deployment('gpg export')
+
     keys = args.keys
     if not keys:
         keys = spack.util.gpg.signing_keys()
@@ -156,11 +161,14 @@ def gpg_sign(args):
 
 def gpg_trust(args):
     """add a key to the keyring"""
+    deployment.die_if_deployment('gpg trust')
     spack.util.gpg.trust(args.keyfile)
 
 
 def gpg_init(args):
     """add the default keys to the keyring"""
+    deployment.die_if_deployment('gpg init')
+
     import_dir = args.import_dir
     if import_dir is None:
         import_dir = spack.paths.gpg_keys_path
@@ -174,6 +182,7 @@ def gpg_init(args):
 
 def gpg_untrust(args):
     """remove a key from the keyring"""
+    deployment.die_if_deployment('gpg untrust')
     spack.util.gpg.untrust(args.signing, *args.keys)
 
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -15,6 +15,8 @@ import llnl.util.tty as tty
 import spack.build_environment
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
+import spack.config
 import spack.environment as ev
 import spack.fetch_strategy
 import spack.paths
@@ -235,6 +237,15 @@ environment variables:
         arguments.add_cdash_args(parser, True)
         parser.print_help()
         return
+
+    # Enforce restrictions on Spack in deployment mode
+    deployment_required_args = {
+        'use_cache': True,
+        'cache_only': True,
+        'dirty': False,
+        'unsigned': False,
+    }
+    deployment.setup_deployment_args('install', args, deployment_required_args)
 
     reporter = spack.report.collect_info(
         spack.package.PackageInstaller, '_install_task', args.log_format, args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -10,6 +10,7 @@ from llnl.util.tty.colify import colify
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.concretize
 import spack.config
 import spack.environment as ev
@@ -116,6 +117,8 @@ def setup_parser(subparser):
 
 def mirror_add(args):
     """Add a mirror to Spack."""
+    deployment.die_if_deployment('mirror add')
+
     url = url_util.format(args.url)
 
     mirrors = spack.config.get('mirrors', scope=args.scope)
@@ -133,6 +136,8 @@ def mirror_add(args):
 
 def mirror_remove(args):
     """Remove a mirror by name."""
+    deployment.die_if_deployment('mirror remove')
+
     name = args.name
 
     mirrors = spack.config.get('mirrors', scope=args.scope)
@@ -165,6 +170,8 @@ def mirror_remove(args):
 
 def mirror_set_url(args):
     """Change the URL of a mirror."""
+    deployment.die_if_deployment('mirror set-url')
+
     url = url_util.format(args.url)
 
     mirrors = spack.config.get('mirrors', scope=args.scope)

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -15,6 +15,7 @@ import runpy
 import llnl.util.tty as tty
 
 import spack
+import spack.cmd.common.deployment as deployment
 
 description = "launch an interpreter as spack would launch a command"
 section = "developer"
@@ -42,6 +43,8 @@ def python(parser, args, unknown_args):
     if args.version:
         print('Python', platform.python_version())
         return
+
+    deployment.die_if_deployment('python')
 
     if args.module:
         sys.argv = ['spack-python'] + unknown_args + args.python_args

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -30,7 +30,7 @@ def setup_parser(subparser):
 
 
 def remove(parser, args):
-    deployent.confirm_command_if_deployment('remove')
+    deployment.confirm_command_if_deployment('remove')
 
     env = ev.get_env(args, 'remove', required=True)
 

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -7,6 +7,7 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 
 
@@ -29,6 +30,8 @@ def setup_parser(subparser):
 
 
 def remove(parser, args):
+    deployent.confirm_command_if_deployment('remove')
+
     env = ev.get_env(args, 'remove', required=True)
 
     with env.write_transaction():

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import os
 
 import llnl.util.tty as tty
+import spack.cmd.common.deployment as deployment
 import spack.config
 import spack.repo
 import spack.util.path
@@ -70,6 +71,8 @@ def repo_create(args):
 
 def repo_add(args):
     """Add a package source to Spack's configuration."""
+    deployment.die_if_deployment('repo add')
+
     path = args.path
 
     # real_path is absolute and handles substitution.
@@ -101,6 +104,8 @@ def repo_add(args):
 
 def repo_remove(args):
     """Remove a repository from Spack's configuration."""
+    deployment.die_if_deployment('repo remove')
+
     repos = spack.config.get('repos', scope=args.scope)
     namespace_or_path = args.namespace_or_path
 

--- a/lib/spack/spack/cmd/test_env.py
+++ b/lib/spack/spack/cmd/test_env.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.cmd.common.deployment as deployment
 import spack.cmd.common.env_utility as env_utility
 
 description = "run a command in a spec's test environment, " \
@@ -13,4 +14,5 @@ setup_parser = env_utility.setup_parser
 
 
 def test_env(parser, args):
+    deployment.die_if_deployment('test-env')
     env_utility.emulate_env_utility('test-env', 'test', args)

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -12,6 +12,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.config
 import spack.paths
 import spack.util.gpg
@@ -44,6 +45,8 @@ def setup_parser(subparser):
 
 
 def tutorial(parser, args):
+    deployment.die_if_deployment('tutorial')
+
     if not spack.cmd.spack_is_git_repo():
         tty.die("This command requires a git installation of Spack!")
 

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -7,10 +7,11 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 
 
-description = 'remove specs from an environment'
+description = 'remove development information from an environment'
 section = "environments"
 level = "long"
 
@@ -23,6 +24,8 @@ def setup_parser(subparser):
 
 
 def undevelop(parser, args):
+    deployment.die_if_deployment('undevelop')
+
     env = ev.get_env(args, 'undevelop', required=True)
 
     if args.all:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -9,6 +9,7 @@ import sys
 import itertools
 
 import spack.cmd
+import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 import spack.error
 import spack.package
@@ -353,6 +354,10 @@ def uninstall(parser, args):
     if not args.specs and not args.all:
         tty.die('uninstall requires at least one package argument.',
                 '  Use `spack uninstall --all` to uninstall ALL packages.')
+
+    deployment_required_args = {'yes_to_all', False}
+    deployment.setup_deployment_args(
+        'uninstall', args, deployment_required_args)
 
     # [any] here handles the --all case by forcing all specs to be returned
     specs = spack.cmd.parse_specs(args.specs) if args.specs else [any]

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -355,7 +355,7 @@ def uninstall(parser, args):
         tty.die('uninstall requires at least one package argument.',
                 '  Use `spack uninstall --all` to uninstall ALL packages.')
 
-    deployment_required_args = {'yes_to_all', False}
+    deployment_required_args = {'yes_to_all': False}
     deployment.setup_deployment_args(
         'uninstall', args, deployment_required_args)
 

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -22,6 +22,20 @@ properties = {
                 'type': 'string',
                 'enum': ['rpath', 'runpath']
             },
+            'mode': {
+                'anyOf': [
+                    {
+                        'type': 'string',
+                        'enum': ['standard'],
+                    },
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'env': {'type': 'string'}
+                        },
+                    },
+                ],
+            },
             'install_tree': {
                 'anyOf': [
                     {

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3789,6 +3789,8 @@ class Spec(object):
                             if current == _any_version:
                                 # We don't print empty version lists
                                 return
+                            if current.concrete:
+                                current = current.lowest()
 
                     if callable(current):
                         raise SpecFormatStringError(

--- a/lib/spack/spack/test/cmd/common/deployment.py
+++ b/lib/spack/spack/test/cmd/common/deployment.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+import spack.config
+import spack.environment
+from spack.main import SpackCommand, SpackCommandError
+
+banned_commands = [
+    ('edit',),
+    ('create',),
+    ('test-env',),
+    ('build-env',),
+    ('ci', 'generate'),  # requires subcommand to parse
+    ('dev-build',),
+    ('config', 'add'),
+    ('config', 'remove', 'foo'),  # requires argument to parse
+    ('config', 'edit'),
+    ('config', 'update', 'repos'),  # requires section to parse
+    ('config', 'revert', 'repos'),
+    ('external', 'find'),
+    ('mirror', 'add', 'foo', 'bar'),
+    ('mirror', 'remove', 'foo'),
+    ('mirror', 'rm', 'foo'),
+    ('repo', 'add', 'foo'),
+    ('repo', 'remove', 'foo'),
+    ('repo', 'rm', 'foo'),
+    ('tutorial',),
+    ('python',),
+    ('develop',),
+    ('undevelop',),
+    ('compiler', 'find'),
+    ('compiler', 'add'),
+    ('compiler', 'remove', 'foo'),
+    ('compiler', 'rm', 'foo'),
+    ('env', 'activate', 'foo'),
+    ('env', 'deactivate'),
+    ('env', 'remove', 'foo'),
+    ('env', 'view', 'enable'),
+    ('env', 'view', 'disable'),
+    ('env', 'update', 'foo'),
+    ('env', 'revert', 'foo'),
+    ('buildcache', 'install'),
+    ('buildcache', 'keys'),
+    ('gpg', 'create', 'foo', 'bar'),
+    ('gpg', 'init'),
+    ('gpg', 'trust', 'foo'),
+    ('gpg', 'untrust', 'foo'),
+    ('gpg', 'export', 'foo'),
+]
+
+
+@pytest.fixture
+def deployment_mode(mutable_mock_env_path, monkeypatch):
+    env_cmd = SpackCommand('env')
+    env_cmd('create', 'test')
+
+    monkeypatch.setattr(spack.environment, '_active_environment',
+                        spack.environment.read('test'))
+
+    def return_deployment_mode(*args, **kwargs):
+        return {'deployment': {'env': 'test'}}
+    monkeypatch.setattr(spack.config.restricted_config, 'get',
+                        return_deployment_mode)
+    yield
+
+
+def test_banned_commands_fail_deployment_mode(deployment_mode):
+    for command in banned_commands:
+        with pytest.raises(SpackCommandError):
+            SpackCommand(command[0])(*(command[1:]))
+
+
+def test_modified_install_args_deployment_mode(deployment_mode):
+    # The --cache-only option that is set by deployment mode is first to cause
+    # an error in the test environment, so we test for that error message.
+    install = SpackCommand('install')
+    output = install('libelf', fail_on_error=False)
+    assert 'found when cache-only' in output
+    assert 'Error: No binary' in output


### PR DESCRIPTION
This PR adds a "deployment mode" that can be enabled in Spack.

The goal of deployment mode is to allow Spack to deploy pre-built binaries from either an environment or a raw Spack instance, in a restricted mode that allows Spack to be safely run as root.

To allow Spack to run safely as root, all commands that can edit Spack source, edit Spack configs, or run arbitrary code from anywhere other than a Spack package in a previously configured repo are banned. Attempting to run any of those commands in deployment mode will result in an error. The commands are listed in `$spack/lib/spack/spack/test/cmd/common/deployment.py`. Additionally, all commands and options that modify the active environment are negated, so that either the configured environment or no environment is used, depending on the configuration. Lastly, the `spack -k` option to ignore SSL certificates throws an exception when run in deployment mode.

Commands that modify the specs in the environment (but not its configuration) are allowed, but require user confirmation. These include the `add` and `remove` commands. The `uninstall` and `deprecate` commands require confirmation by default when in the standard Spack mode; when in "deployment" mode, the confirmation is mandatory (that is, the commands ignore the `-y` option).

The `install` command has several modifications in deployment mode. These modifications are equivalent to mandating the following arguments: `--cache-only --use-cache --clean`. In deployment mode, the `install` command also does not accept the `--no-check-signature` option (warns the user and ignores the option).