### PR TITLE
replace libelf with elfutils in hip-rocclr

### DIFF
--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -33,7 +33,7 @@ class HipRocclr(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('mesa18~llvm@18.3: swr=none', type='link')
-    depends_on('libelf', type='link', when="@3.7.0:")
+    depends_on('elfutils', type='link', when="@3.7.0:")
     depends_on('numactl', type='link', when="@3.7.0:")
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -33,7 +33,7 @@ class HipRocclr(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('mesa18~llvm@18.3: swr=none', type='link')
-    depends_on('elfutils', type='link', when="@3.7.0:")
+    depends_on('libelf', type='link', when="@3.7.0:3.8.0")
     depends_on('numactl', type='link', when="@3.7.0:")
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)


### PR DESCRIPTION
i had a ticket that requested to replace libelf with elfutils from @mwkrentel  . i replaced it now and for testing built the packages (rocblas) for rocm-3.9.0,rocm-3.10.0, 4.0.0 . need review on the same.
