### PR TITLE
mfem:  Add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -706,12 +706,15 @@ class Mfem(Package):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(self.examples_src_dir)
-        self.cache_extra_test_sources(self.examples_data_dir)
+        self.cache_extra_test_sources([self.examples_src_dir,
+                                       self.examples_data_dir])
 
     def test(self):
-        test_dir = os.path.join(self.install_test_root, self.examples_src_dir)
+        test_dir = join_path(self.install_test_root, self.examples_src_dir)
         with working_dir(test_dir, create=False):
+            # MFEM has many examples to serve as a suitable smoke check. ex10
+            # was chosen arbitrarily among the examples that work both with
+            # MPI and without it
             test_exe = 'ex10p' if ('+mpi' in self.spec) else 'ex10'
             make('CONFIG_MK={0}/share/mfem/config.mk'.format(self.prefix),
                  test_exe, parallel=False)

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -720,6 +720,7 @@ class Mfem(Package):
                               self.examples_data_dir)],
                           [], installed=True, purpose='Smoke test for mfem',
                           skip_missing=False, work_dir='.')
+            make('clean')
 
     # The files referenced in this patch method do not exist in stable
     # versions earlier than 4.1.

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -19,6 +19,8 @@ class Mfem(Package):
     maintainers = ['v-dobrev', 'tzanio', 'acfisher',
                    'goxberry', 'markcmiller86']
 
+    test_requires_compiler = True
+
     # Recommended mfem builds to test when updating this file: see the shell
     # script 'test_builds.sh' in the same directory as this file.
 
@@ -696,6 +698,28 @@ class Mfem(Package):
 
         if install_em:
             install_tree('data', join_path(prefix_share, 'data'))
+
+    examples_src_dir = 'examples'
+    examples_data_dir = 'data'
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(self.examples_src_dir)
+        self.cache_extra_test_sources(self.examples_data_dir)
+
+    def test(self):
+        test_dir = os.path.join(self.install_test_root, self.examples_src_dir)
+        with working_dir(test_dir, create=False):
+            test_exe = 'ex10p' if ('+mpi' in self.spec) else 'ex10'
+            make('CONFIG_MK={0}/share/mfem/config.mk'.format(self.prefix),
+                 test_exe, parallel=False)
+            self.run_test('./{0}'.format(test_exe),
+                          ['--mesh', '../{0}/beam-quad.mesh'.format(
+                              self.examples_data_dir)],
+                          [], installed=True, purpose='Smoke test for mfem',
+                          skip_missing=False, work_dir='.')
 
     # The files referenced in this patch method do not exist in stable
     # versions earlier than 4.1.


### PR DESCRIPTION
This PR represents a preliminary smoke test for the mfem package and is intended to serve the following purposes:

1. leverage the current E4S test suite for the software; and
2. demonstrate to package maintainers how to start a Spack smoke test.