### PR TITLE
nextflow: new version

### DIFF
--- a/var/spack/repos/builtin/packages/nextflow/package.py
+++ b/var/spack/repos/builtin/packages/nextflow/package.py
@@ -12,6 +12,7 @@ class Nextflow(Package):
     homepage = "http://www.nextflow.io"
     url = "https://github.com/nextflow-io/nextflow/releases/download/v0.24.1/nextflow"
 
+    version('20.10.0', sha256='54f76c83cbabe8ec68d6a878dcf921e647284499f4ae917356e594d873cb78dd', expand=False)
     version('20.07.1', sha256='de4db5747a801af645d9b021c7b36f4a25c3ce1a8fda7705a5f37e8f9357443a', expand=False)
     version('0.25.6', sha256='9498806596c96ba87396194fa6f1d7d1cdb739990f83e7e89d1d055366c5a943', expand=False)
     version('0.24.1', sha256='0bfde5335b385e3cff99bf4aab619e583de5dc0849767240f675037a2e7c1d83', expand=False)


### PR DESCRIPTION
Update `nextflow` to the latest release version `20.10.0`.