### PR TITLE
swarm: Add version 3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/swarm/package.py
+++ b/var/spack/repos/builtin/packages/swarm/package.py
@@ -12,7 +12,10 @@ class Swarm(MakefilePackage):
     homepage = "https://github.com/torognes/swarm"
     url      = "https://github.com/torognes/swarm/archive/v2.1.13.tar.gz"
 
+    version('3.0.0', sha256='b63761a9914ebf1fee14befaffd93af9c795b692c006c644d049a6d985b55810')
     version('2.1.13', sha256='ec4b22cc1874ec6d2c89fe98e23a2fb713aec500bc4a784f0556389d22c02650')
+
+    conflicts('@2.1.13', when='target=aarch64:')
 
     build_directory = 'src'
 


### PR DESCRIPTION
I have added version 3.0.0 which can be built with aarch64.