### PR TITLE
mxnet: Fix cuda build

### DIFF
--- a/var/spack/repos/builtin/packages/mxnet/makefile-cuda-stub-1.6.patch
+++ b/var/spack/repos/builtin/packages/mxnet/makefile-cuda-stub-1.6.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 4746cc434..335c79b64 100644
+--- a/Makefile
++++ b/Makefile
+@@ -518,7 +518,7 @@ ifeq ($(USE_CUDA), 1)
+ 	endif
+ 	# Make sure to add stubs as fallback in order to be able to build
+ 	# without full CUDA install (especially if run without nvidia-docker)
+-	LDFLAGS += -L/usr/local/cuda/lib64/stubs
++	LDFLAGS += -L$(USE_CUDA_PATH)/lib64/stubs
+ 	ifeq ($(USE_NCCL), 1)
+ 		ifneq ($(USE_NCCL_PATH), NONE)
+ 			CFLAGS += -I$(USE_NCCL_PATH)/include

--- a/var/spack/repos/builtin/packages/mxnet/makefile-cudnn-path-1.6.patch
+++ b/var/spack/repos/builtin/packages/mxnet/makefile-cudnn-path-1.6.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 4746cc434..e738fc53f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -509,7 +509,7 @@ LIB_DEP += $(DMLC_CORE)/libdmlc.a $(NNVM_PATH)/lib/libnnvm.a
+ ALL_DEP = $(OBJ) $(EXTRA_OBJ) $(PLUGIN_OBJ) $(LIB_DEP)
+ 
+ ifeq ($(USE_CUDA), 1)
+-	CFLAGS += -I$(ROOTDIR)/3rdparty/nvidia_cub
++	CFLAGS += -I$(CUB_INCLUDE) -I$(CUDNN_PATH)/include
+ 	ALL_DEP += $(CUOBJ) $(EXTRA_CUOBJ) $(PLUGIN_CUOBJ)
+ 	LDFLAGS += -lcufft
+ 	ifeq ($(ENABLE_CUDA_RTC), 1)

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -44,8 +44,9 @@ class Mxnet(MakefilePackage):
     depends_on('py-numpy@1.16:', type=('build', 'run'), when='@1.6.0 +python')
     extends('python', when='+python')
 
-    patch('makefile.patch', when='@0.10:0.11')
     patch('makefile.opencv.patch', when='@1.6.0')
+    patch('makefile-cudnn-path-1.6.patch', when='@1.6.0')
+    patch('makefile-cuda-stub-1.6.patch', when='@1.6.0')
     patch('parallell_shuffle.patch', when='@1.6.0')
 
     def build(self, spec, prefix):


### PR DESCRIPTION
- the cudnn include path was missing

- the Makefile was using the built-in version CUB instead of the Spack one

- the stub lib directory for cuda was not correctly set

Also remove old Makefile patch that is unused in the 1.X packages.

Fixes: #21260