### PR TITLE
pbbam: Fix install_tree

### DIFF
--- a/var/spack/repos/builtin/packages/pbbam/package.py
+++ b/var/spack/repos/builtin/packages/pbbam/package.py
@@ -37,7 +37,7 @@ class Pbbam(CMakePackage):
         with working_dir(self.build_directory):
             install_tree('bin', prefix.bin)
             install_tree('lib', prefix.lib)
-            install_tree('pbbam', prefix.include.pbbam)
+            install_tree('generated', prefix.include.pbbam)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('PacBioBAM_LIBRARIES', self.prefix.lib)


### PR DESCRIPTION
I fixed the following error.
OSError: No such file or directory: 'pbbam'

./spack/var/spack/repos/builtin/packages/pbbam/package.py:40, in install:
         37        with working_dir(self.build_directory):
         38            install_tree('bin', prefix.bin)
         39            install_tree('lib', prefix.lib)
  >>     40            install_tree('pbbam', prefix.include.pbbam)


I have confirmed that it can be built on x86_64 and aarch64 machines.