### PR TITLE
cnvnator: Add -lcrypto to Makefile.

### DIFF
--- a/var/spack/repos/builtin/packages/cnvnator/package.py
+++ b/var/spack/repos/builtin/packages/cnvnator/package.py
@@ -37,7 +37,7 @@ class Cnvnator(MakefilePackage):
         makefile.filter('-I$(SAMDIR)', '-I$(SAMINC)', string=True)
         # Link more libs
         makefile.filter('^override LIBS.*',
-                        'override LIBS += -lz -lbz2 -lcurl -llzma')
+                        'override LIBS += -lz -lbz2 -lcurl -llzma -lcrypto')
 
     def build(self, spec, prefix):
         make('ROOTSYS={0}'.format(spec['root'].prefix),


### PR DESCRIPTION
I fixed the following error.
undefined reference to symbol 'EVP_sha256@@@@OPENSSL_1_1_0'