### PR TITLE
pangolin: Add glu depend

### DIFF
--- a/var/spack/repos/builtin/packages/pangolin/package.py
+++ b/var/spack/repos/builtin/packages/pangolin/package.py
@@ -17,6 +17,7 @@ class Pangolin(CMakePackage):
     depends_on('cmake@2.8.12:', type='build')
     depends_on('gl')
     depends_on('glew')
+    depends_on('glu', type='link')
 
     # Optional dependencies
     depends_on('eigen')


### PR DESCRIPTION
I have fixed the following issues:
115    ./spack/opt/spack/linux-rhel8-thunderx2/gcc-8.3.1/glew-2.1.0-mpofscfnod45xpjeqv7rolrinlktez6v/include/GL/glew.h:1205:14
            : fatal error: GL/glu.h: No such file or directory
 116     #    include <GL/glu.h>