### PR TITLE
mesa: add zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -31,6 +31,7 @@ class Mesa(MesonPackage):
     depends_on('python@3:', type='build')
     depends_on('py-mako@0.8.0:', type='build')
     depends_on('expat')
+    depends_on('zlib@1.2.3:')
 
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")


### PR DESCRIPTION
When installing mesa in an offline environment, mesa tried to download zlib. This change identifies zlib as a dependency of mesa. Mesa in turn sees this dependency and no longer tries to download.