### PR TITLE
lhapdf: Removed boost dependence and other outdated bits

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -26,15 +26,9 @@ class Lhapdf(AutotoolsPackage):
     depends_on('python',        type=('build', 'run'))
     depends_on('py-cython',     type='build')
     depends_on('py-setuptools', type='build')
-    depends_on('boost',         type='build')
-    depends_on('yaml-cpp',      type='build', when='@:6.1.5')
 
     extends('python')
 
     def configure_args(self):
-        args = ['--with-boost=' + self.spec['boost'].prefix,
-                'FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3']
-
-        if self.spec.satisfies('@:6.1.5'):
-            args.append('--with-yaml-cpp=' + self.spec['yaml-cpp'].prefix)
+        args = ['FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3']
         return args


### PR DESCRIPTION
Package already only supports version 6.2.3+. 
Starting with 6.2, boost was no longer needed, but the package still contained it as a dependency along with other bits only relevant for the (unsupported) 6.1.5.