### PR TITLE
Fixed uninstall rm parent folder race condition

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -119,9 +119,14 @@ class DirectoryLayout(object):
         path = os.path.dirname(path)
         while path != self.root:
             if os.path.isdir(path):
-                if os.listdir(path):
+                try:
+                    os.rmdir(path)
+                except FileNotFoundError:
+                    # already deleted, continue with parent
+                    pass
+                except OSError:
+                    # directory wasn't empty, done
                     return
-                os.rmdir(path)
             path = os.path.dirname(path)
 
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import glob
 import tempfile
+import errno
 from contextlib import contextmanager
 
 import ruamel.yaml as yaml
@@ -121,12 +122,15 @@ class DirectoryLayout(object):
             if os.path.isdir(path):
                 try:
                     os.rmdir(path)
-                except FileNotFoundError:
-                    # already deleted, continue with parent
-                    pass
-                except OSError:
-                    # directory wasn't empty, done
-                    return
+                except OSError as e:
+                    if e.errno == errno.ENOENT:
+                        # already deleted, continue with parent
+                        pass
+                    elif e.errno == errno.ENOTEMPTY:
+                        # directory wasn't empty, done
+                        return
+                    else:
+                        raise e
             path = os.path.dirname(path)
 
 


### PR DESCRIPTION
Hey lovely folks! This is my first PR in spack. I think I found a race condition when packages get uninstalled which should be fixed with this PR:

When uninstalling packages, spack also tries to remove empty parent directories of the install prefix up until the spack installation root.  Spack acquires a write lock for the package's installation prefix during uninstallation. However, multiple installation prefixes can share parent directories. So there's a race condition when trying to remove empty parent directories.

This sporadically occurs in our jenkins setup where we uninstall a package in 4 configurations roughly at the same time.