### PR TITLE
libtheora: use utf8 for latex build to avoid log error

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/fix_encoding.patch
+++ b/var/spack/repos/builtin/packages/libtheora/fix_encoding.patch
@@ -1,0 +1,12 @@
+diff --git a/doc/spec/spec.tex b/doc/spec/spec.tex
+index 2206e10..34a0724 100644
+--- a/doc/spec/spec.tex
++++ b/doc/spec/spec.tex
+@@ -14,6 +14,7 @@
+ \usepackage{float}
+ \usepackage[pdfpagemode=None,pdfstartview=FitH,pdfview=FitH,colorlinks=true]%
+  {hyperref}
++\usepackage{utf8x}[inputenc]
+ 
+ \newtheorem{theorem}{Theorem}[section]
+ \newcommand{\idx}[1]{{\ensuremath{\mathit{#1}}}}

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -24,6 +24,7 @@ class Libtheora(AutotoolsPackage):
     depends_on('libpng')
 
     patch('exit-prior-to-running-configure.patch', when='@1.1.1')
+    patch('fix_encoding.patch', when='@1.1:')
     patch('https://gitlab.xiph.org/xiph/theora/-/commit/7288b539c52e99168488dc3a343845c9365617c8.patch',
           sha256='2e4f891f6880386d9391f3e4eaf4a23493de4eea532f9b5cb8a04b5f7cd09301', when='^libpng@1.6:')
 


### PR DESCRIPTION
Avoid the following error:
  File "/home/danlipsa/projects/spack/lib/spack/llnl/util/tty/log.py", line 768, in _writer_daemon
    line = _retry(in_pipe.readline)()
  File "/home/danlipsa/projects/spack/lib/spack/llnl/util/tty/log.py", line 830, in wrapped
    return function(*args, **kwargs)
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 220: invalid start byte