### PR TITLE
gdl: Add libtirpc and libgeotiff depend

### DIFF
--- a/var/spack/repos/builtin/packages/gdl/package.py
+++ b/var/spack/repos/builtin/packages/gdl/package.py
@@ -60,6 +60,8 @@ class Gdl(CMakePackage):
     depends_on('netcdf-c')
     depends_on('pslib')
     depends_on('readline')
+    depends_on('libtirpc', type='link')
+    depends_on('libgeotiff', type='link')
 
     conflicts('+python', when='~embed_python')
 


### PR DESCRIPTION
I fixed the following issue and the subsequent libgeotiff depend issue.
73    CMake Error at CMakeLists.txt:402 (message):
     74      RPC support is mandatory.
     75
     76      Note that SunRPC has been removed in glibc-2.26 and later, while being
     77      optional in earlier versions.  Consider using the recommended and  more
     78      modern libtirpc instead.