### PR TITLE
py-pygeos: add v0.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-pygeos/package.py
+++ b/var/spack/repos/builtin/packages/py-pygeos/package.py
@@ -18,9 +18,11 @@ class PyPygeos(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('0.9', sha256='c0584b20e95f80ee57277a6eb1e5d7f86600f8b1ef3c627d238e243afdcc0cc7')
     version('0.8', sha256='45b7e1aaa5fc9ff53565ef089fb75c53c419ace8cee18385ec1d7c1515c17cbc')
 
     depends_on('python@3:', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-numpy@1.13:', when='@0.9:', type=('build', 'link', 'run'))
     depends_on('py-numpy@1.10:', type=('build', 'link', 'run'))
     depends_on('geos@3.5:')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.

https://github.com/pygeos/pygeos/releases/tag/0.9