### PR TITLE
py-sip: change url because some old package is missing

### DIFF
--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -12,17 +12,17 @@ class PySip(Package):
        and C++ libraries."""
 
     homepage = "https://www.riverbankcomputing.com/software/sip/intro"
-    url      = "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.18/sip-4.19.18.tar.gz"
-    list_url = "https://www.riverbankcomputing.com/software/sip/download"
+    url      = "https://www.riverbankcomputing.com/hg/sip/archive/4.19.21.tar.gz"
+    list_url = "https://www.riverbankcomputing.com/hg/sip/archive"
     hg       = "https://www.riverbankcomputing.com/hg/sip"
 
     version('develop', hg=hg)  # wasn't actually able to clone this
-    version('4.19.21', sha256='6af9979ab41590e8311b8cc94356718429ef96ba0e3592bdd630da01211200ae')
-    version('4.19.20', sha256='04cc2f87ac97e8718d8e1ef036e3ec26050ab44c21f9277618d5b67432fcbfd6')
-    version('4.19.19', sha256='5436b61a78f48c7e8078e93a6b59453ad33780f80c644e5f3af39f94be1ede44')
-    version('4.19.18', sha256='c0bd863800ed9b15dcad477c4017cdb73fa805c25908b0240564add74d697e1e')
-    version('4.19.15', sha256='2b5c0b2c0266b467b365c21376d50dde61a3236722ab87ff1e8dacec283eb610')
-    version('4.19.13', sha256='e353a7056599bf5fbd5d3ff9842a6ab2ea3cf4e0304a0f925ec5862907c0d15e')
+    version('4.19.21', sha256='3bfd58e875a87471c00e008f25a01d8312885aa01efc4f688e5cac861c8676e4')
+    version('4.19.20', sha256='475f85277a6601c406ade508b6c935b9f2a170c16fd3ae9dd4cdee7a4f7f340d')
+    version('4.19.19', sha256='348cd6229b095a3090e851555814f5147bffcb601cec891f1038eb6b38c9d856')
+    version('4.19.18', sha256='e274a8b9424047c094a40a8e70fc5e596c191cb8820472846d7bf739e461b2e8')
+    version('4.19.15', sha256='02bff1ac89253e12cdf1406ad39f841d0e264b0d96a7de13dfe9e29740df2053')
+    version('4.19.13', sha256='92193fcf990503bf29f03e290efc4ee1812d556efc18acf5c8b88c090177a630')
 
     variant('module', default='sip', description='Name of private SIP module',
             values=str, multi=False)
@@ -37,7 +37,7 @@ class PySip(Package):
 
     @run_before('configure')
     def prepare(self):
-        if self.spec.satisfies('@develop'):
+        if not os.path.exists('configure.py'):
             python('build.py', 'prepare')
 
     def configure(self, spec, prefix):


### PR DESCRIPTION
Some old packages are missing, so could we change the url to `hg` package url?

```
[root@Estuary-CentOS8 packages]# wget https://www.riverbankcomputing.com/static/Downloads/sip/4.19.18/sip-4.19.18.tar.gz
--2021-01-30 16:11:17--  https://www.riverbankcomputing.com/static/Downloads/sip/4.19.18/sip-4.19.18.tar.gz
Resolving proxysg.huawei.com (proxysg.huawei.com)... 172.18.157.51
Connecting to proxysg.huawei.com (proxysg.huawei.com)|172.18.157.51|:8080... connected.
Proxy request sent, awaiting response... 404 Not Found
2021-01-30 16:11:18 ERROR 404: Not Found.
```