### PR TITLE
PETSc: add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -16,9 +16,10 @@ class Petsc(Package):
     git = "https://gitlab.com/petsc/petsc.git"
     maintainers = ['balay', 'barrysmith', 'jedbrown']
 
-    # relative path to smoke test sources
-    smoke_test_paths = [join_path('src', 'snes', 'tutorials'),
-                        join_path('lib', 'petsc', 'conf')]
+    # Relative path to smoke test sources, first configuration vars then
+    #   smoke test example.
+    config_dir = join_path('lib', 'petsc', 'conf')
+    snes_dir = join_path('src', 'snes', 'tutorials')
 
     version('develop', branch='master')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
@@ -469,8 +470,7 @@ class Petsc(Package):
         spec = self.spec
         install_prefix = spec.prefix
         if 'mpi' in spec:
-            tutorials_dir = join_path('src', 'ksp', 'ksp', 'examples',
-                                      'tutorials')
+            tutorials_dir = join_path('src', 'ksp', 'ksp', 'tutorials')
             with working_dir(tutorials_dir):
                 env['PETSC_DIR'] = self.prefix
                 cc = Executable(spec['mpi'].mpicc)
@@ -539,14 +539,11 @@ class Petsc(Package):
         Copy all of the files within the examples source directory
         during installation to make them available for smoke testing.
         """
-        self.cache_extra_test_sources(self.smoke_test_paths)
+        self.cache_extra_test_sources([config_dir, snes_dir])
 
     def test(self):
         """Perform smoke tests on installed PETSc package."""
-        test_dir = join_path(self.install_test_root, self.smoke_test_paths[0])
-
-        #required = ['+mpi', '+hypre', '+superlu-dist']
-        #if all([var in self.spec for var in required]):
+        test_dir = join_path(self.install_test_root, self.snes_dir)
 
         if 'hypre' in self.spec:
             self.run_test('make',

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -528,41 +528,48 @@ class Petsc(Package):
     # For the 'libs' property - use the default handler.
 
     def _run_ex19(self):
-        """Run smoke test: ex19 test with hypre."""
+        """Run smoke test: SNES ex19 test with hypre."""
         test_dir = self.prefix.share.petsc.examples.src.snes.tutorials
+        if not os.path.exists(test_dir):
+            return
+
         exe = 'ex19'
 
         if 'hypre' in self.spec:
             self.run_test('make',
-                          ['PETSC_DIR={0}'.format(self.prefix), exe],
+                          # Option 1
+                          # ['PETSC_DIR={0}'.format(self.prefix), exe],
+                          # Option 2 gives same results as option 1
+                          ['-f', join_path(self.prefix.share.petsc,
+                                           'Makefile.user'), exe],
                           [], installed=False,
-                          purpose='test: building the {0} example'.format(exe),
+                          purpose='test: building the SNES {0} example'.format(
+                              exe),
                           skip_missing=False, work_dir=test_dir)
 
-            # Only check the first two and last lines due to numeric diffs
-            # - line 1: values
-            # - line 2: initial norm
-            # - last line: number of iterations
-            output = get_escaped_text_output(join_path(test_dir, 'output',
-                                             '{0}_hypre.out'.format(exe)))
-            expected = output[:2]
-            expected.append(output[-1])
-
-            reason = 'test: ensuring {0} with hypre runs'.format(exe)
+            # This test check ensures the example runs with the options
+            # and produces a very basic expected output string.
+            reason = 'test: ensuring SNES {0} with hypre runs'.format(exe)
             self.run_test('./{0}'.format(exe),
                           ['-da_refine', '3', '-snes_monitor_short',
                            '-pc_type', 'hypre'],
-                          expected, installed=False, purpose=reason,
+                          ['SNES Function norm'],
+                          installed=False, purpose=reason,
                           work_dir=test_dir)
 
-            reason = 'test: ensuring {0} test cleanup'.format(exe)
-            self.run_test('make', ['clean'], [], installed=False,
+            reason = 'test: ensuring SNES {0} test cleanup'.format(exe)
+            self.run_test('make',
+                          ['clean'],
+                          [], installed=False,
                           purpose=reason, skip_missing=False,
                           work_dir=test_dir)
 
     def _run_ex50(self):
-        """Run smoke test: ex50 test with hypre."""
+        """Run smoke test: KSP ex50 test with different options."""
         test_dir = self.prefix.share.petsc.examples.src.ksp.ksp.tutorials
+        if not os.path.exists(test_dir):
+            return
+
         exe = 'ex50'
 
         self.run_test('make',
@@ -575,7 +582,9 @@ class Petsc(Package):
             self.spec.satisfies('@:3.8') else '-pc_factor_mat_solver_type'
 
         if 'superlu-dist' in self.spec:
-            reason = 'test: ensuring {0} with superlu_dist runs'.format(exe)
+            # This test check ensures the example runs with the options
+            # but does not expect or check outputs.
+            reason = 'test: ensuring KSP {0} with superlu-dist runs'.format(exe)
             self.run_test(exe,
                           ['-da_grid_x', '4',
                            '-da_grid_y', '4',
@@ -585,7 +594,9 @@ class Petsc(Package):
                           work_dir=test_dir)
 
         if 'mumps' in self.spec:
-            reason = 'test: ensuring {0} with mumps runs'.format(exe)
+            # This test check ensures the example runs with the options
+            # but does not expect or check outputs.
+            reason = 'test: ensuring KSP {0} with mumps runs'.format(exe)
             self.run_test(exe,
                           ['-da_grid_x', '4',
                            '-da_grid_y', '4',
@@ -595,7 +606,9 @@ class Petsc(Package):
                           work_dir=test_dir)
 
         if 'hypre' in self.spec:
-            reason = 'test: ensuring {0} with hypre runs'.format(exe)
+            # This test check ensures the example runs with the options
+            # but does not expect or check outputs.
+            reason = 'test: ensuring KSP {0} with hypre runs'.format(exe)
             self.run_test(exe,
                           ['-da_grid_x', '4',
                            '-da_grid_y', '4',
@@ -604,7 +617,7 @@ class Petsc(Package):
                           [], installed=False, purpose=reason,
                           work_dir=test_dir)
 
-        reason = 'test: ensuring {0} test cleanup'.format(exe)
+        reason = 'test: ensuring KSP {0} test cleanup'.format(exe)
         self.run_test('make', ['clean'], [], installed=False,
                       purpose=reason, skip_missing=False,
                       work_dir=test_dir)

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -16,15 +16,6 @@ class Petsc(Package):
     git = "https://gitlab.com/petsc/petsc.git"
     maintainers = ['balay', 'barrysmith', 'jedbrown']
 
-    # Relative path to smoke test sources: configuration variable files
-    config_dir = join_path('lib', 'petsc', 'conf')
-
-    # Relative path to smoke test sources
-    ksp_dir = join_path('src', 'ksp', 'ksp', 'tutorials')
-
-    # Relative path to smoke test sources
-    snes_dir = join_path('src', 'snes', 'tutorials')
-
     version('develop', branch='master')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
 
@@ -536,18 +527,9 @@ class Petsc(Package):
 
     # For the 'libs' property - use the default handler.
 
-    @run_after('install')
-    def cache_test_sources(self):
-        """
-        Copy all of the files within the examples source directory
-        during installation to make them available for smoke testing.
-        """
-        self.cache_extra_test_sources([self.config_dir, self.ksp_dir,
-                                       self.snes_dir])
-
     def _run_ex19(self):
         """Run smoke test: ex19 test with hypre."""
-        test_dir = join_path(self.install_test_root, self.snes_dir)
+        test_dir = self.prefix.share.petsc.examples.src.snes.tutorials
         exe = 'ex19'
 
         if 'hypre' in self.spec:
@@ -565,7 +547,7 @@ class Petsc(Package):
                                              '{0}_hypre.out'.format(exe)))
             expected = output[:2]
             expected.append(output[-1])
-            
+
             reason = 'test: ensuring {0} with hypre runs'.format(exe)
             self.run_test('./{0}'.format(exe),
                           ['-da_refine', '3', '-snes_monitor_short',
@@ -580,7 +562,7 @@ class Petsc(Package):
 
     def _run_ex50(self):
         """Run smoke test: ex50 test with hypre."""
-        test_dir = join_path(self.install_test_root, self.ksp_dir)
+        test_dir = self.prefix.share.petsc.examples.src.ksp.ksp.tutorials
         exe = 'ex50'
 
         self.run_test('make',


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `petsc` package and is intended to serve the following purposes:

1. leverage the current E4S test suite for the software; and
2. demonstrate to package maintainers how to start a Spack smoke test.

This PR also converts the existing install test to a more "standard" `check_install`.