### PR TITLE
gearshifft: added args.append('-DCMAKE_CXX_FLAGS=-pthread')

### DIFF
--- a/var/spack/repos/builtin/packages/gearshifft/gearshifft-v0.4.0-cmake-variable-name.patch
+++ b/var/spack/repos/builtin/packages/gearshifft/gearshifft-v0.4.0-cmake-variable-name.patch
@@ -1,0 +1,22 @@
+diff --git spack-src/cmake/init_build_type.cmake.org spack-src/cmake/init_build_type.cmake
+index c826f5d..4239dd0 100644
+--- spack-src/cmake/init_build_type.cmake.org
++++ spack-src/cmake/init_build_type.cmake
+@@ -1,6 +1,6 @@
+ # Default build type to use if none was specified
+-if(NOT DEFINED CMAKE_DEFAULT_BUILD_TYPE)
+-  set(CMAKE_DEFAULT_BUILD_TYPE "Release")
++if(NOT DEFINED GEARSHIFFT_DEFAULT_BUILD_TYPE)
++  set(GEARSHIFFT_DEFAULT_BUILD_TYPE "Release")
+ endif()
+
+ set(CMAKE_BUILD_TYPE ${CMAKE_DEFAULT_BUILD_TYPE} CACHE STRING "Build type")
+@@ -14,6 +14,6 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+
+ # sets default build type if none was specified
+ if(NOT CMAKE_BUILD_TYPE)
+-  message(STATUS "No build type selected, default to ${CMAKE_DEFAULT_BUILD_TYPE}")
+-  set(CMAKE_BUILD_TYPE ${CMAKE_DEFAULT_BUILD_TYPE} CACHE STRING "Build type" FORCE)
++  message(STATUS "No build type selected, default to ${GEARSHIFFT_DEFAULT_BUILD_TYPE}")
++  set(CMAKE_BUILD_TYPE ${GEARSHIFFT_DEFAULT_BUILD_TYPE} CACHE STRING "Build type" FORCE)
+ endif()

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -12,7 +12,7 @@ class Gearshifft(CMakePackage):
     homepage = "https://github.com/mpicbg-scicomp/gearshifft"
     url      = "https://github.com/mpicbg-scicomp/gearshifft/archive/v0.2.1-lw.tar.gz"
 
-    maintainers = ['ax3l']
+    maintainers = ['zyzzyxdonta']
 
     version('0.4.0', sha256='15b9e4bfa1d9b4fe4ae316f289c67b7be0774cdada5bd7310df4d0e026d9d227')
 
@@ -56,5 +56,4 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
                 'ON' if '+clfft' in spec else 'OFF')
         ])
-
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -54,5 +54,6 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
                 'ON' if '+clfft' in spec else 'OFF')
         ])
-        args.append('-DCMAKE_CXX_FLAGS=-pthread')
+        if '%gcc' in spec:
+            args.append('-DCMAKE_CXX_FLAGS=-pthread')
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -54,6 +54,7 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
                 'ON' if '+clfft' in spec else 'OFF')
         ])
-        if '%gcc' in spec:
+        if self.spec.target.family == 'aarch64':
             args.append('-DCMAKE_CXX_FLAGS=-pthread')
+
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -54,4 +54,5 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
                 'ON' if '+clfft' in spec else 'OFF')
         ])
+        args.append('-DCMAKE_CXX_FLAGS=-pthread')
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -14,7 +14,9 @@ class Gearshifft(CMakePackage):
 
     maintainers = ['ax3l']
 
-    version('0.2.1-lw', sha256='04ba7401615ab29a37089c0dce8580270c0c4aa1ba328c9d438d6e4f163899c5')
+    version('0.4.0', sha256='15b9e4bfa1d9b4fe4ae316f289c67b7be0774cdada5bd7310df4d0e026d9d227')
+
+    patch('gearshifft-v0.4.0-cmake-variable-name.patch', when='@0.4.0')
 
     variant('cufft', default=True,
             description='Compile gearshifft_cufft')
@@ -54,7 +56,5 @@ class Gearshifft(CMakePackage):
             '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
                 'ON' if '+clfft' in spec else 'OFF')
         ])
-        if self.spec.target.family == 'aarch64':
-            args.append('-DCMAKE_CXX_FLAGS=-pthread')
 
         return args


### PR DESCRIPTION
I got the following error during my installation of gearshifft.
Because "-DCMAKE_CXX_FLAGS=-pthread'" is missing.


```
  >> 152    /usr/bin/ld: CMakeFiles/gearshifft_fftw.dir/benchmark.cpp.o: undefined reference to symbol 'pthread_key_de
            lete@@@@GLIBC_2.17'
  >> 153    //usr/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
  >> 154    collect2: error: ld returned 1 exit status

```