### PR TITLE
openmpi find external fixup

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -446,10 +446,11 @@ class Openmpi(AutotoolsPackage):
 
             # Get the appropriate compiler
             match = re.search(r'\bC compiler absolute: (\S+)', output)
-            compiler_spec = get_spack_compiler_spec(
-                os.path.dirname(match.group(1)))
-            if compiler_spec:
-                variants += "%" + str(compiler_spec)
+            if match:
+                compiler_spec = get_spack_compiler_spec(
+                    os.path.dirname(match.group(1)))
+                if compiler_spec:
+                    variants += "%" + str(compiler_spec)
             results.append(variants)
         return results
 


### PR DESCRIPTION
@bvanessen reported an error on slack in which `spack external find` would fail due to raising an Exception in the openmpi `determine_variants` method. 

This PR fixes the error.