### PR TITLE
mxnet: Fix python lib installation

### DIFF
--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -127,5 +127,8 @@ class Mxnet(MakefilePackage, CudaPackage):
 
         # install python bindings
         if '+python' in spec:
-            python = which('python')
-            python('python/setup.py', 'install', '--prefix={0}'.format(prefix))
+            # The python libs are in a separate dir, and it is necessary to change
+            # directory so that setup.py picks them up.
+            with working_dir('python'):
+                setup_py('install', '--prefix={0}'.format(prefix),
+                         '--single-version-externally-managed', '--root=/')


### PR DESCRIPTION
The python install process only installed the "benchmark" and "ci"
directories and missed the actual "mxnet" python package.  This is because
it only looks at top-level directories in the mxnet sources.

Fix this by changing directory before launching setup.py

While at it, add setup.py options that prevent installing an egg and
instead directly install the library (see PythonPackage class).  We can't
inherit from PythonPackage because the setup.py is not at the root of the
mxnet souces.