### PR TITLE
Introduce a SPACK_PYTHON environment variable

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -10,9 +10,12 @@
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
 """:"
-# prefer python3, then python, then python2
-for cmd in python3 python python2; do
-   command -v > /dev/null $cmd && exec $cmd $0 "$@"
+# prefer SPACK_PYTHON environment variable, python3, python, then python2
+for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
+    if command -v > /dev/null "$cmd"; then
+        export SPACK_PYTHON="$(command -v "$cmd")"
+        exec "${SPACK_PYTHON}" "$0" "$@"
+    fi
 done
 
 echo "==> Error: spack could not find a python interpreter!" >&2

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -75,6 +75,14 @@ shell integration for :ref:`certain commands <packaging-shell-support>`,
 If you do not want to use Spack's shell support, you can always just run
 the ``spack`` command directly from ``spack/bin/spack``.
 
+When the ``spack`` command is executed it searches for an appropriate
+Python interpreter to use, which can be explicitly overridden by setting
+the ``SPACK_PYTHON`` environment variable.  When sourcing the appropriate shell
+setup script, ``SPACK_PYTHON`` will be set to the interpreter found at
+sourcing time, ensuring future invocations of the ``spack`` command will
+continue to use the same consistent python version regardless of changes in
+the environment.
+
 
 ^^^^^^^^^^^^^^^^^^
 Check Installation

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -58,6 +58,18 @@ alias spack          'set _sp_args = (\!*); source $_spack_share_dir/csh/spack.c
 alias spacktivate    'spack env activate'
 alias _spack_pathadd 'set _pa_args = (\!*) && source $_spack_share_dir/csh/pathadd.csh'
 
+# Identify and lock the python interpreter
+if (! $?SPACK_PYTHON) then
+    setenv SPACK_PYTHON ""
+endif
+foreach cmd ("$SPACK_PYTHON" python3 python python2)
+    command -v "$cmd" >& /dev/null
+    if ($status == 0) then
+        setenv SPACK_PYTHON `command -v "$cmd"`
+        break
+    endif
+end
+
 # Set variables needed by this script
 _spack_pathadd PATH "$SPACK_ROOT/bin"
 eval `spack --print-shell-vars csh`

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -253,7 +253,7 @@ function match_flag -d "checks all combinations of flags ocurring inside of a st
     set -l _a (string sub -s 2 (string trim "x$argv[1]"))
     set -l _b (string sub -s 2 (string trim "x$argv[2]"))
 
-    if test -z "$_a" || test -z "$_b"
+    if test -z "$_a" or test -z "$_b"
         return 0
     end
 
@@ -664,6 +664,19 @@ end
 # Figure out where this file is. Below code only needs to work in fish
 #
 set -l sp_source_file (status -f)  # name of current file
+
+
+
+#
+# Identify and lock the python interpreter
+#
+for cmd in "$SPACK_PYTHON" python3 python python2
+    set -l _sp_python (command -s "$cmd")
+    if test $status -eq 0
+        set -x SPACK_PYTHON $_sp_python
+        break
+    end
+end
 
 
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -326,6 +326,14 @@ if [ "$_sp_shell" = bash ]; then
     export -f _spack_shell_wrapper
 fi
 
+# Identify and lock the python interpreter
+for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
+    if command -v > /dev/null "$cmd"; then
+        export SPACK_PYTHON="$(command -v "$cmd")"
+        break
+    fi
+done
+
 #
 # make available environment-modules
 #


### PR DESCRIPTION
The `SPACK_PYTHON` environment variable can be set to a python interpreter to be used by the `spack` command.  This allows the `spack` command itself to use a consistent and separate interpreter from whatever python installation might be used for package building.

One example of the use case for this would be in RHEL 8 / CentOS 8 to use the system python for the spack command:
```
$ export SPACK_PYTHON=/usr/libexec/platform-python
$ . share/spack/setup-env.sh
$ spack load python@3.8.6
$ python --version
Python 3.8.6
$ spack python --version
Python 3.6.8
$ spack unload python@3.8.6
$ spack load python@3.7.6
$ python --version
Python 3.7.6
$ spack python --version
Python 3.6.8
$
```

Here we have the `spack` command always use the stable system provided python 3.6.8 in `/usr/libexec/platform-python`, the same use used by the system's `dnf` command, while continuing to be able to load and unload different versions of python from the current environment for use with packages.