### PR TITLE
autoconf: add version 2.70

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 
 
@@ -13,10 +14,16 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     gnu_mirror_path = 'autoconf/autoconf-2.69.tar.gz'
 
     version('2.70', sha256='f05f410fda74323ada4bdc4610db37f8dbd556602ba65bc843edb4d4d4a1b2b7')
-    version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969')
+    version('2.69', sha256='954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969',
+            preferred=True)
     version('2.62', sha256='83aa747e6443def0ebd1882509c53f5a2133f502ddefa21b3de141c433914bdd')
     version('2.59', sha256='9cd05c73c5fcb1f5ccae53dd6cac36bb8cb9c7b3e97ffae5a7c05c72594c88d8')
     version('2.13', sha256='f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e')
+
+    # https://savannah.gnu.org/support/?110396
+    patch('https://git.savannah.gnu.org/cgit/autoconf.git/patch/?id=05972f49ee632cd98057a3caf82ebfb9574846da',
+          sha256='eaa3f69d927a853313a0b06e2117c51adab6377a2278549b05abc5df93643e16',
+          when='@2.70')
 
     # Note: m4 is not a pure build-time dependency of autoconf. m4 is
     # needed when autoconf runs, not only when autoconf is built.
@@ -39,9 +46,14 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     def patch(self):
         # The full perl shebang might be too long; we have to fix this here
         # because autom4te is called during the build
-        filter_file('^#! @PERL@ -w',
-                    '#! /usr/bin/env perl',
-                    'bin/autom4te.in')
+        patched_file = 'bin/autom4te.in'
+
+        # We save and restore the modification timestamp of the file to prevent
+        # regeneration of the respective man page:
+        with keep_modification_time(patched_file):
+            filter_file('^#! @PERL@ -w',
+                        '#! /usr/bin/env perl',
+                        patched_file)
 
     @run_after('install')
     def filter_sbang(self):

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import re
 
 


### PR DESCRIPTION
This PR adds a new version of Autoconf together with:
1. A patch that fixes a bug in version `2.70` (will be fixed upstream in the next release: https://savannah.gnu.org/support/?110396).
2. A fix for the way we patch shebang in `bin/autom4te.in`. We need to keep the original modification timestamp of the file. Otherwise, we either get an empty man page for `autom4te` (versions `2.69` and before) or a failure at the build time (versions `2.70` and after). The difference has to do with the update of the `missing` script: https://git.savannah.gnu.org/cgit/automake.git/commit/lib/missing?id=a22717dffe37f30ef2ad2c355b68c9b3b5e4b8c7


It will take time until developers of Autotools-based packages adjust their scripts to the new version, therefore, `2.69` is marked as `preferred`.