### PR TITLE
allow multiple compatible deps from CLI

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1564,7 +1564,8 @@ class Spec(object):
             # allow redundant identical dependency specifications
             # depspec equality checks by name, so we need to check components
             # separately to test whether the specs are identical
-            if dspec != self._dependencies[spec.name]:
+            orig = self._dependencies[spec.name]
+            if dspec.spec != orig.spec or dspec.deptypes != orig.deptypes:
                 raise DuplicateDependencyError("Cannot depend on '%s' twice" % spec)
 
         # create an edge and add to parent and child

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1558,14 +1558,15 @@ class Spec(object):
 
     def _add_dependency(self, spec, deptypes):
         """Called by the parser to add another spec as a dependency."""
-        dspec = DependencySpec(self, spec, deptypes)
-
         if spec.name in self._dependencies:
             # allow redundant identical dependency specifications
             # depspec equality checks by name, so we need to check components
             # separately to test whether the specs are identical
             orig = self._dependencies[spec.name]
-            if dspec.spec != orig.spec or dspec.deptypes != orig.deptypes:
+            for dspec in orig:
+                if spec == dspec.spec and deptypes == dspec.deptypes:
+                    return
+            else:
                 raise DuplicateDependencyError("Cannot depend on '%s' twice" % spec)
 
         # create an edge and add to parent and child

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1558,9 +1558,16 @@ class Spec(object):
 
     def _add_dependency(self, spec, deptypes):
         """Called by the parser to add another spec as a dependency."""
-        if spec.name in self._dependencies:
-            raise DuplicateDependencyError("Cannot depend on '%s' twice" % spec)
+        dspec = DependencySpec(self, spec, deptypes)
 
+        if spec.name in self._dependencies:
+            # allow redundant identical dependency specifications
+            # depspec equality checks by name, so we need to check components
+            # separately to test whether the specs are identical
+            if dspec != self._dependencies[spec.name]:
+                raise DuplicateDependencyError("Cannot depend on '%s' twice" % spec)
+
+        # create an edge and add to parent and child
         self.add_dependency_edge(spec, deptypes)
 
     def add_dependency_edge(self, dependency_spec, deptype):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -293,6 +293,9 @@ class TestSpecSyntax(object):
 
         self.check_parse("x ^y", "x@: ^y@:")
 
+    def test_parse_redundant_deps(self):
+        self.check_parse('x ^y@foo', 'x ^y@foo ^y@foo')
+
     def test_parse_errors(self):
         errors = ["x@@1.2", "x ^y@@1.2", "x@1.2::", "x::"]
         self._check_raises(SpecParseError, errors)
@@ -481,7 +484,7 @@ class TestSpecSyntax(object):
         self._check_raises(MultipleVersionError, multiples)
 
     def test_duplicate_dependency(self):
-        self._check_raises(DuplicateDependencyError, ["x ^y ^y"])
+        self._check_raises(DuplicateDependencyError, ["x ^y@1 ^y"])
 
     def test_duplicate_compiler(self):
         duplicates = [

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -294,7 +294,7 @@ class TestSpecSyntax(object):
         self.check_parse("x ^y", "x@: ^y@:")
 
     def test_parse_redundant_deps(self):
-        self.check_parse('x ^y@foo', 'x ^y@foo ^y@foo')
+        self.check_parse("x ^y@foo", "x ^y@foo ^y@foo")
 
     def test_parse_errors(self):
         errors = ["x@@1.2", "x ^y@@1.2", "x@1.2::", "x::"]

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -295,6 +295,9 @@ class TestSpecSyntax(object):
 
     def test_parse_redundant_deps(self):
         self.check_parse("x ^y@foo", "x ^y@foo ^y@foo")
+        self.check_parse("x ^y@foo+bar", "x ^y@foo ^y+bar")
+        self.check_parse("x ^y@foo+bar", "x ^y@foo+bar ^y")
+        self.check_parse("x ^y@foo+bar", "x ^y ^y@foo+bar")
 
     def test_parse_errors(self):
         errors = ["x@@1.2", "x ^y@@1.2", "x@1.2::", "x::"]
@@ -484,7 +487,7 @@ class TestSpecSyntax(object):
         self._check_raises(MultipleVersionError, multiples)
 
     def test_duplicate_dependency(self):
-        self._check_raises(DuplicateDependencyError, ["x ^y@1 ^y"])
+        self._check_raises(DuplicateDependencyError, ["x ^y@1 ^y@2"])
 
     def test_duplicate_compiler(self):
         duplicates = [


### PR DESCRIPTION
Currently, Spack can fail for a valid spec if the spec is constructed from overlapping, but not conflicting, concrete specs via the hash.

For example, if `abcdef` and `ghijkl` are the hashes of specs that both depend on `zlib/mnopqr`, then `foo ^/abcdef ^/ghijkl` will fail to construct a spec, with the error message "Cannot depend on zlib... twice".

This PR changes this behavior to check whether the specs are identical before failing.

With this PR, `foo ^/abcdef ^/ghijkl` will concretize.

As a side-effect, so will `foo ^zlib ^zlib` and other specs that are redundant on their dependencies.