### PR TITLE
ldak: build only x86_64 linux.

### DIFF
--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2012-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -20,6 +20,11 @@ class Ldak(Package):
     depends_on('blas')
     depends_on('lapack')
     depends_on('mkl', when='+mkl')
+
+    conflicts('target=aarch64:', msg='libspot is avilable linux x86_64 only')
+    conflicts('target=ppc64:', msg='libspot is avilable linux x86_64 only')
+    conflicts('target=ppc64le:', msg='libspot is avilable linux x86_64 only')
+    conflicts('platform=darwin', msg='libspot is avilable linux x86_64 only')
 
     def setup_build_environment(self, env):
         env.append_flags('LDLIBS', '-lm')

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -12,7 +12,7 @@ class Ldak(Package):
     homepage = "http://dougspeed.com/ldak/"
     url      = "http://dougspeed.com/wp-content/uploads/source.zip"
 
-    version('5.1', sha256='9a3fe2fafc7b68cc57a17748a64db66f76b13acbd5e9a538ede20a46447fcf4a')
+    version('5.1', sha256='ae3eb8c2ef31af210e138336fd6edcd0e3a26ea9bae89fd6c0c6ea33e3a1517e')
 
     variant('mkl', default=False, description='Use MKL')
 
@@ -21,10 +21,10 @@ class Ldak(Package):
     depends_on('lapack')
     depends_on('mkl', when='+mkl')
 
-    conflicts('target=aarch64:', msg='libspot is avilable linux x86_64 only')
-    conflicts('target=ppc64:', msg='libspot is avilable linux x86_64 only')
-    conflicts('target=ppc64le:', msg='libspot is avilable linux x86_64 only')
-    conflicts('platform=darwin', msg='libspot is avilable linux x86_64 only')
+    for t in ['aarch64', 'arm', 'ppc', 'ppc64', 'ppc64le',
+              'ppcle', 'sparc', 'sparc64', 'x86']:
+        conflicts('target={0}:'.format(t),
+                  msg='libspot is available linux x86_64 only')
 
     def setup_build_environment(self, env):
         env.append_flags('LDLIBS', '-lm')
@@ -37,11 +37,8 @@ class Ldak(Package):
             env.append_flags('LDLIBS', 'libqsopt.linux.a')
 
     def install(self, spec, prefix):
-        if '+mkl' in spec:
-            make('ldak')
-            mkdirp(prefix.bin)
-            install('ldak', prefix.bin)
-        else:
-            make('ldak_slow')
-            mkdirp(prefix.bin)
-            install('ldak_slow', prefix.bin.ldak)
+        if self.spec.satisfies('~mkl'):
+            filter_file('#define MKL.*', '#define MKL 0', 'ldak.c')
+        make('ldak')
+        mkdirp(prefix.bin)
+        install('ldak', prefix.bin.ldak)


### PR DESCRIPTION
ldak include libspotliux*.a
This files can be linkes only x86_64 only.
This PR add conflicts other than x86_64 linux.