### PR TITLE
Spack checkout command

### DIFF
--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -14,6 +14,7 @@ level = "long"
 
 git = None
 
+
 def setup_parser(subparser):
     subparser.add_argument(
         '-r', '--remote', action='store', default='origin',

--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -2,11 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import sys
-
 import llnl.util.tty as tty
-from spack.util.executable import ProcessError, which
+from spack.util.executable import which
+import spack.cmd.common.deployment as deployment
 
 _SPACK_UPSTREAM = 'https://github.com/spack/spack'
 
@@ -60,7 +58,7 @@ def checkout(parser, args):
     deployment.setup_deployment_args('checkout', args,
                                      deployment_required_args)
 
-    remote = args.remote or origin
+    remote = args.remote or 'origin'
     url = args.url
     ref = args.ref
 

--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -1,0 +1,78 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+import llnl.util.tty as tty
+from spack.util.executable import ProcessError, which
+
+_SPACK_UPSTREAM = 'https://github.com/spack/spack'
+
+description = "update the spack prefix to a git ref"
+section = "admin"
+level = "long"
+
+git = None
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-r', '--remote', action='store', default='origin',
+        help="name of the git remote from which to fetch")
+    subparser.add_argument(
+        '--url', action='store', default=None,
+        help="url to use if the remote does not already exist")
+    subparser.add_argument(
+        'ref', help="git reference to checkout")
+
+
+def fetch_remote(remote, url):
+    # Ensure we have the appropriate remote configured
+    remotes = git('remote', output=str, errror=str).split('\n')
+    if remote in remotes:
+        remote_url = git('remote', 'get-url', remote, output=str, error=str)
+        remote_url = remote_url.strip('\n')
+        if url and remote_url != url:
+            msg = "Git url %s does not match given url %s" % (remote_url, url)
+            msg += " for remote '%s'. Either use the git url or" % remote
+            msg += " specify a new remote name for the new url."
+            tty.die(msg)
+    elif not url:
+        msg = "Spack requires url to checkout from unknown remote %s" % remote
+        tty.die(msg)
+    else:
+        git('remote', 'add', remote, url)
+    git('fetch', remote)
+
+
+def known_commit_or_tag(ref):
+    # No need to fetch for tags and commits if we have the ref already
+    # Fetch on other types rather than failing here because a tree ref could
+    # be ambiguous with a commit ref after fetching
+    ref_type = git('cat-file', '-t', ref,
+                   output=str, error=str, fail_on_error=False).strip('\n ')
+    return ref_type in ('commit', 'tag')
+
+
+def checkout(parser, args):
+    deployment_required_args = {'remote': 'origin'}
+    deployment.setup_deployment_args('checkout', args,
+                                     deployment_required_args)
+
+    remote = args.remote or origin
+    url = args.url
+    ref = args.ref
+
+    global git  # make git available to called methods
+    git = which('git', required=True)
+
+    # Always fetch branches
+    branches = map(lambda b: b.strip('* '),
+                   git('branch', output=str, error=str).split('\n'))
+    if ref in branches or not known_commit_or_tag(ref):
+        fetch_remote(remote, url)
+
+    # For branches, ensure we're getting the version from the correct remote
+    full_ref = '%s/%s' % (remote, ref) if ref in branches else ref
+    git('checkout', full_ref)

--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -6,6 +6,8 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.environment as ev
+import spack.paths
+import spack.repo
 from spack.util.executable import which
 
 _SPACK_UPSTREAM = 'https://github.com/spack/spack'

--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -5,7 +5,6 @@
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
-import spack.cmd.common.deployment as deployment
 import spack.environment as ev
 from spack.util.executable import which
 

--- a/lib/spack/spack/cmd/checkout.py
+++ b/lib/spack/spack/cmd/checkout.py
@@ -55,10 +55,6 @@ def known_commit_or_tag(ref):
 
 
 def checkout(parser, args):
-    deployment_required_args = {'remote': 'origin'}
-    deployment.setup_deployment_args('checkout', args,
-                                     deployment_required_args)
-
     remote = args.remote or 'origin'
     url = args.url
     ref = args.ref
@@ -66,12 +62,13 @@ def checkout(parser, args):
     global git  # make git available to called methods
     git = which('git', required=True)
 
-    # Always fetch branches
-    branches = map(lambda b: b.strip('* '),
-                   git('branch', output=str, error=str).split('\n'))
-    if ref in branches or not known_commit_or_tag(ref):
-        fetch_remote(remote, url)
+    with working_dir(spack.paths.prefix):
+        # Always fetch branches
+        branches = map(lambda b: b.strip('* '),
+                       git('branch', output=str, error=str).split('\n'))
+        if ref in branches or not known_commit_or_tag(ref):
+            fetch_remote(remote, url)
 
-    # For branches, ensure we're getting the version from the correct remote
-    full_ref = '%s/%s' % (remote, ref) if ref in branches else ref
-    git('checkout', full_ref)
+        # For branches, ensure we're getting the version from the correct remote
+        full_ref = '%s/%s' % (remote, ref) if ref in branches else ref
+        git('checkout', full_ref)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -462,7 +462,7 @@ _spack_cd() {
 _spack_checkout() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --remote --url"
+        SPACK_COMPREPLY="-h --help -r --remote --url --env --repo"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -333,7 +333,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="activate add arch blame build-env buildcache cd checkout checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -456,6 +456,15 @@ _spack_cd() {
         SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -b --build-dir -e --env"
     else
         _all_packages
+    fi
+}
+
+_spack_checkout() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -r --remote --url"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 


### PR DESCRIPTION
This PR adds a `spack checkout` command to update the spack source to a particular git revision.

This PR builds on the "deployment mode" feature to restrict `spack checkout` to the origin remote when in deployment mode. This will allow users with permission to run Spack, but not to modify the source, to select a git revision to use.

Requires #21189