### PR TITLE
pugixml: adds version 1.11.4

### DIFF
--- a/var/spack/repos/builtin/packages/pugixml/package.py
+++ b/var/spack/repos/builtin/packages/pugixml/package.py
@@ -13,6 +13,7 @@ class Pugixml(CMakePackage):
     homepage = "http://pugixml.org/"
     url      = "https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz"
 
+    version('1.11.4', sha256='8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716')
     version('1.11', sha256='26913d3e63b9c07431401cf826df17ed832a20d19333d043991e611d23beaa2c')
     version('1.10', sha256='55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a')
     version('1.8.1', sha256='929c4657c207260f8cc28e5b788b7499dffdba60d83d59f55ea33d873d729cd4')


### PR DESCRIPTION
It simply adds the latest version of `pugixml` to its corresponding Spack package.

This is needed since the current Spack package contains a version that breaks other Spack packages as seen in here:

https://github.com/spack/spack/issues/21198

