### PR TITLE
r-xvector: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-xvector/package.py
+++ b/var/spack/repos/builtin/packages/r-xvector/package.py
@@ -27,6 +27,7 @@ class RXvector(RPackage):
     depends_on('r-s4vectors@0.13.13:', type=('build', 'run'))
     depends_on('r-iranges@2.9.18:', type=('build', 'run'))
     depends_on('r-zlibbioc', type=('build', 'run'))
+    depends_on('zlib')
 
     depends_on('r-s4vectors@0.15.14:', when='@0.18.0:', type=('build', 'run'))
 


### PR DESCRIPTION
According to the source code, we should add `zlib` as a dependency:
```
[root@Estuary-CentOS8 spack-src]# pwd; grep -nr "zlib.h"
/tmp/root/spack-stage/spack-stage-r-xvector-0.24.0-gj73wlinkbij2zbbf7o6jysb4eprjzir/spack-src
src/io_utils.c:16:#include <zlib.h>
```