### PR TITLE
xrootd: Add version 4.12.6, 5.0.3; drop preferred

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -13,8 +13,10 @@ class Xrootd(CMakePackage):
     homepage = "http://xrootd.org"
     url      = "http://xrootd.org/download/v5.0.1/xrootd-5.0.1.tar.gz"
 
+    version('5.0.3', sha256='be40a1897d6c1f153d3e23c39fe96e45063bfafc3cc073db88a1a9531db79ac5')
     version('5.0.1', sha256='ff4462b0b61db4cc01dda0e26abdd78e43649ee7ac5e90f7a05b74328ff5ac83')
-    version('4.12.3', sha256='6f2ca1accc8d49d605706bb556777c753860bf46d845b1ee11393a5cb5987f15', preferred=True)
+    version('4.12.6', sha256='1a9056ab7aeeaafa586ea77e442960c71d233c9ba60c7f9db9262c1410954ac4')
+    version('4.12.3', sha256='6f2ca1accc8d49d605706bb556777c753860bf46d845b1ee11393a5cb5987f15')
     version('4.12.2', sha256='29f7bc3ea51b9d5d310eabd177152245d4160223325933c67f938ed5120f67bb')
     version('4.12.1', sha256='7350d9196a26d17719b839fd242849e3995692fda25f242e67ac6ec907218d13')
     version('4.12.0', sha256='69ef4732256d9a88127de4bfdf96bbf73348e0c70ce1d756264871a0ffadd2fc')


### PR DESCRIPTION
Add version 4.12.6, 5.0.3

I think, the preferred was there to keep version 4.
But that's why we have spack, because people can install whatever version they want.
And root has a properly versioned dependency.

@vvolkl Can you comment on the preferred setting? You added it in #18101

cc: @ajkotobi 