### PR TITLE
util.module_cmd: add bash module function to env

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -37,8 +37,11 @@ def module(
     # function to have the module commands work properly.
     #
     # Added caveat: `modulecmd` needs to be in PATH.
-    if b"BASH_FUNC_module()" not in environb:
-        environb[b"BASH_FUNC_module()"] = b"() { eval `modulecmd bash $*`\n}"
+    #
+    # Bash 4 uses (), 5 uses %%
+    for suffix in (b"%%", b"()"):
+        if b"BASH_FUNC_module" + suffix not in environb:
+            environb[b"BASH_FUNC_module" + suffix] = b"() { eval `modulecmd bash $*`\n}"
 
     if args[0] in module_change_commands:
         # Suppress module output

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -68,11 +68,6 @@ def module(
         environb.update(new_environb)  # novermin
 
     else:
-        # See note above
-        environ = dict(os.environ)
-        if "BASH_FUNC_module()" not in environ:
-            environ["BASH_FUNC_module()"] = "() { eval `modulecmd bash $*`\n}"
-
         # Simply execute commands that don't change state and return output
         module_p = subprocess.Popen(
             module_cmd,
@@ -81,6 +76,8 @@ def module(
             shell=True,
             executable="/bin/bash",
         )
+        # Decode and str to return a string object in both python 2 and 3
+        return str(module_p.communicate()[0].decode())
 
 
 def load_module(mod):


### PR DESCRIPTION
When using shells other than bash, e.g., zsh, modules can only be
sourced in the current shell. Bash has the module handling function
exported into a bash-specific environment variable that will allow other
bash run in subprocesses to inherit said function.

Here I'm proposing to populate the environment for `/bin/bash` with said
function in case the user runs a different shell. As mentioned in the
comments, this would require `modulecmd` to be found in PATH, which
seems to be a reasonable assumption. This will make `module_cmd.load`
etc work for hopefully all shells, not just bash.
