### PR TITLE
libqglviewer: Add glu depend

### DIFF
--- a/var/spack/repos/builtin/packages/libqglviewer/package.py
+++ b/var/spack/repos/builtin/packages/libqglviewer/package.py
@@ -18,6 +18,7 @@ class Libqglviewer(QMakePackage):
 
     depends_on('qt+gui+opengl')
     depends_on('freeglut', when='^qt@:3.0')
+    depends_on('glu', type='link')
 
     build_directory = 'QGLViewer'
 


### PR DESCRIPTION
I have fixed the following issues:
config.h:86:10: fatal error: GL/glu.h: No such file or directory