### PR TITLE
update hpx: fix apex version in 1.5.x

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -166,4 +166,8 @@ class Hpx(CMakePackage, CudaPackage):
                 self.define('OTF2_ROOT', spec['otf2'].prefix),
             ]
 
+            # it seems like there was a bug in the default version of APEX in 1.5.x
+            if spec.satisfies("@:1.5"):
+                args += [self.define('HPX_WITH_APEX_TAG', "v2.3.0")]
+
         return args


### PR DESCRIPTION
It seems there was a bug in the version of APEX that we set by default in 1.5.x, with APEX 2.3.0 it works better.

Thanks @msimberg for the support, maybe you can also check if it is what you meant in our discussion.