### PR TITLE
py-paramiko: New variant invoke

### DIFF
--- a/var/spack/repos/builtin/packages/py-paramiko/package.py
+++ b/var/spack/repos/builtin/packages/py-paramiko/package.py
@@ -16,9 +16,13 @@ class PyParamiko(PythonPackage):
     version('2.7.1', sha256='920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f')
     version('2.1.2', sha256='5fae49bed35e2e3d45c4f7b0db2d38b9ca626312d91119b3991d0ecf8125e310')
 
+    variant('invoke', default=False, description='Enable invoke support')
+
     depends_on('py-setuptools', type='build')
     depends_on('py-bcrypt@3.1.3:', when='@2.7:', type=('build', 'run'))
     depends_on('py-cryptography@1.1:', type=('build', 'run'))
     depends_on('py-cryptography@2.5:', when='@2.7:', type=('build', 'run'))
     depends_on('py-pyasn1@0.1.7:', when='@:2.1', type=('build', 'run'))
     depends_on('py-pynacl@1.0.1:', when='@2.7:', type=('build', 'run'))
+
+    depends_on('py-invoke@1.3:', when='@2.7:+invoke', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-paramiko/package.py
+++ b/var/spack/repos/builtin/packages/py-paramiko/package.py
@@ -25,4 +25,5 @@ class PyParamiko(PythonPackage):
     depends_on('py-pyasn1@0.1.7:', when='@:2.1', type=('build', 'run'))
     depends_on('py-pynacl@1.0.1:', when='@2.7:', type=('build', 'run'))
 
-    depends_on('py-invoke@1.3:', when='@2.7:+invoke', type=('build', 'run'))
+    depends_on('py-invoke@1.3:', when='+invoke', type=('build', 'run'))
+    conflicts('+invoke', when='@2.1.2')


### PR DESCRIPTION
A new variant, invoke, was added to support the eventual py-dvc package.