### PR TITLE
WIP: Add --with-env-vars flag to `spack env activate --sh`

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -77,8 +77,8 @@ def env_activate_setup_parser(subparser):
         '-p', '--prompt', action='store_true', default=False,
         help="decorate the command line prompt when activating")
     subparser.add_argument(
-        '-s', '--sourceable', action='store_true', default=False,
-        help="output a sourceable script when used with a print command")
+        '-s', '--with-env-vars', action='store_true', default=False,
+        help="output a script that uses en used with a print command")
     subparser.add_argument(
         metavar='env', dest='activate_env',
         help='name of environment to activate')
@@ -113,7 +113,7 @@ def env_activate(args):
                             'activate')
     cmds = ev.activate(
         active_env, add_view=args.with_view, shell=args.shell,
-        sourceable=args.sourceable,
+        with_env_vars=args.with_env_vars,
         prompt=env_prompt if args.prompt else None
     )
     sys.stdout.write(cmds)

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -59,6 +59,9 @@ def env_activate_setup_parser(subparser):
     shells.add_argument(
         '--fish', action='store_const', dest='shell', const='fish',
         help="print fish commands to activate the environment")
+    subparser.add_argument(
+        '--with-env-vars', action='store_true', default=False,
+        help="print prepend commands to activate the environment")
 
     view_options = subparser.add_mutually_exclusive_group()
     view_options.add_argument(
@@ -76,9 +79,6 @@ def env_activate_setup_parser(subparser):
     subparser.add_argument(
         '-p', '--prompt', action='store_true', default=False,
         help="decorate the command line prompt when activating")
-    subparser.add_argument(
-        '-s', '--with-env-vars', action='store_true', default=False,
-        help="output a script that uses en used with a print command")
     subparser.add_argument(
         metavar='env', dest='activate_env',
         help='name of environment to activate')

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -77,6 +77,9 @@ def env_activate_setup_parser(subparser):
         '-p', '--prompt', action='store_true', default=False,
         help="decorate the command line prompt when activating")
     subparser.add_argument(
+        '-s', '--sourceable', action='store_true', default=False,
+        help="output a sourceable script when used with a print command")
+    subparser.add_argument(
         metavar='env', dest='activate_env',
         help='name of environment to activate')
 
@@ -110,6 +113,7 @@ def env_activate(args):
                             'activate')
     cmds = ev.activate(
         active_env, add_view=args.with_view, shell=args.shell,
+        sourceable=args.sourceable,
         prompt=env_prompt if args.prompt else None
     )
     sys.stdout.write(cmds)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -105,7 +105,7 @@ def validate_env_name(name):
 
 
 def activate(
-    env, use_env_repo=False, add_view=True, shell='sh', prompt=None
+    env, use_env_repo=False, add_view=True, shell='sh', prompt=None, sourceable=False
 ):
     """Activate an environment.
 
@@ -181,7 +181,7 @@ def activate(
     try:
         if add_view and default_view_name in env.views:
             with spack.store.db.read_transaction():
-                cmds += env.add_default_view_to_shell(shell)
+                cmds += env.add_default_view_to_shell(shell, sourceable)
     except (spack.repo.UnknownPackageError,
             spack.repo.UnknownNamespaceError) as e:
         tty.error(e)
@@ -1265,12 +1265,12 @@ class Environment(object):
 
         return all_mods, errors
 
-    def add_default_view_to_shell(self, shell):
+    def add_default_view_to_shell(self, shell, sourceable):
         env_mod = spack.util.environment.EnvironmentModifications()
 
         if default_view_name not in self.views:
             # No default view to add to shell
-            return env_mod.shell_modifications(shell)
+            return env_mod.shell_modifications(shell, sourceable)
 
         env_mod.extend(uenv.unconditional_environment_modifications(
             self.default_view))
@@ -1285,7 +1285,7 @@ class Environment(object):
         for env_var in env_mod.group_by_name():
             env_mod.prune_duplicate_paths(env_var)
 
-        return env_mod.shell_modifications(shell)
+        return env_mod.shell_modifications(shell, sourceable)
 
     def rm_default_view_from_shell(self, shell):
         env_mod = spack.util.environment.EnvironmentModifications()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -105,7 +105,7 @@ def validate_env_name(name):
 
 
 def activate(
-    env, use_env_repo=False, add_view=True, shell='sh', prompt=None, sourceable=False
+    env, use_env_repo=False, add_view=True, shell='sh', prompt=None, with_env_vars=False
 ):
     """Activate an environment.
 
