### PR TITLE
autoconf: Add help2man depend

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -22,6 +22,7 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     # needed when autoconf runs, not only when autoconf is built.
     depends_on('m4@1.4.6:', type=('build', 'run'))
     depends_on('perl', type=('build', 'run'))
+    depends_on('help2man', type='build')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
When I built autoconf @ 2.70, I found and fixed the following issues:

179    WARNING: 'help2man' is missing on your system.
     180             You should only need it if you modified a dependency of a man page.
     181             You may want to install the GNU Help2man package:
     182             <https://www.gnu.org/software/help2man/>
     183    make[1]: *** [Makefile:2209: man/autom4te.1] Error 127