### PR TITLE
py-mypy: add v0.800

### DIFF
--- a/.github/workflows/style_and_docs.yaml
+++ b/.github/workflows/style_and_docs.yaml
@@ -36,7 +36,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools flake8 mypy black
+        pip install --upgrade pip six setuptools flake8 mypy>=0.800 black
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.

--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -12,10 +12,11 @@ class PyMypy(PythonPackage):
     homepage = "http://www.mypy-lang.org/"
     pypi = "mypy/mypy-0.740.tar.gz"
 
+    version('0.800', sha256='e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a')
     version('0.740', sha256='48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d')
 
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-typed-ast@1.4.0:1.4.999', type=('build', 'run'))
     depends_on('py-typing-extensions@3.7.4:', type=('build', 'run'))
-    depends_on('py-mypy-extensions@0.4.0:0.4.999', type=('build', 'run'))
+    depends_on('py-mypy-extensions@0.4.3:0.4.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs and passes all import tests on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.