### PR TITLE
add a context wrapper for mtime preservation

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1828,7 +1828,8 @@ def keep_modification_time(*filenames):
     Context manager to keep the modification timestamps of the input files.
 
     Parameters:
-        *filenames: glob expressions for files
+        *filenames: one or more files that must have their modification
+            timestamps unchanged
     """
     mtimes = {}
     for f in filenames:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1831,7 +1831,7 @@ def keep_modification_time(*filenames):
         *filenames: glob expressions for files
     """
     mtimes = {}
-    for f in itertools.chain(*[glob.glob(x) for x in filenames]):
+    for f in filenames:
         mtimes[f] = os.path.getmtime(f)
     yield
     for f, mtime in mtimes.items():

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1832,8 +1832,13 @@ def keep_modification_time(*filenames):
     """
     mtimes = {}
     for f in filenames:
-        mtimes[f] = os.path.getmtime(f)
+        try:
+            mtimes[f] = os.path.getmtime(f)
+        except (IOError, OSError):
+            pass
     yield
     for f, mtime in mtimes.items():
-        if os.path.exists(f):
+        try:
             os.utime(f, (os.path.getatime(f), mtime))
+        except (IOError, OSError):
+            pass

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -63,7 +63,8 @@ __all__ = [
     'touchp',
     'traverse_tree',
     'unset_executable_mode',
-    'working_dir'
+    'working_dir',
+    'keep_modification_time'
 ]
 
 
@@ -1819,3 +1820,20 @@ def remove_directory_contents(dir):
                 os.unlink(entry)
             else:
                 shutil.rmtree(entry)
+
+
+@contextmanager
+def keep_modification_time(*filenames):
+    """
+    Context manager to keep the modification timestamps of the input files.
+
+    Parameters:
+        *filenames: glob expressions for files
+    """
+    mtimes = {}
+    for f in itertools.chain(*[glob.glob(x) for x in filenames]):
+        mtimes[f] = os.path.getmtime(f)
+    yield
+    for f, mtime in mtimes.items():
+        if os.path.exists(f):
+            os.utime(f, (os.path.getatime(f), mtime))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1826,6 +1826,8 @@ def remove_directory_contents(dir):
 def keep_modification_time(*filenames):
     """
     Context manager to keep the modification timestamps of the input files.
+    Tolerates and has no effect on non-existent files and files that are
+    deleted by the nested code.
 
     Parameters:
         *filenames: one or more files that must have their modification
@@ -1833,13 +1835,9 @@ def keep_modification_time(*filenames):
     """
     mtimes = {}
     for f in filenames:
-        try:
+        if os.path.exists(f):
             mtimes[f] = os.path.getmtime(f)
-        except (IOError, OSError):
-            pass
     yield
     for f, mtime in mtimes.items():
-        try:
+        if os.path.exists(f):
             os.utime(f, (os.path.getatime(f), mtime))
-        except (IOError, OSError):
-            pass

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -592,9 +592,20 @@ def test_content_of_files_with_same_name(tmpdir):
 
 def test_keep_modification_time(tmpdir):
     file1 = tmpdir.ensure('file1')
-    mtime1 = file1.mtime()
+    file2 = tmpdir.ensure('file2')
 
-    with fs.keep_modification_time(file1.strpath):
-        file1.setmtime(mtime1 + 10)
+    # Shift the modification time of the file 10 seconds back:
+    mtime1 = file1.mtime() - 10
+    file1.setmtime(mtime1)
 
+    with fs.keep_modification_time(file1.strpath,
+                                   file2.strpath,
+                                   'non-existing-file'):
+        file1.write('file1')
+        os.unlink(file2.strpath)
+
+    # Assert that the modifications took place the modification time has not
+    # changed;
+    assert file1.read().strip() == 'file1'
+    assert not file2.exists()
     assert int(mtime1) == int(file1.mtime())

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -592,30 +592,9 @@ def test_content_of_files_with_same_name(tmpdir):
 
 def test_keep_modification_time(tmpdir):
     file1 = tmpdir.ensure('file1')
-    file2 = tmpdir.ensure('file2')
+    mtime1 = file1.mtime()
 
-    # Account for the time resolution: pretend that the first and the second
-    # files were modified 10 and 5 seconds ago, respectively.
-    now = file1.mtime()
-    file1.setmtime(now - 10)
-    file2.setmtime(now - 5)
-
-    # Assert that the second file was modified later than the first one:
-    assert file2.mtime() > file1.mtime()
-
-    # Make sure that the write operation modifies the timestamp as expected and
-    # the time resolution is enough to make the following tests demonstrative:
-    file1.write('1')
-    assert file1.mtime() > file2.mtime()
-
-    # Restore the modification time to the previous value and re-run the write
-    # operation inside the tested context wrapper:
-    file1.setmtime(now - 10)
     with fs.keep_modification_time(file1.strpath):
-        file1.write('2')
+        file1.setmtime(mtime1 + 10)
 
-    # Assert that the last operation modified the file:
-    assert file1.read().strip() == '2'
-
-    # Assert that the last operation didn't change the modification timestamp:
-    assert file2.mtime() > file1.mtime()
+    assert int(mtime1) == int(file1.mtime())

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -602,7 +602,7 @@ def test_keep_modification_time(tmpdir):
                                    file2.strpath,
                                    'non-existing-file'):
         file1.write('file1')
-        os.unlink(file2.strpath)
+        file2.remove()
 
     # Assert that the modifications took place the modification time has not
     # changed;


### PR DESCRIPTION
Sometimes we need to patch a file that is a dependency for some other automatically generated file that comes in a release tarball. As a result, `make` tries to regenerate the dependent file using additional tools (e.g. `help2man`), which would not be needed otherwise. In some cases, it's preferable to avoid that (e.g. see #21255). A way to do that is to save the modification timestamps before patching and restoring them afterwards. This PR introduces a context wrapper that does that.

In the aforementioned PR #21255, the following code:
```python
mtime = os.path.getmtime(patched_file)
filter_file('^#! @PERL@ -w', '#! /usr/bin/env perl', patched_file)
os.utime(patched_file, (os.path.getatime(patched_file), mtime))
```
could be replaced with:
```python
with keep_modification_time(patched_file):
    filter_file('^#! @PERL@ -w', '#! /usr/bin/env perl', patched_file)
```
