### PR TITLE
cpio: fix for intel@18

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -32,7 +32,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
 
         if name == 'cflags':
-            if '%intel@:18.999' in spec:
+            if '%intel@:17.999' in spec:
                 flags.append('-no-gcc')
 
             elif '%clang' in spec or '%fj' in spec:


### PR DESCRIPTION
Intel version 18 does not compile cpio because of the -no-gcc flag. When removing this flag, cpio compiles with Intel version 18.