### PR TITLE
openfoam: modified 'setup_run_environment'

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -461,6 +461,10 @@ class Openfoam(Package):
             except Exception:
                 minimal = True
 
+        # Avoid the exception that occurs at runtime with the Fujitsu compiler.
+        if self.spec.satisfies('%fj'):
+            env.set('FOAM_SIGFPE', 'false')
+
         if minimal:
             # pre-build or minimal environment
             self.setup_minimal_environment(env)


### PR DESCRIPTION
Added the setting of environment variables at running openfoam when using the FJ compiler.
(I confirmed that Ver.1812 can be run.)