@@ -181,7 +181,9 @@ def activate(
     try:
         if add_view and default_view_name in env.views:
             with spack.store.db.read_transaction():
-                cmds += env.add_default_view_to_shell(shell, sourceable)
+                cmds += env.add_default_view_to_shell(
+                    shell, with_env_vars=with_env_vars
+                )
     except (spack.repo.UnknownPackageError,
             spack.repo.UnknownNamespaceError) as e:
         tty.error(e)
@@ -1265,12 +1267,12 @@ class Environment(object):
 
         return all_mods, errors
 
-    def add_default_view_to_shell(self, shell, sourceable):
+    def add_default_view_to_shell(self, shell, with_env_vars=False):
         env_mod = spack.util.environment.EnvironmentModifications()
 
         if default_view_name not in self.views:
             # No default view to add to shell
-            return env_mod.shell_modifications(shell, sourceable)
+            return env_mod.shell_modifications(shell, with_env_vars)
 
         env_mod.extend(uenv.unconditional_environment_modifications(
             self.default_view))
@@ -1285,7 +1287,7 @@ class Environment(object):
         for env_var in env_mod.group_by_name():
             env_mod.prune_duplicate_paths(env_var)
 
-        return env_mod.shell_modifications(shell, sourceable)
+        return env_mod.shell_modifications(shell, with_env_vars)
 
     def rm_default_view_from_shell(self, shell):
         env_mod = spack.util.environment.EnvironmentModifications()

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -536,7 +536,7 @@ class EnvironmentModifications(object):
             for x in actions:
                 x.execute(os.environ)
 
-    def shell_modifications(self, shell='sh', sourceable=False):
+    def shell_modifications(self, shell='sh', with_env_vars=False):
         """Return shell code to apply the modifications and clears the list."""
         modifications = self.group_by_name()
         new_env = os.environ.copy()
@@ -554,7 +554,7 @@ class EnvironmentModifications(object):
                 if new is None:
                     cmds += _shell_unset_strings[shell].format(name)
                 else:
-                    if sourceable:
+                    if with_env_vars:
                         if old:
                             new_env[name] = new_env[name].replace(
                                 old, "${0}".format(name))

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -556,9 +556,11 @@ class EnvironmentModifications(object):
                 else:
                     if sourceable:
                         if old:
-                            new_env[name] = new_env[name].replace(old, "${}".format(name))
+                            new_env[name] = new_env[name].replace(
+                                old, "${0}".format(name))
                         else:
-                            new_env[name] = "{}:${}".format(new_env[name], name)
+                            new_env[name] = "{0}:${1}".format(
+                                new_env[name], name)
                         # no `cmd_quote` here as this is sourced and variable
                         # expansion does not happen in the quotes
                         cmds += _shell_set_strings[shell].format(

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -556,9 +556,9 @@ class EnvironmentModifications(object):
                 else:
                     if sourceable:
                         if old:
-                            new_env[name] = new_env[name].replace(old, f"${name}")
+                            new_env[name] = new_env[name].replace(old, "${}".format(name))
                         else:
-                            new_env[name] = f"{new_env[name]}:${name}"
+                            new_env[name] = "{}:${}".format(new_env[name], name)
                         # no `cmd_quote` here as this is sourced and variable
                         # expansion does not happen in the quotes
                         cmds += _shell_set_strings[shell].format(

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -772,7 +772,7 @@ _spack_env() {
 _spack_env_activate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish -v --with-view -V --without-view -d --dir -p --prompt -s --with-env-vars"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --with-env-vars -v --with-view -V --without-view -d --dir -p --prompt"
     else
         _environments
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -772,7 +772,7 @@ _spack_env() {
 _spack_env_activate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish -v --with-view -V --without-view -d --dir -p --prompt -s --sourceable"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish -v --with-view -V --without-view -d --dir -p --prompt -s --with-env-vars"
     else
         _environments
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -772,7 +772,7 @@ _spack_env() {
 _spack_env_activate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish -v --with-view -V --without-view -d --dir -p --prompt"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish -v --with-view -V --without-view -d --dir -p --prompt -s --sourceable"
     else
         _environments
     fi


### PR DESCRIPTION
PR is for #21413, I'm still not sure if this is a good idea but the changes were simple enough that I just made them here anyway to illustrate what I meant.

This adds a `--sourceable` flag to `spack env activate` that gets passed through to the `shell_modifications` function. When the flag is on any references to the users current environment get removed and replaced with environment variables.

For example, the standard output is:

```bash
export SPACK_ENV=/home/roscar/tmp/example-environment;
alias despacktivate='spack env deactivate';
if [ -z ${SPACK_OLD_PS1+x} ]; then
    if [ -z ${PS1+x} ]; then
        PS1='$$$$';
    fi;
    export SPACK_OLD_PS1="${PS1}";
fi;
export PS1="[example-environment] ${PS1}";
export PATH=/home/roscar/tmp/example-environment/.spack-env/view/bin:/home/roscar/work/github.com/RobertRosca/spack/bin:/home/roscar/.zinit/plugins/ajeetdsouza---zoxide:/home/roscar/.poetry/bin:/home/roscar/.zinit/plugins/sharkdp---fd/fd:/home/roscar/.zinit/plugins/junegunn---fzf-bin:/home/roscar/.scripts:/home/roscar/.zinit/polaris/bin:/home/roscar/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl;
export PKG_CONFIG_PATH=/home/roscar/tmp/example-environment/.spack-env/view/share/pkgconfig:/home/roscar/tmp/example-environment/.spack-env/view/lib64/pkgconfig:/home/roscar/tmp/example-environment/.spack-env/view/lib/pkgconfig;
export CMAKE_PREFIX_PATH=/home/roscar/tmp/example-environment/.spack-env/view;
export MANPATH=/home/roscar/tmp/example-environment/.spack-env/view/share/man:/home/roscar/tmp/example-environment/.spack-env/view/man;
export C_INCLUDE_PATH=/home/roscar/tmp/example-environment/.spack-env/view/include;
export INCLUDE=/home/roscar/tmp/example-environment/.spack-env/view/include;
export CPLUS_INCLUDE_PATH=/home/roscar/tmp/example-environment/.spack-env/view/include;
export LIBRARY_PATH=/home/roscar/tmp/example-environment/.spack-env/view/lib64:/home/roscar/tmp/example-environment/.spack-env/view/lib;
export LD_LIBRARY_PATH=/home/roscar/tmp/example-environment/.spack-env/view/lib64:/home/roscar/tmp/example-environment/.spack-env/view/lib;
export ACLOCAL_PATH=/home/roscar/tmp/example-environment/.spack-env/view/share/aclocal;
```

And with the `--sourceable` flag:

```bash
❯ spack env activate --sh -v -p --sourceable ./example-environment
export SPACK_ENV=/home/roscar/tmp/example-environment;
alias despacktivate='spack env deactivate';
if [ -z ${SPACK_OLD_PS1+x} ]; then
    if [ -z ${PS1+x} ]; then
        PS1='$$$$';
    fi;
    export SPACK_OLD_PS1="${PS1}";
fi;
export PS1="[example-environment] ${PS1}";
export C_INCLUDE_PATH=/home/roscar/tmp/example-environment/.spack-env/view/include:$C_INCLUDE_PATH;
export MANPATH=/home/roscar/tmp/example-environment/.spack-env/view/share/man:/home/roscar/tmp/example-environment/.spack-env/view/man:$MANPATH;
export CMAKE_PREFIX_PATH=/home/roscar/tmp/example-environment/.spack-env/view:$CMAKE_PREFIX_PATH;
export LIBRARY_PATH=/home/roscar/tmp/example-environment/.spack-env/view/lib64:/home/roscar/tmp/example-environment/.spack-env/view/lib:$LIBRARY_PATH;
export ACLOCAL_PATH=/home/roscar/tmp/example-environment/.spack-env/view/share/aclocal:$ACLOCAL_PATH;
export PATH=/home/roscar/tmp/example-environment/.spack-env/view/bin:$PATH;
export PKG_CONFIG_PATH=/home/roscar/tmp/example-environment/.spack-env/view/share/pkgconfig:/home/roscar/tmp/example-environment/.spack-env/view/lib64/pkgconfig:/home/roscar/tmp/example-environment/.spack-env/view/lib/pkgconfig:$PKG_CONFIG_PATH;
export INCLUDE=/home/roscar/tmp/example-environment/.spack-env/view/include:$INCLUDE;
export LD_LIBRARY_PATH=/home/roscar/tmp/example-environment/.spack-env/view/lib64:/home/roscar/tmp/example-environment/.spack-env/view/lib:$LD_LIBRARY_PATH;
export CPLUS_INCLUDE_PATH=/home/roscar/tmp/example-environment/.spack-env/view/include:$CPLUS_INCLUDE_PATH;
```

This means you can do `spack env activate --sh -v -p ./example-environment > activate` and any users can run `source activate` to activate the environment, without having to load spack or run `spack env activate`. Only major issue is that `spack env deactivate` requires the full spack shell integration, so a workaround for that would be needed.

May also be useful to have a module file generation flag, as generating module files for environments seems like a useful feature to me as well, but maybe that doesn't fit in with the way environments are meant to be used.

- [x] Rough implementation of changes to `shell_modifications`
- [x] Propagate arguments through to CLI call function and subparser
- [ ] Try to implement a sourceable `deactivate` script
- [ ] Add tests
- [ ] Module file generation? 