### PR TITLE
py-pyparsing: added version 2.4.7

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -11,6 +11,7 @@ class PyPyparsing(PythonPackage):
     homepage = "http://pyparsing.wikispaces.com/"
     pypi = "pyparsing/pyparsing-2.4.2.tar.gz"
 
+    version('2.4.7',  sha256='c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1')
     version('2.4.2',  sha256='6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80')
     version('2.4.0',  sha256='1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a')
     version('2.3.1',  sha256='66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a')


### PR DESCRIPTION
This version is required for eventual py-dvc package.