### PR TITLE
fox: Add mesa-glu depend

### DIFF
--- a/var/spack/repos/builtin/packages/fox/package.py
+++ b/var/spack/repos/builtin/packages/fox/package.py
@@ -37,7 +37,7 @@ class Fox(AutotoolsPackage):
     depends_on('libxi')
     depends_on('libxrandr')
     depends_on('gl', when='+opengl')
-    depends_on('mesa-glu', when='+opengl', type='link')
+    depends_on('glu', when='+opengl', type='link')
 
     def configure_args(self):
         # Make the png link flags explicit or it will try to pick up libpng15

--- a/var/spack/repos/builtin/packages/fox/package.py
+++ b/var/spack/repos/builtin/packages/fox/package.py
@@ -37,6 +37,7 @@ class Fox(AutotoolsPackage):
     depends_on('libxi')
     depends_on('libxrandr')
     depends_on('gl', when='+opengl')
+    depends_on('mesa-glu', when='+opengl', type='link')
 
     def configure_args(self):
         # Make the png link flags explicit or it will try to pick up libpng15


### PR DESCRIPTION
I have fixed the following issues:
$ spack install fox+opengl %gcc@8.3.1
  >> 994     FXGLCone.cpp:51:23: error: 'GLUquadric' was not declared in this scope
     995      #define GLUquadricObj GLUquadric
