### PR TITLE
 py-cheetah: Add python2 depend and version 2.4.4

### DIFF
--- a/var/spack/repos/builtin/packages/py-cheetah/package.py
+++ b/var/spack/repos/builtin/packages/py-cheetah/package.py
@@ -9,10 +9,11 @@ from spack import *
 class PyCheetah(PythonPackage):
     """Cheetah is a template engine and code generation tool."""
 
-    pypi = "Cheetah3/Cheetah3-3.2.6.tar.gz"
+    pypi = "Cheetah/Cheetah-2.3.0.tar.gz"
 
-    version('3.2.6', sha256='f1c2b693cdcac2ded2823d363f8459ae785261e61c128d68464c8781dba0466b')
+    version('2.4.4', sha256='be308229f0c1e5e5af4f27d7ee06d90bb19e6af3059794e5fd536a6f29a9b550')
     version('2.3.0', sha256='2a32d7f7f70be98c2d57aa581f979bc799d4bf17d09fc0e7d77280501edf3e53')
 
+    depends_on('python@2:2.99.999', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-markdown@2.0.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-cheetah/package.py
+++ b/var/spack/repos/builtin/packages/py-cheetah/package.py
@@ -11,4 +11,7 @@ class PyCheetah(PythonPackage):
 
     pypi = "Cheetah/Cheetah-2.3.0.tar.gz"
 
+    version('2.4.4', sha256='be308229f0c1e5e5af4f27d7ee06d90bb19e6af3059794e5fd536a6f29a9b550')
     version('2.3.0', sha256='2a32d7f7f70be98c2d57aa581f979bc799d4bf17d09fc0e7d77280501edf3e53')
+
+    depends_on('python@2:2.99.999', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-cheetah/package.py
+++ b/var/spack/repos/builtin/packages/py-cheetah/package.py
@@ -9,9 +9,10 @@ from spack import *
 class PyCheetah(PythonPackage):
     """Cheetah is a template engine and code generation tool."""
 
-    pypi = "Cheetah/Cheetah-2.3.0.tar.gz"
+    pypi = "Cheetah3/Cheetah3-3.2.6.tar.gz"
 
-    version('2.4.4', sha256='be308229f0c1e5e5af4f27d7ee06d90bb19e6af3059794e5fd536a6f29a9b550')
+    version('3.2.6', sha256='f1c2b693cdcac2ded2823d363f8459ae785261e61c128d68464c8781dba0466b')
     version('2.3.0', sha256='2a32d7f7f70be98c2d57aa581f979bc799d4bf17d09fc0e7d77280501edf3e53')
 
-    depends_on('python@2:2.99.999', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-markdown@2.0.1:', type=('build', 'run'))


### PR DESCRIPTION
I have fixed the following issues:
  File "./spack-stage/spack-stage-py-cheetah-2.3.0-turnatpttuedmc2gm5dzckrsabw5nhgw/spack-src/SetupTools.py", line 50
    except DistutilsPlatformError, x:
                                                 ^
SyntaxError: invalid syntax


I also verified the latest version of 2.4.4 during the course of this investigation.
Include a fix that adds 2.4.4 to this PR.