### PR TITLE
py-h5py: add build dependency on py-wheel

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -36,6 +36,7 @@ class PyH5py(PythonPackage):
     depends_on('py-cython@0.29:', type=('build'), when='@3.0.0:')
     depends_on('py-pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
+    depends_on('py-wheel', type='build', when='@3.0.0:')
 
     # Build and runtime dependencies
     depends_on('py-cached-property@1.5:', type=('build', 'run'))


### PR DESCRIPTION
h5py requires wheel at build time from version 3.0.0, based on the project's pyproject.toml. Revealed by a local build on the develop branch of spack using an external python.