### PR TITLE
Add Quantum ESPRESSO version 6.7.

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -18,7 +18,10 @@ class QuantumEspresso(Package):
     maintainers = ['naromero77']
 
     version('develop', branch='develop')
-    version('6.6', sha256='924656cb083f52e5d2fe71ade05881389dac64b45316f1bdd6dee1c6170a672c', preferred=True)
+    version('6.7', sha256='fe0ce74ff736b10d2a20c9d59025c01f88f86b00d229c123b1791f1edd7b4315',
+            url='https://gitlab.com/QEF/q-e/-/archive/qe-6.7MaX-Release/q-e-qe-6.7MaX-Release.tar.gz'
+            )
+    version('6.6', sha256='924656cb083f52e5d2fe71ade05881389dac64b45316f1bdd6dee1c6170a672c')
     version('6.5', sha256='258b2a8a6280e86dad779e5c56356d8b35dc96d12ff33dabeee914bc03d6d602')
     version('6.4.1', sha256='b0d7e9f617b848753ad923d8c6ca5490d5d82495f82b032b71a0ff2f2e9cfa08')
     version('6.4', sha256='781366d03da75516fdcf9100a1caadb26ccdd1dedd942a6f8595ff0edca74bfe')


### PR DESCRIPTION
Adds the 6.7 release for package `quantum-espresso`. Since the git tag used to publish this version has a suffix `MaX-Release`, the `url` needs to be explicitly specified for this version.

For previous versions there were both tags with and without the `MaX` suffix, but according to information on the mailing list [1] this is the final release for 6.7.

The patch https://gitlab.com/QEF/q-e/-/commit/cf1fedefc20d39f5cd7551ded700ea4c77ad6e8f.diff which was applied on 6.6 is now included in the release, and is not necessary for this version.

Besides installing it locally I haven't done any manual testing, is there anything else that should be done?

[1] https://www.mail-archive.com/users@lists.quantum-espresso.org/msg39828.html

@naromero77, thanks for maintaining this package.