### PR TITLE
xterm: Add termcap depend

### DIFF
--- a/var/spack/repos/builtin/packages/xterm/package.py
+++ b/var/spack/repos/builtin/packages/xterm/package.py
@@ -38,3 +38,4 @@ class Xterm(AutotoolsPackage):
     depends_on('bzip2')
 
     depends_on('pkgconfig', type='build')
+    depends_on('termcap', type='link')


### PR DESCRIPTION
I have fixed the following issues:
372   ./spack-src/resize.c:427: undefined reference to `tgetent'