### PR TITLE
dssp : Implementation of spack test

### DIFF
--- a/var/spack/repos/builtin/packages/dssp/package.py
+++ b/var/spack/repos/builtin/packages/dssp/package.py
@@ -21,6 +21,16 @@ class Dssp(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('boost@1.48:')
 
+    # pdb data download.
+    # 1ALK.pdb - PDB (protein data bank) : https://www.rcsb.org/
+    resource(
+        name="pdb_data",
+        url="https://files.rcsb.org/download/1ALK.pdb",
+        sha256="99f4cd7ab63b35d64eacc85dc1491af5a03a1a0a89f2c9aadfb705c591b4b6c9",
+        expand=False,
+        placement='pdb'
+    )
+
     def configure_args(self):
         args = [
             "--with-boost=%s" % self.spec['boost'].prefix]
@@ -30,3 +40,11 @@ class Dssp(AutotoolsPackage):
     def edit(self):
         makefile = FileFilter(join_path(self.stage.source_path, 'Makefile'))
         makefile.filter('.*-Werror .*', '                    -Wno-error \\')
+
+    @run_after('install')
+    def cache_test_sources(self):
+        self.cache_extra_test_sources('pdb')
+
+    def test(self):
+        pdb_path  = join_path(self.install_test_root, 'pdb')
+        self.run_test('mkdssp', options=['1ALK.pdb', '1alk.dssp'], work_dir=pdb_path)


### PR DESCRIPTION
spack installed dssp (executable file: mkdssp) can be confirmed by spack test.
The test content is based on the PDB file that contains the 3D structure of 1ALK downloaded from the PDB (protein data bank), and the secondary structure is output to the dssp file.