### PR TITLE
r-rmariadb: add mariadb library path

### DIFF
--- a/var/spack/repos/builtin/packages/r-rmariadb/configure_add_rpath.patch
+++ b/var/spack/repos/builtin/packages/r-rmariadb/configure_add_rpath.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 6c0f43c..bd7f627 100755
+--- a/configure
++++ b/configure
+@@ -29,7 +29,7 @@ fi
+ if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
+   echo "Found INCLUDE_DIR and/or LIB_DIR!"
+   PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
+-  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
++  PKG_LIBS="-L$LIB_DIR -Wl,-rpath,$LIB_DIR $PKG_LIBS"
+ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+   echo "Found mysql_config/mariadb_config cflags and libs!"
+   PKG_CFLAGS=${PKGCONFIG_CFLAGS}

--- a/var/spack/repos/builtin/packages/r-rmariadb/package.py
+++ b/var/spack/repos/builtin/packages/r-rmariadb/package.py
@@ -31,6 +31,8 @@ class RRmariadb(RPackage):
     patch('configure_add_rpath.patch')
 
     def configure_vars(self):
-        args = ['LIB_DIR={0}'.format(self.spec['mariadb-client'].prefix.lib.mariadb),
-                'INCLUDE_DIR={0}'.format(self.spec['mariadb-client'].prefix.include.mariadb)]
+        lib_dir = self.spec['mariadb-client'].prefix.lib.mariadb
+        inc_dir = self.spec['mariadb-client'].prefix.include.mariadb
+        args = ['LIB_DIR={0}'.format(lib_dir),
+                'INCLUDE_DIR={0}'.format(inc_dir)]
         return args

--- a/var/spack/repos/builtin/packages/r-rmariadb/package.py
+++ b/var/spack/repos/builtin/packages/r-rmariadb/package.py
@@ -27,3 +27,7 @@ class RRmariadb(RPackage):
 
     # non-R dependencies
     depends_on('mariadb-client')
+
+    def setup_build_environment(self, env):
+        env.prepend_path('LD_LIBRARY_PATH',
+                         self.spec['mariadb-client'].prefix.lib.mariadb)

--- a/var/spack/repos/builtin/packages/r-rmariadb/package.py
+++ b/var/spack/repos/builtin/packages/r-rmariadb/package.py
@@ -28,6 +28,9 @@ class RRmariadb(RPackage):
     # non-R dependencies
     depends_on('mariadb-client')
 
-    def setup_build_environment(self, env):
-        env.prepend_path('LD_LIBRARY_PATH',
-                         self.spec['mariadb-client'].prefix.lib.mariadb)
+    patch('configure_add_rpath.patch')
+
+    def configure_vars(self):
+        args = ['LIB_DIR={0}'.format(self.spec['mariadb-client'].prefix.lib.mariadb),
+                'INCLUDE_DIR={0}'.format(self.spec['mariadb-client'].prefix.include.mariadb)]
+        return args


### PR DESCRIPTION
`r-rmariadb` build failed caused by the mariadb lib path error:
```
** building package indices
** testing if installed package can be loaded from temporary location
Error: package or namespace load failed for 'RMariaDB' in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-rmariadb-1.0.8-sopsqypom7c4mfpzrwtgu5ftrq3ggnrg/rlib/R/library/00LOCK-spack-src/00new/RMariaDB/libs/RMariaDB.so':
  libmariadb.so.3: cannot open shared object file: No such file or directory
Error: loading failed
Execution halted
ERROR: loading failed
* removing '/home/spack-develop/opt/spack/linux-centos8-aarch64/gcc-8.3.1/r-rmariadb-1.0.8-sopsqypom7c4mfpzrwtgu5ftrq3ggnrg/rlib/R/library/RMariaDB'
```