### PR TITLE
nvshmem: Set the variant to alway be true since requires cuda

### DIFF
--- a/var/spack/repos/builtin/packages/nvshmem/package.py
+++ b/var/spack/repos/builtin/packages/nvshmem/package.py
@@ -22,6 +22,7 @@ class Nvshmem(MakefilePackage, CudaPackage):
 
     version('2.0.3-0', sha256='20da93e8508511e21aaab1863cb4c372a3bec02307b932144a7d757ea5a1bad2', extension='txz')
 
+    variant('cuda', default=True, description='Build with CUDA')
     conflicts('~cuda')
 
     def url_for_version(self, version):


### PR DESCRIPTION
@haampie In a previous PR you suggested that I only use a conflicts statement to make sure that NVSHMEM has CUDA enabled.  However, I think that it should be both, requiring it and forcing it to be on.  Otherwise users of NVSHMEM have to explicitly set +cuda, but it cannot work without it.