### PR TITLE
superlu: Add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 
 
 class Superlu(Package):
@@ -160,13 +159,12 @@ class Superlu(Package):
         config_args = self._generate_make_hdr_for_test()
 
         # Write configuration options to make.inc file
-        make_file_inc = os.path.join(self.install_test_root,
-                                     self.make_hdr_file)
+        make_file_inc = join_path(self.install_test_root, self.make_hdr_file)
         with open(make_file_inc, 'w') as inc:
             for option in config_args:
                 inc.write('{0}\n'.format(option))
 
-        test_dir = os.path.join(self.install_test_root, self.examples_src_dir)
+        test_dir = join_path(self.install_test_root, self.examples_src_dir)
         with working_dir(test_dir, create=False):
             make('HEADER={0}'.format(self.prefix.include), 'superlu',
                  parallel=False)

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-
 class Superlu(Package):
     """SuperLU is a general purpose library for the direct solution of large,
     sparse, nonsymmetric systems of linear equations on high performance

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -172,3 +172,4 @@ class Superlu(Package):
                  parallel=False)
             self.run_test('./superlu', purpose='Smoke test for superlu',
                           work_dir='.')
+            make('clean')

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 
 class Superlu(Package):
     """SuperLU is a general purpose library for the direct solution of large,
@@ -21,11 +23,14 @@ class Superlu(Package):
     depends_on('cmake', when='@5.2.1:', type='build')
     depends_on('blas')
 
+    test_requires_compiler = True
+
     # CMake installation method
     def install(self, spec, prefix):
         cmake_args = [
             '-Denable_blaslib=OFF',
-            '-DBLAS_blas_LIBRARY={0}'.format(spec['blas'].libs.joined())
+            '-DBLAS_blas_LIBRARY={0}'.format(spec['blas'].libs.joined()),
+            '-DCMAKE_INSTALL_LIBDIR={0}'.format(self.prefix.lib)
         ]
 
         if '+pic' in spec:
@@ -93,3 +98,77 @@ class Superlu(Package):
         install_tree('lib', prefix.lib)
         mkdir(prefix.include)
         install(join_path('SRC', '*.h'), prefix.include)
+
+    examples_src_dir = 'EXAMPLE'
+    make_hdr_file = 'make.inc'
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(self.examples_src_dir)
+
+    def _generate_make_hdr_for_test(self):
+        config_args = []
+
+        # Define make.inc file
+        config_args.extend([
+            'SuperLUroot = {0}'.format(self.prefix),
+            'SUPERLULIB = {0}/libsuperlu.a'.format(self.prefix.lib),
+            'BLASLIB    = {0}'.format(self.spec['blas'].libs.ld_flags),
+            'TMGLIB     = libtmglib.a',
+            'LIBS       = $(SUPERLULIB) $(BLASLIB)',
+            'ARCH       = ar',
+            'ARCHFLAGS  = cr',
+            'RANLIB     = {0}'.format('ranlib' if which('ranlib') else 'echo'),
+            'CC         = {0}'.format(self.compiler.cc),
+            'FORTRAN    = {0}'.format(self.compiler.fc),
+            'LOADER     = {0}'.format(self.compiler.cc),
+            'CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_',
+            'NOOPTS     = -O0'
+        ])
+
+        return config_args
+
+    # Pre-cmake configuration
+    @when('@4.3')
+    def _generate_make_hdr_for_test(self):
+        config_args = []
+
+        # Define make.inc file
+        config_args.extend([
+            'PLAT       = _x86_64',
+            'SuperLUroot = {0}'.format(self.prefix),
+            'SUPERLULIB = {0}/libsuperlu_{1}.a'.format(self.prefix.lib,
+                                                       self.spec.version),
+            'BLASLIB    = {0}'.format(self.spec['blas'].libs.ld_flags),
+            'TMGLIB     = libtmglib.a',
+            'LIBS       = $(SUPERLULIB) $(BLASLIB)',
+            'ARCH       = ar',
+            'ARCHFLAGS  = cr',
+            'RANLIB     = {0}'.format('ranlib' if which('ranlib') else 'echo'),
+            'CC         = {0}'.format(self.compiler.cc),
+            'FORTRAN    = {0}'.format(self.compiler.fc),
+            'LOADER     = {0}'.format(self.compiler.cc),
+            'CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_',
+            'NOOPTS     = -O0'
+        ])
+
+        return config_args
+
+    def test(self):
+        config_args = self._generate_make_hdr_for_test()
+
+        # Write configuration options to make.inc file
+        make_file_inc = os.path.join(self.install_test_root,
+                                     self.make_hdr_file)
+        with open(make_file_inc, 'w') as inc:
+            for option in config_args:
+                inc.write('{0}\n'.format(option))
+
+        test_dir = os.path.join(self.install_test_root, self.examples_src_dir)
+        with working_dir(test_dir, create=False):
+            make('HEADER={0}'.format(self.prefix.include), 'superlu',
+                 parallel=False)
+            self.run_test('./superlu', purpose='Smoke test for superlu',
+                          work_dir='.')


### PR DESCRIPTION
@tldahlgren smoke test for superlu package

This PR represents a preliminary smoke test for the `super` package and is intended to serve the following purposes:

1. leverage the current E4S test suite for the software; and
2. demonstrate to package maintainers how to start a Spack smoke test.