### PR TITLE
chrony: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/chrony/package.py
+++ b/var/spack/repos/builtin/packages/chrony/package.py
@@ -21,6 +21,7 @@ class Chrony(AutotoolsPackage):
     version('3.3',   sha256='0dd7323b5ed9e3208236c1b39fcabf2ad03469fa07ac516ba9c682206133f66d')
 
     depends_on('ruby-asciidoctor')
+    depends_on('bison', type='build')
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', self.prefix.sbin)


### PR DESCRIPTION
`chrony` build failed by `no bison command`:
```
==> chrony: Executing phase: 'build'
==> [2020-12-28-18:43:48.065247] 'make' '-j16'
bison -o getdate.c getdate.y
make: bison: Command not found
```