### PR TITLE
gobject-introspection: enable gobject option in cairo

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -23,7 +23,7 @@ class GobjectIntrospection(Package):
     # version 1.48.0 build fails with glib 2.49.4
     depends_on("glib@2.48.1", when="@1.48.0")
     depends_on("python")
-    depends_on("cairo")
+    depends_on("cairo+gobject")
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
There is a fail on `gobject`'s testcase, we should enable `cairo+gobject` to pass the testcase.
```
============================================================================
Testsuite summary for gobject-introspection 1.56.1
============================================================================
# TOTAL: 21
# PASS:  20
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See tests/scanner/test-suite.log
Please report to http://bugzilla.gnome.org/enter_bug.cgi?product=gobject-introspection
============================================================================
make[7]: *** [Makefile:1215: test-suite.log] Error 1
make[7]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests/scanner'
make[6]: *** [Makefile:1323: check-TESTS] Error 2
make[6]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests/scanner'
make[5]: *** [Makefile:1586: check-am] Error 2
make[5]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests/scanner'
make[4]: *** [Makefile:1107: check-recursive] Error 1
make[4]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests/scanner'
make[3]: *** [Makefile:795: check-recursive] Error 1
make[3]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests'
make[2]: *** [Makefile:1115: check] Error 2
make[2]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src/tests'
make[1]: *** [Makefile:3053: check-recursive] Error 1
make[1]: Leaving directory '/home/spack-stage/root/spack-stage-gobject-introspection-1.56.1-53a67me56cofqmxgpi42o3ctadcy2wmq/spack-src'
make: *** [Makefile:3513: check] Error 2
```