### PR TITLE
py-pynacl: Added missing dep py-wheel

### DIFF
--- a/var/spack/repos/builtin/packages/py-pynacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pynacl/package.py
@@ -16,3 +16,4 @@ class PyPynacl(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-cffi@1.4.1:', type=('build', 'run'))
+    depends_on('py-wheel', type='build')


### PR DESCRIPTION
Wheel was being download on the fly when installing py-pynacl. This change adds it to the dep list. See setup.py, setup_requires: https://github.com/pyca/pynacl/blob/1.4.0/setup.py 