### PR TITLE
spack: raise an exception if compiler module not found

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -601,13 +601,21 @@ class Compiler(object):
         backup_env = os.environ.copy()
 
         try:
-            # load modules and set env variables
-            for module in self.modules:
+            if (self.modules
+                and os.environ.get("CRAY_CPU_TARGET") == 'mic-knl'):
                 # On cray, mic-knl module cannot be loaded without cce module
                 # See: https://github.com/spack/spack/issues/3153
-                if os.environ.get("CRAY_CPU_TARGET") == 'mic-knl':
-                    spack.util.module_cmd.load_module('cce')
+                spack.util.module_cmd.load_module('cce')
+
+            # load modules and set env variables
+            for module in self.modules:
                 spack.util.module_cmd.load_module(module)
+
+            loaded_modules = os.environ.get("LOADEDMODULES", "").split(":")
+
+            for module in self.modules:
+                if module not in loaded_modules:
+                    raise InvalidCompilerModuleError(self, module)
 
             # apply other compiler environment changes
             env = spack.util.environment.EnvironmentModifications()
@@ -635,6 +643,13 @@ class InvalidCompilerError(spack.error.SpackError):
     def __init__(self):
         super(InvalidCompilerError, self).__init__(
             "Compiler has no executables.")
+
+
+class InvalidCompilerModuleError(spack.error.SpackError):
+    def __init__(self, compiler, module):
+        msg = ("Module specified for compiler '{0}' could not be loaded: {1}"
+               .format(compiler.spec, module))
+        super(InvalidCompilerModuleError, self).__init__(msg)
 
 
 class UnsupportedCompilerFlag(spack.error.SpackError):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -292,7 +292,7 @@ def test_xl_version_detection(version_str, expected_version):
 def test_cray_frontend_compiler_detection(
         compiler, version, tmpdir, monkeypatch, working_env
 ):
-    """Test that the Cray frontend properly finds compilers form modules"""
+    """Test that the Cray frontend properly finds compilers from modules"""
     # setup the fake compiler directory
     compiler_dir = tmpdir.join(compiler)
     compiler_exe = compiler_dir.join('cc').ensure()


### PR DESCRIPTION
Currently when loading modules from the `modules` list for a compiler, Spack ignores any errors, making it harder than necessary to figure out what's wrong when debugging issues like #18606, #10308, #17100 (and possible some others since the module loading is fuzzy and hence different compilers could be picked up). A simple call to `avail` before the load should return a non-empty list of matching available modules.
This might break a couple of installations where the loading currently fails silently.