### PR TITLE
libsodium: Fix build on ppc64le

### DIFF
--- a/var/spack/repos/builtin/packages/libsodium/package.py
+++ b/var/spack/repos/builtin/packages/libsodium/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import llnl.util.tty as tty
+import os
 
 
 class Libsodium(AutotoolsPackage):
@@ -31,3 +33,14 @@ class Libsodium(AutotoolsPackage):
         elif version < Version('1.0.16'):
             url += 'old/'
         return url + 'libsodium-{0}.tar.gz'.format(version)
+
+    def patch(self):
+        # Necessary on ppc64le / aarch64, because Spack tries to execute these scripts
+        # to check if they work (see lib/spack/spack/build_systems/autotools.py).
+        try:
+            os.chmod("build-aux/config.guess", 0o755)
+            os.chmod("build-aux/config.sub", 0o755)
+        except OSError:
+            # Old versions of libsodium don't have these files.
+            tty.debug("Couldn't chmod config.guess or config.sub: file not found")
+            pass


### PR DESCRIPTION
On ppc64le and aarch64, Spack tries to execute any "config.guess" and
"config.sub" scripts it finds in the source package.

However, in the libsodium tarball, these files are present but not
executable.  This causes the following error when trying to install
libsodium with spack:

    Error: RuntimeError: Failed to find suitable substitutes for config.sub, config.guess

Fix this by chmod-ing the scripts in the patch() function of libsodium.