### PR TITLE
es-shell: add missing depends

### DIFF
--- a/var/spack/repos/builtin/packages/es-shell/package.py
+++ b/var/spack/repos/builtin/packages/es-shell/package.py
@@ -19,3 +19,4 @@ class EsShell(AutotoolsPackage):
     version('0.9.1', sha256='b0b41fce99b122a173a06b899a4d92e5bd3cc48b227b2736159f596a58fff4ba')
 
     depends_on('readline')
+    depends_on('yacc')


### PR DESCRIPTION
There's a compile error on `SUSE 15`:
```
==> Installing es-shell
==> No binary for es-shell found: installing from source
==> Fetching http://172.19.16.223/spack_mirror/_source-cache/archive/b0/b0b41fce99b122a173a06b899a4d92e5bd3cc48b227b2736159f596a58fff4ba.tar.gz
==> es-shell: Executing phase: 'autoreconf'
==> es-shell: Executing phase: 'configure'
==> es-shell: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'
7 errors found in build log:
...
     182    y.tab.c: In function 'yyparse':
  >> 183    y.tab.c:1877:3: error: unterminated comment
     184       /* User semantic actions sometimes alter yychar, and that requir
            es
     185       ^
  >> 186    y.tab.c:1876:5: error: expected declaration or statement at end of 
            input
     187         }
     188         ^
```

So we need `yacc` to fix this issue.