### PR TITLE
boost: Fix B2/BJam bootstrap toolchain

### DIFF
--- a/var/spack/repos/builtin/packages/boost/bootstrap-toolset.patch
+++ b/var/spack/repos/builtin/packages/boost/bootstrap-toolset.patch
@@ -1,0 +1,11 @@
+--- a/bootstrap.sh	2020-12-03 00:00:59.000000000 -0500
++++ a/bootstrap.sh	2021-01-08 13:38:30.000000000 -0500
+@@ -223,7 +223,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  (cd "$my_dir/tools/build/src/engine" && ./build.sh)
++  (cd "$my_dir/tools/build/src/engine" && ./build.sh "$TOOLSET")
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -260,6 +260,11 @@ class Boost(Package):
     # See https://github.com/boostorg/python/pull/218
     patch('boost_218.patch', when='@1.63.0:1.67.99')
 
+    # Fix B2 bootstrap toolset during installation
+    # See https://github.com/spack/spack/issues/20757
+    # and https://github.com/spack/spack/pull/21408
+    patch("bootstrap-toolset.patch", when="@1.75:")
+
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler
         if self.spec.satisfies('%nvhpc'):


### PR DESCRIPTION
Boost's `bootstrap.sh` does not pass any toolchain when building B2 / BJam for its own use, which causes that part of the build to attempt to autodetect which toolchain to use.
This can cause builds to fail if the autodetected toolchain differs from the toolchain Spack wants to use.
For example, this can happen on systems with xl installed (see #20757).

This changes the install phase to first specifically build B2 / BJam using `tools/build/src/engine/build.sh`, passing an appropriate toolset parameter; the built `b2` / `bjam` executable is then passed as an additional parameter to the main `bootstrap.sh` script, and used for later parts of the install phase.