### PR TITLE
imake: add dependency

### DIFF
--- a/var/spack/repos/builtin/packages/imake/package.py
+++ b/var/spack/repos/builtin/packages/imake/package.py
@@ -15,4 +15,12 @@ class Imake(AutotoolsPackage, XorgPackage):
     version('1.0.7', sha256='6bda266a07eb33445d513f1e3c82a61e4822ccb94d420643d58e1be5f881e5cb')
 
     depends_on('xproto')
+    depends_on('xorg-cf-files')
     depends_on('pkgconfig', type='build')
+
+    def configure_args(self):
+        args = []
+        cfglib = self.spec['xorg-cf-files'].prefix.lib
+        cfgdir = join_path(cfglib, 'X11', 'config')
+        args.append('--with-config-dir={0}'.format(cfgdir))
+        return args

--- a/var/spack/repos/builtin/packages/imake/package.py
+++ b/var/spack/repos/builtin/packages/imake/package.py
@@ -15,12 +15,11 @@ class Imake(AutotoolsPackage, XorgPackage):
     version('1.0.7', sha256='6bda266a07eb33445d513f1e3c82a61e4822ccb94d420643d58e1be5f881e5cb')
 
     depends_on('xproto')
-    depends_on('xorg-cf-files')
+    depends_on('xorg-cf-files', type='run')
     depends_on('pkgconfig', type='build')
 
     def configure_args(self):
         args = []
-        cfglib = self.spec['xorg-cf-files'].prefix.lib
-        cfgdir = join_path(cfglib, 'X11', 'config')
+        cfgdir = self.spec['xorg-cf-files'].prefix.lib.X11.config
         args.append('--with-config-dir={0}'.format(cfgdir))
         return args


### PR DESCRIPTION
`xmkmf` command failed due to lack of `Imake.tmpl`.
`Imake.tmpl` (and configuration files) are found in `xorg-cf-files` package.
So I added the `depend_on` and `configure_args`.