### PR TITLE
py-prompt-toolkit: Add version 2.0.10 for py-spatialist

### DIFF
--- a/var/spack/repos/builtin/packages/py-prompt-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/py-prompt-toolkit/package.py
@@ -12,6 +12,7 @@ class PyPromptToolkit(PythonPackage):
     pypi = "prompt_toolkit/prompt_toolkit-1.0.9.tar.gz"
 
     version('3.0.7',  sha256='822f4605f28f7d2ba6b0b09a31e25e140871e96364d1d377667b547bb3bf4489')
+    version('2.0.10',  sha256='f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db')
     version('2.0.9',  sha256='2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1')
     version('1.0.16', sha256='c1cedd626e08b8ee830ee65897de754113ff3f3035880030c08b01674d85c5b4')
     version('1.0.9',  sha256='cd6523b36adc174cc10d54b1193eb626b4268609ff6ea92c15bcf1996609599c')


### PR DESCRIPTION
I fixed the following issues:

$ spack install py-spatialist %gcc@8.3.1

==> Warning: There is no checksum on file to fetch py-prompt-toolkit@2.0.999 safely.
==>   Fetch anyway? [y/N]