### PR TITLE
py-dictdiffer: fix offline dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-dictdiffer/package.py
+++ b/var/spack/repos/builtin/packages/py-dictdiffer/package.py
@@ -14,7 +14,7 @@ class PyDictdiffer(PythonPackage):
 
     version('0.8.1', sha256='1adec0d67cdf6166bda96ae2934ddb5e54433998ceab63c984574d187cc563d2')
 
-    depends_on('python@3.4:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-setuptools-scm@3.1.0:', type='build')
     depends_on('py-pytest-runner@2.7:', type='build')

--- a/var/spack/repos/builtin/packages/py-dictdiffer/package.py
+++ b/var/spack/repos/builtin/packages/py-dictdiffer/package.py
@@ -16,4 +16,5 @@ class PyDictdiffer(PythonPackage):
 
     depends_on('python@3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-setuptools-scm@3.1.0:', type=('build'))
+    depends_on('py-setuptools-scm@3.1.0:', type='build')
+    depends_on('py-pytest-runner@2.7:', type='build')


### PR DESCRIPTION
Add py-testrunner dependency to support offline build/install