### PR TITLE
[dd4hep] fix assimp variant

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -12,7 +12,9 @@ class Assimp(CMakePackage):
 
     homepage = "https://www.assimp.org"
     url      = "https://github.com/assimp/assimp/archive/v4.0.1.tar.gz"
+    git      = "https://github.com/assimp/assimp.git"
 
+    version('master', branch='master')
     version('5.0.1', sha256='11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc')
     version('4.0.1', sha256='60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e')
 

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -49,7 +49,9 @@ class Dd4hep(CMakePackage):
     variant('hepmc3', default=False, description="Enable build with hepmc3")
     variant('lcio', default=False, description="Enable build with lcio")
     variant('edm4hep', default=True, description="Enable build with edm4hep")
-    variant('debug', default=False, description="Enable debug build")
+    variant('debug', default=False,
+            description="Enable debug build flag - adds extra info in"
+            " some places in addtion to the debug build type")
 
     depends_on('cmake @3.12:', type='build')
     depends_on('ninja', type='build')
@@ -58,7 +60,7 @@ class Dd4hep(CMakePackage):
     extends('python')
     depends_on('xerces-c', when='+xercesc')
     depends_on('geant4@10.2.2:', when='+geant4')
-    depends_on('assimp', when='+assimp')
+    depends_on('assimp@5.0.2:', when='+assimp')
     depends_on('hepmc3', when="+hepmc3")
     depends_on('lcio', when="+lcio")
     depends_on('edm4hep', when="+edm4hep")
@@ -75,8 +77,11 @@ class Dd4hep(CMakePackage):
             self.define_from_variant('DD4HEP_USE_GEANT4', 'geant4'),
             self.define_from_variant('DD4HEP_USE_LCIO', 'lcio'),
             self.define_from_variant('DD4HEP_USE_HEPMC3', 'hepmc3'),
-            self.define_from_variant('DD4HEP_LOAD_ASSIMP', 'assimp'),
             self.define_from_variant('DD4HEP_BUILD_DEBUG', 'debug'),
+            # Downloads assimp from github and builds it on the fly.
+            # However, with spack it is preferrable to have a proper external
+            # dependency, so we disable it.
+            self.define('DD4HEP_LOAD_ASSIMP', False),
             "-DCMAKE_CXX_STANDARD={0}".format(cxxstd),
             "-DBUILD_TESTING={0}".format(self.run_tests),
             "-DBOOST_ROOT={0}".format(spec['boost'].prefix),


### PR DESCRIPTION
    The assimp variant up to now is buggy - the subpackage that uses assimp is not
    actually enabled by the DD4HEP_LOAD_ASSIMP flag as the recipe assumes, it will
    enable automatically if it finds the assimp::assimp target (the flag instead
    will trigger an on-the-fly build). This commit fixes this by disabling the flag.
    The assimp dependency is updated to the not-yet-released version 5.0.2, as it
    actually needs the current master or newer, otherwise there is a cmake failure.

To get a working version of assimp, I also add the master branch.